### PR TITLE
MINOR: reduce sizeInBytes for percentiles metrics

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -534,12 +534,12 @@ public class MetricsTest {
     @Test
     public void testPercentilesWithRandomNumbersAndLinearBucketing() {
         long seed = new Random().nextLong();
-        int sizeInBytes = 1000 * 1000;   // 1MB
+        int sizeInBytes = 100 * 1000;   // 100kB
         long maximumValue = 1000 * 24 * 60 * 60 * 1000L; // if values are ms, max is 1000 days
 
         try {
             Random prng = new Random(seed);
-            int numberOfValues = 5000 + prng.nextInt(10_000);  // ranges is [5000, 15000]
+            int numberOfValues = 5000 + prng.nextInt(10_000);  // range is [5000, 15000]
 
             Percentiles percs = new Percentiles(sizeInBytes,
                                                 maximumValue,

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -534,7 +534,7 @@ public class MetricsTest {
     @Test
     public void testPercentilesWithRandomNumbersAndLinearBucketing() {
         long seed = new Random().nextLong();
-        int sizeInBytes = 500 * 1000;   // 500kB
+        int sizeInBytes = 100 * 1000;   // 100kB
         long maximumValue = 1000 * 24 * 60 * 60 * 1000L; // if values are ms, max is 1000 days
 
         try {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -534,7 +534,7 @@ public class MetricsTest {
     @Test
     public void testPercentilesWithRandomNumbersAndLinearBucketing() {
         long seed = new Random().nextLong();
-        int sizeInBytes = 100 * 1000;   // 100kB
+        int sizeInBytes = 500 * 1000;   // 500kB
         long maximumValue = 1000 * 24 * 60 * 60 * 1000L; // if values are ms, max is 1000 days
 
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -154,7 +154,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
     public static final String RATE_DESCRIPTION_SUFFIX = " per second";
 
-    private static final int PERCENTILES_SIZE_IN_BYTES = 1000 * 1000;    // 1 MB
+    private static final int PERCENTILES_SIZE_IN_BYTES = 100 * 1000;    // 100 kB
     private static double MAXIMUM_E2E_LATENCY = 10 * 24 * 60 * 60 * 1000d; // maximum latency is 10 days; values above that will be pinned
 
     public StreamsMetricsImpl(final Metrics metrics, final String clientId, final String builtInMetricsVersion) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -154,7 +154,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
     public static final String RATE_DESCRIPTION_SUFFIX = " per second";
 
-    private static final int PERCENTILES_SIZE_IN_BYTES = 100 * 1000;    // 100 kB
+    private static final int PERCENTILES_SIZE_IN_BYTES = 500 * 1000;    // 500 kB
     private static double MAXIMUM_E2E_LATENCY = 10 * 24 * 60 * 60 * 1000d; // maximum latency is 10 days; values above that will be pinned
 
     public StreamsMetricsImpl(final Metrics metrics, final String clientId, final String builtInMetricsVersion) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -154,7 +154,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
     public static final String RATE_DESCRIPTION_SUFFIX = " per second";
 
-    private static final int PERCENTILES_SIZE_IN_BYTES = 500 * 1000;    // 500 kB
+    private static final int PERCENTILES_SIZE_IN_BYTES = 100 * 1000;    // 100 kB
     private static double MAXIMUM_E2E_LATENCY = 10 * 24 * 60 * 60 * 1000d; // maximum latency is 10 days; values above that will be pinned
 
     public StreamsMetricsImpl(final Metrics metrics, final String clientId, final String builtInMetricsVersion) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -519,7 +519,7 @@ public class StreamTaskTest {
             task.maybeRecordE2ELatency(0L, sourceNode);
         }
 
-        double expectedAccuracy = 0.25d; // Make sure it's accurate to within 25% of the expected value
+        final double expectedAccuracy = 0.25d; // Make sure it's accurate to within 25% of the expected value
 
         assertEquals((double) p99Metric.metricValue(), 99d, 99 * expectedAccuracy);
         assertEquals((double) p90Metric.metricValue(), 90d, 90 * expectedAccuracy);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -519,8 +519,10 @@ public class StreamTaskTest {
             task.maybeRecordE2ELatency(0L, sourceNode);
         }
 
-        assertEquals((double) p99Metric.metricValue(), 99d, 5.0);
-        assertEquals((double) p90Metric.metricValue(), 90d, 5.0);
+        double expectedAccuracy = 0.25d; // Make sure it's accurate to within 25% of the expected value
+
+        assertEquals((double) p99Metric.metricValue(), 99d, 99 * expectedAccuracy);
+        assertEquals((double) p90Metric.metricValue(), 90d, 90 * expectedAccuracy);
     }
 
     @Test


### PR DESCRIPTION
The total amount of memory per Percentiles metric is actually the sizeInBytes * number of samples, where the default number of samples is 2. There are also at least 2 Percentiles metrics per task (and more when there are multiple sources or multiple terminal nodes). So the total memory we allocate for the current e2e latency metrics is `4 * sizeInBytes * numTasks`

The current sizeInBytes we chose was 1MB. This is still not particularly large, but may add up and cause unnecessary pressure for users running on lean machines.

I reduced the size to 100kB and still found it accurate enough* so we may as well reduce the size so we don't have to worry. (*1,000 runs of the randomized test all passed, meaning it was accurate to within 25% of the expected value)