### PR TITLE
HOTFIX: fix validity check in sticky assignor tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -767,9 +767,12 @@ public abstract class AbstractStickyAssignorTest {
                 Map<String, List<Integer>> map = CollectionUtils.groupPartitionsByTopic(partitions);
                 Map<String, List<Integer>> otherMap = CollectionUtils.groupPartitionsByTopic(otherPartitions);
 
+                int moreLoaded = len > otherLen ? i : j;
+                int lessLoaded = len > otherLen ? j : i;
+
                 // If there's any overlap in the subscribed topics, we should have been able to balance partitions
                 for (String topic: map.keySet()) {
-                    assertFalse("Error: Some partitions can be moved from c" + i + " to c" + j
+                    assertFalse("Error: Some partitions can be moved from c" + moreLoaded + " to c" + lessLoaded
                             + " to achieve a better balance"
                             + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen
                             + " partitions."

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -767,32 +767,15 @@ public abstract class AbstractStickyAssignorTest {
                 Map<String, List<Integer>> map = CollectionUtils.groupPartitionsByTopic(partitions);
                 Map<String, List<Integer>> otherMap = CollectionUtils.groupPartitionsByTopic(otherPartitions);
 
-                if (len > otherLen) {
-                    for (String topic: map.keySet())
-                        if (otherMap.containsKey(topic))
-                            //assertTrue(true);
-                        assertFalse("Error: Some partitions can be moved from c" + i + " to c" + j
-                                + " to achieve a better balance"
-                                + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen
-                                + " partitions."
-                                + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments
-                                .toString(),
-                            otherMap.containsKey(topic));
-
-
-
-                }
-
-                if (otherLen > len) {
-                    for (String topic: otherMap.keySet())
-                        if (otherMap.containsKey(topic))
-                            //assertTrue(true);
-                        assertFalse("Error: Some partitions can be moved from c" + j + " to c" + i + " to achieve a better balance"
-                                + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen + " partitions."
-                                + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString(),
-                            map.containsKey(topic));
-
-
+                // If there's any overlap in the subscribed topics, we should have been able to balance partitions
+                for (String topic: map.keySet()) {
+                    assertFalse("Error: Some partitions can be moved from c" + i + " to c" + j
+                            + " to achieve a better balance"
+                            + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen
+                            + " partitions."
+                            + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments
+                            .toString(),
+                        otherMap.containsKey(topic));
                 }
             }
         }


### PR DESCRIPTION
Not sure what happened here, but there's a commented out line and incorrect indentation that checkstyle didn't catch. Not to mention the code itself is just generally questionable

Should be cherrypicked to 2.6, 2.5, and 2.4
