### PR TITLE
KAFKA-10102: update ProcessorTopology instead of rebuilding it

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
@@ -118,7 +120,8 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
-    public void update(final Set<TopicPartition> topicPartitions) {
+    public void update(final Set<TopicPartition> topicPartitions, final Map<String, List<String>> nodeToSourceTopics) {
         this.inputPartitions = topicPartitions;
+        topology.updateSourceTopics(nodeToSourceTopics);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -118,8 +118,7 @@ public abstract class AbstractTask implements Task {
     }
 
     @Override
-    public void update(final Set<TopicPartition> topicPartitions, final ProcessorTopology processorTopology) {
+    public void update(final Set<TopicPartition> topicPartitions) {
         this.inputPartitions = topicPartitions;
-        this.topology = processorTopology;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1096,6 +1096,10 @@ public class InternalTopologyBuilder {
         return Collections.unmodifiableMap(topicGroups);
     }
 
+    public Map<String, List<String>> nodeToSourceTopics() {
+        return Collections.unmodifiableMap(nodeToSourceTopics);
+    }
+
     private RepartitionTopicConfig buildRepartitionTopicConfig(final String internalTopic,
                                                                final Optional<Integer> numberOfPartitions) {
         return numberOfPartitions

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -270,16 +270,7 @@ public class InternalTopologyBuilder {
 
         @Override
         public ProcessorNode<K, V> build() {
-            final List<String> sourceTopics = nodeToSourceTopics.get(name);
-
-            // if it is subscribed via patterns, it is possible that the topic metadata has not been updated
-            // yet and hence the map from source node to topics is stale, in this case we put the pattern as a place holder;
-            // this should only happen for debugging since during runtime this function should always be called after the metadata has updated.
-            if (sourceTopics == null) {
-                return new SourceNode<>(name, Collections.singletonList(String.valueOf(pattern)), timestampExtractor, keyDeserializer, valDeserializer);
-            } else {
-                return new SourceNode<>(name, maybeDecorateInternalSourceTopics(sourceTopics), timestampExtractor, keyDeserializer, valDeserializer);
-            }
+            return new SourceNode<>(name, timestampExtractor, keyDeserializer, valDeserializer);
         }
 
         private boolean isMatch(final String topic) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -48,7 +48,7 @@ public class ProcessorTopology {
                              final Map<String, String> storeToChangelogTopic,
                              final Set<String> repartitionTopics) {
         this.processorNodes = Collections.unmodifiableList(processorNodes);
-        this.sourcesByTopic = Collections.unmodifiableMap(sourcesByTopic);
+        this.sourcesByTopic = new HashMap<>(sourcesByTopic);
         this.sinksByTopic = Collections.unmodifiableMap(sinksByTopic);
         this.stateStores = Collections.unmodifiableList(stateStores);
         this.globalStateStores = Collections.unmodifiableList(globalStateStores);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -139,7 +139,7 @@ public class ProcessorTopology {
         return false;
     }
 
-    public void updateSourceTopics(Map<String, List<String>> nodeToSourceTopics) {
+    public void updateSourceTopics(final Map<String, List<String>> nodeToSourceTopics) {
         sourcesByTopic.clear();
         for (final Map.Entry<String, List<String>> sourceEntry : nodeToSourceTopics.entrySet()) {
             final String nodeName = sourceEntry.getKey();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import org.apache.kafka.streams.processor.StateStore;
 
 import java.util.Collections;
@@ -131,6 +133,10 @@ public class ProcessorTopology {
         return false;
     }
 
+    public void updateSourceTopics(final Set<String> topics) {
+
+    }
+
     private String childrenToString(final String indent, final List<ProcessorNode<?, ?>> children) {
         if (children == null || children.isEmpty()) {
             return "";
@@ -167,11 +173,21 @@ public class ProcessorTopology {
      * @return A string representation of this instance.
      */
     public String toString(final String indent) {
+        final Map<SourceNode<?, ?>, List<String>> sourceToTopics = new HashMap<>();
+        for (final Map.Entry<String, SourceNode<?, ?>> sourceNodeEntry : sourcesByTopic.entrySet()) {
+            final String topic = sourceNodeEntry.getKey();
+            final SourceNode<?, ?> source = sourceNodeEntry.getValue();
+            sourceToTopics.computeIfAbsent(source, s -> new ArrayList<>());
+            sourceToTopics.get(source).add(topic);
+        }
+
         final StringBuilder sb = new StringBuilder(indent + "ProcessorTopology:\n");
 
         // start from sources
-        for (final SourceNode<?, ?> source : sourcesByTopic.values()) {
-            sb.append(source.toString(indent + "\t")).append(childrenToString(indent + "\t", source.children()));
+        for (final Map.Entry<SourceNode<?, ?>, List<String>> sourceNodeEntry : sourceToTopics.entrySet()) {
+            final SourceNode<?, ?> source  = sourceNodeEntry.getKey();
+            final List<String> topics = sourceNodeEntry.getValue();
+            sb.append(source.toString(indent + "\t", topics)).append(childrenToString(indent + "\t", source.children()));
         }
         return sb.toString();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -29,6 +29,7 @@ import java.util.Set;
 public class ProcessorTopology {
 
     private final List<ProcessorNode<?, ?>> processorNodes;
+    private final Map<String, SourceNode<?, ?>> sourceNodesByName;
     private final Map<String, SourceNode<?, ?>> sourcesByTopic;
     private final Map<String, SinkNode<?, ?>> sinksByTopic;
     private final Set<String> terminalNodes;
@@ -59,6 +60,11 @@ public class ProcessorTopology {
             if (node.isTerminalNode()) {
                 terminalNodes.add(node.name());
             }
+        }
+
+        this.sourceNodesByName = new HashMap<>();
+        for (final SourceNode<?, ?> source : sourcesByTopic.values()) {
+            sourceNodesByName.put(source.name(), source);
         }
     }
 
@@ -133,8 +139,14 @@ public class ProcessorTopology {
         return false;
     }
 
-    public void updateSourceTopics(final Set<String> topics) {
-
+    public void updateSourceTopics(Map<String, List<String>> nodeToSourceTopics) {
+        sourcesByTopic.clear();
+        for (final Map.Entry<String, List<String>> sourceEntry : nodeToSourceTopics.entrySet()) {
+            final String nodeName = sourceEntry.getKey();
+            for (final String topic : sourceEntry.getValue()) {
+                sourcesByTopic.put(topic, sourceNodesByName.get(nodeName));
+            }
+        }
     }
 
     private String childrenToString(final String indent, final List<ProcessorNode<?, ?>> children) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -154,6 +154,10 @@ public class ProcessorTopology {
         for (final Map.Entry<String, List<String>> sourceEntry : sourceTopicsByName.entrySet()) {
             final String nodeName = sourceEntry.getKey();
             for (final String topic : sourceEntry.getValue()) {
+                if (sourceNodesByTopic.containsKey(topic)) {
+                    throw new IllegalStateException("Topic " + topic + " was already registered to source node "
+                        + sourceNodesByTopic.get(topic).name());
+                }
                 sourceNodesByTopic.put(topic, sourceNodesByName.get(nodeName));
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.List;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -101,21 +100,6 @@ public class SourceNode<K, V> extends ProcessorNode<K, V> {
     @Override
     public String toString() {
         return toString("");
-    }
-
-    /**
-     * @return a string representation of this node starting with the given indent, useful for debugging.
-     */
-    public String toString(final String indent, final List<String> topics) {
-        final StringBuilder sb = new StringBuilder(super.toString(indent));
-        sb.append(indent).append("\ttopics:\t\t[");
-        for (final String topic : topics) {
-            sb.append(topic);
-            sb.append(", ");
-        }
-        sb.setLength(sb.length() - 2);  // remove the last comma
-        sb.append("]\n");
-        return sb.toString();
     }
 
     public TimestampExtractor getTimestampExtractor() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.List;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -23,11 +24,7 @@ import org.apache.kafka.streams.kstream.internals.WrappingNullableDeserializer;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics;
 
-import java.util.List;
-
 public class SourceNode<K, V> extends ProcessorNode<K, V> {
-
-    private final List<String> topics;
 
     private InternalProcessorContext context;
     private Deserializer<K> keyDeserializer;
@@ -36,22 +33,19 @@ public class SourceNode<K, V> extends ProcessorNode<K, V> {
     private Sensor processAtSourceSensor;
 
     public SourceNode(final String name,
-                      final List<String> topics,
                       final TimestampExtractor timestampExtractor,
                       final Deserializer<K> keyDeserializer,
                       final Deserializer<V> valDeserializer) {
         super(name);
-        this.topics = topics;
         this.timestampExtractor = timestampExtractor;
         this.keyDeserializer = keyDeserializer;
         this.valDeserializer = valDeserializer;
     }
 
     public SourceNode(final String name,
-                      final List<String> topics,
                       final Deserializer<K> keyDeserializer,
                       final Deserializer<V> valDeserializer) {
-        this(name, topics, null, keyDeserializer, valDeserializer);
+        this(name, null, keyDeserializer, valDeserializer);
     }
 
     K deserializeKey(final String topic, final Headers headers, final byte[] data) {
@@ -112,7 +106,7 @@ public class SourceNode<K, V> extends ProcessorNode<K, V> {
     /**
      * @return a string representation of this node starting with the given indent, useful for debugging.
      */
-    public String toString(final String indent) {
+    public String toString(final String indent, final List<String> topics) {
         final StringBuilder sb = new StringBuilder(super.toString(indent));
         sb.append(indent).append("\ttopics:\t\t[");
         for (final String topic : topics) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -495,17 +496,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     }
 
     @Override
-    public void update(final Set<TopicPartition> topicPartitions) {
-        super.update(topicPartitions);
+    public void update(final Set<TopicPartition> topicPartitions, final Map<String, List<String>> nodeToSourceTopics) {
+        super.update(topicPartitions, nodeToSourceTopics);
         partitionGroup.updatePartitions(topicPartitions, recordQueueCreator::createQueue);
-        switch (state()) {
-            case CREATED:
-            case RESTORING:
-            case RUNNING:
-            case SUSPENDED:
-            default:
-                throw new IllegalStateException("Unknown state " + state() + " while updating active task " + id);
-        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -167,7 +168,7 @@ public interface Task {
     /**
      * Updates input partitions and topology after rebalance
      */
-    void update(final Set<TopicPartition> topicPartitions);
+    void update(final Set<TopicPartition> topicPartitions, final Map<String, List<String>> nodeToSourceTopics);
 
     /**
      * Attempt a clean close but do not close the underlying state

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -167,7 +167,7 @@ public interface Task {
     /**
      * Updates input partitions and topology after rebalance
      */
-    void update(final Set<TopicPartition> topicPartitions, final ProcessorTopology processorTopology);
+    void update(final Set<TopicPartition> topicPartitions);
 
     /**
      * Attempt a clean close but do not close the underlying state

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -359,7 +359,7 @@ public class TaskManager {
             for (final TopicPartition topicPartition : topicPartitions) {
                 partitionToTask.put(topicPartition, task);
             }
-            task.update(topicPartitions, builder.buildSubtopology(task.id().topicGroupId));
+            task.update(topicPartitions);
         }
         task.resume();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -359,7 +359,7 @@ public class TaskManager {
             for (final TopicPartition topicPartition : topicPartitions) {
                 partitionToTask.put(topicPartition, task);
             }
-            task.update(topicPartitions);
+            task.update(topicPartitions, builder.nodeToSourceTopics());
         }
         task.resume();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateTaskTest.java
@@ -56,11 +56,9 @@ public class GlobalStateTaskTest {
     private final TopicPartition t1 = new TopicPartition(topic1, 1);
     private final TopicPartition t2 = new TopicPartition(topic2, 1);
     private final MockSourceNode<String, String> sourceOne = new MockSourceNode<>(
-        new String[]{topic1},
         new StringDeserializer(),
         new StringDeserializer());
     private final MockSourceNode<Integer, Integer>  sourceTwo = new MockSourceNode<>(
-        new String[]{topic2},
         new IntegerDeserializer(),
         new IntegerDeserializer());
     private final MockProcessorNode<?, ?> processorOne = new MockProcessorNode<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -100,7 +100,7 @@ public class PartitionGroupTest {
     private RecordQueue createQueue1() {
         return new RecordQueue(
                 partition1,
-                new MockSourceNode<>(topics, intDeserializer, intDeserializer),
+                new MockSourceNode<>(intDeserializer, intDeserializer),
                 timestampExtractor,
                 new LogAndContinueExceptionHandler(),
                 new InternalMockProcessorContext(),
@@ -111,7 +111,7 @@ public class PartitionGroupTest {
     private RecordQueue createQueue2() {
         return new RecordQueue(
                 partition2,
-                new MockSourceNode<>(topics, intDeserializer, intDeserializer),
+                new MockSourceNode<>(intDeserializer, intDeserializer),
                 timestampExtractor,
                 new LogAndContinueExceptionHandler(),
                 new InternalMockProcessorContext(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -58,9 +58,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -87,7 +89,6 @@ public class ProcessorTopologyTest {
 
     private TopologyTestDriver driver;
     private final Properties props = new Properties();
-
 
     @Before
     public void setup() {
@@ -147,6 +148,29 @@ public class ProcessorTopologyTest {
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
 
         assertThat(processorTopology.terminalNodes(), equalTo(mkSet("processor-2", "sink-1")));
+    }
+
+    @Test
+    public void shouldUpdateSourceTopicsWithNewMatchingTopic() {
+        topology.addSource("source-1", "topic-1");
+        final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
+
+        assertNull(processorTopology.source("topic-2"));
+        processorTopology.updateSourceTopics(Collections.singletonMap("source-1", asList("topic-1", "topic-2")));
+
+        assertThat(processorTopology.source("topic-2"), instanceOf(SourceNode.class));
+    }
+
+    @Test
+    public void shouldUpdateSourceTopicsWithRemovedTopic() {
+        topology.addSource("source-1", "topic-1", "topic-2");
+        final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
+
+        assertThat(processorTopology.source("topic-2"), instanceOf(SourceNode.class));
+
+        processorTopology.updateSourceTopics(Collections.singletonMap("source-1", asList("topic-1")));
+
+        assertNull(processorTopology.source("topic-2"));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -62,7 +62,6 @@ import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -158,7 +158,7 @@ public class ProcessorTopologyTest {
         assertNull(processorTopology.source("topic-2"));
         processorTopology.updateSourceTopics(Collections.singletonMap("source-1", asList("topic-1", "topic-2")));
 
-        assertThat(processorTopology.source("topic-2"), instanceOf(SourceNode.class));
+        assertThat(processorTopology.source("topic-2").name(), equalTo("source-1"));
     }
 
     @Test
@@ -166,9 +166,9 @@ public class ProcessorTopologyTest {
         topology.addSource("source-1", "topic-1", "topic-2");
         final ProcessorTopology processorTopology = topology.getInternalBuilder("X").buildTopology();
 
-        assertThat(processorTopology.source("topic-2"), instanceOf(SourceNode.class));
+        assertThat(processorTopology.source("topic-2").name(), equalTo("source-1"));
 
-        processorTopology.updateSourceTopics(Collections.singletonMap("source-1", asList("topic-1")));
+        processorTopology.updateSourceTopics(Collections.singletonMap("source-1", Collections.singletonList("topic-1")));
 
         assertNull(processorTopology.source("topic-2"));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordDeserializerTest.java
@@ -26,8 +26,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.LogContext;
 import org.junit.Test;
 
-import java.util.Collections;
-
 import static org.junit.Assert.assertEquals;
 
 public class RecordDeserializerTest {
@@ -80,7 +78,7 @@ public class RecordDeserializerTest {
                       final boolean valueThrowsException,
                       final Object key,
                       final Object value) {
-            super("", Collections.emptyList(), null, null);
+            super("", null, null);
             this.keyThrowsException = keyThrowsException;
             this.valueThrowsException = valueThrowsException;
             this.key = key;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -65,7 +65,7 @@ public class RecordQueueTest {
         new MockRecordCollector()
     );
     private final MockSourceNode<Integer, Integer> mockSourceNodeWithMetrics
-        = new MockSourceNode<>(new String[] {"topic"}, intDeserializer, intDeserializer);
+        = new MockSourceNode<>(intDeserializer, intDeserializer);
     private final RecordQueue queue = new RecordQueue(
         new TopicPartition("topic", 1),
         mockSourceNodeWithMetrics,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -44,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 public class SourceNodeTest {
     @Test
     public void shouldProvideTopicHeadersAndDataToKeyDeserializer() {
-        final SourceNode<String, String> sourceNode = new MockSourceNode<>(new String[]{""}, new TheDeserializer(), new TheDeserializer());
+        final SourceNode<String, String> sourceNode = new MockSourceNode<>(new TheDeserializer(), new TheDeserializer());
         final RecordHeaders headers = new RecordHeaders();
         final String deserializeKey = sourceNode.deserializeKey("topic", headers, "data".getBytes(StandardCharsets.UTF_8));
         assertThat(deserializeKey, is("topic" + headers + "data"));
@@ -52,7 +51,7 @@ public class SourceNodeTest {
 
     @Test
     public void shouldProvideTopicHeadersAndDataToValueDeserializer() {
-        final SourceNode<String, String> sourceNode = new MockSourceNode<>(new String[]{""}, new TheDeserializer(), new TheDeserializer());
+        final SourceNode<String, String> sourceNode = new MockSourceNode<>(new TheDeserializer(), new TheDeserializer());
         final RecordHeaders headers = new RecordHeaders();
         final String deserializedValue = sourceNode.deserializeValue("topic", headers, "data".getBytes(StandardCharsets.UTF_8));
         assertThat(deserializedValue, is("topic" + headers + "data"));
@@ -85,7 +84,7 @@ public class SourceNodeTest {
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "test-client", builtInMetricsVersion);
         final InternalMockProcessorContext context = new InternalMockProcessorContext(streamsMetrics);
         final SourceNode<String, String> node =
-            new SourceNode<>(context.currentNode().name(), Collections.singletonList("topic"), new TheDeserializer(), new TheDeserializer());
+            new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
         node.init(context);
 
         final String threadId = Thread.currentThread().getName();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.HashSet;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -1804,6 +1805,20 @@ public class StreamTaskTest {
 
         EasyMock.reset(stateManager);
         EasyMock.replay(stateManager);
+    }
+
+    @Test
+    public void shouldUpdatePartitions() {
+        task = createStatelessTask(createConfig(false, "0"), StreamsConfig.METRICS_LATEST);
+        final Set<TopicPartition> newPartitions = new HashSet<>(task.inputPartitions());
+        newPartitions.add(new TopicPartition("newTopic", 0));
+
+        task.update(newPartitions, mkMap(
+            mkEntry(source1.name(), asList(topic1, "newTopic")),
+            mkEntry(source2.name(), singletonList(topic2)))
+        );
+
+        assertThat(task.inputPartitions(), equalTo(newPartitions));
     }
 
     private StreamTask createOptimizedStatefulTask(final StreamsConfig config, final Consumer<byte[], byte[]> consumer) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -116,9 +116,9 @@ public class StreamTaskTest {
     private final Serializer<Integer> intSerializer = Serdes.Integer().serializer();
     private final Deserializer<Integer> intDeserializer = Serdes.Integer().deserializer();
 
-    private final MockSourceNode<Integer, Integer> source1 = new MockSourceNode<>(new String[] {topic1}, intDeserializer, intDeserializer);
-    private final MockSourceNode<Integer, Integer> source2 = new MockSourceNode<>(new String[] {topic2}, intDeserializer, intDeserializer);
-    private final MockSourceNode<Integer, Integer> source3 = new MockSourceNode<Integer, Integer>(new String[] {topic2}, intDeserializer, intDeserializer) {
+    private final MockSourceNode<Integer, Integer> source1 = new MockSourceNode<>(intDeserializer, intDeserializer);
+    private final MockSourceNode<Integer, Integer> source2 = new MockSourceNode<>(intDeserializer, intDeserializer);
+    private final MockSourceNode<Integer, Integer> source3 = new MockSourceNode<Integer, Integer>(intDeserializer, intDeserializer) {
         @Override
         public void process(final Integer key, final Integer value) {
             throw new RuntimeException("KABOOM!");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2624,7 +2624,6 @@ public class TaskManagerTest {
         private Map<TopicPartition, OffsetAndMetadata> committableOffsets = Collections.emptyMap();
         private Map<TopicPartition, Long> purgeableOffsets;
         private Map<TopicPartition, Long> changelogOffsets = Collections.emptyMap();
-        private InternalProcessorContext processorContext = mock(InternalProcessorContext.class);
 
         private final Map<TopicPartition, LinkedList<ConsumerRecord<byte[], byte[]>>> queue = new HashMap<>();
 
@@ -2724,6 +2723,11 @@ public class TaskManagerTest {
         @Override
         public void closeAndRecycleState() {
             transitionTo(State.CLOSED);
+        }
+
+        @Override
+        public void update(final Set<TopicPartition> topicPartitions, final Map<String, List<String>> nodeToSourceTopics) {
+            inputPartitions = topicPartitions;
         }
 
         void setCommittableOffsetsAndMetadata(final Map<TopicPartition, OffsetAndMetadata> committableOffsets) {

--- a/streams/src/test/java/org/apache/kafka/test/MockSourceNode.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockSourceNode.java
@@ -16,13 +16,11 @@
  */
 package org.apache.kafka.test;
 
-
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.SourceNode;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class MockSourceNode<K, V> extends SourceNode<K, V> {
@@ -36,8 +34,8 @@ public class MockSourceNode<K, V> extends SourceNode<K, V> {
     public boolean initialized;
     public boolean closed;
 
-    public MockSourceNode(final String[] topics, final Deserializer<K> keyDeserializer, final Deserializer<V> valDeserializer) {
-        super(NAME + INDEX.getAndIncrement(), Arrays.asList(topics), keyDeserializer, valDeserializer);
+    public MockSourceNode(final Deserializer<K> keyDeserializer, final Deserializer<V> valDeserializer) {
+        super(NAME + INDEX.getAndIncrement(), keyDeserializer, valDeserializer);
     }
 
     @Override


### PR DESCRIPTION
Rather than recreate the entire topology when we find new regex matched input partitions, we can just update the relevant pieces.

Only the SourceNodes and ProcessorTopology seem to care about the input topics, and we can actually extract this information out of the SourceNode altogether by pulling it into the ProcessorTopology.

Should go to 2.6