### PR TITLE
KAFKA-10048: Possible data gap for a consumer after a failover when u…

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointTask.java
@@ -168,7 +168,7 @@ public class MirrorCheckpointTask extends SourceTask {
         return listConsumerGroupOffsets(group).entrySet().stream()
             .filter(x -> shouldCheckpointTopic(x.getKey().topic()))
             .map(x -> checkpoint(group, x.getKey(), x.getValue()))
-            .filter(x -> x.downstreamOffset() > 0)  // ignore offsets we cannot translate accurately
+            .filter(x -> x.downstreamOffset() >= 0)  // ignore offsets we cannot translate accurately
             .collect(Collectors.toList());
     }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.mirror;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -33,21 +34,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -63,16 +67,17 @@ public class MirrorConnectorsIntegrationTest {
 
     private static final Logger log = LoggerFactory.getLogger(MirrorConnectorsIntegrationTest.class);
 
-    private static final int NUM_RECORDS_PRODUCED = 100;  // to save trees
+    private static final int NUM_RECORDS_PER_PARTITION = 10;
     private static final int NUM_PARTITIONS = 10;
-    private static final int RECORD_TRANSFER_DURATION_MS = 20_000;
+    private static final int NUM_RECORDS_PRODUCED = NUM_PARTITIONS * NUM_RECORDS_PER_PARTITION;
+    private static final int RECORD_TRANSFER_DURATION_MS = 30_000;
     private static final int CHECKPOINT_DURATION_MS = 20_000;
     private static final int RECORD_CONSUME_DURATION_MS = 20_000;
     private static final int OFFSET_SYNC_DURATION_MS = 30_000;
 
     private final AtomicBoolean exited = new AtomicBoolean(false);
     private Map<String, String> mm2Props;
-    private MirrorMakerConfig mm2Config; 
+    private MirrorMakerConfig mm2Config;
     private EmbeddedConnectCluster primary;
     private EmbeddedConnectCluster backup;
 
@@ -136,10 +141,18 @@ public class MirrorConnectorsIntegrationTest {
         backup.kafka().createTopic("primary.test-topic-1", 1);
         backup.kafka().createTopic("heartbeats", 1);
 
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            primary.kafka().produce("test-topic-1", i % NUM_PARTITIONS, "key", "message-1-" + i);
-            backup.kafka().produce("test-topic-1", i % NUM_PARTITIONS, "key", "message-2-" + i);
-        }
+        // produce to all partitions of test-topic-1
+        produceMessages(primary, "test-topic-1", "message-1-");
+        produceMessages(backup, "test-topic-1", "message-2-");
+
+        // Generate some consumer activity on both clusters to ensure the checkpoint connector always starts promptly
+        Map<String, Object> dummyProps = Collections.singletonMap("group.id", "consumer-group-dummy");
+        Consumer<byte[], byte[]> dummyConsumer = primary.kafka().createConsumerAndSubscribeTo(dummyProps, "test-topic-1");
+        consumeAllMessages(dummyConsumer);
+        dummyConsumer.close();
+        dummyConsumer = backup.kafka().createConsumerAndSubscribeTo(dummyProps, "test-topic-1");
+        consumeAllMessages(dummyConsumer);
+        dummyConsumer.close();
 
         log.info("primary REST service: {}", primary.endpointForResource("connectors"));
         log.info("backup REST service: {}", backup.endpointForResource("connectors"));
@@ -150,6 +163,7 @@ public class MirrorConnectorsIntegrationTest {
         // now that the brokers are running, we can finish setting up the Connectors
         mm2Props.put("primary.bootstrap.servers", primary.kafka().bootstrapServers());
         mm2Props.put("backup.bootstrap.servers", backup.kafka().bootstrapServers());
+        mm2Config = new MirrorMakerConfig(mm2Props);
 
         Exit.setExitProcedure((status, errorCode) -> exited.set(true));
     }
@@ -158,14 +172,12 @@ public class MirrorConnectorsIntegrationTest {
     private void waitUntilMirrorMakerIsRunning(EmbeddedConnectCluster connectCluster,
         MirrorMakerConfig mm2Config, String primary, String backup) throws InterruptedException {
 
-        connectCluster.configureConnector("MirrorSourceConnector", mm2Config.connectorBaseConfig(new SourceAndTarget(primary, backup),
-                                                                                         MirrorSourceConnector.class));
-
-        connectCluster.configureConnector("MirrorCheckpointConnector", mm2Config.connectorBaseConfig(new SourceAndTarget(primary, backup),
-                                                                                             MirrorCheckpointConnector.class));
-
-        connectCluster.configureConnector("MirrorHeartbeatConnector", mm2Config.connectorBaseConfig(new SourceAndTarget(primary, backup),
-                                                                                            MirrorHeartbeatConnector.class));
+        connectCluster.configureConnector("MirrorSourceConnector",
+                mm2Config.connectorBaseConfig(new SourceAndTarget(primary, backup), MirrorSourceConnector.class));
+        connectCluster.configureConnector("MirrorCheckpointConnector",
+                mm2Config.connectorBaseConfig(new SourceAndTarget(primary, backup), MirrorCheckpointConnector.class));
+        connectCluster.configureConnector("MirrorHeartbeatConnector",
+                mm2Config.connectorBaseConfig(new SourceAndTarget(primary, backup), MirrorHeartbeatConnector.class));
 
         // we wait for the connector and tasks to come up for each connector, so that when we do the
         // actual testing, we are certain that the tasks are up and running; this will prevent
@@ -201,26 +213,23 @@ public class MirrorConnectorsIntegrationTest {
 
     @Test
     public void testReplication() throws InterruptedException {
+        String consumerGroupName = "consumer-group-testReplication";
+        Map<String, Object> consumerProps = new HashMap<String, Object>() {{
+                put("group.id", consumerGroupName);
+                put("auto.offset.reset", "latest");
+            }};
 
         // create consumers before starting the connectors so we don't need to wait for discovery
-        Consumer<byte[], byte[]> consumer1 = primary.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
-            "group.id", "consumer-group-1"), "test-topic-1", "backup.test-topic-1");
-        consumer1.poll(Duration.ofMillis(500));
-        consumer1.commitSync();
-        consumer1.close();
+        Consumer<byte[], byte[]> primaryConsumer = primary.kafka().createConsumerAndSubscribeTo(consumerProps, "test-topic-1");
+        consumeAllMessages(primaryConsumer, 0);
+        primaryConsumer.close();
 
-        Consumer<byte[], byte[]> consumer2 = backup.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
-            "group.id", "consumer-group-1"), "test-topic-1", "primary.test-topic-1");
-        consumer2.poll(Duration.ofMillis(500));
-        consumer2.commitSync();
-        consumer2.close();
-
-        mm2Config = new MirrorMakerConfig(mm2Props);
+        Consumer<byte[], byte[]> backupConsumer = backup.kafka().createConsumerAndSubscribeTo(consumerProps, "test-topic-1");
+        consumeAllMessages(backupConsumer, 0);
+        backupConsumer.close();
 
         waitUntilMirrorMakerIsRunning(backup, mm2Config, "primary", "backup");
-
         waitUntilMirrorMakerIsRunning(primary, mm2Config, "backup", "primary");
-
         MirrorClient primaryClient = new MirrorClient(mm2Config.clientConfig("primary"));
         MirrorClient backupClient = new MirrorClient(mm2Config.clientConfig("backup"));
 
@@ -232,49 +241,52 @@ public class MirrorConnectorsIntegrationTest {
             backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count());
         assertEquals("Records were not replicated to primary cluster.", NUM_RECORDS_PRODUCED,
             primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1").count());
+
         assertEquals("Primary cluster doesn't have all records from both clusters.", NUM_RECORDS_PRODUCED * 2,
             primary.kafka().consume(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1", "test-topic-1").count());
         assertEquals("Backup cluster doesn't have all records from both clusters.", NUM_RECORDS_PRODUCED * 2,
             backup.kafka().consume(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1", "test-topic-1").count());
-        assertTrue("Heartbeats were not emitted to primary cluster.", primary.kafka().consume(1,
-            RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0);
-        assertTrue("Heartbeats were not emitted to backup cluster.", backup.kafka().consume(1,
-            RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0);
-        assertTrue("Heartbeats were not replicated downstream to backup cluster.", backup.kafka().consume(1,
-            RECORD_TRANSFER_DURATION_MS, "primary.heartbeats").count() > 0);
-        assertTrue("Heartbeats were not replicated downstream to primary cluster.", primary.kafka().consume(1,
-            RECORD_TRANSFER_DURATION_MS, "backup.heartbeats").count() > 0);
+
+        assertTrue("Heartbeats were not emitted to primary cluster.",
+            primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0);
+        assertTrue("Heartbeats were not emitted to backup cluster.",
+            backup.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0);
+        assertTrue("Heartbeats were not replicated downstream to backup cluster.",
+            backup.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "primary.heartbeats").count() > 0);
+        assertTrue("Heartbeats were not replicated downstream to primary cluster.",
+            primary.kafka().consume(1, RECORD_TRANSFER_DURATION_MS, "backup.heartbeats").count() > 0);
+
         assertTrue("Did not find upstream primary cluster.", backupClient.upstreamClusters().contains("primary"));
         assertEquals("Did not calculate replication hops correctly.", 1, backupClient.replicationHops("primary"));
         assertTrue("Did not find upstream backup cluster.", primaryClient.upstreamClusters().contains("backup"));
         assertEquals("Did not calculate replication hops correctly.", 1, primaryClient.replicationHops("backup"));
-        assertTrue("Checkpoints were not emitted downstream to backup cluster.", backup.kafka().consume(1,
-            CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0);
 
-        Map<TopicPartition, OffsetAndMetadata> backupOffsets = backupClient.remoteConsumerOffsets("consumer-group-1", "primary",
+        assertTrue("Checkpoints were not emitted downstream to backup cluster.",
+            backup.kafka().consume(1, CHECKPOINT_DURATION_MS, "primary.checkpoints.internal").count() > 0);
+
+        Map<TopicPartition, OffsetAndMetadata> backupOffsets = backupClient.remoteConsumerOffsets(consumerGroupName, "primary",
             Duration.ofMillis(CHECKPOINT_DURATION_MS));
 
         assertTrue("Offsets not translated downstream to backup cluster. Found: " + backupOffsets, backupOffsets.containsKey(
             new TopicPartition("primary.test-topic-1", 0)));
 
         // Failover consumer group to backup cluster.
-        consumer1 = backup.kafka().createConsumer(Collections.singletonMap("group.id", "consumer-group-1"));
-        consumer1.assign(backupOffsets.keySet());
-        backupOffsets.forEach(consumer1::seek);
-        consumer1.poll(Duration.ofMillis(500));
-        consumer1.commitSync();
+        backupConsumer = backup.kafka().createConsumer(consumerProps);
+        backupConsumer.assign(allPartitions("test-topic-1", "primary.test-topic-1"));
+        seek(backupConsumer, backupOffsets);
+        consumeAllMessages(backupConsumer, 0);
 
-        assertTrue("Consumer failedover to zero offset.", consumer1.position(new TopicPartition("primary.test-topic-1", 0)) > 0);
-        assertTrue("Consumer failedover beyond expected offset.", consumer1.position(
+        assertTrue("Consumer failedover to zero offset.", backupConsumer.position(new TopicPartition("primary.test-topic-1", 0)) > 0);
+        assertTrue("Consumer failedover beyond expected offset.", backupConsumer.position(
             new TopicPartition("primary.test-topic-1", 0)) <= NUM_RECORDS_PRODUCED);
         assertTrue("Checkpoints were not emitted upstream to primary cluster.", primary.kafka().consume(1,
             CHECKPOINT_DURATION_MS, "backup.checkpoints.internal").count() > 0);
 
-        consumer1.close();
+        backupConsumer.close();
 
         waitForCondition(() -> {
             try {
-                return primaryClient.remoteConsumerOffsets("consumer-group-1", "backup",
+                return primaryClient.remoteConsumerOffsets(consumerGroupName, "backup",
                     Duration.ofMillis(CHECKPOINT_DURATION_MS)).containsKey(new TopicPartition("backup.test-topic-1", 0));
             } catch (Throwable e) {
                 return false;
@@ -283,52 +295,81 @@ public class MirrorConnectorsIntegrationTest {
 
         waitForCondition(() -> {
             try {
-                return primaryClient.remoteConsumerOffsets("consumer-group-1", "backup",
+                return primaryClient.remoteConsumerOffsets(consumerGroupName, "backup",
                     Duration.ofMillis(CHECKPOINT_DURATION_MS)).containsKey(new TopicPartition("test-topic-1", 0));
             } catch (Throwable e) {
                 return false;
             }
         }, CHECKPOINT_DURATION_MS, "Offsets not translated upstream to primary cluster.");
 
-        Map<TopicPartition, OffsetAndMetadata> primaryOffsets = primaryClient.remoteConsumerOffsets("consumer-group-1", "backup",
+        Map<TopicPartition, OffsetAndMetadata> primaryOffsets = primaryClient.remoteConsumerOffsets(consumerGroupName, "backup",
                 Duration.ofMillis(CHECKPOINT_DURATION_MS));
- 
-        // Failback consumer group to primary cluster
-        consumer2 = primary.kafka().createConsumer(Collections.singletonMap("group.id", "consumer-group-1"));
-        consumer2.assign(primaryOffsets.keySet());
-        primaryOffsets.forEach(consumer2::seek);
-        consumer2.poll(Duration.ofMillis(500));
 
-        assertTrue("Consumer failedback to zero upstream offset.", consumer2.position(new TopicPartition("test-topic-1", 0)) > 0);
-        assertTrue("Consumer failedback to zero downstream offset.", consumer2.position(new TopicPartition("backup.test-topic-1", 0)) > 0);
-        assertTrue("Consumer failedback beyond expected upstream offset.", consumer2.position(
-            new TopicPartition("test-topic-1", 0)) <= NUM_RECORDS_PRODUCED);
-        assertTrue("Consumer failedback beyond expected downstream offset.", consumer2.position(
-            new TopicPartition("backup.test-topic-1", 0)) <= NUM_RECORDS_PRODUCED);
-        
-        consumer2.close();
-      
+        // Failback consumer group to primary cluster
+        primaryConsumer = primary.kafka().createConsumer(consumerProps);
+        primaryConsumer.assign(allPartitions("test-topic-1", "backup.test-topic-1"));
+        seek(primaryConsumer, primaryOffsets);
+        consumeAllMessages(primaryConsumer, 0);
+
+        assertTrue("Consumer failedback to zero upstream offset.", primaryConsumer.position(new TopicPartition("test-topic-1", 0)) > 0);
+        assertTrue("Consumer failedback to zero downstream offset.", primaryConsumer.position(new TopicPartition("backup.test-topic-1", 0)) > 0);
+        assertTrue("Consumer failedback beyond expected upstream offset.", primaryConsumer.position(
+            new TopicPartition("test-topic-1", 0)) <= NUM_RECORDS_PER_PARTITION);
+        assertTrue("Consumer failedback beyond expected downstream offset.", primaryConsumer.position(
+            new TopicPartition("backup.test-topic-1", 0)) <= NUM_RECORDS_PER_PARTITION);
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> messages2 = consumeAllMessages(primaryConsumer, 0);
+        // If offset translation was successful we expect no messages to be consumed after failback
+        assertEquals("Data was consumed from partitions: " + messages2.keySet() + ".", 0, messages2.size());
+        primaryConsumer.close();
+
         // create more matching topics
         primary.kafka().createTopic("test-topic-2", NUM_PARTITIONS);
         backup.kafka().createTopic("test-topic-3", NUM_PARTITIONS);
 
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            primary.kafka().produce("test-topic-2", 0, "key", "message-2-" + i);
-            backup.kafka().produce("test-topic-3", 0, "key", "message-3-" + i);
-        }
+        produceMessages(primary, "test-topic-2", "message-3-", 1);
+        produceMessages(backup, "test-topic-3", "message-4-", 1);
 
-        assertEquals("Records were not produced to primary cluster.", NUM_RECORDS_PRODUCED,
-            primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-2").count());
-        assertEquals("Records were not produced to backup cluster.", NUM_RECORDS_PRODUCED,
-            backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-3").count());
- 
-        assertEquals("New topic was not replicated to primary cluster.", NUM_RECORDS_PRODUCED,
-            primary.kafka().consume(NUM_RECORDS_PRODUCED, 2 * RECORD_TRANSFER_DURATION_MS, "backup.test-topic-3").count());
-        assertEquals("New topic was not replicated to backup cluster.", NUM_RECORDS_PRODUCED,
-            backup.kafka().consume(NUM_RECORDS_PRODUCED, 2 * RECORD_TRANSFER_DURATION_MS, "primary.test-topic-2").count());
+        assertEquals("Records were not produced to primary cluster.", NUM_RECORDS_PER_PARTITION,
+            primary.kafka().consume(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-2").count());
+        assertEquals("Records were not produced to backup cluster.", NUM_RECORDS_PER_PARTITION,
+            backup.kafka().consume(NUM_RECORDS_PER_PARTITION, RECORD_TRANSFER_DURATION_MS, "test-topic-3").count());
+
+        assertEquals("New topic was not replicated to primary cluster.", NUM_RECORDS_PER_PARTITION,
+            primary.kafka().consume(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "backup.test-topic-3").count());
+        assertEquals("New topic was not replicated to backup cluster.", NUM_RECORDS_PER_PARTITION,
+            backup.kafka().consume(NUM_RECORDS_PER_PARTITION, 2 * RECORD_TRANSFER_DURATION_MS, "primary.test-topic-2").count());
     }
 
-    private void waitForConsumerGroupOffsetSync(Consumer<byte[], byte[]> consumer, List<String> topics, String consumerGroupId)
+    @Test
+    public void testReplicationWithEmptyPartition() throws Exception {
+        String consumerGroupName = "consumer-group-testReplicationWithEmptyPartition";
+        Map<String, Object> consumerProps  = Collections.singletonMap("group.id", consumerGroupName);
+
+        // create topics
+        String topic = "test-topic-with-empty-partition";
+        primary.kafka().createTopic(topic, NUM_PARTITIONS);
+
+        // produce to all test-topic-empty's partitions *but the last one*, on the primary cluster
+        produceMessages(primary, topic, "message-1-", NUM_PARTITIONS - 1);
+        // Consume, from the primary cluster, before starting the connectors so we don't need to wait for discovery
+        int expectedRecords = NUM_RECORDS_PER_PARTITION * (NUM_PARTITIONS - 1);
+        try (Consumer<byte[], byte[]> consumer = primary.kafka().createConsumerAndSubscribeTo(consumerProps, topic)) {
+            consumeAllMessages(consumer, expectedRecords);
+        }
+
+        waitUntilMirrorMakerIsRunning(backup, mm2Config, "primary", "backup");
+
+        Map<TopicPartition, OffsetAndMetadata> offsets = waitForConsumerGroupOffsetReplication(
+                Collections.singletonList("primary." + topic), consumerGroupName, false);
+
+        // check translated offset for the last partition (empty partition)
+        OffsetAndMetadata oam = offsets.get(new TopicPartition("primary." + topic, NUM_PARTITIONS - 1));
+        assertNotNull("Offset of last partition was not replicated", oam);
+        assertEquals("Offset of last partition is not zero", 0, oam.offset());
+    }
+
+    private Map<TopicPartition, OffsetAndMetadata> waitForConsumerGroupOffsetReplication(List<String> topics, String consumerGroupId, boolean waitForAutoSync)
             throws InterruptedException {
         Admin backupClient = backup.kafka().createAdminClient();
         List<TopicPartition> tps = new ArrayList<>(NUM_PARTITIONS * topics.size());
@@ -337,38 +378,56 @@ public class MirrorConnectorsIntegrationTest {
                 tps.add(new TopicPartition(topic, partitionIndex));
             }
         }
-        long expectedTotalOffsets = NUM_RECORDS_PRODUCED * topics.size();
-
+        long expectedTotalOffsets = NUM_PARTITIONS * topics.size();
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         waitForCondition(() -> {
-            Map<TopicPartition, OffsetAndMetadata> consumerGroupOffsets =
-                backupClient.listConsumerGroupOffsets(consumerGroupId).partitionsToOffsetAndMetadata().get();
-            long consumerGroupOffsetTotal = consumerGroupOffsets.values().stream().mapToLong(metadata -> metadata.offset()).sum();
-
-            Map<TopicPartition, Long> offsets = consumer.endOffsets(tps, Duration.ofMillis(500));
-            long totalOffsets = offsets.values().stream().mapToLong(l -> l).sum();
-
-            // make sure the consumer group offsets are synced to expected number
-            return totalOffsets == expectedTotalOffsets && consumerGroupOffsetTotal > 0;
-        }, OFFSET_SYNC_DURATION_MS, "Consumer group offset sync is not complete in time");
+            offsets.clear();
+            Map<TopicPartition, OffsetAndMetadata> translatedOffsets = getTranslatedOffsets(consumerGroupId);
+            Map<TopicPartition, OffsetAndMetadata> remoteOffsets =
+                    backupClient.listConsumerGroupOffsets(consumerGroupId).partitionsToOffsetAndMetadata().get();
+            boolean isConsumerUpdated = true;
+            for (TopicPartition tp : tps) {
+                OffsetAndMetadata translatedOam = translatedOffsets.get(tp);
+                OffsetAndMetadata remoteOam = remoteOffsets.get(tp);
+                if (translatedOam != null) {
+                    offsets.put(tp, translatedOam);
+                    if (waitForAutoSync && remoteOam.offset() != translatedOam.offset())
+                        isConsumerUpdated = false;
+                }
+            }
+            return offsets.size() == expectedTotalOffsets && isConsumerUpdated;
+        }, OFFSET_SYNC_DURATION_MS, "Consumer group offset sync did not complete in time");
+        return offsets;
     }
 
-    private void waitForConsumingAllRecords(Consumer<byte[], byte[]> consumer) throws InterruptedException {
-        final AtomicInteger totalConsumedRecords = new AtomicInteger(0);
-        waitForCondition(() -> {
-            ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofMillis(500));
-            return NUM_RECORDS_PRODUCED == totalConsumedRecords.addAndGet(records.count());
-        }, RECORD_CONSUME_DURATION_MS, "Consumer cannot consume all records in time");
-        consumer.commitSync();
+    private Map<TopicPartition, OffsetAndMetadata> getTranslatedOffsets(String consumerGroupId)
+            throws TimeoutException, InterruptedException {
+        return RemoteClusterUtils.translateOffsets(
+                mm2Config.clientConfig("backup").adminConfig(),
+                "primary",
+                consumerGroupId,
+                Duration.ofMillis(CHECKPOINT_DURATION_MS));
     }
 
     @Test
     public void testOneWayReplicationWithAutoOffsetSync() throws InterruptedException {
+        String topic1 = "test-topic-auto-offset-sync-1";
+        String topic2 = "test-topic-auto-offset-sync-2";
+        String consumerGroupName = "consumer-group-testOneWayReplicationWithAutoOffsetSync";
+        Map<String, Object> consumerProps  = new HashMap<String, Object>() {{
+                put("group.id", consumerGroupName);
+                put("auto.offset.reset", "earliest");
+            }};
 
+        // create new topic
+        primary.kafka().createTopic(topic1, NUM_PARTITIONS);
+        backup.kafka().createTopic("primary." + topic1, 1);
+
+        // produce some records to the new topic in primary cluster
+        produceMessages(primary, topic1, "message-1-");
         // create consumers before starting the connectors so we don't need to wait for discovery
-        try (Consumer<byte[], byte[]> consumer1 = primary.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
-            "group.id", "consumer-group-1"), "test-topic-1")) {
-            // we need to wait for consuming all the records for MM2 replicating the expected offsets
-            waitForConsumingAllRecords(consumer1);
+        try (Consumer<byte[], byte[]> primaryConsumer = primary.kafka().createConsumerAndSubscribeTo(consumerProps, topic1)) {
+            consumeAllMessages(primaryConsumer);
         }
 
         // enable automated consumer group offset sync
@@ -381,45 +440,45 @@ public class MirrorConnectorsIntegrationTest {
 
         waitUntilMirrorMakerIsRunning(backup, mm2Config, "primary", "backup");
 
+        waitForConsumerGroupOffsetReplication(
+                Collections.singletonList("primary." + topic1), consumerGroupName, true);
+
         // create a consumer at backup cluster with same consumer group Id to consume 1 topic
-        Consumer<byte[], byte[]> consumer = backup.kafka().createConsumerAndSubscribeTo(
-            Collections.singletonMap("group.id", "consumer-group-1"), "primary.test-topic-1");
-
-        waitForConsumerGroupOffsetSync(consumer, Collections.singletonList("primary.test-topic-1"), "consumer-group-1");
-
-        ConsumerRecords records = consumer.poll(Duration.ofMillis(500));
+        ConsumerRecords<byte[], byte[]> records = null;
+        try (Consumer<byte[], byte[]> backupConsumer = backup.kafka().createConsumerAndSubscribeTo(
+                consumerProps, "primary." + topic1)) {
+            records = backupConsumer.poll(Duration.ofMillis(500));
+        }
 
         // the size of consumer record should be zero, because the offsets of the same consumer group
         // have been automatically synchronized from primary to backup by the background job, so no
         // more records to consume from the replicated topic by the same consumer group at backup cluster
         assertEquals("consumer record size is not zero", 0, records.count());
 
-        // now create a new topic in primary cluster
-        primary.kafka().createTopic("test-topic-2", NUM_PARTITIONS);
-        backup.kafka().createTopic("primary.test-topic-2", 1);
+        // create a second topic
+        primary.kafka().createTopic(topic2, NUM_PARTITIONS);
+        backup.kafka().createTopic("primary." + topic2, 1);
+
         // produce some records to the new topic in primary cluster
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            primary.kafka().produce("test-topic-2", i % NUM_PARTITIONS, "key", "message-1-" + i);
-        }
+        produceMessages(primary, topic2, "message-1-");
 
         // create a consumer at primary cluster to consume the new topic
-        try (Consumer<byte[], byte[]> consumer1 = primary.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
-            "group.id", "consumer-group-1"), "test-topic-2")) {
+        try (Consumer<byte[], byte[]> primaryConsumer = primary.kafka().createConsumerAndSubscribeTo(
+            consumerProps, topic2)) {
             // we need to wait for consuming all the records for MM2 replicating the expected offsets
-            waitForConsumingAllRecords(consumer1);
+            consumeAllMessages(primaryConsumer);
         }
 
+        waitForConsumerGroupOffsetReplication(Arrays.asList("primary." + topic1, "primary." + topic2), consumerGroupName, true);
+
         // create a consumer at backup cluster with same consumer group Id to consume old and new topic
-        consumer = backup.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
-            "group.id", "consumer-group-1"), "primary.test-topic-1", "primary.test-topic-2");
+        try (Consumer<byte[], byte[]> backupConsumer = backup.kafka().createConsumerAndSubscribeTo(
+                consumerProps, "primary." + topic1, "primary." + topic2)) {
+            records = backupConsumer.poll(Duration.ofMillis(500));
+        }
 
-        waitForConsumerGroupOffsetSync(consumer, Arrays.asList("primary.test-topic-1", "primary.test-topic-2"), "consumer-group-1");
-
-        records = consumer.poll(Duration.ofMillis(500));
         // similar reasoning as above, no more records to consume by the same consumer group at backup cluster
         assertEquals("consumer record size is not zero", 0, records.count());
-        consumer.close();
-
     }
 
     private void deleteAllTopics(EmbeddedKafkaCluster cluster) {
@@ -428,5 +487,69 @@ public class MirrorConnectorsIntegrationTest {
             client.deleteTopics(client.listTopics().names().get());
         } catch (Throwable e) {
         }
+    }
+
+    private void produceMessages(EmbeddedConnectCluster cluster, String topicName, String msgPrefix) {
+        produceMessages(cluster, topicName, msgPrefix, NUM_PARTITIONS);
+    }
+
+    private void produceMessages(EmbeddedConnectCluster cluster, String topicName, String msgPrefix, int numPartitions) {
+        // produce the configured number of records to all specified partitions
+        int cnt = 0;
+        for (int r = 0; r < NUM_RECORDS_PER_PARTITION; r++)
+            for (int p = 0; p < numPartitions; p++)
+                cluster.kafka().produce(topicName, p, "key", msgPrefix + cnt++);
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> consumeAllMessages(Consumer<byte[], byte[]> consumer) throws InterruptedException {
+        return consumeAllMessages(consumer, null, null);
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> consumeAllMessages(Consumer<byte[], byte[]> consumer, Integer expectedRecords) throws InterruptedException {
+        return consumeAllMessages(consumer, expectedRecords, null);
+    }
+
+    private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> consumeAllMessages(Consumer<byte[], byte[]> consumer, Integer numExpectedRecords, Duration timeoutDurationMs)
+            throws InterruptedException {
+        int expectedRecords = numExpectedRecords != null ? numExpectedRecords : NUM_RECORDS_PRODUCED;
+        int timeoutMs = (int) (timeoutDurationMs != null ? timeoutDurationMs.toMillis() : RECORD_CONSUME_DURATION_MS);
+
+        List<ConsumerRecord<byte[], byte[]>> records = new ArrayList<>();
+        waitForCondition(() -> {
+            ConsumerRecords<byte[], byte[]> crs = consumer.poll(Duration.ofMillis(1000));
+            for (ConsumerRecord<byte[], byte[]> cr : crs)
+                records.add(cr);
+            assertTrue("Consumer consumed more records than expected: " + records.size() + " (expected " + expectedRecords + ").",
+                    records.size() <= expectedRecords);
+            return records.size() == expectedRecords;
+        }, timeoutMs, "Consumer could not consume all records in time.");
+
+        consumer.commitSync();
+        return records.stream().collect(Collectors.groupingBy(c -> new TopicPartition(c.topic(), c.partition())));
+    }
+
+    private void seek(Consumer<byte[], byte[]> consumer, Map<TopicPartition, OffsetAndMetadata> offsets) throws InterruptedException {
+        // In case offsets are replicated faster than actual records, wait until records are replicated before seeking
+        waitForCondition(() -> {
+            boolean ready = true;
+            Map<TopicPartition, Long> endOffsets = consumer.endOffsets(offsets.keySet());
+            for (TopicPartition tp : offsets.keySet()) {
+                if (offsets.get(tp).offset() > endOffsets.get(tp)) {
+                    ready = false;
+                    break;
+                }
+            }
+            if (!ready)
+                Thread.sleep(1000);
+            return ready;
+        }, RECORD_TRANSFER_DURATION_MS, "Records were not replicated in time.");
+        offsets.forEach(consumer::seek);
+    }
+
+    private List<TopicPartition> allPartitions(String... topics) {
+        return IntStream.range(0, NUM_PARTITIONS)
+                .boxed()
+                .flatMap(p -> Arrays.stream(topics).map(t -> new TopicPartition(t, p)))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Changed the MM2 checkpoint mirror task to ensure it replicates consumer offsets even when they are equal to zero to avoid issues with consumers after failovers.

Modified the test case to cover the possible scenario of consumer gap, as described on KAFKA-10048. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
