### PR TITLE
KAFKA-9891: fix corrupted StandbyTask state

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.FixedOrderMap;
@@ -34,12 +32,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -124,6 +124,9 @@ public class ProcessorStateManager implements StateManager {
         log.debug("Created state store manager for task {}", taskId);
     }
 
+    boolean hadCheckpoint(final TopicPartition partition) {
+        return initialLoadedCheckpoints.get(partition) != null;
+    }
 
     public static String storeChangelogTopic(final String applicationId,
                                              final String storeName) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -88,6 +88,7 @@ public class StandbyTask extends AbstractTask {
 
         if (eosEnabled) {
             final Set<TopicPartition> partitionsToReinitialize = new HashSet<>();
+            // the state manager actually returns the next checkpoint to be written
             for (final TopicPartition partition : stateMgr.checkpointed().keySet()) {
                 if (!stateMgr.hadCheckpoint(partition)) {
                     partitionsToReinitialize.add(partition);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -85,6 +85,21 @@ public class StandbyTask extends AbstractTask {
     public boolean initializeStateStores() {
         log.trace("Initializing state stores");
         registerStateStores();
+
+        if (eosEnabled) {
+            final Set<TopicPartition> partitionsToReinitialize = new HashSet<>();
+            for (final TopicPartition partition : stateMgr.checkpointed().keySet()) {
+                if (!stateMgr.hadCheckpoint(partition)) {
+                    partitionsToReinitialize.add(partition);
+                }
+
+            }
+
+            if (!partitionsToReinitialize.isEmpty()) {
+                reinitializeStateStoresForPartitions(partitionsToReinitialize);
+            }
+        }
+
         processorContext.initialize();
         taskInitialized = true;
         return true;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+
+/**
+ * An integration test to verify the conversion of a dirty-closed EOS
+ * task towards a standby task is safe across restarts of the application.
+ */
+public class StandbyTaskEOSIntegrationTest {
+
+    private final AtomicBoolean skip = new AtomicBoolean(false);
+
+    private String appId;
+    private String inputTopic;
+    private String storeName;
+    private String outputTopic;
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
+
+    @Before
+    public void createTopics() throws Exception {
+        appId = "standbyTest";
+        inputTopic = "testInputTopic";
+        outputTopic = "testOutputTopic";
+        storeName = "dedupStore";
+        CLUSTER.deleteTopicsAndWait(inputTopic, outputTopic);
+        CLUSTER.createTopic(inputTopic, 1, 3);
+        CLUSTER.createTopic(outputTopic, 1, 3);
+    }
+
+    @Test
+    public void shouldWipeOutStandbyStateDirectoryIfCheckpointIsMissing() throws Exception {
+        final String base = TestUtils.tempDirectory(appId).getPath();
+
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            inputTopic,
+            Collections.singletonList(
+                new KeyValue<>(0, 0)
+            ),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                IntegerSerializer.class,
+                IntegerSerializer.class,
+                new Properties()
+            ),
+            10L
+        );
+
+        try (
+            final KafkaStreams streamInstanceOne = buildWithDeduplicationTopology(base + "-1");
+            final KafkaStreams streamInstanceTwo = buildWithDeduplicationTopology(base + "-2");
+            final KafkaStreams streamInstanceOneRecovery = buildWithDeduplicationTopology(base + "-1")
+        ) {
+            // start first instance and wait for processing
+            startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceOne), Duration.ofSeconds(30));
+            IntegrationTestUtils.waitUntilMinRecordsReceived(
+                TestUtils.consumerConfig(
+                    CLUSTER.bootstrapServers(),
+                    IntegerDeserializer.class,
+                    IntegerDeserializer.class
+                ),
+                outputTopic,
+                1
+            );
+
+            // start second instance and wait for standby replication
+            startApplicationAndWaitUntilRunning(Collections.singletonList(streamInstanceTwo), Duration.ofSeconds(30));
+            waitForCondition(
+                () -> streamInstanceTwo.store(
+                    StoreQueryParameters.fromNameAndType(
+                        storeName,
+                        QueryableStoreTypes.<Integer, Integer>keyValueStore()
+                    ).enableStaleStores()
+                ).get(0) != null,
+                120_000L, // use increased timeout to encounter for rebalancing time
+                "Could not get key from standby store"
+            );
+            // sanity check that first instance is still active
+            waitForCondition(
+                () -> streamInstanceOne.store(
+                    StoreQueryParameters.fromNameAndType(
+                        storeName,
+                        QueryableStoreTypes.<Integer, Integer>keyValueStore()
+                    )
+                ).get(0) != null,
+                "Could not get key from main store"
+            );
+
+            // inject poison pill and wait for crash of first instance and recovery on second instance
+            IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+                inputTopic,
+                Collections.singletonList(
+                    new KeyValue<>(1, 0)
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    IntegerSerializer.class,
+                    IntegerSerializer.class,
+                    new Properties()
+                ),
+                10L
+            );
+            waitForCondition(
+                () -> streamInstanceOne.state() == KafkaStreams.State.ERROR,
+                "Stream instance 1 did not go into error state"
+            );
+            streamInstanceOne.close();
+
+            waitForCondition(
+                () -> streamInstanceTwo.store(
+                    StoreQueryParameters.fromNameAndType(
+                        storeName,
+                        QueryableStoreTypes.keyValueStore()
+                    )
+                ).get(0) != null,
+                120_000L, // use increased timeout to encounter for rebalancing time
+                "Could not get key from recovered main store"
+            );
+
+            // "restart" first client and wait for standby recovery
+            startApplicationAndWaitUntilRunning(
+                Collections.singletonList(streamInstanceOneRecovery),
+                Duration.ofSeconds(30)
+            );
+            waitForCondition(
+                () -> streamInstanceOneRecovery.store(
+                    StoreQueryParameters.fromNameAndType(
+                        storeName,
+                        QueryableStoreTypes.<Integer, Integer>keyValueStore()
+                    ).enableStaleStores()
+                ).get(0) != null,
+                "Could not get key from recovered standby store"
+            );
+            // sanity check that second instance is still active
+            waitForCondition(
+                () -> streamInstanceTwo.store(
+                    StoreQueryParameters.fromNameAndType(
+                        storeName,
+                        QueryableStoreTypes.keyValueStore()
+                    )
+                ).get(0) != null,
+                "Could not get key from recovered main store"
+            );
+
+            streamInstanceTwo.close();
+            waitForCondition(
+                () -> streamInstanceOneRecovery.store(
+                    StoreQueryParameters.fromNameAndType(
+                        storeName,
+                        QueryableStoreTypes.<Integer, Integer>keyValueStore()
+                    )
+                ).get(0) != null,
+                120_000L, // use increased timeout to encounter for rebalancing time
+                "Could not get key from recovered main store"
+            );
+
+            // re-inject poison pill and wait for crash of first instance
+            skip.set(false);
+            IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+                inputTopic,
+                Collections.singletonList(
+                    new KeyValue<>(1, 0)
+                ),
+                TestUtils.producerConfig(
+                    CLUSTER.bootstrapServers(),
+                    IntegerSerializer.class,
+                    IntegerSerializer.class,
+                    new Properties()
+                ),
+                10L
+            );
+            waitForCondition(
+                () -> streamInstanceOneRecovery.state() == KafkaStreams.State.ERROR,
+                "Stream instance 1 did not go into error state"
+            );
+        }
+    }
+
+    private KafkaStreams buildWithDeduplicationTopology(final String stateDirPath) {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        builder.addStateStore(Stores.keyValueStoreBuilder(
+            Stores.persistentKeyValueStore(storeName),
+            Serdes.Integer(),
+            Serdes.Integer())
+        );
+        builder.<Integer, Integer>stream(inputTopic)
+            .transform(
+                () -> new Transformer<Integer, Integer, KeyValue<Integer, Integer>>() {
+                    private KeyValueStore<Integer, Integer> store;
+
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    public void init(final ProcessorContext context) {
+                        store = (KeyValueStore<Integer, Integer>) context.getStateStore(storeName);
+
+                        final KeyValueIterator<Integer, Integer> it = store.all();
+                        System.err.println("mjsax: store content begin");
+                        while (it.hasNext()) {
+                            final KeyValue<Integer, Integer> next = it.next();
+                            System.err.println("mjsax: key/value -> " + next.key + "/" + next.value);
+                        }
+                        System.err.println("mjsax: store content end");
+                    }
+
+                    @Override
+                    public KeyValue<Integer, Integer> transform(final Integer key, final Integer value) {
+                        if (skip.get()) {
+                            System.err.println("mjsax skip key " + key);
+                            return null;
+                        }
+
+                        if (store.get(key) != null) {
+                            System.err.println("mjsax found duplicate for key " + key);
+                            return null;
+                        }
+
+                        System.err.println("mjsax put key " + key);
+                        store.put(key, value);
+                        store.flush();
+
+                        if (key == 1) {
+                            skip.set(true);
+                            throw new RuntimeException("Injected test error");
+                        }
+
+                        return KeyValue.pair(key, value);
+                    }
+
+                    @Override
+                    public void close() { }
+                },
+                storeName
+            )
+            .to(outputTopic);
+
+        return new KafkaStreams(builder.build(), props(stateDirPath));
+    }
+
+    private Properties props(final String stateDirPath) {
+        final Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, stateDirPath);
+        streamsConfiguration.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1);
+        streamsConfiguration.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        return streamsConfiguration;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -52,6 +52,8 @@ import static org.apache.kafka.test.TestUtils.waitForCondition;
 public class StandbyTaskEOSIntegrationTest {
 
     private final static long REBALANCE_TIMEOUT = Duration.ofMinutes(2L).toMillis();
+    private final static int KEY_0 = 0;
+    private final static int KEY_1 = 1;
 
     private final AtomicBoolean skipRecord = new AtomicBoolean(false);
 
@@ -81,7 +83,7 @@ public class StandbyTaskEOSIntegrationTest {
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             inputTopic,
             Collections.singletonList(
-                new KeyValue<>(0, 0)
+                new KeyValue<>(KEY_0, 0)
             ),
             TestUtils.producerConfig(
                 CLUSTER.bootstrapServers(),
@@ -117,7 +119,7 @@ public class StandbyTaskEOSIntegrationTest {
                         storeName,
                         QueryableStoreTypes.<Integer, Integer>keyValueStore()
                     ).enableStaleStores()
-                ).get(0) != null,
+                ).get(KEY_0) != null,
                 REBALANCE_TIMEOUT,
                 "Could not get key from standby store"
             );
@@ -128,7 +130,7 @@ public class StandbyTaskEOSIntegrationTest {
                         storeName,
                         QueryableStoreTypes.<Integer, Integer>keyValueStore()
                     )
-                ).get(0) != null,
+                ).get(KEY_0) != null,
                 "Could not get key from main store"
             );
 
@@ -173,7 +175,7 @@ public class StandbyTaskEOSIntegrationTest {
                         storeName,
                         QueryableStoreTypes.<Integer, Integer>keyValueStore()
                     ).enableStaleStores()
-                ).get(0) != null,
+                ).get(KEY_0) != null,
                 "Could not get key from recovered standby store"
             );
 
@@ -184,7 +186,7 @@ public class StandbyTaskEOSIntegrationTest {
                         storeName,
                         QueryableStoreTypes.<Integer, Integer>keyValueStore()
                     )
-                ).get(0) != null,
+                ).get(KEY_0) != null,
                 REBALANCE_TIMEOUT,
                 "Could not get key from recovered main store"
             );
@@ -194,7 +196,7 @@ public class StandbyTaskEOSIntegrationTest {
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
                 inputTopic,
                 Collections.singletonList(
-                    new KeyValue<>(1, 0)
+                    new KeyValue<>(KEY_1, 0)
                 ),
                 TestUtils.producerConfig(
                     CLUSTER.bootstrapServers(),


### PR DESCRIPTION
A StandbyTask must wipe its local state if EOS is enabled and no local
checkpoint file is found.

I left debug statement in on purpose to people can verify the test locally if they want.
 - when the first instance starts up, the store should be empty
 - if should process key 0 and put into the store
 - after the second instance is running and has replicated the state, the first instance should process key 1 and crash
 - after fail-over to instance 2, the store should only contain key 0
 - instance 2 should reprocess key 1 (we skip it to avoid the crash for this case; note that the store content in not modified; we only need to do this to make sure instance 1 can be restarted and rebuild the standby store)
 - instance 1 is restarted and rebuild the standby store
 - we stop instance 2 an the store is migrated to instance 1: the store should only contain key 0 (if the fix in `StandbyTask` is remove, one can observe that the store content is 0 and 1)
 - we re-enable error injection and re-inject the poison pill: instance 1 should fail again (without the fix, no error occurs because key 1 is detected as duplicated)

Call for review @abbccdda @guozhangwang 