### PR TITLE
KAFKA-10120: Deprecate DescribeLogDirsResult.all() and .values()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2314,13 +2314,11 @@ public class KafkaAdminClient extends AdminClient {
         HashMap<String, LogDirDescription> result = new HashMap<>(response.data().results().size());
         for (DescribeLogDirsResponseData.DescribeLogDirsResult logDirResult : response.data().results()) {
             Map<TopicPartition, ReplicaInfo> replicaInfoMap = new HashMap<>();
-            if (logDirResult.topics() != null) {
-                for (DescribeLogDirsResponseData.DescribeLogDirsTopic t : logDirResult.topics()) {
-                    for (DescribeLogDirsResponseData.DescribeLogDirsPartition p : t.partitions()) {
-                        replicaInfoMap.put(
-                                new TopicPartition(t.name(), p.partitionIndex()),
-                                new ReplicaInfo(p.partitionSize(), p.offsetLag(), p.isFutureKey()));
-                    }
+            for (DescribeLogDirsResponseData.DescribeLogDirsTopic t : logDirResult.topics()) {
+                for (DescribeLogDirsResponseData.DescribeLogDirsPartition p : t.partitions()) {
+                    replicaInfoMap.put(
+                            new TopicPartition(t.name(), p.partitionIndex()),
+                            new ReplicaInfo(p.partitionSize(), p.offsetLag(), p.isFutureKey()));
                 }
             }
             result.put(logDirResult.logDir(), new LogDirDescription(Errors.forCode(logDirResult.errorCode()).exception(), replicaInfoMap));
@@ -2392,8 +2390,7 @@ public class KafkaAdminClient extends AdminClient {
                             ReplicaInfo replicaInfo = replicaInfoEntry.getValue();
                             ReplicaLogDirInfo replicaLogDirInfo = replicaDirInfoByPartition.get(tp);
                             if (replicaLogDirInfo == null) {
-                                handleFailure(new IllegalStateException(
-                                    "The partition " + tp + " in the response from broker " + brokerId + " is not in the request"));
+                                log.warn("Server response from broker {} mentioned unknown partition {}", brokerId, tp);
                             } else if (replicaInfo.isFuture()) {
                                 replicaDirInfoByPartition.put(tp, new ReplicaLogDirInfo(replicaLogDirInfo.getCurrentReplicaLogDir(),
                                                                                         replicaLogDirInfo.getCurrentReplicaOffsetLag(),

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2310,8 +2310,8 @@ public class KafkaAdminClient extends AdminClient {
         return new DescribeLogDirsResult(new HashMap<>(futures));
     }
 
-    private Map<String, LogDirDescription> logDirDescriptions(DescribeLogDirsResponse response) {
-        HashMap<String, LogDirDescription> result = new HashMap<>(response.data().results().size());
+    private static Map<String, LogDirDescription> logDirDescriptions(DescribeLogDirsResponse response) {
+        Map<String, LogDirDescription> result = new HashMap<>(response.data().results().size());
         for (DescribeLogDirsResponseData.DescribeLogDirsResult logDirResult : response.data().results()) {
             Map<TopicPartition, ReplicaInfo> replicaInfoMap = new HashMap<>();
             for (DescribeLogDirsResponseData.DescribeLogDirsTopic t : logDirResult.topics()) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2296,7 +2296,7 @@ public class KafkaAdminClient extends AdminClient {
                     if (descriptions.size() > 0) {
                         future.complete(descriptions);
                     } else {
-                        // response/descriptions will be empty if and only if the user is not authorized to describe cluster resource.
+                        // descriptions will be empty if and only if the user is not authorized to describe cluster resource.
                         future.completeExceptionally(Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
                     }
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -61,6 +61,7 @@ import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
@@ -108,6 +109,7 @@ import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroup
 import org.apache.kafka.common.message.DescribeGroupsResponseData.DescribedGroupMember;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData.DescribableLogDirTopic;
+import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData;
@@ -2270,11 +2272,11 @@ public class KafkaAdminClient extends AdminClient {
 
     @Override
     public DescribeLogDirsResult describeLogDirs(Collection<Integer> brokers, DescribeLogDirsOptions options) {
-        final Map<Integer, KafkaFutureImpl<Map<String, DescribeLogDirsResponse.LogDirInfo>>> futures = new HashMap<>(brokers.size());
+        final Map<Integer, KafkaFutureImpl<Map<String, LogDirDescription>>> futures = new HashMap<>(brokers.size());
 
         final long now = time.milliseconds();
         for (final Integer brokerId : brokers) {
-            KafkaFutureImpl<Map<String, DescribeLogDirsResponse.LogDirInfo>> future = new KafkaFutureImpl<>();
+            KafkaFutureImpl<Map<String, LogDirDescription>> future = new KafkaFutureImpl<>();
             futures.put(brokerId, future);
 
             runnable.call(new Call("describeLogDirs", calcDeadlineMs(now, options.timeoutMs()),
@@ -2286,13 +2288,15 @@ public class KafkaAdminClient extends AdminClient {
                     return new DescribeLogDirsRequest.Builder(new DescribeLogDirsRequestData().setTopics(null));
                 }
 
+                @SuppressWarnings("deprecation")
                 @Override
                 public void handleResponse(AbstractResponse abstractResponse) {
                     DescribeLogDirsResponse response = (DescribeLogDirsResponse) abstractResponse;
-                    if (response.logDirInfos().size() > 0) {
-                        future.complete(response.logDirInfos());
+                    Map<String, LogDirDescription> descriptions = logDirDescriptions(response);
+                    if (descriptions.size() > 0) {
+                        future.complete(descriptions);
                     } else {
-                        // response.logDirInfos() will be empty if and only if the user is not authorized to describe clsuter resource.
+                        // response/descriptions will be empty if and only if the user is not authorized to describe cluster resource.
                         future.completeExceptionally(Errors.CLUSTER_AUTHORIZATION_FAILED.exception());
                     }
                 }
@@ -2304,6 +2308,24 @@ public class KafkaAdminClient extends AdminClient {
         }
 
         return new DescribeLogDirsResult(new HashMap<>(futures));
+    }
+
+    private Map<String, LogDirDescription> logDirDescriptions(DescribeLogDirsResponse response) {
+        HashMap<String, LogDirDescription> result = new HashMap<>(response.data().results().size());
+        for (DescribeLogDirsResponseData.DescribeLogDirsResult logDirResult : response.data().results()) {
+            Map<TopicPartition, ReplicaInfo> replicaInfoMap = new HashMap<>();
+            if (logDirResult.topics() != null) {
+                for (DescribeLogDirsResponseData.DescribeLogDirsTopic t : logDirResult.topics()) {
+                    for (DescribeLogDirsResponseData.DescribeLogDirsPartition p : t.partitions()) {
+                        replicaInfoMap.put(
+                                new TopicPartition(t.name(), p.partitionIndex()),
+                                new ReplicaInfo(p.partitionSize(), p.offsetLag(), p.isFutureKey()));
+                    }
+                }
+            }
+            result.put(logDirResult.logDir(), new LogDirDescription(Errors.forCode(logDirResult.errorCode()).exception(), replicaInfoMap));
+        }
+        return result;
     }
 
     @Override
@@ -2354,32 +2376,32 @@ public class KafkaAdminClient extends AdminClient {
                 @Override
                 public void handleResponse(AbstractResponse abstractResponse) {
                     DescribeLogDirsResponse response = (DescribeLogDirsResponse) abstractResponse;
-                    for (Map.Entry<String, DescribeLogDirsResponse.LogDirInfo> responseEntry: response.logDirInfos().entrySet()) {
+                    for (Map.Entry<String, LogDirDescription> responseEntry: logDirDescriptions(response).entrySet()) {
                         String logDir = responseEntry.getKey();
-                        DescribeLogDirsResponse.LogDirInfo logDirInfo = responseEntry.getValue();
+                        LogDirDescription logDirInfo = responseEntry.getValue();
 
                         // No replica info will be provided if the log directory is offline
-                        if (logDirInfo.error == Errors.KAFKA_STORAGE_ERROR)
+                        if (logDirInfo.error() instanceof KafkaStorageException)
                             continue;
-                        if (logDirInfo.error != Errors.NONE)
+                        if (logDirInfo.error() != null)
                             handleFailure(new IllegalStateException(
-                                "The error " + logDirInfo.error + " for log directory " + logDir + " in the response from broker " + brokerId + " is illegal"));
+                                "The error " + logDirInfo.error().getClass().getName() + " for log directory " + logDir + " in the response from broker " + brokerId + " is illegal"));
 
-                        for (Map.Entry<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> replicaInfoEntry: logDirInfo.replicaInfos.entrySet()) {
+                        for (Map.Entry<TopicPartition, ReplicaInfo> replicaInfoEntry: logDirInfo.replicaInfos().entrySet()) {
                             TopicPartition tp = replicaInfoEntry.getKey();
-                            DescribeLogDirsResponse.ReplicaInfo replicaInfo = replicaInfoEntry.getValue();
+                            ReplicaInfo replicaInfo = replicaInfoEntry.getValue();
                             ReplicaLogDirInfo replicaLogDirInfo = replicaDirInfoByPartition.get(tp);
                             if (replicaLogDirInfo == null) {
                                 handleFailure(new IllegalStateException(
                                     "The partition " + tp + " in the response from broker " + brokerId + " is not in the request"));
-                            } else if (replicaInfo.isFuture) {
+                            } else if (replicaInfo.isFuture()) {
                                 replicaDirInfoByPartition.put(tp, new ReplicaLogDirInfo(replicaLogDirInfo.getCurrentReplicaLogDir(),
                                                                                         replicaLogDirInfo.getCurrentReplicaOffsetLag(),
                                                                                         logDir,
-                                                                                        replicaInfo.offsetLag));
+                                                                                        replicaInfo.offsetLag()));
                             } else {
                                 replicaDirInfoByPartition.put(tp, new ReplicaLogDirInfo(logDir,
-                                                                                        replicaInfo.offsetLag,
+                                                                                        replicaInfo.offsetLag(),
                                                                                         replicaLogDirInfo.getFutureReplicaLogDir(),
                                                                                         replicaLogDirInfo.getFutureReplicaOffsetLag()));
                             }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
@@ -37,7 +37,6 @@ public class LogDirDescription {
 
     /**
      * Returns `ApiException` if the log directory is offline or an error occurred, otherwise returns null.
-     * <p>
      * <ul>
      * <li> KafkaStorageException - The log directory is offline.
      * <li> UnknownServerException - The server experienced an unexpected error when processing the request.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
@@ -36,9 +36,11 @@ public class LogDirDescription {
     }
 
     /**
-     * A KafkaStorageException if this log directory is offline,
-     * possibly some other exception if there were problems describing the log directory
-     * or null if the directory is online.
+     * <p>Returns `ApiException` if the log directory is offline or an error occurred, otherwise returns null.</p>
+     * <ul>
+     * <li> KafkaStorageException - The log directory is offline.
+     * <li> UnknownServerException - The server experienced an unexpected error when processing the request.
+     * </ul>
      */
     public ApiException error() {
         return error;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ApiException;
+
+import java.util.Map;
+
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * A description of a log directory on a particular broker.
+ */
+public class LogDirDescription {
+    private final Map<TopicPartition, ReplicaInfo> replicaInfos;
+    private final ApiException error;
+
+    public LogDirDescription(ApiException error, Map<TopicPartition, ReplicaInfo> replicaInfos) {
+        this.error = error;
+        this.replicaInfos = replicaInfos;
+    }
+
+    /**
+     * A KafkaStorageException if this log directory is offline,
+     * possibly some other exception if there were problems describing the log directory
+     * or null if the directory is online.
+     */
+    public ApiException error() {
+        return error;
+    }
+
+    /**
+     * A map from topic partition to replica information for that partition
+     * in this log directory.
+     */
+    public Map<TopicPartition, ReplicaInfo> replicaInfos() {
+        return unmodifiableMap(replicaInfos);
+    }
+
+    @Override
+    public String toString() {
+        return "LogDirDescription{" +
+                "replicaInfos=" + replicaInfos +
+                ", error=" + error +
+                '}';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
@@ -36,7 +36,8 @@ public class LogDirDescription {
     }
 
     /**
-     * <p>Returns `ApiException` if the log directory is offline or an error occurred, otherwise returns null.</p>
+     * Returns `ApiException` if the log directory is offline or an error occurred, otherwise returns null.
+     * <p>
      * <ul>
      * <li> KafkaStorageException - The log directory is offline.
      * <li> UnknownServerException - The server experienced an unexpected error when processing the request.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/LogDirDescription.java
@@ -54,9 +54,9 @@ public class LogDirDescription {
 
     @Override
     public String toString() {
-        return "LogDirDescription{" +
+        return "LogDirDescription(" +
                 "replicaInfos=" + replicaInfos +
                 ", error=" + error +
-                '}';
+                ')';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ReplicaInfo.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ReplicaInfo.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+/**
+ * A description of a replica on a particular broker.
+ */
+public class ReplicaInfo {
+
+    private final long size;
+    private final long offsetLag;
+    private final boolean isFuture;
+
+    public ReplicaInfo(long size, long offsetLag, boolean isFuture) {
+        this.size = size;
+        this.offsetLag = offsetLag;
+        this.isFuture = isFuture;
+    }
+
+    /**
+     * The total size of the log segments in this replica in bytes.
+     */
+    public long size() {
+        return size;
+    }
+
+    /**
+     * The lag of the log's LEO with respect to the partition's
+     * high watermark (if it is the current log for the partition)
+     * or the current replica's LEO (if it is the {@linkplain #isFuture() future log}
+     * for the partition).
+     */
+    public long offsetLag() {
+        return offsetLag;
+    }
+
+    /**
+     * Whether this replica has been created by a AlterReplicaLogDirsRequest
+     * but not yet replaced the current replica on the broker.
+     *
+     * @return true if this log is created by AlterReplicaLogDirsRequest and will replace the current log
+     * of the replica at some time in the future.
+     */
+    public boolean isFuture() {
+        return isFuture;
+    }
+
+    @Override
+    public String toString() {
+        return "ReplicaInfo{" +
+                "size=" + size +
+                ", offsetLag=" + offsetLag +
+                ", isFuture=" + isFuture +
+                '}';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ReplicaInfo.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ReplicaInfo.java
@@ -61,10 +61,10 @@ public class ReplicaInfo {
 
     @Override
     public String toString() {
-        return "ReplicaInfo{" +
+        return "ReplicaInfo(" +
                 "size=" + size +
                 ", offsetLag=" + offsetLag +
                 ", isFuture=" + isFuture +
-                '}';
+                ')';
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -19,9 +19,6 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.DescribeLogDirsResponseData;
-import org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsPartition;
-import org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsResult;
-import org.apache.kafka.common.message.DescribeLogDirsResponseData.DescribeLogDirsTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -68,22 +65,6 @@ public class DescribeLogDirsResponse extends AbstractResponse {
         return errorCounts;
     }
 
-    public Map<String, LogDirInfo> logDirInfos() {
-        HashMap<String, LogDirInfo> result = new HashMap<>(data.results().size());
-        for (DescribeLogDirsResult logDirResult : data.results()) {
-            Map<TopicPartition, ReplicaInfo> replicaInfoMap = new HashMap<>();
-            for (DescribeLogDirsTopic t : logDirResult.topics()) {
-                for (DescribeLogDirsPartition p : t.partitions()) {
-                    replicaInfoMap.put(
-                            new TopicPartition(t.name(), p.partitionIndex()),
-                            new ReplicaInfo(p.partitionSize(), p.offsetLag(), p.isFutureKey()));
-                }
-            }
-            result.put(logDirResult.logDir(), new LogDirInfo(Errors.forCode(logDirResult.errorCode()), replicaInfoMap));
-        }
-        return result;
-    }
-
     public static DescribeLogDirsResponse parse(ByteBuffer buffer, short version) {
         return new DescribeLogDirsResponse(ApiKeys.DESCRIBE_LOG_DIRS.responseSchema(version).read(buffer), version);
     }
@@ -95,6 +76,7 @@ public class DescribeLogDirsResponse extends AbstractResponse {
      * KAFKA_STORAGE_ERROR (56)
      * UNKNOWN (-1)
      */
+    @Deprecated
     static public class LogDirInfo {
         public final Errors error;
         public final Map<TopicPartition, ReplicaInfo> replicaInfos;
@@ -117,6 +99,7 @@ public class DescribeLogDirsResponse extends AbstractResponse {
     }
 
     // Note this class is part of the public API, reachable from Admin.describeLogDirs()
+    @Deprecated
     static public class ReplicaInfo {
 
         public final long size;

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeLogDirsResponse.java
@@ -75,6 +75,11 @@ public class DescribeLogDirsResponse extends AbstractResponse {
      *
      * KAFKA_STORAGE_ERROR (56)
      * UNKNOWN (-1)
+     *
+     * @deprecated Deprecated Since Kafka 2.7.
+     * Use {@link org.apache.kafka.clients.admin.DescribeLogDirsResult#descriptions()}
+     * and {@link org.apache.kafka.clients.admin.DescribeLogDirsResult#allDescriptions()} to access the replacement
+     * class {@link org.apache.kafka.clients.admin.LogDirDescription}.
      */
     @Deprecated
     static public class LogDirInfo {
@@ -99,6 +104,13 @@ public class DescribeLogDirsResponse extends AbstractResponse {
     }
 
     // Note this class is part of the public API, reachable from Admin.describeLogDirs()
+
+    /**
+     * @deprecated Deprecated Since Kafka 2.7.
+     * Use {@link org.apache.kafka.clients.admin.DescribeLogDirsResult#descriptions()}
+     * and {@link org.apache.kafka.clients.admin.DescribeLogDirsResult#allDescriptions()} to access the replacement
+     * class {@link org.apache.kafka.clients.admin.ReplicaInfo}.
+     */
     @Deprecated
     static public class ReplicaInfo {
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1163,7 +1163,7 @@ public class KafkaAdminClientTest {
                     new DescribeLogDirsResponseData().setResults(asList(new DescribeLogDirsResponseData.DescribeLogDirsResult()
                             .setErrorCode(Errors.KAFKA_STORAGE_ERROR.code())
                             .setLogDir("/var/data/kafka")
-                            .setTopics(null)
+                            .setTopics(emptyList())
                     ))), env.cluster().nodeById(0));
             DescribeLogDirsResult result = env.adminClient().describeLogDirs(brokers);
             Map<Integer, KafkaFuture<Map<String, LogDirDescription>>> descriptions = result.descriptions();
@@ -1195,7 +1195,7 @@ public class KafkaAdminClientTest {
                     new DescribeLogDirsResponseData().setResults(asList(new DescribeLogDirsResponseData.DescribeLogDirsResult()
                             .setErrorCode(Errors.KAFKA_STORAGE_ERROR.code())
                             .setLogDir("/var/data/kafka")
-                            .setTopics(null)
+                            .setTopics(emptyList())
                     ))), env.cluster().nodeById(0));
             DescribeLogDirsResult result = env.adminClient().describeLogDirs(brokers);
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -1059,12 +1059,12 @@ public class KafkaAdminClientTest {
         }
     }
 
-    private DescribeLogDirsResponse prepareDescribeLogDirsResponse(Errors error, String logDir, TopicPartition tp, long partitionSize, long offsetLag) {
+    private static DescribeLogDirsResponse prepareDescribeLogDirsResponse(Errors error, String logDir, TopicPartition tp, long partitionSize, long offsetLag) {
         return prepareDescribeLogDirsResponse(error, logDir,
                 prepareDescribeLogDirsTopics(partitionSize, offsetLag, tp.topic(), tp.partition(), false));
     }
 
-    private List<DescribeLogDirsTopic> prepareDescribeLogDirsTopics(
+    private static List<DescribeLogDirsTopic> prepareDescribeLogDirsTopics(
             long partitionSize, long offsetLag, String topic, int partition, boolean isFuture) {
         return singletonList(new DescribeLogDirsTopic()
                 .setName(topic)
@@ -1075,7 +1075,7 @@ public class KafkaAdminClientTest {
                         .setOffsetLag(offsetLag))));
     }
 
-    private DescribeLogDirsResponse prepareDescribeLogDirsResponse(Errors error, String logDir,
+    private static DescribeLogDirsResponse prepareDescribeLogDirsResponse(Errors error, String logDir,
                                                                    List<DescribeLogDirsTopic> topics) {
         return new DescribeLogDirsResponse(
                 new DescribeLogDirsResponseData().setResults(singletonList(new DescribeLogDirsResponseData.DescribeLogDirsResult()
@@ -1112,7 +1112,7 @@ public class KafkaAdminClientTest {
         }
     }
 
-    private void assertDescriptionContains(Map<String, LogDirDescription> descriptionsMap, String logDir,
+    private static void assertDescriptionContains(Map<String, LogDirDescription> descriptionsMap, String logDir,
                                            TopicPartition tp, long partitionSize, long offsetLag) {
         assertNotNull(descriptionsMap);
         assertEquals(Collections.singleton(logDir), descriptionsMap.keySet());
@@ -1154,7 +1154,7 @@ public class KafkaAdminClientTest {
     }
 
     @SuppressWarnings("deprecation")
-    private void assertDescriptionContains(Map<String, DescribeLogDirsResponse.LogDirInfo> descriptionsMap,
+    private static  void assertDescriptionContains(Map<String, DescribeLogDirsResponse.LogDirInfo> descriptionsMap,
                                            String logDir, TopicPartition tp, Errors error,
                                            int offsetLag, long partitionSize) {
         assertNotNull(descriptionsMap);
@@ -1276,7 +1276,7 @@ public class KafkaAdminClientTest {
         }
     }
 
-    private DescribeLogDirsResponseData.DescribeLogDirsResult prepareDescribeLogDirsResult(TopicPartitionReplica tpr, String logDir, int partitionSize, int offsetLag, boolean isFuture) {
+    private static DescribeLogDirsResponseData.DescribeLogDirsResult prepareDescribeLogDirsResult(TopicPartitionReplica tpr, String logDir, int partitionSize, int offsetLag, boolean isFuture) {
         return new DescribeLogDirsResponseData.DescribeLogDirsResult()
                 .setErrorCode(Errors.NONE.code())
                 .setLogDir(logDir)

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -21,8 +21,7 @@ import java.io.PrintStream
 import java.util.Properties
 
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Json}
-import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, DescribeLogDirsResult}
-import org.apache.kafka.common.requests.DescribeLogDirsResponse.LogDirInfo
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, DescribeLogDirsResult, LogDirDescription}
 import org.apache.kafka.common.utils.Utils
 
 import scala.jdk.CollectionConverters._
@@ -48,14 +47,14 @@ object LogDirsCommand {
 
         out.println("Querying brokers for log directories information")
         val describeLogDirsResult: DescribeLogDirsResult = adminClient.describeLogDirs(brokerList.map(Integer.valueOf).toSeq.asJava)
-        val logDirInfosByBroker = describeLogDirsResult.all.get().asScala.map { case (k, v) => k -> v.asScala }
+        val logDirInfosByBroker = describeLogDirsResult.allDescriptions.get().asScala.map { case (k, v) => k -> v.asScala }
 
         out.println(s"Received log directory information from brokers ${brokerList.mkString(",")}")
         out.println(formatAsJson(logDirInfosByBroker, topicList.toSet))
         adminClient.close()
     }
 
-    private def formatAsJson(logDirInfosByBroker: Map[Integer, Map[String, LogDirInfo]], topicSet: Set[String]): String = {
+    private def formatAsJson(logDirInfosByBroker: Map[Integer, Map[String, LogDirDescription]], topicSet: Set[String]): String = {
         Json.encodeAsString(Map(
             "version" -> 1,
             "brokers" -> logDirInfosByBroker.map { case (broker, logDirInfos) =>
@@ -64,7 +63,7 @@ object LogDirsCommand {
                     "logDirs" -> logDirInfos.map { case (logDir, logDirInfo) =>
                         Map(
                             "logDir" -> logDir,
-                            "error" -> logDirInfo.error.exceptionName(),
+                            "error" -> Option(logDirInfo.error).flatMap(ex => Some(ex.getClass.getName)).orNull,
                             "partitions" -> logDirInfo.replicaInfos.asScala.filter { case (topicPartition, _) =>
                                 topicSet.isEmpty || topicSet.contains(topicPartition.topic)
                             }.map { case (topicPartition, replicaInfo) =>

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -63,7 +63,7 @@ object LogDirsCommand {
                     "logDirs" -> logDirInfos.map { case (logDir, logDirInfo) =>
                         Map(
                             "logDir" -> logDir,
-                            "error" -> Option(logDirInfo.error).flatMap(ex => Some(ex.getClass.getName)).orNull,
+                            "error" -> Option(logDirInfo.error).map(ex => ex.getClass.getName).orNull,
                             "partitions" -> logDirInfo.replicaInfos.asScala.filter { case (topicPartition, _) =>
                                 topicSet.isEmpty || topicSet.contains(topicPartition.topic)
                             }.map { case (topicPartition, replicaInfo) =>

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -490,7 +490,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
     val logDirs = new mutable.HashSet[String]
     val curLogDirs = new mutable.HashMap[TopicPartition, String]
     val futureLogDirs = new mutable.HashMap[TopicPartition, String]
-    result.values.get(brokerId).get().forEach {
+    result.descriptions.get(brokerId).get().forEach {
       case (logDirName, logDirInfo) => {
         logDirs.add(logDirName)
         logDirInfo.replicaInfos.forEach {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -197,7 +197,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       .find(x => x.topicName == tp.topic).get.partitions.asScala
       .find(p => p.partitionIndex == tp.partition).get.errorCode)),
     ApiKeys.DESCRIBE_LOG_DIRS -> ((resp: DescribeLogDirsResponse) =>
-      if (resp.logDirInfos.size() > 0) resp.logDirInfos.asScala.head._2.error else Errors.CLUSTER_AUTHORIZATION_FAILED),
+      if (resp.data.results.size() > 0) Errors.forCode(resp.data.results.get(0).errorCode) else Errors.CLUSTER_AUTHORIZATION_FAILED),
     ApiKeys.CREATE_PARTITIONS -> ((resp: CreatePartitionsResponse) => Errors.forCode(resp.data.results.asScala.head.errorCode())),
     ApiKeys.ELECT_LEADERS -> ((resp: ElectLeadersResponse) => Errors.forCode(resp.data().errorCode())),
     ApiKeys.INCREMENTAL_ALTER_CONFIGS -> ((resp: IncrementalAlterConfigsResponse) => {

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -176,7 +176,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
       k -> v.keys.toSeq
     }
     val brokers = (0 until brokerCount).map(Integer.valueOf)
-    val logDirInfosByBroker = client.describeLogDirs(brokers.asJava).all.get
+    val logDirInfosByBroker = client.describeLogDirs(brokers.asJava).allDescriptions.get
 
     (0 until brokerCount).foreach { brokerId =>
       val server = servers.find(_.config.brokerId == brokerId).get

--- a/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/PurgeRepartitionTopicIntegrationTest.java
@@ -18,11 +18,12 @@ package org.apache.kafka.streams.integration;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.LogDirDescription;
+import org.apache.kafka.clients.admin.ReplicaInfo;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Time;
@@ -120,13 +121,13 @@ public class PurgeRepartitionTopicIntegrationTest {
             time.sleep(PURGE_INTERVAL_MS);
 
             try {
-                final Collection<DescribeLogDirsResponse.LogDirInfo> logDirInfo =
-                    adminClient.describeLogDirs(Collections.singleton(0)).values().get(0).get().values();
+                final Collection<LogDirDescription> logDirInfo =
+                    adminClient.describeLogDirs(Collections.singleton(0)).descriptions().get(0).get().values();
 
-                for (final DescribeLogDirsResponse.LogDirInfo partitionInfo : logDirInfo) {
-                    final DescribeLogDirsResponse.ReplicaInfo replicaInfo =
-                        partitionInfo.replicaInfos.get(new TopicPartition(REPARTITION_TOPIC, 0));
-                    if (replicaInfo != null && verifier.verify(replicaInfo.size)) {
+                for (final LogDirDescription partitionInfo : logDirInfo) {
+                    final ReplicaInfo replicaInfo =
+                        partitionInfo.replicaInfos().get(new TopicPartition(REPARTITION_TOPIC, 0));
+                    if (replicaInfo != null && verifier.verify(replicaInfo.size())) {
                         return true;
                     }
                 }


### PR DESCRIPTION
As per KIP-621. Also added some tests in KafkaAdminClientTest
