### PR TITLE
KAFKA-10096: Remove unnecessary String.format call.

### DIFF
--- a/generator/src/test/java/org/apache/kafka/message/VersionConditionalTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/VersionConditionalTest.java
@@ -35,7 +35,7 @@ public class VersionConditionalTest {
         buffer.write(stringWriter);
         StringBuilder expectedStringBuilder = new StringBuilder();
         for (String line : lines) {
-            expectedStringBuilder.append(String.format(line));
+            expectedStringBuilder.append(line);
         }
         Assert.assertEquals(expectedStringBuilder.toString(), stringWriter.toString());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10096

Since format is not provided in VersionConditionalTest::assertEquals, we can just pass the string into StringBuilder::append.

This is a newbie ticket to get used to the contribution flow.

Reviewers: @jghoman 