### PR TITLE
KAFKA-10115: Incorporate errors.tolerance with the Errant Record Reporter

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -556,8 +556,9 @@ class WorkerSinkTask extends WorkerTask {
             log.trace("{} Delivering batch of {} messages to task", this, messageBatch.size());
             long start = time.milliseconds();
             task.put(new ArrayList<>(messageBatch));
-            if (workerErrantRecordReporter != null && workerErrantRecordReporter.mustThrowException()) {
-                throw workerErrantRecordReporter.getExceptionToThrow();
+            if (retryWithToleranceOperator.failed() && !retryWithToleranceOperator.withinToleranceLimits()) {
+                throw new ConnectException("Tolerance exceeded in error handler",
+                    retryWithToleranceOperator.error());
             }
             recordBatch(messageBatch.size());
             sinkTaskMetricsGroup.recordPut(time.milliseconds() - start);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -556,6 +556,8 @@ class WorkerSinkTask extends WorkerTask {
             log.trace("{} Delivering batch of {} messages to task", this, messageBatch.size());
             long start = time.milliseconds();
             task.put(new ArrayList<>(messageBatch));
+            // if errors raised from the operator were swallowed by the task implementation, an
+            // exception needs to be thrown to kill the task indicating the tolerance was exceeded
             if (retryWithToleranceOperator.failed() && !retryWithToleranceOperator.withinToleranceLimits()) {
                 throw new ConnectException("Tolerance exceeded in error handler",
                     retryWithToleranceOperator.error());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -556,6 +556,9 @@ class WorkerSinkTask extends WorkerTask {
             log.trace("{} Delivering batch of {} messages to task", this, messageBatch.size());
             long start = time.milliseconds();
             task.put(new ArrayList<>(messageBatch));
+            if (workerErrantRecordReporter != null && workerErrantRecordReporter.mustThrowException()) {
+                throw workerErrantRecordReporter.getExceptionToThrow();
+            }
             recordBatch(messageBatch.size());
             sinkTaskMetricsGroup.recordPut(time.milliseconds() - start);
             currentOffsets.putAll(origOffsets);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.runtime.errors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -93,10 +92,10 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         context.consumerRecord(consumerRecord);
         context.currentContext(stage, executingClass);
         context.error(error);
-        errorHandlingMetrics.recordError();
         errorHandlingMetrics.recordFailure();
         Future<Void> errantRecordFuture = context.report();
         if (!withinToleranceLimits()) {
+            errorHandlingMetrics.recordError();
             throw new ConnectException("Tolerance exceeded in the errant record reporter", error);
         }
         return errantRecordFuture;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperator.java
@@ -96,7 +96,7 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         Future<Void> errantRecordFuture = context.report();
         if (!withinToleranceLimits()) {
             errorHandlingMetrics.recordError();
-            throw new ConnectException("Tolerance exceeded in the errant record reporter", error);
+            throw new ConnectException("Tolerance exceeded in error handler", error);
         }
         return errantRecordFuture;
     }
@@ -207,9 +207,8 @@ public class RetryWithToleranceOperator implements AutoCloseable {
         totalFailures++;
     }
 
-    // Visible for testing
     @SuppressWarnings("fallthrough")
-    boolean withinToleranceLimits() {
+    public boolean withinToleranceLimits() {
         switch (errorToleranceType) {
             case NONE:
                 if (totalFailures > 0) return false;
@@ -287,6 +286,15 @@ public class RetryWithToleranceOperator implements AutoCloseable {
      */
     public boolean failed() {
         return this.context.failed();
+    }
+
+    /**
+     * Returns the error encountered when processing the current stage.
+     *
+     * @return the error encountered when processing the current stage
+     */
+    public Throwable error() {
+        return this.context.error();
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporter.java
@@ -47,9 +47,6 @@ public class WorkerErrantRecordReporter implements ErrantRecordReporter {
     private final Converter valueConverter;
     private final HeaderConverter headerConverter;
 
-    private boolean mustThrowException = false;
-    private Throwable exceptionToThrow = null;
-
     // Visible for testing
     protected final LinkedList<Future<Void>> futures;
 
@@ -102,15 +99,7 @@ public class WorkerErrantRecordReporter implements ErrantRecordReporter {
                 valLength, key, value, headers);
         }
 
-        Future<Void> future;
-        try {
-            future = retryWithToleranceOperator.executeFailed(Stage.TASK_PUT,
-                SinkTask.class, consumerRecord, error);
-        } catch (ConnectException e) {
-            mustThrowException = true;
-            exceptionToThrow = e;
-            throw e;
-        }
+        Future<Void> future = retryWithToleranceOperator.executeFailed(Stage.TASK_PUT, SinkTask.class, consumerRecord, error);
 
         if (!future.isDone()) {
             futures.add(future);
@@ -173,23 +162,5 @@ public class WorkerErrantRecordReporter implements ErrantRecordReporter {
             }
             return null;
         }
-    }
-
-    /**
-     * Returns whether or not the Errant Record Reporter must throw an exception.
-     *
-     * @return boolean indicating whether the Errant Record Reporter must throw an exception
-     */
-    public boolean mustThrowException() {
-        return mustThrowException;
-    }
-
-    /**
-     * Returns the exception that must be thrown by the Errant Record Reporter.
-     *
-     * @return throwable that the Errant Record Reporter must throw
-     */
-    public Throwable getExceptionToThrow() {
-        return exceptionToThrow;
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -181,6 +181,74 @@ public class ErrorHandlingIntegrationTest {
 
     }
 
+    @Test
+    public void testErrantRecordReporter() throws Exception {
+        // create test topic
+        connect.kafka().createTopic("test-topic");
+
+        // setup connector config
+        Map<String, String> props = new HashMap<>();
+        props.put(CONNECTOR_CLASS_CONFIG, ErrantRecordSinkConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
+        props.put(TOPICS_CONFIG, "test-topic");
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+
+        // log all errors, along with message metadata
+        props.put(ERRORS_LOG_ENABLE_CONFIG, "true");
+        props.put(ERRORS_LOG_INCLUDE_MESSAGES_CONFIG, "true");
+
+        // produce bad messages into dead letter queue
+        props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC);
+        props.put(DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, "true");
+        props.put(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
+
+        // tolerate all erros
+        props.put(ERRORS_TOLERANCE_CONFIG, "all");
+
+        // retry for up to one second
+        props.put(ERRORS_RETRY_TIMEOUT_CONFIG, "1000");
+
+        // set expected records to successfully reach the task
+        connectorHandle.taskHandle(TASK_ID).expectedRecords(EXPECTED_CORRECT_RECORDS);
+
+        connect.configureConnector(CONNECTOR_NAME, props);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
+            "Connector tasks did not start in time.");
+
+        waitForCondition(this::checkForPartitionAssignment,
+            CONNECTOR_SETUP_DURATION_MS,
+            "Connector task was not assigned a partition.");
+
+        // produce some strings into test topic
+        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+            connect.kafka().produce("test-topic", "key-" + i, "value-" + i);
+        }
+
+        // consume all records from test topic
+        log.info("Consuming records from test topic");
+        int i = 0;
+        for (ConsumerRecord<byte[], byte[]> rec : connect.kafka().consume(NUM_RECORDS_PRODUCED, CONSUME_MAX_DURATION_MS, "test-topic")) {
+            String k = new String(rec.key());
+            String v = new String(rec.value());
+            log.debug("Consumed record (key='{}', value='{}') from topic {}", k, v, rec.topic());
+            assertEquals("Unexpected key", k, "key-" + i);
+            assertEquals("Unexpected value", v, "value-" + i);
+            i++;
+        }
+
+        // wait for records to reach the task
+        connectorHandle.taskHandle(TASK_ID).awaitRecords(CONSUME_MAX_DURATION_MS);
+
+        // consume failed records from dead letter queue topic
+        log.info("Consuming records from test topic");
+        ConsumerRecords<byte[], byte[]> messages = connect.kafka().consume(EXPECTED_INCORRECT_RECORDS, CONSUME_MAX_DURATION_MS, DLQ_TOPIC);
+
+        connect.deleteConnector(CONNECTOR_NAME);
+        connect.assertions().assertConnectorAndTasksAreStopped(CONNECTOR_NAME,
+            "Connector tasks did not stop in time.");
+    }
+
     /**
      * Check if a partition was assigned to each task. This method swallows exceptions since it is invoked from a
      * {@link org.apache.kafka.test.TestUtils#waitForCondition} that will throw an error if this method continued

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.integration;
 
-import org.apache.kafka.connect.runtime.errors.ToleranceType;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
@@ -34,11 +33,9 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.DEFAULT_TOPIC_CREATION_PREFIX;
 import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
@@ -68,9 +65,6 @@ public class ExampleConnectIntegrationTest {
     private static final String CONNECTOR_NAME = "simple-conn";
     private static final String SINK_CONNECTOR_CLASS_NAME = MonitorableSinkConnector.class.getSimpleName();
     private static final String SOURCE_CONNECTOR_CLASS_NAME = MonitorableSourceConnector.class.getSimpleName();
-    private static final String DLQ_TOPIC = "dlq-topic";
-    private static final String ERRANT_RECORD_SINK_CONNECTOR_CLASS_NAME =
-        ErrantRecordSinkConnector.class.getSimpleName();
 
     private EmbeddedConnectCluster connect;
     private ConnectorHandle connectorHandle;
@@ -220,72 +214,6 @@ public class ExampleConnectIntegrationTest {
         int recordNum = connect.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count();
         assertTrue("Not enough records produced by source connector. Expected at least: " + NUM_RECORDS_PRODUCED + " + but got " + recordNum,
                 recordNum >= NUM_RECORDS_PRODUCED);
-
-        // delete connector
-        connect.deleteConnector(CONNECTOR_NAME);
-    }
-
-    @Test
-    public void testErrantRecordReporter() throws Exception {
-        connect.kafka().createTopic(DLQ_TOPIC, 1);
-        // create test topic
-        connect.kafka().createTopic("test-topic", NUM_TOPIC_PARTITIONS);
-
-        // setup up props for the sink connector
-        Map<String, String> props = new HashMap<>();
-        props.put(CONNECTOR_CLASS_CONFIG, ERRANT_RECORD_SINK_CONNECTOR_CLASS_NAME);
-        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
-        props.put(TOPICS_CONFIG, "test-topic");
-        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-        props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC);
-        props.put(ERRORS_TOLERANCE_CONFIG, ToleranceType.ALL.value());
-
-        // expect all records to be consumed by the connector
-        connectorHandle.expectedRecords(NUM_RECORDS_PRODUCED);
-
-        // expect all records to be consumed by the connector
-        connectorHandle.expectedCommits(NUM_RECORDS_PRODUCED);
-
-        // validate the intended connector configuration, a config that errors
-        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(ERRANT_RECORD_SINK_CONNECTOR_CLASS_NAME, props, 1,
-            "Validating connector configuration produced an unexpected number or errors.");
-
-        // add missing configuration to make the config valid
-        props.put("name", CONNECTOR_NAME);
-
-        // validate the intended connector configuration, a valid config
-        connect.assertions().assertExactlyNumErrorsOnConnectorConfigValidation(ERRANT_RECORD_SINK_CONNECTOR_CLASS_NAME, props, 0,
-            "Validating connector configuration produced an unexpected number or errors.");
-
-        // start a sink connector
-        connect.configureConnector(CONNECTOR_NAME, props);
-
-        waitForCondition(this::checkForPartitionAssignment,
-            CONNECTOR_SETUP_DURATION_MS,
-            "Connector tasks were not assigned a partition each.");
-
-        // produce some messages into source topic partitions
-        for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
-            connect.kafka().produce("test-topic", i % NUM_TOPIC_PARTITIONS, "key", "simple-message-value-" + i);
-        }
-
-        // consume all records from the source topic or fail, to ensure that they were correctly produced.
-        assertEquals("Unexpected number of records consumed", NUM_RECORDS_PRODUCED,
-            connect.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic").count());
-
-        // wait for the connector tasks to consume all records.
-        connectorHandle.awaitRecords(RECORD_TRANSFER_DURATION_MS);
-
-        // wait for the connector tasks to commit all records.
-        connectorHandle.awaitCommits(RECORD_TRANSFER_DURATION_MS);
-
-        // consume all records from the dlq topic or fail, to ensure that they were correctly produced
-        int recordNum = connect.kafka().consume(
-            NUM_RECORDS_PRODUCED,
-            RECORD_TRANSFER_DURATION_MS,
-            DLQ_TOPIC
-        ).count();
 
         // delete connector
         connect.deleteConnector(CONNECTOR_NAME);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.connect.runtime.errors.ToleranceType;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
@@ -33,6 +34,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
@@ -237,6 +239,7 @@ public class ExampleConnectIntegrationTest {
         props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
         props.put(DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC);
+        props.put(ERRORS_TOLERANCE_CONFIG, ToleranceType.ALL.value());
 
         // expect all records to be consumed by the connector
         connectorHandle.expectedRecords(NUM_RECORDS_PRODUCED);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskWithTopicCreationTest.java
@@ -319,6 +319,8 @@ public class ErrorHandlingTaskWithTopicCreationTest {
 
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andReturn(records(record1));
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andReturn(records(record2));
+        EasyMock.expect(workerErrantRecordReporter.mustThrowException()).andReturn(false);
+        EasyMock.expect(workerErrantRecordReporter.mustThrowException()).andReturn(false);
 
         sinkTask.put(EasyMock.anyObject());
         EasyMock.expectLastCall().times(2);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ErrorHandlingTaskWithTopicCreationTest.java
@@ -319,8 +319,6 @@ public class ErrorHandlingTaskWithTopicCreationTest {
 
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andReturn(records(record1));
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andReturn(records(record2));
-        EasyMock.expect(workerErrantRecordReporter.mustThrowException()).andReturn(false);
-        EasyMock.expect(workerErrantRecordReporter.mustThrowException()).andReturn(false);
 
         sinkTask.put(EasyMock.anyObject());
         EasyMock.expectLastCall().times(2);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -100,6 +100,16 @@ public class RetryWithToleranceOperatorTest {
     @Test
     public void testExecuteFailed() {
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(0,
+            ERRORS_RETRY_MAX_DELAY_DEFAULT, ALL, SYSTEM);
+        retryWithToleranceOperator.metrics(errorHandlingMetrics);
+
+        retryWithToleranceOperator.executeFailed(Stage.TASK_PUT,
+            SinkTask.class, consumerRecord, new Throwable());
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testExecuteFailedNoTolerance() {
+        RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(0,
             ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, SYSTEM);
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
 


### PR DESCRIPTION
Currently, the errant record reporter doesn't take into account the value of `errors.tolerance.` Added a check if the reporter is within the tolerance limits; if not, then a `ConnectException` is thrown. This is essentially what is done across other parts of the `RetryAndToleranceOperator`.
