### PR TITLE
KAFKA-3370 nearest offset reset

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -127,6 +127,13 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String AUTO_OFFSET_RESET_DOC = "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): <ul><li>earliest: automatically reset the offset to the earliest offset<li>latest: automatically reset the offset to the latest offset</li><li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li><li>anything else: throw exception to the consumer.</li></ul>";
 
     /**
+     * <code>nearest.offset.reset</code>
+     */
+    public static final String NEAREST_OFFSET_RESET = "nearest.offset.reset";
+    private static final String NEAREST_OFFSET_RESET_DOC = "If true, then out of range errors will reset the consumer's offset to the nearest offset. to the earliest end of the broker range if it was under the range, or to the latest end of the broker range if it was over the range";
+    public static final boolean DEFAULT_NEAREST_OFFSET_RESET = false;
+
+    /**
      * <code>fetch.min.bytes</code>
      */
     public static final String FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
@@ -435,6 +442,11 @@ public class ConsumerConfig extends AbstractConfig {
                                         in("latest", "earliest", "none"),
                                         Importance.MEDIUM,
                                         AUTO_OFFSET_RESET_DOC)
+                                .define(NEAREST_OFFSET_RESET,
+                                        Type.BOOLEAN,
+                                        DEFAULT_NEAREST_OFFSET_RESET,
+                                        Importance.MEDIUM,
+                                        NEAREST_OFFSET_RESET_DOC)
                                 .define(CHECK_CRCS_CONFIG,
                                         Type.BOOLEAN,
                                         true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -802,6 +802,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.retryBackoffMs,
                     this.requestTimeoutMs,
                     isolationLevel,
+                    config.getBoolean(ConsumerConfig.NEAREST_OFFSET_RESET),
                     apiVersions);
 
             this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, metricGrpPrefix);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
@@ -17,5 +17,5 @@
 package org.apache.kafka.clients.consumer;
 
 public enum OffsetResetStrategy {
-    LATEST, EARLIEST, NONE
+    LATEST, EARLIEST, NEAREST, NONE
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -128,6 +128,7 @@ import static java.util.Collections.emptyList;
  * </ul>
  */
 public class Fetcher<K, V> implements Closeable {
+    private static final long NEAREST_TIMESTAMP = -3L;
     private final Logger log;
     private final LogContext logContext;
     private final ConsumerNetworkClient client;
@@ -157,6 +158,7 @@ public class Fetcher<K, V> implements Closeable {
     private final ApiVersions apiVersions;
 
     private CompletedFetch nextInLineFetch = null;
+    private final boolean useNearestOffsetReset;
 
     public Fetcher(LogContext logContext,
                    ConsumerNetworkClient client,
@@ -177,6 +179,54 @@ public class Fetcher<K, V> implements Closeable {
                    long retryBackoffMs,
                    long requestTimeoutMs,
                    IsolationLevel isolationLevel,
+                   ApiVersions apiVersions) {
+        this(logContext,
+                client,
+                minBytes,
+                maxBytes,
+                maxWaitMs,
+                fetchSize,
+                maxPollRecords,
+                checkCrcs,
+                clientRackId,
+                keyDeserializer,
+                valueDeserializer,
+                metadata,
+                subscriptions,
+                metrics,
+                metricsRegistry,
+                time,
+                retryBackoffMs,
+                requestTimeoutMs,
+                isolationLevel,
+                /* Disable nearest offset for code path that use this constructor. The nearest offset reset is meant to be used only in client consumer.
+                We don't want to risk using nearest reset with other internal module of kafka eg. follower broker replication.
+                This also make the nearest reset feature not effect the old test case.
+                */
+                true,
+                apiVersions);
+    }
+
+    public Fetcher(LogContext logContext,
+                   ConsumerNetworkClient client,
+                   int minBytes,
+                   int maxBytes,
+                   int maxWaitMs,
+                   int fetchSize,
+                   int maxPollRecords,
+                   boolean checkCrcs,
+                   String clientRackId,
+                   Deserializer<K> keyDeserializer,
+                   Deserializer<V> valueDeserializer,
+                   ConsumerMetadata metadata,
+                   SubscriptionState subscriptions,
+                   Metrics metrics,
+                   FetcherMetricsRegistry metricsRegistry,
+                   Time time,
+                   long retryBackoffMs,
+                   long requestTimeoutMs,
+                   IsolationLevel isolationLevel,
+                   boolean useNearestOffsetReset,
                    ApiVersions apiVersions) {
         this.log = logContext.logger(Fetcher.class);
         this.logContext = logContext;
@@ -202,6 +252,7 @@ public class Fetcher<K, V> implements Closeable {
         this.sessionHandlers = new HashMap<>();
         this.offsetsForLeaderEpochClient = new OffsetsForLeaderEpochClient(client, logContext);
         this.nodesWithPendingFetchRequests = new HashSet<>();
+        this.useNearestOffsetReset = useNearestOffsetReset;
     }
 
     /**
@@ -438,6 +489,8 @@ public class Fetcher<K, V> implements Closeable {
             return ListOffsetRequest.EARLIEST_TIMESTAMP;
         else if (strategy == OffsetResetStrategy.LATEST)
             return ListOffsetRequest.LATEST_TIMESTAMP;
+        else if (strategy == OffsetResetStrategy.NEAREST)
+            return NEAREST_TIMESTAMP;
         else
             return null;
     }
@@ -727,6 +780,20 @@ public class Fetcher<K, V> implements Closeable {
         subscriptions.maybeSeekUnvalidated(partition, position.offset, requestedResetStrategy);
     }
 
+    private Map<TopicPartition, ListOffsetRequest.PartitionData> formatToValidResetTimestamp(Map<TopicPartition, ListOffsetRequest.PartitionData> original) {
+        Map<TopicPartition, ListOffsetRequest.PartitionData> newFormat = new HashMap<>();
+        original.forEach((tp, pd) -> {
+            // since NEAREST_TIMESTAMP is not implemented on the broker,
+            // we'll try get earliest timestamp first
+            if (pd.timestamp == NEAREST_TIMESTAMP) {
+                newFormat.put(tp, new ListOffsetRequest.PartitionData(ListOffsetRequest.EARLIEST_TIMESTAMP, pd.currentLeaderEpoch));
+            } else {
+                newFormat.put(tp, pd);
+            }
+        });
+        return newFormat;
+    }
+
     private void resetOffsetsAsync(Map<TopicPartition, Long> partitionResetTimestamps) {
         Map<Node, Map<TopicPartition, ListOffsetRequest.PartitionData>> timestampsToSearchByNode =
                 groupListOffsetRequests(partitionResetTimestamps, new HashSet<>());
@@ -735,7 +802,8 @@ public class Fetcher<K, V> implements Closeable {
             final Map<TopicPartition, ListOffsetRequest.PartitionData> resetTimestamps = entry.getValue();
             subscriptions.setNextAllowedRetry(resetTimestamps.keySet(), time.milliseconds() + requestTimeoutMs);
 
-            RequestFuture<ListOffsetResult> future = sendListOffsetRequest(node, resetTimestamps, false);
+            Map<TopicPartition, ListOffsetRequest.PartitionData> validResetTimestamps = formatToValidResetTimestamp(resetTimestamps);
+            RequestFuture<ListOffsetResult> future = sendListOffsetRequest(node, validResetTimestamps, false);
             future.addListener(new RequestFutureListener<ListOffsetResult>() {
                 @Override
                 public void onSuccess(ListOffsetResult result) {
@@ -744,11 +812,25 @@ public class Fetcher<K, V> implements Closeable {
                         metadata.requestUpdate();
                     }
 
+                    Map<TopicPartition, Long> needNewReset = new HashMap<>();
                     for (Map.Entry<TopicPartition, ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
                         TopicPartition partition = fetchedOffset.getKey();
                         ListOffsetData offsetData = fetchedOffset.getValue();
-                        ListOffsetRequest.PartitionData requestedReset = resetTimestamps.get(partition);
+                        ListOffsetRequest.PartitionData timestamp = resetTimestamps.get(partition);
+                        if (timestamp != null && timestamp.timestamp == NEAREST_TIMESTAMP) {
+                            // outOffRangeOffset is higher than earliest offset in kafka,
+                            // meaning that the outOffRangeOffset is also higher than logsize
+                            // so we will send a request again to reset to latest
+                            if (subscriptions.outOffRangeOffset(partition) > offsetData.offset) {
+                                needNewReset.put(partition, ListOffsetRequest.LATEST_TIMESTAMP);
+                                continue;
+                            }
+                        }
+                        ListOffsetRequest.PartitionData requestedReset = validResetTimestamps.get(partition);
                         resetOffsetIfNeeded(partition, timestampToOffsetResetStrategy(requestedReset.timestamp), offsetData);
+                    }
+                    if (needNewReset.size() > 0) {
+                        resetOffsetsAsync(needNewReset);
                     }
                 }
 
@@ -1336,8 +1418,13 @@ public class Fetcher<K, V> implements Closeable {
     private void handleOffsetOutOfRange(FetchPosition fetchPosition, TopicPartition topicPartition) {
         String errorMessage = "Fetch position " + fetchPosition + " is out of range for partition " + topicPartition;
         if (subscriptions.hasDefaultOffsetResetPolicy()) {
-            log.info("{}, resetting offset", errorMessage);
-            subscriptions.requestOffsetReset(topicPartition);
+            if (useNearestOffsetReset) {
+                log.info("{}, resetting offset with nearest offset", errorMessage);
+                subscriptions.requestOffsetReset(topicPartition, OffsetResetStrategy.NEAREST, fetchPosition.offset);
+            } else {
+                log.info("{}, resetting offset", errorMessage);
+                subscriptions.requestOffsetReset(topicPartition);
+            }
         } else {
             log.info("{}, raising error to the application since no reset policy is configured", errorMessage);
             throw new OffsetOutOfRangeException(errorMessage,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -179,53 +179,6 @@ public class Fetcher<K, V> implements Closeable {
                    long retryBackoffMs,
                    long requestTimeoutMs,
                    IsolationLevel isolationLevel,
-                   ApiVersions apiVersions) {
-        this(logContext,
-                client,
-                minBytes,
-                maxBytes,
-                maxWaitMs,
-                fetchSize,
-                maxPollRecords,
-                checkCrcs,
-                clientRackId,
-                keyDeserializer,
-                valueDeserializer,
-                metadata,
-                subscriptions,
-                metrics,
-                metricsRegistry,
-                time,
-                retryBackoffMs,
-                requestTimeoutMs,
-                isolationLevel,
-                /* Disable nearest offset for code path that use this constructor. The nearest offset reset is meant to be used only in client consumer.
-                We don't want to risk using nearest reset with other internal module of kafka eg. follower broker replication.
-                This also make the nearest reset feature not effect the old test case.
-                */
-                true,
-                apiVersions);
-    }
-
-    public Fetcher(LogContext logContext,
-                   ConsumerNetworkClient client,
-                   int minBytes,
-                   int maxBytes,
-                   int maxWaitMs,
-                   int fetchSize,
-                   int maxPollRecords,
-                   boolean checkCrcs,
-                   String clientRackId,
-                   Deserializer<K> keyDeserializer,
-                   Deserializer<V> valueDeserializer,
-                   ConsumerMetadata metadata,
-                   SubscriptionState subscriptions,
-                   Metrics metrics,
-                   FetcherMetricsRegistry metricsRegistry,
-                   Time time,
-                   long retryBackoffMs,
-                   long requestTimeoutMs,
-                   IsolationLevel isolationLevel,
                    boolean useNearestOffsetReset,
                    ApiVersions apiVersions) {
         this.log = logContext.logger(Fetcher.class);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2231,6 +2231,7 @@ public class KafkaConsumerTest {
         int maxPollRecords = Integer.MAX_VALUE;
         boolean checkCrcs = true;
         int rebalanceTimeoutMs = 60000;
+        boolean nearestOffsetReset = false;
 
         Deserializer<String> keyDeserializer = new StringDeserializer();
         Deserializer<String> valueDeserializer = new StringDeserializer();
@@ -2285,6 +2286,7 @@ public class KafkaConsumerTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 IsolationLevel.READ_UNCOMMITTED,
+                nearestOffsetReset,
                 new ApiVersions());
 
         return new KafkaConsumer<>(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -3310,6 +3310,7 @@ public class FetcherTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 IsolationLevel.READ_UNCOMMITTED,
+                false,
                 apiVersions) {
             @Override
             protected FetchSessionHandler sessionHandler(int id) {
@@ -4531,6 +4532,7 @@ public class FetcherTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 isolationLevel,
+                false,
                 apiVersions);
     }
 


### PR DESCRIPTION
from discussion in [KAFKA-3370](https://issues.apache.org/jira/browse/KAFKA-3370)
- Introduce nearest.offset.reset option on the Consumer, which will only be used on OffsetOutOfRangeException. 
On enable, the offset will be reset to the earliest if out-of-range offset is not higher than the earliest offset, otherwise it will be reset to the latest offset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
