### PR TITLE
MINOR; Provide lowest and highest supported versions alongside with the schema in the auto-generated protocol

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
@@ -348,5 +348,9 @@ final class SchemaGenerator {
         buffer.decrementIndent();
         buffer.printf("};%n");
         buffer.printf("%n");
+
+        buffer.printf("public static final short LOWEST_SUPPORTED_VERSION = %d;%n", versions.lowest());
+        buffer.printf("public static final short HIGHEST_SUPPORTED_VERSION = %d;%n", versions.highest());
+        buffer.printf("%n");
     }
 }


### PR DESCRIPTION
At the moment, the only way available to get the supported versions of a Message is to look at the number of defined schemas, assuming that the lowest version is 0. This PR adds static constants with the versions alongside with the schemas.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
