### PR TITLE
KAFKA-10069: Correctly remove user-defined "predicate" and "negate" configs from transformation properties

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -331,10 +331,10 @@ public class ConnectorConfig extends AbstractConfig {
                 return super.configDefsForClass(typeConfig)
                     .filter(entry -> {
                         // The implicit parameters mask any from the transformer with the same name
-                        if (PredicatedTransformation.PREDICATE_CONFIG.equals(entry.getValue())
-                                || PredicatedTransformation.NEGATE_CONFIG.equals(entry.getValue())) {
+                        if (PredicatedTransformation.PREDICATE_CONFIG.equals(entry.getKey())
+                                || PredicatedTransformation.NEGATE_CONFIG.equals(entry.getKey())) {
                             log.warn("Transformer config {} is masked by implicit config of that name",
-                                    entry.getValue());
+                                    entry.getKey());
                             return false;
                         } else {
                             return true;


### PR DESCRIPTION
There are official configDef for both "predicate" and "negate" so we should remove user-defined configDef. However, current behavior does incorrect comparison so the duplicate key will destroy the following embed configDef.

https://issues.apache.org/jira/browse/KAFKA-10069

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
