### PR TITLE
KAFKA-9991: Fix flaky unit tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.streams.integration;
 
-
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
@@ -37,6 +36,7 @@ import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -52,30 +52,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 
 @Category({IntegrationTest.class})
 public class KTableSourceTopicRestartIntegrationTest {
     private static final int NUM_BROKERS = 3;
     private static final String SOURCE_TOPIC = "source-topic";
+    private static final Properties PRODUCER_CONFIG = new Properties();
+    private static final Properties STREAMS_CONFIG = new Properties();
 
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+
     private final Time time = CLUSTER.time;
-    private KafkaStreams streamsOne;
     private final StreamsBuilder streamsBuilder = new StreamsBuilder();
     private final Map<String, String> readKeyValues = new ConcurrentHashMap<>();
 
-    private static final Properties PRODUCER_CONFIG = new Properties();
-    private static final Properties STREAMS_CONFIG = new Properties();
+    private String sourceTopic;
+    private KafkaStreams streamsOne;
     private Map<String, String> expectedInitialResultsMap;
     private Map<String, String> expectedResultsWithDataWrittenDuringRestoreMap;
 
     @BeforeClass
-    public static void setUpBeforeAllTests() throws Exception {
-        CLUSTER.createTopic(SOURCE_TOPIC);
-
-        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, "ktable-restore-from-source");
+    public static void setUpBeforeAllTests() {
         STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
@@ -92,12 +90,22 @@ public class KTableSourceTopicRestartIntegrationTest {
         PRODUCER_CONFIG.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     }
 
+    @AfterClass
+    public static void tearDownAfterAllTests() throws InterruptedException {
+        CLUSTER.deleteAllTopicsAndWait(60000L);
+    }
+
     @Rule
     public TestName testName = new TestName();
 
     @Before
-    public void before() {
-        final KTable<String, String> kTable = streamsBuilder.table(SOURCE_TOPIC, Materialized.as("store"));
+    public void before() throws Exception {
+        sourceTopic = SOURCE_TOPIC + "-" + testName.getMethodName();
+        CLUSTER.createTopic(sourceTopic);
+
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, "ktable-restore-from-source-" + testName.getMethodName());
+
+        final KTable<String, String> kTable = streamsBuilder.table(sourceTopic, Materialized.as("store"));
         kTable.toStream().foreach(readKeyValues::put);
 
         expectedInitialResultsMap = createExpectedResultsMap("a", "b", "c");
@@ -107,7 +115,6 @@ public class KTableSourceTopicRestartIntegrationTest {
     @After
     public void after() throws Exception {
         IntegrationTestUtils.purgeLocalStreamsState(STREAMS_CONFIG);
-        CLUSTER.deleteAllTopicsAndWait(60000L);
     }
 
     @Test
@@ -208,14 +215,14 @@ public class KTableSourceTopicRestartIntegrationTest {
             errorMessage);
     }
 
-    private void produceKeyValues(final String... keys) throws ExecutionException, InterruptedException {
+    private void produceKeyValues(final String... keys) {
         final List<KeyValue<String, String>> keyValueList = new ArrayList<>();
 
         for (final String key : keys) {
             keyValueList.add(new KeyValue<>(key, key + "1"));
         }
 
-        IntegrationTestUtils.produceKeyValuesSynchronously(SOURCE_TOPIC,
+        IntegrationTestUtils.produceKeyValuesSynchronously(sourceTopic,
                                                            keyValueList,
                                                            PRODUCER_CONFIG,
                                                            time);
@@ -236,11 +243,7 @@ public class KTableSourceTopicRestartIntegrationTest {
                                    final String storeName,
                                    final long startingOffset,
                                    final long endingOffset) {
-            try {
-                produceKeyValues("d");
-            } catch (final ExecutionException | InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+            produceKeyValues("d");
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -36,7 +36,6 @@ import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -88,11 +87,6 @@ public class KTableSourceTopicRestartIntegrationTest {
         PRODUCER_CONFIG.put(ProducerConfig.ACKS_CONFIG, "all");
         PRODUCER_CONFIG.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         PRODUCER_CONFIG.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    }
-
-    @AfterClass
-    public static void tearDownAfterAllTests() throws InterruptedException {
-        CLUSTER.deleteAllTopicsAndWait(60000L);
     }
 
     @Rule


### PR DESCRIPTION
The latest commit #8254 on this test deleted all topics after each test, but the topic was actually shared among tests before. And after that we are relying on the less-reliable auto-topic generation to get the topic which makes the test flaky.

I'm now using different topics for different tests, also setting the app.id for tests differently.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
