### PR TITLE
MINOR: Upgrade jetty to 9.4.30.v20200611

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ versions += [
   easymock: "4.2",
   jackson: "2.10.2",
   jacoco: "0.8.5",
-  jetty: "9.4.27.v20200227",
+  jetty: "9.4.30.v20200611",
   jersey: "2.31",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
Recently commit 492306a updated both jetty to version 9.4.27.v20200227 and jersey to version 2.31

However in the latest versions of jetty, the renaming of the method `Response#closeOutput` to `Response#completeOutput` has been reverted, with the latest version using again `Response#closeOutput`. 

Jersey has not released a recent version in which `Response#closeOutput` is called directly. In its latest version 2.31 `Response#closeOutput` will be called if `Response#completeOutput` throws a `NoSuchMethodError` exception, which keeps things functional but inefficient. 

Therefore we can choose to merge this PR early, while waiting for a new version of jersey, or we could wait and update both dependencies together again. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
