### PR TITLE
KAFKA-9974: Integration test shouldApplyUpdatesToStandbyStore; Make produce-sync flush

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -255,6 +255,8 @@ public class IntegrationTestUtils {
             }
             if (enableTransactions) {
                 producer.commitTransaction();
+            } else {
+                producer.flush();
             }
         }
     }


### PR DESCRIPTION
I cannot actually re-produce the failure locally, but by looking at the code I think there's an issue in `produceKeyValuesSynchronously`: when Eos is not enabled, we then need to call `flush` to make sure all records are indeed sent "synchronously". If Eos is enabled the `commitTxn` would flush the records already.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
