### PR TITLE
KAFKA-10214: fix flaky zookeeper_tls_test.py

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -225,6 +225,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             for port in self.port_mappings.values():
                 if port.open:
                     self._security_config.enable_security_protocol(port.security_protocol)
+        if self.zk.zk_sasl:
+            self._security_config.enable_sasl()
+            self._security_config.zk_sasl = self.zk.zk_sasl
+        if self.zk_client_secure:
+            self._security_config.enable_ssl()
+            self._security_config.zk_tls = self.zk_client_secure
         return self._security_config
 
     def open_port(self, listener_name):

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -211,6 +211,12 @@ class SecurityConfig(TemplateRenderer):
                               listener_security_config=self.listener_security_config,
                               tls_version=self.tls_version)
 
+    def enable_sasl(self):
+        self.has_sasl = True
+
+    def enable_ssl(self):
+        self.has_ssl = True
+
     def enable_security_protocol(self, security_protocol):
         self.has_sasl = self.has_sasl or self.is_sasl(security_protocol)
         self.has_ssl = self.has_ssl or self.is_ssl(security_protocol)


### PR DESCRIPTION
After 3661f981fff2653aaf1d5ee0b6dde3410b5498db security_config is cached. Hence, the later changes to security flag can't impact the security_config used by later tests.

issue: https://issues.apache.org/jira/browse/KAFKA-10214

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
