### PR TITLE
KAFKA-10066: TestOutputTopic should pass record headers into deserializers

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -802,8 +802,8 @@ public class TopologyTestDriver implements Closeable {
         if (record == null) {
             return null;
         }
-        final K key = keyDeserializer.deserialize(record.topic(), record.key());
-        final V value = valueDeserializer.deserialize(record.topic(), record.value());
+        final K key = keyDeserializer.deserialize(record.topic(), record.headers(), record.key());
+        final V value = valueDeserializer.deserialize(record.topic(), record.headers(), record.value());
         return new ProducerRecord<>(record.topic(), record.partition(), record.timestamp(), key, value, record.headers());
     }
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -906,8 +906,8 @@ public class TopologyTestDriver implements Closeable {
         if (record == null) {
             throw new NoSuchElementException("Empty topic: " + topic);
         }
-        final K key = keyDeserializer.deserialize(record.topic(), record.key());
-        final V value = valueDeserializer.deserialize(record.topic(), record.value());
+        final K key = keyDeserializer.deserialize(record.topic(), record.headers(), record.key());
+        final V value = valueDeserializer.deserialize(record.topic(), record.headers(), record.value());
         return new TestRecord<>(key, value, record.headers(), record.timestamp());
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -457,4 +457,5 @@ public class TestTopicsTest {
         final List<TestRecord<String, Long>> output = outputTopic.readRecordsToList();
         assertThat(output, is(equalTo(expected)));
     }
+
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -21,11 +21,8 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
@@ -46,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -460,37 +456,5 @@ public class TestTopicsTest {
         inputTopic.pipeKeyValueList(input, Instant.parse("2019-06-01T10:00:00Z"), advance);
         final List<TestRecord<String, Long>> output = outputTopic.readRecordsToList();
         assertThat(output, is(equalTo(expected)));
-    }
-
-    @Test
-    public void testOutputTopicShouldPassRecordHeadersToDeserializer() {
-        final AtomicBoolean passedHeadersToKeyDeserializer = new AtomicBoolean(false);
-        final AtomicBoolean passedHeadersToValueDeserializer = new AtomicBoolean(false);
-
-        final Deserializer<String> keyDeserializer = new StringDeserializer() {
-            @Override
-            public String deserialize(String topic, Headers headers, byte[] data) {
-                passedHeadersToKeyDeserializer.set(true);
-                return deserialize(topic, data);
-            }
-        };
-        final Deserializer<Long> valueSerializer = new LongDeserializer() {
-            @Override
-            public Long deserialize(String topic, Headers headers, byte[] data) {
-                passedHeadersToValueDeserializer.set(true);
-                return deserialize(topic, data);
-            }
-        };
-
-        final TestInputTopic<Long, String> inputTopic =
-            testDriver.createInputTopic(INPUT_TOPIC_MAP, longSerde.serializer(), stringSerde.serializer());
-        final TestOutputTopic<String, Long> outputTopic =
-            testDriver.createOutputTopic(OUTPUT_TOPIC_MAP, keyDeserializer, valueSerializer);
-
-        inputTopic.pipeInput(new TestRecord<>(1L, "Hello"));
-        outputTopic.readRecord();
-
-        assertThat(passedHeadersToKeyDeserializer.get(), equalTo(true));
-        assertThat(passedHeadersToValueDeserializer.get(), equalTo(true));
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -716,7 +716,7 @@ public class TopologyTestDriverTest {
     }
 
     @Test
-    public void shouldPassRecordHeadersIntoDeSerializers() {
+    public void shouldPassRecordHeadersIntoSerializersAndDeserializers() {
         testDriver = new TopologyTestDriver(setupSourceSinkTopology(), config);
 
         final AtomicBoolean passedHeadersToKeySerializer = new AtomicBoolean(false);

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -726,14 +726,14 @@ public class TopologyTestDriverTest {
 
         final Serializer<byte[]> keySerializer = new ByteArraySerializer() {
             @Override
-            public byte[] serialize(String topic, Headers headers, byte[] data) {
+            public byte[] serialize(final String topic, final Headers headers, final byte[] data) {
                 passedHeadersToKeySerializer.set(true);
                 return serialize(topic, data);
             }
         };
         final Serializer<byte[]> valueSerializer = new ByteArraySerializer() {
             @Override
-            public byte[] serialize(String topic, Headers headers, byte[] data) {
+            public byte[] serialize(final String topic, final Headers headers, final byte[] data) {
                 passedHeadersToValueSerializer.set(true);
                 return serialize(topic, data);
             }
@@ -741,14 +741,14 @@ public class TopologyTestDriverTest {
 
         final Deserializer<byte[]> keyDeserializer = new ByteArrayDeserializer() {
             @Override
-            public byte[] deserialize(String topic, Headers headers, byte[] data) {
+            public byte[] deserialize(final String topic, final Headers headers, final byte[] data) {
                 passedHeadersToKeyDeserializer.set(true);
                 return deserialize(topic, data);
             }
         };
         final Deserializer<byte[]> valueDeserializer = new ByteArrayDeserializer() {
             @Override
-            public byte[] deserialize(String topic, Headers headers, byte[] data) {
+            public byte[] deserialize(final String topic, final Headers headers, final byte[] data) {
                 passedHeadersToValueDeserializer.set(true);
                 return deserialize(topic, data);
             }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.SystemTime;
@@ -70,6 +71,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -709,6 +711,38 @@ public class TopologyTestDriverTest {
             testDriver.readRecord(SINK_TOPIC_1, Serdes.Integer().deserializer(), Serdes.Double().deserializer());
         assertThat(result2.getKey(), equalTo(source2Key));
         assertThat(result2.getValue(), equalTo(source2Value));
+    }
+
+    @Test
+    public void shouldPassRecordHeadersIntoSerializer() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(SOURCE_TOPIC_1);
+
+        testDriver = new TopologyTestDriver(builder.build(), config);
+
+        final AtomicBoolean passedHeadersToKeySerializer = new AtomicBoolean(false);
+        final AtomicBoolean passedHeadersToValueSerializer = new AtomicBoolean(false);
+
+        final Serializer<byte[]> keySerializer = new ByteArraySerializer() {
+            @Override
+            public byte[] serialize(String topic, Headers headers, byte[] data) {
+                passedHeadersToKeySerializer.set(true);
+                return serialize(topic, data);
+            }
+        };
+        final Serializer<byte[]> valueSerializer = new ByteArraySerializer() {
+            @Override
+            public byte[] serialize(String topic, Headers headers, byte[] data) {
+                passedHeadersToValueSerializer.set(true);
+                return serialize(topic, data);
+            }
+        };
+
+        final TestInputTopic<byte[], byte[]> inputTopic = testDriver.createInputTopic(SOURCE_TOPIC_1, keySerializer, valueSerializer);
+        inputTopic.pipeInput(testRecord1);
+
+        assertThat(passedHeadersToKeySerializer.get(), equalTo(true));
+        assertThat(passedHeadersToValueSerializer.get(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
Call for review @vvcephei 
