### PR TITLE
MINOR: Add toString for RocksDbWindowBytesStoreSupplier

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -170,7 +170,8 @@ class KStreamImplJoin {
         final boolean allMatch = supplier.retentionPeriod() == (joinWindows.size() + joinWindows.gracePeriodMs()) &&
             supplier.windowSize() == joinWindows.size();
         if (!allMatch) {
-            throw new StreamsException(String.format("Window settings mismatch. WindowBytesStoreSupplier settings %s must match JoinWindows settings %s", supplier, joinWindows));
+            throw new StreamsException(String.format("Window settings mismatch. WindowBytesStoreSupplier settings %s must match JoinWindows settings %s" +
+                                                         " for the window size and retention period", supplier, joinWindows));
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbWindowBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDbWindowBytesStoreSupplier.java
@@ -102,4 +102,16 @@ public class RocksDbWindowBytesStoreSupplier implements WindowBytesStoreSupplier
     public long retentionPeriod() {
         return retentionPeriod;
     }
+
+    @Override
+    public String toString() {
+        return "RocksDbWindowBytesStoreSupplier{" +
+                   "name='" + name + '\'' +
+                   ", retentionPeriod=" + retentionPeriod +
+                   ", segmentInterval=" + segmentInterval +
+                   ", windowSize=" + windowSize +
+                   ", retainDuplicates=" + retainDuplicates +
+                   ", returnTimestampedStore=" + returnTimestampedStore +
+                   '}';
+    }
 }


### PR DESCRIPTION
We are missing a `toString` logic in the RocksDbWindowBytesStoreSupplier, such that the error log wasn't able to print out the supplier's actual config:

```
Exception in thread "main" org.apache.kafka.streams.errors.StreamsException: Window settings mismatch. WindowBytesStoreSupplier settings org.apache.kafka.streams.state.internals.RocksDbWindowBytesStoreSupplier@61f8bee4 must match JoinWindows settings JoinWindows{beforeMs=500, afterMs=500, graceMs=-1, maintainDurationMs=86400000, segments=3}
        at org.apache.kafka.streams.kstream.internals.KStreamImplJoin.assertWindowSettings(KStreamImplJoin.java:173)
        at org.apache.kafka.streams.kstream.internals.KStreamImplJoin.join(KStreamImplJoin.java:96)
        at org.apache.kafka.streams.kstream.internals.KStreamImpl.doJoin(KStreamImpl.java:969)
        at org.apache.kafka.streams.kstream.internals.KStreamImpl.join(KStreamImpl.java:858)
        at io.confluent.streams.bench.table.App.getStreamStreamJoinTopology(App.java:1231)
        at io.confluent.streams.bench.table.App.main(App.java:609)
```

This PR amends this gap by providing an implementation for RocksDbWindowBytesStoreSupplier `toString`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
