### PR TITLE
KAFKA-10050: kafka_log4j_appender.py fixed for JDK11

### DIFF
--- a/tests/kafkatest/services/kafka_log4j_appender.py
+++ b/tests/kafkatest/services/kafka_log4j_appender.py
@@ -38,7 +38,10 @@ class KafkaLog4jAppender(KafkaPathResolverMixin, BackgroundThreadService):
         self.security_config = SecurityConfig(self.context, security_protocol)
         self.stop_timeout_sec = 30
 
-    def _worker(self, idx, node):
+        for node in self.nodes:
+            node.version = kafka.nodes[0].version
+
+def _worker(self, idx, node):
         cmd = self.start_cmd(node)
         self.logger.debug("VerifiableLog4jAppender %d command: %s" % (idx, cmd))
         self.security_config.setup_node(node)

--- a/tests/kafkatest/services/kafka_log4j_appender.py
+++ b/tests/kafkatest/services/kafka_log4j_appender.py
@@ -41,7 +41,7 @@ class KafkaLog4jAppender(KafkaPathResolverMixin, BackgroundThreadService):
         for node in self.nodes:
             node.version = kafka.nodes[0].version
 
-def _worker(self, idx, node):
+    def _worker(self, idx, node):
         cmd = self.start_cmd(node)
         self.logger.debug("VerifiableLog4jAppender %d command: %s" % (idx, cmd))
         self.security_config.setup_node(node)


### PR DESCRIPTION
kafka_log4j_appender.py broken on JDK11 by #befd80b38d3ccb1aa0c6d99a899129fd5cf27774
This fix just setup node version for log4j appender.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
