### PR TITLE
MINOR: rename class `RecordTimeDefintion` to `RecordTimeDefinition`

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
@@ -52,7 +52,7 @@ public class SuppressedInternal<K> implements Suppressed<K>, NamedSuppressed<K> 
                               final boolean safeToDropTombstones) {
         this.name = name;
         this.timeToWaitForMoreEvents = suppressionTime == null ? DEFAULT_SUPPRESSION_TIME : suppressionTime;
-        this.timeDefinition = timeDefinition == null ? TimeDefinitions.RecordTimeDefintion.instance() : timeDefinition;
+        this.timeDefinition = timeDefinition == null ? TimeDefinitions.RecordTimeDefinition.instance() : timeDefinition;
         this.bufferConfig = bufferConfig == null ? DEFAULT_BUFFER_CONFIG : (BufferConfigInternal) bufferConfig;
         this.safeToDropTombstones = safeToDropTombstones;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/TimeDefinitions.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/TimeDefinitions.java
@@ -35,14 +35,14 @@ final class TimeDefinitions {
         TimeDefinitionType type();
     }
 
-    public static class RecordTimeDefintion<K> implements TimeDefinition<K> {
-        private static final RecordTimeDefintion INSTANCE = new RecordTimeDefintion();
+    public static class RecordTimeDefinition<K> implements TimeDefinition<K> {
+        private static final RecordTimeDefinition INSTANCE = new RecordTimeDefinition();
 
-        private RecordTimeDefintion() {}
+        private RecordTimeDefinition() {}
 
         @SuppressWarnings("unchecked")
-        public static <K> RecordTimeDefintion<K> instance() {
-            return RecordTimeDefintion.INSTANCE;
+        public static <K> RecordTimeDefinition<K> instance() {
+            return RecordTimeDefinition.INSTANCE;
         }
 
         @Override


### PR DESCRIPTION
The naming of internal class `RecordTimeDefintion` in streams module should be a typo.
This PR fix it to `RecordTimeDefinition`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
