### PR TITLE
KAFKA-10160: Kafka MM2 consumer configuration

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -67,8 +68,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
     protected static final String SYNC_TOPIC_ACLS = "sync.topic.acls";
     protected static final String EMIT_HEARTBEATS = "emit.heartbeats";
     protected static final String EMIT_CHECKPOINTS = "emit.checkpoints";
-    protected static final String AUTH_OFFSET_RESET = "auto.offset.reset";
-    protected static final String ENABLE_AUTO_COMMIT = "enable.auto.commit";
 
     public static final String ENABLED = "enabled";
     private static final String ENABLED_DOC = "Whether to replicate source->target.";
@@ -124,10 +123,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
     public static final String CONSUMER_POLL_TIMEOUT_MILLIS = "consumer.poll.timeout.ms";
     private static final String CONSUMER_POLL_TIMEOUT_MILLIS_DOC = "Timeout when polling source cluster.";
     public static final long CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT = 1000L;
-
-    public static final String CONSUMER_AUTO_OFFSET_RESET = "consumer.auto.offset.reset";
-    private static final String CONSUMER_AUTO_OFFSET_RESET_DOC = "Consumer Auto offset reset, default to earliest unless specified.";
-    public static final String CONSUMER_AUTO_OFFSET_RESET_DEFAULT = "earliest";
 
     public static final String ADMIN_TASK_TIMEOUT_MILLIS = "admin.timeout.ms";
     private static final String ADMIN_TASK_TIMEOUT_MILLIS_DOC = "Timeout for administrative tasks, e.g. detecting new topics.";
@@ -235,8 +230,8 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
-        props.put(ENABLE_AUTO_COMMIT, "false");
-        props.put(AUTH_OFFSET_RESET, CONSUMER_AUTO_OFFSET_RESET);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         return props;
     }
 
@@ -470,12 +465,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
                     CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT,
                     ConfigDef.Importance.LOW,
                     CONSUMER_POLL_TIMEOUT_MILLIS_DOC)
-            .define(
-                    CONSUMER_AUTO_OFFSET_RESET,
-                    ConfigDef.Type.STRING,
-                    CONSUMER_AUTO_OFFSET_RESET_DEFAULT,
-                    ConfigDef.Importance.LOW,
-                    CONSUMER_AUTO_OFFSET_RESET_DOC)
             .define(
                     ADMIN_TASK_TIMEOUT_MILLIS,
                     ConfigDef.Type.LONG,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -67,6 +67,8 @@ public class MirrorConnectorConfig extends AbstractConfig {
     protected static final String SYNC_TOPIC_ACLS = "sync.topic.acls";
     protected static final String EMIT_HEARTBEATS = "emit.heartbeats";
     protected static final String EMIT_CHECKPOINTS = "emit.checkpoints";
+    protected static final String AUTH_OFFSET_RESET = "auto.offset.reset";
+    protected static final String ENABLE_AUTO_COMMIT = "enable.auto.commit";
 
     public static final String ENABLED = "enabled";
     private static final String ENABLED_DOC = "Whether to replicate source->target.";
@@ -122,6 +124,10 @@ public class MirrorConnectorConfig extends AbstractConfig {
     public static final String CONSUMER_POLL_TIMEOUT_MILLIS = "consumer.poll.timeout.ms";
     private static final String CONSUMER_POLL_TIMEOUT_MILLIS_DOC = "Timeout when polling source cluster.";
     public static final long CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT = 1000L;
+
+    public static final String CONSUMER_AUTO_OFFSET_RESET = "consumer.auto.offset.reset";
+    private static final String CONSUMER_AUTO_OFFSET_RESET_DOC = "Consumer Auto offset reset, defaults to earliest unless specify.";
+    public static final String CONSUMER_AUTO_OFFSET_RESET_DEFAULT = "earliest";
 
     public static final String ADMIN_TASK_TIMEOUT_MILLIS = "admin.timeout.ms";
     private static final String ADMIN_TASK_TIMEOUT_MILLIS_DOC = "Timeout for administrative tasks, e.g. detecting new topics.";
@@ -229,8 +235,8 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
-        props.put("enable.auto.commit", "false");
-        props.put("auto.offset.reset", "earliest");
+        props.put(ENABLE_AUTO_COMMIT, "false");
+        props.put(AUTH_OFFSET_RESET, CONSUMER_AUTO_OFFSET_RESET);
         return props;
     }
 
@@ -464,6 +470,12 @@ public class MirrorConnectorConfig extends AbstractConfig {
                     CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT,
                     ConfigDef.Importance.LOW,
                     CONSUMER_POLL_TIMEOUT_MILLIS_DOC)
+            .define(
+                    CONSUMER_AUTO_OFFSET_RESET,
+                    ConfigDef.Type.STRING,
+                    CONSUMER_AUTO_OFFSET_RESET_DEFAULT,
+                    ConfigDef.Importance.LOW,
+                    CONSUMER_AUTO_OFFSET_RESET_DOC)
             .define(
                     ADMIN_TASK_TIMEOUT_MILLIS,
                     ConfigDef.Type.LONG,

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -126,7 +126,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
     public static final long CONSUMER_POLL_TIMEOUT_MILLIS_DEFAULT = 1000L;
 
     public static final String CONSUMER_AUTO_OFFSET_RESET = "consumer.auto.offset.reset";
-    private static final String CONSUMER_AUTO_OFFSET_RESET_DOC = "Consumer Auto offset reset, defaults to earliest unless specify.";
+    private static final String CONSUMER_AUTO_OFFSET_RESET_DOC = "Consumer Auto offset reset, default to earliest unless specified.";
     public static final String CONSUMER_AUTO_OFFSET_RESET_DEFAULT = "earliest";
 
     public static final String ADMIN_TASK_TIMEOUT_MILLIS = "admin.timeout.ms";

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -110,6 +110,20 @@ public class MirrorConnectorConfigTest {
     }
 
     @Test
+    public void testConsumerRestOffsetLatestConfs() {
+        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps("consumer.auto.offset.reset", "latest"));
+        Map<String, Object> sourceConf = config.sourceConsumerConfig();
+        assertEquals("latest", sourceConf.get("auto.offset.reset"));
+    }
+
+    @Test
+    public void testConsumerDefaultConfs() {
+        MirrorConnectorConfig config = new MirrorConnectorConfig(makeProps());
+        Map<String, Object> sourceConf = config.sourceConsumerConfig();
+        assertEquals("earliest", sourceConf.get("auto.offset.reset"));
+    }
+
+    @Test
     public void testNonMutationOfConfigDef() {
         Collection<String> taskSpecificProperties = Arrays.asList(
             MirrorConnectorConfig.TASK_TOPIC_PARTITIONS,


### PR DESCRIPTION
Removed hardcoded auto.offset.reset in MM2 consumer configuration, retained default as earliest unless specified.

### Committer Checklist (excluded from commit message)
- [*] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
