### PR TITLE
KAFKA-10166: always write checkpoint before closing an (initialized) task

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -164,12 +164,8 @@ public class StandbyTask extends AbstractTask implements Task {
 
             case RUNNING:
             case SUSPENDED:
-                if (commitNeeded()) {
-                    stateMgr.flush();
-                    log.debug("Prepared {} task for committing", state());
-                } else {
-                    log.debug("Skipped preparing {} task for commit since there is nothing new to commit", state());
-                }
+                stateMgr.flush();
+                log.debug("Prepared {} task for committing", state());
 
                 break;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -46,14 +46,15 @@ public class StandbyTask extends AbstractTask implements Task {
     private final InternalProcessorContext processorContext;
     private final StreamsMetricsImpl streamsMetrics;
 
-    private Map<TopicPartition, Long> offsetSnapshotSinceLastCommit;
+    private boolean checkpointNeededForSuspended = false;
+    private Map<TopicPartition, Long> offsetSnapshotSinceLastCommit = new HashMap<>();
 
     /**
      * @param id             the ID of this task
      * @param partitions     input topic partitions, used for thread metadata only
      * @param topology       the instance of {@link ProcessorTopology}
      * @param config         the {@link StreamsConfig} specified by the user
-     * @param streamsMetrics        the {@link StreamsMetrics} created by the thread
+     * @param streamsMetrics the {@link StreamsMetrics} created by the thread
      * @param stateMgr       the {@link ProcessorStateManager} for this task
      * @param stateDirectory the {@link StateDirectory} created by the thread
      */
@@ -115,8 +116,15 @@ public class StandbyTask extends AbstractTask implements Task {
     public void suspend() {
         switch (state()) {
             case CREATED:
+                log.info("Suspended created");
+                checkpointNeededForSuspended = false;
+                transitionTo(State.SUSPENDED);
+
+                break;
+
             case RUNNING:
-                log.info("Suspended {}", state());
+                log.info("Suspended running");
+                checkpointNeededForSuspended = true;
                 transitionTo(State.SUSPENDED);
 
                 break;
@@ -144,22 +152,29 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     /**
-     * 1. flush store
-     * 2. write checkpoint file
+     * Flush stores before a commit
      *
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
     public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
-        if (state() == State.RUNNING || state() == State.SUSPENDED) {
-            if (commitNeeded()) {
-                stateMgr.flush();
-                log.debug("Prepared task for committing");
-            } else {
-                log.debug("Skipping prepareCommit since there is nothing new to commit");
-            }
-        } else {
-            throw new IllegalStateException("Illegal state " + state() + " while preparing standby task " + id + " for committing ");
+        switch (state()) {
+            case CREATED:
+                log.debug("Skipped preparing created task for commit");
+
+            case RUNNING:
+            case SUSPENDED:
+                if (commitNeeded()) {
+                    stateMgr.flush();
+                    log.debug("Prepared {} task for committing", state());
+                } else {
+                    log.debug("Skipped preparing {} task for commit since there is nothing new to commit", state());
+                }
+
+                break;
+
+            default:
+                throw new IllegalStateException("Illegal state " + state() + " while preparing standby task " + id + " for committing ");
         }
 
         return Collections.emptyMap();
@@ -167,14 +182,36 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public void postCommit() {
-        if (state() == State.RUNNING || state() == State.SUSPENDED) {
-            // since there's no written offsets we can checkpoint with empty map,
-            // and the state current offset would be used to checkpoint
-            stateMgr.checkpoint(Collections.emptyMap());
-            offsetSnapshotSinceLastCommit = new HashMap<>(stateMgr.changelogOffsets());
-            log.debug("Finalized commit");
-        } else {
-            throw new IllegalStateException("Illegal state " + state() + " while post committing standby task " + id);
+        switch (state()) {
+            case CREATED:
+                // We should never write a checkpoint for a CREATED task as we may overwrite an existing checkpoint
+                // with empty uninitialized offsets
+                log.debug("Skipped writing checkpoint for created task");
+
+                break;
+
+            case RUNNING:
+                if (commitNeeded()) {
+                    writeCheckpoint();
+                }
+                log.debug("Finalized commit for running task");
+
+                break;
+
+            case SUSPENDED:
+                // don't overwrite the existing checkpoint file if we haven't actually initialized the offsets yet
+                if (checkpointNeededForSuspended) {
+                    writeCheckpoint();
+                    log.debug("Finalized commit for suspended task");
+                    checkpointNeededForSuspended = false;
+                } else {
+                    log.debug("Skipped writing checkpoint for uninitialized suspended task");
+                }
+
+                break;
+
+            default:
+                throw new IllegalStateException("Illegal state " + state() + " while post committing standby task " + id);
         }
     }
 
@@ -205,6 +242,13 @@ public class StandbyTask extends AbstractTask implements Task {
         transitionTo(State.CLOSED);
 
         log.info("Closed clean and recycled state");
+    }
+
+    private void writeCheckpoint() {
+        // since there's no written offsets we can checkpoint with empty map,
+        // and the state's current offset would be used to checkpoint
+        stateMgr.checkpoint(Collections.emptyMap());
+        offsetSnapshotSinceLastCommit = new HashMap<>(stateMgr.changelogOffsets());
     }
 
     private void close(final boolean clean) {
@@ -247,7 +291,7 @@ public class StandbyTask extends AbstractTask implements Task {
     @Override
     public boolean commitNeeded() {
         // we can commit if the store's offset has changed since last commit
-        return offsetSnapshotSinceLastCommit == null || !offsetSnapshotSinceLastCommit.equals(stateMgr.changelogOffsets());
+        return !offsetSnapshotSinceLastCommit.equals(stateMgr.changelogOffsets());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -94,6 +94,9 @@ public class StandbyTask extends AbstractTask implements Task {
         if (state() == State.CREATED) {
             StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
 
+            // initialize the snapshot with the current offsets as we don't need to commit then until they change
+            offsetSnapshotSinceLastCommit = new HashMap<>(stateMgr.changelogOffsets());
+
             // no topology needs initialized, we can transit to RUNNING
             // right after registered the stores
             transitionTo(State.RESTORING);
@@ -161,6 +164,8 @@ public class StandbyTask extends AbstractTask implements Task {
         switch (state()) {
             case CREATED:
                 log.debug("Skipped preparing created task for commit");
+
+                break;
 
             case RUNNING:
             case SUSPENDED:

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -152,8 +152,12 @@ public class StandbyTask extends AbstractTask implements Task {
     @Override
     public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
         if (state() == State.RUNNING || state() == State.SUSPENDED) {
-            stateMgr.flush();
-            log.debug("Prepared task for committing");
+            if (commitNeeded()) {
+                stateMgr.flush();
+                log.debug("Prepared task for committing");
+            } else {
+                log.debug("Skipping prepareCommit since there is nothing new to commit");
+            }
         } else {
             throw new IllegalStateException("Illegal state " + state() + " while preparing standby task " + id + " for committing ");
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -340,6 +340,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     public Map<TopicPartition, OffsetAndMetadata> prepareCommit() {
         final Map<TopicPartition, OffsetAndMetadata> offsetsToCommit;
         switch (state()) {
+            case CREATED:
             case RUNNING:
             case RESTORING:
             case SUSPENDED:
@@ -355,8 +356,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 }
 
                 break;
-
-            case CREATED:
+                
             case CLOSED:
                 throw new IllegalStateException("Illegal state " + state() + " while preparing active task " + id + " for committing");
 
@@ -450,6 +450,9 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 break;
 
             case CREATED:
+
+                break;
+
             case CLOSED:
                 throw new IllegalStateException("Illegal state " + state() + " while post committing active task " + id);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -242,16 +242,15 @@ public class TaskManager {
 
         for (final Task task : tasksToClose) {
             try {
-                if (task.isActive()) {
-                    // Active tasks should have already been suspended and committed during handleRevocation.
-                    // We are just responsible for closing them now
-                    cleanUpTaskProducer(task, taskCloseExceptions);
-                } else {
+                if (!task.isActive()) {
+                    // Active tasks should have already been suspended and committed during handleRevocation, but
+                    // standbys must be suspended/committed/closed all here
                     task.suspend();
                     task.prepareCommit();
                     task.postCommit();
                 }
                 completeTaskCloseClean(task);
+                cleanUpTaskProducer(task, taskCloseExceptions);
                 tasks.remove(task.id());
             } catch (final RuntimeException e) {
                 final String uncleanMessage = String.format(

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -1175,6 +1175,8 @@ public class TopologyTestDriver implements Closeable {
     public void close() {
         if (task != null) {
             task.suspend();
+            task.prepareCommit();
+            task.postCommit();
             task.closeClean();
         }
         if (globalStateTask != null) {


### PR DESCRIPTION
This should address at least some of the excessive TaskCorruptedExceptions we've been seeing lately. Basically, at the moment we only commit tasks if `commitNeeded` is true -- this seems obvious by definition. But the problem is we do some essential cleanup in `postCommit` that should always be done before a task is closed:

1. clear the PartitionGroup
2. write the checkpoint

2 is actually fine to skip when `commitNeeded = false` with ALOS, as we will have already written a checkpoint during the last commit. But for EOS, we _only_ write the checkpoint before a close -- so even if there is no new pending data since the last commit, we have to write the current offsets. If we don't, the task will be assumed dirty and we will run into our friend the TaskCorruptedException during (re)initialization.

To fix this, we should just always call `prepareCommit` and `postCommit` at the TaskManager level. Within the task, it can decide whether or not to actually do something in those methods based on `commitNeeded`. 

One subtle issue is that we still need to avoid checkpointing a task that was still in CREATED, to avoid potentially overwriting an existing checkpoint with uninitialized empty offsets. Unfortunately we always suspend a task before closing and committing, so we lose the information about whether the task as in CREATED or RUNNING/RESTORING by the time we get to the checkpoint. For this we introduce a special flag to keep track of whether a suspended task should actually be checkpointed or not