### PR TITLE
KAFKA-8264: decrease the record size for flaky test

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -800,7 +800,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     awaitAssignment(consumer, partitions.toSet)
 
     val producer = createProducer()
-    val producerRecords = partitions.flatMap(sendRecords(producer, partitionCount, _))
+    val producerRecords = partitions.flatMap(sendRecords(producer, numRecords = 15, _))
     val consumerRecords = consumeRecords(consumer, producerRecords.size)
 
     val expected = producerRecords.map { record =>


### PR DESCRIPTION
This flaky test exists for a long time, and it happened more frequently recently. (also happened in my PR testing!! :(  ) In KAFKA-8264 and KAFKA-8460, it described the issue for this test is that 
> Timed out before consuming expected 2700 records. The number consumed was xxxx

I did some investigation. This test is to test: 
> we consume all partitions if fetch max bytes and max.partition.fetch.bytes are low. 

And what it did, is to create 3 topics and 30 partitions for each. And then, iterate through all 90 partitions to send 30 records for each. Finally, verify the we can consume all the records successfully. 

What the error message saying is that it cannot consume all the records in time (might be the busy system) So, we can actually decrease the record size to avoid it. I checked all the error messages we collected in KAFKA-8264 and KAFKA-8460, the failed cases can always consume at least 1440 up (total is 2700). So, I set the records half size of the original setting, it'll become 1350 records in total. It should make this test more stable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
