### PR TITLE
KAFKA-10073: endTxn wait until markers compelete

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -491,11 +491,8 @@ class TransactionCoordinator(brokerId: Int,
                   responseCallback(err)
 
                 case Right((txnMetadata, newPreSendMetadata)) =>
-                  // we can respond to the client immediately and continue to write the txn markers if
-                  // the log append was successful
-                  responseCallback(Errors.NONE)
-
-                  txnMarkerChannelManager.addTxnMarkersToSend(coordinatorEpoch, txnMarkerResult, txnMetadata, newPreSendMetadata)
+                  txnMarkerChannelManager.addTxnMarkersToSend(coordinatorEpoch, txnMarkerResult, txnMetadata,
+                    newPreSendMetadata, Some(responseCallback))
               }
             } else {
               info(s"Aborting sending of transaction markers and returning $error error to client for $transactionalId's EndTransaction request of $txnMarkerResult, " +

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -77,7 +77,9 @@ class TransactionStateManager(brokerId: Int,
 
   this.logIdent = "[Transaction State Manager " + brokerId + "]: "
 
-  type SendTxnMarkersCallback = (Int, TransactionResult, TransactionMetadata, TxnTransitMetadata) => Unit
+  type SendTxnMarkersCallback = (Int, TransactionResult, TransactionMetadata, TxnTransitMetadata, Option[Errors =>
+    Unit]) =>
+    Unit
 
   /** shutting down flag */
   private val shuttingDown = new AtomicBoolean(false)
@@ -424,7 +426,7 @@ class TransactionStateManager(brokerId: Int,
 
           transactionsPendingForCompletion.foreach { txnTransitMetadata =>
             sendTxnMarkers(txnTransitMetadata.coordinatorEpoch, txnTransitMetadata.result,
-              txnTransitMetadata.txnMetadata, txnTransitMetadata.transitMetadata)
+              txnTransitMetadata.txnMetadata, txnTransitMetadata.transitMetadata, None)
           }
         }
       }


### PR DESCRIPTION
First change of KAFKA-9878: endTxn wait until markers compelete

change details can be found in: https://issues.apache.org/jira/browse/KAFKA-9878