### PR TITLE
HOTFIX: checkstyle error in ProcessorStateManager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -510,7 +510,7 @@ public class ProcessorStateManager implements StateManager {
             throw new IllegalStateException("Tried to recycle state for task type conversion but new type was the same.");
         }
 
-        TaskType oldType = taskType;
+        final TaskType oldType = taskType;
         taskType = newType;
         log = logContext.logger(ProcessorStateManager.class);
         logPrefix = logContext.logPrefix();


### PR DESCRIPTION
```
[ant:checkstyle] [ERROR] /home/chia7712/kafka/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java:513:18: Variable 'oldType' should be declared final. [FinalLocalVariable]
```

related to a0da6785a27b13be173762965402b55860ac5635

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
