### PR TITLE
MINOR: Upgrade spotbugs and spotbugsPlugin

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -111,7 +111,7 @@ versions += [
   shadowPlugin: "5.2.0",
   slf4j: "1.7.30",
   snappy: "1.1.7.3",
-  spotbugs: "4.0.2",
+  spotbugs: "4.0.3",
   spotbugsPlugin: "4.2.4",
   spotlessPlugin: "3.28.1",
   testRetryPlugin: "1.1.5",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,7 @@ versions += [
   slf4j: "1.7.30",
   snappy: "1.1.7.3",
   spotbugs: "4.0.2",
-  spotbugsPlugin: "4.0.5",
+  spotbugsPlugin: "4.2.4",
   spotlessPlugin: "3.28.1",
   testRetryPlugin: "1.1.5",
   zinc: "1.3.5",


### PR DESCRIPTION
Upgrade spotbugsPlugin to have clear error output to indicate where the error is. 

When investigating KAFKA-10081, I found the error output of spotbugs is very poor. It doesn't even tell you where the error is and how many errors found, it will take a lot of time for the developers to find out where the error is, and then fix it.
![image](https://user-images.githubusercontent.com/43372967/83590263-efc42a80-a587-11ea-95cf-e9097d9a662e.png)
https://builds.apache.org/blue/organizations/jenkins/kafka-trunk-jdk8/detail/kafka-trunk-jdk8/4596/pipeline/

Then, I found out there's a bug in spotbugsPlugin in V4.0.x, and got fixed in V4.2.x
https://github.com/spotbugs/spotbugs-gradle-plugin/issues/210

So, after upgrading to V4.2.x (I followed to the latest version V4.2.4), the output is like this:
![image](https://user-images.githubusercontent.com/43372967/83590913-60b81200-a589-11ea-9a04-1449d693c2f2.png)
So you know there's 1 error and you can also open the report file to find out the error.

I think this is very important to save the developer's time to fix the spotBug issues while developing. Thanks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
