### PR TITLE
MINOR: Add ApiMessageTypeGenerator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1044,7 +1044,8 @@ project(':clients') {
     classpath = project(':generator').sourceSets.main.runtimeClasspath
     args = [ "org.apache.kafka.common.message",
              "src/generated/java/org/apache/kafka/common/message",
-             "src/main/resources/common/message" ]
+             "src/main/resources/common/message",
+             "ApiMessageTypeGenerator" ]
     inputs.dir("src/main/resources/common/message")
     outputs.dir("src/generated/java/org/apache/kafka/common/message")
   }
@@ -1054,7 +1055,8 @@ project(':clients') {
     classpath = project(':generator').sourceSets.main.runtimeClasspath
     args = [ "org.apache.kafka.common.message",
              "src/generated-test/java/org/apache/kafka/common/message",
-             "src/test/resources/common/message" ]
+             "src/test/resources/common/message",
+             "none" ]
     inputs.dir("src/test/resources/common/message")
     outputs.dir("src/generated-test/java/org/apache/kafka/common/message")
   }
@@ -1189,7 +1191,8 @@ project(':streams') {
     classpath = project(':generator').sourceSets.main.runtimeClasspath
     args = [ "org.apache.kafka.streams.internals.generated",
              "src/generated/java/org/apache/kafka/streams/internals/generated",
-             "src/main/resources/common/message" ]
+             "src/main/resources/common/message",
+             "none" ]
     inputs.dir("src/main/resources/common/message")
     outputs.dir("src/generated/java/org/apache/kafka/streams/internals/generated")
   }

--- a/generator/src/main/java/org/apache/kafka/message/ApiMessageTypeGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/ApiMessageTypeGenerator.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
-public final class ApiMessageTypeGenerator {
+public final class ApiMessageTypeGenerator implements TypeClassGenerator {
     private final HeaderGenerator headerGenerator;
     private final CodeBuffer buffer;
     private final TreeMap<Short, ApiData> apis;
@@ -73,10 +73,12 @@ public final class ApiMessageTypeGenerator {
         this.buffer = new CodeBuffer();
     }
 
-    public boolean hasRegisteredTypes() {
-        return !apis.isEmpty();
+    @Override
+    public String outputName() {
+        return MessageGenerator.API_MESSAGE_TYPE_JAVA;
     }
 
+    @Override
     public void registerMessageType(MessageSpec spec) {
         switch (spec.type()) {
             case REQUEST: {
@@ -113,7 +115,13 @@ public final class ApiMessageTypeGenerator {
         }
     }
 
-    public void generate() {
+    @Override
+    public void generateAndWrite(BufferedWriter writer) throws IOException {
+        generate();
+        write(writer);
+    }
+
+    private void generate() {
         buffer.printf("public enum ApiMessageType {%n");
         buffer.incrementIndent();
         generateEnumValues();
@@ -319,7 +327,7 @@ public final class ApiMessageTypeGenerator {
         buffer.printf("}%n");
     }
 
-    public void write(BufferedWriter writer) throws IOException {
+    private void write(BufferedWriter writer) throws IOException {
         headerGenerator.buffer().write(writer);
         buffer.write(writer);
     }

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -149,10 +149,26 @@ public final class MessageGenerator {
         JSON_SERDE.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 
-    public static void processDirectories(String packageName, String outputDir, String inputDir) throws Exception {
+    private static TypeClassGenerator createTypeClassGenerator(String packageName,
+                                                               String type) {
+        switch (type) {
+            case "none":
+                return null;
+            case "ApiMessageTypeGenerator":
+                return new ApiMessageTypeGenerator(packageName);
+            default:
+                throw new RuntimeException("Unknown type class generator type '" + type + "'");
+        }
+    }
+
+    public static void processDirectories(String packageName,
+                                          String outputDir,
+                                          String inputDir,
+                                          String typeClassGeneratorType) throws Exception {
         Files.createDirectories(Paths.get(outputDir));
         int numProcessed = 0;
-        ApiMessageTypeGenerator messageTypeGenerator = new ApiMessageTypeGenerator(packageName);
+        TypeClassGenerator typeClassGenerator =
+            createTypeClassGenerator(packageName, typeClassGeneratorType);
         HashSet<String> outputFileNames = new HashSet<>();
         try (DirectoryStream<Path> directoryStream = Files
                 .newDirectoryStream(Paths.get(inputDir), JSON_GLOB)) {
@@ -169,20 +185,20 @@ public final class MessageGenerator {
                         generator.write(writer);
                     }
                     numProcessed++;
-                    messageTypeGenerator.registerMessageType(spec);
+                    if (typeClassGenerator != null) {
+                        typeClassGenerator.registerMessageType(spec);
+                    }
                 } catch (Exception e) {
                     throw new RuntimeException("Exception while processing " + inputPath.toString(), e);
                 }
             }
         }
-        if (messageTypeGenerator.hasRegisteredTypes()) {
-            Path factoryOutputPath = Paths.get(outputDir, API_MESSAGE_TYPE_JAVA);
-            outputFileNames.add(API_MESSAGE_TYPE_JAVA);
+        if (typeClassGenerator != null) {
+            outputFileNames.add(typeClassGenerator.outputName());
+            Path factoryOutputPath = Paths.get(outputDir, typeClassGenerator.outputName());
             try (BufferedWriter writer = Files.newBufferedWriter(factoryOutputPath)) {
-                messageTypeGenerator.generate();
-                messageTypeGenerator.write(writer);
+                typeClassGenerator.generateAndWrite(writer);
             }
-            numProcessed++;
         }
         try (DirectoryStream<Path> directoryStream = Files.
                 newDirectoryStream(Paths.get(outputDir))) {
@@ -267,10 +283,10 @@ public final class MessageGenerator {
         if (args.length == 0) {
             System.out.println(USAGE);
             System.exit(0);
-        } else if (args.length != 3) {
+        } else if (args.length != 4) {
             System.out.println(USAGE);
             System.exit(1);
         }
-        processDirectories(args[0], args[1], args[2]);
+        processDirectories(args[0], args[1], args[2], args[3]);
     }
 }

--- a/generator/src/main/java/org/apache/kafka/message/TypeClassGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/TypeClassGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+public interface TypeClassGenerator {
+    /**
+     * The short name of the type class file we are generating. For example,
+     * ApiMessageType.java.
+     */
+    String outputName();
+
+    /**
+     * Registers a message spec with the generator.
+     *
+     * @param spec      The spec to register.
+     */
+    void registerMessageType(MessageSpec spec);
+
+    /**
+     * Write out the internal state.
+     *
+     * @param writer    The writer to write out the state to.
+     */
+    void generateAndWrite(BufferedWriter writer) throws IOException;
+}

--- a/generator/src/main/java/org/apache/kafka/message/TypeClassGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/TypeClassGenerator.java
@@ -35,7 +35,7 @@ public interface TypeClassGenerator {
     void registerMessageType(MessageSpec spec);
 
     /**
-     * Write out the internal state.
+     * Generate the type, and then write it out.
      *
      * @param writer    The writer to write out the state to.
      */


### PR DESCRIPTION
Previously, we had some code hard-coded to generate message type classes
for RPCs.  We might want to generate message type classes for other
things as well, so make it more generic.