### PR TITLE
KIP-557: Add emit on change support to Kafka Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -92,6 +92,10 @@ public class MeteredTimestampedKeyValueStore<K, V>
         }
     }
 
+    public byte[] getSerializedValue(final ValueAndTimestamp<V> value) {
+        return serdes.rawValue(value);
+    }
+
     public static class RawAndDeserializedValue<ValueType> {
         public final byte[] serializedValue;
         public final ValueAndTimestamp<ValueType> value;


### PR DESCRIPTION
This is a continuation of the previous PR #8254, and will move to implement emit on change support more extensively and cover most basic KTable operations.