### PR TITLE
MINOR: Code cleanup and assertion message fixes in Connect integration tests

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -88,8 +88,6 @@ public class InternalTopicsIntegrationTest {
         log.info("Verifying the internal topics for Connect");
         connect.assertions().assertTopicsExist(configTopic(), offsetTopic(), statusTopic());
         assertInternalTopicSettings();
-
-        connect.stop();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -181,7 +181,7 @@ public class EmbeddedConnectClusterAssertions {
                                                      .collect(Collectors.toSet());
             return Optional.of(comp.apply(actualExistingTopics, topicNames));
         } catch (Exception e) {
-            log.error("Could not check config validation error count.", e);
+            log.error("Failed to describe the topic(s): {}.", topicNames, e);
             return Optional.empty();
         }
     }
@@ -223,7 +223,7 @@ public class EmbeddedConnectClusterAssertions {
                     && topicDesc.partitions().stream().allMatch(p -> p.replicas().size() >= replicas);
             return Optional.of(result);
         } catch (Exception e) {
-            log.error("Could not check config validation error count.", e);
+            log.error("Failed to describe the topic: {}.", topicName, e);
             return Optional.empty();
         }
     }


### PR DESCRIPTION
1. Remove redundant `connect.stop();` since we'll do it after each test case in `close()` function
2. Refine the error message to make it better explain the errors

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
