### PR TITLE
KAFKA-10165: Remove Percentiles from e2e metrics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -235,7 +235,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         setCurrentNode(child);
         child.process(key, value);
         if (child.isTerminalNode()) {
-            streamTask.maybeRecordE2ELatency(timestamp(), child.name());
+            streamTask.maybeRecordE2ELatency(timestamp(), currentSystemTimeMs(), child.name());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -671,15 +671,9 @@ public class TaskManager {
 
     // Note: this MUST be called *before* actually closing the task
     private void cleanupTask(final Task task) {
-        // 1. remove the input partitions from the materialized map;
-        // 2. remove the task metrics from the metrics registry
-
         for (final TopicPartition inputPartition : task.inputPartitions()) {
             partitionToTask.remove(inputPartition);
         }
-
-        final String threadId = Thread.currentThread().getName();
-        streamsMetrics.removeAllTaskLevelSensors(threadId, task.id().toString());
     }
 
     void shutdown(final boolean clean) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetrics.java
@@ -29,7 +29,6 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addMinAndMaxAndP99AndP90ToSensor;
 
 public class ProcessorNodeMetrics {
     private ProcessorNodeMetrics() {}
@@ -98,15 +97,6 @@ public class ProcessorNodeMetrics {
     private static final String LATE_RECORD_DROP_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + LATE_RECORD_DROP_DESCRIPTION;
     private static final String LATE_RECORD_DROP_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + LATE_RECORD_DROP_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
-
-    private static final String RECORD_E2E_LATENCY = "record-e2e-latency";
-    private static final String RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX =
-        "end-to-end latency of a record, measuring by comparing the record timestamp with the "
-            + "system time when it has been fully processed by the node";
-    private static final String RECORD_E2E_LATENCY_MIN_DESCRIPTION = "The minimum " + RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX;
-    private static final String RECORD_E2E_LATENCY_MAX_DESCRIPTION = "The maximum " + RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX;
-    private static final String RECORD_E2E_LATENCY_P99_DESCRIPTION = "The 99th percentile " + RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX;
-    private static final String RECORD_E2E_LATENCY_P90_DESCRIPTION = "The 90th percentile " + RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX;
 
     public static Sensor suppressionEmitSensor(final String threadId,
                                                final String taskId,
@@ -299,26 +289,6 @@ public class ProcessorNodeMetrics {
         return processAtSourceSensor(threadId, taskId, processorNodeId, streamsMetrics);
     }
 
-    public static Sensor recordE2ELatencySensor(final String threadId,
-                                                final String taskId,
-                                                final String processorNodeId,
-                                                final RecordingLevel recordingLevel,
-                                                final StreamsMetricsImpl streamsMetrics) {
-        final Sensor sensor = streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, RECORD_E2E_LATENCY, recordingLevel);
-        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
-        addMinAndMaxAndP99AndP90ToSensor(
-            sensor,
-            PROCESSOR_NODE_LEVEL_GROUP,
-            tagMap,
-            RECORD_E2E_LATENCY,
-            RECORD_E2E_LATENCY_MIN_DESCRIPTION,
-            RECORD_E2E_LATENCY_MAX_DESCRIPTION,
-            RECORD_E2E_LATENCY_P99_DESCRIPTION,
-            RECORD_E2E_LATENCY_P90_DESCRIPTION
-        );
-        return sensor;
-    }
-
     private static Sensor throughputAndLatencySensorWithParent(final String threadId,
                                                                final String taskId,
                                                                final String processorNodeId,
@@ -337,7 +307,7 @@ public class ProcessorNodeMetrics {
             descriptionOfCount,
             descriptionOfAvgLatency,
             descriptionOfMaxLatency,
-            RecordingLevel.DEBUG,
+            recordingLevel,
             streamsMetrics
         );
         return throughputAndLatencySensor(
@@ -349,7 +319,7 @@ public class ProcessorNodeMetrics {
             descriptionOfCount,
             descriptionOfAvgLatency,
             descriptionOfMaxLatency,
-            RecordingLevel.DEBUG,
+            recordingLevel,
             streamsMetrics,
             parentSensor
         );

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -28,9 +28,6 @@ import org.apache.kafka.common.metrics.stats.CumulativeCount;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Min;
-import org.apache.kafka.common.metrics.stats.Percentile;
-import org.apache.kafka.common.metrics.stats.Percentiles;
-import org.apache.kafka.common.metrics.stats.Percentiles.BucketSizing;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
@@ -47,9 +44,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.Optional;
 
 public class StreamsMetricsImpl implements StreamsMetrics {
 
@@ -153,9 +150,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String MAX_LATENCY_DESCRIPTION = "The maximum latency of ";
     public static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
     public static final String RATE_DESCRIPTION_SUFFIX = " per second";
-
-    private static final int PERCENTILES_SIZE_IN_BYTES = 100 * 1000;    // 100 kB
-    private static double MAXIMUM_E2E_LATENCY = 10 * 24 * 60 * 60 * 1000d; // maximum latency is 10 days; values above that will be pinned
 
     public StreamsMetricsImpl(final Metrics metrics, final String clientId, final String builtInMetricsVersion) {
         Objects.requireNonNull(metrics, "Metrics cannot be null");
@@ -650,14 +644,12 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         );
     }
 
-    public static void addMinAndMaxAndP99AndP90ToSensor(final Sensor sensor,
-                                                        final String group,
-                                                        final Map<String, String> tags,
-                                                        final String operation,
-                                                        final String descriptionOfMin,
-                                                        final String descriptionOfMax,
-                                                        final String descriptionOfP99,
-                                                        final String descriptionOfP90) {
+    public static void addMinAndMaxToSensor(final Sensor sensor,
+                                            final String group,
+                                            final Map<String, String> tags,
+                                            final String operation,
+                                            final String descriptionOfMin,
+                                            final String descriptionOfMax) {
         sensor.add(
             new MetricName(
                 operation + MIN_SUFFIX,
@@ -674,27 +666,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                 descriptionOfMax,
                 tags),
             new Max()
-        );
-
-        sensor.add(
-            new Percentiles(
-                PERCENTILES_SIZE_IN_BYTES,
-                MAXIMUM_E2E_LATENCY,
-                BucketSizing.LINEAR,
-                new Percentile(
-                    new MetricName(
-                        operation + P99_SUFFIX,
-                        group,
-                        descriptionOfP99,
-                        tags),
-                    99),
-                new Percentile(
-                    new MetricName(
-                        operation + P90_SUFFIX,
-                        group,
-                        descriptionOfP90,
-                        tags),
-                    90))
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -24,11 +24,13 @@ import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RATIO_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addMinAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addValueMetricToSensor;
 
 public class TaskMetrics {
@@ -86,6 +88,13 @@ public class TaskMetrics {
     private static final String NUM_BUFFERED_RECORDS_DESCRIPTION = "The count of buffered records that are polled " +
         "from consumer and not yet processed for this active task";
 
+    private static final String RECORD_E2E_LATENCY = "record-e2e-latency";
+    private static final String RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX =
+        "end-to-end latency of a record, measuring by comparing the record timestamp with the "
+            + "system time when it has been fully processed by the node";
+    private static final String RECORD_E2E_LATENCY_MIN_DESCRIPTION = "The minimum " + RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX;
+    private static final String RECORD_E2E_LATENCY_MAX_DESCRIPTION = "The maximum " + RECORD_E2E_LATENCY_DESCRIPTION_SUFFIX;
+
     public static Sensor processLatencySensor(final String threadId,
                                               final String taskId,
                                               final StreamsMetricsImpl streamsMetrics) {
@@ -129,6 +138,25 @@ public class TaskMetrics {
             streamsMetrics.taskLevelTagMap(threadId, taskId),
             name,
             NUM_BUFFERED_RECORDS_DESCRIPTION
+        );
+        return sensor;
+    }
+
+    public static Sensor e2ELatencySensor(final String threadId,
+                                          final String taskId,
+                                          final String processorNodeId,
+                                          final RecordingLevel recordingLevel,
+                                          final StreamsMetricsImpl streamsMetrics) {
+        final String sensorName = processorNodeId + "-" + RECORD_E2E_LATENCY;
+        final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, sensorName, recordingLevel);
+        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
+        addMinAndMaxToSensor(
+            sensor,
+            PROCESSOR_NODE_LEVEL_GROUP,
+            tagMap,
+            RECORD_E2E_LATENCY,
+            RECORD_E2E_LATENCY_MIN_DESCRIPTION,
+            RECORD_E2E_LATENCY_MAX_DESCRIPTION
         );
         return sensor;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -206,8 +206,6 @@ public class MetricsIntegrationTest {
     private static final String EXPIRED_WINDOW_RECORD_DROP_TOTAL = "expired-window-record-drop-total";
     private static final String E2E_LATENCY_MIN = "record-e2e-latency-min";
     private static final String E2E_LATENCY_MAX = "record-e2e-latency-max";
-    private static final String E2E_LATENCY_P99 = "record-e2e-latency-p99";
-    private static final String E2E_LATENCY_P90 = "record-e2e-latency-p90";
 
     // stores name
     private static final String TIME_WINDOWED_AGGREGATED_STREAM_STORE = "time-windowed-aggregated-stream-store";
@@ -608,8 +606,6 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricProcessor, FORWARD_RATE, numberOfModifiedForwardMetrics);
         checkMetricByName(listMetricProcessor, E2E_LATENCY_MIN, numberOfSourceNodes + numberOfTerminalNodes);
         checkMetricByName(listMetricProcessor, E2E_LATENCY_MAX, numberOfSourceNodes + numberOfTerminalNodes);
-        checkMetricByName(listMetricProcessor, E2E_LATENCY_P99, numberOfSourceNodes + numberOfTerminalNodes);
-        checkMetricByName(listMetricProcessor, E2E_LATENCY_P90, numberOfSourceNodes + numberOfTerminalNodes);
     }
 
     private void checkKeyValueStoreMetrics(final String group0100To24,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.HashSet;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -74,6 +73,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -97,7 +97,9 @@ import static org.apache.kafka.test.StreamsTestUtils.getMetricByNameFilterByTags
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -404,7 +406,7 @@ public class StreamTaskTest {
 
         final KafkaMetric metric = getMetric("active-buffer", "%s-count", task.id().toString(), StreamsConfig.METRICS_LATEST);
 
-        assertThat(metric.metricValue(), equalTo(0.0d));
+        assertThat(metric.metricValue(), equalTo(0.0));
 
         task.addRecords(partition1, asList(
             getConsumerRecord(partition1, 10),
@@ -412,12 +414,12 @@ public class StreamTaskTest {
         ));
         task.recordProcessTimeRatioAndBufferSize(100L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(2.0d));
+        assertThat(metric.metricValue(), equalTo(2.0));
 
         task.process(0L);
         task.recordProcessTimeRatioAndBufferSize(100L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(1.0d));
+        assertThat(metric.metricValue(), equalTo(1.0));
     }
 
     @Test
@@ -426,22 +428,22 @@ public class StreamTaskTest {
 
         final KafkaMetric metric = getMetric("active-process", "%s-ratio", task.id().toString(), StreamsConfig.METRICS_LATEST);
 
-        assertThat(metric.metricValue(), equalTo(0.0d));
+        assertThat(metric.metricValue(), equalTo(0.0));
 
         task.recordProcessBatchTime(10L);
         task.recordProcessBatchTime(15L);
         task.recordProcessTimeRatioAndBufferSize(100L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(0.25d));
+        assertThat(metric.metricValue(), equalTo(0.25));
 
         task.recordProcessBatchTime(10L);
 
-        assertThat(metric.metricValue(), equalTo(0.25d));
+        assertThat(metric.metricValue(), equalTo(0.25));
 
         task.recordProcessBatchTime(10L);
         task.recordProcessTimeRatioAndBufferSize(20L, time.milliseconds());
 
-        assertThat(metric.metricValue(), equalTo(1.0d));
+        assertThat(metric.metricValue(), equalTo(1.0));
     }
 
     @Test
@@ -458,24 +460,7 @@ public class StreamTaskTest {
         task.addRecords(partition1, singletonList(getConsumerRecord(partition1, 0L)));
         task.process(100L);
 
-        assertThat(maxMetric.metricValue(), equalTo(100d));
-    }
-
-    @Test
-    public void shouldRecordE2ELatencyOnProcessForTerminalNodes() {
-        time = new MockTime(0L, 0L, 0L);
-        metrics = new Metrics(new MetricConfig().recordLevel(Sensor.RecordingLevel.INFO), time);
-        task = createStatelessTask(createConfig(false, "0"), StreamsConfig.METRICS_LATEST);
-
-        final String terminalNode = processorStreamTime.name();
-
-        final Metric maxMetric = getProcessorMetric("record-e2e-latency", "%s-max", task.id().toString(), terminalNode, StreamsConfig.METRICS_LATEST);
-
-        // e2e latency = 100
-        time.setCurrentTimeMs(100L);
-        task.maybeRecordE2ELatency(0L, terminalNode);
-
-        assertThat(maxMetric.metricValue(), equalTo(100d));
+        assertThat(maxMetric.metricValue(), equalTo(100.0));
     }
 
     @Test
@@ -493,50 +478,24 @@ public class StreamTaskTest {
         assertThat(maxMetric.metricValue(), equalTo(Double.NaN));
 
         // e2e latency = 10
-        time.setCurrentTimeMs(10L);
-        task.maybeRecordE2ELatency(0L, sourceNode);
-        assertThat(minMetric.metricValue(), equalTo(10d));
-        assertThat(maxMetric.metricValue(), equalTo(10d));
+        task.maybeRecordE2ELatency(0L, 10L, sourceNode);
+        assertThat(minMetric.metricValue(), equalTo(10.0));
+        assertThat(maxMetric.metricValue(), equalTo(10.0));
 
         // e2e latency = 15
-        time.setCurrentTimeMs(25L);
-        task.maybeRecordE2ELatency(10L, sourceNode);
-        assertThat(minMetric.metricValue(), equalTo(10d));
-        assertThat(maxMetric.metricValue(), equalTo(15d));
+        task.maybeRecordE2ELatency(10L, 25L, sourceNode);
+        assertThat(minMetric.metricValue(), equalTo(10.0));
+        assertThat(maxMetric.metricValue(), equalTo(15.0));
 
         // e2e latency = 25
-        time.setCurrentTimeMs(30L);
-        task.maybeRecordE2ELatency(5L, sourceNode);
-        assertThat(minMetric.metricValue(), equalTo(10d));
-        assertThat(maxMetric.metricValue(), equalTo(25d));
+        task.maybeRecordE2ELatency(5L, 30L, sourceNode);
+        assertThat(minMetric.metricValue(), equalTo(10.0));
+        assertThat(maxMetric.metricValue(), equalTo(25.0));
 
         // e2e latency = 20
-        time.setCurrentTimeMs(40L);
-        task.maybeRecordE2ELatency(35L, sourceNode);
-        assertThat(minMetric.metricValue(), equalTo(5d));
-        assertThat(maxMetric.metricValue(), equalTo(25d));
-    }
-
-    @Test
-    public void shouldRecordE2ELatencyPercentiles() {
-        time = new MockTime(0L, 0L, 0L);
-        metrics = new Metrics(new MetricConfig().recordLevel(Sensor.RecordingLevel.INFO), time);
-        task = createStatelessTask(createConfig(false, "0"), StreamsConfig.METRICS_LATEST);
-
-        final String sourceNode = source1.name();
-
-        final Metric p99Metric = getProcessorMetric("record-e2e-latency", "%s-p99", task.id().toString(), sourceNode, StreamsConfig.METRICS_LATEST);
-        final Metric p90Metric = getProcessorMetric("record-e2e-latency", "%s-p90", task.id().toString(), sourceNode, StreamsConfig.METRICS_LATEST);
-
-        for (int i = 0; i < 100; i++) {
-            time.setCurrentTimeMs(i);
-            task.maybeRecordE2ELatency(0L, sourceNode);
-        }
-
-        final double expectedAccuracy = 0.25d; // Make sure it's accurate to within 25% of the expected value
-
-        assertEquals((double) p99Metric.metricValue(), 99d, 99 * expectedAccuracy);
-        assertEquals((double) p90Metric.metricValue(), 90d, 90 * expectedAccuracy);
+        task.maybeRecordE2ELatency(35L, 40L, sourceNode);
+        assertThat(minMetric.metricValue(), equalTo(5.0));
+        assertThat(maxMetric.metricValue(), equalTo(25.0));
     }
 
     @Test
@@ -1765,6 +1724,34 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldUnregisterMetricsInCloseClean() {
+        EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
+        EasyMock.expect(recordCollector.offsets()).andReturn(Collections.emptyMap()).anyTimes();
+        EasyMock.replay(stateManager, recordCollector);
+
+        task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
+
+        task.suspend();
+        assertThat(getTaskMetrics(), not(empty()));
+        task.closeClean();
+        assertThat(getTaskMetrics(), empty());
+    }
+
+    @Test
+    public void shouldUnregisterMetricsInCloseDirty() {
+        EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
+        EasyMock.expect(recordCollector.offsets()).andReturn(Collections.emptyMap()).anyTimes();
+        EasyMock.replay(stateManager, recordCollector);
+
+        task = createOptimizedStatefulTask(createConfig(false, "100"), consumer);
+
+        task.suspend();
+        assertThat(getTaskMetrics(), not(empty()));
+        task.closeDirty();
+        assertThat(getTaskMetrics(), empty());
+    }
+
+    @Test
     public void closeShouldBeIdempotent() {
         EasyMock.expect(stateManager.changelogPartitions()).andReturn(Collections.emptySet()).anyTimes();
         EasyMock.expect(recordCollector.offsets()).andReturn(Collections.emptyMap()).anyTimes();
@@ -1813,7 +1800,10 @@ public class StreamTaskTest {
         assertThrows(IllegalStateException.class, () -> task.closeAndRecycleState()); // RUNNING
 
         task.suspend();
+
+        assertThat(getTaskMetrics(), not(empty()));
         task.closeAndRecycleState(); // SUSPENDED
+        assertThat(getTaskMetrics(), empty());
 
         EasyMock.verify(stateManager, recordCollector);
     }
@@ -1846,6 +1836,10 @@ public class StreamTaskTest {
         assertThat(task.state(), equalTo(RUNNING));
         assertThrows(RuntimeException.class, () -> task.suspend());
         assertThat(task.state(), equalTo(SUSPENDED));
+    }
+
+    private List<MetricName> getTaskMetrics() {
+        return metrics.metrics().keySet().stream().filter(m -> m.tags().containsKey("task-id")).collect(Collectors.toList());
     }
 
     private StreamTask createOptimizedStatefulTask(final StreamsConfig config, final Consumer<byte[], byte[]> consumer) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetricsTest.java
@@ -87,7 +87,7 @@ public class ProcessorNodeMetricsTest {
         expect(streamsMetrics.nodeLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             tagMap,
             metricNamePrefix,
             descriptionOfRate,
@@ -108,7 +108,7 @@ public class ProcessorNodeMetricsTest {
         expect(streamsMetrics.nodeLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             tagMap,
             metricNamePrefix,
             descriptionOfRate,
@@ -261,38 +261,6 @@ public class ProcessorNodeMetricsTest {
         }
     }
 
-    @Test
-    public void shouldGetRecordE2ELatencySensor() {
-        final String operation = "record-e2e-latency";
-        final String recordE2ELatencyMinDescription =
-            "The minimum end-to-end latency of a record, measuring by comparing the record timestamp with the "
-                + "system time when it has been fully processed by the node";
-        final String recordE2ELatencyMaxDescription =
-            "The maximum end-to-end latency of a record, measuring by comparing the record timestamp with the "
-                + "system time when it has been fully processed by the node";
-        final String recordE2ELatencyP99Description =
-            "The 99th percentile end-to-end latency of a record, measuring by comparing the record timestamp with the "
-                + "system time when it has been fully processed by the node";
-        final String recordE2ELatencyP90Description =
-            "The 90th percentile end-to-end latency of a record, measuring by comparing the record timestamp with the "
-                + "system time when it has been fully processed by the node";
-        expect(streamsMetrics.nodeLevelSensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, operation, RecordingLevel.INFO))
-            .andReturn(expectedSensor);
-        expect(streamsMetrics.nodeLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID)).andReturn(tagMap);
-        StreamsMetricsImpl.addMinAndMaxAndP99AndP90ToSensor(
-            expectedSensor,
-            PROCESSOR_NODE_LEVEL_GROUP,
-            tagMap,
-            operation,
-            recordE2ELatencyMinDescription,
-            recordE2ELatencyMaxDescription,
-            recordE2ELatencyP99Description,
-            recordE2ELatencyP90Description
-        );
-
-        verifySensor(() -> ProcessorNodeMetrics.recordE2ELatencySensor(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID, RecordingLevel.INFO, streamsMetrics));
-    }
-
     private void shouldGetThroughputAndLatencySensorWithParentOrEmptySensor(final String metricNamePrefix,
                                                                             final String descriptionOfRate,
                                                                             final String descriptionOfCount,
@@ -353,7 +321,7 @@ public class ProcessorNodeMetricsTest {
             .andReturn(parentTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedParentSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             parentTagMap,
             metricNamePrefix,
             descriptionOfRate,
@@ -361,7 +329,7 @@ public class ProcessorNodeMetricsTest {
         );
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedParentSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             parentTagMap,
             metricNamePrefix + StreamsMetricsImpl.LATENCY_SUFFIX,
             descriptionOfAvg,
@@ -378,7 +346,7 @@ public class ProcessorNodeMetricsTest {
             .andReturn(parentTagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedParentSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             parentTagMap,
             metricNamePrefix,
             descriptionOfRate,
@@ -395,7 +363,7 @@ public class ProcessorNodeMetricsTest {
         setUpThroughputSensor(metricNamePrefix, descriptionOfRate, descriptionOfCount, RecordingLevel.DEBUG, parentSensors);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             tagMap,
             metricNamePrefix + StreamsMetricsImpl.LATENCY_SUFFIX,
             descriptionOfAvgLatency,
@@ -419,7 +387,7 @@ public class ProcessorNodeMetricsTest {
         expect(streamsMetrics.nodeLevelTagMap(THREAD_ID, TASK_ID, PROCESSOR_NODE_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP,
+            PROCESSOR_NODE_LEVEL_GROUP,
             tagMap,
             metricNamePrefix,
             descriptionOfRate,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -999,17 +999,15 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldAddMinAndMaxAndP99AndP90MetricsToSensor() {
+    public void shouldAddMinAndMaxMetricsToSensor() {
         StreamsMetricsImpl
-            .addMinAndMaxAndP99AndP90ToSensor(sensor, group, tags, metricNamePrefix, description1, description2, description3, description4);
+            .addMinAndMaxToSensor(sensor, group, tags, metricNamePrefix, description1, description2);
 
         final double valueToRecord1 = 18.0;
         final double valueToRecord2 = 42.0;
         verifyMetric(metricNamePrefix + "-min", description1, valueToRecord1, valueToRecord2, valueToRecord1);
         verifyMetric(metricNamePrefix + "-max", description2, valueToRecord1, valueToRecord2, valueToRecord2);
-        verifyMetricWithinError(metricNamePrefix + "-p99", description3, valueToRecord1, valueToRecord2, valueToRecord2, 1.0);
-        verifyMetricWithinError(metricNamePrefix + "-p90", description4, valueToRecord1, valueToRecord2, valueToRecord2, 1.0);
-        assertThat(metrics.metrics().size(), equalTo(4 + 1)); // one metric is added automatically in the constructor of Metrics
+        assertThat(metrics.metrics().size(), equalTo(2 + 1)); // one metric is added automatically in the constructor of Metrics
     }
 
     @Test


### PR DESCRIPTION
* Remove problematic Percentiles measurements until the implementation is fixed
* Fix leaking e2e metrics when task is closed
* Fix leaking metrics when tasks are recycled

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
