### PR TITLE
[WIP] KAFKA-6520: Add DISCONNECTED state to Kafka Streams

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
@@ -37,6 +37,8 @@ public class FetcherMetricsRegistry {
     public MetricNameTemplate fetchLatencyMax;
     public MetricNameTemplate fetchRequestRate;
     public MetricNameTemplate fetchRequestTotal;
+    public MetricNameTemplate fetchRequestSuccessPercent;
+    public MetricNameTemplate fetchRequestFailurePercent;
     public MetricNameTemplate recordsLagMax;
     public MetricNameTemplate recordsLeadMin;
     public MetricNameTemplate fetchThrottleTimeAvg;
@@ -74,6 +76,12 @@ public class FetcherMetricsRegistry {
 
         this.fetchSizeMax = new MetricNameTemplate("fetch-size-max", groupName,
                 "The maximum number of bytes fetched per request", tags);
+
+        this.fetchRequestSuccessPercent = new MetricNameTemplate("fetch-success-percent",groupName,
+                "percentage of fetch request succeeded",tags);
+        this.fetchRequestFailurePercent = new MetricNameTemplate("fetch-failure-percent",groupName,
+                "percentage of fetch requests failed",tags);
+
         this.bytesConsumedRate = new MetricNameTemplate("bytes-consumed-rate", groupName,
                 "The average number of bytes consumed per second", tags);
         this.bytesConsumedTotal = new MetricNameTemplate("bytes-consumed-total", groupName,


### PR DESCRIPTION
Work in progress,  appreciate any feedback on my initial approach. 

Adding a disconnect status to Kafka streams. This is achieved by introducing by recording fetch disconnectedExceptions in Fetcher and then measuring them through 2 new metrics _fetchRequestSuccessPercent_ and
_fetchRequestFailurePercent_. Currently when the percentage of failed fetches is above an arbitrary threshold we transition the streamThread to a disconnected state. Then when percentage of failed fetches dips below another arbitrary threshold we transition the streamThread to it's previous state. 

If my approach is satisfactory, I'll start writing tests.



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
