### PR TITLE
Kafka 5514: KafkaConsumer ignores default values in Properties object because of incorrect use of Properties object.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -1239,6 +1239,8 @@ public final class Utils {
                 if (val == null) val = properties.getProperty(propName);
                 map.put(propName, val);
             }
+        } catch (ClassCastException cce) {
+            throw new ConfigException("All property keys must be a string: " + properties.toString(), cce);
         }
         return map;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -214,6 +214,19 @@ public class KafkaProducerTest {
     }
 
     @Test
+    public void testConstructorWitDefaults() {
+        Properties defProps = new Properties();
+        defProps.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        Properties newProps = new Properties(defProps);
+
+        try {
+            new KafkaProducer<>(newProps, new StringSerializer(), new StringSerializer());
+        } catch (ConfigException e) {
+            fail("Constructor should have worked with default properties");
+        }
+    }
+
+    @Test
     public void testSerializerClose() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.CLIENT_ID_CONFIG, "testConstructorClose");

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -691,6 +691,7 @@ public class UtilsTest {
             props.put(1, 2);
             Utils.propsToMap(props);
         });
+
         assertValue(false);
         assertValue(1);
         assertValue("string");
@@ -698,11 +699,19 @@ public class UtilsTest {
         assertValue(Collections.emptySet());
         assertValue(Collections.emptyList());
         assertValue(Collections.emptyMap());
+
+        // Test respecting defaults
+        Properties defaults = new Properties();
+        defaults.setProperty("defaultKey", "defaultValue");
+        Properties newProps = new Properties(defaults);
+        newProps.setProperty("newKey", "newValue");
+        assertEquals("defaultValue", Utils.propsToMap(newProps).get("defaultKey"));
+        assertEquals("newValue", Utils.propsToMap(newProps).get("newKey"));
     }
 
     private static void assertValue(Object value) {
         Properties props = new Properties();
         props.put("key", value);
-        assertEquals(Utils.propsToMap(props).get("key"), value);
+        assertEquals(value, Utils.propsToMap(props).get("key"));
     }
 }


### PR DESCRIPTION
KafkaConsumer (and some other classes like KafkaProducer) does not respect defaults in Properties objects.  This is because a process translates the Properties to a Map in the Utils class which uses the underlying Hastable methods rather than the Propoerty methods.  This pull request corrects that to use the appropriate Properties methods a well as being backwards compatible for code that has been using the underlying Hashtable methods to contruct properties (there are differences due to the fact that Properties key and values must be Strings.

Performed full suite of unit test and integration tests.  Added unit tests for fix.

No documntation changes required as the behavior is the same.  The only slight difference is in the message for the ConfigException.

This contribution is my original work and I license this work to the project under the project's open source license.