### PR TITLE
MINOR: fix warning of javadoc task

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/LagInfo.java
@@ -40,7 +40,7 @@ public class LagInfo {
      * Get the current maximum offset on the store partition's changelog topic, that has been successfully written into
      * the store partition's state store.
      *
-     * @return current consume offset for standby/restoring store partitions & simply endoffset for active store partition replicas
+     * @return current consume offset for standby/restoring store partitions &amp; simply endOffset for active store partition replicas
      */
     public long currentOffsetPosition() {
         return this.currentOffsetPosition;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java
@@ -181,7 +181,7 @@ public interface CogroupedKStream<K, VOut> {
      * <p>
      * To query the local {@link ReadOnlyKeyValueStore} it must be obtained via
      * {@link KafkaStreams#store(StoreQueryParameters) KafkaStreams#store(...)}:
-     * <pre>
+     * <pre>{@code
      * KafkaStreams streams = ... // some aggregation on value type double
      * String queryableStoreName = "storeName" // the store name should be the name of the store as defined by the Materialized instance
      * ReadOnlyKeyValueStore<K, ValueAndTimestamp<VOut>> localStore = streams.store(queryableStoreName, QueryableStoreTypes.<K, ValueAndTimestamp<VOut>> timestampedKeyValueStore());
@@ -233,7 +233,7 @@ public interface CogroupedKStream<K, VOut> {
      * <p>
      * To query the local {@link org.apache.kafka.streams.state.ReadOnlyKeyValueStore} it must be obtained via
      * {@link KafkaStreams#store(StoreQueryParameters) KafkaStreams#store(...)}:
-     * <pre>
+     * <pre>{@code
      * KafkaStreams streams = ... // some aggregation on value type double
      * String queryableStoreName = "storeName" // the store name should be the name of the store as defined by the Materialized instance
      * ReadOnlyKeyValueStore<K, ValueAndTimestamp<VOut>> localStore = streams.store(queryableStoreName, QueryableStoreTypes.<K, ValueAndTimestamp<VOut>> timestampedKeyValueStore());


### PR DESCRIPTION
Fix following task warning:
```
> Task :streams:javadoc
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:187: warning - invalid usage of tag <
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:187: warning - invalid usage of tag >
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:187: warning - invalid usage of tag <
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:187: warning - invalid usage of tag >
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:239: warning - invalid usage of tag <
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:239: warning - invalid usage of tag >
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:239: warning - invalid usage of tag <
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java:239: warning - invalid usage of tag >
/Users/vitojeng/kafka/streams/src/main/java/org/apache/kafka/streams/LagInfo.java:43: warning - invalid usage of tag &
9 warnings
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
