### PR TITLE
MINOR: Do not swallow exception when collecting PIDs

### DIFF
--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -214,10 +214,7 @@ class StreamsTestBaseService(KafkaPathResolverMixin, JmxMixin, Service):
         return self.nodes[0]
 
     def pids(self, node):
-        try:
-            return [pid for pid in node.account.ssh_capture("cat " + self.PID_FILE, callback=int)]
-        except:
-            return []
+        return [pid for pid in node.account.ssh_capture("cat " + self.PID_FILE, callback=int)]
 
     def stop_nodes(self, clean_shutdown=True):
         for node in self.nodes:

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -219,8 +219,7 @@ class StreamsTestBaseService(KafkaPathResolverMixin, JmxMixin, Service):
             pids = [pid for pid in node.account.ssh_capture("cat " + self.PID_FILE, callback=str)]
             return [int(pid) for pid in pids]
         except Exception, exception:
-            self.logger.debug("Retrieval of PIDs of Streams clients failed with: "
-                              + str(exception))
+            self.logger.debug(str(exception))
             return []
 
     def stop_nodes(self, clean_shutdown=True):

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -17,6 +17,7 @@ import os.path
 import signal
 import streams_property
 import consumer_property
+from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
@@ -214,7 +215,13 @@ class StreamsTestBaseService(KafkaPathResolverMixin, JmxMixin, Service):
         return self.nodes[0]
 
     def pids(self, node):
-        return [pid for pid in node.account.ssh_capture("cat " + self.PID_FILE, callback=int)]
+        try:
+            pids = [pid for pid in node.account.ssh_capture("cat " + self.PID_FILE, callback=str)]
+            return [int(pid) for pid in pids]
+        except Exception, exception:
+            self.logger.debug("Retrieval of PIDs of Streams clients failed with: "
+                              + str(exception))
+            return []
 
     def stop_nodes(self, clean_shutdown=True):
         for node in self.nodes:


### PR DESCRIPTION
During Streams' system tests the PIDs of the Streams
clients are collected. The method the collects the PIDs
swallows any exception that might be thrown by the
`ssh_capture()` function. Swallowing any exceptions
might make the investigation of failures harder,
because no information about what happened are recorded.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
