### PR TITLE
KAFKA-10243; ConcurrentModificationException while processing connection setup timeouts

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -445,7 +445,7 @@ final class ClusterConnectionStates {
      * Return the Set of nodes whose connection setup has timed out.
      * @param now the current time in ms
      */
-    public Set<String> timedOutConnections(long now) {
+    public Set<String> nodesWithConnectionSetupTimeout(long now) {
         Set<String> nodes = new HashSet<>();
         for (String nodeId : connectingNodes) {
             if (isConnectionSetupTimeout(nodeId, now)) {

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients;
 import java.util.HashSet;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.ExponentialBackoff;
 import org.apache.kafka.common.utils.LogContext;
@@ -446,13 +447,9 @@ final class ClusterConnectionStates {
      * @param now the current time in ms
      */
     public Set<String> nodesWithConnectionSetupTimeout(long now) {
-        Set<String> nodes = new HashSet<>();
-        for (String nodeId : connectingNodes) {
-            if (isConnectionSetupTimeout(nodeId, now)) {
-                nodes.add(nodeId);
-            }
-        }
-        return nodes;
+        return connectingNodes.stream()
+            .filter(id -> isConnectionSetupTimeout(id, now))
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -405,7 +405,8 @@ final class ClusterConnectionStates {
     /**
      * Get the id set of nodes which are in CONNECTING state
      */
-    public Set<String> connectingNodes() {
+    // package private for testing only
+    Set<String> connectingNodes() {
         return this.connectingNodes;
     }
 
@@ -438,6 +439,20 @@ final class ClusterConnectionStates {
         if (nodeState.state != ConnectionState.CONNECTING)
             throw new IllegalStateException("Node " + id + " is not in connecting state");
         return now - lastConnectAttemptMs(id) > connectionSetupTimeoutMs(id);
+    }
+
+    /**
+     * Return the Set of nodes whose connection setup has timed out.
+     * @param now the current time in ms
+     */
+    public Set<String> timedOutConnections(long now) {
+        Set<String> nodes = new HashSet<>();
+        for (String nodeId : connectingNodes) {
+            if (isConnectionSetupTimeout(nodeId, now)) {
+                nodes.add(nodeId);
+            }
+        }
+        return nodes;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -818,8 +818,8 @@ public class NetworkClient implements KafkaClient {
      * @param now The current time
      */
     private void handleTimedOutConnections(List<ClientResponse> responses, long now) {
-        Set<String> timedOutConnections = connectionStates.timedOutConnections(now);
-        for (String nodeId : timedOutConnections) {
+        Set<String> nodes = connectionStates.nodesWithConnectionSetupTimeout(now);
+        for (String nodeId : nodes) {
             this.selector.close(nodeId);
             log.debug(
                 "Disconnecting from node {} due to socket connection setup timeout. " +

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -818,17 +818,15 @@ public class NetworkClient implements KafkaClient {
      * @param now The current time
      */
     private void handleTimedOutConnections(List<ClientResponse> responses, long now) {
-        Set<String> connectingNodes = connectionStates.connectingNodes();
-        for (String nodeId : connectingNodes) {
-            if (connectionStates.isConnectionSetupTimeout(nodeId, now)) {
-                this.selector.close(nodeId);
-                log.debug(
-                    "Disconnecting from node {} due to socket connection setup timeout. " +
-                    "The timeout value is {} ms.",
-                    nodeId,
-                    connectionStates.connectionSetupTimeoutMs(nodeId));
-                processDisconnection(responses, nodeId, now, ChannelState.LOCAL_CLOSE);
-            }
+        Set<String> timedOutConnections = connectionStates.timedOutConnections(now);
+        for (String nodeId : timedOutConnections) {
+            this.selector.close(nodeId);
+            log.debug(
+                "Disconnecting from node {} due to socket connection setup timeout. " +
+                "The timeout value is {} ms.",
+                nodeId,
+                connectionStates.connectionSetupTimeoutMs(nodeId));
+            processDisconnection(responses, nodeId, now, ChannelState.LOCAL_CLOSE);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -375,7 +375,7 @@ public class ClusterConnectionStatesTest {
         connectionStates.connecting(nodeId2, time.milliseconds(), "localhost", ClientDnsLookup.DEFAULT);
 
         // Expect no timed out connections
-        assertTrue(connectionStates.timedOutConnections(time.milliseconds()).isEmpty());
+        assertTrue(connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds()).isEmpty());
 
         // Advance time by half of the connection setup timeout
         time.sleep(connectionSetupTimeoutMs / 2);
@@ -387,7 +387,7 @@ public class ClusterConnectionStatesTest {
         time.sleep((long) (connectionSetupTimeoutMs / 2 + connectionSetupTimeoutMs * connectionSetupTimeoutJitter));
 
         // Expect two timed out connections.
-        Set<String> timedOutConnections = connectionStates.timedOutConnections(time.milliseconds());
+        Set<String> timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
         assertEquals(2, timedOutConnections.size());
         assertTrue(timedOutConnections.contains(nodeId1));
         assertTrue(timedOutConnections.contains(nodeId2));
@@ -400,7 +400,7 @@ public class ClusterConnectionStatesTest {
         time.sleep((long) (connectionSetupTimeoutMs / 2 + connectionSetupTimeoutMs * connectionSetupTimeoutJitter));
 
         // Expect two timed out connections.
-        timedOutConnections = connectionStates.timedOutConnections(time.milliseconds());
+        timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
         assertEquals(1, timedOutConnections.size());
         assertTrue(timedOutConnections.contains(nodeId3));
 
@@ -408,7 +408,7 @@ public class ClusterConnectionStatesTest {
         connectionStates.disconnected(nodeId3, time.milliseconds());
 
         // Expect no timed out connections
-        timedOutConnections = connectionStates.timedOutConnections(time.milliseconds());
+        timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
         assertEquals(0, timedOutConnections.size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -375,12 +375,12 @@ public class ClusterConnectionStatesTest {
         connectionStates.connecting(nodeId2, time.milliseconds(), "localhost", ClientDnsLookup.DEFAULT);
 
         // Expect no timed out connections
-        assertTrue(connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds()).isEmpty());
+        assertEquals(0, connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds()).size());
 
         // Advance time by half of the connection setup timeout
         time.sleep(connectionSetupTimeoutMs / 2);
 
-        // Initiate a third connections
+        // Initiate a third connection
         connectionStates.connecting(nodeId3, time.milliseconds(), "localhost", ClientDnsLookup.DEFAULT);
 
         // Advance time beyond the connection setup timeout (+ max jitter) for the first two connections
@@ -396,10 +396,10 @@ public class ClusterConnectionStatesTest {
         connectionStates.disconnected(nodeId1, time.milliseconds());
         connectionStates.disconnected(nodeId2, time.milliseconds());
 
-        // Advance time beyond the connection setup timeout (+ max jitter) for for the third connections
+        // Advance time beyond the connection setup timeout (+ max jitter) for the third connections
         time.sleep((long) (connectionSetupTimeoutMs / 2 + connectionSetupTimeoutMs * connectionSetupTimeoutJitter));
 
-        // Expect two timed out connections.
+        // Expect one timed out connection
         timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
         assertEquals(1, timedOutConnections.size());
         assertTrue(timedOutConnections.contains(nodeId3));
@@ -408,7 +408,6 @@ public class ClusterConnectionStatesTest {
         connectionStates.disconnected(nodeId3, time.milliseconds());
 
         // Expect no timed out connections
-        timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
-        assertEquals(0, timedOutConnections.size());
+        assertEquals(0, connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds()).size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import java.util.Set;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -48,6 +49,7 @@ public class ClusterConnectionStatesTest {
     private final double connectionSetupTimeoutJitter = ClusterConnectionStates.CONNECTION_SETUP_TIMEOUT_JITTER;
     private final String nodeId1 = "1001";
     private final String nodeId2 = "2002";
+    private final String nodeId3 = "3003";
     private final String hostTwoIps = "kafka.apache.org";
 
     private ClusterConnectionStates connectionStates;
@@ -364,5 +366,49 @@ public class ClusterConnectionStatesTest {
                 connectionStates.connectionSetupTimeoutMs(nodeId1),
                 connectionSetupTimeoutMs * connectionSetupTimeoutJitter);
         assertTrue(connectionStates.connectingNodes().contains(nodeId1));
+    }
+
+    @Test
+    public void testTimedOutConnections() {
+        // Initiate two connections
+        connectionStates.connecting(nodeId1, time.milliseconds(), "localhost", ClientDnsLookup.DEFAULT);
+        connectionStates.connecting(nodeId2, time.milliseconds(), "localhost", ClientDnsLookup.DEFAULT);
+
+        // Expect no timed out connections
+        assertTrue(connectionStates.timedOutConnections(time.milliseconds()).isEmpty());
+
+        // Advance time by half of the connection setup timeout
+        time.sleep(connectionSetupTimeoutMs / 2);
+
+        // Initiate a third connections
+        connectionStates.connecting(nodeId3, time.milliseconds(), "localhost", ClientDnsLookup.DEFAULT);
+
+        // Advance time beyond the connection setup timeout (+ max jitter) for the first two connections
+        time.sleep((long) (connectionSetupTimeoutMs / 2 + connectionSetupTimeoutMs * connectionSetupTimeoutJitter));
+
+        // Expect two timed out connections.
+        Set<String> timedOutConnections = connectionStates.timedOutConnections(time.milliseconds());
+        assertEquals(2, timedOutConnections.size());
+        assertTrue(timedOutConnections.contains(nodeId1));
+        assertTrue(timedOutConnections.contains(nodeId2));
+
+        // Disconnect the first two connections
+        connectionStates.disconnected(nodeId1, time.milliseconds());
+        connectionStates.disconnected(nodeId2, time.milliseconds());
+
+        // Advance time beyond the connection setup timeout (+ max jitter) for for the third connections
+        time.sleep((long) (connectionSetupTimeoutMs / 2 + connectionSetupTimeoutMs * connectionSetupTimeoutJitter));
+
+        // Expect two timed out connections.
+        timedOutConnections = connectionStates.timedOutConnections(time.milliseconds());
+        assertEquals(1, timedOutConnections.size());
+        assertTrue(timedOutConnections.contains(nodeId3));
+
+        // Disconnect the third connection
+        connectionStates.disconnected(nodeId3, time.milliseconds());
+
+        // Expect no timed out connections
+        timedOutConnections = connectionStates.timedOutConnections(time.milliseconds());
+        assertEquals(0, timedOutConnections.size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -469,19 +469,28 @@ public class NetworkClientTest {
 
     @Test
     public void testConnectionSetupTimeout() {
-        client.ready(node, time.milliseconds());
-        selector.serverConnectionBlocked(node.idString());
+        // Use two nodes to ensure that the logic iterate over a set of more than one
+        // element. ConcurrentModificationException is not triggered otherwise.
+        final Cluster cluster = TestUtils.clusterWith(2);
+        final Node node0 = cluster.nodeById(0);
+        final Node node1 = cluster.nodeById(1);
+
+        client.ready(node0, time.milliseconds());
+        selector.serverConnectionBlocked(node0.idString());
+
+        client.ready(node1, time.milliseconds());
+        selector.serverConnectionBlocked(node1.idString());
 
         client.poll(0, time.milliseconds());
         assertFalse(
-                "The connection should not fail before the socket connection setup timeout elapsed",
+                "The connections should not fail before the socket connection setup timeout elapsed",
                 client.connectionFailed(node)
         );
 
         time.sleep((long) (connectionSetupTimeoutMsTest * 1.2) + 1);
         client.poll(0, time.milliseconds());
         assertTrue(
-                "Expected the connection to fail due to the socket connection setup timeout",
+                "Expected the connections to fail due to the socket connection setup timeout",
                 client.connectionFailed(node)
         );
     }


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/apache/kafka/pull/8683/.

While processing connection set up timeouts, we are iterating through the connecting nodes to process timeouts and we disconnect within the loop, removing the entry from the set in the loop that it iterating over the set. That raises an `ConcurrentModificationException` exception. The current unit test did not catch this because it was using only one node.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
