### PR TITLE
KAFKA-10221: Backport fix for KAFKA-9603 to 2.5

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -29,7 +29,7 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 
 import java.time.Duration;
 
-class StandbyContextImpl extends AbstractProcessorContext implements RecordCollector.Supplier {
+public class StandbyContextImpl extends AbstractProcessorContext implements RecordCollector.Supplier {
 
     StandbyContextImpl(final TaskId id,
                        final StreamsConfig config,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.processor.AbstractNotifyingBatchingRestoreCallba
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -251,7 +252,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
                 // This handles the case that state store is moved to a new client and does not
                 // have the local RocksDB instance for the segment. In this case, toggleDBForBulkLoading
                 // will only close the database and open it again with bulk loading enabled.
-                if (!bulkLoadSegments.contains(segment)) {
+                if (!bulkLoadSegments.contains(segment) && context instanceof ProcessorContextImpl) {
                     segment.toggleDbForBulkLoading(true);
                     // If the store does not exist yet, the getOrCreateSegmentIfLive will call openDB that
                     // makes the open flag for the newly created store.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -252,7 +252,7 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
                 // This handles the case that state store is moved to a new client and does not
                 // have the local RocksDB instance for the segment. In this case, toggleDBForBulkLoading
                 // will only close the database and open it again with bulk loading enabled.
-                if (!bulkLoadSegments.contains(segment) && context instanceof ProcessorContextImpl) {
+                if (!bulkLoadSegments.contains(segment) && isStoreForActiveTask()) {
                     segment.toggleDbForBulkLoading(true);
                     // If the store does not exist yet, the getOrCreateSegmentIfLive will call openDB that
                     // makes the open flag for the newly created store.
@@ -269,6 +269,10 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
             }
         }
         return writeBatchMap;
+    }
+
+    private boolean isStoreForActiveTask() {
+        return context instanceof ProcessorContextImpl;
     }
 
     private void toggleForBulkLoading(final boolean prepareForBulkload) {


### PR DESCRIPTION
KAFKA-9603 reports that the number of open files keeps increasing
in RocksDB. The reason is that bulk loading is turned on but
never turned off in segmented state stores for standby tasks.

This bug was fixed in 2.6 through PR #8661 by using code that is not present in 2.5.
So cherry-picking was not possible.

This PR backports the fix to 2.5.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
