### PR TITLE
MINOR; Move quota integration tests to using the new quota API.

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -23,12 +23,15 @@ import kafka.api.QuotaTestClients._
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server.{ClientQuotaManager, ClientQuotaManagerConfig, DynamicConfig, KafkaConfig, KafkaServer, QuotaType}
 import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 import org.apache.kafka.common.metrics.{KafkaMetric, Quota}
 import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.quota.ClientQuotaAlteration
+import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.Assert._
 import org.junit.{Before, Test}
@@ -189,7 +192,8 @@ abstract class QuotaTestClients(topic: String,
                                 producerClientId: String,
                                 consumerClientId: String,
                                 val producer: KafkaProducer[Array[Byte], Array[Byte]],
-                                val consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {
+                                val consumer: KafkaConsumer[Array[Byte], Array[Byte]],
+                                val adminClient: Admin) {
 
   def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit
   def removeQuotaOverrides(): Unit
@@ -224,7 +228,7 @@ abstract class QuotaTestClients(topic: String,
       numConsumed += consumer.poll(Duration.ofMillis(100L)).count
       val metric = throttleMetric(QuotaType.Fetch, consumerClientId)
       throttled = metric != null && metricValue(metric) > 0
-    }  while (numConsumed < maxRecords && !throttled && System.currentTimeMillis < startMs + timeoutMs)
+    } while (numConsumed < maxRecords && !throttled && System.currentTimeMillis < startMs + timeoutMs)
 
     // If throttled, wait for the records from the last fetch to be received
     if (throttled && numConsumed < maxRecords && waitForRequestCompletion) {
@@ -335,12 +339,31 @@ abstract class QuotaTestClients(topic: String,
       assertEquals("Should not have been throttled", 0.0, metricValue(maxMetric), 0.0)
   }
 
-  def quotaProperties(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Properties = {
-    val props = new Properties()
-    props.put(DynamicConfig.Client.ProducerByteRateOverrideProp, producerQuota.toString)
-    props.put(DynamicConfig.Client.ConsumerByteRateOverrideProp, consumerQuota.toString)
-    props.put(DynamicConfig.Client.RequestPercentageOverrideProp, requestQuota.toString)
-    props
+  // Default is set by using Some(null) for either or both user and clientId
+  def clientQuotaEntity(user: Option[String], clientId: Option[String]): ClientQuotaEntity = {
+    var entries = Map.empty[String, String]
+    user.foreach(user => entries = entries ++ Map(ClientQuotaEntity.USER -> user))
+    clientId.foreach(clientId => entries = entries ++ Map(ClientQuotaEntity.CLIENT_ID -> clientId))
+    new ClientQuotaEntity(entries.asJava)
+  }
+
+  // None is translated to `null` which remove the quota
+  def clientQuotaAlteration(quotaEntity: ClientQuotaEntity,
+                            producerQuota: Option[Long],
+                            consumerQuota: Option[Long],
+                            requestQuota: Option[Double]): ClientQuotaAlteration = {
+    var ops = Seq.empty[ClientQuotaAlteration.Op]
+    def addOp(key: String, value: Option[Double]): Unit = {
+      ops = ops ++ Seq(new ClientQuotaAlteration.Op(key, value.map(Double.box).orNull))
+    }
+    addOp(DynamicConfig.Client.ProducerByteRateOverrideProp, producerQuota.map(_.toDouble))
+    addOp(DynamicConfig.Client.ConsumerByteRateOverrideProp, consumerQuota.map(_.toDouble))
+    addOp(DynamicConfig.Client.RequestPercentageOverrideProp, requestQuota)
+    new ClientQuotaAlteration(quotaEntity, ops.asJava)
+  }
+
+  def alterClientQuotas(quotaAlterations: ClientQuotaAlteration *): Unit = {
+    adminClient.alterClientQuotas(quotaAlterations.asJava).all().get()
   }
 
   def waitForQuotaUpdate(producerQuota: Long, consumerQuota: Long, requestQuota: Double, server: KafkaServer = leaderNode): Unit = {

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -184,6 +184,8 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 }
 
 object QuotaTestClients {
+  val DefaultEntity: String = null
+
   def metricValue(metric: Metric): Double = metric.metricValue().asInstanceOf[Double]
 }
 
@@ -339,7 +341,6 @@ abstract class QuotaTestClients(topic: String,
       assertEquals("Should not have been throttled", 0.0, metricValue(maxMetric), 0.0)
   }
 
-  // Default is set by using Some(null) for either or both user and clientId
   def clientQuotaEntity(user: Option[String], clientId: Option[String]): ClientQuotaEntity = {
     var entries = Map.empty[String, String]
     user.foreach(user => entries = entries ++ Map(ClientQuotaEntity.USER -> user))

--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -14,11 +14,8 @@
 
 package kafka.api
 
-import java.util.Properties
-
-import kafka.server.{DynamicConfig, KafkaConfig, KafkaServer}
+import kafka.server.{KafkaConfig, KafkaServer}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.apache.kafka.common.utils.Sanitizer
 import org.junit.Before
 
 class ClientIdQuotaTest extends BaseQuotaTest {
@@ -36,33 +33,39 @@ class ClientIdQuotaTest extends BaseQuotaTest {
   override def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients = {
     val producer = createProducer()
     val consumer = createConsumer()
+    val adminClient = createAdminClient()
 
-    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
+    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer, adminClient) {
       override def userPrincipal: KafkaPrincipal = KafkaPrincipal.ANONYMOUS
+
       override def quotaMetricTags(clientId: String): Map[String, String] = {
         Map("user" -> "", "client-id" -> clientId)
       }
 
       override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {
-        val producerProps = new Properties()
-        producerProps.put(DynamicConfig.Client.ProducerByteRateOverrideProp, producerQuota.toString)
-        producerProps.put(DynamicConfig.Client.RequestPercentageOverrideProp, requestQuota.toString)
-        updateQuotaOverride(producerClientId, producerProps)
-
-        val consumerProps = new Properties()
-        consumerProps.put(DynamicConfig.Client.ConsumerByteRateOverrideProp, consumerQuota.toString)
-        consumerProps.put(DynamicConfig.Client.RequestPercentageOverrideProp, requestQuota.toString)
-        updateQuotaOverride(consumerClientId, consumerProps)
+        alterClientQuotas(
+          clientQuotaAlteration(
+            clientQuotaEntity(None, Some(producerClientId)),
+            Some(producerQuota), None, Some(requestQuota)
+          ),
+          clientQuotaAlteration(
+            clientQuotaEntity(None, Some(consumerClientId)),
+            None, Some(consumerQuota), Some(requestQuota)
+          )
+        )
       }
 
       override def removeQuotaOverrides(): Unit = {
-        val emptyProps = new Properties
-        updateQuotaOverride(producerClientId, emptyProps)
-        updateQuotaOverride(consumerClientId, emptyProps)
-      }
-
-      private def updateQuotaOverride(clientId: String, properties: Properties): Unit = {
-        adminZkClient.changeClientIdConfig(Sanitizer.sanitize(clientId), properties)
+        alterClientQuotas(
+          clientQuotaAlteration(
+            clientQuotaEntity(None, Some(producerClientId)),
+            None, None, None
+          ),
+          clientQuotaAlteration(
+            clientQuotaEntity(None, Some(consumerClientId)),
+            None, None, None
+          )
+        )
       }
     }
   }

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -37,7 +37,7 @@ class UserClientIdQuotaTest extends BaseQuotaTest {
     super.setUp()
     quotaTestClients.alterClientQuotas(
       quotaTestClients.clientQuotaAlteration(
-        quotaTestClients.clientQuotaEntity(Some(null), Some(null)),
+        quotaTestClients.clientQuotaEntity(Some(QuotaTestClients.DefaultEntity), Some(QuotaTestClients.DefaultEntity)),
         Some(defaultProducerQuota), Some(defaultConsumerQuota), Some(defaultRequestQuota)
       )
     )

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -15,7 +15,6 @@
 package kafka.api
 
 import java.io.File
-import java.util.Properties
 
 import kafka.server._
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
@@ -36,43 +35,51 @@ class UserClientIdQuotaTest extends BaseQuotaTest {
     this.serverConfig.setProperty(KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp, Long.MaxValue.toString)
     this.serverConfig.setProperty(KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp, Long.MaxValue.toString)
     super.setUp()
-    val defaultProps = quotaTestClients.quotaProperties(defaultProducerQuota, defaultConsumerQuota, defaultRequestQuota)
-    adminZkClient.changeUserOrUserClientIdConfig(ConfigEntityName.Default + "/clients/" + ConfigEntityName.Default, defaultProps)
+    quotaTestClients.alterClientQuotas(
+      quotaTestClients.clientQuotaAlteration(
+        quotaTestClients.clientQuotaEntity(Some(null), Some(null)),
+        Some(defaultProducerQuota), Some(defaultConsumerQuota), Some(defaultRequestQuota)
+      )
+    )
     quotaTestClients.waitForQuotaUpdate(defaultProducerQuota, defaultConsumerQuota, defaultRequestQuota)
   }
 
   override def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients = {
     val producer = createProducer()
     val consumer = createConsumer()
+    val adminClient = createAdminClient()
 
-    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
+    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer, adminClient) {
       override def userPrincipal: KafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "O=A client,CN=localhost")
+
       override def quotaMetricTags(clientId: String): Map[String, String] = {
         Map("user" -> Sanitizer.sanitize(userPrincipal.getName), "client-id" -> clientId)
       }
 
       override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {
-        val producerProps = new Properties()
-        producerProps.setProperty(DynamicConfig.Client.ProducerByteRateOverrideProp, producerQuota.toString)
-        producerProps.setProperty(DynamicConfig.Client.RequestPercentageOverrideProp, requestQuota.toString)
-        updateQuotaOverride(userPrincipal.getName, producerClientId, producerProps)
-
-        val consumerProps = new Properties()
-        consumerProps.setProperty(DynamicConfig.Client.ConsumerByteRateOverrideProp, consumerQuota.toString)
-        consumerProps.setProperty(DynamicConfig.Client.RequestPercentageOverrideProp, requestQuota.toString)
-        updateQuotaOverride(userPrincipal.getName, consumerClientId, consumerProps)
+        alterClientQuotas(
+          clientQuotaAlteration(
+            clientQuotaEntity(Some(userPrincipal.getName), Some(producerClientId)),
+            Some(producerQuota), None, Some(requestQuota)
+          ),
+          clientQuotaAlteration(
+            clientQuotaEntity(Some(userPrincipal.getName), Some(consumerClientId)),
+            None, Some(consumerQuota), Some(requestQuota)
+          )
+        )
       }
 
       override def removeQuotaOverrides(): Unit = {
-        val emptyProps = new Properties
-        adminZkClient.changeUserOrUserClientIdConfig(Sanitizer.sanitize(userPrincipal.getName) +
-          "/clients/" + Sanitizer.sanitize(producerClientId), emptyProps)
-        adminZkClient.changeUserOrUserClientIdConfig(Sanitizer.sanitize(userPrincipal.getName) +
-          "/clients/" + Sanitizer.sanitize(consumerClientId), emptyProps)
-      }
-
-      private def updateQuotaOverride(userPrincipal: String, clientId: String, properties: Properties): Unit = {
-        adminZkClient.changeUserOrUserClientIdConfig(Sanitizer.sanitize(userPrincipal) + "/clients/" + Sanitizer.sanitize(clientId), properties)
+        alterClientQuotas(
+          clientQuotaAlteration(
+            clientQuotaEntity(Some(userPrincipal.getName), Some(producerClientId)),
+            None, None, None
+          ),
+          clientQuotaAlteration(
+            clientQuotaEntity(Some(userPrincipal.getName), Some(consumerClientId)),
+            None, None, None
+          )
+        )
       }
     }
   }

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -15,12 +15,10 @@
 package kafka.api
 
 import java.io.File
-import java.util.Properties
 
-import kafka.server.{ConfigEntityName, KafkaConfig, KafkaServer}
+import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.JaasTestUtils
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
-import org.apache.kafka.common.utils.Sanitizer
 import org.junit.{After, Before}
 
 class UserQuotaTest extends BaseQuotaTest with SaslSetup {
@@ -38,8 +36,12 @@ class UserQuotaTest extends BaseQuotaTest with SaslSetup {
     this.serverConfig.setProperty(KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp, Long.MaxValue.toString)
     this.serverConfig.setProperty(KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp, Long.MaxValue.toString)
     super.setUp()
-    val defaultProps = quotaTestClients.quotaProperties(defaultProducerQuota, defaultConsumerQuota, defaultRequestQuota)
-    adminZkClient.changeUserOrUserClientIdConfig(ConfigEntityName.Default, defaultProps)
+    quotaTestClients.alterClientQuotas(
+      quotaTestClients.clientQuotaAlteration(
+        quotaTestClients.clientQuotaEntity(Some(null), None),
+        Some(defaultProducerQuota), Some(defaultConsumerQuota), Some(defaultRequestQuota)
+      )
+    )
     quotaTestClients.waitForQuotaUpdate(defaultProducerQuota, defaultConsumerQuota, defaultRequestQuota)
   }
 
@@ -52,26 +54,31 @@ class UserQuotaTest extends BaseQuotaTest with SaslSetup {
   override def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients = {
     val producer = createProducer()
     val consumer = createConsumer()
+    val adminClient = createAdminClient()
 
-    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
+    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer, adminClient) {
       override val userPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaClientPrincipalUnqualifiedName2)
+
       override def quotaMetricTags(clientId: String): Map[String, String] = {
         Map("user" -> userPrincipal.getName, "client-id" -> "")
       }
 
       override def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double): Unit = {
-        val props = quotaProperties(producerQuota, consumerQuota, requestQuota)
-        updateQuotaOverride(props)
+        alterClientQuotas(
+          clientQuotaAlteration(
+            clientQuotaEntity(Some(userPrincipal.getName), None),
+            Some(producerQuota), Some(consumerQuota), Some(requestQuota)
+          )
+        )
       }
 
       override def removeQuotaOverrides(): Unit = {
-        val emptyProps = new Properties
-        updateQuotaOverride(emptyProps)
-        updateQuotaOverride(emptyProps)
-      }
-
-      private def updateQuotaOverride(properties: Properties): Unit = {
-        adminZkClient.changeUserOrUserClientIdConfig(Sanitizer.sanitize(userPrincipal.getName), properties)
+        alterClientQuotas(
+          clientQuotaAlteration(
+            clientQuotaEntity(Some(userPrincipal.getName), None),
+            None, None, None
+          )
+        )
       }
     }
   }

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -38,7 +38,7 @@ class UserQuotaTest extends BaseQuotaTest with SaslSetup {
     super.setUp()
     quotaTestClients.alterClientQuotas(
       quotaTestClients.clientQuotaAlteration(
-        quotaTestClients.clientQuotaEntity(Some(null), None),
+        quotaTestClients.clientQuotaEntity(Some(QuotaTestClients.DefaultEntity), None),
         Some(defaultProducerQuota), Some(defaultConsumerQuota), Some(defaultRequestQuota)
       )
     )


### PR DESCRIPTION
This PR refactors the various quota integration tests in the `kafka.api` package and migrates them to using the new quota API instead of writing the quota to ZK directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
