### PR TITLE
KAFKA-4996: Fix findbugs multithreaded correctness warnings for streams

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -348,8 +348,10 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- Suppress warning about a value that gets initialized
-             before any other threads are created. -->
+        <!-- Suppress warning about applicationID that gets initialized before
+        any other threads are created, but is used in synchronized and
+        unsynchronized methods because it comes from the configs,
+        passed through rewriteTopology. -->
             <Package name="org.apache.kafka.streams.processor.internals"/>
             <Source name="InternalTopologyBuilder.java"/>
             <Bug pattern="IS2_INCONSISTENT_SYNC"/>

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -348,14 +348,11 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
-        <!-- TODO: fix this (see KAFKA-4996) -->
-        <Or>
-            <Package name="org.apache.kafka.streams.state.internals"/>
+        <!-- Suppress warning about a value that gets initialized
+             before any other threads are created. -->
             <Package name="org.apache.kafka.streams.processor.internals"/>
-            <Package name="org.apache.kafka.streams.processor"/>
-            <Package name="org.apache.kafka.streams"/>
-        </Or>
-        <Bug pattern="IS2_INCONSISTENT_SYNC"/>
+            <Source name="InternalTopologyBuilder.java"/>
+            <Bug pattern="IS2_INCONSISTENT_SYNC"/>
     </Match>
 
     <Match>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -51,7 +51,7 @@ public class StreamsMetadataState {
     private final HostInfo thisHost;
     private List<StreamsMetadata> allMetadata = Collections.emptyList();
     private Cluster clusterMetadata;
-    private AtomicReference<StreamsMetadata> localMetadata;
+    private AtomicReference<StreamsMetadata> localMetadata = new AtomicReference<>(null);
 
     public StreamsMetadataState(final InternalTopologyBuilder builder, final HostInfo thisHost) {
         this.builder = builder;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
@@ -50,7 +51,7 @@ public class StreamsMetadataState {
     private final HostInfo thisHost;
     private List<StreamsMetadata> allMetadata = Collections.emptyList();
     private Cluster clusterMetadata;
-    private StreamsMetadata localMetadata;
+    private AtomicReference<StreamsMetadata> localMetadata;
 
     public StreamsMetadataState(final InternalTopologyBuilder builder, final HostInfo thisHost) {
         this.builder = builder;
@@ -79,7 +80,7 @@ public class StreamsMetadataState {
      * @return the {@link StreamsMetadata}s for the local instance in a {@link KafkaStreams} application
      */
     public StreamsMetadata getLocalMetadata() {
-        return localMetadata;
+        return localMetadata.get();
     }
 
     /**
@@ -157,7 +158,7 @@ public class StreamsMetadataState {
             if (thisHost.equals(UNKNOWN_HOST)) {
                 return allMetadata.get(0);
             }
-            return localMetadata;
+            return localMetadata.get();
         }
 
         final SourceTopicsInfo sourceTopicsInfo = getSourceTopicsInfo(storeName);
@@ -226,7 +227,7 @@ public class StreamsMetadataState {
             if (thisHost.equals(UNKNOWN_HOST)) {
                 return new KeyQueryMetadata(allMetadata.get(0).hostInfo(), Collections.emptySet(), -1);
             }
-            return new KeyQueryMetadata(localMetadata.hostInfo(), Collections.emptySet(), -1);
+            return new KeyQueryMetadata(localMetadata.get().hostInfo(), Collections.emptySet(), -1);
         }
 
         final SourceTopicsInfo sourceTopicsInfo = getSourceTopicsInfo(storeName);
@@ -268,7 +269,7 @@ public class StreamsMetadataState {
             if (thisHost.equals(UNKNOWN_HOST)) {
                 return allMetadata.get(0);
             }
-            return localMetadata;
+            return localMetadata.get();
         }
 
         final SourceTopicsInfo sourceTopicsInfo = getSourceTopicsInfo(storeName);
@@ -348,7 +349,7 @@ public class StreamsMetadataState {
                                                                      standbyPartitionsOnHost);
                 rebuiltMetadata.add(metadata);
                 if (hostInfo.equals(thisHost)) {
-                    localMetadata = metadata;
+                    localMetadata.set(metadata);
                 }
             });
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -51,7 +51,7 @@ public class StreamsMetadataState {
     private final HostInfo thisHost;
     private List<StreamsMetadata> allMetadata = Collections.emptyList();
     private Cluster clusterMetadata;
-    private AtomicReference<StreamsMetadata> localMetadata = new AtomicReference<>(null);
+    private final AtomicReference<StreamsMetadata> localMetadata = new AtomicReference<>(null);
 
     public StreamsMetadataState(final InternalTopologyBuilder builder, final HostInfo thisHost) {
         this.builder = builder;
@@ -319,6 +319,12 @@ public class StreamsMetadataState {
                                  final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap) {
         if (activePartitionHostMap.isEmpty() && standbyPartitionHostMap.isEmpty()) {
             allMetadata = Collections.emptyList();
+            localMetadata.set(new StreamsMetadata(thisHost,
+                                                  Collections.emptySet(),
+                                                  Collections.emptySet(),
+                                                  Collections.emptySet(),
+                                                  Collections.emptySet()
+            ));
             return;
         }
 
@@ -422,7 +428,8 @@ public class StreamsMetadataState {
     }
 
     private boolean isInitialized() {
-        return clusterMetadata != null && !clusterMetadata.topics().isEmpty();
+
+        return clusterMetadata != null && !clusterMetadata.topics().isEmpty() && localMetadata.get() != null;
     }
 
     public String getStoreForChangelogTopic(final String topicName) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.kafka.streams.state.internals.ExceptionUtils.executeAll;
 import static org.apache.kafka.streams.state.internals.ExceptionUtils.throwSuppressed;
@@ -54,7 +55,7 @@ class CachingWindowStore
     private StateSerdes<Bytes, byte[]> bytesSerdes;
     private CacheFlushListener<byte[], byte[]> flushListener;
 
-    private long maxObservedTimestamp;
+    private AtomicLong maxObservedTimestamp;
 
     private final SegmentedCacheFunction cacheFunction;
 
@@ -64,7 +65,7 @@ class CachingWindowStore
         super(underlying);
         this.windowSize = windowSize;
         this.cacheFunction = new SegmentedCacheFunction(keySchema, segmentInterval);
-        this.maxObservedTimestamp = RecordQueue.UNKNOWN;
+        this.maxObservedTimestamp = new AtomicLong(RecordQueue.UNKNOWN);
     }
 
     @Override
@@ -161,7 +162,7 @@ class CachingWindowStore
                 context.topic());
         context.cache().put(name, cacheFunction.cacheKey(keyBytes), entry);
 
-        maxObservedTimestamp = Math.max(keySchema.segmentTimestamp(keyBytes), maxObservedTimestamp);
+        maxObservedTimestamp.set(Math.max(keySchema.segmentTimestamp(keyBytes), maxObservedTimestamp.get()));
     }
 
     @Override
@@ -338,7 +339,7 @@ class CachingWindowStore
             this.keyFrom = keyFrom;
             this.keyTo = keyTo;
             this.timeTo = timeTo;
-            this.lastSegmentId = cacheFunction.segmentId(Math.min(timeTo, maxObservedTimestamp));
+            this.lastSegmentId = cacheFunction.segmentId(Math.min(timeTo, maxObservedTimestamp.get()));
 
             this.segmentInterval = cacheFunction.getSegmentInterval();
             this.currentSegmentId = cacheFunction.segmentId(timeFrom);
@@ -406,7 +407,7 @@ class CachingWindowStore
 
         private void getNextSegmentIterator() {
             ++currentSegmentId;
-            lastSegmentId = cacheFunction.segmentId(Math.min(timeTo, maxObservedTimestamp));
+            lastSegmentId = cacheFunction.segmentId(Math.min(timeTo, maxObservedTimestamp.get()));
 
             if (currentSegmentId > lastSegmentId) {
                 current = null;


### PR DESCRIPTION
Fix findbugs multithreaded correctness warnings for streams, updated variables to be threadsafe

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
