### PR TITLE
MINOR: Add explanation for disabling forwarding from value transformers

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 public final class ForwardingDisabledProcessorContext implements ProcessorContext {
     private final ProcessorContext delegate;
 
-    private String explanation = "ProcessorContext#forward() is not supported from this context, "
+    private static final String explanation = "ProcessorContext#forward() is not supported from this context, "
         + "as the framework must ensure the key is not changed (#forward allows changing the key on "
         + "messages which are sent). Try plain other functions which don't allow the key to be changed.";
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -42,7 +42,7 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
 
     private static final String explanation = "ProcessorContext#forward() is not supported from this context, "
         + "as the framework must ensure the key is not changed (#forward allows changing the key on "
-        + "messages which are sent). Try plain other functions which don't allow the key to be changed.";
+        + "messages which are sent). Try other plain functions, which don't allow the key to be changed.";
 
     public ForwardingDisabledProcessorContext(final ProcessorContext delegate) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -42,7 +42,7 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
 
     private static final String explanation = "ProcessorContext#forward() is not supported from this context, "
         + "as the framework must ensure the key is not changed (#forward allows changing the key on "
-        + "messages which are sent). Try other plain functions, which don't allow the key to be changed.";
+        + "messages which are sent). Try other plain functions, which doesn't allow the key to be changed.";
 
     public ForwardingDisabledProcessorContext(final ProcessorContext delegate) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -42,7 +42,8 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
 
     private static final String explanation = "ProcessorContext#forward() is not supported from this context, "
         + "as the framework must ensure the key is not changed (#forward allows changing the key on "
-        + "messages which are sent). Try other plain functions, which doesn't allow the key to be changed.";
+        + "messages which are sent). Try another function, which doesn't allow the key to be changed "
+        + "(for example - #tranformValues).";
 
     public ForwardingDisabledProcessorContext(final ProcessorContext delegate) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -40,6 +40,10 @@ import java.util.Objects;
 public final class ForwardingDisabledProcessorContext implements ProcessorContext {
     private final ProcessorContext delegate;
 
+    private String explanation = "ProcessorContext#forward() is not supported from this context, "
+        + "as the framework must ensure the key is not changed (#forward allows changing the key on "
+        + "messages which are sent). Try plain other functions which don't allow the key to be changed.";
+
     public ForwardingDisabledProcessorContext(final ProcessorContext delegate) {
         this.delegate = Objects.requireNonNull(delegate, "delegate");
     }
@@ -102,24 +106,24 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
 
     @Override
     public <K, V> void forward(final K key, final V value) {
-        throw new StreamsException("ProcessorContext#forward() not supported.");
+        throw new StreamsException(explanation);
     }
 
     @Override
     public <K, V> void forward(final K key, final V value, final To to) {
-        throw new StreamsException("ProcessorContext#forward() not supported.");
+        throw new StreamsException(explanation);
     }
 
     @Override
     @Deprecated
     public <K, V> void forward(final K key, final V value, final int childIndex) {
-        throw new StreamsException("ProcessorContext#forward() not supported.");
+        throw new StreamsException(explanation);
     }
 
     @Override
     @Deprecated
     public <K, V> void forward(final K key, final V value, final String childName) {
-        throw new StreamsException("ProcessorContext#forward() not supported.");
+        throw new StreamsException(explanation);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 public final class ForwardingDisabledProcessorContext implements ProcessorContext {
     private final ProcessorContext delegate;
 
-    private static final String explanation = "ProcessorContext#forward() is not supported from this context, "
+    private static final String EXPLANATION = "ProcessorContext#forward() is not supported from this context, "
         + "as the framework must ensure the key is not changed (#forward allows changing the key on "
         + "messages which are sent). Try another function, which doesn't allow the key to be changed "
         + "(for example - #tranformValues).";
@@ -107,24 +107,24 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
 
     @Override
     public <K, V> void forward(final K key, final V value) {
-        throw new StreamsException(explanation);
+        throw new StreamsException(EXPLANATION);
     }
 
     @Override
     public <K, V> void forward(final K key, final V value, final To to) {
-        throw new StreamsException(explanation);
+        throw new StreamsException(EXPLANATION);
     }
 
     @Override
     @Deprecated
     public <K, V> void forward(final K key, final V value, final int childIndex) {
-        throw new StreamsException(explanation);
+        throw new StreamsException(EXPLANATION);
     }
 
     @Override
     @Deprecated
     public <K, V> void forward(final K key, final V value, final String childName) {
-        throw new StreamsException(explanation);
+        throw new StreamsException(EXPLANATION);
     }
 
     @Override


### PR DESCRIPTION
Improve code to be self documenting, in cases where forwarding of messages is disabled due to the type of processor being used,