### PR TITLE
MINOR: Update to Gradle 6.5 and tweak build jvm config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,9 @@ ext {
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 
+  defaultMaxHeapSize = "2g"
+  defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC"]
+
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
 
   userMaxTestRetries = project.hasProperty('maxTestRetries') ? maxTestRetries.toInteger() : 0
@@ -293,8 +296,8 @@ subprojects {
   test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
 
-    minHeapSize = "256m"
-    maxHeapSize = "2048m"
+    maxHeapSize = defaultMaxHeapSize
+    jvmArgs = defaultJvmArgs
 
     testLogging {
       events = userTestLoggingEvents ?: testLoggingEvents
@@ -316,8 +319,9 @@ subprojects {
   task integrationTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
 
-    minHeapSize = "256m"
-    maxHeapSize = "2048m"
+    maxHeapSize = defaultMaxHeapSize
+    jvmArgs = defaultJvmArgs
+
 
     testLogging {
       events = userTestLoggingEvents ?: testLoggingEvents
@@ -343,8 +347,8 @@ subprojects {
   task unitTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
 
-    minHeapSize = "256m"
-    maxHeapSize = "2048m"
+    maxHeapSize = defaultMaxHeapSize
+    jvmArgs = defaultJvmArgs
 
     testLogging {
       events = userTestLoggingEvents ?: testLoggingEvents
@@ -506,8 +510,8 @@ subprojects {
       scalaCompileOptions.additionalParameters += ["-release", minJavaVersion]
 
     configure(scalaCompileOptions.forkOptions) {
-      jvmArgs = ['-Xss4m']
-      memoryMaximumSize = '2g'
+      memoryMaximumSize = defaultMaxHeapSize
+      jvmArgs = defaultJvmArgs
     }
   }
 
@@ -542,7 +546,8 @@ subprojects {
       xml.enabled(project.hasProperty('xmlSpotBugsReport') || project.hasProperty('xmlFindBugsReport'))
       html.enabled(!project.hasProperty('xmlSpotBugsReport') && !project.hasProperty('xmlFindBugsReport'))
     }
-    maxHeapSize = "2g"
+    maxHeapSize = defaultMaxHeapSize
+    jvmArgs = defaultJvmArgs
   }
 
   // Ignore core since its a scala project

--- a/build.gradle
+++ b/build.gradle
@@ -506,8 +506,8 @@ subprojects {
       scalaCompileOptions.additionalParameters += ["-release", minJavaVersion]
 
     configure(scalaCompileOptions.forkOptions) {
-      memoryMaximumSize = '1g'
       jvmArgs = ['-Xss4m']
+      memoryMaximumSize = '2g'
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,4 +23,4 @@ group=org.apache.kafka
 version=2.6.0-SNAPSHOT
 scalaVersion=2.13.2
 task=build
-org.gradle.jvmargs=-Xmx2g -Xss2m
+org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ versions += [
   bcpkix: "1.64",
   checkstyle: "8.20",
   commonsCli: "1.4",
-  gradle: "6.4.1",
+  gradle: "6.5-rc-1",
   gradleVersionsPlugin: "0.28.0",
   grgit: "4.0.1",
   httpclient: "4.5.11",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,7 @@ versions += [
   bcpkix: "1.64",
   checkstyle: "8.20",
   commonsCli: "1.4",
-  gradle: "6.5-rc-1",
+  gradle: "6.5",
   gradleVersionsPlugin: "0.28.0",
   grgit: "4.0.1",
   httpclient: "4.5.11",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -84,7 +84,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v6.5-rc-1.0/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v6.5.0/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5

--- a/gradlew
+++ b/gradlew
@@ -84,7 +84,7 @@ esac
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
   if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v6.4.1/gradle/wrapper/gradle-wrapper.jar"; then
+    if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v6.5-rc-1.0/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.
       sleep 5


### PR DESCRIPTION
Gradle 6.5 includes a fix for https://github.com/gradle/gradle/pull/12866, which
affects the performance of Scala compilation.

I profiled the scalac build with async profiler and 54% of the time was on GC
even after the Gradle upgrade (it was more than 60% before), so I switched to
the throughput GC (GC latency is less important for batch builds) and it
was reduced to 38%.

I also centralized the jvm configuration in `build.gradle` and simplified it a bit
by removing the minHeapSize configuration from the test tasks.

On my desktop, the time to execute clean builds with no cached Gradle daemon
was reduced from 127 seconds to 97 seconds. With a cached daemon, it was
reduced from 120 seconds to 88 seconds. The performance regression when
we upgraded to Gradle 6.x was 27 seconds with a cached daemon 
(https://github.com/apache/kafka/pull/7677#issuecomment-616271179), so it
should be fixed now.

Gradle 6.4 with no cached daemon:

```
BUILD SUCCESSFUL in 2m 7s
115 actionable tasks: 112 executed, 3 up-to-date
./gradlew clean compileScala compileJava compileTestScala compileTestJava  1.15s user 0.12s system 0% cpu 2:08.06 total
```

Gradle 6.4 with cached daemon:

```
BUILD SUCCESSFUL in 2m 0s
115 actionable tasks: 111 executed, 4 up-to-date
./gradlew clean compileScala compileJava compileTestScala compileTestJava  0.95s user 0.10s system 0% cpu 2:01.42 total
```

Gradle 6.5 with no cached daemon:

```
BUILD SUCCESSFUL in 1m 46s
115 actionable tasks: 111 executed, 4 up-to-date
./gradlew clean compileScala compileJava compileTestScala compileTestJava  1.27s user 0.12s system 1% cpu 1:47.71 total
```

Gradle 6.5 with cached daemon:

```
BUILD SUCCESSFUL in 1m 37s
115 actionable tasks: 111 executed, 4 up-to-date
./gradlew clean compileScala compileJava compileTestScala compileTestJava  1.02s user 0.10s system 1% cpu 1:38.31 total
```

This PR with no cached Gradle daemon:

```
BUILD SUCCESSFUL in 1m 37s
115 actionable tasks: 81 executed, 34 up-to-date
./gradlew clean compileScala compileJava compileTestScala compileTestJava  1.27s user 0.10s system 1% cpu 1:38.70 total
```

This PR with cached Gradle daemon:

```
BUILD SUCCESSFUL in 1m 28s
115 actionable tasks: 111 executed, 4 up-to-date
./gradlew clean compileScala compileJava compileTestScala compileTestJava  1.02s user 0.10s system 1% cpu 1:29.35 total
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
