### PR TITLE
KAFKA-7833: Add StateStore name conflict check in InternalTopologyBuilder

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -526,6 +526,9 @@ public class InternalTopologyBuilder {
         if (!allowOverride && stateFactory != null && stateFactory.builder != storeBuilder) {
             throw new TopologyException("A different StateStore has already been added with the name " + storeBuilder.name());
         }
+        if (globalStateBuilders.containsKey(storeBuilder.name())) {
+            throw new TopologyException("A different GlobalStateStore has already been added with the name " + storeBuilder.name());
+        }
 
         stateFactories.put(storeBuilder.name(), new StateStoreFactory<>(storeBuilder));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -381,6 +381,42 @@ public class InternalTopologyBuilderTest {
     }
 
     @Test
+    public void shouldNotAllowToAddStoresWithSameNameWhenFirstStoreIsGlobal() {
+        final StoreBuilder storeBuilder = new MockKeyValueStoreBuilder("store", false).withLoggingDisabled();
+        builder.addGlobalStore(
+                storeBuilder,
+                "global-store",
+                null,
+                null,
+                null,
+                "global-topic",
+                "global-processor",
+                new MockProcessorSupplier<>());
+        try {
+            builder.addStateStore(storeBuilder);
+            fail("Should throw TopologyException with store name conflict");
+        } catch (final TopologyException expected) { /* ok */ }
+    }
+
+    @Test
+    public void shouldNotAllowToAddStoresWithSameNameWhenSecondStoreIsGlobal() {
+        final StoreBuilder storeBuilder = new MockKeyValueStoreBuilder("store", false).withLoggingDisabled();
+        builder.addStateStore(storeBuilder);
+        try {
+            builder.addGlobalStore(
+                    storeBuilder,
+                    "global-store",
+                    null,
+                    null,
+                    null,
+                    "global-topic",
+                    "global-processor",
+                    new MockProcessorSupplier<>());
+            fail("Should throw TopologyException with store name conflict");
+        } catch (final TopologyException expected) { /* ok */ }
+    }
+
+    @Test
     public void testAddStateStore() {
         builder.addStateStore(storeBuilder);
         builder.setApplicationId("X");


### PR DESCRIPTION
*Summary of testing strategy (including rationale)
* Added two tests that calls `addGlobalStore` and `addStateStore` in two different orders
* Added check for name conflict with a global store in the `addStateStore` path

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
