### PR TITLE
KAFKA-8398 Avoiding NPE in ByteBufferUnmapper#unmap()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteBufferUnmapper.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteBufferUnmapper.java
@@ -72,6 +72,10 @@ public final class ByteBufferUnmapper {
      * @throws IllegalArgumentException if buffer is not mapped or direct.
      */
     public static void unmap(String resourceDescription, ByteBuffer buffer) throws IOException {
+        if (buffer == null) {
+            return;
+        }
+
         if (!buffer.isDirect())
             throw new IllegalArgumentException("Unmapping only works with direct buffers");
         if (UNMAP == null)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-8398

Regularly seeing this NPE when shutting down the broker in our tests. I *think* simply returning early in this case should suffice.

Hey @ijuma, could you take a a look at this one perhaps? Thanks!