### PR TITLE
KAFKA-10129 Fail QA if there are javadoc warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,8 @@ allprojects {
     // disable the crazy super-strict doclint tool in Java 8
     // noinspection SpellCheckingInspection
     options.addStringOption('Xdoclint:none', '-quiet')
+    // fail javadoc if there are javadoc warnings
+    options.addStringOption('Xwerror', '-quiet')
   }
 
 }

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -19,7 +19,7 @@
 # the modules are executed before the integration tests.
 
 # Run validation checks (compilation and static analysis)
-./gradlew clean compileJava compileScala compileTestJava compileTestScala \
+./gradlew clean compileJava compileScala compileTestJava compileTestScala javadoc \
     spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
     --profile --no-daemon --continue -PxmlSpotBugsReport=true "$@" \
     || { echo 'Validation steps failed'; exit 1; }


### PR DESCRIPTION
from @hachikuji  (https://github.com/apache/kafka/pull/8660#pullrequestreview-425856179)

> One other question I had is whether we should consider making doc failures also fail the build?

issue: https://issues.apache.org/jira/browse/KAFKA-10129

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
