### PR TITLE
MINOR: Fix timestampDelta type in doc

### DIFF
--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -85,7 +85,7 @@
 		length: varint
 		attributes: int8
 			bit 0~7: unused
-		timestampDelta: varint
+		timestampDelta: varlong
 		offsetDelta: varint
 		keyLength: varint
 		key: byte[]


### PR DESCRIPTION
- Type of `timestampDelta` is written as `varint` in the doc, but actually it's `varlong`
  * https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java#L47

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
