### PR TITLE
KAFKA-5235: GetOffsetShell: support for multiple topics and consumer configuration override

### DIFF
--- a/bin/kafka-get-offsets.sh
+++ b/bin/kafka-get-offsets.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.GetOffsetShell "$@"

--- a/bin/windows/kafka-get-offsets.bat
+++ b/bin/windows/kafka-get-offsets.bat
@@ -1,0 +1,17 @@
+@echo off
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+"%~dp0kafka-run-class.bat" kafka.tools.GetOffsetShell %*

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceConnectorConfig.java
@@ -47,9 +47,9 @@ public class SourceConnectorConfig extends ConnectorConfig {
             + "created by source connectors";
     private static final String TOPIC_CREATION_GROUPS_DISPLAY = "Topic Creation Groups";
 
-    private static class EnrichedSourceConnectorConfig extends AbstractConfig {
-        EnrichedSourceConnectorConfig(ConfigDef configDef, Map<String, String> props) {
-            super(configDef, props);
+    private static class EnrichedSourceConnectorConfig extends ConnectorConfig {
+        EnrichedSourceConnectorConfig(Plugins plugins, ConfigDef configDef, Map<String, String> props) {
+            super(plugins, configDef, props);
         }
 
         @Override
@@ -129,8 +129,9 @@ public class SourceConnectorConfig extends ConnectorConfig {
             propsWithoutRegexForDefaultGroup.entrySet()
                     .removeIf(e -> e.getKey().equals(DEFAULT_TOPIC_CREATION_PREFIX + INCLUDE_REGEX_CONFIG)
                             || e.getKey().equals(DEFAULT_TOPIC_CREATION_PREFIX + EXCLUDE_REGEX_CONFIG));
-            enrichedSourceConfig = new EnrichedSourceConnectorConfig(enrich(defaultConfigDef, props,
-                    defaultGroup), propsWithoutRegexForDefaultGroup);
+            enrichedSourceConfig = new EnrichedSourceConnectorConfig(plugins,
+                    enrich(defaultConfigDef, props, defaultGroup),
+                    propsWithoutRegexForDefaultGroup);
         } else {
             enrichedSourceConfig = null;
         }

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kafka.network.RequestChannel
 import kafka.network.RequestChannel._
 import kafka.server.ClientQuotaManager._
-import kafka.utils.{Logging, ShutdownableThread}
+import kafka.utils.{Logging, QuotaUtils, ShutdownableThread}
 import org.apache.kafka.common.{Cluster, MetricName}
 import org.apache.kafka.common.metrics._
 import org.apache.kafka.common.metrics.Metrics
@@ -372,10 +372,10 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
    * This calculates the amount of time needed to bring the metric within quota
    * assuming that no new metrics are recorded.
    *
-   * See {ClientQuotaManager.throttleTime} for the details.
+   * See {QuotaUtils.throttleTime} for the details.
    */
   protected def throttleTime(e: QuotaViolationException, timeMs: Long): Long = {
-    ClientQuotaManager.throttleTime(e, timeMs)
+    QuotaUtils.throttleTime(e, timeMs)
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -19,6 +19,7 @@ package kafka.server
 import java.util.concurrent.TimeUnit
 
 import kafka.network.RequestChannel
+import kafka.utils.QuotaUtils
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.metrics._
 import org.apache.kafka.common.utils.Time
@@ -75,7 +76,7 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
   }
 
   override protected def throttleTime(e: QuotaViolationException, timeMs: Long): Long = {
-    math.min(super.throttleTime(e, timeMs), maxThrottleTimeMs)
+    QuotaUtils.boundedThrottleTime(e, maxThrottleTimeMs, timeMs)
   }
 
   override protected def clientRateMetricName(quotaMetricTags: Map[String, String]): MetricName = {

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -84,7 +84,7 @@ object DynamicBrokerConfig {
     DynamicListenerConfig.ReconfigurableConfigs ++
     SocketServer.ReconfigurableConfigs
 
-  private val ClusterLevelListenerConfigs = Set(KafkaConfig.MaxConnectionsProp)
+  private val ClusterLevelListenerConfigs = Set(KafkaConfig.MaxConnectionsProp, KafkaConfig.MaxConnectionCreationRateProp)
   private val PerBrokerConfigs = (DynamicSecurityConfigs ++ DynamicListenerConfig.ReconfigurableConfigs).diff(
     ClusterLevelListenerConfigs)
   private val ListenerMechanismConfigs = Set(KafkaConfig.SaslJaasConfigProp,
@@ -851,7 +851,8 @@ object DynamicListenerConfig {
     KafkaConfig.SaslLoginRefreshBufferSecondsProp,
 
     // Connection limit configs
-    KafkaConfig.MaxConnectionsProp
+    KafkaConfig.MaxConnectionsProp,
+    KafkaConfig.MaxConnectionCreationRateProp
   )
 }
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -86,6 +86,7 @@ object Defaults {
   val MaxConnectionsPerIp: Int = Int.MaxValue
   val MaxConnectionsPerIpOverrides: String = ""
   val MaxConnections: Int = Int.MaxValue
+  val MaxConnectionCreationRate: Int = Int.MaxValue
   val ConnectionsMaxIdleMs = 10 * 60 * 1000L
   val RequestTimeoutMs = 30000
   val ConnectionSetupTimeoutMs = CommonClientConfigs.DEFAULT_SOCKET_CONNECTION_SETUP_TIMEOUT_MS
@@ -367,6 +368,7 @@ object KafkaConfig {
   val MaxConnectionsPerIpProp = "max.connections.per.ip"
   val MaxConnectionsPerIpOverridesProp = "max.connections.per.ip.overrides"
   val MaxConnectionsProp = "max.connections"
+  val MaxConnectionCreationRateProp = "max.connection.creation.rate"
   val ConnectionsMaxIdleMsProp = "connections.max.idle.ms"
   val FailedAuthenticationDelayMsProp = "connection.failed.authentication.delay.ms"
   /***************** rack configuration *************/
@@ -699,6 +701,11 @@ object KafkaConfig {
     "should be configured based on broker capacity while listener limits should be configured based on application requirements. " +
     "New connections are blocked if either the listener or broker limit is reached. Connections on the inter-broker listener are " +
     "permitted even if broker-wide limit is reached. The least recently used connection on another listener will be closed in this case."
+  val MaxConnectionCreationRateDoc = "The maximum connection creation rate we allow in the broker at any time. Listener-level limits " +
+    s"may also be configured by prefixing the config name with the listener prefix, for example, <code>listener.name.internal.$MaxConnectionCreationRateProp</code>." +
+    "Broker-wide connection rate limit should be configured based on broker capacity while listener limits should be configured based on " +
+    "application requirements. New connections will be throttled if either the listener or the broker limit is reached, with the exception " +
+    "of inter-broker listener. Connections on the inter-broker listener will be throttled only when the listener-level rate limit is reached."
   val ConnectionsMaxIdleMsDoc = "Idle connections timeout: the server socket processor threads close the connections that idle more than this"
   val FailedAuthenticationDelayMsDoc = "Connection close delay on failed authentication: this is the time (in milliseconds) by which connection close will be delayed on authentication failure. " +
     s"This must be configured to be less than $ConnectionsMaxIdleMsProp to prevent connection timeout."
@@ -1026,6 +1033,7 @@ object KafkaConfig {
       .define(MaxConnectionsPerIpProp, INT, Defaults.MaxConnectionsPerIp, atLeast(0), MEDIUM, MaxConnectionsPerIpDoc)
       .define(MaxConnectionsPerIpOverridesProp, STRING, Defaults.MaxConnectionsPerIpOverrides, MEDIUM, MaxConnectionsPerIpOverridesDoc)
       .define(MaxConnectionsProp, INT, Defaults.MaxConnections, atLeast(0), MEDIUM, MaxConnectionsDoc)
+      .define(MaxConnectionCreationRateProp, INT, Defaults.MaxConnectionCreationRate, atLeast(0), MEDIUM, MaxConnectionCreationRateDoc)
       .define(ConnectionsMaxIdleMsProp, LONG, Defaults.ConnectionsMaxIdleMs, MEDIUM, ConnectionsMaxIdleMsDoc)
       .define(FailedAuthenticationDelayMsProp, INT, Defaults.FailedAuthenticationDelayMs, atLeast(0), LOW, FailedAuthenticationDelayMsDoc)
 
@@ -1450,6 +1458,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val maxConnectionsPerIpOverrides: Map[String, Int] =
     getMap(KafkaConfig.MaxConnectionsPerIpOverridesProp, getString(KafkaConfig.MaxConnectionsPerIpOverridesProp)).map { case (k, v) => (k, v.toInt)}
   def maxConnections = getInt(KafkaConfig.MaxConnectionsProp)
+  def maxConnectionCreationRate = getInt(KafkaConfig.MaxConnectionCreationRateProp)
   val connectionsMaxIdleMs = getLong(KafkaConfig.ConnectionsMaxIdleMsProp)
   val failedAuthenticationDelayMs = getInt(KafkaConfig.FailedAuthenticationDelayMsProp)
 

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -40,17 +40,17 @@ object GetOffsetShell {
                            .withRequiredArg
                            .describedAs("hostname:port,...,hostname:port")
                            .ofType(classOf[String])
-    val topicPartitionOpt = parser.accepts("topic-partitions", "Comma separated list of topic-partition specifications to get the offsets for, with the format of topic:partition. The 'topic' part can be a regex or may be omitted to only specify the partitions, and query all topics." +
+    val topicPartitionOpt = parser.accepts("topic-partitions", "Comma separated list of topic-partition specifications to get the offsets for, with the format of topic:partition. The 'topic' part can be a regex or may be omitted to only specify the partitions, and query all authorized topics." +
                                             " The 'partition' part can be: a number, a range in the format of 'NUMBER-NUMBER' (lower inclusive, upper exclusive), an inclusive lower bound in the format of 'NUMBER-', an exclusive upper bound in the format of '-NUMBER' or may be omitted to accept all partitions of the specified topic.")
                            .withRequiredArg
                            .describedAs("topic:partition,...,topic:partition")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val topicOpt = parser.accepts("topic", s"The topic to get the offsets for. It also accepts a regular expression. If not present, all topics are queried. Ignored if $topicPartitionOpt is present.")
+    val topicOpt = parser.accepts("topic", s"The topic to get the offsets for. It also accepts a regular expression. If not present, all authorized topics are queried. Ignored if $topicPartitionOpt is present.")
                            .withRequiredArg
                            .describedAs("topic")
                            .ofType(classOf[String])
-    val partitionOpt = parser.accepts("partitions", s"Comma separated list of partition ids to get the offsets for. If not present, all partitions of the topics are queried. Ignored if $topicPartitionOpt is present.")
+    val partitionOpt = parser.accepts("partitions", s"Comma separated list of partition ids to get the offsets for. If not present, all partitions of the authorized topics are queried. Ignored if $topicPartitionOpt is present.")
                            .withRequiredArg
                            .describedAs("partition ids")
                            .ofType(classOf[String])

--- a/core/src/main/scala/kafka/utils/QuotaUtils.scala
+++ b/core/src/main/scala/kafka/utils/QuotaUtils.scala
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils
+
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.{KafkaMetric, Measurable, QuotaViolationException}
+import org.apache.kafka.common.metrics.stats.Rate
+
+/**
+ * Helper functions related to quotas
+ */
+object QuotaUtils {
+
+  /**
+   * This calculates the amount of time needed to bring the observed rate within quota
+   * assuming that no new metrics are recorded.
+   *
+   * If O is the observed rate and T is the target rate over a window of W, to bring O down to T,
+   * we need to add a delay of X to W such that O * W / (W + X) = T.
+   * Solving for X, we get X = (O - T)/T * W.
+   *
+   * @param timeMs current time in milliseconds
+   * @return Delay in milliseconds
+   */
+  def throttleTime(e: QuotaViolationException, timeMs: Long): Long = {
+    val difference = e.value - e.bound
+    // Use the precise window used by the rate calculation
+    val throttleTimeMs = difference / e.bound * windowSize(e.metric, timeMs)
+    Math.round(throttleTimeMs)
+  }
+
+  /**
+   * Calculates the amount of time needed to bring the observed rate within quota using the same algorithm as
+   * throttleTime() utility method but the returned value is capped to given maxThrottleTime
+   */
+  def boundedThrottleTime(e: QuotaViolationException, maxThrottleTime: Long, timeMs: Long): Long = {
+    math.min(throttleTime(e, timeMs), maxThrottleTime)
+  }
+
+  /**
+   * Returns window size of the given metric
+   *
+   * @param metric metric with measurable of type Rate
+   * @param timeMs current time in milliseconds
+   * @throws IllegalArgumentException if given measurable is not Rate
+   */
+  private def windowSize(metric: KafkaMetric, timeMs: Long): Long =
+    measurableAsRate(metric.metricName, metric.measurable).windowSize(metric.config, timeMs)
+
+  /**
+   * Casts provided Measurable to Rate
+   * @throws IllegalArgumentException if given measurable is not Rate
+   */
+  private def measurableAsRate(name: MetricName, measurable: Measurable): Rate = {
+    measurable match {
+      case r: Rate => r
+      case _ => throw new IllegalArgumentException(s"Metric $name is not a Rate metric, value $measurable")
+    }
+  }
+}

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -52,7 +52,9 @@ abstract class BaseConsumerTest extends AbstractConsumerTest {
   def testCoordinatorFailover(): Unit = {
     val listener = new TestConsumerReassignmentListener()
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "5001")
-    this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "2000")
+    this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "1000")
+    // Use higher poll timeout to avoid consumer leaving the group due to timeout
+    this.consumerConfig.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "15000")
     val consumer = createConsumer()
 
     consumer.subscribe(List(topic).asJava, listener)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -678,9 +678,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     sendRecords(producer, totalRecords, tp)
     consumer.assign(List(tp).asJava)
 
-    // poll should fail because there is no offset reset strategy set
+    // poll should fail because there is no offset reset strategy set.
+    // we fail only when resetting positions after coordinator is known, so using a long timeout.
     intercept[NoOffsetForPartitionException] {
-      consumer.poll(Duration.ofMillis(50))
+      consumer.poll(Duration.ofMillis(15000))
     }
 
     // seek to out of range position

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -144,7 +144,7 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
     }
 
     def verifySendSuccess(future: Future[RecordMetadata]): Unit = {
-      val recordMetadata = future.get(10, TimeUnit.SECONDS)
+      val recordMetadata = future.get(30, TimeUnit.SECONDS)
       assertEquals(topic, recordMetadata.topic)
       assertEquals(0, recordMetadata.partition)
       assertTrue(s"Invalid offset $recordMetadata", recordMetadata.offset >= 0)

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -47,6 +47,10 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
   val localAddress = InetAddress.getByName("127.0.0.1")
   var executor: ExecutorService = _
 
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.put(KafkaConfig.NumQuotaSamplesProp, "2".toString)
+  }
+
   @Before
   override def setUp(): Unit = {
     super.setUp()
@@ -163,13 +167,66 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     TestUtils.waitUntilTrue(() => initialConnectionCount == connectionCount, "Connections not closed")
   }
 
+  @Test
+  def testDynamicListenerConnectionCreationRateQuota(): Unit = {
+    // Create another listener. PLAINTEXT is an inter-broker listener
+    // keep default limits
+    val newListenerNames = Seq("PLAINTEXT", "EXTERNAL")
+    val newListeners = "PLAINTEXT://localhost:0,EXTERNAL://localhost:0"
+    val props = new Properties
+    props.put(KafkaConfig.ListenersProp, newListeners)
+    props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT")
+    reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.ListenersProp, newListeners))
+    waitForListener("EXTERNAL")
+
+    // new broker-wide connection rate limit
+    val connRateLimit = 18
+
+    // before setting connection rate to 10, verify we can do at least double that by default (no limit)
+    verifyConnectionRate(2 * connRateLimit, Int.MaxValue, "PLAINTEXT")
+
+    // Reduce total broker connection rate limit to 18 at the cluster level and verify the limit is enforced
+    props.clear()  // so that we do not pass security protocol map which cannot be set at the cluster level
+    props.put(KafkaConfig.MaxConnectionCreationRateProp, connRateLimit.toString)
+    reconfigureServers(props, perBrokerConfig = false, (KafkaConfig.MaxConnectionCreationRateProp, connRateLimit.toString))
+    verifyConnectionRate(10, connRateLimit, "PLAINTEXT")
+
+    // Set 7 conn/sec rate limit for each listener and verify it gets enforced
+    val listenerConnRateLimit = 7
+    val plaintextListenerProp = s"${listener.configPrefix}${KafkaConfig.MaxConnectionCreationRateProp}"
+    props.put(s"listener.name.external.${KafkaConfig.MaxConnectionCreationRateProp}", listenerConnRateLimit.toString)
+    props.put(plaintextListenerProp, listenerConnRateLimit.toString)
+    reconfigureServers(props, perBrokerConfig = true, (plaintextListenerProp, listenerConnRateLimit.toString))
+
+    executor = Executors.newFixedThreadPool(newListenerNames.size)
+    val futures = newListenerNames.map { listener =>
+      executor.submit((() => verifyConnectionRate(3, listenerConnRateLimit, listener)): Runnable)
+    }
+    futures.foreach(_.get(40, TimeUnit.SECONDS))
+
+    // increase connection rate limit on PLAINTEXT (inter-broker) listener to 22 and verify that it will be able to
+    // achieve this rate even though total connection rate may exceed broker-wide rate limit, while EXTERNAL listener
+    // should not exceed its listener limit
+    val newPlaintextRateLimit = 22
+    props.put(plaintextListenerProp, newPlaintextRateLimit.toString)
+    reconfigureServers(props, perBrokerConfig = true, (plaintextListenerProp, newPlaintextRateLimit.toString))
+
+    val plaintextFuture = executor.submit((() =>
+      verifyConnectionRate(18, newPlaintextRateLimit, "PLAINTEXT")): Runnable)
+    val externalFuture = executor.submit((() =>
+      verifyConnectionRate(5, listenerConnRateLimit, "EXTERNAL")): Runnable)
+    plaintextFuture.get(40, TimeUnit.SECONDS)
+    externalFuture.get(40, TimeUnit.SECONDS)
+  }
+
   private def reconfigureServers(newProps: Properties, perBrokerConfig: Boolean, aPropToVerify: (String, String)): Unit = {
     val initialConnectionCount = connectionCount
     val adminClient = createAdminClient()
     TestUtils.incrementalAlterConfigs(servers, adminClient, newProps, perBrokerConfig).all.get()
     waitForConfigOnServer(aPropToVerify._1, aPropToVerify._2)
     adminClient.close()
-    TestUtils.waitUntilTrue(() => initialConnectionCount == connectionCount, "Admin client connection not closed")
+    TestUtils.waitUntilTrue(() => initialConnectionCount == connectionCount,
+      s"Admin client connection not closed (initial = $initialConnectionCount, current = $connectionCount)")
   }
 
   private def waitForListener(listenerName: String): Unit = {
@@ -249,5 +306,47 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
 
     conns.foreach(_.close())
     TestUtils.waitUntilTrue(() => initialConnectionCount == connectionCount, "Connections not closed")
+  }
+
+  private def connectAndVerify(listener: String): Unit = {
+    val socket = connect(listener)
+    try {
+      sendAndReceive[ProduceResponse](produceRequest, socket)
+    } finally {
+      socket.close()
+    }
+  }
+
+  /**
+   * this method simulates a workload that creates connection, sends produce request, closes connection,
+   * and verifies that rate does not exceed the given maximum limit `maxConnectionRate`
+   *
+   * Since producing a request and closing a connection also takes time, this method does not verify that the lower bound
+   * of actual rate is close to `maxConnectionRate`. Instead, use `minConnectionRate` parameter to verify that the rate
+   * is at least certain value. Note that throttling is tested and verified more accurately in ConnectionQuotasTest
+   */
+  private def verifyConnectionRate(minConnectionRate: Int, maxConnectionRate: Int, listener: String): Unit = {
+    val initialConnectionCount = connectionCount
+
+    // duration such that the maximum rate should be at most 10% higher than the rate limit. Since all connections
+    // can fall in the beginning of quota window, it is OK to create extra 2 seconds (window size) worth of connections
+    val runTimeMs = TimeUnit.SECONDS.toMillis(25)
+    val startTimeMs = System.currentTimeMillis
+    val endTimeMs = startTimeMs + runTimeMs
+
+    var connCount = 0
+    while (System.currentTimeMillis < endTimeMs) {
+      connectAndVerify(listener)
+      connCount += 1
+    }
+    val elapsedMs = System.currentTimeMillis - startTimeMs
+    val actualRate = (connCount.toDouble / elapsedMs) * 1000
+    val rateCap = if (maxConnectionRate < Int.MaxValue) 1.1 * maxConnectionRate.toDouble else Int.MaxValue.toDouble
+    assertTrue(s"Listener $listener connection rate $actualRate must be below $rateCap", actualRate <= rateCap)
+    assertTrue(s"Listener $listener connection rate $actualRate must be above $minConnectionRate", actualRate >= minConnectionRate)
+
+    // make sure the state is the same as before the method call
+    TestUtils.waitUntilTrue(() => initialConnectionCount == connectionCount,
+      s"Connections not closed (initial = $initialConnectionCount current = $connectionCount)")
   }
 }

--- a/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/network/ConnectionQuotasTest.scala
@@ -18,26 +18,32 @@
 package kafka.network
 
 import java.net.InetAddress
-import java.util.concurrent.{Executors, TimeUnit}
-import java.util.Properties
+import java.util
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
+import java.util.{Collections, Properties}
 
 import com.yammer.metrics.core.Meter
 import kafka.metrics.KafkaMetricsGroup
 import kafka.network.Processor.ListenerMetricTag
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
+import org.apache.kafka.common.config.ConfigException
+import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Metrics}
 import org.apache.kafka.common.network._
-import org.apache.kafka.common.utils.MockTime
+import org.apache.kafka.common.utils.{Time, Utils}
 import org.junit.Assert._
 import org.junit._
-import org.scalatest.Assertions.intercept
+import org.scalatest.Assertions.{assertThrows, intercept}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, mutable}
 import scala.concurrent.TimeoutException
 
 class ConnectionQuotasTest {
-  private val time = new MockTime
+  private var metrics: Metrics = _
+  private var executor: ExecutorService = _
+  private var connectionQuotas: ConnectionQuotas = _
+
   private val listeners = Map(
     "EXTERNAL" -> ListenerDesc(new ListenerName("EXTERNAL"), InetAddress.getByName("192.168.1.1")),
     "ADMIN" -> ListenerDesc(new ListenerName("ADMIN"), InetAddress.getByName("192.168.1.2")),
@@ -45,6 +51,9 @@ class ConnectionQuotasTest {
   private val blockedPercentMeters = mutable.Map[String, Meter]()
   private val knownHost = InetAddress.getByName("192.168.10.0")
   private val unknownHost = InetAddress.getByName("192.168.2.0")
+
+  private val numQuotaSamples = 2
+  private val quotaWindowSizeSeconds = 1
 
   case class ListenerDesc(listenerName: ListenerName, defaultIp: InetAddress) {
     override def toString: String = {
@@ -58,6 +67,8 @@ class ConnectionQuotasTest {
     // ConnectionQuotas does not limit inter-broker listener even when broker-wide connection limit is reached
     props.put(KafkaConfig.InterBrokerListenerNameProp, "REPLICATION")
     props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "EXTERNAL:PLAINTEXT,REPLICATION:PLAINTEXT,ADMIN:PLAINTEXT")
+    props.put(KafkaConfig.NumQuotaSamplesProp, numQuotaSamples.toString)
+    props.put(KafkaConfig.QuotaWindowSizeSecondsProp, quotaWindowSizeSeconds.toString)
     props
   }
 
@@ -70,10 +81,19 @@ class ConnectionQuotasTest {
         blockedPercentMeters.put(name, KafkaMetricsGroup.newMeter(
           s"${name}BlockedPercent", "blocked time", TimeUnit.NANOSECONDS, Map(ListenerMetricTag -> name)))
     }
+    // use system time, because ConnectionQuota causes the current thread to wait with timeout, which waits based on
+    // system time; so using mock time will likely result in test flakiness due to a mixed use of mock and system time
+    metrics = new Metrics(new MetricConfig(), Collections.emptyList(), Time.SYSTEM)
+    executor = Executors.newFixedThreadPool(listeners.size)
   }
 
   @After
   def tearDown(): Unit = {
+    executor.shutdownNow()
+    if (connectionQuotas != null) {
+      connectionQuotas.close()
+    }
+    metrics.close()
     TestUtils.clearYammerMetrics()
     blockedPercentMeters.clear()
   }
@@ -81,26 +101,21 @@ class ConnectionQuotasTest {
   @Test
   def testFailWhenNoListeners(): Unit = {
     val config = KafkaConfig.fromProps(brokerPropsWithDefaultConnectionLimits)
-    val connectionQuotas = new ConnectionQuotas(config, time)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
 
-    val executor = Executors.newSingleThreadExecutor
-    try {
-      // inc() on a separate thread in case it blocks
-      val listener = listeners("EXTERNAL")
-      executor.submit((() =>
-        intercept[RuntimeException](
-          connectionQuotas.inc(listener.listenerName, listener.defaultIp, blockedPercentMeters("EXTERNAL"))
-        )): Runnable
-      ).get(5, TimeUnit.SECONDS)
-    } finally {
-      executor.shutdownNow()
-    }
+    // inc() on a separate thread in case it blocks
+    val listener = listeners("EXTERNAL")
+    executor.submit((() =>
+      intercept[RuntimeException](
+        connectionQuotas.inc(listener.listenerName, listener.defaultIp, blockedPercentMeters("EXTERNAL"))
+      )): Runnable
+    ).get(5, TimeUnit.SECONDS)
   }
 
   @Test
   def testFailDecrementForUnknownIp(): Unit = {
     val config = KafkaConfig.fromProps(brokerPropsWithDefaultConnectionLimits)
-    val connectionQuotas = new ConnectionQuotas(config, time)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
     addListenersAndVerify(config, connectionQuotas)
 
     // calling dec() for an IP for which we didn't call inc() should throw an exception
@@ -110,29 +125,31 @@ class ConnectionQuotasTest {
   @Test
   def testNoConnectionLimitsByDefault(): Unit = {
     val config = KafkaConfig.fromProps(brokerPropsWithDefaultConnectionLimits)
-    val connectionQuotas = new ConnectionQuotas(config, time)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
     addListenersAndVerify(config, connectionQuotas)
 
-    val executor = Executors.newFixedThreadPool(listeners.size)
-    try {
-      // verify there is no limit by accepting 10000 connections as fast as possible
-      val numConnections = 10000
-      val futures = listeners.values.map { listener =>
-        executor.submit((() => acceptConnections(connectionQuotas, listener, numConnections)): Runnable)
-      }
-      futures.foreach(_.get(10, TimeUnit.SECONDS))
-      listeners.values.foreach { listener =>
-        assertEquals(s"Number of connections on $listener:",
-          numConnections, connectionQuotas.get(listener.defaultIp))
-
-        // verify removing one connection
-        connectionQuotas.dec(listener.listenerName, listener.defaultIp)
-        assertEquals(s"Number of connections on $listener:",
-          numConnections - 1, connectionQuotas.get(listener.defaultIp))
-      }
-    } finally {
-      executor.shutdownNow()
+    // verify there is no limit by accepting 10000 connections as fast as possible
+    val numConnections = 10000
+    val futures = listeners.values.map { listener =>
+      executor.submit((() => acceptConnections(connectionQuotas, listener, numConnections)): Runnable)
     }
+    futures.foreach(_.get(10, TimeUnit.SECONDS))
+    assertTrue("Expected broker-connection-accept-rate metric to get recorded",
+      brokerConnRateMetric().metricValue.asInstanceOf[Double].toLong > 0)
+    listeners.values.foreach { listener =>
+      assertEquals(s"Number of connections on $listener:",
+        numConnections, connectionQuotas.get(listener.defaultIp))
+
+      assertTrue(s"Expected connection-accept-rate metric to get recorded for listener $listener",
+        listenerConnRateMetric(listener.listenerName.value).metricValue.asInstanceOf[Double].toLong > 0)
+
+      // verify removing one connection
+      connectionQuotas.dec(listener.listenerName, listener.defaultIp)
+      assertEquals(s"Number of connections on $listener:",
+        numConnections - 1, connectionQuotas.get(listener.defaultIp))
+    }
+    // the blocked percent should still be 0, because no limits were reached
+    verifyNoBlockedPercentRecordedOnAllListeners()
   }
 
   @Test
@@ -141,44 +158,39 @@ class ConnectionQuotasTest {
     val props = brokerPropsWithDefaultConnectionLimits
     props.put(KafkaConfig.MaxConnectionsPerIpProp, maxConnectionsPerIp.toString)
     val config = KafkaConfig.fromProps(props)
-    val connectionQuotas = new ConnectionQuotas(config, time)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
 
     addListenersAndVerify(config, connectionQuotas)
 
-    val executor = Executors.newFixedThreadPool(listeners.size)
-    try {
-      val externalListener = listeners("EXTERNAL")
-      executor.submit((() =>
-        acceptConnections(connectionQuotas, externalListener, maxConnectionsPerIp)): Runnable
-      ).get(5, TimeUnit.SECONDS)
-      assertEquals(s"Number of connections on $externalListener:",
-        maxConnectionsPerIp, connectionQuotas.get(externalListener.defaultIp))
+    val externalListener = listeners("EXTERNAL")
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, externalListener, maxConnectionsPerIp)): Runnable
+    ).get(5, TimeUnit.SECONDS)
+    assertEquals(s"Number of connections on $externalListener:",
+      maxConnectionsPerIp, connectionQuotas.get(externalListener.defaultIp))
 
-      // all subsequent connections will be added to the counters, but inc() will throw TooManyConnectionsException for each
-      executor.submit((() =>
-        acceptConnectionsAboveIpLimit(connectionQuotas, externalListener, 2)): Runnable
-      ).get(5, TimeUnit.SECONDS)
-      assertEquals(s"Number of connections on $externalListener:",
-        maxConnectionsPerIp + 2, connectionQuotas.get(externalListener.defaultIp))
+    // all subsequent connections will be added to the counters, but inc() will throw TooManyConnectionsException for each
+    executor.submit((() =>
+      acceptConnectionsAboveIpLimit(connectionQuotas, externalListener, 2)): Runnable
+    ).get(5, TimeUnit.SECONDS)
+    assertEquals(s"Number of connections on $externalListener:",
+      maxConnectionsPerIp + 2, connectionQuotas.get(externalListener.defaultIp))
 
-      // connections on the same listener but from a different IP should be accepted
-      executor.submit((() =>
-        acceptConnections(connectionQuotas, externalListener.listenerName, knownHost, maxConnectionsPerIp, 0)): Runnable
-      ).get(5, TimeUnit.SECONDS)
+    // connections on the same listener but from a different IP should be accepted
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, externalListener.listenerName, knownHost, maxConnectionsPerIp, 0)): Runnable
+    ).get(5, TimeUnit.SECONDS)
 
-      // remove two "rejected" connections and remove 2 more connections to free up the space for another 2 connections
-      for (_ <- 0 until 4) connectionQuotas.dec(externalListener.listenerName, externalListener.defaultIp)
-      assertEquals(s"Number of connections on $externalListener:",
-        maxConnectionsPerIp - 2, connectionQuotas.get(externalListener.defaultIp))
+    // remove two "rejected" connections and remove 2 more connections to free up the space for another 2 connections
+    for (_ <- 0 until 4) connectionQuotas.dec(externalListener.listenerName, externalListener.defaultIp)
+    assertEquals(s"Number of connections on $externalListener:",
+      maxConnectionsPerIp - 2, connectionQuotas.get(externalListener.defaultIp))
 
-      executor.submit((() =>
-        acceptConnections(connectionQuotas, externalListener, 2)): Runnable
-      ).get(5, TimeUnit.SECONDS)
-      assertEquals(s"Number of connections on $externalListener:",
-        maxConnectionsPerIp, connectionQuotas.get(externalListener.defaultIp))
-    } finally {
-      executor.shutdownNow()
-    }
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, externalListener, 2)): Runnable
+    ).get(5, TimeUnit.SECONDS)
+    assertEquals(s"Number of connections on $externalListener:",
+      maxConnectionsPerIp, connectionQuotas.get(externalListener.defaultIp))
   }
 
   @Test
@@ -187,74 +199,63 @@ class ConnectionQuotasTest {
     val props = brokerPropsWithDefaultConnectionLimits
     props.put(KafkaConfig.MaxConnectionsProp, maxConnections.toString)
     val config = KafkaConfig.fromProps(props)
-    val connectionQuotas = new ConnectionQuotas(config, time)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
 
     addListenersAndVerify(config, connectionQuotas)
 
-    val executor = Executors.newFixedThreadPool(listeners.size)
-    try {
-      // the metric should be 0, because we did not advance the time yet
-      assertEquals(0, blockedPercentMeters("EXTERNAL").count())
+    // verify that ConnectionQuota can give all connections to one listener
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("EXTERNAL"), maxConnections)): Runnable
+    ).get(5, TimeUnit.SECONDS)
+    assertEquals(s"Number of connections on ${listeners("EXTERNAL")}:",
+      maxConnections, connectionQuotas.get(listeners("EXTERNAL").defaultIp))
 
-      // verify that ConnectionQuota can give all connections to one listener
-      // also add connections with a time interval between connections to make sure that time gets advanced
-      executor.submit((() =>
-        acceptConnections(connectionQuotas, listeners("EXTERNAL"), maxConnections, 1)): Runnable
-      ).get(5, TimeUnit.SECONDS)
-      assertEquals(s"Number of connections on ${listeners("EXTERNAL")}:",
-        maxConnections, connectionQuotas.get(listeners("EXTERNAL").defaultIp))
+    // the blocked percent should still be 0, because there should be no wait for a connection slot
+    assertEquals(0, blockedPercentMeters("EXTERNAL").count())
 
-      // the blocked percent should still be 0, because there should be no wait for a connection slot
-      assertEquals(0, blockedPercentMeters("EXTERNAL").count())
+    // the number of connections should be above max for maxConnectionsExceeded to return true
+    assertFalse("Total number of connections is exactly the maximum.",
+      connectionQuotas.maxConnectionsExceeded(listeners("EXTERNAL").listenerName))
 
-      // the number of connections should be above max for maxConnectionsExceeded to return true
-      assertFalse("Total number of connections is exactly the maximum.",
-        connectionQuotas.maxConnectionsExceeded(listeners("EXTERNAL").listenerName))
+    // adding one more connection will block ConnectionQuota.inc()
+    val future = executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("EXTERNAL"), 1)): Runnable
+    )
+    intercept[TimeoutException](future.get(100, TimeUnit.MILLISECONDS))
 
-      // adding one more connection will block ConnectionQuota.inc()
-      val future = executor.submit((() =>
-        acceptConnections(connectionQuotas, listeners("EXTERNAL"), 1)): Runnable
-      )
-      intercept[TimeoutException](future.get(100, TimeUnit.MILLISECONDS))
-      // advance time by 3ms so that when the waiting connection gets accepted, the blocked percent is non-zero
-      time.sleep(3)
+    // removing one connection should make the waiting connection to succeed
+    connectionQuotas.dec(listeners("EXTERNAL").listenerName, listeners("EXTERNAL").defaultIp)
+    future.get(1, TimeUnit.SECONDS)
+    assertEquals(s"Number of connections on ${listeners("EXTERNAL")}:",
+      maxConnections, connectionQuotas.get(listeners("EXTERNAL").defaultIp))
+    // metric is recorded in nanoseconds
+    assertTrue("Expected BlockedPercentMeter metric to be recorded",
+      blockedPercentMeters("EXTERNAL").count() > 0)
 
-      // removing one connection should make the waiting connection to succeed
-      connectionQuotas.dec(listeners("EXTERNAL").listenerName, listeners("EXTERNAL").defaultIp)
-      future.get(1, TimeUnit.SECONDS)
-      assertEquals(s"Number of connections on ${listeners("EXTERNAL")}:",
-        maxConnections, connectionQuotas.get(listeners("EXTERNAL").defaultIp))
-      // metric is recorded in nanoseconds
-      assertTrue("Expected BlockedPercentMeter metric to be recorded",
-        blockedPercentMeters("EXTERNAL").count() > 0)
+    // adding inter-broker connections should succeed even when the total number of connections reached the max
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("REPLICATION"), 1)): Runnable
+    ).get(5, TimeUnit.SECONDS)
+    assertTrue("Expected the number of connections to exceed the maximum.",
+      connectionQuotas.maxConnectionsExceeded(listeners("EXTERNAL").listenerName))
 
-      // adding inter-broker connections should succeed even when the total number of connections reached the max
-      executor.submit((() =>
-        acceptConnections(connectionQuotas, listeners("REPLICATION"), 1)): Runnable
-      ).get(5, TimeUnit.SECONDS)
-      assertTrue("Expected the number of connections to exceed the maximum.",
-        connectionQuotas.maxConnectionsExceeded(listeners("EXTERNAL").listenerName))
+    // adding one more connection on another non-inter-broker will block ConnectionQuota.inc()
+    val future1 = executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("ADMIN"), 1)): Runnable
+    )
+    intercept[TimeoutException](future1.get(1, TimeUnit.SECONDS))
 
-      // adding one more connection on another non-inter-broker will block ConnectionQuota.inc()
-      val future1 = executor.submit((() =>
-        acceptConnections(connectionQuotas, listeners("ADMIN"), 1)): Runnable
-      )
-      intercept[TimeoutException](future1.get(1, TimeUnit.SECONDS))
+    // adding inter-broker connection should still succeed, even though a connection from another listener is waiting
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("REPLICATION"), 1)): Runnable
+    ).get(5, TimeUnit.SECONDS)
 
-      // adding inter-broker connection should still succeed, even though a connection from another listener is waiting
-      executor.submit((() =>
-        acceptConnections(connectionQuotas, listeners("REPLICATION"), 1)): Runnable
-      ).get(5, TimeUnit.SECONDS)
-
-      // at this point, we need to remove 3 connections for the waiting connection to succeed
-      // remove 2 first -- should not be enough to accept the waiting connection
-      for (_ <- 0 until 2) connectionQuotas.dec(listeners("EXTERNAL").listenerName, listeners("EXTERNAL").defaultIp)
-      intercept[TimeoutException](future1.get(100, TimeUnit.MILLISECONDS))
-      connectionQuotas.dec(listeners("EXTERNAL").listenerName, listeners("EXTERNAL").defaultIp)
-      future1.get(1, TimeUnit.SECONDS)
-    } finally {
-      executor.shutdownNow()
-    }
+    // at this point, we need to remove 3 connections for the waiting connection to succeed
+    // remove 2 first -- should not be enough to accept the waiting connection
+    for (_ <- 0 until 2) connectionQuotas.dec(listeners("EXTERNAL").listenerName, listeners("EXTERNAL").defaultIp)
+    intercept[TimeoutException](future1.get(100, TimeUnit.MILLISECONDS))
+    connectionQuotas.dec(listeners("EXTERNAL").listenerName, listeners("EXTERNAL").defaultIp)
+    future1.get(1, TimeUnit.SECONDS)
   }
 
   @Test
@@ -265,7 +266,7 @@ class ConnectionQuotasTest {
     val props = brokerPropsWithDefaultConnectionLimits
     props.put(KafkaConfig.MaxConnectionsProp, maxConnections.toString)
     val config = KafkaConfig.fromProps(props)
-    val connectionQuotas = new ConnectionQuotas(config, time)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
 
     addListenersAndVerify(config, connectionQuotas)
 
@@ -274,50 +275,312 @@ class ConnectionQuotasTest {
       connectionQuotas.maxConnectionsPerListener(listener.listenerName).configure(listenerConfig)
     }
 
-    val executor = Executors.newFixedThreadPool(listeners.size)
-    try {
-      // verify each listener can create up to max connections configured for that listener
-      val futures = listeners.values.map { listener =>
-        executor.submit((() => acceptConnections(connectionQuotas, listener, listenerMaxConnections)): Runnable)
-      }
-      futures.foreach(_.get(5, TimeUnit.SECONDS))
-      listeners.values.foreach { listener =>
-        assertEquals(s"Number of connections on $listener:",
-          listenerMaxConnections, connectionQuotas.get(listener.defaultIp))
-        assertFalse(s"Total number of connections on $listener should be exactly the maximum.",
-          connectionQuotas.maxConnectionsExceeded(listener.listenerName))
-      }
+    // verify each listener can create up to max connections configured for that listener
+    val futures = listeners.values.map { listener =>
+      executor.submit((() => acceptConnections(connectionQuotas, listener, listenerMaxConnections)): Runnable)
+    }
+    futures.foreach(_.get(5, TimeUnit.SECONDS))
+    listeners.values.foreach { listener =>
+      assertEquals(s"Number of connections on $listener:",
+        listenerMaxConnections, connectionQuotas.get(listener.defaultIp))
+      assertFalse(s"Total number of connections on $listener should be exactly the maximum.",
+        connectionQuotas.maxConnectionsExceeded(listener.listenerName))
+    }
 
-      // since every listener has exactly the max number of listener connections,
-      // every listener should block on the next connection creation, even the inter-broker listener
-      val overLimitFutures = listeners.values.map { listener =>
-        executor.submit((() => acceptConnections(connectionQuotas, listener, 1)): Runnable)
-      }
-      overLimitFutures.foreach { future =>
-        intercept[TimeoutException](future.get(1, TimeUnit.SECONDS))
-      }
-      listeners.values.foreach { listener =>
-        // free up one connection slot
-        connectionQuotas.dec(listener.listenerName, listener.defaultIp)
-      }
-      // all connections should get added
-      overLimitFutures.foreach(_.get(5, TimeUnit.SECONDS))
-      listeners.values.foreach { listener =>
-        assertEquals(s"Number of connections on $listener:",
-          listenerMaxConnections, connectionQuotas.get(listener.defaultIp))
-      }
-    } finally {
-      executor.shutdownNow()
+    // since every listener has exactly the max number of listener connections,
+    // every listener should block on the next connection creation, even the inter-broker listener
+    val overLimitFutures = listeners.values.map { listener =>
+      executor.submit((() => acceptConnections(connectionQuotas, listener, 1)): Runnable)
+    }
+    overLimitFutures.foreach { future =>
+      intercept[TimeoutException](future.get(1, TimeUnit.SECONDS))
+    }
+    listeners.values.foreach { listener =>
+      // free up one connection slot
+      connectionQuotas.dec(listener.listenerName, listener.defaultIp)
+    }
+    // all connections should get added
+    overLimitFutures.foreach(_.get(5, TimeUnit.SECONDS))
+    verifyConnectionCountOnEveryListener(connectionQuotas, listenerMaxConnections)
+  }
+
+  @Test
+  def testBrokerConnectionRateLimitWhenActualRateBelowLimit(): Unit = {
+    val brokerRateLimit = 125
+    // create connections with the total rate < broker-wide quota, and verify there is no throttling
+    val connCreateIntervalMs = 25 // connection creation rate = 40/sec per listener (3 * 40 = 120/sec total)
+    val connectionsPerListener = 200 // should take 5 seconds to create 200 connections with rate = 40/sec
+    val props = brokerPropsWithDefaultConnectionLimits
+    props.put(KafkaConfig.MaxConnectionCreationRateProp, brokerRateLimit.toString)
+    val config = KafkaConfig.fromProps(props)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+
+    addListenersAndVerify(config, connectionQuotas)
+
+    val futures = listeners.values.map { listener =>
+      executor.submit((() => acceptConnections(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs)): Runnable)
+    }
+    futures.foreach(_.get(10, TimeUnit.SECONDS))
+
+    // the blocked percent should still be 0, because no limits were reached
+    verifyNoBlockedPercentRecordedOnAllListeners()
+    verifyConnectionCountOnEveryListener(connectionQuotas, connectionsPerListener)
+  }
+
+  @Test
+  def testBrokerConnectionRateLimitWhenActualRateAboveLimit(): Unit = {
+    val brokerRateLimit = 90
+    val props = brokerPropsWithDefaultConnectionLimits
+    props.put(KafkaConfig.MaxConnectionCreationRateProp, brokerRateLimit.toString)
+    val config = KafkaConfig.fromProps(props)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+
+    addListenersAndVerify(config, connectionQuotas)
+
+    // each listener creates connections such that the total connection rate > broker-wide quota
+    val connCreateIntervalMs = 10      // connection creation rate = 100
+    val connectionsPerListener = 400
+    val futures = listeners.values.map { listener =>
+      executor.submit((() => acceptConnections(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs)): Runnable)
+    }
+    futures.foreach(_.get(20, TimeUnit.SECONDS))
+
+    // verify that connections on non-inter-broker listener are throttled
+    verifyOnlyNonInterBrokerListenersBlockedPercentRecorded()
+
+    // expect all connections to be created (no limit on the number of connections)
+    verifyConnectionCountOnEveryListener(connectionQuotas, connectionsPerListener)
+  }
+
+  @Test
+  def testListenerConnectionRateLimitWhenActualRateBelowLimit(): Unit = {
+    val brokerRateLimit = 125
+    val listenerRateLimit = 50
+    val connCreateIntervalMs = 25 // connection creation rate = 40/sec per listener (3 * 40 = 120/sec total)
+    val props = brokerPropsWithDefaultConnectionLimits
+    props.put(KafkaConfig.MaxConnectionCreationRateProp, brokerRateLimit.toString)
+    val config = KafkaConfig.fromProps(props)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+
+    val listenerConfig = Map(KafkaConfig.MaxConnectionCreationRateProp -> listenerRateLimit.toString).asJava
+    addListenersAndVerify(config, listenerConfig, connectionQuotas)
+
+    // create connections with the rate < listener quota on every listener, and verify there is no throttling
+    val connectionsPerListener = 200 // should take 5 seconds to create 200 connections with rate = 40/sec
+    val futures = listeners.values.map { listener =>
+      executor.submit((() => acceptConnections(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs)): Runnable)
+    }
+    futures.foreach(_.get(10, TimeUnit.SECONDS))
+
+    // the blocked percent should still be 0, because no limits were reached
+    verifyNoBlockedPercentRecordedOnAllListeners()
+
+    verifyConnectionCountOnEveryListener(connectionQuotas, connectionsPerListener)
+  }
+
+  @Test
+  def testListenerConnectionRateLimitWhenActualRateAboveLimit(): Unit = {
+    val brokerRateLimit = 125
+    val listenerRateLimit = 30
+    val connCreateIntervalMs = 25 // connection creation rate = 40/sec per listener (3 * 40 = 120/sec total)
+    val props = brokerPropsWithDefaultConnectionLimits
+    props.put(KafkaConfig.MaxConnectionCreationRateProp, brokerRateLimit.toString)
+    val config = KafkaConfig.fromProps(props)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+
+    val listenerConfig = Map(KafkaConfig.MaxConnectionCreationRateProp -> listenerRateLimit.toString).asJava
+    addListenersAndVerify(config, listenerConfig, connectionQuotas)
+
+    // create connections with the rate > listener quota on every listener
+    // run a bit longer (20 seconds) to also verify the throttle rate
+    val connectionsPerListener = 600 // should take 20 seconds to create 600 connections with rate = 30/sec
+    val futures = listeners.values.map { listener =>
+      executor.submit((() =>
+        // epsilon is set to account for the worst-case where the measurement is taken just before or after the quota window
+        acceptConnectionsAndVerifyRate(connectionQuotas, listener, connectionsPerListener, connCreateIntervalMs, listenerRateLimit, 7)): Runnable)
+    }
+    futures.foreach(_.get(30, TimeUnit.SECONDS))
+
+    // verify that every listener was throttled
+    verifyNonZeroBlockedPercentRecordedOnAllListeners()
+
+    // while the connection creation rate was throttled,
+    // expect all connections got created (not limit on the number of connections)
+    verifyConnectionCountOnEveryListener(connectionQuotas, connectionsPerListener)
+  }
+
+  @Test
+  def testMaxListenerConnectionListenerMustBeAboveZero(): Unit = {
+    val config = KafkaConfig.fromProps(brokerPropsWithDefaultConnectionLimits)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+
+    connectionQuotas.addListener(config, listeners("EXTERNAL").listenerName)
+
+    val maxListenerConnectionRate = 0
+    val listenerConfig = Map(KafkaConfig.MaxConnectionCreationRateProp -> maxListenerConnectionRate.toString).asJava
+    assertThrows[ConfigException] {
+      connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).validateReconfiguration(listenerConfig)
     }
   }
 
+  @Test
+  def testMaxListenerConnectionRateReconfiguration(): Unit = {
+    val config = KafkaConfig.fromProps(brokerPropsWithDefaultConnectionLimits)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+    connectionQuotas.addListener(config, listeners("EXTERNAL").listenerName)
+
+    val listenerRateLimit = 20
+    val listenerConfig = Map(KafkaConfig.MaxConnectionCreationRateProp -> listenerRateLimit.toString).asJava
+    connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).configure(listenerConfig)
+
+    // remove connection rate limit
+    connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).reconfigure(Map.empty.asJava)
+
+    // create connections as fast as possible, will timeout if connections get throttled with previous rate
+    // (50s to create 1000 connections)
+    executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("EXTERNAL"), 1000)): Runnable
+    ).get(10, TimeUnit.SECONDS)
+    // verify no throttling
+    assertEquals(s"BlockedPercentMeter metric for EXTERNAL listener", 0, blockedPercentMeters("EXTERNAL").count())
+
+    // configure 100 connection/second rate limit
+    val newMaxListenerConnectionRate = 10
+    val newListenerConfig = Map(KafkaConfig.MaxConnectionCreationRateProp -> newMaxListenerConnectionRate.toString).asJava
+    connectionQuotas.maxConnectionsPerListener(listeners("EXTERNAL").listenerName).reconfigure(newListenerConfig)
+
+    // verify rate limit
+    val connectionsPerListener = 200 // should take 20 seconds to create 200 connections with rate = 10/sec
+    executor.submit((() =>
+      acceptConnectionsAndVerifyRate(connectionQuotas, listeners("EXTERNAL"), connectionsPerListener, 5, newMaxListenerConnectionRate, 3)): Runnable
+    ).get(30, TimeUnit.SECONDS)
+    assertTrue("Expected BlockedPercentMeter metric for EXTERNAL listener to be recorded", blockedPercentMeters("EXTERNAL").count() > 0)
+  }
+
+  @Test
+  def testMaxBrokerConnectionRateReconfiguration(): Unit = {
+    val config = KafkaConfig.fromProps(brokerPropsWithDefaultConnectionLimits)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+    connectionQuotas.addListener(config, listeners("EXTERNAL").listenerName)
+
+    addListenersAndVerify(config, connectionQuotas)
+
+    val maxBrokerConnectionRate = 50
+    connectionQuotas.updateBrokerMaxConnectionRate(maxBrokerConnectionRate)
+
+    // create connections with rate = 200 conn/sec (5ms interval), so that connection rate gets throttled
+    val totalConnections = 400
+    executor.submit((() =>
+      // this is a short run, so setting epsilon higher (enough to check that the rate is not unlimited)
+      acceptConnectionsAndVerifyRate(connectionQuotas, listeners("EXTERNAL"), totalConnections, 5, maxBrokerConnectionRate, 20)): Runnable
+    ).get(10, TimeUnit.SECONDS)
+    assertTrue("Expected BlockedPercentMeter metric for EXTERNAL listener to be recorded", blockedPercentMeters("EXTERNAL").count() > 0)
+  }
+
+  @Test
+  def testNonDefaultConnectionCountLimitAndRateLimit(): Unit = {
+    val brokerRateLimit = 25
+    val maxConnections = 350  // with rate == 25, will run out of connections in 14 seconds
+    val props = brokerPropsWithDefaultConnectionLimits
+    props.put(KafkaConfig.MaxConnectionsProp, maxConnections.toString)
+    props.put(KafkaConfig.MaxConnectionCreationRateProp, brokerRateLimit.toString)
+    val config = KafkaConfig.fromProps(props)
+    connectionQuotas = new ConnectionQuotas(config, Time.SYSTEM, metrics)
+    connectionQuotas.addListener(config, listeners("EXTERNAL").listenerName)
+
+    addListenersAndVerify(config, connectionQuotas)
+
+    // create connections with rate = 100 conn/sec (10ms interval), so that connection rate gets throttled
+    val listener = listeners("EXTERNAL")
+    executor.submit((() =>
+      acceptConnectionsAndVerifyRate(connectionQuotas, listener, maxConnections, 10, brokerRateLimit, 8)): Runnable
+    ).get(20, TimeUnit.SECONDS)
+    assertTrue("Expected BlockedPercentMeter metric for EXTERNAL listener to be recorded", blockedPercentMeters("EXTERNAL").count() > 0)
+    assertEquals(s"Number of connections on EXTERNAL listener:", maxConnections, connectionQuotas.get(listener.defaultIp))
+
+    // adding one more connection will block ConnectionQuota.inc()
+    val future = executor.submit((() =>
+      acceptConnections(connectionQuotas, listeners("EXTERNAL"), 1)): Runnable
+    )
+    intercept[TimeoutException](future.get(100, TimeUnit.MILLISECONDS))
+
+    // removing one connection should make the waiting connection to succeed
+    connectionQuotas.dec(listener.listenerName, listener.defaultIp)
+    future.get(1, TimeUnit.SECONDS)
+    assertEquals(s"Number of connections on EXTERNAL listener:", maxConnections, connectionQuotas.get(listener.defaultIp))
+  }
+
   private def addListenersAndVerify(config: KafkaConfig, connectionQuotas: ConnectionQuotas) : Unit = {
+    addListenersAndVerify(config, Map.empty.asJava, connectionQuotas)
+  }
+
+  private def addListenersAndVerify(config: KafkaConfig,
+                                    listenerConfig: util.Map[String, _],
+                                    connectionQuotas: ConnectionQuotas) : Unit = {
+    assertNotNull("Expected broker-connection-accept-rate metric to exist", brokerConnRateMetric())
+
     // add listeners and verify connection limits not exceeded
     listeners.foreach { case (name, listener) =>
-      connectionQuotas.addListener(config, listener.listenerName)
+      val listenerName = listener.listenerName
+      connectionQuotas.addListener(config, listenerName)
+      connectionQuotas.maxConnectionsPerListener(listenerName).configure(listenerConfig)
       assertFalse(s"Should not exceed max connection limit on $name listener after initialization",
-        connectionQuotas.maxConnectionsExceeded(listener.listenerName))
+        connectionQuotas.maxConnectionsExceeded(listenerName))
+      assertEquals(s"Number of connections on $listener listener:",
+        0, connectionQuotas.get(listener.defaultIp))
+      assertNotNull(s"Expected connection-accept-rate metric to exist for listener ${listenerName.value}",
+        listenerConnRateMetric(listenerName.value))
+      assertEquals(s"Connection acceptance rate metric for listener ${listenerName.value}",
+          0, listenerConnRateMetric(listenerName.value).metricValue.asInstanceOf[Double].toLong)
     }
+    verifyNoBlockedPercentRecordedOnAllListeners()
+    assertEquals("Broker-wide connection acceptance rate metric",
+      0, brokerConnRateMetric().metricValue.asInstanceOf[Double].toLong)
+  }
+
+  private def verifyNoBlockedPercentRecordedOnAllListeners(): Unit = {
+    blockedPercentMeters.foreach { case (name, meter) =>
+      assertEquals(s"BlockedPercentMeter metric for $name listener", 0, meter.count())
+    }
+  }
+
+  private def verifyNonZeroBlockedPercentRecordedOnAllListeners(): Unit = {
+    blockedPercentMeters.foreach { case (name, meter) =>
+      assertTrue(s"Expected BlockedPercentMeter metric for $name listener to be recorded", meter.count() > 0)
+    }
+  }
+
+  private def verifyOnlyNonInterBrokerListenersBlockedPercentRecorded(): Unit = {
+    blockedPercentMeters.foreach { case (name, meter) =>
+      name match {
+        case "REPLICATION" =>
+          assertEquals(s"BlockedPercentMeter metric for $name listener", 0, meter.count())
+        case _ =>
+          assertTrue(s"Expected BlockedPercentMeter metric for $name listener to be recorded", meter.count() > 0)
+      }
+    }
+  }
+
+  private def verifyConnectionCountOnEveryListener(connectionQuotas: ConnectionQuotas, expectedConnectionCount: Int): Unit = {
+    listeners.values.foreach { listener =>
+      assertEquals(s"Number of connections on $listener:",
+        expectedConnectionCount, connectionQuotas.get(listener.defaultIp))
+    }
+  }
+
+  private def listenerConnRateMetric(listener: String) : KafkaMetric = {
+    val metricName = metrics.metricName(
+      s"connection-accept-rate",
+      "socket-server-metrics",
+      Collections.singletonMap("listener", listener))
+    metrics.metric(metricName)
+  }
+
+  private def brokerConnRateMetric() : KafkaMetric = {
+    val metricName = metrics.metricName(
+      s"broker-connection-accept-rate",
+      "socket-server-metrics")
+    metrics.metric(metricName)
   }
 
   // this method must be called on a separate thread, because connectionQuotas.inc() may block
@@ -329,15 +592,42 @@ class ConnectionQuotasTest {
   }
 
   // this method must be called on a separate thread, because connectionQuotas.inc() may block
+  private def acceptConnectionsAndVerifyRate(connectionQuotas: ConnectionQuotas,
+                                             listenerDesc: ListenerDesc,
+                                             numConnections: Long,
+                                             timeIntervalMs: Long,
+                                             expectedRate: Int,
+                                             epsilon: Int) : Unit = {
+    val startTimeMs = System.currentTimeMillis
+    acceptConnections(connectionQuotas, listenerDesc.listenerName, listenerDesc.defaultIp, numConnections, timeIntervalMs)
+    val elapsedSeconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis - startTimeMs)
+    val actualRate = (numConnections.toDouble / elapsedSeconds).toInt
+    assertTrue(s"Expected rate ($expectedRate +- $epsilon), but got $actualRate ($numConnections connections / $elapsedSeconds sec)",
+      actualRate <= expectedRate + epsilon && actualRate >= expectedRate - epsilon)
+  }
+
+  /**
+   * This method will "create" connections every 'timeIntervalMs' which translates to 1000/timeIntervalMs connection rate,
+   * as long as the rate is below the connection rate limit. Otherwise, connections will be essentially created as
+   * fast as possible, which would result in the maximum connection creation rate.
+   *
+   * This method must be called on a separate thread, because connectionQuotas.inc() may block
+   */
   private def acceptConnections(connectionQuotas: ConnectionQuotas,
                                 listenerName: ListenerName,
                                 address: InetAddress,
                                 numConnections: Long,
                                 timeIntervalMs: Long) : Unit = {
+    var nextSendTime = System.currentTimeMillis + timeIntervalMs
     for (_ <- 0L until numConnections) {
-      // this method may block if broker-wide or listener limit is reached
+      // this method may block if broker-wide or listener limit on the number of connections is reached
       connectionQuotas.inc(listenerName, address, blockedPercentMeters(listenerName.value))
-      time.sleep(timeIntervalMs)
+
+      val sleepMs = math.max(nextSendTime - System.currentTimeMillis, 0)
+      if (sleepMs > 0)
+        Utils.sleep(sleepMs)
+
+      nextSendTime = nextSendTime + timeIntervalMs
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -197,6 +197,15 @@ class DynamicBrokerConfigTest {
     verifyConfigUpdate(listenerMaxConnectionsProp, "10", perBrokerConfig = false, expectFailure = false)
   }
 
+  @Test
+  def testConnectionRateQuota(): Unit = {
+    verifyConfigUpdate(KafkaConfig.MaxConnectionCreationRateProp, "110", perBrokerConfig = true, expectFailure = false)
+    verifyConfigUpdate(KafkaConfig.MaxConnectionCreationRateProp, "120", perBrokerConfig = false, expectFailure = false)
+    val listenerMaxConnectionsProp = s"listener.name.external.${KafkaConfig.MaxConnectionCreationRateProp}"
+    verifyConfigUpdate(listenerMaxConnectionsProp, "20", perBrokerConfig = true, expectFailure = false)
+    verifyConfigUpdate(listenerMaxConnectionsProp, "30", perBrokerConfig = false, expectFailure = false)
+  }
+
   private def verifyConfigUpdate(name: String, value: Object, perBrokerConfig: Boolean, expectFailure: Boolean): Unit = {
     val configProps = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     configProps.put(KafkaConfig.PasswordEncoderSecretProp, "broker.secret")

--- a/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.kafka.common.MetricName
+import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Quota, QuotaViolationException}
+import org.apache.kafka.common.metrics.stats.{Rate, Value}
+
+import scala.jdk.CollectionConverters._
+import org.junit.Assert._
+import org.junit.Test
+import org.scalatest.Assertions.assertThrows
+
+class QuotaUtilsTest {
+
+  private val time = new MockTime
+  private val numSamples = 10
+  private val sampleWindowSec = 1
+  private val maxThrottleTimeMs = 500
+  private val metricName = new MetricName("test-metric", "groupA", "testA", Map.empty.asJava)
+
+  @Test
+  def testThrottleTimeObservedRateEqualsQuota(): Unit = {
+    val numSamples = 10
+    val observedValue = 16.5
+
+    assertEquals(0, throttleTime(observedValue, observedValue, numSamples))
+
+    // should be independent of window size
+    assertEquals(0, throttleTime(observedValue, observedValue, numSamples + 1))
+  }
+
+  @Test
+  def testThrottleTimeObservedRateBelowQuota(): Unit = {
+    val observedValue = 16.5
+    val quota = 20.4
+    assertTrue(throttleTime(observedValue, quota, numSamples) < 0)
+
+    // should be independent of window size
+    assertTrue(throttleTime(observedValue, quota, numSamples + 1) < 0)
+  }
+
+  @Test
+  def testThrottleTimeObservedRateAboveQuota(): Unit = {
+    val quota = 50.0
+    val observedValue = 100.0
+    assertEquals(2000, throttleTime(observedValue, quota, 3))
+  }
+
+  @Test
+  def testBoundedThrottleTimeObservedRateEqualsQuota(): Unit = {
+    val observedValue = 18.2
+    assertEquals(0, boundedThrottleTime(observedValue, observedValue, numSamples, maxThrottleTimeMs))
+
+    // should be independent of window size
+    assertEquals(0, boundedThrottleTime(observedValue, observedValue, numSamples + 1, maxThrottleTimeMs))
+  }
+
+  @Test
+  def testBoundedThrottleTimeObservedRateBelowQuota(): Unit = {
+    val observedValue = 16.5
+    val quota = 22.4
+
+    assertTrue(boundedThrottleTime(observedValue, quota, numSamples, maxThrottleTimeMs) < 0)
+
+    // should be independent of window size
+    assertTrue(boundedThrottleTime(observedValue, quota, numSamples + 1, maxThrottleTimeMs) < 0)
+  }
+
+  @Test
+  def testBoundedThrottleTimeObservedRateAboveQuotaBelowLimit(): Unit = {
+    val quota = 50.0
+    val observedValue = 55.0
+    assertEquals(100, boundedThrottleTime(observedValue, quota, 2, maxThrottleTimeMs))
+  }
+
+  @Test
+  def testBoundedThrottleTimeObservedRateAboveQuotaAboveLimit(): Unit = {
+    val quota = 50.0
+    val observedValue = 100.0
+    assertEquals(maxThrottleTimeMs, boundedThrottleTime(observedValue, quota, numSamples, maxThrottleTimeMs))
+  }
+
+  @Test
+  def testThrottleTimeThrowsExceptionIfProvidedNonRateMetric(): Unit = {
+    val testMetric = new KafkaMetric(new Object(), metricName, new Value(), new MetricConfig, time);
+
+    assertThrows[IllegalArgumentException] {
+      QuotaUtils.throttleTime(new QuotaViolationException(testMetric, 10.0, 20.0), time.milliseconds)
+    }
+  }
+
+  @Test
+  def testBoundedThrottleTimeThrowsExceptionIfProvidedNonRateMetric(): Unit = {
+    val testMetric = new KafkaMetric(new Object(), metricName, new Value(), new MetricConfig, time);
+
+    assertThrows[IllegalArgumentException] {
+      QuotaUtils.boundedThrottleTime(new QuotaViolationException(testMetric, 10.0, 20.0), maxThrottleTimeMs, time.milliseconds)
+    }
+  }
+
+  // the `metric` passed into the returned QuotaViolationException will return windowSize = 'numSamples' - 1
+  private def quotaViolationException(observedValue: Double, quota: Double, numSamples: Int): QuotaViolationException = {
+    val metricConfig = new MetricConfig()
+      .timeWindow(sampleWindowSec, TimeUnit.SECONDS)
+      .samples(numSamples)
+      .quota(new Quota(quota, true))
+    val metric = new KafkaMetric(new Object(), metricName, new Rate(), metricConfig, time)
+    new QuotaViolationException(metric, observedValue, quota)
+  }
+
+  private def throttleTime(observedValue: Double, quota: Double, numSamples: Int): Long = {
+    val e = quotaViolationException(observedValue, quota, numSamples)
+    QuotaUtils.throttleTime(e, time.milliseconds)
+  }
+
+  private def boundedThrottleTime(observedValue: Double, quota: Double, numSamples: Int, maxThrottleTime: Long): Long = {
+    val e = quotaViolationException(observedValue, quota, numSamples)
+    QuotaUtils.boundedThrottleTime(e, maxThrottleTime, time.milliseconds)
+  }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
@@ -37,9 +36,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
@@ -66,9 +63,6 @@ import static org.hamcrest.core.IsEqual.equalTo;
 @Category({IntegrationTest.class})
 @RunWith(value = Parameterized.class)
 public abstract class AbstractJoinIntegrationTest {
-    @ClassRule
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
-
     @Rule
     public final TemporaryFolder testFolder = new TemporaryFolder(TestUtils.tempDirectory());
 
@@ -122,25 +116,19 @@ public abstract class AbstractJoinIntegrationTest {
     @BeforeClass
     public static void setupConfigsAndUtils() {
 
+        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "topology_driver:0000");
         STREAMS_CONFIG.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL);
     }
 
     void prepareEnvironment() throws InterruptedException {
-        CLUSTER.createTopics(INPUT_TOPIC_LEFT, INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
-
         if (!cacheEnabled) {
             STREAMS_CONFIG.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         }
 
         STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, testFolder.getRoot().getPath());
-    }
-    @After
-    public void cleanup() throws InterruptedException {
-        CLUSTER.deleteAllTopicsAndWait(120000);
     }
 
     void runTestWithDriver(final List<List<TestRecord<Long, String>>> expectedResult) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/JoinStoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/JoinStoreIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import static java.time.Duration.ofMillis;
+import static org.junit.Assert.assertThrows;
+
+@Category({IntegrationTest.class})
+public class JoinStoreIntegrationTest {
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    @Rule
+    public final TemporaryFolder testFolder = new TemporaryFolder(TestUtils.tempDirectory());
+
+    private static final String APP_ID = "join-store-integration-test";
+    private static final Long COMMIT_INTERVAL = 100L;
+    static final Properties STREAMS_CONFIG = new Properties();
+    static final String INPUT_TOPIC_RIGHT = "inputTopicRight";
+    static final String INPUT_TOPIC_LEFT = "inputTopicLeft";
+    static final String OUTPUT_TOPIC = "outputTopic";
+
+    StreamsBuilder builder;
+
+    @BeforeClass
+    public static void setupConfigsAndUtils() {
+        STREAMS_CONFIG.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL);
+    }
+
+    @Before
+    public void prepareTopology() throws InterruptedException {
+        CLUSTER.createTopics(INPUT_TOPIC_LEFT, INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
+        STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, testFolder.getRoot().getPath());
+
+        builder = new StreamsBuilder();
+    }
+
+    @After
+    public void cleanup() throws InterruptedException {
+        CLUSTER.deleteAllTopicsAndWait(120000);
+    }
+
+    @Test
+    public void shouldNotAccessJoinStoresWhenGivingName() throws InterruptedException {
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID + "-no-store-access");
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<String, Integer> left = builder.stream(INPUT_TOPIC_LEFT, Consumed.with(Serdes.String(), Serdes.Integer()));
+        final KStream<String, Integer> right = builder.stream(INPUT_TOPIC_RIGHT, Consumed.with(Serdes.String(), Serdes.Integer()));
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        left.join(
+            right,
+            (value1, value2) -> value1 + value2,
+            JoinWindows.of(ofMillis(100)),
+            StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer()).withStoreName("join-store"));
+
+        try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), STREAMS_CONFIG)) {
+            kafkaStreams.setStateListener((newState, oldState) -> {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    latch.countDown();
+                }
+            });
+
+            kafkaStreams.start();
+            latch.await();
+            assertThrows(InvalidStateStoreException.class, () -> kafkaStreams.store(StoreQueryParameters.fromNameAndType("join-store", QueryableStoreTypes.keyValueStore())));
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/JoinWithIncompleteMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/JoinWithIncompleteMetadataIntegrationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreamsWrapper;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertTrue;
+
+@Category({IntegrationTest.class})
+public class JoinWithIncompleteMetadataIntegrationTest {
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+
+    @Rule
+    public final TemporaryFolder testFolder = new TemporaryFolder(TestUtils.tempDirectory());
+
+    private static final String APP_ID = "join-incomplete-metadata-integration-test";
+    private static final Long COMMIT_INTERVAL = 100L;
+    static final Properties STREAMS_CONFIG = new Properties();
+    static final String INPUT_TOPIC_RIGHT = "inputTopicRight";
+    static final String NON_EXISTENT_INPUT_TOPIC_LEFT = "inputTopicLeft-not-exist";
+    static final String OUTPUT_TOPIC = "outputTopic";
+
+    StreamsBuilder builder;
+    final ValueJoiner<String, String, String> valueJoiner = (value1, value2) -> value1 + "-" + value2;
+    private KTable<Long, String> rightTable;
+
+    @BeforeClass
+    public static void setupConfigsAndUtils() {
+        STREAMS_CONFIG.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, COMMIT_INTERVAL);
+    }
+
+    @Before
+    public void prepareTopology() throws InterruptedException {
+        CLUSTER.createTopics(INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
+        STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, testFolder.getRoot().getPath());
+
+        builder = new StreamsBuilder();
+        rightTable = builder.table(INPUT_TOPIC_RIGHT);
+    }
+
+    @After
+    public void cleanup() throws InterruptedException {
+        CLUSTER.deleteAllTopicsAndWait(120000);
+    }
+
+    @Test
+    public void testShouldAutoShutdownOnJoinWithIncompleteMetadata() throws InterruptedException {
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID);
+        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+
+        final KStream<Long, String> notExistStream = builder.stream(NON_EXISTENT_INPUT_TOPIC_LEFT);
+
+        final KTable<Long, String> aggregatedTable = notExistStream.leftJoin(rightTable, valueJoiner)
+                .groupBy((key, value) -> key)
+                .reduce((value1, value2) -> value1 + value2);
+
+        // Write the (continuously updating) results to the output topic.
+        aggregatedTable.toStream().to(OUTPUT_TOPIC);
+
+        final KafkaStreamsWrapper streams = new KafkaStreamsWrapper(builder.build(), STREAMS_CONFIG);
+        final IntegrationTestUtils.StateListenerStub listener = new IntegrationTestUtils.StateListenerStub();
+        streams.setStreamThreadStateListener(listener);
+        streams.start();
+
+        TestUtils.waitForCondition(listener::transitToPendingShutdownSeen, "Did not seen thread state transited to PENDING_SHUTDOWN");
+
+        streams.close();
+        assertTrue(listener.transitToPendingShutdownSeen());
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -16,17 +16,10 @@
  */
 package org.apache.kafka.streams.integration;
 
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.InvalidStateStoreException;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.StreamJoined;
-import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockMapper;
@@ -40,11 +33,8 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
-import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofSeconds;
-import static org.junit.Assert.assertThrows;
 
 /**
  * Tests all available joins of Kafka Streams DSL.
@@ -68,34 +58,6 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         builder = new StreamsBuilder();
         leftStream = builder.stream(INPUT_TOPIC_LEFT);
         rightStream = builder.stream(INPUT_TOPIC_RIGHT);
-    }
-
-    @Test
-    public void shouldNotAccessJoinStoresWhenGivingName() throws InterruptedException {
-        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-no-store-access");
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        final KStream<String, Integer> left = builder.stream(INPUT_TOPIC_LEFT, Consumed.with(Serdes.String(), Serdes.Integer()));
-        final KStream<String, Integer> right = builder.stream(INPUT_TOPIC_RIGHT, Consumed.with(Serdes.String(), Serdes.Integer()));
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        left.join(
-            right,
-            (value1, value2) -> value1 + value2,
-            JoinWindows.of(ofMillis(100)),
-            StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer()).withStoreName("join-store"));
-
-        try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), STREAMS_CONFIG)) {
-            kafkaStreams.setStateListener((newState, oldState) -> {
-                if (newState == KafkaStreams.State.RUNNING) {
-                    latch.countDown();
-                }
-            });
-
-            kafkaStreams.start();
-            latch.await();
-            assertThrows(InvalidStateStoreException.class, () -> kafkaStreams.store(StoreQueryParameters.fromNameAndType("join-store", QueryableStoreTypes.keyValueStore())));
-        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamTableJoinIntegrationTest.java
@@ -16,15 +16,12 @@
  */
 package org.apache.kafka.streams.integration;
 
-import org.apache.kafka.streams.KafkaStreamsWrapper;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,8 +31,6 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests all available joins of Kafka Streams DSL.
@@ -62,34 +57,8 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
     }
 
     @Test
-    public void testShouldAutoShutdownOnIncompleteMetadata() throws InterruptedException {
-        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-incomplete");
-        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-
-        final KStream<Long, String> notExistStream = builder.stream(INPUT_TOPIC_LEFT + "-not-existed");
-
-        final KTable<Long, String> aggregatedTable = notExistStream.leftJoin(rightTable, valueJoiner)
-                .groupBy((key, value) -> key)
-                .reduce((value1, value2) -> value1 + value2);
-
-        // Write the (continuously updating) results to the output topic.
-        aggregatedTable.toStream().to(OUTPUT_TOPIC);
-
-        final KafkaStreamsWrapper streams = new KafkaStreamsWrapper(builder.build(), STREAMS_CONFIG);
-        final IntegrationTestUtils.StateListenerStub listener = new IntegrationTestUtils.StateListenerStub();
-        streams.setStreamThreadStateListener(listener);
-        streams.start();
-
-        TestUtils.waitForCondition(listener::transitToPendingShutdownSeen, "Did not seen thread state transited to PENDING_SHUTDOWN");
-
-        streams.close();
-        assertTrue(listener.transitToPendingShutdownSeen());
-    }
-
-    @Test
     public void testInner() {
         STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-inner");
-        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "topology_driver:0000");
 
         final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
             null,
@@ -116,7 +85,6 @@ public class StreamTableJoinIntegrationTest extends AbstractJoinIntegrationTest 
     @Test
     public void testLeft() {
         STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, appID + "-left");
-        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "topology_driver:0000");
 
         final List<List<TestRecord<Long, String>>> expectedResult = Arrays.asList(
             null,

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -34,7 +34,7 @@ LABEL ducker.creator=$ducker_creator
 # Update Linux and install necessary utilities.
 RUN apt update && apt install -y sudo netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python-pip python-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
 RUN python -m pip install -U pip==9.0.3;
-RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.8
+RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.9
 
 # Set up ssh
 COPY ./ssh-config /root/.ssh/config

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -921,16 +921,24 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.debug("Broker info: %s", broker_info)
         return broker_info is not None
 
-    def get_offset_shell(self, topic, partitions, max_wait_ms, offsets, time):
+    def get_offset_shell(self, time=None, topic=None, partitions=None, topic_partitions=None, exclude_internal_topics=False):
         node = self.nodes[0]
 
         cmd = fix_opts_for_new_jvm(node)
         cmd += self.path.script("kafka-run-class.sh", node)
         cmd += " kafka.tools.GetOffsetShell"
-        cmd += " --topic %s --broker-list %s --max-wait-ms %s --offsets %s --time %s" % (topic, self.bootstrap_servers(self.security_protocol), max_wait_ms, offsets, time)
+        cmd += " --broker-list %s" % self.bootstrap_servers(self.security_protocol)
 
+        if time:
+            cmd += ' --time %s' % time
+        if topic_partitions:
+            cmd += ' --topic-partitions %s' % topic_partitions
+        if topic:
+            cmd += ' --topic %s' % topic
         if partitions:
             cmd += '  --partitions %s' % partitions
+        if exclude_internal_topics:
+            cmd += ' --exclude-internal-topics'
 
         cmd += " 2>> %s/get_offset_shell.log" % KafkaService.PERSISTENT_ROOT
         cmd += " | tee -a %s/get_offset_shell.log &" % KafkaService.PERSISTENT_ROOT

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -927,7 +927,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         cmd = fix_opts_for_new_jvm(node)
         cmd += self.path.script("kafka-run-class.sh", node)
         cmd += " kafka.tools.GetOffsetShell"
-        cmd += " --broker-list %s" % self.bootstrap_servers(self.security_protocol)
+        cmd += " --boostrap-server %s" % self.bootstrap_servers(self.security_protocol)
 
         if time:
             cmd += ' --time %s' % time

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -97,7 +97,7 @@ class ConsumerEventHandler(object):
                     if tp in self.position:
                         self.position[tp] = max_offset + 1
                     logger.warn(msg)
-            self.total_consumed += event["count"]
+        self.total_consumed += event["count"]
 
     def handle_partitions_revoked(self, event):
         self.revoked_count += 1

--- a/tests/kafkatest/tests/core/get_offset_shell_test.py
+++ b/tests/kafkatest/tests/core/get_offset_shell_test.py
@@ -22,12 +22,26 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.console_consumer import ConsoleConsumer
-from kafkatest.services.security.security_config import SecurityConfig
 
-TOPIC = "topic-get-offset-shell"
 MAX_MESSAGES = 100
 NUM_PARTITIONS = 1
 REPLICATION_FACTOR = 1
+
+TOPIC_TEST_NAME = "topic-get-offset-shell-topic-name"
+
+TOPIC_TEST_PATTERN_PREFIX = "topic-get-offset-shell-topic-pattern"
+TOPIC_TEST_PATTERN_PATTERN = TOPIC_TEST_PATTERN_PREFIX + ".*"
+TOPIC_TEST_PATTERN1 = TOPIC_TEST_PATTERN_PREFIX + "1"
+TOPIC_TEST_PATTERN2 = TOPIC_TEST_PATTERN_PREFIX + "2"
+
+TOPIC_TEST_PARTITIONS = "topic-get-offset-shell-partitions"
+
+TOPIC_TEST_INTERNAL_FILTER = "topic-get-offset-shell-consumer_offsets"
+
+TOPIC_TEST_TOPIC_PARTITIONS_PREFIX = "topic-get-offset-shell-topic-partitions"
+TOPIC_TEST_TOPIC_PARTITIONS_PATTERN = TOPIC_TEST_TOPIC_PARTITIONS_PREFIX + ".*"
+TOPIC_TEST_TOPIC_PARTITIONS1 = TOPIC_TEST_TOPIC_PARTITIONS_PREFIX + "1"
+TOPIC_TEST_TOPIC_PARTITIONS2 = TOPIC_TEST_TOPIC_PARTITIONS_PREFIX + "2"
 
 
 class GetOffsetShellTest(Test):
@@ -40,11 +54,16 @@ class GetOffsetShellTest(Test):
         self.num_brokers = 1
         self.messages_received_count = 0
         self.topics = {
-            TOPIC: {'partitions': NUM_PARTITIONS, 'replication-factor': REPLICATION_FACTOR}
+            TOPIC_TEST_NAME: {'partitions': NUM_PARTITIONS, 'replication-factor': REPLICATION_FACTOR},
+            TOPIC_TEST_PATTERN1: {'partitions': 1, 'replication-factor': REPLICATION_FACTOR},
+            TOPIC_TEST_PATTERN2: {'partitions': 1, 'replication-factor': REPLICATION_FACTOR},
+            TOPIC_TEST_PARTITIONS: {'partitions': 2, 'replication-factor': REPLICATION_FACTOR},
+            TOPIC_TEST_INTERNAL_FILTER: {'partitions': 1, 'replication-factor': REPLICATION_FACTOR},
+            TOPIC_TEST_TOPIC_PARTITIONS1: {'partitions': 2, 'replication-factor': REPLICATION_FACTOR},
+            TOPIC_TEST_TOPIC_PARTITIONS2: {'partitions': 2, 'replication-factor': REPLICATION_FACTOR}
         }
 
         self.zk = ZookeeperService(test_context, self.num_zk)
-
 
     def setUp(self):
         self.zk.start()
@@ -56,37 +75,179 @@ class GetOffsetShellTest(Test):
             interbroker_security_protocol=interbroker_security_protocol, topics=self.topics)
         self.kafka.start()
 
-    def start_producer(self):
+    def start_producer(self, topic):
         # This will produce to kafka cluster
-        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka, topic=TOPIC, throughput=1000, max_messages=MAX_MESSAGES)
+        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka, topic=topic,
+                                           throughput=1000, max_messages=MAX_MESSAGES, repeating_keys=MAX_MESSAGES)
         self.producer.start()
         current_acked = self.producer.num_acked
         wait_until(lambda: self.producer.num_acked >= current_acked + MAX_MESSAGES, timeout_sec=10,
                    err_msg="Timeout awaiting messages to be produced and acked")
 
-    def start_consumer(self):
-        self.consumer = ConsoleConsumer(self.test_context, num_nodes=self.num_brokers, kafka=self.kafka, topic=TOPIC,
+    def start_consumer(self, topic):
+        self.consumer = ConsoleConsumer(self.test_context, num_nodes=self.num_brokers, kafka=self.kafka, topic=topic,
                                         consumer_timeout_ms=1000)
         self.consumer.start()
 
-    @cluster(num_nodes=4)
-    def test_get_offset_shell(self, security_protocol='PLAINTEXT'):
+    def check_message_count_sum_equals(self, message_count, **kwargs):
+        sum = self.extract_message_count_sum(**kwargs)
+        return sum == message_count
+
+    def extract_message_count_sum(self, **kwargs):
+        offsets = self.kafka.get_offset_shell(**kwargs).split("\n")
+        sum = 0
+        for offset in offsets:
+            if len(offset) == 0:
+                continue
+            sum += int(offset.split(":")[-1])
+        return sum
+
+    @cluster(num_nodes=3)
+    def test_get_offset_shell_topic_name(self, security_protocol='PLAINTEXT'):
         """
-        Tests if GetOffsetShell is getting offsets correctly
+        Tests if GetOffsetShell handles --topic argument with a simple name correctly
         :return: None
         """
         self.start_kafka(security_protocol, security_protocol)
-        self.start_producer()
-
-        # Assert that offset fetched without any consumers consuming is 0
-        assert self.kafka.get_offset_shell(TOPIC, None, 1000, 1, -1), "%s:%s:%s" % (TOPIC, NUM_PARTITIONS - 1, 0)
-
-        self.start_consumer()
-
-        node = self.consumer.nodes[0]
-
-        wait_until(lambda: self.consumer.alive(node), timeout_sec=20, backoff_sec=.2, err_msg="Consumer was too slow to start")
+        self.start_producer(TOPIC_TEST_NAME)
 
         # Assert that offset is correctly indicated by GetOffsetShell tool
-        wait_until(lambda: "%s:%s:%s" % (TOPIC, NUM_PARTITIONS - 1, MAX_MESSAGES) in self.kafka.get_offset_shell(TOPIC, None, 1000, 1, -1), timeout_sec=10,
-                   err_msg="Timed out waiting to reach expected offset.")
+        wait_until(lambda: self.check_message_count_sum_equals(MAX_MESSAGES, topic=TOPIC_TEST_NAME),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+    @cluster(num_nodes=4)
+    def test_get_offset_shell_topic_pattern(self, security_protocol='PLAINTEXT'):
+        """
+        Tests if GetOffsetShell handles --topic argument with a pattern correctly
+        :return: None
+        """
+        self.start_kafka(security_protocol, security_protocol)
+        self.start_producer(TOPIC_TEST_PATTERN1)
+        self.start_producer(TOPIC_TEST_PATTERN2)
+
+        # Assert that offset is correctly indicated by GetOffsetShell tool
+        wait_until(lambda: self.check_message_count_sum_equals(2*MAX_MESSAGES, topic=TOPIC_TEST_PATTERN_PATTERN),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+    @cluster(num_nodes=3)
+    def test_get_offset_shell_partitions(self, security_protocol='PLAINTEXT'):
+        """
+        Tests if GetOffsetShell handles --partitions argument correctly
+        :return: None
+        """
+        self.start_kafka(security_protocol, security_protocol)
+        self.start_producer(TOPIC_TEST_PARTITIONS)
+
+        def fetch_and_sum_partitions_separately():
+            partition_count0 = self.extract_message_count_sum(topic=TOPIC_TEST_PARTITIONS, partitions="0")
+            partition_count1 = self.extract_message_count_sum(topic=TOPIC_TEST_PARTITIONS, partitions="1")
+            return partition_count0 + partition_count1 == MAX_MESSAGES
+
+        # Assert that offset is correctly indicated when fetching partitions one by one
+        wait_until(fetch_and_sum_partitions_separately, timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+        # Assert that offset is correctly indicated when fetching partitions together
+        wait_until(lambda: self.check_message_count_sum_equals(MAX_MESSAGES, topic=TOPIC_TEST_PARTITIONS),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+    @cluster(num_nodes=4)
+    def test_get_offset_shell_topic_partitions(self, security_protocol='PLAINTEXT'):
+        """
+        Tests if GetOffsetShell handles --topic-partitions argument correctly
+        :return: None
+        """
+        self.start_kafka(security_protocol, security_protocol)
+        self.start_producer(TOPIC_TEST_TOPIC_PARTITIONS1)
+        self.start_producer(TOPIC_TEST_TOPIC_PARTITIONS2)
+
+        # Assert that a single topic pattern matches all 4 partitions
+        wait_until(lambda: self.check_message_count_sum_equals(2*MAX_MESSAGES, topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS_PATTERN),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+        # Assert that a topic pattern with partition range matches all 4 partitions
+        wait_until(lambda: self.check_message_count_sum_equals(2*MAX_MESSAGES, topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS_PATTERN + ":0-2"),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+        # Assert that 2 separate topic patterns match all 4 partitions
+        wait_until(lambda: self.check_message_count_sum_equals(2*MAX_MESSAGES, topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS1 + "," + TOPIC_TEST_TOPIC_PARTITIONS2),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+        # Assert that 4 separate topic-partition patterns match all 4 partitions
+        wait_until(lambda: self.check_message_count_sum_equals(2*MAX_MESSAGES,
+                                                               topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS1 + ":0," +
+                                                                                TOPIC_TEST_TOPIC_PARTITIONS1 + ":1," +
+                                                                                TOPIC_TEST_TOPIC_PARTITIONS2 + ":0," +
+                                                                                TOPIC_TEST_TOPIC_PARTITIONS2 + ":1"),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+        # Assert that only partitions #0 are matched with topic pattern and fix partition number
+        filtered_partitions = self.kafka.get_offset_shell(topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS_PATTERN + ":0")
+        assert 1 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS1, 0))
+        assert 0 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS1, 1))
+        assert 1 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS2, 0))
+        assert 0 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS2, 1))
+
+        # Assert that only partitions #1 are matched with topic pattern and partition lower bound
+        filtered_partitions = self.kafka.get_offset_shell(topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS_PATTERN + ":1-")
+        assert 1 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS1, 1))
+        assert 0 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS1, 0))
+        assert 1 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS2, 1))
+        assert 0 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS2, 0))
+
+        # Assert that only partitions #0 are matched with topic pattern and partition upper bound
+        filtered_partitions = self.kafka.get_offset_shell(topic_partitions=TOPIC_TEST_TOPIC_PARTITIONS_PATTERN + ":-1")
+        assert 1 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS1, 0))
+        assert 0 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS1, 1))
+        assert 1 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS2, 0))
+        assert 0 == filtered_partitions.count("%s:%s" % (TOPIC_TEST_TOPIC_PARTITIONS2, 1))
+
+    @cluster(num_nodes=4)
+    def test_get_offset_shell_internal_filter(self, security_protocol='PLAINTEXT'):
+        """
+        Tests if GetOffsetShell handles --exclude-internal-topics flag correctly
+        :return: None
+        """
+        self.start_kafka(security_protocol, security_protocol)
+        self.start_producer(TOPIC_TEST_INTERNAL_FILTER)
+
+        # Create consumer and poll messages to create consumer offset record
+        self.start_consumer(TOPIC_TEST_INTERNAL_FILTER)
+        node = self.consumer.nodes[0]
+        wait_until(lambda: self.consumer.alive(node), timeout_sec=20, backoff_sec=.2, err_msg="Consumer was too slow to start")
+
+        # Assert that a single topic pattern matches all 4 partitions
+        wait_until(lambda: self.check_message_count_sum_equals(MAX_MESSAGES, topic_partitions=TOPIC_TEST_INTERNAL_FILTER),
+                   timeout_sec=10, err_msg="Timed out waiting to reach expected offset.")
+
+        # No filters
+        # Assert that without exclusion, we can find both the test topic and the __consumer_offsets internal topic
+        offset_output = self.kafka.get_offset_shell()
+        assert "__consumer_offsets" in offset_output
+        assert TOPIC_TEST_INTERNAL_FILTER in offset_output
+
+        # Assert that with exclusion, we can find the test topic but not the __consumer_offsets internal topic
+        offset_output = self.kafka.get_offset_shell(exclude_internal_topics=True)
+        assert "__consumer_offsets" not in offset_output
+        assert TOPIC_TEST_INTERNAL_FILTER in offset_output
+
+        # Topic filter
+        # Assert that without exclusion, we can find both the test topic and the __consumer_offsets internal topic
+        offset_output = self.kafka.get_offset_shell(topic=".*consumer_offsets")
+        assert "__consumer_offsets" in offset_output
+        assert TOPIC_TEST_INTERNAL_FILTER in offset_output
+
+        # Assert that with exclusion, we can find the test topic but not the __consumer_offsets internal topic
+        offset_output = self.kafka.get_offset_shell(topic=".*consumer_offsets", exclude_internal_topics=True)
+        assert "__consumer_offsets" not in offset_output
+        assert TOPIC_TEST_INTERNAL_FILTER in offset_output
+
+        # Topic-partition filter
+        # Assert that without exclusion, we can find both the test topic and the __consumer_offsets internal topic
+        offset_output = self.kafka.get_offset_shell(topic_partitions=".*consumer_offsets:0")
+        assert "__consumer_offsets" in offset_output
+        assert TOPIC_TEST_INTERNAL_FILTER in offset_output
+
+        # Assert that with exclusion, we can find the test topic but not the __consumer_offsets internal topic
+        offset_output = self.kafka.get_offset_shell(topic_partitions=".*consumer_offsets:0", exclude_internal_topics=True)
+        assert "__consumer_offsets" not in offset_output
+        assert TOPIC_TEST_INTERNAL_FILTER in offset_output

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.7.8", "requests==2.22.0"],
+      install_requires=["ducktape==0.7.9", "requests==2.22.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       )


### PR DESCRIPTION
Implements KIP-635

Changes:
- Added kafka-get-offsets.sh script
- Removed deprecated max-wait-ms and offsets arguments
- Updated tool to query all topic-partitions by default
- Updated topic argument to support patterns
- Added topic-partitions argument to support a list of topic-partition patterns
- Added exclude-internal-topics to support filtering internal topics

Testing done: added new ducktape tests for the tool.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
