### PR TITLE
KAFKA-10143: Improve test coverage for throttle changes during reassignment

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -1218,14 +1218,13 @@ object ReassignPartitionsCommand extends Logging {
       adminClient.alterPartitionReassignments(reassignments.map {
           (_, (None: Option[NewPartitionReassignment]).asJava)
         }.toMap.asJava).values().asScala
-    results.flatMap {
-      case (part, future) =>
-        try {
-          future.get()
-          None
-        } catch {
-          case t: ExecutionException => Some(part, t.getCause())
-        }
+    results.flatMap { case (part, future) =>
+      try {
+        future.get()
+        None
+      } catch {
+        case t: ExecutionException => Some(part, t.getCause())
+      }
     }
   }
 
@@ -1234,9 +1233,9 @@ object ReassignPartitionsCommand extends Logging {
     // Add the current reassignments to the move map.
     currentReassignments.foreach { case (part, reassignment) =>
       val move = PartitionMove(new mutable.HashSet[Int](), new mutable.HashSet[Int]())
-      reassignment.replicas.forEach {
-        replica => move.sources += replica
-          move.destinations += replica
+      reassignment.replicas.forEach { replica =>
+        move.sources += replica
+        move.destinations += replica
       }
       reassignment.addingReplicas.forEach(move.destinations += _)
       reassignment.removingReplicas.forEach(move.destinations -= _)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -965,15 +965,15 @@ object ReassignPartitionsCommand extends Logging {
     val currentParts = getReplicaAssignmentForPartitions(adminClient, proposedParts.keySet.toSet)
     println(currentPartitionReplicaAssignmentToString(proposedParts, currentParts))
 
-    if (interBrokerThrottle > 0 || logDirThrottle > 0) {
+    if (interBrokerThrottle >= 0 || logDirThrottle >= 0) {
       println(youMustRunVerifyPeriodicallyMessage)
 
-      if (interBrokerThrottle > 0) {
+      if (interBrokerThrottle >= 0) {
         val moveMap = calculateProposedMoveMap(currentReassignments, proposedParts, currentParts)
         modifyReassignmentThrottle(adminClient, moveMap, interBrokerThrottle)
       }
 
-      if (logDirThrottle > 0) {
+      if (logDirThrottle >= 0) {
         val movingBrokers = calculateMovingBrokers(proposedReplicas.keySet.toSet)
         modifyLogDirThrottle(adminClient, movingBrokers, logDirThrottle)
       }

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -817,14 +817,8 @@ class KafkaController(val config: KafkaConfig,
         info(s"Skipping reassignment of $tp since the topic is currently being deleted")
         new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "The partition does not exist.")
       } else {
-        val assignment = controllerContext.partitionFullReplicaAssignment(tp)
-        if (assignment == ReplicaAssignment.empty) {
-          new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "The partition does not exist.")
-        } else if (assignment == reassignment) {
-          info(s"Skipping assignment update of partition $tp to $reassignment since it " +
-            "matches the existing assignment")
-          ApiError.NONE
-        } else {
+        val assignedReplicas = controllerContext.partitionReplicaAssignment(tp)
+        if (assignedReplicas.nonEmpty) {
           try {
             onPartitionReassignment(tp, reassignment)
             ApiError.NONE
@@ -836,6 +830,8 @@ class KafkaController(val config: KafkaConfig,
               error(s"Error completing reassignment of partition $tp", e)
               new ApiError(Errors.UNKNOWN_SERVER_ERROR)
           }
+        } else {
+          new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "The partition does not exist.")
         }
       }
 

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -168,10 +168,10 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     cluster.setup()
     cluster.produceMessages("foo", 0, 50)
     cluster.produceMessages("baz", 2, 60)
-    val assignment = """{"version":1,"partitions":""" +
-      """[{"topic":"foo","partition":0,"replicas":[0,3,2],"log_dirs":["any","any","any"]},""" +
-      """{"topic":"baz","partition":2,"replicas":[3,2,1],"log_dirs":["any","any","any"]}""" +
-      """]}"""
+    val assignment = """{"version":1,"partitions":
+      [{"topic":"foo","partition":0,"replicas":[0,3,2],"log_dirs":["any","any","any"]},
+      {"topic":"baz","partition":2,"replicas":[3,2,1],"log_dirs":["any","any","any"]}
+      ]}"""
 
     // Execute the assignment with a low throttle
     val initialThrottle = 1L
@@ -487,7 +487,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
 
     val logDirs = replicas.map { replicaId =>
       if (replicaId == brokerId)
-        "\"%s\"".format(newDir)
+        s""""$newDir""""
       else
         "\"any\""
     }

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -162,6 +162,39 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
       localLogOrException(part).highWatermark)
   }
 
+  @Test
+  def testAlterReassignmentThrottle(): Unit = {
+    cluster = new ReassignPartitionsTestCluster(zkConnect)
+    cluster.setup()
+    cluster.produceMessages("foo", 0, 50)
+    cluster.produceMessages("baz", 2, 60)
+    val assignment = """{"version":1,"partitions":""" +
+      """[{"topic":"foo","partition":0,"replicas":[0,3,2],"log_dirs":["any","any","any"]},""" +
+      """{"topic":"baz","partition":2,"replicas":[3,2,1],"log_dirs":["any","any","any"]}""" +
+      """]}"""
+
+    // Execute the assignment with a low throttle
+    val initialThrottle = 1L
+    runExecuteAssignment(cluster.adminClient, false, assignment, initialThrottle, -1L)
+    waitForInterBrokerThrottle(Set(0, 1, 2, 3), initialThrottle)
+
+    // Now update the throttle and verify the reassignment completes
+    val updatedThrottle = 300000L
+    runAlterThrottles(cluster.adminClient, interBrokerThrottle = updatedThrottle, replicaAlterLogDirsThrottle = -1L)
+    waitForInterBrokerThrottle(Set(0, 1, 2, 3), updatedThrottle)
+
+    val finalAssignment = Map(
+      new TopicPartition("foo", 0) ->
+        PartitionReassignmentState(Seq(0, 3, 2), Seq(0, 3, 2), true),
+      new TopicPartition("baz", 2) ->
+        PartitionReassignmentState(Seq(3, 2, 1), Seq(3, 2, 1), true))
+
+    // Now remove the throttles.
+    waitForVerifyAssignment(cluster.adminClient, assignment, false,
+      VerifyAssignmentResult(finalAssignment))
+    waitForBrokerLevelThrottles(unthrottledBrokerConfigs)
+  }
+
   /**
    * Test running a reassignment with the interBrokerThrottle set.
    */
@@ -192,20 +225,8 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     // Execute the assignment
     val interBrokerThrottle = 300000L
     runExecuteAssignment(cluster.adminClient, false, assignment, interBrokerThrottle, -1L)
+    waitForInterBrokerThrottle(Set(0, 1, 2, 3), interBrokerThrottle)
 
-    val throttledConfigMap = Map[String, Long](
-      brokerLevelLeaderThrottle -> interBrokerThrottle,
-      brokerLevelFollowerThrottle -> interBrokerThrottle,
-      brokerLevelLogDirThrottle -> -1L
-    )
-    val throttledBrokerConfigs = Map[Int, Map[String, Long]](
-      0 -> throttledConfigMap,
-      1 -> throttledConfigMap,
-      2 -> throttledConfigMap,
-      3 -> throttledConfigMap,
-      4 -> unthrottledBrokerConfigs(4)
-    )
-    waitForBrokerLevelThrottles(throttledBrokerConfigs)
     val finalAssignment = Map(
       new TopicPartition("foo", 0) ->
         PartitionReassignmentState(Seq(0, 3, 2), Seq(0, 3, 2), true),
@@ -227,7 +248,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
           assertEquals(Seq(3, 2, 1),
             result.partStates(new TopicPartition("baz", 2)).targetReplicas)
           logger.info(s"Current result: ${result}")
-          waitForBrokerLevelThrottles(throttledBrokerConfigs)
+          waitForInterBrokerThrottle(Set(0, 1, 2, 3), interBrokerThrottle)
           false
         }
       }, "Expected reassignment to complete.")
@@ -236,7 +257,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     waitForVerifyAssignment(zkClient, assignment, true,
       VerifyAssignmentResult(finalAssignment))
     // The throttles should still have been preserved, since we ran with --preserve-throttles
-    waitForBrokerLevelThrottles(throttledBrokerConfigs)
+    waitForInterBrokerThrottle(Set(0, 1, 2, 3), interBrokerThrottle)
     // Now remove the throttles.
     waitForVerifyAssignment(cluster.adminClient, assignment, false,
       VerifyAssignmentResult(finalAssignment))
@@ -285,19 +306,8 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
       describeBrokerLevelThrottles(unthrottledBrokerConfigs.keySet.toSeq))
     val interBrokerThrottle = 1L
     runExecuteAssignment(cluster.adminClient, false, assignment, interBrokerThrottle, -1L)
-    val throttledConfigMap = Map[String, Long](
-      brokerLevelLeaderThrottle -> interBrokerThrottle,
-      brokerLevelFollowerThrottle -> interBrokerThrottle,
-      brokerLevelLogDirThrottle -> -1L
-    )
-    val throttledBrokerConfigs = Map[Int, Map[String, Long]](
-      0 -> throttledConfigMap,
-      1 -> throttledConfigMap,
-      2 -> throttledConfigMap,
-      3 -> throttledConfigMap,
-      4 -> unthrottledBrokerConfigs(4)
-    )
-    waitForBrokerLevelThrottles(throttledBrokerConfigs)
+    waitForInterBrokerThrottle(Set(0, 1, 2, 3), interBrokerThrottle)
+
     // Verify that the reassignment is running.  The very low throttle should keep it
     // from completing before this runs.
     waitForVerifyAssignment(cluster.adminClient, assignment, true,
@@ -311,13 +321,41 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
         new TopicPartition("baz", 1)
       ), Set()), runCancelAssignment(cluster.adminClient, assignment, true))
     // Broker throttles are still active because we passed --preserve-throttles
-    waitForBrokerLevelThrottles(throttledBrokerConfigs)
+    waitForInterBrokerThrottle(Set(0, 1, 2, 3), interBrokerThrottle)
     // Cancelling the reassignment again should reveal nothing to cancel.
     assertEquals((Set(), Set()), runCancelAssignment(cluster.adminClient, assignment, false))
     // This time, the broker throttles were removed.
     waitForBrokerLevelThrottles(unthrottledBrokerConfigs)
     // Verify that there are no ongoing reassignments.
     assertFalse(runVerifyAssignment(cluster.adminClient, assignment, false).partsOngoing)
+  }
+
+  private def waitForLogDirThrottle(throttledBrokers: Set[Int], logDirThrottle: Long): Unit = {
+    val throttledConfigMap = Map[String, Long](
+      brokerLevelLeaderThrottle -> -1,
+      brokerLevelFollowerThrottle -> -1,
+      brokerLevelLogDirThrottle -> logDirThrottle)
+    waitForBrokerThrottles(throttledBrokers, throttledConfigMap)
+  }
+
+  private def waitForInterBrokerThrottle(throttledBrokers: Set[Int], interBrokerThrottle: Long): Unit = {
+    val throttledConfigMap = Map[String, Long](
+      brokerLevelLeaderThrottle -> interBrokerThrottle,
+      brokerLevelFollowerThrottle -> interBrokerThrottle,
+      brokerLevelLogDirThrottle -> -1L)
+    waitForBrokerThrottles(throttledBrokers, throttledConfigMap)
+  }
+
+  private def waitForBrokerThrottles(throttledBrokers: Set[Int], throttleConfig: Map[String, Long]): Unit = {
+    val throttledBrokerConfigs = unthrottledBrokerConfigs.map { case (brokerId, unthrottledConfig) =>
+      val expectedThrottleConfig = if (throttledBrokers.contains(brokerId)) {
+        throttleConfig
+      } else {
+        unthrottledConfig
+      }
+      brokerId -> expectedThrottleConfig
+    }
+    waitForBrokerLevelThrottles(throttledBrokerConfigs)
   }
 
   private def waitForBrokerLevelThrottles(targetThrottles: Map[Int, Map[String, Long]]): Unit = {
@@ -349,54 +387,32 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
    * Test moving partitions between directories.
    */
   @Test
-  def testReplicaDirectoryMoves(): Unit = {
+  def testLogDirReassignment(): Unit = {
+    val topicPartition = new TopicPartition("foo", 0)
+
     cluster = new ReassignPartitionsTestCluster(zkConnect)
     cluster.setup()
-    cluster.produceMessages("foo", 0, 7000)
-    cluster.produceMessages("baz", 1, 6000)
+    cluster.produceMessages(topicPartition.topic, topicPartition.partition, 700)
 
-    val result0 = cluster.adminClient.describeLogDirs(
-        0.to(4).map(_.asInstanceOf[Integer]).asJavaCollection)
-    val info0 = new BrokerDirs(result0, 0)
-    assertTrue(info0.futureLogDirs.isEmpty)
-    assertEquals(Set(new TopicPartition("foo", 0),
-        new TopicPartition("baz", 0),
-        new TopicPartition("baz", 1),
-        new TopicPartition("baz", 2)),
-      info0.curLogDirs.keySet)
-    val curFoo1Dir = info0.curLogDirs.getOrElse(new TopicPartition("foo", 0), "")
-    assertFalse(curFoo1Dir.equals(""))
-    val newFoo1Dir = info0.logDirs.find(!_.equals(curFoo1Dir)).get
-    val assignment = """{"version":1,"partitions":""" +
-        """[{"topic":"foo","partition":0,"replicas":[0,1,2],""" +
-          "\"log_dirs\":[\"%s\",\"any\",\"any\"]}".format(newFoo1Dir) +
-            "]}"
+    val targetBrokerId = 0
+    val replicas = Seq(0, 1, 2)
+    val reassignment = buildLogDirReassignment(topicPartition, targetBrokerId, replicas)
+
     // Start the replica move, but throttle it to be very slow so that it can't complete
     // before our next checks happen.
-    runExecuteAssignment(cluster.adminClient, false, assignment, -1L, 1L)
+    val logDirThrottle = 1L
+    runExecuteAssignment(cluster.adminClient, additional = false, reassignment.json,
+      interBrokerThrottle = -1L, logDirThrottle)
 
     // Check the output of --verify
-    waitForVerifyAssignment(cluster.adminClient, assignment, true,
+    waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
       VerifyAssignmentResult(Map(
-          new TopicPartition("foo", 0) -> PartitionReassignmentState(Seq(0, 1, 2), Seq(0, 1, 2), true)
+          topicPartition -> PartitionReassignmentState(Seq(0, 1, 2), Seq(0, 1, 2), true)
         ), false, Map(
-          new TopicPartitionReplica("foo", 0, 0) -> ActiveMoveState(curFoo1Dir, newFoo1Dir, newFoo1Dir)
+          new TopicPartitionReplica(topicPartition.topic, topicPartition.partition, 0) ->
+            ActiveMoveState(reassignment.currentDir, reassignment.targetDir, reassignment.targetDir)
         ), true))
-
-    // Check that the appropriate broker throttle is in place.
-    val throttledConfigMap = Map[String, Long](
-      brokerLevelLeaderThrottle -> -1,
-      brokerLevelFollowerThrottle -> -1,
-      brokerLevelLogDirThrottle -> 1L
-    )
-    val throttledBrokerConfigs = Map[Int, Map[String, Long]](
-      0 -> throttledConfigMap,
-      1 -> unthrottledBrokerConfigs(1),
-      2 -> unthrottledBrokerConfigs(2),
-      3 -> unthrottledBrokerConfigs(3),
-      4 -> unthrottledBrokerConfigs(4)
-    )
-    waitForBrokerLevelThrottles(throttledBrokerConfigs)
+    waitForLogDirThrottle(Set(0), logDirThrottle)
 
     // Remove the throttle
     cluster.adminClient.incrementalAlterConfigs(Collections.singletonMap(
@@ -407,17 +423,90 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     waitForBrokerLevelThrottles(unthrottledBrokerConfigs)
 
     // Wait for the directory movement to complete.
-    waitForVerifyAssignment(cluster.adminClient, assignment, true,
+    waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
         VerifyAssignmentResult(Map(
-          new TopicPartition("foo", 0) -> PartitionReassignmentState(Seq(0, 1, 2), Seq(0, 1, 2), true)
+          topicPartition -> PartitionReassignmentState(Seq(0, 1, 2), Seq(0, 1, 2), true)
         ), false, Map(
-          new TopicPartitionReplica("foo", 0, 0) -> CompletedMoveState(newFoo1Dir)
+          new TopicPartitionReplica(topicPartition.topic, topicPartition.partition, 0) ->
+            CompletedMoveState(reassignment.targetDir)
         ), false))
 
     val info1 = new BrokerDirs(cluster.adminClient.describeLogDirs(0.to(4).
         map(_.asInstanceOf[Integer]).asJavaCollection), 0)
-    assertEquals(newFoo1Dir,
-      info1.curLogDirs.getOrElse(new TopicPartition("foo", 0), ""))
+    assertEquals(reassignment.targetDir,
+      info1.curLogDirs.getOrElse(topicPartition, ""))
+  }
+
+  @Test
+  def testAlterLogDirReassignmentThrottle(): Unit = {
+    val topicPartition = new TopicPartition("foo", 0)
+
+    cluster = new ReassignPartitionsTestCluster(zkConnect)
+    cluster.setup()
+    cluster.produceMessages(topicPartition.topic, topicPartition.partition, 700)
+
+    val targetBrokerId = 0
+    val replicas = Seq(0, 1, 2)
+    val reassignment = buildLogDirReassignment(topicPartition, targetBrokerId, replicas)
+
+    // Start the replica move with a low throttle so it does not complete
+    val initialLogDirThrottle = 1L
+    runExecuteAssignment(cluster.adminClient, false, reassignment.json,
+      interBrokerThrottle = -1L, initialLogDirThrottle)
+    waitForLogDirThrottle(Set(0), initialLogDirThrottle)
+
+    // Now increase the throttle and verify that the log dir movement completes
+    val updatedLogDirThrottle = 3000000L
+    runAlterThrottles(cluster.adminClient, interBrokerThrottle = -1L,
+      replicaAlterLogDirsThrottle = updatedLogDirThrottle)
+    waitForLogDirThrottle(Set(0), updatedLogDirThrottle)
+
+    waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
+      VerifyAssignmentResult(Map(
+        topicPartition -> PartitionReassignmentState(Seq(0, 1, 2), Seq(0, 1, 2), true)
+      ), false, Map(
+        new TopicPartitionReplica(topicPartition.topic, topicPartition.partition, targetBrokerId) ->
+          CompletedMoveState(reassignment.targetDir)
+      ), false))
+  }
+
+  case class LogDirReassignment(json: String, currentDir: String, targetDir: String)
+
+  private def buildLogDirReassignment(topicPartition: TopicPartition,
+                                      brokerId: Int,
+                                      replicas: Seq[Int]): LogDirReassignment = {
+
+    val describeLogDirsResult = cluster.adminClient.describeLogDirs(
+      0.to(4).map(_.asInstanceOf[Integer]).asJavaCollection)
+
+    val logDirInfo = new BrokerDirs(describeLogDirsResult, brokerId)
+    assertTrue(logDirInfo.futureLogDirs.isEmpty)
+
+    val currentDir = logDirInfo.curLogDirs(topicPartition)
+    val newDir = logDirInfo.logDirs.find(!_.equals(currentDir)).get
+
+    val logDirs = replicas.map { replicaId =>
+      if (replicaId == brokerId)
+        "\"%s\"".format(newDir)
+      else
+        "\"any\""
+    }
+
+    val reassignmentJson =
+      s"""
+         | { "version": 1,
+         |  "partitions": [
+         |    {
+         |     "topic": "${topicPartition.topic}",
+         |     "partition": ${topicPartition.partition},
+         |     "replicas": [${replicas.mkString(",")}],
+         |     "log_dirs": [${logDirs.mkString(",")}]
+         |    }
+         |   ]
+         |  }
+         |""".stripMargin
+
+    LogDirReassignment(reassignmentJson, currentDir = currentDir, targetDir = newDir)
   }
 
   private def runVerifyAssignment(adminClient: Admin, jsonString: String,
@@ -459,16 +548,25 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
   }
 
   private def runExecuteAssignment(adminClient: Admin,
-                        additional: Boolean,
-                        reassignmentJson: String,
-                        interBrokerThrottle: Long,
-                        replicaAlterLogDirsThrottle: Long) = {
+                                   additional: Boolean,
+                                   reassignmentJson: String,
+                                   interBrokerThrottle: Long,
+                                   replicaAlterLogDirsThrottle: Long) = {
     println(s"==> executeAssignment(adminClient, additional=${additional}, " +
       s"reassignmentJson=${reassignmentJson}, " +
       s"interBrokerThrottle=${interBrokerThrottle}, " +
       s"replicaAlterLogDirsThrottle=${replicaAlterLogDirsThrottle}))")
     executeAssignment(adminClient, additional, reassignmentJson,
       interBrokerThrottle, replicaAlterLogDirsThrottle)
+  }
+
+  private def runAlterThrottles(admin: Admin,
+                                interBrokerThrottle: Long,
+                                replicaAlterLogDirsThrottle: Long): Unit = {
+    println(s"==> alterThrottles(adminClient, " +
+      s"interBrokerThrottle=${interBrokerThrottle}, " +
+      s"replicaAlterLogDirsThrottle=${replicaAlterLogDirsThrottle}))")
+    alterThrottles(admin, interBrokerThrottle, replicaAlterLogDirsThrottle)
   }
 
   private def runExecuteAssignment(zkClient: KafkaZkClient,

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -180,7 +180,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
 
     // Now update the throttle and verify the reassignment completes
     val updatedThrottle = 300000L
-    runAlterThrottles(cluster.adminClient, interBrokerThrottle = updatedThrottle, replicaAlterLogDirsThrottle = -1L)
+    runExecuteAssignment(cluster.adminClient, additional = true, assignment, updatedThrottle, -1L)
     waitForInterBrokerThrottle(Set(0, 1, 2, 3), updatedThrottle)
 
     val finalAssignment = Map(
@@ -457,8 +457,8 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
 
     // Now increase the throttle and verify that the log dir movement completes
     val updatedLogDirThrottle = 3000000L
-    runAlterThrottles(cluster.adminClient, interBrokerThrottle = -1L,
-      replicaAlterLogDirsThrottle = updatedLogDirThrottle)
+    runExecuteAssignment(cluster.adminClient, additional = true, reassignment.json,
+      interBrokerThrottle = -1L, replicaAlterLogDirsThrottle = updatedLogDirThrottle)
     waitForLogDirThrottle(Set(0), updatedLogDirThrottle)
 
     waitForVerifyAssignment(cluster.adminClient, reassignment.json, true,
@@ -558,15 +558,6 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
       s"replicaAlterLogDirsThrottle=${replicaAlterLogDirsThrottle}))")
     executeAssignment(adminClient, additional, reassignmentJson,
       interBrokerThrottle, replicaAlterLogDirsThrottle)
-  }
-
-  private def runAlterThrottles(admin: Admin,
-                                interBrokerThrottle: Long,
-                                replicaAlterLogDirsThrottle: Long): Unit = {
-    println(s"==> alterThrottles(adminClient, " +
-      s"interBrokerThrottle=${interBrokerThrottle}, " +
-      s"replicaAlterLogDirsThrottle=${replicaAlterLogDirsThrottle}))")
-    alterThrottles(admin, interBrokerThrottle, replicaAlterLogDirsThrottle)
   }
 
   private def runExecuteAssignment(zkClient: KafkaZkClient,

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
@@ -145,32 +145,6 @@ class ReassignPartitionsCommandArgsTest {
     shouldFailWith("Command must include exactly one action", args)
   }
 
-  @Test
-  def testAlterThrottleWithValidInterBrokerThrottle(): Unit = {
-    val args = Array(
-      "--alter-throttle",
-      "--bootstrap-server", "localhost:1234",
-      "--throttle", "5")
-    ReassignPartitionsCommand.validateAndParseArgs(args)
-  }
-
-  @Test
-  def testAlterThrottleWithValidLogDirThrottle(): Unit = {
-    val args = Array(
-      "--alter-throttle",
-      "--bootstrap-server", "localhost:1234",
-      "--replica-alter-log-dirs-throttle", "5")
-    ReassignPartitionsCommand.validateAndParseArgs(args)
-  }
-
-  @Test
-  def testAlterThrottleFailsWithZookeeperOption(): Unit = {
-    val args = Array(
-      "--alter-throttle",
-      "--zookeeper", "localhost:1234")
-    shouldFailWith("Option \"[zookeeper]\" can't be used with action \"[alter-throttle]\"", args)
-  }
-
   ///// Test --execute
   @Test
   def shouldNotAllowExecuteWithTopicsOption(): Unit = {

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
@@ -145,6 +145,32 @@ class ReassignPartitionsCommandArgsTest {
     shouldFailWith("Command must include exactly one action", args)
   }
 
+  @Test
+  def testAlterThrottleWithValidInterBrokerThrottle(): Unit = {
+    val args = Array(
+      "--alter-throttle",
+      "--bootstrap-server", "localhost:1234",
+      "--throttle", "5")
+    ReassignPartitionsCommand.validateAndParseArgs(args)
+  }
+
+  @Test
+  def testAlterThrottleWithValidLogDirThrottle(): Unit = {
+    val args = Array(
+      "--alter-throttle",
+      "--bootstrap-server", "localhost:1234",
+      "--replica-alter-log-dirs-throttle", "5")
+    ReassignPartitionsCommand.validateAndParseArgs(args)
+  }
+
+  @Test
+  def testAlterThrottleFailsWithZookeeperOption(): Unit = {
+    val args = Array(
+      "--alter-throttle",
+      "--zookeeper", "localhost:1234")
+    shouldFailWith("Option \"[zookeeper]\" can't be used with action \"[alter-throttle]\"", args)
+  }
+
   ///// Test --execute
   @Test
   def shouldNotAllowExecuteWithTopicsOption(): Unit = {

--- a/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
@@ -152,6 +152,20 @@ class ControllerContextTest {
   }
 
   @Test
+  def testReassignToIdempotence(): Unit = {
+    val assignment1 = ReplicaAssignment(Seq(1, 2, 3))
+    assertEquals(assignment1, assignment1.reassignTo(assignment1.targetReplicas))
+
+    val assignment2 = ReplicaAssignment(Seq(4, 5, 6, 1, 2, 3),
+      addingReplicas = Seq(4, 5, 6), removingReplicas = Seq(1, 2, 3))
+    assertEquals(assignment2, assignment2.reassignTo(assignment2.targetReplicas))
+
+    val assignment3 = ReplicaAssignment(Seq(4, 2, 3, 1),
+      addingReplicas = Seq(4), removingReplicas = Seq(1))
+    assertEquals(assignment3, assignment3.reassignTo(assignment3.targetReplicas))
+  }
+
+  @Test
   def testReassignTo(): Unit = {
     val assignment = ReplicaAssignment(Seq(1, 2, 3))
     val firstReassign = assignment.reassignTo(Seq(4, 5, 6))


### PR DESCRIPTION
In KIP-455, we changed the behavior of the reassignment tool so that the `--additional` flag is required in order to use the command to alter the throttle. This patch improves the documentation to make this clearer and adds some integration tests to validate the behavior.

This patch also contains a few minor code quality improvements:

- Factor out a helper `calculateCurrentMoveMap` from `calculateMoveMap` to compute the current move map, which makes the logic easier to follow
- Rename `calculateMoveMap` to `calculateProposedMoveMap` to make intention clearer
- Split `modifyBrokerThrottles` into two methods `modifyLogDirThrottle` and `modifyInterBrokerThrottle`
- Move logic to compute leader and follower throttles into a new method `modifyReassignmentThrottle`, which takes it out of the execution path when log dir throttles are changed
- Minor stylistic improvements such as replacing `.map.flatten` with `.flatMap`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
