### PR TITLE
KAFKA-10141: Add more detail to log segment delete messages

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1791,10 +1791,12 @@ class Log(@volatile private var _dir: File,
         segment.largestRecordTimestamp match {
           case Some(ts) =>
             info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-              s" retentionMs breach. Largest record timestamp of segment is $ts")
+              s" retentionMs breach based on the largest record timestamp from the segment, which" +
+              s" is $ts")
           case None =>
             info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-              s" retentionMs breach. Last modified timestamp of segment is ${segment.lastModified}")
+              s" retentionMs breach based on the last modified timestamp from the segment, which" +
+              s" is ${segment.lastModified}")
         }
         true
       } else {
@@ -1812,7 +1814,8 @@ class Log(@volatile private var _dir: File,
       if (diff - segment.size >= 0) {
         diff -= segment.size
         info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-          s" retentionSize breach. Segment size is ${segment.size}")
+          s" retentionSize breach. Segment size is ${segment.size} and total log size after" +
+          s" deletion will be ${size - diff}")
         true
       } else {
         false

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1706,8 +1706,6 @@ class Log(@volatile private var _dir: File,
     lock synchronized {
       val deletable = deletableSegments(predicate)
       if (deletable.nonEmpty) {
-        info(s"Found deletable segments with base offsets" +
-          s" [${deletable.map(_.baseOffset).mkString(",")}]. Deleting ${deletable.size} segments.")
         deleteSegments(deletable)
       } else 0
     }
@@ -1791,12 +1789,12 @@ class Log(@volatile private var _dir: File,
         segment.largestRecordTimestamp match {
           case Some(ts) =>
             info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-              s" retentionMs breach based on the largest record timestamp from the segment, which" +
-              s" is $ts")
+              s" ${config.retentionMs} ms breach based on the largest record timestamp from the" +
+              s" segment, which is $ts")
           case None =>
             info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-              s" retentionMs breach based on the last modified timestamp from the segment, which" +
-              s" is ${segment.lastModified}")
+              s" ${config.retentionMs} ms breach based on the last modified timestamp from the" +
+              s" segment, which is ${segment.lastModified}")
         }
         true
       } else {
@@ -1814,8 +1812,8 @@ class Log(@volatile private var _dir: File,
       if (diff - segment.size >= 0) {
         diff -= segment.size
         info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-          s" retentionSize breach. Segment size is ${segment.size} and total log size after" +
-          s" deletion will be ${size - diff}")
+          s" ${config.retentionSize} breach. Segment size is ${segment.size} and total log size" +
+          s" after deletion will be ${size - diff}")
         true
       } else {
         false
@@ -1829,7 +1827,7 @@ class Log(@volatile private var _dir: File,
     def shouldDelete(segment: LogSegment, nextSegmentOpt: Option[LogSegment]) = {
       if (nextSegmentOpt.exists(_.baseOffset <= logStartOffset)) {
         info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-          s" startOffset breach. logStartOffset is ${logStartOffset}")
+          s" startOffset breach. logStartOffset is $logStartOffset")
         true
       } else {
         false

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1812,8 +1812,8 @@ class Log(@volatile private var _dir: File,
       if (diff - segment.size >= 0) {
         diff -= segment.size
         info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-          s" ${config.retentionSize} breach. Segment size is ${segment.size} and total log size" +
-          s" after deletion will be ${size - diff}")
+          s" retention size in bytes ${config.retentionSize} breach. Segment size is" +
+          s" ${segment.size} and total log size after deletion will be ${size - diff}")
         true
       } else {
         false

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1789,11 +1789,11 @@ class Log(@volatile private var _dir: File,
         segment.largestRecordTimestamp match {
           case Some(ts) =>
             info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-              s" ${config.retentionMs} ms breach based on the largest record timestamp from the" +
+              s" retention time ${config.retentionMs}ms breach based on the largest record timestamp from the" +
               s" segment, which is $ts")
           case None =>
             info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-              s" ${config.retentionMs} ms breach based on the last modified timestamp from the" +
+              s" retention time ${config.retentionMs}ms breach based on the last modified timestamp from the" +
               s" segment, which is ${segment.lastModified}")
         }
         true
@@ -1812,7 +1812,7 @@ class Log(@volatile private var _dir: File,
       if (diff - segment.size >= 0) {
         diff -= segment.size
         info(s"Segment with base offset ${segment.baseOffset} will be deleted due to" +
-          s" retention size in bytes ${config.retentionSize} breach. Segment size is" +
+          s" retention size ${config.retentionSize} bytes breach. Segment size is" +
           s" ${segment.size} and total log size after deletion will be ${size - diff}")
         true
       } else {

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -634,6 +634,11 @@ class LogSegment private[log] (val log: FileRecords,
   def lastModified = log.file.lastModified
 
   /**
+   * The largest timestamp this segment contains, if maxTimestampSoFar >= 0, otherwise None.
+   */
+  def largestRecordTimestamp: Option[Long] = if (maxTimestampSoFar >= 0) Some(maxTimestampSoFar) else None
+
+  /**
    * The largest timestamp this segment contains.
    */
   def largestTimestamp = if (maxTimestampSoFar >= 0) maxTimestampSoFar else lastModified


### PR DESCRIPTION
As specified in https://issues.apache.org/jira/browse/KAFKA-10141, it would be helpful to include as much information as possible when deleting log segments. This patch introduces log messages that give more specific details as to why the log segment was deleted and the specific metadata regarding that log segment.


*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
