### PR TITLE
KAFKA-10083: fix failed testReassignmentWithRandomSubscriptionsAndChanges tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignor.java
@@ -43,7 +43,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
 
     public static final int DEFAULT_GENERATION = -1;
 
-    private PartitionMovements partitionMovements = new PartitionMovements();
+    private PartitionMovements partitionMovements;
 
     // Keep track of the partitions being migrated from one consumer to another during assignment
     // so the cooperative assignor can adjust the assignment
@@ -272,6 +272,7 @@ public abstract class AbstractStickyAssignor extends AbstractPartitionAssignor {
                                                             Map<String, Subscription> subscriptions) {
         Map<String, List<TopicPartition>> currentAssignment = new HashMap<>();
         Map<TopicPartition, ConsumerGenerationPair> prevAssignment = new HashMap<>();
+        partitionMovements = new PartitionMovements();
 
         prepopulateCurrentAssignments(subscriptions, currentAssignment, prevAssignment);
         boolean isFreshAssignment = currentAssignment.isEmpty();


### PR DESCRIPTION
The failed test is because we changed the class member `partitionMovements` initialization to when the class instance created, from initialized when used within `assign` method. This won't have any issue when 1st used the `AbstractStickyAssignor` instance. But if it is used later, the `partitionMovements` will store the old info, and cause this failed tests. Fix it by moving the `partitionMovements` initialization back to `assign` method.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
