### PR TITLE
KAFKA-10249: don't try to read un-checkpointed offsets of in-memory stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -222,6 +222,11 @@ public class ProcessorStateManager implements StateManager {
             log.trace("Loaded offsets from the checkpoint file: {}", loadedCheckpoints);
 
             for (final StateStoreMetadata store : stores.values()) {
+                if (store.corrupted) {
+                    log.error("Tried to initialize store offsets for corrupted store {}", store);
+                    throw new IllegalStateException("Should not initialize offsets for a corrupted task");
+                }
+
                 if (store.changelogPartition == null) {
                     log.info("State store {} is not logged and hence would not be restored", store.stateStore.name());
                 } else if (!store.stateStore.persistent()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -224,6 +224,8 @@ public class ProcessorStateManager implements StateManager {
             for (final StateStoreMetadata store : stores.values()) {
                 if (store.changelogPartition == null) {
                     log.info("State store {} is not logged and hence would not be restored", store.stateStore.name());
+                } else if (!store.stateStore.persistent()) {
+                    log.debug("Skipping initialization of offset from checkpoint for in-memory state store {}", store.stateStore.name());
                 } else if (store.offset() == null) {
                     if (loadedCheckpoints.containsKey(store.changelogPartition)) {
                         final Long offset = changelogOffsetFromCheckpointedOffset(loadedCheckpoints.remove(store.changelogPartition));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -225,7 +225,8 @@ public class ProcessorStateManager implements StateManager {
                 if (store.changelogPartition == null) {
                     log.info("State store {} is not logged and hence would not be restored", store.stateStore.name());
                 } else if (!store.stateStore.persistent()) {
-                    log.debug("Skipping initialization of offset from checkpoint for in-memory state store {}", store.stateStore.name());
+                    log.info("Initializing to the starting offset for changelog {} of in-memory state store {}",
+                             store.changelogPartition, store.stateStore.name());
                 } else if (store.offset() == null) {
                     if (loadedCheckpoints.containsKey(store.changelogPartition)) {
                         final Long offset = changelogOffsetFromCheckpointedOffset(loadedCheckpoints.remove(store.changelogPartition));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -107,14 +107,17 @@ final class StateManagerUtil {
                 } catch (final ProcessorStateException e) {
                     firstException.compareAndSet(null, e);
                 } finally {
-                    if (wipeStateStore) {
-                        log.debug("Wiping state stores for {} task {}", taskType, id);
-                        // we can just delete the whole dir of the task, including the state store images and the checkpoint files,
-                        // and then we write an empty checkpoint file indicating that the previous close is graceful and we just
-                        // need to re-bootstrap the restoration from the beginning
-                        Utils.delete(stateMgr.baseDir());
+                    try {
+                        if (wipeStateStore) {
+                            log.debug("Wiping state stores for {} task {}", taskType, id);
+                            // we can just delete the whole dir of the task, including the state store images and the checkpoint files,
+                            // and then we write an empty checkpoint file indicating that the previous close is graceful and we just
+                            // need to re-bootstrap the restoration from the beginning
+                            Utils.delete(stateMgr.baseDir());
+                        }
+                    } finally {
+                        stateDirectory.unlock(id);
                     }
-                    stateDirectory.unlock(id);
                 }
             }
         } catch (final IOException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -104,7 +104,9 @@ final class StateManagerUtil {
             if (stateDirectory.lock(id)) {
                 try {
                     stateMgr.close();
-
+                } catch (final ProcessorStateException e) {
+                    firstException.compareAndSet(null, e);
+                } finally {
                     if (wipeStateStore) {
                         log.debug("Wiping state stores for {} task {}", taskType, id);
                         // we can just delete the whole dir of the task, including the state store images and the checkpoint files,
@@ -112,9 +114,6 @@ final class StateManagerUtil {
                         // need to re-bootstrap the restoration from the beginning
                         Utils.delete(stateMgr.baseDir());
                     }
-                } catch (final ProcessorStateException e) {
-                    firstException.compareAndSet(null, e);
-                } finally {
                     stateDirectory.unlock(id);
                 }
             }
@@ -123,7 +122,6 @@ final class StateManagerUtil {
                 String.format("%sFatal error while trying to close the state manager for task %s", logPrefix, id), e
             );
             firstException.compareAndSet(null, exception);
-
         }
 
         final ProcessorStateException exception = firstException.get();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -410,14 +410,14 @@ public class ProcessorStateManagerTest {
             assertEquals(mkMap(
                 mkEntry(persistentStorePartition, checkpointOffset + 1L),
                 mkEntry(persistentStoreTwoPartition, 0L),
-                mkEntry(nonPersistentStorePartition, checkpointOffset + 1L)),
+                mkEntry(nonPersistentStorePartition, 0L)),
                 stateMgr.changelogOffsets()
             );
 
             assertNull(stateMgr.storeMetadata(irrelevantPartition));
             assertNull(stateMgr.storeMetadata(persistentStoreTwoPartition).offset());
             assertThat(stateMgr.storeMetadata(persistentStorePartition).offset(), equalTo(checkpointOffset));
-            assertThat(stateMgr.storeMetadata(nonPersistentStorePartition).offset(), equalTo(checkpointOffset));
+            assertNull(stateMgr.storeMetadata(nonPersistentStorePartition).offset());
         } finally {
             stateMgr.close();
         }
@@ -533,7 +533,7 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
-    public void shouldNotWriteCheckpointForNonPersistent() throws IOException {
+    public void shouldNotWriteCheckpointForNonPersistentStore() throws IOException {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
 
         try {
@@ -784,7 +784,7 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
-    public void shouldThrowTaskCorruptedWithoutCheckpointNonEmptyDir() throws IOException {
+    public void shouldThrowTaskCorruptedWithoutPersistentStoreCheckpointAndNonEmptyDir() throws IOException {
         final long checkpointOffset = 10L;
 
         final Map<TopicPartition, Long> offsets = mkMap(
@@ -808,6 +808,62 @@ public class ProcessorStateManagerTest {
                 Collections.singletonMap(taskId, stateMgr.changelogPartitions()),
                 exception.corruptedTaskWithChangelogs()
             );
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowTaskCorruptedWithWithoutInMemoryStoreCheckpointAndNonEmptyDir() throws IOException {
+        final long checkpointOffset = 10L;
+
+        final Map<TopicPartition, Long> offsets = mkMap(
+            mkEntry(persistentStorePartition, checkpointOffset),
+            mkEntry(irrelevantPartition, 999L)
+        );
+        checkpoint.write(offsets);
+
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE, true);
+
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback);
+            stateMgr.registerStore(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
+
+            stateMgr.initializeStoreOffsetsFromCheckpoint(false);
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowTaskCorruptedExceptionAfterCheckpointing() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE, true);
+
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback);
+            stateMgr.registerStore(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
+            stateMgr.initializeStoreOffsetsFromCheckpoint(true);
+
+            assertThat(stateMgr.storeMetadata(nonPersistentStorePartition), notNullValue());
+            assertThat(stateMgr.storeMetadata(persistentStorePartition), notNullValue());
+
+            stateMgr.checkpoint(mkMap(
+                mkEntry(nonPersistentStorePartition, 876L),
+                mkEntry(persistentStorePartition, 666L))
+            );
+
+            // reset the state and offsets, for example as in a corrupted task
+            stateMgr.close();
+            assertNull(stateMgr.storeMetadata(nonPersistentStorePartition));
+            assertNull(stateMgr.storeMetadata(persistentStorePartition));
+
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback);
+            stateMgr.registerStore(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
+
+            // This should not throw a TaskCorruptedException!
+            stateMgr.initializeStoreOffsetsFromCheckpoint(false);
+            assertThat(stateMgr.storeMetadata(nonPersistentStorePartition), notNullValue());
+            assertThat(stateMgr.storeMetadata(persistentStorePartition), notNullValue());
         } finally {
             stateMgr.close();
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -870,6 +870,21 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
+    public void shouldThrowIllegalStateIfInitializingOffsetsForCorruptedTasks() {
+        final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE, true);
+
+        try {
+            stateMgr.registerStore(persistentStore, persistentStore.stateRestoreCallback);
+            stateMgr.markChangelogAsCorrupted(mkSet(persistentStorePartition));
+
+            final ProcessorStateException thrown = assertThrows(ProcessorStateException.class, () -> stateMgr.initializeStoreOffsetsFromCheckpoint(true));
+            assertTrue(thrown.getCause() instanceof IllegalStateException);
+        } finally {
+            stateMgr.close();
+        }
+    }
+
+    @Test
     public void shouldBeAbleToCloseWithoutRegisteringAnyStores() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE, true);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -814,7 +814,7 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
-    public void shouldNotThrowTaskCorruptedWithWithoutInMemoryStoreCheckpointAndNonEmptyDir() throws IOException {
+    public void shouldNotThrowTaskCorruptedWithoutInMemoryStoreCheckpointAndNonEmptyDir() throws IOException {
         final long checkpointOffset = 10L;
 
         final Map<TopicPartition, Long> offsets = mkMap(


### PR DESCRIPTION
We have this asymmetry in how the ProcessorStateManager handles in-memory stores: we explicitly skip over them when writing offsets to the checkpoint file, but don't do the same when reading from the checkpoint file to initialize offsets. With eos, this is taken to mean that the state is dirty, and thus we mistakenly mark the entire task as corrupted.