### PR TITLE
inLock is redundant in ControllerEventManager 

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -97,7 +97,7 @@ class ControllerEventManager(controllerId: Int,
     }
   }
 
-  def put(event: ControllerEvent): QueuedEvent = inLock(putLock) {
+  def put(event: ControllerEvent): QueuedEvent = {
     val queuedEvent = new QueuedEvent(event, time.milliseconds())
     queue.put(queuedEvent)
     queuedEvent


### PR DESCRIPTION
LinkedBlockingQueue is threadsafe for put, outter inLock is unnecessary.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
