### PR TITLE
KAFKA-10240: Stop throwing WakeupExceptions during sink task shutdown

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -196,6 +196,9 @@ class WorkerSinkTask extends WorkerTask {
         try (UncheckedCloseable suppressible = this::closePartitions) {
             while (!isStopping())
                 iteration();
+        } catch (WakeupException e) {
+            log.trace("Consumer woken up during initial offset commit attempt, " 
+                + "but succeeded during a later attempt");
         }
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-10240)

A benign `WakeupException` can be thrown by a sink task's consumer if the task is scheduled for shutdown by the worker. This is caught and handled gracefully if the exception is thrown when calling `poll` on the consumer, but not if calling `commitSync`, which is invoked by a task during shutdown and also when its partition assignment is updated.

If thrown during a partition assignment update, the `WakeupException` is caught and handled gracefully as part of the task's `iteration` loop. If thrown during shutdown, however, it is not caught and instead leads to the scary-looking log message "Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted.".

These changes catch the `WakeupException` during shutdown and handle it gracefully with a `TRACE`-level log message.

A unit test is added to verify this behavior by simulating a thrown `WakeupException` during `Consumer::commitSync`, running through the `WorkerSinkTask::execute` method, and confirming that it does not throw a `WakeupException` itself.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
