### PR TITLE
KAFKA-10191 fix flaky StreamsOptimizedTest

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -168,7 +168,6 @@ public class StreamsResetter {
             consumerConfig.putAll(properties);
             exitCode = maybeResetInputAndSeekToEndIntermediateTopicOffsets(consumerConfig, dryRun);
             maybeDeleteInternalTopics(adminClient, dryRun);
-            System.out.println("succeed to reset stream application: " + groupId);
         } catch (final Throwable e) {
             exitCode = EXIT_CODE_ERROR;
             System.err.println("ERROR: " + e);

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -168,7 +168,7 @@ public class StreamsResetter {
             consumerConfig.putAll(properties);
             exitCode = maybeResetInputAndSeekToEndIntermediateTopicOffsets(consumerConfig, dryRun);
             maybeDeleteInternalTopics(adminClient, dryRun);
-
+            System.out.println("succeed to reset stream application: " + groupId);
         } catch (final Throwable e) {
             exitCode = EXIT_CODE_ERROR;
             System.err.println("ERROR: " + e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -303,7 +303,8 @@ public class ClientState {
     public long lagFor(final TaskId task) {
         final Long totalLag = taskLagTotals.get(task);
         if (totalLag == null) {
-            throw new IllegalStateException("Tried to lookup lag for unknown task " + task);
+            throw new IllegalStateException("Tried to lookup lag for unknown task: " + task
+                + " (This exception may be caused by that you don't call KafkaStreams#cleanUp when topology optimization is enabled)");
         }
         return totalLag;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -303,8 +303,7 @@ public class ClientState {
     public long lagFor(final TaskId task) {
         final Long totalLag = taskLagTotals.get(task);
         if (totalLag == null) {
-            throw new IllegalStateException("Tried to lookup lag for unknown task: " + task
-                + " (This exception may be caused by that you don't call KafkaStreams#cleanUp when topology optimization is enabled)");
+            throw new IllegalStateException("Tried to lookup lag for unknown task: " + task);
         }
         return totalLag;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -303,7 +303,7 @@ public class ClientState {
     public long lagFor(final TaskId task) {
         final Long totalLag = taskLagTotals.get(task);
         if (totalLag == null) {
-            throw new IllegalStateException("Tried to lookup lag for unknown task: " + task);
+            throw new IllegalStateException("Tried to lookup lag for unknown task " + task);
         }
         return totalLag;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -130,6 +130,8 @@ public class StreamsOptimizedTest {
             }
         });
 
+        if (streamsProperties.containsKey("streams.cleanup")
+            && Boolean.parseBoolean(streamsProperties.getProperty("streams.cleanup"))) streams.cleanUp();
         streams.start();
 
         Exit.addShutdownHook("streams-shutdown-hook", () -> {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsOptimizedTest.java
@@ -130,8 +130,7 @@ public class StreamsOptimizedTest {
             }
         });
 
-        if (streamsProperties.containsKey("streams.cleanup")
-            && Boolean.parseBoolean(streamsProperties.getProperty("streams.cleanup"))) streams.cleanUp();
+        streams.cleanUp();
         streams.start();
 
         Exit.addShutdownHook("streams-shutdown-hook", () -> {

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -502,11 +502,13 @@ class StreamsStandbyTaskService(StreamsTestBaseService):
                                                         configs)
 
 class StreamsResetter(StreamsTestBaseService):
-    def __init__(self, test_context, kafka):
+    def __init__(self, test_context, kafka, topic, applicationId):
         super(StreamsResetter, self).__init__(test_context,
                                               kafka,
                                               "kafka.tools.StreamsResetter",
                                               "")
+        self.topic = topic
+        self.applicationId = applicationId
 
     @property
     def expectedMessage(self):
@@ -519,14 +521,16 @@ class StreamsResetter(StreamsTestBaseService):
         args['stderr'] = self.STDERR_FILE
         args['pidfile'] = self.PID_FILE
         args['log4j'] = self.LOG4J_CONFIG_FILE
+        args['application.id'] = self.applicationId
+        args['input.topics'] = self.topic
         args['kafka_run_class'] = self.path.script("kafka-run-class.sh", node)
 
         cmd = "(export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%(log4j)s\"; " \
               "%(kafka_run_class)s %(streams_class_name)s " \
               "--bootstrap-servers %(bootstrap.servers)s " \
               "--force " \
-              "--application-id StreamsOptimizedTest " \
-              "--input-topics input.topic " \
+              "--application-id %(application.id)s " \
+              "--input-topics %(input.topics)s " \
               "& echo $! >&3 ) " \
               "1>> %(stdout)s " \
               "2>> %(stderr)s " \

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -510,7 +510,7 @@ class StreamsResetter(StreamsTestBaseService):
 
     @property
     def expectedMessage(self):
-        return 'succeed to reset stream application'
+        return 'Done.'
 
     def start_cmd(self, node):
         args = self.args.copy()
@@ -526,6 +526,7 @@ class StreamsResetter(StreamsTestBaseService):
               "--bootstrap-servers %(bootstrap.servers)s " \
               "--force " \
               "--application-id StreamsOptimizedTest " \
+              "--input-topics input.topic " \
               "& echo $! >&3 ) " \
               "1>> %(stdout)s " \
               "2>> %(stderr)s " \

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -303,10 +303,6 @@ class StreamsTestBaseService(KafkaPathResolverMixin, JmxMixin, Service):
         cfg = KafkaConfig(**{streams_property.STATE_DIR: self.PERSISTENT_ROOT, streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers()})
         return cfg.render()
 
-    def checkPids(self, node):
-        if len(self.pids(node)) == 0:
-            raise RuntimeError("No process ids recorded")
-
     def start_node(self, node):
         node.account.mkdirs(self.PERSISTENT_ROOT)
         prop_file = self.prop_file()
@@ -511,10 +507,6 @@ class StreamsResetter(StreamsTestBaseService):
                                               kafka,
                                               "kafka.tools.StreamsResetter",
                                               "")
-
-    def checkPids(self, node):
-        # resetter doesn't need to check pids
-        pass
 
     @property
     def expectedMessage(self):

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -509,7 +509,6 @@ class StreamsOptimizedUpgradeTestService(StreamsTestBaseService):
         self.AGGREGATION_TOPIC = None
         self.REDUCE_TOPIC = None
         self.JOIN_TOPIC = None
-        self.STREAMS_CLEANUP = 'false'
 
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
@@ -520,7 +519,6 @@ class StreamsOptimizedUpgradeTestService(StreamsTestBaseService):
         properties['aggregation.topic'] = self.AGGREGATION_TOPIC
         properties['reduce.topic'] = self.REDUCE_TOPIC
         properties['join.topic'] = self.JOIN_TOPIC
-        properties['streams.cleanup'] = self.STREAMS_CLEANUP
 
         # Long.MAX_VALUE lets us do the assignment without a warmup
         properties['acceptable.recovery.lag'] = "9223372036854775807"

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -509,6 +509,7 @@ class StreamsOptimizedUpgradeTestService(StreamsTestBaseService):
         self.AGGREGATION_TOPIC = None
         self.REDUCE_TOPIC = None
         self.JOIN_TOPIC = None
+        self.STREAMS_CLEANUP = 'false'
 
     def prop_file(self):
         properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
@@ -519,6 +520,7 @@ class StreamsOptimizedUpgradeTestService(StreamsTestBaseService):
         properties['aggregation.topic'] = self.AGGREGATION_TOPIC
         properties['reduce.topic'] = self.REDUCE_TOPIC
         properties['join.topic'] = self.JOIN_TOPIC
+        properties['streams.cleanup'] = self.STREAMS_CLEANUP
 
         # Long.MAX_VALUE lets us do the assignment without a warmup
         properties['acceptable.recovery.lag'] = "9223372036854775807"

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -33,8 +33,6 @@ class StreamsOptimizedTest(Test):
     join_topic = 'joinTopic'
     operation_pattern = 'AGGREGATED\|REDUCED\|JOINED'
     stopped_message = 'OPTIMIZE_TEST Streams Stopped'
-    # a flag used to make StreamsOptimizedTest call KafkaStreams#cleanUp before KafkaStreams#start
-    streams_cleanup = 'streams.cleanup'
 
     def __init__(self, test_context):
         super(StreamsOptimizedTest, self).__init__(test_context)
@@ -82,8 +80,6 @@ class StreamsOptimizedTest(Test):
         # start again with topology optimized
         for processor in processors:
             processor.OPTIMIZED_CONFIG = 'all'
-            # reset the local environments as topology optimization is enabled
-            processor.STREAMS_CLEANUP = 'true'
             self.verify_running_repartition_topic_count(processor, 1)
 
         self.verify_processing(processors, verify_individual_operations=True)

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -94,7 +94,7 @@ class StreamsOptimizedTest(Test):
         self.zookeeper.stop()
 
     def reset_application(self):
-        resetter = StreamsResetter(self.test_context, self.kafka, topic = 'input.topic', applicationId = 'StreamsOptimizedTest')
+        resetter = StreamsResetter(self.test_context, self.kafka, topic = self.input_topic, applicationId = 'StreamsOptimizedTest')
         resetter.start()
         # resetter is not long-term running but it would be better to check the pid by stopping it
         resetter.stop()

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -96,6 +96,7 @@ class StreamsOptimizedTest(Test):
     def reset_application(self):
         resetter = StreamsResetter(self.test_context, self.kafka)
         resetter.start()
+        # resetter is not long-tern running but it would be better to check the pid by stopping it
         resetter.stop()
 
     @staticmethod

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -33,6 +33,8 @@ class StreamsOptimizedTest(Test):
     join_topic = 'joinTopic'
     operation_pattern = 'AGGREGATED\|REDUCED\|JOINED'
     stopped_message = 'OPTIMIZE_TEST Streams Stopped'
+    # a flag used to make StreamsOptimizedTest call KafkaStreams#cleanUp before KafkaStreams#start
+    streams_cleanup = 'streams.cleanup'
 
     def __init__(self, test_context):
         super(StreamsOptimizedTest, self).__init__(test_context)
@@ -80,6 +82,8 @@ class StreamsOptimizedTest(Test):
         # start again with topology optimized
         for processor in processors:
             processor.OPTIMIZED_CONFIG = 'all'
+            # reset the local environments as topology optimization is enabled
+            processor.STREAMS_CLEANUP = 'true'
             self.verify_running_repartition_topic_count(processor, 1)
 
         self.verify_processing(processors, verify_individual_operations=True)

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -94,9 +94,9 @@ class StreamsOptimizedTest(Test):
         self.zookeeper.stop()
 
     def reset_application(self):
-        resetter = StreamsResetter(self.test_context, self.kafka)
+        resetter = StreamsResetter(self.test_context, self.kafka, topic = 'input.topic', applicationId = 'StreamsOptimizedTest')
         resetter.start()
-        # resetter is not long-tern running but it would be better to check the pid by stopping it
+        # resetter is not long-term running but it would be better to check the pid by stopping it
         resetter.stop()
 
     @staticmethod

--- a/tests/kafkatest/tests/streams/streams_optimized_test.py
+++ b/tests/kafkatest/tests/streams/streams_optimized_test.py
@@ -17,6 +17,7 @@ import time
 from ducktape.tests.test import Test
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsOptimizedUpgradeTestService
+from kafkatest.services.streams import StreamsResetter
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.streams.utils import stop_processors
@@ -77,6 +78,8 @@ class StreamsOptimizedTest(Test):
 
         stop_processors(processors, self.stopped_message)
 
+        self.reset_application()
+
         # start again with topology optimized
         for processor in processors:
             processor.OPTIMIZED_CONFIG = 'all'
@@ -89,6 +92,11 @@ class StreamsOptimizedTest(Test):
         self.producer.stop()
         self.kafka.stop()
         self.zookeeper.stop()
+
+    def reset_application(self):
+        resetter = StreamsResetter(self.test_context, self.kafka)
+        resetter.start()
+        resetter.stop()
 
     @staticmethod
     def verify_running_repartition_topic_count(processor, repartition_topic_count):


### PR DESCRIPTION
We have to call ```KafkaStreams#cleanUp``` to reset local state before starting application up the second run.

issue: https://issues.apache.org/jira/browse/KAFKA-10191

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
