### PR TITLE
KAFKA-10157: Fix broken tests due to InterruptedException from FinalizedFeatureChangeListener

### DIFF
--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -25,7 +25,6 @@ import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler}
 import org.apache.kafka.common.internals.FatalExitError
 
 import scala.concurrent.TimeoutException
-import scala.util.control.Exception.ignoring
 
 /**
  * Listens to changes in the ZK feature node, via the ZK client. Whenever a change notification
@@ -143,13 +142,17 @@ class FinalizedFeatureChangeListener(zkClient: KafkaZkClient) extends Logging {
   private class ChangeNotificationProcessorThread(name: String) extends ShutdownableThread(name = name) {
     override def doWork(): Unit = {
       try {
-        ignoring(classOf[InterruptedException]) {
-          queue.take.updateLatestOrThrow()
-        }
+        queue.take.updateLatestOrThrow()
       } catch {
         case e: Exception => {
-          error("Failed to process feature ZK node change event. The broker will eventually exit.", e)
-          throw new FatalExitError(1)
+          // We ignore InterruptedException. While the queue is empty and this thread is blocking on
+          // taking an item from the queue, a concurrent call to FinalizedFeatureChangeListener.close()
+          // could interrupt the thread and cause an InterruptedException to be raised from queue.take().
+          // In such a case, it is safe to ignore the exception since the thread is being shutdown.
+          if (!e.isInstanceOf[InterruptedException]) {
+            error("Failed to process feature ZK node change event. The broker will eventually exit.", e)
+            throw new FatalExitError(1)
+          }
         }
       }
     }


### PR DESCRIPTION
This PR fixes the cause of failing tests mentioned in the jira:
 - `kafka.network.DynamicConnectionQuotaTest`
 - `kafka.api.CustomQuotaCallbackTest`
 - `kafka.server.DynamicBrokerReconfigurationTest`

**Issue:**
The call to `ChangeNotificationProcessorThread.queue.take()` could throw an `InterruptedException`.  While the queue is empty and the thread is blocking on taking an item from the queue, a concurrent call to `FinalizedFeatureChangeListener.close()` could interrupt the thread and cause an `InterruptedException` to be raised from `queue.take()`. In such a case, it is safe to ignore the exception since the thread is being shutdown.
Definitely ignoring the `InterruptedException` for the above reason was the intent of the code that used the `ignoring` clause for the same. But it seems unfortunately the `ignoring` clause does not ignore `InterruptedException`, so that doesn't work for us. To confirm this theory, I found the following code in `scala.util.control.Exception.scala`: https://github.com/scala/scala/blob/v2.12.0/src/library/scala/util/control/Exception.scala#L167-L176.

**Fix:**
The fix in this PR is to just not use the `ignoring` clause. We rely on existing mechanism in `ShutdownableThread` that ignores the exception during shutdown.

**Test plan:**
Ran the unit and integration tests and found that the test failures are gone now.
I will wait for CI to pass before merging this PR.