### PR TITLE
MINOR: Update zstd to 1.4.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -117,7 +117,7 @@ versions += [
   testRetryPlugin: "1.1.5",
   zinc: "1.3.5",
   zookeeper: "3.5.8",
-  zstd: "1.4.4-7"
+  zstd: "1.4.5-2"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
It improves decompression speed:

>For x64 cpus, expect a speed bump of at least +5%, and up to +10% in favorable cases.
>ARM cpus receive more benefit, with speed improvements ranging from +15% vicinity,
>and up to +50% for certain SoCs and scenarios (ARM‘s situation is more complex due
>to larger differences in SoC designs).

See https://github.com/facebook/zstd/releases/tag/v1.4.5 for more details.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
