### PR TITLE
KAFKA-9441: remove prepareClose() to simplify task management

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
@@ -243,10 +243,6 @@ public class PartitionGroup {
         return allBuffered;
     }
 
-    void close() {
-        clear();
-    }
-
     void clear() {
         for (final RecordQueue queue : partitionQueues.values()) {
             queue.clear();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -99,6 +99,8 @@ public class StandbyTask extends AbstractTask implements Task {
             processorContext.initialize();
 
             log.info("Initialized");
+        } else if (state() == State.RESTORING) {
+            throw new IllegalStateException("Illegal state " + state() + " while initializing standby task " + id);
         }
     }
 
@@ -119,6 +121,9 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public void resume() {
+        if (state() == State.RESTORING) {
+            throw new IllegalStateException("Illegal state " + state() + " while resuming standby task " + id);
+        }
         log.trace("No-op resume with state {}", state());
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -54,6 +53,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -444,7 +444,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
         switch (state()) {
             case CREATED:
+            case SUSPENDED:
+                stateMgr.recycle();
                 recordCollector.close();
+
                 break;
 
             case RESTORING: // we should have transitioned to `SUSPENDED` already

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -453,16 +453,16 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
     @Override
     public void closeAndRecycleState() {
+        suspendCleanAndPrepareCommit();
         writeCheckpointIfNeed();
 
         switch (state()) {
             case CREATED:
-            case RESTORING:
-            case RUNNING:
-            case SUSPENDED:
-                stateMgr.recycle();
                 recordCollector.close();
                 break;
+
+            case RESTORING: // we should have transitioned to `SUSPENDED` already
+            case RUNNING: // we should have transitioned to `SUSPENDED` already
             case CLOSED:
                 throw new IllegalStateException("Illegal state " + state() + " while recycling active task " + id);
             default:

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -123,13 +123,11 @@ public interface Task {
     /**
      * @throws StreamsException fatal error, should close the thread
      */
-    void prepareCommit();
+    Map<TopicPartition, OffsetAndMetadata> prepareCommit();
 
     void postCommit();
 
-    void suspendDirty();
-
-    void suspendCleanAndPrepareCommit();
+    void suspend();
 
     /**
      *
@@ -180,10 +178,6 @@ public interface Task {
     void markChangelogAsCorrupted(final Collection<TopicPartition> partitions);
 
     default Map<TopicPartition, Long> purgeableOffsets() {
-        return Collections.emptyMap();
-    }
-
-    default Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
         return Collections.emptyMap();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetPartitionTimeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetPartitionTimeIntegrationTest.java
@@ -45,11 +45,11 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
-import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
@@ -104,10 +104,9 @@ public class ResetPartitionTimeIntegrationTest {
         cleanStateBeforeTest(CLUSTER, 2, input, outputRaw);
 
         final StreamsBuilder builder = new StreamsBuilder();
-        builder.stream(
-                input,
-                Consumed.with(STRING_SERDE, STRING_SERDE))
-               .to(outputRaw);
+        builder
+            .stream(input, Consumed.with(STRING_SERDE, STRING_SERDE))
+            .to(outputRaw);
 
         final Properties streamsConfig = new Properties();
         streamsConfig.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MaxTimestampExtractor.class);
@@ -123,13 +122,13 @@ public class ResetPartitionTimeIntegrationTest {
             // start sending some records to have partition time committed 
             produceSynchronouslyToPartitionZero(
                 input,
-                asList(
+                Collections.singletonList(
                     new KeyValueTimestamp<>("k3", "v3", 5000)
                 )
             );
             verifyOutput(
                 outputRaw,
-                asList(
+                Collections.singletonList(
                     new KeyValueTimestamp<>("k3", "v3", 5000)
                 )
             );
@@ -144,13 +143,13 @@ public class ResetPartitionTimeIntegrationTest {
             // resend some records and retrieve the last committed timestamp
             produceSynchronouslyToPartitionZero(
                 input,
-                asList(
+                Collections.singletonList(
                     new KeyValueTimestamp<>("k5", "v5", 4999)
                 )
             );
             verifyOutput(
                 outputRaw,
-                asList(
+                Collections.singletonList(
                     new KeyValueTimestamp<>("k5", "v5", 4999)
                 )
             );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -423,26 +423,6 @@ public class PartitionGroupTest {
     }
 
     @Test
-    public void shouldCleanPartitionsOnClose() {
-        final List<ConsumerRecord<byte[], byte[]>> list = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
-        group.addRawRecords(partition1, list);
-        group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds());
-
-        group.close();
-
-        assertThat(group.numBuffered(), equalTo(0));
-        assertThat(group.streamTime(), equalTo(RecordQueue.UNKNOWN));
-        assertThat(group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds()), equalTo(null));
-        assertThat(group.partitionTimestamp(partition1), equalTo(RecordQueue.UNKNOWN));
-
-        // The partition1 should still be able to find.
-        assertThat(group.addRawRecords(partition1, list), equalTo(3));
-    }
-
-    @Test
     public void shouldUpdatePartitionQueuesShrink() {
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
                 new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -277,6 +277,7 @@ public class StandbyTaskTest {
         task.initializeIfNeeded();
         task.suspend();
         task.prepareCommit();
+        task.postCommit();
         task.closeClean();
 
         assertEquals(Task.State.CLOSED, task.state());
@@ -321,7 +322,6 @@ public class StandbyTaskTest {
     public void shouldThrowOnCloseCleanError() {
         stateManager.close();
         EasyMock.expectLastCall().andThrow(new RuntimeException("KABOOM!")).anyTimes();
-        EasyMock.expect(stateManager.changelogOffsets()).andReturn(Collections.singletonMap(partition, 50L));
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.singleton(partition)).anyTimes();
         EasyMock.replay(stateManager);
         final MetricName metricName = setupCloseTaskMetric();
@@ -449,11 +449,8 @@ public class StandbyTaskTest {
     public void shouldRecycleTask() {
         stateManager.flush();
         EasyMock.expectLastCall();
-        stateManager.checkpoint(Collections.emptyMap());
-        EasyMock.expectLastCall();
         stateManager.recycle();
         EasyMock.expectLastCall();
-        EasyMock.expect(stateManager.changelogOffsets()).andReturn(Collections.emptyMap());
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -137,7 +137,7 @@ public class StandbyTaskTest {
     public void cleanup() throws IOException {
         if (task != null) {
             try {
-                task.suspendDirty();
+                task.suspend();
             } catch (final IllegalStateException maybeSwallow) {
                 if (!maybeSwallow.getMessage().startsWith("Invalid transition from CLOSED to SUSPENDED")) {
                     throw maybeSwallow;
@@ -236,7 +236,7 @@ public class StandbyTaskTest {
 
         task = createStandbyTask();
         task.initializeIfNeeded();
-        task.suspendDirty();
+        task.suspend();
         task.closeDirty();
 
         assertEquals(Task.State.CLOSED, task.state());
@@ -256,7 +256,7 @@ public class StandbyTaskTest {
         task = createStandbyTask();
         task.initializeIfNeeded();
 
-        task.suspendDirty();
+        task.suspend();
         task.closeDirty();
 
         EasyMock.verify(stateManager);
@@ -275,7 +275,8 @@ public class StandbyTaskTest {
 
         task = createStandbyTask();
         task.initializeIfNeeded();
-        task.suspendCleanAndPrepareCommit();
+        task.suspend();
+        task.prepareCommit();
         task.closeClean();
 
         assertEquals(Task.State.CLOSED, task.state());
@@ -328,7 +329,7 @@ public class StandbyTaskTest {
         task = createStandbyTask();
         task.initializeIfNeeded();
 
-        task.suspendCleanAndPrepareCommit();
+        task.suspend();
         assertThrows(RuntimeException.class, () -> task.closeClean());
 
         final double expectedCloseTaskMetric = 0.0;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -444,6 +444,26 @@ public class StandbyTaskTest {
         assertEquals(Task.State.CLOSED, task.state());
     }
 
+    @Test
+    public void shouldRecycleTask() {
+        EasyMock.expectLastCall();
+        stateManager.flush();
+        EasyMock.expectLastCall();
+        stateManager.checkpoint(Collections.emptyMap());
+        EasyMock.expectLastCall();
+        stateManager.recycle();
+        EasyMock.expectLastCall();
+        EasyMock.expect(stateManager.changelogOffsets()).andReturn(Collections.emptyMap());
+        EasyMock.replay(stateManager);
+
+        task = createStandbyTask();
+        task.initializeIfNeeded();
+
+        task.closeAndRecycleState();
+
+        EasyMock.verify(stateManager);
+    }
+
     private StandbyTask createStandbyTask() {
 
         final ThreadCache cache = new ThreadCache(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -447,7 +447,6 @@ public class StandbyTaskTest {
 
     @Test
     public void shouldRecycleTask() {
-        EasyMock.expectLastCall();
         stateManager.flush();
         EasyMock.expectLastCall();
         stateManager.checkpoint(Collections.emptyMap());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -423,7 +423,7 @@ public class TaskManagerTest {
     public void shouldCloseDirtyActiveUnassignedSuspendedTasksWhenErrorCommittingRevokedTask() {
         final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
+            public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
                 throw new RuntimeException("KABOOM!");
             }
         };
@@ -604,7 +604,8 @@ public class TaskManagerTest {
 
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true, stateManager) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new RuntimeException("oops");
             }
         };
@@ -948,7 +949,6 @@ public class TaskManagerTest {
         taskManager.handleAssignment(assignmentActive, Collections.emptyMap());
 
         assertThat(task00.commitNeeded, is(true));
-        assertThat(task10.commitPrepared, is(false));
     }
 
     @Test
@@ -1070,10 +1070,11 @@ public class TaskManagerTest {
     }
 
     @Test
-    public void shouldPassUpIfExceptionDuringPrepareSuspend() {
+    public void shouldPassUpIfExceptionDuringSuspend() {
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new RuntimeException("KABOOM!");
             }
         };
@@ -1087,7 +1088,7 @@ public class TaskManagerTest {
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         assertThrows(RuntimeException.class, () -> taskManager.handleRevocation(taskId00Partitions));
-        assertThat(task00.state(), is(Task.State.RUNNING));
+        assertThat(task00.state(), is(Task.State.SUSPENDED));
 
         verify(consumer);
     }
@@ -1107,22 +1108,14 @@ public class TaskManagerTest {
                 return singletonList(changelog);
             }
         };
-        final AtomicBoolean prepareClosedDirtyTask01 = new AtomicBoolean(false);
-        final AtomicBoolean prepareClosedDirtyTask02 = new AtomicBoolean(false);
-        final AtomicBoolean prepareClosedDirtyTask03 = new AtomicBoolean(false);
         final AtomicBoolean closedDirtyTask01 = new AtomicBoolean(false);
         final AtomicBoolean closedDirtyTask02 = new AtomicBoolean(false);
         final AtomicBoolean closedDirtyTask03 = new AtomicBoolean(false);
         final Task task01 = new StateMachineTask(taskId01, taskId01Partitions, true) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new TaskMigratedException("migrated", new RuntimeException("cause"));
-            }
-
-            @Override
-            public void suspendDirty() {
-                super.suspendDirty();
-                prepareClosedDirtyTask01.set(true);
             }
 
             @Override
@@ -1133,14 +1126,9 @@ public class TaskManagerTest {
         };
         final Task task02 = new StateMachineTask(taskId02, taskId02Partitions, true) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new RuntimeException("oops");
-            }
-
-            @Override
-            public void suspendDirty() {
-                super.suspendDirty();
-                prepareClosedDirtyTask02.set(true);
             }
 
             @Override
@@ -1151,14 +1139,9 @@ public class TaskManagerTest {
         };
         final Task task03 = new StateMachineTask(taskId03, taskId03Partitions, true) {
             @Override
-            public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
+            public void suspend() {
+                super.suspend();
                 throw new RuntimeException("oops");
-            }
-
-            @Override
-            public void suspendDirty() {
-                super.suspendDirty();
-                prepareClosedDirtyTask03.set(true);
             }
 
             @Override
@@ -1215,12 +1198,10 @@ public class TaskManagerTest {
             RuntimeException.class,
             () -> taskManager.shutdown(true)
         );
+        assertThat(exception.getMessage(), equalTo("Unexpected exception while closing task"));
 
-        assertThat(prepareClosedDirtyTask01.get(), is(true));
         assertThat(closedDirtyTask01.get(), is(true));
-        assertThat(prepareClosedDirtyTask02.get(), is(true));
         assertThat(closedDirtyTask02.get(), is(true));
-        assertThat(prepareClosedDirtyTask03.get(), is(true));
         assertThat(closedDirtyTask03.get(), is(true));
         assertThat(task00.state(), is(Task.State.CLOSED));
         assertThat(task01.state(), is(Task.State.CLOSED));
@@ -1346,7 +1327,7 @@ public class TaskManagerTest {
 
         final StateMachineTask task01 = new StateMachineTask(taskId01, taskId01Partitions, true) {
             @Override
-            public void prepareCommit() {
+            public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
                 throw new RuntimeException("task 0_1 prepare commit boom!");
             }
         };
@@ -1451,13 +1432,15 @@ public class TaskManagerTest {
         };
         final Task task01 = new StateMachineTask(taskId01, taskId01Partitions, true) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new TaskMigratedException("migrated", new RuntimeException("cause"));
             }
         };
         final Task task02 = new StateMachineTask(taskId02, taskId02Partitions, true) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new RuntimeException("oops");
             }
         };
@@ -1817,7 +1800,7 @@ public class TaskManagerTest {
     public void shouldPropagateExceptionFromActiveCommit() {
         final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public void prepareCommit() {
+            public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
                 throw new RuntimeException("opsh.");
             }
         };
@@ -1844,7 +1827,7 @@ public class TaskManagerTest {
     public void shouldPropagateExceptionFromStandbyCommit() {
         final StateMachineTask task01 = new StateMachineTask(taskId01, taskId01Partitions, false) {
             @Override
-            public void prepareCommit() {
+            public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
                 throw new RuntimeException("opsh.");
             }
         };
@@ -2273,14 +2256,16 @@ public class TaskManagerTest {
     public void shouldThrowTaskMigratedWhenAllTaskCloseExceptionsAreTaskMigrated() {
         final StateMachineTask migratedTask01 = new StateMachineTask(taskId01, taskId01Partitions, false) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new TaskMigratedException("t1 close exception", new RuntimeException());
             }
         };
 
         final StateMachineTask migratedTask02 = new StateMachineTask(taskId02, taskId02Partitions, false) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new TaskMigratedException("t2 close exception", new RuntimeException());
             }
         };
@@ -2303,14 +2288,16 @@ public class TaskManagerTest {
     public void shouldThrowRuntimeExceptionWhenEncounteredUnknownExceptionDuringTaskClose() {
         final StateMachineTask migratedTask01 = new StateMachineTask(taskId01, taskId01Partitions, false) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new TaskMigratedException("t1 close exception", new RuntimeException());
             }
         };
 
         final StateMachineTask migratedTask02 = new StateMachineTask(taskId02, taskId02Partitions, false) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new IllegalStateException("t2 illegal state exception", new RuntimeException());
             }
         };
@@ -2332,14 +2319,16 @@ public class TaskManagerTest {
     public void shouldThrowSameKafkaExceptionWhenEncounteredDuringTaskClose() {
         final StateMachineTask migratedTask01 = new StateMachineTask(taskId01, taskId01Partitions, false) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new TaskMigratedException("t1 close exception", new RuntimeException());
             }
         };
 
         final StateMachineTask migratedTask02 = new StateMachineTask(taskId02, taskId02Partitions, false) {
             @Override
-            public void suspendCleanAndPrepareCommit() {
+            public void suspend() {
+                super.suspend();
                 throw new KafkaException("Kaboom for t2!", new RuntimeException());
             }
         };
@@ -2553,7 +2542,7 @@ public class TaskManagerTest {
         final Map<TopicPartition, OffsetAndMetadata> offsets = singletonMap(t1p0, new OffsetAndMetadata(0L, null));
         final StateMachineTask task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
+            public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
                 return offsets;
             }
         };
@@ -2677,8 +2666,9 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void prepareCommit() {
+        public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
             commitPrepared = true;
+            return committableOffsets;
         }
 
         @Override
@@ -2687,14 +2677,7 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void suspendDirty() {
-            if (state() == State.RUNNING) {
-                transitionTo(State.SUSPENDED);
-            }
-        }
-
-        @Override
-        public void suspendCleanAndPrepareCommit() {
+        public void suspend() {
             if (state() == State.RUNNING) {
                 transitionTo(State.SUSPENDED);
             }
@@ -2732,11 +2715,6 @@ public class TaskManagerTest {
                 throw new IllegalStateException("Cannot set CommittableOffsetsAndMetadate for StandbyTasks");
             }
             this.committableOffsets = committableOffsets;
-        }
-
-        @Override
-        public Map<TopicPartition, OffsetAndMetadata> committableOffsetsAndMetadata() {
-            return committableOffsets;
         }
 
         @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -613,8 +613,8 @@ public class TopologyTestDriver implements Closeable {
                 // Process the record ...
                 task.process(mockWallClockTime.milliseconds());
                 task.maybePunctuateStreamTime();
-                task.prepareCommit();
-                commit(task.committableOffsetsAndMetadata());
+                commit(task.prepareCommit());
+                task.postCommit();
                 captureOutputsAndReEnqueueInternalResults();
             }
             if (task.hasRecordsQueued()) {
@@ -759,8 +759,8 @@ public class TopologyTestDriver implements Closeable {
         mockWallClockTime.sleep(advance.toMillis());
         if (task != null) {
             task.maybePunctuateSystemTime();
-            task.prepareCommit();
-            commit(task.committableOffsetsAndMetadata());
+            commit(task.prepareCommit());
+            task.postCommit();
         }
         completeAllProcessableWork();
     }
@@ -1180,8 +1180,7 @@ public class TopologyTestDriver implements Closeable {
      */
     public void close() {
         if (task != null) {
-            task.suspendCleanAndPrepareCommit();
-            task.postCommit();
+            task.suspend();
             task.closeClean();
         }
         if (globalStateTask != null) {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -1180,7 +1180,8 @@ public class TopologyTestDriver implements Closeable {
      */
     public void close() {
         if (task != null) {
-            task.prepareCloseClean();
+            task.suspendCleanAndPrepareCommit();
+            task.postCommit();
             task.closeClean();
         }
         if (globalStateTask != null) {


### PR DESCRIPTION
- Removes `prepareCloseClean()` and `prepareCloseDirty()`.
- Removes state transition `RUNNING -> CLOSED` (tasks must be suspended before closing now)
- replaces `suspend()` with `suspendDirty` and `suspendAndPrepareCommit()`
- Decouples suspending/committing/closing (ie, no redundant code any longer, but enforces "linear" order of calls)

Call for review @guozhangwang @abbccdda @vvcephei @ableegoldman @cadonna 