### PR TITLE
Avoid WARN log message when re-init from checkpoint skipped

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -247,6 +247,7 @@ public class ProcessorStateManager implements StateManager {
                         }
                     }
                 }  else {
+                    loadedCheckpoints.remove(store.changelogPartition);
                     log.debug("Skipping re-initialization of offset from checkpoint for recycled store {}",
                               store.stateStore.name());
                 }


### PR DESCRIPTION
When a re-initialisation from checkpoint is skipped the following log messages appear in the logs. 

```
DEBUG stream-thread [EosTest-a2c3b21b-7af1-4dce-a3e0-6dc10932e5a2-StreamThread-1] task [0_2] Skipping re-initialization of offset from checkpoint for recycled store KSTREAM-AGGREGATE-STATE-STORE-0000000003 (org.apache.kafka.streams.processor.internals.ProcessorStateManager)
DEBUG stream-thread [EosTest-a2c3b21b-7af1-4dce-a3e0-6dc10932e5a2-StreamThread-1] task [0_2] Skipping re-initialization of offset from checkpoint for recycled store KSTREAM-AGGREGATE-STATE-STORE-0000000007 
WARN stream-thread [EosTest-a2c3b21b-7af1-4dce-a3e0-6dc10932e5a2-StreamThread-1] task [0_2] Some loaded checkpoint offsets cannot find their corresponding state stores: {EosTest-KSTREAM-AGGREGATE-STATE-STORE-0000000003-changelog-2=1491, EosTest-KSTREAM-AGGREGATE-STATE-STORE-0000000007-changelog-2=1491} 
```

The warning appears because the skipped offsets are not removed from the checkpoint. However, there is nothing to warn about, because the offset found there corresponding state stores and they were skipped. 
 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
