### PR TITLE
MINOR; Return timed out connections as a List instead of a Set

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -443,13 +443,13 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Return the Set of nodes whose connection setup has timed out.
+     * Return the List of nodes whose connection setup has timed out.
      * @param now the current time in ms
      */
-    public Set<String> nodesWithConnectionSetupTimeout(long now) {
+    public List<String> nodesWithConnectionSetupTimeout(long now) {
         return connectingNodes.stream()
             .filter(id -> isConnectionSetupTimeout(id, now))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -62,7 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -818,7 +817,7 @@ public class NetworkClient implements KafkaClient {
      * @param now The current time
      */
     private void handleTimedOutConnections(List<ClientResponse> responses, long now) {
-        Set<String> nodes = connectionStates.nodesWithConnectionSetupTimeout(now);
+        List<String> nodes = connectionStates.nodesWithConnectionSetupTimeout(now);
         for (String nodeId : nodes) {
             this.selector.close(nodeId);
             log.debug(

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -29,7 +29,7 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import java.util.Set;
+import java.util.List;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -386,7 +386,7 @@ public class ClusterConnectionStatesTest {
         time.sleep((long) (connectionSetupTimeoutMs / 2 + connectionSetupTimeoutMs * connectionSetupTimeoutJitter));
 
         // Expect two timed out connections.
-        Set<String> timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
+        List<String> timedOutConnections = connectionStates.nodesWithConnectionSetupTimeout(time.milliseconds());
         assertEquals(2, timedOutConnections.size());
         assertTrue(timedOutConnections.contains(nodeId1));
         assertTrue(timedOutConnections.contains(nodeId2));


### PR DESCRIPTION
As pointed out by @ijuma in https://github.com/apache/kafka/pull/8990#discussion_r451059876, using a `Set` is not necessary as the caller only cares about having the list of timed out connections/nodes. It does nothing else but iterating over the list.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
