### PR TITLE
KAFKA-10111: Make SinkTaskContext.errantRecordReporter() a default method

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
@@ -119,6 +119,8 @@ public interface SinkTaskContext {
      * @return the reporter; null if no error reporter has been configured for the connector
      * @since 2.6
      */
-    ErrantRecordReporter errantRecordReporter();
+    default ErrantRecordReporter errantRecordReporter() {
+        return null;
+    }
 
 }


### PR DESCRIPTION
Connector projects may have their own mock or testing implementations of the `SinkTaskContext`, and this newly-added method should be a default method to prevent breaking those projects. Changing this to a default method that returns null also makes sense w/r/t the method semantics, since the method is already defined to return null if the reporter has not been configured.

This should be backported to `2.6`, since that's when [KIP-610](https://cwiki.apache.org/confluence/display/KAFKA/KIP-610%3A+Error+Reporting+in+Sink+Connectors) was introduced.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
