### PR TITLE
MINOR: Upgrade jetty to 9.4.27.v20200227 and jersey to 2.31

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/util/SSLUtils.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-import javax.net.ssl.X509ExtendedKeyManager;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -65,20 +64,7 @@ public class SSLUtils {
     public static SslContextFactory createClientSideSslContextFactory(WorkerConfig config) {
         Map<String, Object> sslConfigValues = config.valuesWithPrefixAllOrNothing("listeners.https.");
 
-        // Override this method in order to avoid running into
-        // https://github.com/eclipse/jetty.project/issues/4385, which would otherwise cause this to
-        // break when the keystore contains multiple certificates.
-        // The override here matches the bug fix in Jetty for that issue:
-        // https://github.com/eclipse/jetty.project/pull/4404/files#diff-58640db0f8f2cd84b7e653d1c1540913R2188-R2193
-        // TODO: Remove this override when the version of Jetty for the framework is bumped to
-        //       9.4.25 or later
-        final SslContextFactory.Client ssl = new SslContextFactory.Client() {
-            @Override
-            @SuppressWarnings("deprecation")
-            protected X509ExtendedKeyManager newSniX509ExtendedKeyManager(X509ExtendedKeyManager keyManager) {
-                return keyManager;
-            }
-        };
+        final SslContextFactory.Client ssl = new SslContextFactory.Client();
 
         configureSslContextFactoryKeyStore(ssl, sslConfigValues);
         configureSslContextFactoryTrustStore(ssl, sslConfigValues);

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,11 +68,8 @@ versions += [
   easymock: "4.2",
   jackson: "2.10.2",
   jacoco: "0.8.5",
-  // 9.4.25 renamed closeOutput to completeOutput (https://github.com/eclipse/jetty.project/commit/c5acf965067478784b54e2d241ec58fdb0b2c9fe)
-  // which is a method used by recent Jersey versions when this comment was written (2.30.1 was the latest). Please
-  // verify that this is fixed in some way before bumping the Jetty version.
-  jetty: "9.4.24.v20191120",
-  jersey: "2.28",
+  jetty: "9.4.27.v20200227",
+  jersey: "2.31",
   jmh: "1.23",
   hamcrest: "2.2",
   log4j: "1.2.17",


### PR DESCRIPTION
Upgrade jetty to 9.4.27.v20200227 and jersey to 2.31

Also remove the workaround used on previous version from Connect's SSLUtils. 
(Reverts KAFKA-9771 - commit ee832d7d)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
