### PR TITLE
KAFKA-10196: Add missing '--version' option to producer-performance

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -173,6 +173,8 @@ public class ClientCompatibilityTest {
             .metavar("DESCRIBE_CONFIGS_SUPPORTED")
             .help("Whether describeConfigs is supported in the AdminClient.");
 
+        ToolsUtils.addOptionVersion(parser);
+
         Namespace res = null;
         try {
             res = parser.parseArgs(args);

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -291,6 +291,7 @@ public class ProducerPerformance {
                .setDefault(0L)
                .help("The max age of each transaction. The commitTransaction will be called after this time has elapsed. Transactions are only enabled if this value is positive.");
 
+       ToolsUtils.addOptionVersion(parser);
 
         return parser;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
@@ -18,9 +18,12 @@ package org.apache.kafka.tools;
 
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.utils.AppInfoParser;
 
 import java.util.Map;
 import java.util.TreeMap;
+import static net.sourceforge.argparse4j.impl.Arguments.version;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
 
 public class ToolsUtils {
 
@@ -51,5 +54,21 @@ public class ToolsUtils {
                 System.out.println(String.format(outputFormat, entry.getKey(), entry.getValue()));
             }
         }
+    }
+
+    /**
+     * Add '--version' option to parser
+     * @param parser   ArgumentParser to which '-version' will be added
+     */
+    public static void addOptionVersion(ArgumentParser parser) {
+        String version = AppInfoParser.getVersion();
+        String commitId = AppInfoParser.getCommitId();
+        String versionString = version + " " + "(" + "Commit:" + commitId + ")";
+        parser.version(versionString);
+        parser.addArgument("--version")
+                .action(version())
+                .required(false)
+                .metavar("VERSION")
+                .help("Display Kafka version.");
     }
 }

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -168,6 +168,8 @@ public class TransactionalMessageCopier {
                 .dest("useGroupMetadata")
                 .help("Whether to use the new transactional commit API with group metadata");
 
+        ToolsUtils.addOptionVersion(parser);
+
         return parser;
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -599,6 +599,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .metavar("CONFIG_FILE")
                 .help("Consumer config properties file (config options shared with command line parameters will be overridden).");
 
+        ToolsUtils.addOptionVersion(parser);
+
         return parser;
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -149,6 +149,8 @@ public class VerifiableLog4jAppender {
             .dest("kerb5ConfPath")
             .help("Path of Kerb5 config file.");
 
+        ToolsUtils.addOptionVersion(parser);
+
         return parser;
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -196,6 +196,8 @@ public class VerifiableProducer implements AutoCloseable {
             .dest("repeatingKeys")
             .help("If specified, each produced record will have a key starting at 0 increment by 1 up to the number specified (exclusive), then the key is set to 0 again");
 
+        ToolsUtils.addOptionVersion(parser);
+
         return parser;
     }
     


### PR DESCRIPTION
Option '--version' is missing in producer-performance. This patch is to add this
option to display kafka version.

Change-Id: Icfbdecfe56fb51439ec83d7ef7dc48ace3116ca2
Signed-off-by: Jiamei Xie <jiamei.xie@arm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
