### PR TITLE
KAFKA-10234 The key/value deserializer used by ConsoleConsumer is not…

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
@@ -26,8 +26,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class MockDeserializer implements ClusterResourceListener, Deserializer<byte[]> {
     public static AtomicInteger initCount = new AtomicInteger(0);
-    public static AtomicReference<ClusterResource> clusterMeta = new AtomicReference<>();
     public static AtomicInteger closeCount = new AtomicInteger(0);
+    public static AtomicReference<ClusterResource> clusterMeta = new AtomicReference<>();
     public static ClusterResource noClusterId = new ClusterResource("no_cluster_id");
     public static AtomicReference<ClusterResource> clusterIdBeforeDeserialize = new AtomicReference<>(noClusterId);
 
@@ -36,6 +36,7 @@ public class MockDeserializer implements ClusterResourceListener, Deserializer<b
 
     public static void resetStaticVariables() {
         initCount = new AtomicInteger(0);
+        closeCount = new AtomicInteger(0);
         clusterMeta = new AtomicReference<>();
         clusterIdBeforeDeserialize = new AtomicReference<>(noClusterId);
     }

--- a/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
@@ -27,12 +27,12 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MockDeserializer implements ClusterResourceListener, Deserializer<byte[]> {
     public static AtomicInteger initCount = new AtomicInteger(0);
     public static AtomicReference<ClusterResource> clusterMeta = new AtomicReference<>();
+    public static AtomicInteger closeCount = new AtomicInteger(0);
     public static ClusterResource noClusterId = new ClusterResource("no_cluster_id");
     public static AtomicReference<ClusterResource> clusterIdBeforeDeserialize = new AtomicReference<>(noClusterId);
 
     public boolean isKey;
     public Map<String, ?> configs;
-    public boolean isClosed = false;
 
     public static void resetStaticVariables() {
         initCount = new AtomicInteger(0);
@@ -60,7 +60,7 @@ public class MockDeserializer implements ClusterResourceListener, Deserializer<b
 
     @Override
     public void close() {
-        isClosed = true;
+        closeCount.incrementAndGet();
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
@@ -26,17 +26,16 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class MockDeserializer implements ClusterResourceListener, Deserializer<byte[]> {
     public static AtomicInteger initCount = new AtomicInteger(0);
-    public static AtomicInteger closeCount = new AtomicInteger(0);
     public static AtomicReference<ClusterResource> clusterMeta = new AtomicReference<>();
     public static ClusterResource noClusterId = new ClusterResource("no_cluster_id");
     public static AtomicReference<ClusterResource> clusterIdBeforeDeserialize = new AtomicReference<>(noClusterId);
 
     public boolean isKey;
     public Map<String, ?> configs;
+    public boolean isClosed = false;
 
     public static void resetStaticVariables() {
         initCount = new AtomicInteger(0);
-        closeCount = new AtomicInteger(0);
         clusterMeta = new AtomicReference<>();
         clusterIdBeforeDeserialize = new AtomicReference<>(noClusterId);
     }
@@ -61,7 +60,7 @@ public class MockDeserializer implements ClusterResourceListener, Deserializer<b
 
     @Override
     public void close() {
-        closeCount.incrementAndGet();
+        isClosed = true;
     }
 
     @Override

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -607,8 +607,7 @@ class DefaultMessageFormatter extends MessageFormatter {
 }
 
 class LoggingMessageFormatter extends MessageFormatter with LazyLogging {
-  // visible for testing
-  private[tools] val defaultWriter: DefaultMessageFormatter = new DefaultMessageFormatter
+  private val defaultWriter: DefaultMessageFormatter = new DefaultMessageFormatter
 
   override def configure(configs: Map[String, _]): Unit = defaultWriter.configure(configs)
 

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -495,7 +495,7 @@ class DefaultMessageFormatter extends MessageFormatter {
     headersDeserializer = getPropertyIfExists(configs, "headers.deserializer", getDeserializerProperty(false))
   }
 
-  def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
+  override def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
 
     def writeSeparator(columnSeparator: Boolean): Unit = {
       if (columnSeparator)
@@ -611,7 +611,7 @@ class LoggingMessageFormatter extends MessageFormatter with LazyLogging {
 
   override def configure(configs: Map[String, _]): Unit = defaultWriter.configure(configs)
 
-  def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
+  override def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
     import consumerRecord._
     defaultWriter.writeTo(consumerRecord, output)
     logger.info({if (timestampType != TimestampType.NO_TIMESTAMP_TYPE) s"$timestampType:$timestamp, " else ""} +

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -421,7 +421,8 @@ class ConsoleConsumerTest {
       "--topic", "test",
       "--property", "print.key=true",
       "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
-      "--property", "key.deserializer.my-props=abc"
+      "--property", "key.deserializer.my-props=abc",
+      "--property", "value.deserializer=org.apache.kafka.test.MockDeserializer",
     )
     val config = new ConsoleConsumer.ConsumerConfig(args)
     assertTrue(config.formatter.isInstanceOf[DefaultMessageFormatter])
@@ -431,6 +432,34 @@ class ConsoleConsumerTest {
     assertEquals(1, formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].configs.size)
     assertEquals("abc", formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].configs.get("my-props"))
     assertTrue(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isKey)
+
+    assertFalse(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    assertFalse(formatter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    formatter.close()
+    assertTrue(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    assertTrue(formatter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+  }
+
+  @Test
+  def testCloseLoggingMessageFormatter(): Unit = {
+    val args = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--formatter", classOf[LoggingMessageFormatter].getName,
+      "--property", "print.key=true",
+      "--property", "key.deserializer=org.apache.kafka.test.MockDeserializer",
+      "--property", "key.deserializer.my-props=abc",
+      "--property", "value.deserializer=org.apache.kafka.test.MockDeserializer",
+    )
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+    assertTrue(config.formatter.isInstanceOf[LoggingMessageFormatter])
+    val formatter = config.formatter.asInstanceOf[LoggingMessageFormatter]
+
+    assertFalse(formatter.defaultWriter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    assertFalse(formatter.defaultWriter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    formatter.close()
+    assertTrue(formatter.defaultWriter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    assertTrue(formatter.defaultWriter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -433,11 +433,10 @@ class ConsoleConsumerTest {
     assertEquals("abc", formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].configs.get("my-props"))
     assertTrue(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isKey)
 
-    assertFalse(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
-    assertFalse(formatter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    val initialCount = MockDeserializer.closeCount.get()
     formatter.close()
-    assertTrue(formatter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
-    assertTrue(formatter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    // 1 (key deserializer) + 1 (value deserializer)
+    assertEquals(2 + initialCount, MockDeserializer.closeCount.get())
   }
 
   @Test
@@ -455,11 +454,10 @@ class ConsoleConsumerTest {
     assertTrue(config.formatter.isInstanceOf[LoggingMessageFormatter])
     val formatter = config.formatter.asInstanceOf[LoggingMessageFormatter]
 
-    assertFalse(formatter.defaultWriter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
-    assertFalse(formatter.defaultWriter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    val initialCount = MockDeserializer.closeCount.get()
     formatter.close()
-    assertTrue(formatter.defaultWriter.keyDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
-    assertTrue(formatter.defaultWriter.valueDeserializer.get.asInstanceOf[MockDeserializer].isClosed)
+    // 1 (key deserializer) + 1 (value deserializer)
+    assertEquals(2 + initialCount, MockDeserializer.closeCount.get())
   }
 
   @Test


### PR DESCRIPTION
We instantiate, configure and use them but them are never closed.

issue: https://issues.apache.org/jira/browse/KAFKA-10234

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
