### PR TITLE
KAFKA-10227: Enforce cleanup policy to only contain compact or delete once

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -271,6 +271,17 @@ object ConfigCommand extends Config {
       println(s"WARNING: The configuration ${LogConfig.MessageFormatVersionProp}=${props.getProperty(LogConfig.MessageFormatVersionProp)} is specified. " +
         s"This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker.")
     }
+    props.forEach((config, value) => {
+      if (value.toString.contains(",")) {
+        val values = value.toString.split(",")
+        if (values.distinct.size != values.size) {
+          println(s"WARNING: The configuration $config=${value.toString} which contains duplicate items is specified. " +
+            "The value with duplicates removed will be applied.")
+          // Remove duplicates from the value
+          props.put(config, values.distinct.mkString(","))
+        }
+      }
+    })
     props
   }
 

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -556,21 +556,19 @@ object TopicCommand extends Logging {
     val props = new Properties
     configsToBeAdded.foreach(pair => props.setProperty(pair(0).trim, pair(1).trim))
     LogConfig.validate(props)
+    LogConfig.processValues(props)
     if (props.containsKey(LogConfig.MessageFormatVersionProp)) {
       println(s"WARNING: The configuration ${LogConfig.MessageFormatVersionProp}=${props.getProperty(LogConfig.MessageFormatVersionProp)} is specified. " +
         s"This configuration will be ignored if the version is newer than the inter.broker.protocol.version specified in the broker.")
     }
-    props.forEach((config, value) => {
-      if (value.toString.contains(",")) {
-        val values = value.toString.split(",")
-        if (values.distinct.size != values.size) {
-          println(s"WARNING: The configuration $config=${value.toString} which contains duplicate items is specified. " +
-            "The value with duplicates removed will be applied.")
-          // Remove duplicates from the value
-          props.put(config, values.distinct.mkString(","))
-        }
-      }
-    })
+    Option(props.getProperty(LogConfig.CleanupPolicyProp)) match {
+      case Some(value) if value.contains(",") =>
+        val originalValue = configsToBeAdded.filter(pair => pair(0) == LogConfig.CleanupPolicyProp).map(_(1)).mkString(",")
+        if (value != originalValue)
+          println(s"WARNING: The configuration ${LogConfig.CleanupPolicyProp}=$originalValue which contains duplicate items is specified. " +
+            "The de-duplicated value will be applied.")
+      case _ => // do nothing
+    }
     props
   }
 

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -344,6 +344,18 @@ object LogConfig {
     validateValues(valueMaps)
   }
 
+  def processValues(props: Properties): Unit = {
+    // de-duplicate items for `cleanup.policy`
+    Option(props.getProperty(CleanupPolicyProp)) match {
+      case Some(value) if value.contains(",") =>
+        val values = value.split(",")
+        if (values.distinct.size != values.size) {
+          props.replace(CleanupPolicyProp, values.distinct.mkString(","))
+        }
+      case _ => // no need to process, do nothing
+    }
+  }
+
   /**
    * Map topic config to the broker config with highest priority. Some of these have additional synonyms
    * that can be obtained using [[kafka.server.DynamicBrokerConfig#brokerConfigSynonyms]]

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -151,6 +151,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
         throw new InvalidReplicaAssignmentException("partitions should be a consecutive 0-based integer sequence")
 
     LogConfig.validate(config)
+    LogConfig.processValues(config)
   }
 
   private def writeTopicPartitionAssignment(topic: String, replicaAssignment: Map[Int, ReplicaAssignment], isUpdate: Boolean): Unit = {
@@ -395,6 +396,7 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
       throw new UnknownTopicOrPartitionException(s"Topic '$topic' does not exist.")
     // remove the topic overrides
     LogConfig.validate(configs)
+    LogConfig.processValues(configs)
   }
 
   /**

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1712,8 +1712,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     // Alter topic configs
     var topic1AlterConfigs = Seq(
       new AlterConfigOp(new ConfigEntry(LogConfig.FlushMsProp, "1000"), AlterConfigOp.OpType.SET),
-      new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp, LogConfig.Delete), AlterConfigOp.OpType.APPEND),
-      new AlterConfigOp(new ConfigEntry(LogConfig.RetentionMsProp, ""), AlterConfigOp.OpType.DELETE)
+      new AlterConfigOp(new ConfigEntry(LogConfig.CleanupPolicyProp,
+        Seq(LogConfig.Delete, LogConfig.Delete, LogConfig.Compact).mkString(",")), AlterConfigOp.OpType.APPEND),
+      new AlterConfigOp(new ConfigEntry(LogConfig.RetentionMsProp, ""), AlterConfigOp.OpType.DELETE),
     ).asJavaCollection
 
     // Test SET and APPEND on previously unset properties
@@ -2296,7 +2297,8 @@ object PlaintextAdminIntegrationTest {
 
     var topicConfigEntries2 = Seq(
       new ConfigEntry(LogConfig.MinCleanableDirtyRatioProp, "0.9"),
-      new ConfigEntry(LogConfig.CompressionTypeProp, "lz4")
+      new ConfigEntry(LogConfig.CompressionTypeProp, "lz4"),
+      new ConfigEntry(LogConfig.CleanupPolicyProp, "delete,compact,compact")
     ).asJava
 
     var alterResult = client.alterConfigs(Map(
@@ -2321,6 +2323,7 @@ object PlaintextAdminIntegrationTest {
 
     assertEquals("0.9", configs.get(topicResource2).get(LogConfig.MinCleanableDirtyRatioProp).value)
     assertEquals("lz4", configs.get(topicResource2).get(LogConfig.CompressionTypeProp).value)
+    assertEquals("delete,compact", configs.get(topicResource2).get(LogConfig.CleanupPolicyProp).value)
 
     // Alter topics with validateOnly=true
     topicConfigEntries1 = Seq(

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -1517,6 +1517,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       zkOpts ++ commonOpts ++ configOpts,
       zkOpts ++ commonOpts ++ fileOpts)) {
       val props = ConfigCommand.parseConfigsToBeAdded(new ConfigCommandOptions(config))
+      ConfigCommand.preProcessTopicConfigs(props)
       assertEquals(2, props.values().size)
       assertEquals("delete,compact", props.get("cleanup.policy"))
     }

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -1501,6 +1501,27 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
         Seq("<default>/clients/client-3", sanitizedPrincipal + "/clients/client-2"))
   }
 
+  @Test
+  def testRemoveDuplicateFromList(): Unit = {
+    val brokerOpts = Array("--bootstrap-server", "localhost:9092")
+    val zkOpts = Array("--zookeeper", "localhost:2181")
+    val commonOpts = Array("--entity-type", "topics", "--entity-name", "test", "--alter")
+    val configOpts = Array("--add-config", "cleanup.policy=[delete,delete,compact],segment.bytes=123456")
+    val addedConfigs = Seq("segment.bytes=123456", "cleanup.policy=delete,delete,compact")
+    val file = TestUtils.tempFile(addedConfigs.mkString("\n"))
+    val fileOpts = Array("--add-config-file", file.getPath)
+
+    for (config <- Array(
+      brokerOpts ++ commonOpts ++ configOpts,
+      brokerOpts ++ commonOpts ++ fileOpts,
+      zkOpts ++ commonOpts ++ configOpts,
+      zkOpts ++ commonOpts ++ fileOpts)) {
+      val props = ConfigCommand.parseConfigsToBeAdded(new ConfigCommandOptions(config))
+      assertEquals(2, props.values().size)
+      assertEquals("delete,compact", props.get("cleanup.policy"))
+    }
+  }
+
   private def registerBrokerInZk(id: Int): Unit = {
     zkClient.createTopLevelPaths()
     val securityProtocol = SecurityProtocol.PLAINTEXT

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -94,6 +94,14 @@ class LogConfigTest {
   }
 
   @Test
+  def testCleanupPolicyDuplicatedItemsRemoved(): Unit = {
+    val props = new Properties
+    props.setProperty(LogConfig.CleanupPolicyProp, "delete,compact,delete,compact")
+    LogConfig.processValues(props)
+    assertEquals("delete,compact", props.getProperty(LogConfig.CleanupPolicyProp))
+  }
+
+  @Test
   def shouldValidateThrottledReplicasConfig(): Unit = {
     assertTrue(isValid("*"))
     assertTrue(isValid("* "))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10227

This patch fixes both TopicCommand and ConfigCommand. When duplicate items are specified in `cleanup.policy`, they will be removed automatically and then applied.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
