### PR TITLE
KAFKA-10189: reset event queue time histogram when queue is empty

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -70,7 +70,7 @@ class ControllerEventManager(controllerId: Int,
                              processor: ControllerEventProcessor,
                              time: Time,
                              rateAndTimeMetrics: Map[ControllerState, KafkaTimer],
-                             eventQueueTimeTimeoutMs: Long = 60000) extends KafkaMetricsGroup {
+                             eventQueueTimeTimeoutMs: Long = 300000) extends KafkaMetricsGroup {
   import ControllerEventManager._
 
   @volatile private var _state: ControllerState = ControllerState.Idle

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -78,7 +78,6 @@ class ControllerEventManager(controllerId: Int,
   private val queue = new LinkedBlockingQueue[QueuedEvent]
   // Visible for test
   private[controller] val thread = new ControllerEventThread(ControllerEventThreadName)
-  val eventQueueTimeMetricTimeoutMs = eventQueueTimeTimeoutMs
 
   private val eventQueueTimeHist = newHistogram(EventQueueTimeMetricName)
 
@@ -144,7 +143,7 @@ class ControllerEventManager(controllerId: Int,
   private def pollFromEventQueue(): QueuedEvent = {
     val count = eventQueueTimeHist.count()
     if (count != 0) {
-      val event  = queue.poll(eventQueueTimeMetricTimeoutMs, TimeUnit.MILLISECONDS)
+      val event  = queue.poll(eventQueueTimeTimeoutMs, TimeUnit.MILLISECONDS)
       if (event == null) {
         eventQueueTimeHist.clear()
         queue.take()

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -70,7 +70,7 @@ class ControllerEventManager(controllerId: Int,
                              processor: ControllerEventProcessor,
                              time: Time,
                              rateAndTimeMetrics: Map[ControllerState, KafkaTimer],
-                             eventQueueTimeTimeoutMs: Long = 1000) extends KafkaMetricsGroup {
+                             eventQueueTimeTimeoutMs: Long = 60000) extends KafkaMetricsGroup {
   import ControllerEventManager._
 
   @volatile private var _state: ControllerState = ControllerState.Idle

--- a/core/src/test/scala/unit/kafka/controller/ControllerEventManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerEventManagerTest.scala
@@ -136,6 +136,44 @@ class ControllerEventManagerTest {
   }
 
   @Test
+  def testEventQueueTimeResetOnTimeout(): Unit = {
+    val metricName = "kafka.controller:type=ControllerEventManager,name=EventQueueTimeMs"
+    val controllerStats = new ControllerStats
+    val time = new MockTime()
+    val latch = new CountDownLatch(1)
+    val processedEvents = new AtomicInteger()
+
+    val eventProcessor = new ControllerEventProcessor {
+      override def process(event: ControllerEvent): Unit = {
+        latch.await()
+        time.sleep(500)
+        processedEvents.incrementAndGet()
+      }
+      override def preempt(event: ControllerEvent): Unit = {}
+    }
+
+    controllerEventManager = new ControllerEventManager(0, eventProcessor,
+      time, controllerStats.rateAndTimeMetrics, 1)
+    controllerEventManager.start()
+
+    controllerEventManager.put(TopicChange)
+    controllerEventManager.put(TopicChange)
+    latch.countDown()
+
+    TestUtils.waitUntilTrue(() => processedEvents.get() == 2,
+      "Timed out waiting for processing of all events")
+
+    val queueTimeHistogram = KafkaYammerMetrics.defaultRegistry.allMetrics.asScala.filter { case (k, _) =>
+      k.getMBeanName == metricName
+    }.values.headOption.getOrElse(fail(s"Unable to find metric $metricName")).asInstanceOf[Histogram]
+
+    TestUtils.waitUntilTrue(() => queueTimeHistogram.count == 0,
+      "Timed out on resetting queueTimeHistogram")
+    assertEquals(0, queueTimeHistogram.min, 0.1)
+    assertEquals(0, queueTimeHistogram.max, 0.1)
+  }
+
+  @Test
   def testSuccessfulEvent(): Unit = {
     check("kafka.controller:type=ControllerStats,name=AutoLeaderBalanceRateAndTimeMs",
       AutoPreferredReplicaLeaderElection, () => ())

--- a/core/src/test/scala/unit/kafka/controller/ControllerEventManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerEventManagerTest.scala
@@ -146,7 +146,6 @@ class ControllerEventManagerTest {
     val eventProcessor = new ControllerEventProcessor {
       override def process(event: ControllerEvent): Unit = {
         latch.await()
-        time.sleep(500)
         processedEvents.incrementAndGet()
       }
       override def preempt(event: ControllerEvent): Unit = {}

--- a/core/src/test/scala/unit/kafka/controller/ControllerEventManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerEventManagerTest.scala
@@ -140,12 +140,10 @@ class ControllerEventManagerTest {
     val metricName = "kafka.controller:type=ControllerEventManager,name=EventQueueTimeMs"
     val controllerStats = new ControllerStats
     val time = new MockTime()
-    val latch = new CountDownLatch(1)
     val processedEvents = new AtomicInteger()
 
     val eventProcessor = new ControllerEventProcessor {
       override def process(event: ControllerEvent): Unit = {
-        latch.await()
         processedEvents.incrementAndGet()
       }
       override def preempt(event: ControllerEvent): Unit = {}
@@ -157,7 +155,6 @@ class ControllerEventManagerTest {
 
     controllerEventManager.put(TopicChange)
     controllerEventManager.put(TopicChange)
-    latch.countDown()
 
     TestUtils.waitUntilTrue(() => processedEvents.get() == 2,
       "Timed out waiting for processing of all events")


### PR DESCRIPTION
* https://issues.apache.org/jira/browse/KAFKA-10189
* add a timeout for event queue time histogram
* reset `eventQueueTimeHist` when the controller event queue is empty
* unit test for resetting event queue time histogram 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
