### PR TITLE
KAFKA-9216: Enforce that Connect’s internal topics use `compact` cleanup policy

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -95,7 +94,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     protected final StatusBackingStore statusBackingStore;
     protected final ConfigBackingStore configBackingStore;
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
-    protected final AtomicBoolean running = new AtomicBoolean(false);
+    protected volatile boolean running = false;
 
     private Map<String, Connector> tempConnectors = new ConcurrentHashMap<>();
 
@@ -135,7 +134,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public boolean isRunning() {
-        return running.get();
+        return running;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -94,6 +95,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     protected final StatusBackingStore statusBackingStore;
     protected final ConfigBackingStore configBackingStore;
     private final ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy;
+    protected final AtomicBoolean running = new AtomicBoolean(false);
 
     private Map<String, Connector> tempConnectors = new ConcurrentHashMap<>();
 
@@ -129,6 +131,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         this.statusBackingStore.stop();
         this.configBackingStore.stop();
         this.worker.stop();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running.get();
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Connect.java
@@ -84,6 +84,10 @@ public class Connect {
         }
     }
 
+    public boolean isRunning() {
+        return herder.isRunning();
+    }
+
     // Visible for testing
     public URI restUrl() {
         return rest.serverUrl();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -59,6 +59,8 @@ public interface Herder {
 
     void stop();
 
+    boolean isRunning();
+
     /**
      * Get a list of connectors currently running in this cluster. This is a full list of connectors in the cluster gathered
      * from the current configuration. However, note

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -285,7 +285,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             startServices();
 
             log.info("Herder started");
-            running.set(true);
+            running = true;
 
             while (!stopping.get()) {
                 tick();
@@ -299,7 +299,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.error("Uncaught exception in herder work thread, exiting: ", t);
             Exit.exit(1);
         } finally {
-            running.set(false);
+            running = false;
         }
     }
 
@@ -638,7 +638,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
 
         log.info("Herder stopped");
-        running.set(false);
+        running = false;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -285,6 +285,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             startServices();
 
             log.info("Herder started");
+            running.set(true);
 
             while (!stopping.get()) {
                 tick();
@@ -297,6 +298,8 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         } catch (Throwable t) {
             log.error("Uncaught exception in herder work thread, exiting: ", t);
             Exit.exit(1);
+        } finally {
+            running.set(false);
         }
     }
 
@@ -635,6 +638,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
 
         log.info("Herder stopped");
+        running.set(false);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -92,7 +92,7 @@ public class StandaloneHerder extends AbstractHerder {
     public synchronized void start() {
         log.info("Herder starting");
         startServices();
-        running.set(true);
+        running = true;
         log.info("Herder started");
     }
 
@@ -115,7 +115,7 @@ public class StandaloneHerder extends AbstractHerder {
             worker.stopConnector(connName);
         }
         stopServices();
-        running.set(false);
+        running = false;
         log.info("Herder stopped");
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -92,6 +92,7 @@ public class StandaloneHerder extends AbstractHerder {
     public synchronized void start() {
         log.info("Herder starting");
         startServices();
+        running.set(true);
         log.info("Herder started");
     }
 
@@ -114,6 +115,7 @@ public class StandaloneHerder extends AbstractHerder {
             worker.stopConnector(connName);
         }
         stopServices();
+        running.set(false);
         log.info("Herder stopped");
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -492,7 +493,27 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
             public void run() {
                 log.debug("Creating admin client to manage Connect internal config topic");
                 try (TopicAdmin admin = new TopicAdmin(adminProps)) {
-                    admin.createTopics(topicDescription);
+                    // Create the topic if it doesn't exist
+                    Set<String> newTopics = admin.createTopics(topicDescription);
+                    if (!newTopics.contains(topic)) {
+                        // It already existed, so check that the topic cleanup policy is compact only and not delete
+                        log.debug("Using admin client to check cleanup policy of '{}' topic is '{}'", topic, TopicConfig.CLEANUP_POLICY_COMPACT);
+                        Set<String> cleanupPolicies = admin.topicCleanupPolicy(topic);
+                        String cleanupPolicyStr = String.join(",", cleanupPolicies);
+                        log.debug("Found cleanup policy for '{}' topic is '{}'", topic, cleanupPolicyStr);
+                        Set<String> expectedPolicies = Collections.singleton(TopicConfig.CLEANUP_POLICY_COMPACT);
+                        String expectedPolicyStr = String.join(",", expectedPolicies);
+                        if (cleanupPolicies != null && !cleanupPolicies.equals(expectedPolicies)) {
+                            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
+                                                       + "to have '%s=%s' to guarantee consistency and durability of "
+                                                       + "connector configurations, but found '%s'. "
+                                                       + "Correct the topic before restarting Connect.",
+                                    topic, DistributedConfig.CONFIG_TOPIC_CONFIG,
+                                    TopicConfig.CLEANUP_POLICY_CONFIG, expectedPolicyStr,
+                                    cleanupPolicyStr);
+                            throw new ConfigException(msg);
+                        }
+                    }
                 }
             }
         };

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -498,21 +498,8 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                     if (!newTopics.contains(topic)) {
                         // It already existed, so check that the topic cleanup policy is compact only and not delete
                         log.debug("Using admin client to check cleanup policy of '{}' topic is '{}'", topic, TopicConfig.CLEANUP_POLICY_COMPACT);
-                        Set<String> cleanupPolicies = admin.topicCleanupPolicy(topic);
-                        String cleanupPolicyStr = String.join(",", cleanupPolicies);
-                        log.debug("Found cleanup policy for '{}' topic is '{}'", topic, cleanupPolicyStr);
-                        Set<String> expectedPolicies = Collections.singleton(TopicConfig.CLEANUP_POLICY_COMPACT);
-                        String expectedPolicyStr = String.join(",", expectedPolicies);
-                        if (cleanupPolicies != null && !cleanupPolicies.equals(expectedPolicies)) {
-                            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
-                                                       + "to have '%s=%s' to guarantee consistency and durability of "
-                                                       + "connector configurations, but found '%s'. "
-                                                       + "Correct the topic before restarting Connect.",
-                                    topic, DistributedConfig.CONFIG_TOPIC_CONFIG,
-                                    TopicConfig.CLEANUP_POLICY_CONFIG, expectedPolicyStr,
-                                    cleanupPolicyStr);
-                            throw new ConfigException(msg);
-                        }
+                        admin.verifyTopicCleanupPolicyOnlyCompact(topic,
+                                DistributedConfig.CONFIG_TOPIC_CONFIG, "connector configurations");
                     }
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.Time;
@@ -40,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -106,7 +108,27 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
             public void run() {
                 log.debug("Creating admin client to manage Connect internal offset topic");
                 try (TopicAdmin admin = new TopicAdmin(adminProps)) {
-                    admin.createTopics(topicDescription);
+                    // Create the topic if it doesn't exist
+                    Set<String> newTopics = admin.createTopics(topicDescription);
+                    if (!newTopics.contains(topic)) {
+                        // It already existed, so check that the topic cleanup policy is compact only and not delete
+                        log.debug("Using admin client to check cleanup policy for '{}' topic is '{}'", topic, TopicConfig.CLEANUP_POLICY_COMPACT);
+                        Set<String> cleanupPolicies = admin.topicCleanupPolicy(topic);
+                        String cleanupPolicyStr = String.join(",", cleanupPolicies);
+                        log.debug("Found cleanup policy for '{}' topic is '{}'", topic, cleanupPolicyStr);
+                        Set<String> expectedPolicies = Collections.singleton(TopicConfig.CLEANUP_POLICY_COMPACT);
+                        String expectedPolicyStr = String.join(",", expectedPolicies);
+                        if (cleanupPolicies != null && !cleanupPolicies.equals(expectedPolicies)) {
+                            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
+                                                       + "to have '%s=%s' to guarantee consistency and durability of "
+                                                       + "source connector offsets, but found '%s'. "
+                                                       + "Correct the topic before restarting Connect.",
+                                    topic, DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG,
+                                    TopicConfig.CLEANUP_POLICY_CONFIG, expectedPolicyStr,
+                                    cleanupPolicyStr);
+                            throw new ConfigException(msg);
+                        }
+                    }
                 }
             }
         };

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -113,21 +113,8 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
                     if (!newTopics.contains(topic)) {
                         // It already existed, so check that the topic cleanup policy is compact only and not delete
                         log.debug("Using admin client to check cleanup policy for '{}' topic is '{}'", topic, TopicConfig.CLEANUP_POLICY_COMPACT);
-                        Set<String> cleanupPolicies = admin.topicCleanupPolicy(topic);
-                        String cleanupPolicyStr = String.join(",", cleanupPolicies);
-                        log.debug("Found cleanup policy for '{}' topic is '{}'", topic, cleanupPolicyStr);
-                        Set<String> expectedPolicies = Collections.singleton(TopicConfig.CLEANUP_POLICY_COMPACT);
-                        String expectedPolicyStr = String.join(",", expectedPolicies);
-                        if (cleanupPolicies != null && !cleanupPolicies.equals(expectedPolicies)) {
-                            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
-                                                       + "to have '%s=%s' to guarantee consistency and durability of "
-                                                       + "source connector offsets, but found '%s'. "
-                                                       + "Correct the topic before restarting Connect.",
-                                    topic, DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG,
-                                    TopicConfig.CLEANUP_POLICY_CONFIG, expectedPolicyStr,
-                                    cleanupPolicyStr);
-                            throw new ConfigException(msg);
-                        }
+                        admin.verifyTopicCleanupPolicyOnlyCompact(topic,
+                                DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "source connector offsets");
                     }
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -203,21 +203,8 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
                     if (!newTopics.contains(topic)) {
                         // It already existed, so check that the topic cleanup policy is compact only and not delete
                         log.debug("Using admin client to check cleanup policy of '{}' topic is '{}'", topic, TopicConfig.CLEANUP_POLICY_COMPACT);
-                        Set<String> cleanupPolicies = admin.topicCleanupPolicy(topic);
-                        String cleanupPolicyStr = String.join(",", cleanupPolicies);
-                        log.debug("Found cleanup policy for '{}' topic is '{}'", topic, cleanupPolicyStr);
-                        Set<String> expectedPolicies = Collections.singleton(TopicConfig.CLEANUP_POLICY_COMPACT);
-                        String expectedPolicyStr = String.join(",", expectedPolicies);
-                        if (cleanupPolicies != null && !cleanupPolicies.equals(expectedPolicies)) {
-                            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
-                                                       + "to have '%s=%s' to guarantee consistency and durability of "
-                                                       + "connector and task statuses, but found '%s'. "
-                                                       + "Correct the topic before restarting Connect.",
-                                    topic, DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG,
-                                    TopicConfig.CLEANUP_POLICY_CONFIG, expectedPolicyStr,
-                                    cleanupPolicyStr);
-                            throw new ConfigException(msg);
-                        }
+                        admin.verifyTopicCleanupPolicyOnlyCompact(topic,
+                                DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "connector and task statuses");
                     }
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -197,7 +198,27 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
             public void run() {
                 log.debug("Creating admin client to manage Connect internal status topic");
                 try (TopicAdmin admin = new TopicAdmin(adminProps)) {
-                    admin.createTopics(topicDescription);
+                    // Create the topic if it doesn't exist
+                    Set<String> newTopics = admin.createTopics(topicDescription);
+                    if (!newTopics.contains(topic)) {
+                        // It already existed, so check that the topic cleanup policy is compact only and not delete
+                        log.debug("Using admin client to check cleanup policy of '{}' topic is '{}'", topic, TopicConfig.CLEANUP_POLICY_COMPACT);
+                        Set<String> cleanupPolicies = admin.topicCleanupPolicy(topic);
+                        String cleanupPolicyStr = String.join(",", cleanupPolicies);
+                        log.debug("Found cleanup policy for '{}' topic is '{}'", topic, cleanupPolicyStr);
+                        Set<String> expectedPolicies = Collections.singleton(TopicConfig.CLEANUP_POLICY_COMPACT);
+                        String expectedPolicyStr = String.join(",", expectedPolicies);
+                        if (cleanupPolicies != null && !cleanupPolicies.equals(expectedPolicies)) {
+                            String msg = String.format("Topic '%s' supplied via the '%s' property is required "
+                                                       + "to have '%s=%s' to guarantee consistency and durability of "
+                                                       + "connector and task statuses, but found '%s'. "
+                                                       + "Correct the topic before restarting Connect.",
+                                    topic, DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG,
+                                    TopicConfig.CLEANUP_POLICY_CONFIG, expectedPolicyStr,
+                                    cleanupPolicyStr);
+                            throw new ConfigException(msg);
+                        }
+                    }
                 }
             }
         };

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -397,7 +397,7 @@ public class TopicAdmin implements AutoCloseable {
             String topicPurpose) {
         Set<String> cleanupPolicies = topicCleanupPolicy(topic);
         if (cleanupPolicies.isEmpty()) {
-            log.debug("Unable to use admin client to verify the cleanup policy of '{}' "
+            log.info("Unable to use admin client to verify the cleanup policy of '{}' "
                       + "topic is '{}', either because the broker is an older "
                       + "version or because the Kafka principal used for Connect "
                       + "internal topics does not have the required permission to "

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/InternalTopicsIntegrationTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.kafka.connect.integration;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.connect.util.clusters.WorkerHandle;
 import org.apache.kafka.test.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
@@ -29,6 +32,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertFalse;
 
 /**
  * Integration test for the creation of internal topics.
@@ -139,6 +144,98 @@ public class InternalTopicsIntegrationTest {
         // the status topic may have been created if timing was right but we don't care
         log.info("Verifying the internal topics for Connect");
         connect.assertions().assertTopicsDoNotExist(configTopic(), offsetTopic());
+    }
+
+    @Test
+    public void testFailToStartWhenInternalTopicsAreNotCompacted() throws InterruptedException {
+        // Change the broker default cleanup policy to something Connect doesn't like
+        brokerProps.put("log." + TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
+        // Start out using the improperly configured topics
+        workerProps.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "bad-config");
+        workerProps.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "bad-offset");
+        workerProps.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "bad-status");
+        workerProps.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
+        workerProps.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
+        workerProps.put(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG, "1");
+        int numWorkers = 0;
+        int numBrokers = 1;
+        connect = new EmbeddedConnectCluster.Builder().name("connect-cluster-1")
+                                                      .workerProps(workerProps)
+                                                      .numWorkers(numWorkers)
+                                                      .numBrokers(numBrokers)
+                                                      .brokerProps(brokerProps)
+                                                      .build();
+
+        // Start the brokers but not Connect
+        log.info("Starting {} Kafka brokers, but no Connect workers yet", numBrokers);
+        connect.start();
+        connect.assertions().assertExactlyNumBrokersAreUp(numBrokers, "Broker did not start in time.");
+        log.info("Completed startup of {} Kafka broker. Expected Connect worker to fail", numBrokers);
+
+        // Create the good topics
+        connect.kafka().createTopic("good-config", 1, 1, compactCleanupPolicy());
+        connect.kafka().createTopic("good-offset", 1, 1, compactCleanupPolicy());
+        connect.kafka().createTopic("good-status", 1, 1, compactCleanupPolicy());
+
+        // Create the poorly-configured topics
+        connect.kafka().createTopic("bad-config", 1, 1, deleteCleanupPolicy());
+        connect.kafka().createTopic("bad-offset", 1, 1, compactAndDeleteCleanupPolicy());
+        connect.kafka().createTopic("bad-status", 1, 1, emptyCleanupPolicy());
+
+        // Check the topics
+        log.info("Verifying the internal topics for Connect were manually created");
+        connect.assertions().assertTopicsExist("good-config", "good-offset", "good-status", "bad-config", "bad-offset", "bad-status");
+
+        // Try to start one worker, with three bad topics
+        WorkerHandle worker = connect.addWorker(); // should have failed to start before returning
+        assertFalse(worker.isRunning());
+        assertFalse(connect.allWorkersRunning());
+        assertFalse(connect.anyWorkersRunning());
+        connect.removeWorker(worker);
+
+        // We rely upon the fact that we can change the worker properties before the workers are started
+        workerProps.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "good-config");
+
+        // Try to start one worker, with two bad topics remaining
+        worker = connect.addWorker(); // should have failed to start before returning
+        assertFalse(worker.isRunning());
+        assertFalse(connect.allWorkersRunning());
+        assertFalse(connect.anyWorkersRunning());
+        connect.removeWorker(worker);
+
+        // We rely upon the fact that we can change the worker properties before the workers are started
+        workerProps.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "good-offset");
+
+        // Try to start one worker, with one bad topic remaining
+        worker = connect.addWorker(); // should have failed to start before returning
+        assertFalse(worker.isRunning());
+        assertFalse(connect.allWorkersRunning());
+        assertFalse(connect.anyWorkersRunning());
+        connect.removeWorker(worker);
+        // We rely upon the fact that we can change the worker properties before the workers are started
+        workerProps.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "good-status");
+
+        // Try to start one worker, now using all good internal topics
+        connect.addWorker();
+        connect.assertions().assertAtLeastNumWorkersAreUp(1, "Worker did not start in time.");
+    }
+
+    protected Map<String, String> compactCleanupPolicy() {
+        return Collections.singletonMap(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
+    }
+
+    protected Map<String, String> deleteCleanupPolicy() {
+        return Collections.singletonMap(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
+    }
+
+    protected Map<String, String> emptyCleanupPolicy() {
+        return Collections.emptyMap();
+    }
+
+    protected Map<String, String> compactAndDeleteCleanupPolicy() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE + "," + TopicConfig.CLEANUP_POLICY_COMPACT);
+        return config;
     }
 
     protected void assertInternalTopicSettings() throws InterruptedException {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.util;
 
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.admin.AdminClientUnitTestEnv;
+import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -27,6 +28,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
@@ -36,11 +38,14 @@ import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
+import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,6 +55,8 @@ import java.util.concurrent.ExecutionException;
 import static org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -261,6 +268,90 @@ public class TopicAdminTest {
         }
     }
 
+    @Test
+    public void describeTopicConfigShouldReturnEmptyMapWhenNoTopicsAreSpecified() {
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
+            env.kafkaClient().prepareResponse(describeConfigsResponseWithUnsupportedVersion(newTopic));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, Config> results = admin.describeTopicConfigs();
+            assertTrue(results.isEmpty());
+        }
+    }
+
+    @Test
+    public void describeTopicConfigShouldReturnEmptyMapWhenUnsupportedVersionFailure() {
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
+            env.kafkaClient().prepareResponse(describeConfigsResponseWithUnsupportedVersion(newTopic));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
+            assertTrue(results.isEmpty());
+        }
+    }
+
+    @Test
+    public void describeTopicConfigShouldReturnEmptyMapWhenClusterAuthorizationFailure() {
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
+            env.kafkaClient().prepareResponse(describeConfigsResponseWithClusterAuthorizationException(newTopic));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
+            assertTrue(results.isEmpty());
+        }
+    }
+
+    @Test
+    public void describeTopicConfigShouldReturnEmptyMapWhenTopicAuthorizationFailure() {
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(new MockTime(), cluster)) {
+            env.kafkaClient().prepareResponse(describeConfigsResponseWithTopicAuthorizationException(newTopic));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
+            assertTrue(results.isEmpty());
+        }
+    }
+
+    @Test
+    public void describeTopicConfigShouldReturnMapWithNullValueWhenTopicDoesNotExist() {
+        NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (TopicAdmin admin = new TopicAdmin(null, new MockAdminClient(cluster.nodes(), cluster.nodeById(0)))) {
+            Map<String, Config> results = admin.describeTopicConfigs(newTopic.name());
+            assertFalse(results.isEmpty());
+            assertEquals(1, results.size());
+            assertNull(results.get("myTopic"));
+        }
+    }
+
+    @Test
+    public void describeTopicConfigShouldReturnTopicConfigWhenTopicExists() {
+        String topicName = "myTopic";
+        NewTopic newTopic = TopicAdmin.defineTopic(topicName)
+                                      .config(Collections.singletonMap("foo", "bar"))
+                                      .partitions(1)
+                                      .compacted()
+                                      .build();
+        Cluster cluster = createCluster(1);
+        try (MockAdminClient mockAdminClient = new MockAdminClient(cluster.nodes(), cluster.nodeById(0))) {
+            TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(0, cluster.nodeById(0), cluster.nodes(), Collections.<Node>emptyList());
+            mockAdminClient.addTopic(false, topicName, Collections.singletonList(topicPartitionInfo), null);
+            TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
+            Map<String, Config> result = admin.describeTopicConfigs(newTopic.name());
+            assertFalse(result.isEmpty());
+            assertEquals(1, result.size());
+            Config config = result.get("myTopic");
+            assertNotNull(config);
+            config.entries().forEach(entry -> {
+                assertEquals(newTopic.configs().get(entry.name()), entry.value());
+            });
+        }
+    }
+
     private Cluster createCluster(int numNodes) {
         HashMap<Integer, Node> nodes = new HashMap<>();
         for (int i = 0; i < numNodes; ++i) {
@@ -363,4 +454,33 @@ public class TopicAdminTest {
         }
         return new MetadataResponse(response);
     }
+
+    private DescribeConfigsResponse describeConfigsResponseWithUnsupportedVersion(NewTopic... topics) {
+        return describeConfigsResponse(new ApiError(Errors.UNSUPPORTED_VERSION, "This version of the API is not supported"), topics);
+    }
+
+    private DescribeConfigsResponse describeConfigsResponseWithClusterAuthorizationException(NewTopic... topics) {
+        return describeConfigsResponse(new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED, "Not authorized to create topic(s)"), topics);
+    }
+
+    private DescribeConfigsResponse describeConfigsResponseWithTopicAuthorizationException(NewTopic... topics) {
+        return describeConfigsResponse(new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED, "Not authorized to create topic(s)"), topics);
+    }
+
+    private DescribeConfigsResponse describeConfigsResponse(ApiError error, NewTopic... topics) {
+        if (error == null) error = new ApiError(Errors.NONE, "");
+        Map<ConfigResource, DescribeConfigsResponse.Config> configs = new HashMap<>();
+        for (NewTopic topic : topics) {
+            ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topic.name());
+            DescribeConfigsResponse.ConfigSource source = DescribeConfigsResponse.ConfigSource.TOPIC_CONFIG;
+            Collection<DescribeConfigsResponse.ConfigEntry> entries = new ArrayList<>();
+            topic.configs().forEach((k, v) -> new DescribeConfigsResponse.ConfigEntry(
+                    k, v, source, false, false, Collections.emptySet()
+            ));
+            DescribeConfigsResponse.Config config = new DescribeConfigsResponse.Config(error, entries);
+            configs.put(resource, config);
+        }
+        return new DescribeConfigsResponse(1000, configs);
+    }
+
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -447,7 +447,7 @@ public class TopicAdminTest {
             TopicAdmin admin = new TopicAdmin(null, mockAdminClient);
             Set<String> policies = admin.topicCleanupPolicy("myTopic");
             assertEquals(1, policies.size());
-            assertEquals(TopicConfig.CLEANUP_POLICY_DELETE, policies.iterator().next());
+            assertEquals(TopicConfig.CLEANUP_POLICY_COMPACT, policies.iterator().next());
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -183,7 +183,9 @@ public class EmbeddedConnectCluster {
         WorkerHandle toRemove = null;
         for (Iterator<WorkerHandle> it = connectCluster.iterator(); it.hasNext(); toRemove = it.next()) {
         }
-        removeWorker(toRemove);
+        if (toRemove != null) {
+            removeWorker(toRemove);
+        }
     }
 
     /**
@@ -210,6 +212,24 @@ public class EmbeddedConnectCluster {
             log.error("Could not stop connect", e);
             throw new RuntimeException("Could not stop worker", e);
         }
+    }
+
+    /**
+     * Determine whether the Connect cluster has any workers running.
+     *
+     * @return true if any worker is running, or false otherwise
+     */
+    public boolean anyWorkersRunning() {
+        return workers().stream().anyMatch(WorkerHandle::isRunning);
+    }
+
+    /**
+     * Determine whether the Connect cluster has all workers running.
+     *
+     * @return true if all workers are running, or false otherwise
+     */
+    public boolean allWorkersRunning() {
+        return workers().stream().allMatch(WorkerHandle::isRunning);
     }
 
     @SuppressWarnings("deprecation")

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -174,7 +174,9 @@ public class EmbeddedKafkaCluster extends ExternalResource {
 
     private void stop(boolean deleteLogDirs, boolean stopZK) {
         try {
-            producer.close();
+            if (producer != null) {
+                producer.close();
+            }
         } catch (Exception e) {
             log.error("Could not shutdown producer ", e);
             throw new RuntimeException("Could not shutdown producer", e);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/WorkerHandle.java
@@ -58,6 +58,15 @@ public class WorkerHandle {
     }
 
     /**
+     * Determine if this worker is running.
+     *
+     * @return true if the worker is running, or false otherwise
+     */
+    public boolean isRunning() {
+        return worker.isRunning();
+    }
+
+    /**
      * Get the workers's name corresponding to this handle.
      *
      * @return the worker's name


### PR DESCRIPTION
Supplements #8270 

This change adds a check to the KafkaConfigBackingStore, KafkaOffsetBackingStore, and KafkaStatusBackingStore to use the admin client to verify that the internal topics are compacted and do not use the `delete` cleanup policy.

Connect already will create the internal topics with `cleanup.policy=compact` if the topics do not yet exist when the Connect workers are started; the new topics are created always as compacted, overwriting any user-specified `cleanup.policy`. However, if the topics already exist the worker did not previously verify the internal topics were compacted, such as when a user manually creates the internal topics before starting Connect or manually changes the topic settings after the fact.

The current change helps guard against users running Connect with topics that have delete cleanup policy enabled, which will remove all connector configurations, source offsets, and connector & task statuses that are older than the retention time. This means that, for example, the configuation for a long-running connector could be deleted by the broker, and this will cause restart issues upon a subsequent rebalance or restarting of Connect worker(s).

Connect behavior requires that its internal topics are compacted and not deleted after some retention time. Therefore, this additional check is simply enforcing the existing expectations, and therefore does not need a KIP.

Added unit tests for the new logic, and added an integration test that verifies that the worker will fail to start if each of the three internal topics does not use only `cleanup.policy=compact`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
