### PR TITLE
KAFKA-9509: Increase timeout when consuming records to fix flaky test in MM2

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -58,17 +58,12 @@ public class MirrorConnectorsIntegrationTest {
 
     private static final int NUM_RECORDS_PRODUCED = 100;  // to save trees
     private static final int NUM_PARTITIONS = 10;
-    private static final int RECORD_TRANSFER_DURATION_MS = 10_000;
+    private static final int RECORD_TRANSFER_DURATION_MS = 20_000;
     private static final int CHECKPOINT_DURATION_MS = 20_000;
 
     private MirrorMakerConfig mm2Config; 
     private EmbeddedConnectCluster primary;
     private EmbeddedConnectCluster backup;
-
-    private enum ClusterType {
-        PRIMARY,
-        BACKUP
-    }
 
     @Before
     public void setup() throws InterruptedException {
@@ -212,45 +207,23 @@ public class MirrorConnectorsIntegrationTest {
         backup.stop();
     }
 
-    // throw exception after 3 retries, and print expected error messages
-    private void assertEqualsWithConsumeRetries(final String errorMsg,
-                                                final int numRecordsProduces,
-                                                final int timeout,
-                                                final ClusterType clusterType,
-                                                final String... topics) throws InterruptedException {
-        int retries = 3;
-        while (retries-- > 0) {
-            try {
-                int actualNum = clusterType == ClusterType.PRIMARY ?
-                        primary.kafka().consume(numRecordsProduces, timeout, topics).count() :
-                        backup.kafka().consume(numRecordsProduces, timeout, topics).count();
-                if (numRecordsProduces == actualNum)
-                    return;
-            } catch (Throwable e) {
-                log.error("Could not find enough records with {} retries left", retries, e);
-            }
-        }
-        throw new InterruptedException(errorMsg);
-    }
-
     @Test
     public void testReplication() throws InterruptedException {
         MirrorClient primaryClient = new MirrorClient(mm2Config.clientConfig("primary"));
         MirrorClient backupClient = new MirrorClient(mm2Config.clientConfig("backup"));
 
-        assertEqualsWithConsumeRetries("Records were not produced to primary cluster.", NUM_RECORDS_PRODUCED,
-                RECORD_TRANSFER_DURATION_MS, ClusterType.PRIMARY, "test-topic-1");
-        assertEqualsWithConsumeRetries("Records were not replicated to backup cluster.", NUM_RECORDS_PRODUCED,
-                RECORD_TRANSFER_DURATION_MS, ClusterType.BACKUP, "primary.test-topic-1");
-        assertEqualsWithConsumeRetries("Records were not produced to backup cluster.", NUM_RECORDS_PRODUCED,
-                RECORD_TRANSFER_DURATION_MS, ClusterType.BACKUP, "test-topic-1");
-        assertEqualsWithConsumeRetries("Records were not replicated to primary cluster.", NUM_RECORDS_PRODUCED,
-                RECORD_TRANSFER_DURATION_MS, ClusterType.PRIMARY, "backup.test-topic-1");
-        assertEqualsWithConsumeRetries("Primary cluster doesn't have all records from both clusters.", NUM_RECORDS_PRODUCED * 2,
-                RECORD_TRANSFER_DURATION_MS, ClusterType.PRIMARY, "backup.test-topic-1", "test-topic-1");
-        assertEqualsWithConsumeRetries("Backup cluster doesn't have all records from both clusters.", NUM_RECORDS_PRODUCED * 2,
-                RECORD_TRANSFER_DURATION_MS, ClusterType.BACKUP, "primary.test-topic-1", "test-topic-1");
-
+        assertEquals("Records were not produced to primary cluster.", NUM_RECORDS_PRODUCED,
+            primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count());
+        assertEquals("Records were not replicated to backup cluster.", NUM_RECORDS_PRODUCED,
+            backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1").count());
+        assertEquals("Records were not produced to backup cluster.", NUM_RECORDS_PRODUCED,
+            backup.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "test-topic-1").count());
+        assertEquals("Records were not replicated to primary cluster.", NUM_RECORDS_PRODUCED,
+            primary.kafka().consume(NUM_RECORDS_PRODUCED, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1").count());
+        assertEquals("Primary cluster doesn't have all records from both clusters.", NUM_RECORDS_PRODUCED * 2,
+            primary.kafka().consume(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "backup.test-topic-1", "test-topic-1").count());
+        assertEquals("Backup cluster doesn't have all records from both clusters.", NUM_RECORDS_PRODUCED * 2,
+            backup.kafka().consume(NUM_RECORDS_PRODUCED * 2, RECORD_TRANSFER_DURATION_MS, "primary.test-topic-1", "test-topic-1").count());
         assertTrue("Heartbeats were not emitted to primary cluster.", primary.kafka().consume(1,
             RECORD_TRANSFER_DURATION_MS, "heartbeats").count() > 0);
         assertTrue("Heartbeats were not emitted to backup cluster.", backup.kafka().consume(1,


### PR DESCRIPTION
The test `MirrorConnectorsIntegrationTest.testReplication` failed too often recently. It failed at least 6 times (I didn't check all failed builds) in today's(6/17) trunk build, and also failed my PR testing! I think it should be fixed soon to save developer's time. 

The test is to test MM2 replication. And recently, it failed all because the Records were not replicated to primary/backup cluster yet, so that the consumer cannot retrieve the records in time.  In this PR, I add retries to these consumer.poll, to have 3 retries to poll the records. It should make the tests more stable.

Moreover, the assertion error message didn't display successfully because the `consume()` will throw exception directly and got displayed. After my change, the assertion error message can be displayed, and will let us know exactly which assertion failed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
