### PR TITLE
KAFKA-10079: improve thread-level stickiness

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1073,8 +1073,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      * balance. The stateful and total task load are both balanced across threads. Tasks without previous owners
      * will be interleaved by group id to spread subtopologies across threads and further balance the workload.
      */
-    static Map<String, List<TaskId>> assignTasksToThreads(final Set<TaskId> statefulTasksToAssign,
-                                                          final Set<TaskId> statelessTasksToAssign,
+    static Map<String, List<TaskId>> assignTasksToThreads(final Collection<TaskId> statefulTasksToAssign,
+                                                          final Collection<TaskId> statelessTasksToAssign,
                                                           final Set<String> consumers,
                                                           final Function<String, Set<TaskId>> previousTasksForConsumer) {
         final Map<String, List<TaskId>> assignment = new HashMap<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -982,16 +982,14 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             if (tasksRevoked) {
                 // TODO: once KAFKA-10078 is resolved we can leave it to the client to trigger this rebalance
-                log.debug("Requesting followup rebalance be scheduled immediately due to tasks changing ownership.");
+                log.info("Requesting followup rebalance be scheduled immediately due to tasks changing ownership.");
                 info.setNextRebalanceTime(0L);
                 followupRebalanceRequiredForRevokedTasks = true;
                 // Don't bother to schedule a probing rebalance if an immediate one is already scheduled
                 shouldEncodeProbingRebalance = false;
-            }
-
-            if (shouldEncodeProbingRebalance) {
+            } else if (shouldEncodeProbingRebalance) {
                 final long nextRebalanceTimeMs = time.milliseconds() + probingRebalanceIntervalMs();
-                log.debug("Requesting followup rebalance be scheduled for {} ms to probe for caught-up replica tasks.", nextRebalanceTimeMs);
+                log.info("Requesting followup rebalance be scheduled for {} ms to probe for caught-up replica tasks.", nextRebalanceTimeMs);
                 info.setNextRebalanceTime(nextRebalanceTimeMs);
                 shouldEncodeProbingRebalance = false;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -882,17 +882,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final SortedSet<String> consumers = clientMetadata.consumers;
 
             final Map<String, List<TaskId>> activeTaskAssignment = assignTasksToThreads(
-                    state.statefulActiveTasks(),
-                    state.statelessActiveTasks(),
-                    consumers,
-                    state
+                state.statefulActiveTasks(),
+                state.statelessActiveTasks(),
+                consumers,
+                state
             );
 
             final Map<String, List<TaskId>> standbyTaskAssignment = assignTasksToThreads(
-                    state.standbyTasks(),
-                    Collections.emptySet(),
-                    consumers,
-                    state
+                state.standbyTasks(),
+                Collections.emptySet(),
+                consumers,
+                state
             );
 
             // Arbitrarily choose the leader's client to be responsible for triggering the probing rebalance

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1098,17 +1098,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             for (final String consumer : consumers) {
                 final List<TaskId> threadAssignment = assignment.get(consumer);
 
-                int i = 0;
+                int assignedTasks = 0;
                 for (final TaskId task : getPreviousTasksByLag(state, consumer)) {
                     if (unassignedStatefulTasks.contains(task)) {
-                        if (i < minStatefulTasksPerThread) {
+                        if (assignedTasks < minStatefulTasksPerThread) {
                             threadAssignment.add(task);
                             unassignedStatefulTasks.remove(task);
+                            ++assignedTasks;
                         } else {
                             unassignedTaskToPreviousOwner.put(task, consumer);
                         }
                     }
-                    ++i;
                 }
 
                 if (threadAssignment.size() < minStatefulTasksPerThread) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -76,6 +76,7 @@ import static org.apache.kafka.streams.processor.internals.ClientUtils.fetchEndO
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.EARLIEST_PROBEABLE_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
+import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 
 public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Configurable {
 
@@ -767,7 +768,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             allTaskEndOffsetSums = computeEndOffsetSumsByTask(endOffsets, changelogsByStatefulTask, allNewlyCreatedChangelogPartitions);
             fetchEndOffsetsSuccessful = true;
         } catch (final StreamsException e) {
-            allTaskEndOffsetSums = null;
+            allTaskEndOffsetSums = changelogsByStatefulTask.keySet().stream().collect(Collectors.toMap(t -> t, t -> UNKNOWN_OFFSET_SUM));
             fetchEndOffsetsSuccessful = false;
         }
 
@@ -776,9 +777,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final ClientState state = entry.getValue().state;
             state.initializePrevTasks(taskForPartition);
 
-            if (fetchEndOffsetsSuccessful) {
-                state.computeTaskLags(uuid, allTaskEndOffsetSums);
-            }
+            state.computeTaskLags(uuid, allTaskEndOffsetSums);
             clientStates.put(uuid, state);
         }
         return fetchEndOffsetsSuccessful;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.processor.internals;
 import java.util.Iterator;
 import java.util.PriorityQueue;
 import java.util.Queue;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
@@ -114,7 +116,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private static class ClientMetadata {
 
         private final HostInfo hostInfo;
-        private final Set<String> consumers;
+        private final SortedSet<String> consumers;
         private final ClientState state;
 
         ClientMetadata(final String endPoint) {
@@ -123,7 +125,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             hostInfo = HostInfo.buildFromEndpoint(endPoint);
 
             // initialize the consumer memberIds
-            consumers = new HashSet<>();
+            consumers = new TreeSet<>();
 
             // initialize the client state
             state = new ClientState();
@@ -878,7 +880,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final UUID clientId = clientEntry.getKey();
             final ClientMetadata clientMetadata = clientEntry.getValue();
             final ClientState state = clientMetadata.state;
-            final Set<String> consumers = clientMetadata.consumers;
+            final SortedSet<String> consumers = clientMetadata.consumers;
 
             final Map<String, List<TaskId>> activeTaskAssignment = assignTasksToThreads(
                     state.statefulActiveTasks(),
@@ -1075,7 +1077,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      */
     static Map<String, List<TaskId>> assignTasksToThreads(final Collection<TaskId> statefulTasksToAssign,
                                                           final Collection<TaskId> statelessTasksToAssign,
-                                                          final Set<String> consumers,
+                                                          final SortedSet<String> consumers,
                                                           final Function<String, Set<TaskId>> previousTasksForConsumer) {
         final Map<String, List<TaskId>> assignment = new HashMap<>();
         for (final String consumer : consumers) {
@@ -1085,7 +1087,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         final int minStatefulTasksPerThread = (int) Math.floor(((double) statefulTasksToAssign.size()) / consumers.size());
         final PriorityQueue<TaskId> unassignedStatefulTasks = new PriorityQueue<>(statefulTasksToAssign);
 
-        final PriorityQueue<String> consumersToFill = new PriorityQueue<>();
+        final Queue<String> consumersToFill = new LinkedList<>();
         // keep track of tasks that we have to skip during the first pass in case we can reassign them later
         final Map<TaskId, String> unassignedTaskToPreviousOwner = new HashMap<>();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1138,7 +1138,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 for (final Map.Entry<TaskId, String> taskEntry : unassignedTaskToPreviousOwner.entrySet()) {
                     final TaskId task = taskEntry.getKey();
                     final String consumer = taskEntry.getValue();
-                    if (consumersToFill.contains(consumer)) {
+                    if (consumersToFill.contains(consumer) && unassignedStatefulTasks.contains(task)) {
                         assignment.get(consumer).add(task);
                         unassignedStatefulTasks.remove(task);
                         // Remove this consumer since we know it is now at minCapacity + 1

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -886,7 +886,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                     state.statefulActiveTasks(),
                     state.statelessActiveTasks(),
                     consumers,
-                    state::previousStatefulActiveTasksForConsumer
+                    state::previousActiveTasksForConsumer
             );
 
             final Map<String, List<TaskId>> standbyTaskAssignment = assignTasksToThreads(
@@ -1097,11 +1097,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             int i = 0;
             for (final TaskId task : previousTasksForConsumer.apply(consumer)) {
-                if (i < minStatefulTasksPerThread) {
-                    threadAssignment.add(task);
-                    unassignedStatefulTasks.remove(task);
-                } else {
-                    unassignedTaskToPreviousOwner.put(task, consumer);
+                if (unassignedStatefulTasks.contains(task)) {
+                    if (i < minStatefulTasksPerThread) {
+                        threadAssignment.add(task);
+                        unassignedStatefulTasks.remove(task);
+                    } else {
+                        unassignedTaskToPreviousOwner.put(task, consumer);
+                    }
                 }
                 ++i;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -932,7 +932,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
     /**
      * Adds the encoded assignment for each StreamThread consumer in the client to the overall assignment map
-     * @return true if a followup rebalance will be required due to revoekd tasks
+     * @return true if a followup rebalance will be required due to revoked tasks
      */
     private boolean addClientAssignments(final Map<String, Assignment> assignment,
                                          final ClientMetadata clientMetadata,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1098,13 +1098,11 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             for (final String consumer : consumers) {
                 final List<TaskId> threadAssignment = assignment.get(consumer);
 
-                int assignedTasks = 0;
                 for (final TaskId task : getPreviousTasksByLag(state, consumer)) {
                     if (unassignedStatefulTasks.contains(task)) {
-                        if (assignedTasks < minStatefulTasksPerThread) {
+                        if (threadAssignment.size() < minStatefulTasksPerThread) {
                             threadAssignment.add(task);
                             unassignedStatefulTasks.remove(task);
-                            ++assignedTasks;
                         } else {
                             unassignedTaskToPreviousOwner.put(task, consumer);
                         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -301,6 +301,11 @@ public class ClientState {
         }
     }
 
+    public Set<TaskId> previousStatefulTasksForConsumer(final String memberId) {
+        //TODO
+        return null;
+    }
+
     boolean hasUnfulfilledQuota(final int tasksPerThread) {
         return activeTasks.size() < capacity * tasksPerThread;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -301,14 +301,7 @@ public class ClientState {
      *          Task.LATEST_OFFSET if this was previously an active running task on this client
      */
     public long lagFor(final TaskId task) {
-        final Long totalLag;
-        if (taskLagTotals.isEmpty()) {
-            // If we couldn't compute the task lags due to failure to fetch offsets, just return a flat constant
-            totalLag = 0L;
-        } else {
-            totalLag = taskLagTotals.get(task);
-        }
-
+        final Long totalLag = taskLagTotals.get(task);
         if (totalLag == null) {
             throw new IllegalStateException("Tried to lookup lag for unknown task " + task);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals.assignment;
 
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.TaskId;
@@ -38,7 +37,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Comparator.comparing;
-import static java.util.Comparator.comparingLong;
 import static org.apache.kafka.common.utils.Utils.union;
 import static org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo.UNKNOWN_OFFSET_SUM;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -318,10 +318,10 @@ public class ClientState {
         return activeTasks.stream().filter(task -> !isStateful(task)).collect(Collectors.toSet());
     }
 
-    public Set<TaskId> previousStatefulActiveTasksForConsumer(final String memberId) {
+    public Set<TaskId> previousActiveTasksForConsumer(final String memberId) {
         final Set<TaskId> prevTasks = new HashSet<>();
         for (final TaskId task : consumerToPreviousTaskIds.get(memberId)) {
-            if (isStateful(task) && prevActiveTasks.contains(task)) {
+            if (prevActiveTasks.contains(task)) {
                 prevTasks.add(task);
             }
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -104,8 +104,6 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_1_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_0;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_1;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_2;
-import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.TASK_2_3;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_1;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.UUID_2;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
@@ -114,7 +112,6 @@ import static org.easymock.EasyMock.expect;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -434,7 +431,7 @@ public class StreamsPartitionAssignorTest {
         // Consumer 4 joins the group
         consumers.add(CONSUMER_4);
         state.addPreviousTasksAndOffsetSums(CONSUMER_4, getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS));
-        
+
         state.initializePrevTasks(emptyMap());
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -128,8 +128,7 @@ public class StreamsPartitionAssignorTest {
     private static final String CONSUMER_1 = "consumer1";
     private static final String CONSUMER_2 = "consumer2";
     private static final String CONSUMER_3 = "consumer3";
-    private static final String CONSUMER_4 = "consumer4";
-    
+
     private final Set<String> allTopics = mkSet("topic1", "topic2");
 
     private final TopicPartition t1p0 = new TopicPartition("topic1", 0);
@@ -351,7 +350,7 @@ public class StreamsPartitionAssignorTest {
                 allTasks,
                 emptySet(),
                 consumers,
-                state::previousActiveTasksForConsumer
+                state
             )
         );
     }
@@ -369,9 +368,9 @@ public class StreamsPartitionAssignorTest {
 
         final ClientState state = new ClientState();
         final SortedSet<String> consumers = mkSortedSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
-        state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
+        state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
-        state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
+        state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
         state.initializePrevTasks(emptyMap());
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
@@ -385,7 +384,7 @@ public class StreamsPartitionAssignorTest {
                 allTasks,
                 emptySet(),
                 consumers,
-                state::previousActiveTasksForConsumer
+                state
             );
 
         previousAssignment.get(CONSUMER_2).add(newTask);
@@ -416,7 +415,7 @@ public class StreamsPartitionAssignorTest {
                 allTasks,
                 emptySet(),
                 consumers,
-                state::previousActiveTasksForConsumer
+                state
             );
 
         assertThat(interleavedTaskIds, equalTo(assignment));
@@ -573,16 +572,6 @@ public class StreamsPartitionAssignorTest {
 
         final List<String> topics = asList("topic1", "topic2");
 
-        final TaskId taskIdA0 = new TaskId(0, 0);
-        final TaskId taskIdA1 = new TaskId(0, 1);
-        final TaskId taskIdA2 = new TaskId(0, 2);
-        final TaskId taskIdA3 = new TaskId(0, 3);
-
-        final TaskId taskIdB0 = new TaskId(1, 0);
-        final TaskId taskIdB1 = new TaskId(1, 1);
-        final TaskId taskIdB2 = new TaskId(1, 2);
-        final TaskId taskIdB3 = new TaskId(1, 3);
-
         configureDefault();
 
         subscriptions.put("consumer10",
@@ -605,12 +594,12 @@ public class StreamsPartitionAssignorTest {
         // the first consumer
         final AssignmentInfo info10 = AssignmentInfo.decode(assignments.get("consumer10").userData());
 
-        final List<TaskId> expectedInfo10TaskIds = asList(taskIdA0, taskIdA2, taskIdB0, taskIdB2);
+        final List<TaskId> expectedInfo10TaskIds = asList(TASK_0_0, TASK_0_2, TASK_1_0, TASK_1_2);
         assertEquals(expectedInfo10TaskIds, info10.activeTasks());
 
         // the second consumer
         final AssignmentInfo info11 = AssignmentInfo.decode(assignments.get("consumer11").userData());
-        final List<TaskId> expectedInfo11TaskIds = asList(taskIdA1, taskIdA3, taskIdB1, taskIdB3);
+        final List<TaskId> expectedInfo11TaskIds = asList(TASK_0_1, TASK_0_3, TASK_1_1, TASK_1_3);
 
         assertEquals(expectedInfo11TaskIds, info11.activeTasks());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -351,7 +351,7 @@ public class StreamsPartitionAssignorTest {
                 allTasks,
                 emptySet(),
                 consumers,
-                state::previousStatefulActiveTasksForConsumer
+                state::previousActiveTasksForConsumer
             )
         );
     }
@@ -385,7 +385,7 @@ public class StreamsPartitionAssignorTest {
                 allTasks,
                 emptySet(),
                 consumers,
-                state::previousStatefulActiveTasksForConsumer
+                state::previousActiveTasksForConsumer
             );
 
         previousAssignment.get(CONSUMER_2).add(newTask);
@@ -416,7 +416,7 @@ public class StreamsPartitionAssignorTest {
                 allTasks,
                 emptySet(),
                 consumers,
-                state::previousStatefulActiveTasksForConsumer
+                state::previousActiveTasksForConsumer
             );
 
         assertThat(interleavedTaskIds, equalTo(assignment));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -142,10 +142,6 @@ public class StreamsPartitionAssignorTest {
     private final TopicPartition t3p1 = new TopicPartition("topic3", 1);
     private final TopicPartition t3p2 = new TopicPartition("topic3", 2);
     private final TopicPartition t3p3 = new TopicPartition("topic3", 3);
-    private final TopicPartition t4p0 = new TopicPartition("topic4", 0);
-    private final TopicPartition t4p1 = new TopicPartition("topic4", 1);
-    private final TopicPartition t4p2 = new TopicPartition("topic4", 2);
-    private final TopicPartition t4p3 = new TopicPartition("topic4", 3);
 
     private final List<PartitionInfo> infos = asList(
         new PartitionInfo("topic1", 0, Node.noNode(), new Node[0], new Node[0]),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.SortedSet;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
@@ -88,6 +89,7 @@ import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.common.utils.Utils.mkSortedSet;
 import static org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.assignTasksToThreads;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_CHANGELOG_END_OFFSETS;
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.EMPTY_TASKS;
@@ -336,7 +338,7 @@ public class StreamsPartitionAssignorTest {
         );
 
         final ClientState state = new ClientState();
-        final Set<String> consumers = mkSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
+        final SortedSet<String> consumers = mkSortedSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
         state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
@@ -357,7 +359,7 @@ public class StreamsPartitionAssignorTest {
     @Test
     public void shouldProduceStickyAndBalancedAssignmentWhenNewTasksAreAdded() {
         final List<TaskId> allTasks =
-            asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3);
+            new ArrayList<>(asList(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3, TASK_1_0, TASK_1_1, TASK_1_2, TASK_1_3));
 
         final Map<String, List<TaskId>> previousAssignment = mkMap(
             mkEntry(CONSUMER_1, new ArrayList<>(asList(TASK_0_0, TASK_1_1, TASK_1_3))),
@@ -366,10 +368,10 @@ public class StreamsPartitionAssignorTest {
         );
 
         final ClientState state = new ClientState();
-        final Set<String> consumers = mkSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
-        state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
+        final SortedSet<String> consumers = mkSortedSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
+        state.addPreviousTasksAndOffsetSums(CONSUMER_1, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, getTaskOffsetSums(asList(TASK_0_3, TASK_1_0), EMPTY_TASKS));
-        state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_1, TASK_0_2, TASK_1_2), EMPTY_TASKS));
+        state.addPreviousTasksAndOffsetSums(CONSUMER_3, getTaskOffsetSums(asList(TASK_0_0, TASK_1_1, TASK_1_3), EMPTY_TASKS));
         state.initializePrevTasks(emptyMap());
         state.computeTaskLags(UUID_1, getTaskEndOffsetSums(allTasks));
 
@@ -402,7 +404,7 @@ public class StreamsPartitionAssignorTest {
         );
 
         final ClientState state = new ClientState();
-        final Set<String> consumers = mkSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
+        final SortedSet<String> consumers = mkSortedSet(CONSUMER_1, CONSUMER_2, CONSUMER_3);
         state.addPreviousTasksAndOffsetSums(CONSUMER_1, emptyMap());
         state.addPreviousTasksAndOffsetSums(CONSUMER_2, emptyMap());
         state.addPreviousTasksAndOffsetSums(CONSUMER_3, emptyMap());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1963,7 +1963,7 @@ public class StreamsPartitionAssignorTest {
 
     // Stub end offsets sums for situations where we don't really care about computing exact lags
     private static Map<TaskId, Long> getTaskEndOffsetSums(final Collection<TaskId> allStatefulTasks) {
-        return allStatefulTasks.stream().collect(Collectors.toMap(t -> t, t-> Long.MAX_VALUE));
+        return allStatefulTasks.stream().collect(Collectors.toMap(t -> t, t -> Long.MAX_VALUE));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -323,9 +323,9 @@ public class ClientStateTest {
             )
         );
 
-        assertThat(client.previousStatefulActiveTasksForConsumer("c1"), equalTo(Collections.singleton(TASK_0_0)));
-        assertTrue(client.previousStatefulActiveTasksForConsumer("c2").isEmpty());
-        assertTrue(client.previousStatefulActiveTasksForConsumer("c3").isEmpty());
+        assertThat(client.previousActiveTasksForConsumer("c1"), equalTo(Collections.singleton(TASK_0_0)));
+        assertTrue(client.previousActiveTasksForConsumer("c2").isEmpty());
+        assertTrue(client.previousActiveTasksForConsumer("c3").isEmpty());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -415,16 +415,6 @@ public class ClientStateTest {
     }
 
     @Test
-    public void shouldReturnZeroForAllTasksIfLagNotComputed() {
-        client.addPreviousTasksAndOffsetSums("c1", Collections.singletonMap(TASK_0_1, 0L));
-        client.addPreviousTasksAndOffsetSums("c2", Collections.singletonMap(TASK_0_2, Task.LATEST_OFFSET));
-        client.addPreviousTasksAndOffsetSums("c3", Collections.singletonMap(TASK_0_3, 500L));
-        assertThat(client.lagFor(TASK_0_1), equalTo(0L));
-        assertThat(client.lagFor(TASK_0_2), equalTo(0L));
-        assertThat(client.lagFor(TASK_0_3), equalTo(0L));
-    }
-
-    @Test
     public void shouldThrowIllegalStateExceptionOnLagForUnknownTask() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, 0L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(TASK_0_1, 500L);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -300,7 +300,7 @@ public class ClientStateTest {
     @Test
     public void shouldAddTasksWithLatestOffsetToPrevActiveTasks() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, Task.LATEST_OFFSET);
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.initializePrevTasks(Collections.emptyMap());
         assertThat(client.prevActiveTasks(), equalTo(Collections.singleton(TASK_0_1)));
         assertThat(client.previousAssignedTasks(), equalTo(Collections.singleton(TASK_0_1)));
@@ -313,7 +313,7 @@ public class ClientStateTest {
             mkEntry(TASK_0_1, 0L),
             mkEntry(TASK_0_2, 100L)
         );
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.initializePrevTasks(Collections.emptyMap());
         assertThat(client.prevStandbyTasks(), equalTo(mkSet(TASK_0_1, TASK_0_2)));
         assertThat(client.previousAssignedTasks(), equalTo(mkSet(TASK_0_1, TASK_0_2)));
@@ -330,7 +330,7 @@ public class ClientStateTest {
             mkEntry(TASK_0_1, 500L),
             mkEntry(TASK_0_2, 100L)
         );
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
 
         assertThat(client.lagFor(TASK_0_1), equalTo(500L));
@@ -341,7 +341,7 @@ public class ClientStateTest {
     public void shouldReturnEndOffsetSumForLagOfTaskWeDidNotPreviouslyOwn() {
         final Map<TaskId, Long> taskOffsetSums = Collections.emptyMap();
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(TASK_0_1, 500L);
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(TASK_0_1), equalTo(500L));
     }
@@ -350,7 +350,7 @@ public class ClientStateTest {
     public void shouldReturnLatestOffsetForLagOfPreviousActiveRunningTask() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, Task.LATEST_OFFSET);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(TASK_0_1, 500L);
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(TASK_0_1), equalTo(Task.LATEST_OFFSET));
     }
@@ -359,7 +359,7 @@ public class ClientStateTest {
     public void shouldReturnUnknownOffsetSumForLagOfTaskWithUnknownOffset() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, UNKNOWN_OFFSET_SUM);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(TASK_0_1, 500L);
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(TASK_0_1), equalTo(UNKNOWN_OFFSET_SUM));
     }
@@ -368,7 +368,7 @@ public class ClientStateTest {
     public void shouldReturnEndOffsetSumIfOffsetSumIsGreaterThanEndOffsetSum() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, 5L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(TASK_0_1, 1L);
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThat(client.lagFor(TASK_0_1), equalTo(1L));
     }
@@ -385,7 +385,7 @@ public class ClientStateTest {
     public void shouldThrowIllegalStateExceptionOnLagForUnknownTask() {
         final Map<TaskId, Long> taskOffsetSums = Collections.singletonMap(TASK_0_1, 0L);
         final Map<TaskId, Long> allTaskEndOffsetSums = Collections.singletonMap(TASK_0_1, 500L);
-        client.addPreviousTasksAndOffsetSums(taskOffsetSums);
+        client.addPreviousTasksAndOffsetSums("c1", taskOffsetSums);
         client.computeTaskLags(null, allTaskEndOffsetSums);
         assertThrows(IllegalStateException.class, () -> client.lagFor(TASK_0_2));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorConvergenceTest.java
@@ -185,7 +185,7 @@ public class TaskAssignorConvergenceTest {
                 }
                 newClientState.addPreviousActiveTasks(clientState.activeTasks());
                 newClientState.addPreviousStandbyTasks(clientState.standbyTasks());
-                newClientState.addPreviousTasksAndOffsetSums(taskOffsetSums);
+                newClientState.addPreviousTasksAndOffsetSums("consumer", taskOffsetSums);
                 newClientState.computeTaskLags(uuid, statefulTaskEndOffsetSums);
                 newClientStates.put(uuid, newClientState);
             }


### PR DESCRIPTION
Uses a similar (but slightly different) algorithm as in [KAFKA-9987](https://issues.apache.org/jira/browse/KAFKA-9987) to produce a maximally sticky -- and perfectly balanced -- assignment of tasks to threads within a single client. This is important for in-memory stores which get wiped out when transferred between threads.

Must be cherrypicked to 2.6