### PR TITLE
MINOR: fix backwards incompatibility in JmxReporter introduced by KIP-606

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -332,6 +332,14 @@ public class JmxReporter implements MetricsReporter {
             if (!mbeans.isEmpty()) {
                 throw new IllegalStateException("JMX MetricsContext can only be updated before JMX metrics are created");
             }
+
+            // prevent prefix from getting reset back to empty for backwards compatibility
+            // with the deprecated JmxReporter(String prefix) constructor, in case contextChange gets called
+            // via one of the Metrics() constructor with a default empty MetricsContext()
+            if (namespace.isEmpty()) {
+                return;
+            }
+
             prefix = namespace;
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -175,4 +175,23 @@ public class JmxReporterTest {
             metrics.close();
         }
     }
+
+    @Test
+    public void testDeprecatedJmxPrefixWithDefaultMetrics() throws Exception {
+        @SuppressWarnings("deprecation")
+        JmxReporter reporter = new JmxReporter("my-prefix");
+
+        // for backwards compatibility, ensure prefix does not get overridden by the default empty namespace in metricscontext
+        MetricConfig metricConfig = new MetricConfig();
+        Metrics metrics = new Metrics(metricConfig, new ArrayList<>(Arrays.asList(reporter)), Time.SYSTEM);
+
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        try {
+            Sensor sensor = metrics.sensor("my-sensor");
+            sensor.add(metrics.metricName("pack.bean1.avg", "grp1"), new Avg());
+            assertEquals("my-prefix", server.getObjectInstance(new ObjectName("my-prefix:type=grp1")).getObjectName().getDomain());
+        } finally {
+            metrics.close();
+        }
+    }
 }


### PR DESCRIPTION
cc @omkreddy this should also get backported to 2.6.x