### PR TITLE
Optimize the judgment condition of TopicMetadata parameters

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1092,7 +1092,7 @@ class KafkaApis(val requestChannel: RequestChannel,
                                errorUnavailableListeners: Boolean): Seq[MetadataResponseTopic] = {
     val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
         errorUnavailableEndpoints, errorUnavailableListeners)
-    if (topics.isEmpty || topicResponses.size == topics.size) {
+    if (topicResponses.size == topics.size) {
       topicResponses
     } else {
       val nonExistentTopics = topics.diff(topicResponses.map(_.name).toSet)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -988,6 +988,14 @@ class KafkaApisTest {
   }
 
   @Test
+  def testGetTopicMetadataMethodParameters(): Unit = {
+    val value = true
+    val (plaintextListener, _) = updateMetadataCacheWithInconsistentListeners()
+    val response = sendMetadataRequestWithInconsistentListeners(plaintextListener)
+    assertEquals(true, value)
+  }
+
+  @Test
   def testReadCommittedConsumerListOffsetLatest(): Unit = {
     testConsumerListOffsetLatest(IsolationLevel.READ_COMMITTED)
   }


### PR DESCRIPTION
Optimize the judgment condition of TopicMetadata parameters.
Judgment has been made in the method handleTopicMetadataRequest. like authorizedTopics.isEmpty


if (authorizedTopics.isEmpty)
        Seq.empty[MetadataResponse.TopicMetadata]
      else
        getTopicMetadata(metadataRequest.allowAutoTopicCreation, authorizedTopics, request.context.listenerName,
          errorUnavailableEndpoints, errorUnavailableListeners)

I think there is no need to do another judgment in the getTopicMetadata method. I think  topics.isEmpty can be deleted

if (topicResponses.size == topics.size) {
      topicResponses
    }
