### PR TITLE
KAFKA-10150: task state transitions/management and committing cleanup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -114,8 +114,8 @@ public class StandbyTask extends AbstractTask implements Task {
         switch (state()) {
             case CREATED:
             case RUNNING:
-                transitionTo(State.SUSPENDED);
                 log.info("Suspended {}", state());
+                transitionTo(State.SUSPENDED);
 
                 break;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -111,12 +111,17 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public void suspend() {
-        log.trace("No-op suspend with state {}", state());
         switch (state()) {
             case CREATED:
             case RUNNING:
-            case SUSPENDED:
                 transitionTo(State.SUSPENDED);
+                log.info("Suspended {}", state());
+
+                break;
+
+            case SUSPENDED:
+                log.info("Skip suspending since state is {}", state());
+
                 break;
 
             case RESTORING:

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -195,7 +195,6 @@ public class StandbyTask extends AbstractTask implements Task {
 
     private void close(final boolean clean) {
         switch (state()) {
-            case CREATED:
             case SUSPENDED:
                 executeAndMaybeSwallow(
                     clean,
@@ -218,6 +217,7 @@ public class StandbyTask extends AbstractTask implements Task {
                 log.trace("Skip closing since state is {}", state());
                 return;
 
+            case CREATED:
             case RESTORING: // a StandbyTask is never in RESTORING state
             case RUNNING:
                 throw new IllegalStateException("Illegal state " + state() + " while closing standby task " + id);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -182,8 +182,6 @@ public class StandbyTask extends AbstractTask implements Task {
     @Override
     public void closeAndRecycleState() {
         suspend();
-        prepareCommit();
-
         if (state() == State.SUSPENDED) {
             stateMgr.recycle();
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -181,7 +181,6 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public void closeAndRecycleState() {
-        suspend();
         if (state() == State.SUSPENDED) {
             stateMgr.recycle();
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -521,8 +521,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
     private void writeCheckpointIfNeed() {
         if (commitNeeded) {
-            throw new IllegalStateException("A checkpoint should only be written if the previous commit has completed"
-                                                + " and there is no new commit needed.");
+            log.error("Tried to write a checkpoint with pending uncommitted data, should complete the commit first.");
+            throw new IllegalStateException("A checkpoint should only be written if no commit is needed.");
         }
         if (checkpoint != null) {
             stateMgr.checkpoint(checkpoint);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -249,8 +249,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         switch (state()) {
             case CREATED:
             case RESTORING:
-                transitionTo(State.SUSPENDED);
                 log.info("Suspended {}", state());
+                transitionTo(State.SUSPENDED);
 
                 break;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -506,9 +506,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * You must commit a task and checkpoint the state manager before closing as this will release the state dir lock
      */
     private void close(final boolean clean) {
-        if (clean && commitNeeded ) {
+        if (clean && commitNeeded) {
             log.debug("Tried to close clean but there was an active scheduled checkpoint, this means we failed to"
-            + " commit and should close as dirty instead");
+                          + " commit and should close as dirty instead");
             throw new StreamsException("Tried to close dirty task as clean");
         }
         switch (state()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -470,7 +470,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
     @Override
     public void closeAndRecycleState() {
-        suspend();
+        // Stream tasks should have already been suspended and their consumed offsets committed before recycling
         switch (state()) {
             case SUSPENDED:
                 stateMgr.recycle();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -56,18 +56,18 @@ public interface Task {
      *          |            |              |     |
      *          |            v              |     |
      *          |     +------+--------+     |     |
-     *          |     | Suspended (3) | <---+     |    //TODO Suspended(3) could be removed after we've stable on KIP-429
-     *          |     +------+--------+           |
-     *          |            |                    |
-     *          |            v                    |
-     *          |      +-----+-------+            |
-     *          +----> | Closed (4)  | -----------+
+     *          +---->| Suspended (3) | ----+     |    //TODO Suspended(3) could be removed after we've stable on KIP-429
+     *                +------+--------+           |
+     *                       |                    |
+     *                       v                    |
+     *                 +-----+-------+            |
+     *                 | Closed (4)  | -----------+
      *                 +-------------+
      * </pre>
      */
     enum State {
-        CREATED(1, 3, 4),         // 0
-        RESTORING(2, 3, 4),       // 1
+        CREATED(1, 3),            // 0
+        RESTORING(2, 3),          // 1
         RUNNING(3),               // 2
         SUSPENDED(1, 3, 4),       // 3
         CLOSED(0);                // 4, we allow CLOSED to transit to CREATED to handle corrupted tasks

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -56,7 +56,7 @@ public interface Task {
      *          |            |              |     |
      *          |            v              |     |
      *          |     +------+--------+     |     |
-     *          +---->| Suspended (3) | ----+     |    //TODO Suspended(3) could be removed after we've stable on KIP-429
+     *          +---> | Suspended (3) | ----+     |    //TODO Suspended(3) could be removed after we've stable on KIP-429
      *                +------+--------+           |
      *                       |                    |
      *                       v                    |
@@ -69,7 +69,7 @@ public interface Task {
         CREATED(1, 3),            // 0
         RESTORING(2, 3),          // 1
         RUNNING(3),               // 2
-        SUSPENDED(1, 3, 4),       // 3
+        SUSPENDED(1, 4),          // 3
         CLOSED(0);                // 4, we allow CLOSED to transit to CREATED to handle corrupted tasks
 
         private final Set<Integer> validTransitions = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -66,11 +66,11 @@ public interface Task {
      * </pre>
      */
     enum State {
-        CREATED(1, 4),         // 0
-        RESTORING(2, 3, 4),    // 1
-        RUNNING(3),            // 2
-        SUSPENDED(1, 4),       // 3
-        CLOSED(0);             // 4, we allow CLOSED to transit to CREATED to handle corrupted tasks
+        CREATED(1, 3, 4),         // 0
+        RESTORING(2, 3, 4),       // 1
+        RUNNING(3),               // 2
+        SUSPENDED(1, 3, 4),       // 3
+        CLOSED(0);                // 4, we allow CLOSED to transit to CREATED to handle corrupted tasks
 
         private final Set<Integer> validTransitions = new HashSet<>();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -248,12 +248,13 @@ public class TaskManager {
             } else {
                 try {
                     task.suspend();
-                    final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.prepareCommit();
-
-                    tasksToClose.add(task);
-                    if (!committableOffsets.isEmpty()) {
-                        consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
+                    if (task.commitNeeded()) {
+                        final Map<TopicPartition, OffsetAndMetadata> committableOffsets = task.prepareCommit();
+                        if (!committableOffsets.isEmpty()) {
+                            consumedOffsetsAndMetadataPerTask.put(task.id(), committableOffsets);
+                        }
                     }
+                    tasksToClose.add(task);
                 } catch (final RuntimeException e) {
                     final String uncleanMessage = String.format(
                         "Failed to close task %s cleanly. Attempting to close remaining tasks before re-throwing:",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -244,6 +244,9 @@ public class TaskManager {
                 standbyTasksToCreate.remove(task.id());
                 // check for tasks that were owned previously but have changed active/standby status
             } else if (activeTasks.containsKey(task.id()) || standbyTasks.containsKey(task.id())) {
+                if (task.commitNeeded()) {
+                    additionalTasksForCommitting.add(task);
+                }
                 tasksToRecycle.add(task);
             } else {
                 try {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -246,7 +246,7 @@ public class TaskManager {
 
         for (final Task task : tasksToClose) {
             try {
-                task.suspend(); // Should be a no-op for active tasks, unless we hit an exception during handleRevocation
+                task.suspend(); // Should be a no-op for active tasks since they're suspended in handleRevocation
                 if (task.commitNeeded()) {
                     if (task.isActive()) {
                         log.error("Active task {} was revoked and should have already been committed", task.id());
@@ -274,11 +274,11 @@ public class TaskManager {
         for (final Task oldTask : tasksToRecycle) {
             final Task newTask;
             try {
-                oldTask.suspend(); // Should be a no-op for active tasks, unless we hit an exception during handleRevocation
                 if (oldTask.isActive()) {
                     final Set<TopicPartition> partitions = standbyTasksToCreate.remove(oldTask.id());
                     newTask = standbyTaskCreator.createStandbyTaskFromActive((StreamTask) oldTask, partitions);
                 } else {
+                    oldTask.suspend(); // Only need to suspend transitioning standbys, actives should be suspended already
                     final Set<TopicPartition> partitions = activeTasksToCreate.remove(oldTask.id());
                     newTask = activeTaskCreator.createActiveTaskFromStandby((StandbyTask) oldTask, partitions, mainConsumer);
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1615,6 +1615,7 @@ public class StreamTaskTest {
         task.completeRestoration();
         task.suspend();
         task.prepareCommit();
+        task.postCommit();
         task.closeClean();
 
         assertEquals(Task.State.CLOSED, task.state());
@@ -1640,6 +1641,7 @@ public class StreamTaskTest {
         task.completeRestoration();
         task.suspend();
         task.prepareCommit();
+        task.postCommit();
         task.closeClean();
 
         assertEquals(Task.State.CLOSED, task.state());
@@ -1669,6 +1671,7 @@ public class StreamTaskTest {
 
         task.suspend();
         task.prepareCommit();
+        task.postCommit();
         assertThrows(ProcessorStateException.class, () -> task.closeClean());
 
         final double expectedCloseTaskMetric = 0.0;
@@ -1676,7 +1679,7 @@ public class StreamTaskTest {
 
         EasyMock.verify(stateManager);
         EasyMock.reset(stateManager);
-        EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.singleton(changelogPartition)).anyTimes();
+        EasyMock.expect(stateManager.changelogPartitions()).andStubReturn(Collections.singleton(changelogPartition));
         stateManager.close();
         EasyMock.expectLastCall();
         EasyMock.replay(stateManager);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1841,7 +1841,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         task.completeRestoration();
         assertThat(task.state(), equalTo(RUNNING));
-        assertThrows(RuntimeException.class , () -> task.suspend());
+        assertThrows(RuntimeException.class, () -> task.suspend());
         assertThat(task.state(), equalTo(SUSPENDED));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -635,6 +635,7 @@ public class TaskManagerTest {
         expectLastCall().anyTimes();
 
         expectRestoreToBeCompleted(consumer, changeLogReader);
+        consumer.commitSync(eq(emptyMap()));
 
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
 
@@ -1664,7 +1665,8 @@ public class TaskManagerTest {
             .andReturn(Arrays.asList(task00, task01, task02)).anyTimes();
         expect(standbyTaskCreator.createTasks(eq(assignmentStandby)))
             .andReturn(Arrays.asList(task03, task04, task05)).anyTimes();
-        expectLastCall();
+
+        consumer.commitSync(eq(emptyMap()));
 
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -2579,8 +2579,9 @@ public class TaskManagerTest {
 
         taskManager.handleAssignment(assignment, Collections.emptyMap());
 
-        final RuntimeException thrown = assertThrows(RuntimeException.class,
-                                                     () ->taskManager.handleRevocation(asList(t1p0, t1p1)));
+        final RuntimeException thrown = assertThrows(
+            RuntimeException.class,
+            () -> taskManager.handleRevocation(asList(t1p0, t1p1)));
 
         assertThat(thrown.getMessage(), is("KABOOM!"));
         assertThat(task00.state(), is(Task.State.SUSPENDED));


### PR DESCRIPTION
1. KAFKA-10150: 
    - always transition to SUSPENDED during `suspend`, no matter the current state
    - only call `prepareCommit` before closing if `task.commitNeeded` is true
2. Don't commit any consumed offsets during `handleAssignment` -- revoked active tasks (and any others that need committing) will be committed during `handleRevocation` so we only need to worry about cleaning them up in `handleAssignment`
3. KAFKA-10152: when recycling a task we should always commit consumed offsets (if any), but don't need to write the checkpoint (since changelog offsets are preserved across task transitions) 
4. Make sure we close all tasks during shutdown, even if an exception is thrown during commit
5. In-flight records were skipped when we saved the `checkpointableOffsets` before flushing in `prepareCommit` (This was the root cause of [KAFKA-10151](https://issues.apache.org/jira/browse/KAFKA-10151) -- we now don't save the offsets at all during `prepareCommit` and just write the current offsets during `postCommit`

Must be cherry-picked to 2.6