### PR TITLE
modify the judgment condition in KafkaApis getTopicMetadata

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1068,7 +1068,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                                errorUnavailableListeners: Boolean): Seq[MetadataResponse.TopicMetadata] = {
     val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
         errorUnavailableEndpoints, errorUnavailableListeners)
-    if (topics.isEmpty || topicResponses.size == topics.size) {
+    if (topicResponses.size == topics.size) {
       topicResponses
     } else {
       val nonExistentTopics = topics -- topicResponses.map(_.topic).toSet

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -584,6 +584,14 @@ class KafkaApisTest {
   }
 
   @Test
+  def testGetTopicMetadataMethodParameters(): Unit = {
+    val value = true
+    val (plaintextListener, _) = updateMetadataCacheWithInconsistentListeners()
+    val response = sendMetadataRequestWithInconsistentListeners(plaintextListener)
+    assertEquals(true, value)
+  }
+
+  @Test
   def testReadCommittedConsumerListOffsetLatest(): Unit = {
     testConsumerListOffsetLatest(IsolationLevel.READ_COMMITTED)
   }


### PR DESCRIPTION
in the method handleTopicMetadataRequest it has been determined whether authorizedTopics is empty，no need to judge again in the getTopicMetadata method，the method getTopicMetadata should be removed  topics.isEmpty. Maybe in the future getTopicMetadata method will use the single judgment condition.
