### PR TITLE
KAFKA-10095: Simplify calls in LogCleanerManagerTest

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -571,12 +571,12 @@ class LogCleanerManagerTest extends Logging {
     cleanerManager.setCleaningState(topicPartition, LogCleaningInProgress)
     cleanerManager.doneCleaning(topicPartition, log.dir, 1)
     assertTrue(cleanerManager.cleaningState(topicPartition).isEmpty)
-    assertTrue(cleanerManager.allCleanerCheckpoints.get(topicPartition).nonEmpty)
+    assertTrue(cleanerManager.allCleanerCheckpoints.contains(topicPartition))
 
     cleanerManager.setCleaningState(topicPartition, LogCleaningAborted)
     cleanerManager.doneCleaning(topicPartition, log.dir, 1)
     assertEquals(LogCleaningPaused(1), cleanerManager.cleaningState(topicPartition).get)
-    assertTrue(cleanerManager.allCleanerCheckpoints.get(topicPartition).nonEmpty)
+    assertTrue(cleanerManager.allCleanerCheckpoints.contains(topicPartition))
   }
 
   @Test


### PR DESCRIPTION
In kafka.log.LogCleanerManagerTest we have two calls to .get(something).nonEmpty, which is equivalent to .contains(something). Making changes to simplify these calls.

Reviewers: Jakob Homan jghoman@gmail.com

This is a newbie ticket to get used to the contribution flow.

