### PR TITLE
KAFKA-10138: Prefer --bootstrap-server for reassign_partitions command in ducktape tests

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -59,6 +59,9 @@ class KafkaVersion(LooseVersion):
         # indicate if KIP-515 is available
         return self > LATEST_2_4
 
+    def reassign_partitions_command_supports_bootstrap_server(self):
+        return self >= V_2_5_0
+
 def get_version(node=None):
     """Return the version attached to the given node.
     Default to DEV_BRANCH if node or node.version is undefined (aka None)
@@ -147,3 +150,7 @@ LATEST_2_4 = V_2_4_1
 # 2.5.x versions
 V_2_5_0 = KafkaVersion("2.5.0")
 LATEST_2_5 = V_2_5_0
+
+# 2.6.x versions
+V_2_6_0 = KafkaVersion("2.6.0")
+LATEST_2_6 = V_2_6_0


### PR DESCRIPTION

http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2020-06-17--001.1592453352--vinothchandar--KC342-ducktape--e64cc463b/report.html

Both ThrottlingTest and ReassignPartitionsTest, which invokes these methods pass locally and twice in CI. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
