### PR TITLE
MINOR; KafkaAdminClient#alterReplicaLogDirs should not fail all the futures when only one call fails

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2255,7 +2255,12 @@ public class KafkaAdminClient extends AdminClient {
                 }
                 @Override
                 void handleFailure(Throwable throwable) {
-                    completeAllExceptionally(futures.values(), throwable);
+                    // Only completes the futures of brokerId
+                    completeAllExceptionally(
+                        futures.entrySet().stream()
+                            .filter(entry -> entry.getKey().brokerId() == brokerId)
+                            .map(Entry::getValue),
+                        throwable);
                 }
             }, now);
         }


### PR DESCRIPTION
I have noticed that `alterReplicaLogDirs` fails all the unrealised futures when one of the call sent out fails (e.g. timeout). So if two calls A and B are sent out, if A fails before B comes back, all the futures are failed even if B is successful. I think that each call should realised their related futures only.

This PR adds a unit test to reproduce the issue and fix it.

It seems that other calls may suffer from the same issue. I will review them and open other PRs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
