### PR TITLE
KAFKA-10052: Harden assertion of topic settings in Connect integration tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -143,22 +143,25 @@ public class InternalTopicsIntegrationTest {
         connect.assertions().assertTopicsDoNotExist(configTopic(), offsetTopic());
     }
 
-    protected void assertInternalTopicSettings() {
+    protected void assertInternalTopicSettings() throws InterruptedException {
         DistributedConfig config = new DistributedConfig(workerProps);
         connect.assertions().assertTopicSettings(
                 configTopic(),
                 config.getShort(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG),
-                1
+                1,
+                "Config topic does not have the expected settings"
         );
         connect.assertions().assertTopicSettings(
                 statusTopic(),
                 config.getShort(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG),
-                config.getInt(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG)
+                config.getInt(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG),
+                "Status topic does not have the expected settings"
         );
         connect.assertions().assertTopicSettings(
                 offsetTopic(),
                 config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG),
-                config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG)
+                config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG),
+                "Offset topic does not have the expected settings"
         );
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SourceConnectorsIntegrationTest.java
@@ -118,7 +118,8 @@ public class SourceConnectorsIntegrationTest {
                 "Connector tasks did not start in time.");
 
         connect.assertions().assertTopicsExist(FOO_TOPIC);
-        connect.assertions().assertTopicSettings(FOO_TOPIC, DEFAULT_REPLICATION_FACTOR, DEFAULT_PARTITIONS);
+        connect.assertions().assertTopicSettings(FOO_TOPIC, DEFAULT_REPLICATION_FACTOR,
+                DEFAULT_PARTITIONS, "Topic " + FOO_TOPIC + " does not have the expected settings");
     }
 
     @Test
@@ -142,7 +143,8 @@ public class SourceConnectorsIntegrationTest {
                 "Connector tasks did not start in time.");
 
         connect.assertions().assertTopicsExist(FOO_TOPIC);
-        connect.assertions().assertTopicSettings(FOO_TOPIC, FOO_GROUP_REPLICATION_FACTOR, FOO_GROUP_PARTITIONS);
+        connect.assertions().assertTopicSettings(FOO_TOPIC, FOO_GROUP_REPLICATION_FACTOR,
+                FOO_GROUP_PARTITIONS, "Topic " + FOO_TOPIC + " does not have the expected settings");
     }
 
     @Test
@@ -155,7 +157,8 @@ public class SourceConnectorsIntegrationTest {
         connect.kafka().createTopic(BAR_TOPIC, DEFAULT_PARTITIONS, DEFAULT_REPLICATION_FACTOR, Collections.emptyMap());
 
         connect.assertions().assertTopicsExist(BAR_TOPIC);
-        connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR, DEFAULT_PARTITIONS);
+        connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR,
+                DEFAULT_PARTITIONS, "Topic " + BAR_TOPIC + " does not have the expected settings");
 
         connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
 
@@ -182,7 +185,8 @@ public class SourceConnectorsIntegrationTest {
                 "Connector tasks did not start in time.");
 
         connect.assertions().assertTopicsExist(BAR_TOPIC);
-        connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR, DEFAULT_PARTITIONS);
+        connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR,
+                DEFAULT_PARTITIONS, "Topic " + BAR_TOPIC + " does not have the expected settings");
 
         connect.assertions().assertTopicsDoNotExist(FOO_TOPIC);
 
@@ -200,9 +204,11 @@ public class SourceConnectorsIntegrationTest {
                 "Connector tasks did not start in time.");
 
         connect.assertions().assertTopicsExist(FOO_TOPIC);
-        connect.assertions().assertTopicSettings(FOO_TOPIC, FOO_GROUP_REPLICATION_FACTOR, FOO_GROUP_PARTITIONS);
+        connect.assertions().assertTopicSettings(FOO_TOPIC, FOO_GROUP_REPLICATION_FACTOR,
+                FOO_GROUP_PARTITIONS, "Topic " + FOO_TOPIC + " does not have the expected settings");
         connect.assertions().assertTopicsExist(BAR_TOPIC);
-        connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR, DEFAULT_PARTITIONS);
+        connect.assertions().assertTopicSettings(BAR_TOPIC, DEFAULT_REPLICATION_FACTOR,
+                DEFAULT_PARTITIONS, "Topic " + BAR_TOPIC + " does not have the expected settings");
     }
 
     private Map<String, String> defaultSourceConnectorProps(String topic) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -17,8 +17,6 @@
 package org.apache.kafka.connect.util.clusters;
 
 import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -29,20 +27,16 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.test.TestUtils.waitForCondition;
-import static org.junit.Assert.assertEquals;
 
 /**
  * A set of common assertions that can be applied to a Connect cluster during integration testing
@@ -202,7 +196,7 @@ public class EmbeddedConnectClusterAssertions {
      * @param detailMessage the assertion message
      */
     public void assertTopicSettings(String topicName, int replicas, int partitions, String detailMessage)
-            throws InterruptedException{
+            throws InterruptedException {
         try {
             waitForCondition(
                 () -> checkTopicSettings(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -199,16 +199,38 @@ public class EmbeddedConnectClusterAssertions {
      * @param topicName  the name of the topic that is expected to exist
      * @param replicas   the replication factor
      * @param partitions the number of partitions
+     * @param detailMessage the assertion message
      */
-    public void assertTopicSettings(String topicName, int replicas, int partitions) {
-        Map<String, Object> consumerProps = Collections.singletonMap("group.id", UUID.randomUUID().toString());
-        try (Consumer<byte[], byte[]> verifiableConsumer = connect.kafka().createConsumer(consumerProps);) {
-            List<PartitionInfo> infos = verifiableConsumer.partitionsFor(topicName);
-            assertEquals(partitions, infos.size());
-            for (PartitionInfo info : infos) {
-                assertEquals(topicName, info.topic());
-                assertEquals(replicas, info.replicas().length);
-            }
+    public void assertTopicSettings(String topicName, int replicas, int partitions, String detailMessage)
+            throws InterruptedException{
+        try {
+            waitForCondition(
+                () -> checkTopicSettings(
+                    topicName,
+                    replicas,
+                    partitions
+                ).orElse(false),
+                VALIDATION_DURATION_MS,
+                "Topic " + topicName + " does not exist or does not have exactly "
+                        + partitions + " partitions or at least "
+                        + replicas + " per partition");
+        } catch (AssertionError e) {
+            throw new AssertionError(detailMessage, e);
+        }
+    }
+
+    protected Optional<Boolean> checkTopicSettings(String topicName, int replicas, int partitions) {
+        try {
+            Map<String, Optional<TopicDescription>> topics = connect.kafka().describeTopics(topicName);
+            TopicDescription topicDesc = topics.get(topicName).orElse(null);
+            boolean result = topicDesc != null
+                    && topicDesc.name().equals(topicName)
+                    && topicDesc.partitions().size() == partitions
+                    && topicDesc.partitions().stream().allMatch(p -> p.replicas().size() >= replicas);
+            return Optional.of(result);
+        } catch (Exception e) {
+            log.error("Could not check config validation error count.", e);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
A recently added assertion in Connect integration tests uses `consumer#partitionsFor` to verify that a topic was created with the expected number of partitions and replicas. However, probably because of metadata propagation delays, this call doesn't always return a valid `PartitionInfo` for the topic that has just been created and the test is terminated with a NPE. 

This commit changes the assertion to perform retries in order to verify the topic settings and uses the admin client instead.

Tests have been adjusted to use the new assertion. 
 
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
