### PR TITLE
KAFKA-8657:Client-side automatic topic creation on Producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -416,6 +416,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 this.metadata = new ProducerMetadata(retryBackoffMs,
                         config.getLong(ProducerConfig.METADATA_MAX_AGE_CONFIG),
                         config.getLong(ProducerConfig.METADATA_MAX_IDLE_CONFIG),
+                        config.getBoolean(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG),
                         logContext,
                         clusterResourceListeners,
                         Time.SYSTEM);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -252,6 +252,14 @@ public class ProducerConfig extends AbstractConfig {
             "By default the TransactionId is not configured, which means transactions cannot be used. " +
             "Note that, by default, transactions require a cluster of at least three brokers which is the recommended setting for production; for development you can change this, by adjusting broker setting <code>transaction.state.log.replication.factor</code>.";
 
+    /** <code>allow.auto.create.topics</code> */
+    public static final String ALLOW_AUTO_CREATE_TOPICS_CONFIG = "allow.auto.create.topics";
+    public static final String ALLOW_AUTO_CREATE_TOPICS_DOC = "Allow automatic topic creation on the broker when" +
+            " subscribing to or assigning a topic. A topic being subscribed to will be automatically created only if the" +
+            " broker allows for it using `auto.create.topics.enable` broker configuration. This configuration must" +
+            " be set to `false` when using brokers older than 0.11.0";
+    public static final boolean DEFAULT_ALLOW_AUTO_CREATE_TOPICS = true;
+
     /**
      * <code>security.providers</code>
      */
@@ -405,6 +413,11 @@ public class ProducerConfig extends AbstractConfig {
                                         new ConfigDef.NonEmptyString(),
                                         Importance.LOW,
                                         TRANSACTIONAL_ID_DOC)
+                                .define(ALLOW_AUTO_CREATE_TOPICS_CONFIG,
+                                        Type.BOOLEAN,
+                                        DEFAULT_ALLOW_AUTO_CREATE_TOPICS,
+                                        Importance.MEDIUM,
+                                        ALLOW_AUTO_CREATE_TOPICS_DOC)
                                 .defineInternal(AUTO_DOWNGRADE_TXN_COMMIT,
                                         Type.BOOLEAN,
                                         false,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerMetadata.java
@@ -41,10 +41,12 @@ public class ProducerMetadata extends Metadata {
     private final Set<String> newTopics = new HashSet<>();
     private final Logger log;
     private final Time time;
+    private boolean allowAutoTopicCreation;
 
     public ProducerMetadata(long refreshBackoffMs,
                             long metadataExpireMs,
                             long metadataIdleMs,
+                            boolean allowAutoTopicCreation,
                             LogContext logContext,
                             ClusterResourceListeners clusterResourceListeners,
                             Time time) {
@@ -52,16 +54,17 @@ public class ProducerMetadata extends Metadata {
         this.metadataIdleMs = metadataIdleMs;
         this.log = logContext.logger(ProducerMetadata.class);
         this.time = time;
+        this.allowAutoTopicCreation = allowAutoTopicCreation;
     }
 
     @Override
     public synchronized MetadataRequest.Builder newMetadataRequestBuilder() {
-        return new MetadataRequest.Builder(new ArrayList<>(topics.keySet()), true);
+        return new MetadataRequest.Builder(new ArrayList<>(topics.keySet()), this.allowAutoTopicCreation);
     }
 
     @Override
     public synchronized MetadataRequest.Builder newMetadataRequestBuilderForNewTopics() {
-        return new MetadataRequest.Builder(new ArrayList<>(newTopics), true);
+        return new MetadataRequest.Builder(new ArrayList<>(newTopics), this.allowAutoTopicCreation);
     }
 
     public synchronized void add(String topic, long nowMs) {
@@ -154,6 +157,10 @@ public class ProducerMetadata extends Metadata {
     public synchronized void close() {
         super.close();
         notifyAll();
+    }
+
+    public boolean allowAutoTopicCreation() {
+        return allowAutoTopicCreation;
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -561,7 +561,7 @@ public class KafkaProducerTest {
         long metadataIdleMs = 60000L;
         final Time time = new MockTime();
         final ProducerMetadata metadata = new ProducerMetadata(refreshBackoffMs, metadataExpireMs, metadataIdleMs,
-                new LogContext(), new ClusterResourceListeners(), time);
+                true, new LogContext(), new ClusterResourceListeners(), time);
         final String topic = "topic";
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(),
                 new StringSerializer(), metadata, new MockClient(time, metadata), null, time)) {
@@ -595,7 +595,7 @@ public class KafkaProducerTest {
         long metadataIdleMs = 60000L;
         final Time time = new MockTime();
         final ProducerMetadata metadata = new ProducerMetadata(refreshBackoffMs, metadataExpireMs, metadataIdleMs,
-                new LogContext(), new ClusterResourceListeners(), time);
+                true, new LogContext(), new ClusterResourceListeners(), time);
         final String topic = "topic";
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(configs, new StringSerializer(),
                 new StringSerializer(), metadata, new MockClient(time, metadata), null, time)) {
@@ -1051,7 +1051,7 @@ public class KafkaProducerTest {
         Time time = Time.SYSTEM;
         MetadataResponse initialUpdateResponse = TestUtils.metadataUpdateWith(1, emptyMap());
         ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE,
-                new LogContext(), new ClusterResourceListeners(), time);
+                true, new LogContext(), new ClusterResourceListeners(), time);
         metadata.updateWithCurrentRequestVersion(initialUpdateResponse, false, time.milliseconds());
         MockClient client = new MockClient(time, metadata);
 
@@ -1191,7 +1191,7 @@ public class KafkaProducerTest {
 
     private ProducerMetadata newMetadata(long refreshBackoffMs, long expirationMs) {
         return new ProducerMetadata(refreshBackoffMs, expirationMs, defaultMetadataIdleMs,
-                new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
+                true, new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
@@ -47,7 +47,7 @@ public class ProducerMetadataTest {
     private long refreshBackoffMs = 100;
     private long metadataExpireMs = 1000;
     private ProducerMetadata metadata = new ProducerMetadata(refreshBackoffMs, metadataExpireMs, METADATA_IDLE_MS,
-            new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
+            true, new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
     private AtomicReference<Exception> backgroundError = new AtomicReference<>();
 
     @After

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -131,7 +131,7 @@ public class SenderTest {
     private MockTime time = new MockTime();
     private int batchSize = 16 * 1024;
     private ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, TOPIC_IDLE_MS,
-            new LogContext(), new ClusterResourceListeners(), time);
+            true, new LogContext(), new ClusterResourceListeners(), time);
     private MockClient client = new MockClient(time, metadata);
     private ApiVersions apiVersions = new ApiVersions();
     private Metrics metrics = null;
@@ -1299,7 +1299,6 @@ public class SenderTest {
         Sender sender = new Sender(logContext, client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, 10,
             senderMetrics, time, REQUEST_TIMEOUT, RETRY_BACKOFF_MS, transactionManager, apiVersions);
 
-        Future<RecordMetadata> failedResponse = appendToAccumulator(tp0);
         Future<RecordMetadata> successfulResponse = appendToAccumulator(tp1);
         sender.runOnce();  // connect and send.
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -130,7 +130,7 @@ public class TransactionManagerTest {
     private final LogContext logContext = new LogContext();
     private final MockTime time = new MockTime();
     private final ProducerMetadata metadata = new ProducerMetadata(0, Long.MAX_VALUE, Long.MAX_VALUE,
-            logContext, new ClusterResourceListeners(), time);
+            true, logContext, new ClusterResourceListeners(), time);
     private final MockClient client = new MockClient(time, metadata);
     private final ApiVersions apiVersions = new ApiVersions();
 

--- a/core/src/test/scala/integration/kafka/api/ProducerTopicCreationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerTopicCreationTest.scala
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.api
+
+import java.lang.{Boolean => JBoolean}
+
+import kafka.server.KafkaConfig
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import java.util.concurrent.ExecutionException
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import org.scalatest.Assertions.intercept
+
+/**
+ * Tests behavior of specifying auto topic creation configuration for the consumer and broker
+ */
+@RunWith(value = classOf[Parameterized])
+class ProducerTopicCreationTest(brokerAutoTopicCreationEnable: JBoolean, producerAllowAutoCreateTopics: JBoolean) extends IntegrationTestHarness {
+  override protected def brokerCount: Int = 1
+
+  val topic = "topic"
+  val producerClientId = "TestProducer"
+
+  // configure server properties
+  this.serverConfig.setProperty(KafkaConfig.ControlledShutdownEnableProp, "false") // speed up shutdown
+  this.serverConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableProp, brokerAutoTopicCreationEnable.toString)
+
+  // configure client properties
+  this.producerConfig.setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
+  this.producerConfig.setProperty(ProducerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, producerAllowAutoCreateTopics.toString)
+
+  @Test
+  def testAutoTopicCreation(): Unit = {
+    val producer = createProducer()
+    val record = new ProducerRecord(topic, 0, "key".getBytes, "value".getBytes)
+    if (!(brokerAutoTopicCreationEnable && producerAllowAutoCreateTopics )) {
+      intercept[ExecutionException] {
+      producer.send(record).get
+      }
+    } else {
+    producer.send(record).get
+    // MetadataRequest is guaranteed to create the topic znode if creation was required
+    val topicCreated = zkClient.getAllTopicsInCluster().contains(topic)
+    assertTrue(topicCreated)
+    }
+  }
+}
+
+object ProducerTopicCreationTest {
+  @Parameters(name = "brokerTopicCreation={0}, producerTopicCreation={1}")
+  def parameters: java.util.Collection[Array[Object]] = {
+    val data = new java.util.ArrayList[Array[Object]]()
+    for (brokerAutoTopicCreationEnable <- Array(JBoolean.TRUE, JBoolean.FALSE))
+      for (producerAutoCreateTopicsPolicy <- Array(JBoolean.TRUE, JBoolean.FALSE))
+        data.add(Array(brokerAutoTopicCreationEnable, producerAutoCreateTopicsPolicy))
+    data
+  }
+}


### PR DESCRIPTION
Add support to configure allow.auto.create.topics.enable on producer client.
This patch is based on https://github.com/apache/kafka/pull/7075, with rebase
to current HEAD and add new test cases

Change-Id: I24444e152f7ca57e21fa6148cedc3428e2443732
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
