### PR TITLE
KAFKA-10181: AlterConfig/IncrementalAlterConfig should route to the controller for non validation calls

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2037,9 +2037,9 @@ public class KafkaAdminClient extends AdminClient {
     @Deprecated
     public AlterConfigsResult alterConfigs(Map<ConfigResource, Config> configs, final AlterConfigsOptions options) {
         final Map<ConfigResource, KafkaFutureImpl<Void>> allFutures = new HashMap<>();
-        // We must make a separate AlterConfigs request for every BROKER resource we want to alter
-        // and send the request to that specific broker. Other resources are grouped together into
-        // a single request that must be sent to the controller broker.
+        // For all the actual alter config requests (validateOnly = false), we should group the resources together
+        // a single request to be sent to the controller. If we are only doing validation, we could make a separate
+        // AlterConfigs request for every BROKER resource and a random node for topic resources.
         final Collection<ConfigResource> unifiedRequestResources = new ArrayList<>();
 
         for (ConfigResource resource : configs.keySet()) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2038,7 +2038,7 @@ public class KafkaAdminClient extends AdminClient {
     public AlterConfigsResult alterConfigs(Map<ConfigResource, Config> configs, final AlterConfigsOptions options) {
         final Map<ConfigResource, KafkaFutureImpl<Void>> allFutures = new HashMap<>();
         // For all the actual alter config requests (validateOnly = false), we should group the resources together
-        // a single request to be sent to the controller. If we are only doing validation, we could make a separate
+        // as a single request to be sent to the controller. If we are only doing validation, we could make a separate
         // AlterConfigs request for every BROKER resource and a random node for topic resources.
         final Collection<ConfigResource> unifiedRequestResources = new ArrayList<>();
 
@@ -2101,8 +2101,8 @@ public class KafkaAdminClient extends AdminClient {
         final Map<ConfigResource, KafkaFutureImpl<Void>> allFutures = new HashMap<>();
 
         // For all the actual alter config requests (validateOnly = false), we should group the resources together
-        // a single request to be sent to the controller. If we are only doing validation, we could make a separate
-        // AlterConfigs request for every BROKER resource and a random node for topic resources.
+        // as a single request to be sent to the controller. If we are only doing validation, we could make a separate
+        // IncrementalAlterConfigs request for every BROKER resource and a random node for topic resources.
         final Collection<ConfigResource> unifiedRequestResources = new ArrayList<>();
 
         for (ConfigResource resource : configs.keySet()) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsResponse.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 
 public class AlterConfigsResponse extends AbstractResponse {
 
-    private final AlterConfigsResponseData data;
+    public final AlterConfigsResponseData data;
 
     public AlterConfigsResponse(AlterConfigsResponseData data) {
         this.data = data;

--- a/clients/src/main/resources/common/message/AlterConfigsRequest.json
+++ b/clients/src/main/resources/common/message/AlterConfigsRequest.json
@@ -18,7 +18,9 @@
   "type": "request",
   "name": "AlterConfigsRequest",
   // Version 1 is the same as version 0.
-  "validVersions": "0-1",
+  //
+  // Version 2 will always route to the controller for topic resources change.
+  "validVersions": "0-2",
   "flexibleVersions": "none",
   "fields": [
     { "name": "Resources", "type": "[]AlterConfigsResource", "versions": "0+", 

--- a/clients/src/main/resources/common/message/AlterConfigsResponse.json
+++ b/clients/src/main/resources/common/message/AlterConfigsResponse.json
@@ -18,7 +18,9 @@
   "type": "response",
   "name": "AlterConfigsResponse",
   // Starting in version 1, on quota violation brokers send out responses before throttling.
-  "validVersions": "0-1",
+  //
+  // Version 2 will always route to the controller for topic resources change.
+  "validVersions": "0-2",
   "flexibleVersions": "none",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",

--- a/clients/src/main/resources/common/message/IncrementalAlterConfigsRequest.json
+++ b/clients/src/main/resources/common/message/IncrementalAlterConfigsRequest.json
@@ -18,7 +18,9 @@
   "type": "request",
   "name": "IncrementalAlterConfigsRequest",
   // Version 1 is the first flexible version.
-  "validVersions": "0-1",
+  //
+  // Version 2 will always route to the controller for topic resources change.
+  "validVersions": "0-2",
   "flexibleVersions": "1+",
   "fields": [
     { "name": "Resources", "type": "[]AlterConfigsResource", "versions": "0+",

--- a/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
+++ b/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
@@ -18,7 +18,9 @@
   "type": "response",
   "name": "IncrementalAlterConfigsResponse",
   // Version 1 is the first flexible version.
-  "validVersions": "0-1",
+  //
+  // Version 2 will always route to the controller for topic resources change.
+  "validVersions": "0-2",
   "flexibleVersions": "1+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -352,6 +352,7 @@ class AdminManager(val config: KafkaConfig,
       def allConfigs(config: AbstractConfig) = {
         config.originals.asScala.filter(_._2 != null) ++ config.values.asScala
       }
+
       def createResponseConfig(configs: Map[String, Any],
                                createConfigEntry: (String, Any) => DescribeConfigsResponseData.DescribeConfigsResourceResult): DescribeConfigsResponseData.DescribeConfigsResult = {
         val filteredConfigPairs = configs.filter { case (configName, _) =>
@@ -382,10 +383,10 @@ class AdminManager(val config: KafkaConfig,
           case ConfigResource.Type.BROKER =>
             if (resource.resourceName == null || resource.resourceName.isEmpty)
               createResponseConfig(config.dynamicConfig.currentDynamicDefaultConfigs,
-                  createBrokerConfigEntry(perBrokerConfig = false, includeSynonyms, includeDocumentation))
+                createBrokerConfigEntry(perBrokerConfig = false, includeSynonyms, includeDocumentation))
             else if (resourceNameToBrokerId(resource.resourceName) == config.brokerId)
               createResponseConfig(allConfigs(config),
-                  createBrokerConfigEntry(perBrokerConfig = true, includeSynonyms, includeDocumentation))
+                createBrokerConfigEntry(perBrokerConfig = true, includeSynonyms, includeDocumentation))
             else
               throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId} or empty string, but received ${resource.resourceName}")
 
@@ -412,18 +413,17 @@ class AdminManager(val config: KafkaConfig,
             error(message, e)
           val err = ApiError.fromThrowable(e)
           new DescribeConfigsResponseData.DescribeConfigsResult()
-              .setResourceName(resource.resourceName)
-              .setResourceType(resource.resourceType)
-              .setErrorMessage(err.message)
-              .setErrorCode(err.error.code)
-              .setConfigs(Collections.emptyList[DescribeConfigsResponseData.DescribeConfigsResourceResult])
+            .setResourceName(resource.resourceName)
+            .setResourceType(resource.resourceType)
+            .setErrorMessage(err.message)
+            .setErrorCode(err.error.code)
+            .setConfigs(Collections.emptyList[DescribeConfigsResponseData.DescribeConfigsResourceResult])
       }
-    }.toList
+    }
   }
 
   def alterConfigs(configs: Map[ConfigResource, AlterConfigsRequest.Config], validateOnly: Boolean): Map[ConfigResource, ApiError] = {
     configs.map { case (resource, config) =>
-
       try {
         val nullUpdates = config.entries.asScala.filter(_.value == null).map(_.name)
         if (nullUpdates.nonEmpty)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2443,8 +2443,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       sendResponseMaybeThrottle(request, responseCallback)
     }
 
-    if (alterConfigsRequest.version() >= 2
-      && !alterConfigsRequest.validateOnly()
+    if (alterConfigsRequest.version >= 2
+      && !alterConfigsRequest.validateOnly
       && !controller.isActive) {
       val requireControllerResult = requestResources.keys.map {
         resource => resource -> new ApiError(Errors.NOT_CONTROLLER, null)
@@ -2587,8 +2587,8 @@ class KafkaApis(val requestChannel: RequestChannel,
       sendResponseMaybeThrottle(request, responseCallback)
     }
 
-    if (incrementalAlterConfigsRequest.version() >= 2
-      && !incrementalAlterConfigsRequest.data.validateOnly()
+    if (incrementalAlterConfigsRequest.version >= 2
+      && !incrementalAlterConfigsRequest.data.validateOnly
       && !controller.isActive) {
       val requireControllerResult = configs.keys.map {
         resource => resource -> new ApiError(Errors.NOT_CONTROLLER, null)

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2438,7 +2438,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     val (controllerRequiredResources, remainingAuthorizedResources) =
-      filterControllerOnlyResources(alterConfigsRequest.version(), authorizedResources)
+      filterControllerOnlyTopicResources(alterConfigsRequest.version(), authorizedResources)
 
     val authorizedResult = adminManager.alterConfigs(
       remainingAuthorizedResources, alterConfigsRequest.validateOnly)
@@ -2559,9 +2559,9 @@ class KafkaApis(val requestChannel: RequestChannel,
   }
 
   def handleIncrementalAlterConfigsRequest(request: RequestChannel.Request): Unit = {
-    val alterConfigsRequest = request.body[IncrementalAlterConfigsRequest]
+    val incrementalAlterConfigsRequest = request.body[IncrementalAlterConfigsRequest]
 
-    val configs = alterConfigsRequest.data.resources.iterator.asScala.map { alterConfigResource =>
+    val configs = incrementalAlterConfigsRequest.data.resources.iterator.asScala.map { alterConfigResource =>
       val configResource = new ConfigResource(ConfigResource.Type.forId(alterConfigResource.resourceType),
         alterConfigResource.resourceName)
       configResource -> alterConfigResource.configs.iterator.asScala.map {
@@ -2581,10 +2581,10 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     val (controllerRequiredResources, remainingAuthorizedResources) =
-      filterControllerOnlyResources(alterConfigsRequest.version(), authorizedResources)
+      filterControllerOnlyTopicResources(incrementalAlterConfigsRequest.version(), authorizedResources)
 
     val authorizedResult = adminManager.incrementalAlterConfigs(
-      remainingAuthorizedResources, alterConfigsRequest.data.validateOnly)
+      remainingAuthorizedResources, incrementalAlterConfigsRequest.data.validateOnly)
     val unauthorizedResult = unauthorizedResources.keys.map { resource =>
       resource -> configsAuthorizationApiError(resource)
     }
@@ -2598,7 +2598,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         (authorizedResult ++ unauthorizedResult ++ requireControllerResult).asJava)))
   }
 
-  private def filterControllerOnlyResources[O](requestVersion: Short, authorizedResources: Map[ConfigResource, O]): (
+  private def filterControllerOnlyTopicResources[O](requestVersion: Short, authorizedResources: Map[ConfigResource, O]): (
     Map[ConfigResource, O], Map[ConfigResource, O]
     ) = {
     val requireController = requestVersion >= 2 && !controller.isActive

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2993,8 +2993,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     authorizer.forall { authZ =>
       val resource = new ResourcePattern(resourceType, resourceName, PatternType.LITERAL)
       val actions = Collections.singletonList(new Action(operation, resource, refCount, logIfAllowed, logIfDenied))
-      val result = authZ.authorize(requestContext, actions).get(0)
-      result == AuthorizationResult.ALLOWED
+      authZ.authorize(requestContext, actions).get(0) == AuthorizationResult.ALLOWED
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -64,7 +64,7 @@ import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest.TxnMarkerEntry
 import org.apache.kafka.common.requests.{FetchMetadata => JFetchMetadata, _}
-import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern, ResourceType}
+import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.server.authorizer.Action
 import org.apache.kafka.server.authorizer.AuthorizationResult
@@ -281,44 +281,34 @@ class KafkaApisTest {
 
     val operation = AclOperation.ALTER_CONFIGS
     val resourceType = ResourceType.TOPIC
-    val topicName = "topic-1"
+    val resourceName = "topic-1"
     val requestHeader = new RequestHeader(ApiKeys.ALTER_CONFIGS, ApiKeys.ALTER_CONFIGS.latestVersion,
       clientId, 0)
 
-    val brokerActions = Seq(
-      new Action(operation, new ResourcePattern(ResourceType.CLUSTER, Resource.CLUSTER_NAME, PatternType.LITERAL),
-        1, true, true))
-    EasyMock.expect(authorizer.authorize(anyObject[RequestContext], EasyMock.eq(brokerActions.asJava)))
-      .andReturn(Seq(AuthorizationResult.ALLOWED).asJava)
-      .once()
+    val expectedActions = Seq(
+      new Action(operation, new ResourcePattern(resourceType, resourceName, PatternType.LITERAL),
+        1, true, true)
+    )
 
-    val topicActions = Seq(
-      new Action(operation, new ResourcePattern(resourceType, topicName, PatternType.LITERAL),
-        1, true, true))
-    EasyMock.expect(authorizer.authorize(anyObject[RequestContext], EasyMock.eq(topicActions.asJava)))
+    EasyMock.expect(controller.isActive).andReturn(true)
+
+    // Verify that authorize is only called once
+    EasyMock.expect(authorizer.authorize(anyObject[RequestContext], EasyMock.eq(expectedActions.asJava)))
       .andReturn(Seq(AuthorizationResult.ALLOWED).asJava)
       .once()
 
     val capturedResponse = expectNoThrottling()
 
-    val brokerResource = new ConfigResource(ConfigResource.Type.BROKER, "broker")
-    val brokerConfig = new AlterConfigsRequest.Config(
-      Seq(new AlterConfigsRequest.ConfigEntry("foo", "bar")).asJava)
-
-    val topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName)
-    val topicConfig = new AlterConfigsRequest.Config(
-      Seq(new AlterConfigsRequest.ConfigEntry("foo2", "bar2")).asJava)
-
-    EasyMock.expect(controller.isActive).andReturn(false)
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
     EasyMock.expect(adminManager.alterConfigs(anyObject(), EasyMock.eq(false)))
-      .andReturn(Map(brokerResource -> ApiError.NONE)).once()
+      .andReturn(Map(configResource -> ApiError.NONE))
 
-    EasyMock.replay(replicaManager, clientRequestQuotaManager, controller,
-      requestChannel, authorizer, adminManager)
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, authorizer,
+      adminManager, controller)
 
     val configs = Map(
-      brokerResource -> brokerConfig,
-      topicResource -> topicConfig)
+      configResource -> new AlterConfigsRequest.Config(
+        Seq(new AlterConfigsRequest.ConfigEntry("foo", "bar")).asJava))
     val alterConfigsRequest = new AlterConfigsRequest.Builder(configs.asJava, false)
       .build(requestHeader.apiVersion)
     val request = buildRequest(alterConfigsRequest)
@@ -331,10 +321,44 @@ class KafkaApisTest {
     val responseMap = response.data.responses().asScala.map { resourceResponse =>
       resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)
     }.toMap
-    assertEquals(Map("broker" -> Errors.NONE, topicName -> Errors.NOT_CONTROLLER),
-      responseMap)
+    assertEquals(Map(resourceName -> Errors.NONE), responseMap)
 
     verify(authorizer, adminManager)
+  }
+
+  @Test
+  def testAlterConfigsWithNonController(): Unit = {
+    val authorizer: Authorizer = EasyMock.niceMock(classOf[Authorizer])
+
+    val resourceName = "topic-1"
+    val requestHeader = new RequestHeader(ApiKeys.ALTER_CONFIGS, ApiKeys.ALTER_CONFIGS.latestVersion,
+      clientId, 0)
+
+    EasyMock.expect(controller.isActive).andReturn(false)
+
+    val capturedResponse = expectNoThrottling()
+
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
+
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, authorizer, controller)
+
+    val configs = Map(
+      configResource -> new AlterConfigsRequest.Config(
+        Seq(new AlterConfigsRequest.ConfigEntry("foo", "bar")).asJava))
+
+    val alterConfigsRequest = new AlterConfigsRequest.Builder(configs.asJava, false)
+      .build(requestHeader.apiVersion)
+    val request = buildRequest(alterConfigsRequest)
+
+    createKafkaApis(authorizer = Some(authorizer)).handleAlterConfigsRequest(request)
+
+    val response = readResponse(ApiKeys.ALTER_CONFIGS, alterConfigsRequest, capturedResponse)
+      .asInstanceOf[AlterConfigsResponse]
+
+    val responseMap = response.data.responses().asScala.map { resourceResponse =>
+      resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)
+    }.toMap
+    assertEquals(Map(resourceName -> Errors.NOT_CONTROLLER), responseMap)
   }
 
   @Test
@@ -343,67 +367,94 @@ class KafkaApisTest {
 
     val operation = AclOperation.ALTER_CONFIGS
     val resourceType = ResourceType.TOPIC
-    val topicName = "topic-1"
+    val resourceName = "topic-1"
     val requestHeader = new RequestHeader(ApiKeys.INCREMENTAL_ALTER_CONFIGS,
       ApiKeys.INCREMENTAL_ALTER_CONFIGS.latestVersion, clientId, 0)
 
-    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, topicName)
-    val topicActions = Seq(
-      new Action(operation, new ResourcePattern(resourceType, topicName, PatternType.LITERAL),
-        1, true, true))
-    EasyMock.expect(authorizer.authorize(anyObject[RequestContext], EasyMock.eq(topicActions.asJava)))
-      .andReturn(Seq(AuthorizationResult.ALLOWED).asJava)
-      .once()
+    val expectedActions = Seq(
+      new Action(operation, new ResourcePattern(resourceType, resourceName, PatternType.LITERAL),
+        1, true, true)
+    )
 
-    val brokerResource = new ConfigResource(ConfigResource.Type.BROKER, "broker")
-    val brokerActions = Seq(
-      new Action(operation, new ResourcePattern(ResourceType.CLUSTER, Resource.CLUSTER_NAME, PatternType.LITERAL),
-        1, true, true))
-    EasyMock.expect(authorizer.authorize(anyObject[RequestContext], EasyMock.eq(brokerActions.asJava)))
+    // Verify that authorize is only called once
+    EasyMock.expect(authorizer.authorize(anyObject[RequestContext], EasyMock.eq(expectedActions.asJava)))
       .andReturn(Seq(AuthorizationResult.ALLOWED).asJava)
       .once()
 
     val capturedResponse = expectNoThrottling()
 
-    EasyMock.expect(controller.isActive).andReturn(false)
+    EasyMock.expect(controller.isActive).andReturn(true)
+
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
     EasyMock.expect(adminManager.incrementalAlterConfigs(anyObject(), EasyMock.eq(false)))
-      .andReturn(Map(brokerResource -> ApiError.NONE))
+      .andReturn(Map(configResource -> ApiError.NONE))
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, authorizer,
-      adminManager)
+      controller, adminManager)
 
     val requestData = new IncrementalAlterConfigsRequestData()
-    val alterTopicResource = new IncrementalAlterConfigsRequestData.AlterConfigsResource()
+    val alterResource = new IncrementalAlterConfigsRequestData.AlterConfigsResource()
       .setResourceName(configResource.name)
       .setResourceType(configResource.`type`.id)
-    alterTopicResource.configs.add(new AlterableConfig()
+    alterResource.configs.add(new AlterableConfig()
       .setName("foo")
       .setValue("bar"))
-    requestData.resources.add(alterTopicResource)
-
-    val alterBrokerResource = new IncrementalAlterConfigsRequestData.AlterConfigsResource()
-      .setResourceName(brokerResource.name)
-      .setResourceType(brokerResource.`type`.id)
-    alterBrokerResource.configs.add(new AlterableConfig()
-      .setName("foo2")
-      .setValue("bar2"))
-    requestData.resources.add(alterBrokerResource)
+    requestData.resources.add(alterResource)
 
     val incrementalAlterConfigsRequest = new IncrementalAlterConfigsRequest.Builder(requestData)
       .build(requestHeader.apiVersion)
     val request = buildRequest(incrementalAlterConfigsRequest)
     createKafkaApis(authorizer = Some(authorizer)).handleIncrementalAlterConfigsRequest(request)
 
-    val response = readResponse(ApiKeys.INCREMENTAL_ALTER_CONFIGS,
-      incrementalAlterConfigsRequest, capturedResponse).asInstanceOf[IncrementalAlterConfigsResponse]
+    val response = readResponse(ApiKeys.INCREMENTAL_ALTER_CONFIGS, incrementalAlterConfigsRequest, capturedResponse)
+      .asInstanceOf[IncrementalAlterConfigsResponse]
 
     val responseMap = response.data.responses().asScala.map { resourceResponse =>
       resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)
     }.toMap
-    assertEquals(Map("broker" -> Errors.NONE, topicName -> Errors.NOT_CONTROLLER),
-      responseMap)
+    assertEquals(Map(resourceName -> Errors.NONE), responseMap)
 
     verify(authorizer, adminManager)
+  }
+
+  @Test
+  def testIncrementalAlterConfigsWithNonController(): Unit = {
+    val authorizer: Authorizer = EasyMock.niceMock(classOf[Authorizer])
+
+    val resourceName = "topic-1"
+    val requestHeader = new RequestHeader(ApiKeys.ALTER_CONFIGS, ApiKeys.ALTER_CONFIGS.latestVersion,
+      clientId, 0)
+
+    EasyMock.expect(controller.isActive).andReturn(false)
+
+    val capturedResponse = expectNoThrottling()
+
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, resourceName)
+
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, authorizer, controller)
+
+    val requestData = new IncrementalAlterConfigsRequestData()
+    val alterResource = new IncrementalAlterConfigsRequestData.AlterConfigsResource()
+      .setResourceName(configResource.name)
+      .setResourceType(configResource.`type`.id)
+    alterResource.configs.add(new AlterableConfig()
+      .setName("foo")
+      .setValue("bar"))
+    requestData.resources.add(alterResource)
+
+    val incrementalAlterConfigsRequest = new IncrementalAlterConfigsRequest.Builder(requestData)
+      .build(requestHeader.apiVersion)
+    val request = buildRequest(incrementalAlterConfigsRequest)
+
+    createKafkaApis(authorizer = Some(authorizer)).handleIncrementalAlterConfigsRequest(request)
+
+    val response = readResponse(ApiKeys.INCREMENTAL_ALTER_CONFIGS, incrementalAlterConfigsRequest, capturedResponse)
+      .asInstanceOf[IncrementalAlterConfigsResponse]
+
+    val responseMap = response.data.responses().asScala.map { resourceResponse =>
+      resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)
+    }.toMap
+    assertEquals(Map(resourceName -> Errors.NOT_CONTROLLER), responseMap)
   }
 
   @Test


### PR DESCRIPTION
Per KIP-590 requirement, we need to route the AlterConfig protocols toward the controller, instead of letting individual brokers handle them. 

In this change, if the call is for validation only, we could still follow what we currently have by:
1. Send topic resource changes to a random node
2. Send broker resource changes to the specified node

Otherwise, if this is not a validation only call (we are actually changing the config), all resources should be bundled and sent to the controller.

Bumped AlterConfig/IncrementalAlterConfig RPC to v2. When the 3 conditions are met:
1. Request >= v2
2. Not a validation request
3. The target broker is not the controller

we would fail individual resource change request with `NOT_CONTROLLER` error.

Although AlterConfig is deprecated, we still need to maintain the backward compatibility instead of leaving a possible RPC which could still be routing to non controller for actual config changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
