### PR TITLE
MINOR: Improve logging around initial log loading

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -279,8 +279,6 @@ class Log(@volatile private var _dir: File,
   @volatile var leaderEpochCache: Option[LeaderEpochFileCache] = None
 
   locally {
-    val startMs = time.milliseconds
-
     // create the log directory if it doesn't exist
     Files.createDirectories(dir.toPath)
 
@@ -303,9 +301,6 @@ class Log(@volatile private var _dir: File,
     if (!producerStateManager.isEmpty)
       throw new IllegalStateException("Producer state must be empty during log initialization")
     loadProducerState(logEndOffset, reloadFromCleanShutdown = hasCleanShutdownFile)
-
-    info(s"Completed load of log with ${segments.size} segments, log start offset $logStartOffset and " +
-      s"log end offset $logEndOffset in ${time.milliseconds() - startMs} ms")
   }
 
   def dir: File = _dir

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -396,7 +396,7 @@ class LogManager(logDirs: Seq[File],
       threadPools.foreach(_.shutdown())
     }
 
-    info(s"Loaded $numTotalLogs in ${time.hiResClockMs() - startMs}ms.")
+    info(s"Loaded $numTotalLogs logs in ${time.hiResClockMs() - startMs}ms.")
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -20,6 +20,7 @@ package kafka.log
 import java.io._
 import java.nio.file.Files
 import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
 
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.checkpoints.OffsetCheckpointFile
@@ -252,8 +253,9 @@ class LogManager(logDirs: Seq[File],
   // Only for testing
   private[log] def hasLogsToBeDeleted: Boolean = !logsToBeDeleted.isEmpty
 
-  private def loadLog(logDir: File, recoveryPoints: Map[TopicPartition, Long], logStartOffsets: Map[TopicPartition, Long]): Unit = {
-    debug(s"Loading log '${logDir.getName}'")
+  private def loadLog(logDir: File,
+                      recoveryPoints: Map[TopicPartition, Long],
+                      logStartOffsets: Map[TopicPartition, Long]): Log = {
     val topicPartition = Log.parseTopicPartitionName(logDir)
     val config = topicConfigs.getOrElse(topicPartition.topic, currentDefaultConfig)
     val logRecoveryPoint = recoveryPoints.getOrElse(topicPartition, 0L)
@@ -290,13 +292,15 @@ class LogManager(logDirs: Seq[File],
             s"for this partition. It is recommended to delete the partition in the log directory that is known to have failed recently.")
       }
     }
+
+    log
   }
 
   /**
    * Recover and load all logs in the given data directories
    */
   private def loadLogs(): Unit = {
-    info("Loading logs.")
+    info(s"Loading logs from log dirs $liveLogDirs")
     val startMs = time.milliseconds
     val threadPools = ArrayBuffer.empty[ExecutorService]
     val offlineDirs = mutable.Set.empty[(String, IOException)]
@@ -308,11 +312,11 @@ class LogManager(logDirs: Seq[File],
         threadPools.append(pool)
 
         val cleanShutdownFile = new File(dir, Log.CleanShutdownFile)
-
         if (cleanShutdownFile.exists) {
-          debug(s"Found clean shutdown file. Skipping recovery for all logs in data directory: ${dir.getAbsolutePath}")
+          info(s"Skipping recovery for all logs in $dir since clean shutdown file was found")
         } else {
           // log recovery itself is being performed by `Log` class during initialization
+          info(s"Attempting recovery for all logs in $dir since no clean shutdown file was found")
           brokerState.newState(RecoveringFromUncleanShutdown)
         }
 
@@ -321,8 +325,8 @@ class LogManager(logDirs: Seq[File],
           recoveryPoints = this.recoveryPointCheckpoints(dir).read()
         } catch {
           case e: Exception =>
-            warn(s"Error occurred while reading recovery-point-offset-checkpoint file of directory $dir", e)
-            warn("Resetting the recovery checkpoint to 0")
+            warn(s"Error occurred while reading recovery-point-offset-checkpoint file of directory $dir, " +
+              "resetting the recovery checkpoint to 0", e)
         }
 
         var logStartOffsets = Map[TopicPartition, Long]()
@@ -330,16 +334,23 @@ class LogManager(logDirs: Seq[File],
           logStartOffsets = this.logStartOffsetCheckpoints(dir).read()
         } catch {
           case e: Exception =>
-            warn(s"Error occurred while reading log-start-offset-checkpoint file of directory $dir", e)
+            warn(s"Error occurred while reading log-start-offset-checkpoint file of directory $dir, " +
+              "resetting to the base offset of the first segment", e)
         }
 
-        val jobsForDir = for {
-          dirContent <- Option(dir.listFiles).toList
-          logDir <- dirContent if logDir.isDirectory
-        } yield {
+        val logsToLoad = Option(dir.listFiles).getOrElse(Array.empty).filter(_.isDirectory)
+        val numRemainingLogsToLoad = new AtomicInteger(logsToLoad.length)
+
+        val jobsForDir = logsToLoad.map { logDir =>
           val runnable: Runnable = () => {
             try {
-              loadLog(logDir, recoveryPoints, logStartOffsets)
+              debug(s"Loading log $logDir")
+              val logLoadStartMs = time.milliseconds()
+              val log = loadLog(logDir, recoveryPoints, logStartOffsets)
+              numRemainingLogsToLoad.decrementAndGet()
+              info(s"Completed load of $log with ${log.numberOfSegments} segments " +
+                s"in ${time.milliseconds() - logLoadStartMs}ms " +
+                s"(${numRemainingLogsToLoad.get} logs remaining to load in $dir)")
             } catch {
               case e: IOException =>
                 offlineDirs.add((dir.getAbsolutePath, e))
@@ -348,6 +359,7 @@ class LogManager(logDirs: Seq[File],
           }
           runnable
         }
+
         jobs(cleanShutdownFile) = jobsForDir.map(pool.submit)
       } catch {
         case e: IOException =>
@@ -379,7 +391,7 @@ class LogManager(logDirs: Seq[File],
       threadPools.foreach(_.shutdown())
     }
 
-    info(s"Logs loading complete in ${time.milliseconds - startMs} ms.")
+    info(s"Log loading completed after ${time.milliseconds - startMs}ms.")
   }
 
   /**


### PR DESCRIPTION
Users often get confused after an unclean shutdown when log recovery takes a long time. This patch attempts to make the logging clearer and provide a simple indication of loading progress.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
