### PR TITLE
KAFKA-10222:Incorrect methods show up in 0.10 Kafka Streams docs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -71,7 +71,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *    StreamsConfig config = new StreamsConfig(props);
  *
  *    KStreamBuilder builder = new KStreamBuilder();
- *    builder.from("my-input-topic").mapValue(value -&gt; value.length().toString()).to("my-output-topic");
+ *    builder.stream("my-input-topic").mapValues(value -&gt; value.length().toString()).to("my-output-topic");
  *
  *    KafkaStreams streams = new KafkaStreams(builder, config);
  *    streams.start();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10222

Non-existent methods show up in the doc:
builder.from("my-input-topic").mapValue(value -> value.length().toString()).to("my-output-topic");

There is no method named from or mapValues. They should be stream and mapValues respectively.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
