### PR TITLE
KAFKA-10126:Add a warning message for ConsumerPerformance

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -258,7 +258,7 @@ object ConsumerPerformance extends LazyLogging {
     options = parser.parse(args: _*)
 
     if(options.has(numThreadsOpt) || options.has(numFetchersOpt))
-      println("WARNING: option threads and num-fetch-threads have been deprecated and ignored")
+      println("WARNING: option [threads] and [num-fetch-threads] have been deprecated and will be ignored by the test")
 
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps in performance test for the full zookeeper consumer")
 

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -232,12 +232,12 @@ object ConsumerPerformance extends LazyLogging {
       .describedAs("size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(2 * 1024 * 1024)
-    val numThreadsOpt = parser.accepts("threads", "Number of processing threads.")
+    val numThreadsOpt = parser.accepts("threads", "Number of processing threads. It has not been implemented.")
       .withRequiredArg
       .describedAs("count")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(10)
-    val numFetchersOpt = parser.accepts("num-fetch-threads", "Number of fetcher threads.")
+    val numFetchersOpt = parser.accepts("num-fetch-threads", "Number of fetcher threads. It has not been implemented.")
       .withRequiredArg
       .describedAs("count")
       .ofType(classOf[java.lang.Integer])
@@ -256,6 +256,10 @@ object ConsumerPerformance extends LazyLogging {
       .defaultsTo(10000)
 
     options = parser.parse(args: _*)
+
+    if(options.has(numThreadsOpt) || options.has(numFetchersOpt))
+      println("WARNING: option threads and num-fetch-threads has not been implemented.")
+
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps in performance test for the full zookeeper consumer")
 
     CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt)

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -232,12 +232,12 @@ object ConsumerPerformance extends LazyLogging {
       .describedAs("size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(2 * 1024 * 1024)
-    val numThreadsOpt = parser.accepts("threads", "Number of processing threads. It has not been implemented.")
+    val numThreadsOpt = parser.accepts("threads", "DEPRECATED AND IGNORED: Number of processing threads.")
       .withRequiredArg
       .describedAs("count")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(10)
-    val numFetchersOpt = parser.accepts("num-fetch-threads", "Number of fetcher threads. It has not been implemented.")
+    val numFetchersOpt = parser.accepts("num-fetch-threads", "DEPRECATED AND IGNORED: Number of fetcher threads.")
       .withRequiredArg
       .describedAs("count")
       .ofType(classOf[java.lang.Integer])
@@ -258,7 +258,7 @@ object ConsumerPerformance extends LazyLogging {
     options = parser.parse(args: _*)
 
     if(options.has(numThreadsOpt) || options.has(numFetchersOpt))
-      println("WARNING: option threads and num-fetch-threads has not been implemented.")
+      println("WARNING: option threads and num-fetch-threads have been deprecated and ignored")
 
     CommandLineUtils.printHelpAndExitIfNeeded(this, "This tool helps in performance test for the full zookeeper consumer")
 


### PR DESCRIPTION
ConsumerPerformance has not implemented options numThreadsOpt and numFetchersOpt as so far. This patch adds a warning message when used these options according to comments from https://issues.apache.org/jira/browse/KAFKA-10126 . Once these two options are implemented, this warning message should be removed.

Change-Id: Iae34b11210a361373eda42274ebfc153b636a989
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
