### PR TITLE
MINOR: Remove retries entry from Streams config table

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -785,10 +785,6 @@
               <td>Consumer</td>
               <td>1000</td>
               </tr>
-              <tr class="row-even"><td>retries</td>
-              <td>Producer</td>
-              <td>10</td>
-              </tr>
               </tbody>
               </table>
         <div class="section" id="enable-auto-commit">


### PR DESCRIPTION
Streams doesn't override the `retries` config now.