### PR TITLE
KAFKA-10100; LiveLeaders field in LeaderAndIsrRequest is not used anymore

### DIFF
--- a/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+++ b/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
@@ -43,6 +43,8 @@
       { "name": "PartitionStates", "type": "[]LeaderAndIsrPartitionState", "versions": "2+",
         "about": "The state of each partition" }
     ]},
+    // In v1+ requests, LiveLeaders is not populated anymore starting from AK 2.7 as it is
+    // only used by AK 0.8.
     { "name": "LiveLeaders", "type": "[]LeaderAndIsrLiveLeader", "versions": "0+",
       "about": "The current live leaders.", "fields": [
       { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -185,8 +185,16 @@ class ControllerChannelManagerTest {
 
     val leaderAndIsrRequests = batch.collectLeaderAndIsrRequestsFor(2)
     assertEquals(1, leaderAndIsrRequests.size)
+    val leaderAndIsrRequest = leaderAndIsrRequests.head
     assertEquals(s"IBP $interBrokerProtocolVersion should use version $expectedLeaderAndIsrVersion",
-      expectedLeaderAndIsrVersion, leaderAndIsrRequests.head.version)
+      expectedLeaderAndIsrVersion, leaderAndIsrRequest.version)
+    assertEquals(Seq(partition), leaderAndIsrRequest.partitionStates
+      .asScala.map(p => new TopicPartition(p.topicName, p.partitionIndex)))
+    if (expectedLeaderAndIsrVersion == 0) {
+      assertEquals(Set(1), leaderAndIsrRequest.liveLeaders.asScala.map(_.brokerId).toSet)
+    } else {
+      assertTrue(leaderAndIsrRequest.liveLeaders.isEmpty)
+    }
   }
 
   @Test


### PR DESCRIPTION
We have noticed that the `LiveLeaders` field in the LeaderAndIsrRequest is not used anywhere but still populated by the controller.

It seems that that field was introduced in AK `0.8.0` and was supposed to be removed in AK `0.8.1`: https://github.com/apache/kafka/blob/0.8.0/core/src/main/scala/kafka/cluster/Partition.scala#L194. It has not been used since then.

This PR proposes to simply stop populating the field for any version > 0. It avoids to compute the live leaders set and also reduces the size of the request on the wire.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
