### PR TITLE
KAFKA-8528: Expose Trogdor-specific JMX metrics for Tasks and Agents

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.trogdor.common.JsonUtil;
 import org.apache.kafka.trogdor.common.Node;
 import org.apache.kafka.trogdor.common.Platform;
+import org.apache.kafka.trogdor.coordinator.TrogdorMetrics;
 import org.apache.kafka.trogdor.rest.AgentStatusResponse;
 import org.apache.kafka.trogdor.rest.CreateWorkerRequest;
 import org.apache.kafka.trogdor.rest.DestroyWorkerRequest;
@@ -92,6 +93,8 @@ public final class Agent {
 
     private final Time time;
 
+    final TrogdorMetrics trogdorMetrics;
+
     /**
      * Create a new Agent.
      *
@@ -107,6 +110,8 @@ public final class Agent {
         this.serverStartMs = time.milliseconds();
         this.workerManager = new WorkerManager(platform, scheduler);
         this.restServer = restServer;
+        this.trogdorMetrics = Platform.MetricsContainer.buildMetrics(Time.SYSTEM);
+        trogdorMetrics.recordActiveAgent();
         resource.setAgent(this);
     }
 
@@ -122,6 +127,7 @@ public final class Agent {
     public void waitForShutdown() throws Exception {
         restServer.waitForShutdown();
         workerManager.waitForShutdown();
+        Platform.MetricsContainer.close();
     }
 
     public AgentStatusResponse status() throws Exception {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TrogdorMetrics.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TrogdorMetrics.java
@@ -1,0 +1,77 @@
+package org.apache.kafka.trogdor.coordinator;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TrogdorMetrics implements AutoCloseable {
+    private final Sensor createdTasks;
+    private final Sensor runningTasks;
+    private final Sensor doneTasks;
+    private final Sensor activeAgents;
+
+    private final Metrics metrics;
+    private final List<Sensor> sensors = new ArrayList<>();
+
+    public TrogdorMetrics(Metrics metrics, String metricGrpPrefix) {
+        this.metrics = metrics;
+        String metricGroupName = metricGrpPrefix + "-metrics";
+
+        this.createdTasks = sensor("tasks-created");
+        MetricName createdTasksMetricName = metrics.metricName("created-task-count",
+                metricGroupName, "The total number of created tasks in the Trogdor cluster");
+        this.createdTasks.add(createdTasksMetricName, new CumulativeSum());
+
+        this.runningTasks = sensor("tasks-running");
+        MetricName runningTasksMetricName = metrics.metricName("running-task-count",
+                metricGroupName, "The total number of running tasks in the Trogdor cluster");
+        this.runningTasks.add(runningTasksMetricName, new CumulativeSum());
+
+        this.doneTasks = sensor("tasks-done");
+        MetricName doneTasksMetricName = metrics.metricName("done-task-count",
+                metricGroupName, "The total number of done tasks in the Trogdor cluster");
+        this.doneTasks.add(doneTasksMetricName, new CumulativeSum());
+
+        this.activeAgents = sensor("active-agents");
+        MetricName activeAgentsMetricName = metrics.metricName("active-agents-count",
+                metricGroupName, "The total number of active agents in the Trogdor cluster");
+        this.activeAgents.add(activeAgentsMetricName, new CumulativeSum());
+    }
+
+    private Sensor sensor(String name, Sensor... parents) {
+        Sensor sensor = metrics.sensor(name, parents);
+        sensors.add(sensor);
+        return sensor;
+    }
+
+    @Override
+    public void close() {
+        for (Sensor sensor : sensors)
+            metrics.removeSensor(sensor.name());
+        metrics.close();
+    }
+
+    public Metrics getMetrics() {
+        return metrics;
+    }
+
+    public void recordCreatedTask() {
+        this.createdTasks.record(1);
+    }
+
+    public void recordRunningTask() {
+        this.runningTasks.record(1);
+    }
+
+    public void recordDoneTask() {
+        this.doneTasks.record(1);
+    }
+
+    public void recordActiveAgent() {
+        this.activeAgents.record(1);
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TrogdorMetrics.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/TrogdorMetrics.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.trogdor.coordinator;
 
 import org.apache.kafka.common.MetricName;

--- a/tools/src/test/java/org/apache/kafka/trogdor/agent/AgentTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/agent/AgentTest.java
@@ -18,6 +18,8 @@
 package org.apache.kafka.trogdor.agent;
 
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockScheduler;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Scheduler;
@@ -67,6 +69,7 @@ import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class AgentTest {
     @Rule
@@ -371,7 +374,7 @@ public class AgentTest {
         new ExpectedTasks().waitFor(client);
 
         try (MockKibosh mockKibosh = new MockKibosh()) {
-            Assert.assertEquals(KiboshControlFile.EMPTY, mockKibosh.read());
+            assertEquals(KiboshControlFile.EMPTY, mockKibosh.read());
             FilesUnreadableFaultSpec fooSpec = new FilesUnreadableFaultSpec(0, 900000,
                 Collections.singleton("myAgent"), mockKibosh.tempDir.getPath(), "/foo", 123);
             client.createWorker(new CreateWorkerRequest(0, "foo", fooSpec));
@@ -380,7 +383,7 @@ public class AgentTest {
                     workerState(new WorkerRunning("foo", fooSpec, 0, new TextNode("Added fault foo"))).
                     build()).
                 waitFor(client);
-            Assert.assertEquals(new KiboshControlFile(Collections.<Kibosh.KiboshFaultSpec>singletonList(
+            assertEquals(new KiboshControlFile(Collections.<Kibosh.KiboshFaultSpec>singletonList(
                 new KiboshFilesUnreadableFaultSpec("/foo", 123))), mockKibosh.read());
             FilesUnreadableFaultSpec barSpec = new FilesUnreadableFaultSpec(0, 900000,
                 Collections.singleton("myAgent"), mockKibosh.tempDir.getPath(), "/bar", 456);
@@ -391,7 +394,7 @@ public class AgentTest {
                 addTask(new ExpectedTaskBuilder("bar").
                     workerState(new WorkerRunning("bar", barSpec, 0, new TextNode("Added fault bar"))).build()).
                 waitFor(client);
-            Assert.assertEquals(new KiboshControlFile(new ArrayList<Kibosh.KiboshFaultSpec>() {{
+            assertEquals(new KiboshControlFile(new ArrayList<Kibosh.KiboshFaultSpec>() {{
                     add(new KiboshFilesUnreadableFaultSpec("/foo", 123));
                     add(new KiboshFilesUnreadableFaultSpec("/bar", 456));
                 }}), mockKibosh.read());
@@ -403,7 +406,7 @@ public class AgentTest {
                 addTask(new ExpectedTaskBuilder("bar").
                     workerState(new WorkerRunning("bar", barSpec, 0, new TextNode("Added fault bar"))).build()).
                 waitFor(client);
-            Assert.assertEquals(new KiboshControlFile(Collections.<Kibosh.KiboshFaultSpec>singletonList(
+            assertEquals(new KiboshControlFile(Collections.<Kibosh.KiboshFaultSpec>singletonList(
                 new KiboshFilesUnreadableFaultSpec("/bar", 456))), mockKibosh.read());
         }
     }
@@ -492,4 +495,34 @@ public class AgentTest {
         agent.waitForShutdown();
     }
 
+    @Test
+    public void testAgentMetrics() throws Exception {
+        MockTime time = new MockTime(0, 0, 0);
+        MockScheduler scheduler = new MockScheduler(time);
+        Agent agent = createAgent(scheduler);
+        AgentClient client = new AgentClient.Builder().
+                maxTries(10).target("localhost", agent.port()).build();
+        AgentStatusResponse status = client.status();
+        Metrics metrics = agent.trogdorMetrics.getMetrics();
+
+        assertEquals(Collections.emptyMap(), status.workers());
+        new ExpectedTasks().waitFor(client);
+
+        HashMap<String, Double> expectedMetricMap = new HashMap<>();
+        expectedMetricMap.put("count", 5.0);
+        expectedMetricMap.put("created-task-count", 0.0);
+        expectedMetricMap.put("running-task-count", 0.0);
+        expectedMetricMap.put("done-task-count", 0.0);
+        expectedMetricMap.put("active-agents-count", 1.0);
+
+        assertEquals(5, metrics.metrics().size());
+
+        for (KafkaMetric metric : metrics.metrics().values()) {
+            assertTrue(expectedMetricMap.containsKey(metric.metricName().name()));
+            assertEquals(expectedMetricMap.get(metric.metricName().name()), (double) metric.metricValue(), 0);
+        }
+
+        agent.beginShutdown();
+        agent.waitForShutdown();
+    }
 };


### PR DESCRIPTION
Adds JMX metrics to Trogdor to keep track of Created, Running, and Done tasks and the number of Active Agents in a Trogdor cluster as seen in [KAFKA-8528](https://issues.apache.org/jira/browse/KAFKA-8528).

Adds a `TrogdorMetrics` class that contains a metric and sensors for tasks in the aforementioned states as well as for active agents. Utilizes the `Platform` interface shared by Tasks and Agents to create  a common `TrogdorMetrics` instance in a `MetricsContainer` class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
