### PR TITLE
KAFKA-10158 Fix flaky kafka.admin.TopicCommandWithAdminClientTest#testDescribeUnderReplicatedPartitionsWhenReassignmentIsInProgress

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -697,6 +697,10 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     assertTrue(simpleDescribeOutputRows(0).startsWith(s"Topic: $testTopicName"))
     assertEquals(2, simpleDescribeOutputRows.size)
 
+    // let's wait until the LAIR is NOT propagated
+    TestUtils.waitUntilTrue(() => !adminClient.listPartitionReassignments(Collections.singleton(tp)).reassignments().get().containsKey(tp),
+      "Reassignment is NOT completed")
+
     val underReplicatedOutput = TestUtils.grabConsoleOutput(
       topicService.describeTopic(new TopicCommandOptions(Array("--under-replicated-partitions"))))
     assertEquals(s"--under-replicated-partitions shouldn't return anything: '$underReplicatedOutput'", "", underReplicatedOutput)


### PR DESCRIPTION
```TopicCommandWithAdminClientTest.testDescribeUnderReplicatedPartitionsWhenReassignmentIsInProgress``` frequently fails on my local.

Altering the assignments is a async request so it is possible that the reassignment is still in progress when we start to verify the "under-replicated-partitions". In order to make it stable, it needs a wait for the reassignment completion before verifying the topic command with "under-replicated-partitions".

issue: https://issues.apache.org/jira/browse/KAFKA-10158

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
