### PR TITLE
KAFKA-9896: fix flaky StandbyTaskEOSIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -50,7 +50,9 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertTrue;
 
@@ -63,7 +65,7 @@ public class StandbyTaskEOSIntegrationTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<String[]> data() {
-        return Arrays.asList(new String[][] {
+        return asList(new String[][] {
             {StreamsConfig.EXACTLY_ONCE},
             {StreamsConfig.EXACTLY_ONCE_BETA}
         });
@@ -91,7 +93,7 @@ public class StandbyTaskEOSIntegrationTest {
     }
 
     @Test
-    public void surviveWithOneTaskAsStandby() throws Exception {
+    public void shouldSurviveWithOneTaskAsStandby() throws Exception {
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             inputTopic,
             Collections.singletonList(
@@ -111,17 +113,10 @@ public class StandbyTaskEOSIntegrationTest {
             final KafkaStreams streamInstanceOne = buildStreamWithDirtyStateDir(stateDirPath + "/" + appId + "-1/", instanceLatch);
             final KafkaStreams streamInstanceTwo = buildStreamWithDirtyStateDir(stateDirPath + "/" + appId + "-2/", instanceLatch);
         ) {
-            streamInstanceOne.start();
-
-            streamInstanceTwo.start();
+            startApplicationAndWaitUntilRunning(asList(streamInstanceOne, streamInstanceTwo), Duration.ofSeconds(60));
 
             // Wait for the record to be processed
             assertTrue(instanceLatch.await(15, TimeUnit.SECONDS));
-
-            waitForCondition(() -> streamInstanceOne.state().equals(KafkaStreams.State.RUNNING),
-                             "Stream instance one should be up and running by now");
-            waitForCondition(() -> streamInstanceTwo.state().equals(KafkaStreams.State.RUNNING),
-                             "Stream instance two should be up and running by now");
 
             streamInstanceOne.close(Duration.ZERO);
             streamInstanceTwo.close(Duration.ZERO);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
@@ -53,7 +52,6 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
-import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertTrue;
 
 /**


### PR DESCRIPTION
We seem to typically fail on waiting for the first record to be processed, which we only give 15s. 15s to process a single record is reasonable, but we don't wait for the instances to reach the RUNNIG state until _after_ we wait for the record to be processed.

We should first make sure the instance reaches running (for which a 60s timeout seems to be the common case in other integration tests), and then wait on the record to be processed.