### PR TITLE
HOTFIX: relax constraint on randomized percentiles test

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -568,8 +568,8 @@ public class MetricsTest {
             double expectedP90 = values.get(p90Index - 1);
             double expectedP99 = values.get(p99Index - 1);
 
-            assertEquals(expectedP90, (Double) p90.metricValue(), expectedP90 / 10);
-            assertEquals(expectedP99, (Double) p99.metricValue(), expectedP99 / 10);
+            assertEquals(expectedP90, (Double) p90.metricValue(), expectedP90 / 5);
+            assertEquals(expectedP99, (Double) p99.metricValue(), expectedP99 / 5);
         } catch (AssertionError e) {
             throw new AssertionError("Assertion failed in randomized test. Reproduce with seed = " + seed + " .", e);
         }


### PR DESCRIPTION
The intent of this test isn't to validate that it's accurate to 10% exactly, just to make sure it isn't orders of magnitude off, we should just relax the constraint to be within 20%

Should go to 2.6
