### PR TITLE
MINOR: Create ChannelBuilder for each connection in ConnectionStressWorker workload

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -160,6 +160,7 @@ public class ConnectionStressWorker implements TaskWorker {
             try {
                 List<Node> nodes = updater.fetchNodes();
                 Node targetNode = nodes.get(ThreadLocalRandom.current().nextInt(nodes.size()));
+                // channelBuilder will be closed as part of Selector.close()
                 ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(conf, TIME, logContext);
                 try (Metrics metrics = new Metrics()) {
                     try (Selector selector = new Selector(conf.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -142,7 +142,6 @@ public class ConnectionStressWorker implements TaskWorker {
     static class ConnectStressor implements Stressor {
         private final AdminClientConfig conf;
         private final ManualMetadataUpdater updater;
-        private final ChannelBuilder channelBuilder;
         private final LogContext logContext = new LogContext();
 
         ConnectStressor(ConnectionStressSpec spec) {
@@ -154,7 +153,6 @@ public class ConnectionStressWorker implements TaskWorker {
                 conf.getList(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG),
                 conf.getString(AdminClientConfig.CLIENT_DNS_LOOKUP_CONFIG));
             this.updater = new ManualMetadataUpdater(Cluster.bootstrap(addresses).nodes());
-            this.channelBuilder = ClientUtils.createChannelBuilder(conf, TIME, logContext);
         }
 
         @Override
@@ -162,6 +160,7 @@ public class ConnectionStressWorker implements TaskWorker {
             try {
                 List<Node> nodes = updater.fetchNodes();
                 Node targetNode = nodes.get(ThreadLocalRandom.current().nextInt(nodes.size()));
+                ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(conf, TIME, logContext);
                 try (Metrics metrics = new Metrics()) {
                     try (Selector selector = new Selector(conf.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
                         metrics, TIME, "", channelBuilder, logContext)) {
@@ -179,7 +178,7 @@ public class ConnectionStressWorker implements TaskWorker {
                             false,
                             new ApiVersions(),
                             logContext)) {
-                            NetworkClientUtils.awaitReady(client, targetNode, TIME, 100);
+                            NetworkClientUtils.awaitReady(client, targetNode, TIME, 500);
                         }
                     }
                 }
@@ -192,7 +191,6 @@ public class ConnectionStressWorker implements TaskWorker {
         @Override
         public void close() throws Exception {
             Utils.closeQuietly(updater, "ManualMetadataUpdater");
-            Utils.closeQuietly(channelBuilder, "ChannelBuilder");
         }
     }
 


### PR DESCRIPTION
- Currently we create single channel builder and reuse it in ConnectStressor workload.  This will fail when testing with secure connections, as we close channel builder after first connection.  This PR creates  ChannelBuilder for each test connection. 
- Also increase to connect ready wait timeout to 500ms. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
