### PR TITLE
MINOR: reuse toConfigObject(Map) to generate Config

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class MockAdminClient extends AdminClient {
     public static final String DEFAULT_CLUSTER_ID = "I4ZmrWqfT2e-upky_4fdPA";
@@ -532,9 +531,7 @@ public class MockAdminClient extends AdminClient {
                 if (topicMetadata != null && !topicMetadata.markedForDeletion) {
                     if (topicMetadata.fetchesRemainingUntilVisible > 0)
                         topicMetadata.fetchesRemainingUntilVisible = Math.max(0, topicMetadata.fetchesRemainingUntilVisible - 1);
-                    else return new Config(topicMetadata.configs.entrySet().stream()
-                                .map(entry -> new ConfigEntry(entry.getKey(), entry.getValue()))
-                                .collect(Collectors.toList()));
+                    else return toConfigObject(topicMetadata.configs);
 
                 }
                 throw new UnknownTopicOrPartitionException("Resource " + resource + " not found.");


### PR DESCRIPTION
from https://github.com/apache/kafka/pull/8853#discussion_r441609880

```
nit: I think that we can use toConfigObject(topicMetadata.configs) here.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
