### PR TITLE
KAFKA-9514; The protocol generator generated useless condition when a field is made nullable and flexible version is used

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -1436,8 +1436,8 @@ public final class MessageDataGenerator {
             alwaysEmitBlockScope(type.isString()).
             ifNull(() -> {
                 VersionConditional.forVersions(nullableVersions, possibleVersions).
-                    ifMember(__ -> {
-                        VersionConditional.forVersions(fieldFlexibleVersions, possibleVersions).
+                    ifMember(presentVersions -> {
+                        VersionConditional.forVersions(fieldFlexibleVersions, presentVersions).
                             ifMember(___ -> {
                                 buffer.printf("_writable.writeUnsignedVarint(0);%n");
                             }).

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -244,12 +244,6 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- The code generator generates useless condition. Disable the check temporarily. -->
-        <Class name="org.apache.kafka.common.message.JoinGroupResponseData"/>
-        <Bug pattern="UC_USELESS_CONDITION"/>
-    </Match>
-
-    <Match>
         <!-- Suppress warnings about ignoring the return value of await.
              This is done intentionally because we use other clues to determine
              if the wait was cut short. -->


### PR DESCRIPTION
The protocol generator generates useless conditions when a field of type string is made nullable after the request has been converted to using optional fields.

As an example, we have make the field `ProtocolName` nullable in the `JoinGroupResponse`. The `JoinGroupResponse` supports optional fields since version 6 and the field is nullable since version 7. Under these conditions, the generator generates the following code:

```
if (protocolName == null) {
 if (_version >= 7) {
   if (_version >= 6) {
     _writable.writeUnsignedVarint(0);
   } else {
     _writable.writeShort((short) -1);
  }
 } else {
   throw new NullPointerException();
 }
}
```

spotbugs raises an `UC_USELESS_CONDITION` because `_version >= 6` is always true.

This PR fixes the bug by propagating the outer versions to the underlying `VersionConditional` so it can generate the code accordingly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
