### PR TITLE
KAFKA-10270: A broker to controller channel manager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -39,7 +39,7 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     private List<Node> nodes;
 
     public ManualMetadataUpdater() {
-        this(new ArrayList<Node>(0));
+        this(new ArrayList<>(0));
     }
 
     public ManualMetadataUpdater(List<Node> nodes) {

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -145,8 +145,7 @@ abstract class InterBrokerSendThread(name: String,
 
 case class RequestAndCompletionHandler(destination: Node,
                                        request: AbstractRequest.Builder[_ <: AbstractRequest],
-                                       handler: RequestCompletionHandler,
-                                       initialPrincipalName: String)
+                                       handler: RequestCompletionHandler)
 
 private class UnsentRequests {
   private val unsent = new HashMap[Node, ArrayDeque[ClientRequest]]

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -212,7 +212,7 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
     }.filter { case (_, entries) => !entries.isEmpty }.map { case (node, entries) =>
       val markersToSend = entries.asScala.map(_.txnMarkerEntry).asJava
       val requestCompletionHandler = new TransactionMarkerRequestCompletionHandler(node.id, txnStateManager, this, entries)
-      RequestAndCompletionHandler(node, new WriteTxnMarkersRequest.Builder(markersToSend), requestCompletionHandler, "")
+      RequestAndCompletionHandler(node, new WriteTxnMarkersRequest.Builder(markersToSend), requestCompletionHandler)
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -212,7 +212,7 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
     }.filter { case (_, entries) => !entries.isEmpty }.map { case (node, entries) =>
       val markersToSend = entries.asScala.map(_.txnMarkerEntry).asJava
       val requestCompletionHandler = new TransactionMarkerRequestCompletionHandler(node.id, txnStateManager, this, entries)
-      RequestAndCompletionHandler(node, new WriteTxnMarkersRequest.Builder(markersToSend), requestCompletionHandler)
+      RequestAndCompletionHandler(node, new WriteTxnMarkersRequest.Builder(markersToSend), requestCompletionHandler, "")
     }
   }
 

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -97,7 +97,7 @@ class BrokerToControllerChannelManager(metadataCache: kafka.server.MetadataCache
         config.requestTimeoutMs,
         config.connectionSetupTimeoutMs,
         config.connectionSetupTimeoutMaxMs,
-        ClientDnsLookup.DEFAULT,
+        ClientDnsLookup.USE_ALL_DNS_IPS,
         time,
         false,
         new ApiVersions,
@@ -160,6 +160,7 @@ class BrokerToControllerRequestThread(networkClient: KafkaClient,
       // just close the controller connection and wait for metadata cache update in doWork
       networkClient.close(activeController.get.idString)
       activeController = None
+      requestQueue.putFirst(request)
     } else {
       request.callback.onComplete(response)
     }

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -138,9 +138,8 @@ class BrokerToControllerRequestThread(networkClient: KafkaClient,
 
   override def generateRequests(): Iterable[RequestAndCompletionHandler] = {
     val requestsToSend = new mutable.Queue[RequestAndCompletionHandler]
-    if (requestQueue.peek() != null) {
-      val topRequest = requestQueue.poll()
-
+    val topRequest = requestQueue.poll()
+    if (topRequest != null) {
       val request = RequestAndCompletionHandler(
         activeController.get,
         topRequest.request,

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.concurrent.{LinkedBlockingDeque, TimeUnit}
+
+import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
+import kafka.utils.Logging
+import org.apache.kafka.clients._
+import org.apache.kafka.common.requests.AbstractRequest
+import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network._
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.security.JaasContext
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+/**
+ * This class manages the connection between a broker and the controller. It runs a single
+ * {@link BrokerToControllerRequestThread} which uses the broker's metadata cache as its own metadata to find
+ * and connect to the controller. The channel is async and runs the network connection in the background.
+ * The maximum number of in-flight requests are set to one to ensure orderly response from the controller, therefore
+ * care must be taken to not block on outstanding requests for too long.
+ */
+class BrokerToControllerChannelManager(metadataCache: kafka.server.MetadataCache,
+                                       time: Time,
+                                       metrics: Metrics,
+                                       config: KafkaConfig,
+                                       threadNamePrefix: Option[String] = None) extends Logging {
+  private val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]
+  private val logContext = new LogContext(s"[broker-${config.brokerId}-to-controller] ")
+  private val manualMetadataUpdater = new ManualMetadataUpdater()
+  private val requestThread = newRequestThread
+
+  def start(): Unit = {
+    requestThread.start()
+  }
+
+  def shutdown(): Unit = {
+    requestThread.shutdown()
+    requestThread.awaitShutdown()
+  }
+
+  private[server] def newRequestThread = {
+    val brokerToControllerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
+    val brokerToControllerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
+
+    val networkClient = {
+      val channelBuilder = ChannelBuilders.clientChannelBuilder(
+        brokerToControllerSecurityProtocol,
+        JaasContext.Type.SERVER,
+        config,
+        brokerToControllerListenerName,
+        config.saslMechanismInterBrokerProtocol,
+        time,
+        config.saslInterBrokerHandshakeRequestEnable,
+        logContext
+      )
+      val selector = new Selector(
+        NetworkReceive.UNLIMITED,
+        Selector.NO_IDLE_TIMEOUT_MS,
+        metrics,
+        time,
+        "BrokerToControllerChannel",
+        Map("BrokerId" -> config.brokerId.toString).asJava,
+        false,
+        channelBuilder,
+        logContext
+      )
+      new NetworkClient(
+        selector,
+        manualMetadataUpdater,
+        config.brokerId.toString,
+        1,
+        0,
+        0,
+        Selectable.USE_DEFAULT_BUFFER_SIZE,
+        Selectable.USE_DEFAULT_BUFFER_SIZE,
+        config.requestTimeoutMs,
+        config.connectionSetupTimeoutMs,
+        config.connectionSetupTimeoutMaxMs,
+        ClientDnsLookup.DEFAULT,
+        time,
+        false,
+        new ApiVersions,
+        logContext
+      )
+    }
+    val threadName = threadNamePrefix match {
+      case None => s"broker-${config.brokerId}-to-controller-send-thread"
+      case Some(name) => s"$name:broker-${config.brokerId}-to-controller-send-thread"
+    }
+
+    new BrokerToControllerRequestThread(networkClient, manualMetadataUpdater, requestQueue, metadataCache, config,
+      brokerToControllerListenerName, time, threadName)
+  }
+
+  private[server] def sendRequest(request: AbstractRequest.Builder[_ <: AbstractRequest],
+                                  callback: RequestCompletionHandler): Unit = {
+    requestQueue.put(BrokerToControllerQueueItem(request, callback, ""))
+  }
+}
+
+case class BrokerToControllerQueueItem(request: AbstractRequest.Builder[_ <: AbstractRequest],
+                                       callback: RequestCompletionHandler,
+                                       initialPrincipalName: String)
+
+class BrokerToControllerRequestThread(networkClient: KafkaClient,
+                                      metadataUpdater: ManualMetadataUpdater,
+                                      requestQueue: LinkedBlockingDeque[BrokerToControllerQueueItem],
+                                      metadataCache: kafka.server.MetadataCache,
+                                      config: KafkaConfig,
+                                      listenerName: ListenerName,
+                                      time: Time,
+                                      threadName: String)
+  extends InterBrokerSendThread(threadName, networkClient, time, isInterruptible = false) {
+
+  private var activeController: Option[Node] = None
+
+  override def requestTimeoutMs: Int = config.controllerSocketTimeoutMs
+
+  override def generateRequests(): Iterable[RequestAndCompletionHandler] = {
+    val requestsToSend = new mutable.Queue[RequestAndCompletionHandler]
+    if (requestQueue.peek() != null) {
+      val topRequest = requestQueue.poll()
+
+      val request = RequestAndCompletionHandler(
+        activeController.get,
+        topRequest.request,
+        handleResponse(topRequest),
+        topRequest.initialPrincipalName)
+      requestsToSend.enqueue(request)
+    }
+    requestsToSend
+  }
+
+  private[server] def handleResponse(request: BrokerToControllerQueueItem)(response: ClientResponse): Unit = {
+    if (response.wasDisconnected()) {
+      activeController = None
+      requestQueue.putFirst(request)
+    } else if (response.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
+      // just close the controller connection and wait for metadata cache update in doWork
+      networkClient.close(activeController.get.idString)
+      activeController = None
+    } else {
+      request.callback.onComplete(response)
+    }
+  }
+
+  private[server] def backoff(): Unit = pause(100, TimeUnit.MILLISECONDS)
+
+  override def doWork(): Unit = {
+    if (activeController.isDefined) {
+      super.doWork()
+    } else {
+      debug("Controller isn't cached, looking for local metadata changes")
+      val controllerOpt = metadataCache.getControllerId.flatMap(metadataCache.getAliveBroker)
+      if (controllerOpt.isDefined) {
+        if (activeController.isEmpty || activeController.exists(_.id != controllerOpt.get.id))
+          info(s"Recorded new controller, from now on will use broker ${controllerOpt.get.id}")
+        activeController = Option(controllerOpt.get.node(listenerName))
+        metadataUpdater.setNodes(metadataCache.getAliveBrokers.map(_.node(listenerName)).asJava)
+      } else {
+        // need to backoff to avoid tight loops
+        debug("No controller defined in metadata cache, retrying after backoff")
+        backoff()
+      }
+    }
+  }
+}

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -115,13 +115,12 @@ class BrokerToControllerChannelManager(metadataCache: kafka.server.MetadataCache
 
   private[server] def sendRequest(request: AbstractRequest.Builder[_ <: AbstractRequest],
                                   callback: RequestCompletionHandler): Unit = {
-    requestQueue.put(BrokerToControllerQueueItem(request, callback, ""))
+    requestQueue.put(BrokerToControllerQueueItem(request, callback))
   }
 }
 
 case class BrokerToControllerQueueItem(request: AbstractRequest.Builder[_ <: AbstractRequest],
-                                       callback: RequestCompletionHandler,
-                                       initialPrincipalName: String)
+                                       callback: RequestCompletionHandler)
 
 class BrokerToControllerRequestThread(networkClient: KafkaClient,
                                       metadataUpdater: ManualMetadataUpdater,
@@ -146,7 +145,7 @@ class BrokerToControllerRequestThread(networkClient: KafkaClient,
         activeController.get,
         topRequest.request,
         handleResponse(topRequest),
-        topRequest.initialPrincipalName)
+        )
       requestsToSend.enqueue(request)
     }
     requestsToSend

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -168,6 +168,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
   var kafkaController: KafkaController = null
 
+  var brokerToControllerChannelManager: BrokerToControllerChannelManager = null
+
   var kafkaScheduler: KafkaScheduler = null
 
   var metadataCache: MetadataCache = null
@@ -313,6 +315,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         /* start kafka controller */
         kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, threadNamePrefix)
         kafkaController.startup()
+
+        brokerToControllerChannelManager = new BrokerToControllerChannelManager(metadataCache, time, metrics, config, threadNamePrefix)
 
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)
 

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -18,7 +18,7 @@
 package kafka.server
 
 import java.util
-import java.util.{Collections}
+import java.util.Collections
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.collection.{mutable, Seq, Set}
@@ -37,7 +37,6 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataResponse, UpdateMetadataRequest}
 import org.apache.kafka.common.security.auth.SecurityProtocol
-
 
 /**
  *  A cache for the state (e.g., current leader) of each partition. This cache is updated through

--- a/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
+++ b/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
@@ -33,7 +33,6 @@ class InterBrokerSendThreadTest {
   private val time = new MockTime()
   private val networkClient: NetworkClient = EasyMock.createMock(classOf[NetworkClient])
   private val completionHandler = new StubCompletionHandler
-  private val initialPrincipalName = "principalName"
   private val requestTimeoutMs = 1000
 
   @Test
@@ -59,7 +58,7 @@ class InterBrokerSendThreadTest {
   def shouldCreateClientRequestAndSendWhenNodeIsReady(): Unit = {
     val request = new StubRequestBuilder()
     val node = new Node(1, "", 8080)
-    val handler = RequestAndCompletionHandler(node, request, completionHandler, initialPrincipalName)
+    val handler = RequestAndCompletionHandler(node, request, completionHandler)
     val sendThread = new InterBrokerSendThread("name", networkClient, time) {
       override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
       override def generateRequests() = List[RequestAndCompletionHandler](handler)
@@ -96,7 +95,7 @@ class InterBrokerSendThreadTest {
   def shouldCallCompletionHandlerWithDisconnectedResponseWhenNodeNotReady(): Unit = {
     val request = new StubRequestBuilder
     val node = new Node(1, "", 8080)
-    val requestAndCompletionHandler = RequestAndCompletionHandler(node, request, completionHandler, initialPrincipalName)
+    val requestAndCompletionHandler = RequestAndCompletionHandler(node, request, completionHandler)
     val sendThread = new InterBrokerSendThread("name", networkClient, time) {
       override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
       override def generateRequests() = List[RequestAndCompletionHandler](requestAndCompletionHandler)
@@ -140,7 +139,7 @@ class InterBrokerSendThreadTest {
   def testFailingExpiredRequests(): Unit = {
     val request = new StubRequestBuilder()
     val node = new Node(1, "", 8080)
-    val handler = RequestAndCompletionHandler(node, request, completionHandler, initialPrincipalName)
+    val handler = RequestAndCompletionHandler(node, request, completionHandler)
     val sendThread = new InterBrokerSendThread("name", networkClient, time) {
       override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
       override def generateRequests() = List[RequestAndCompletionHandler](handler)

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.concurrent.{CountDownLatch, LinkedBlockingDeque, TimeUnit}
+import java.util.Collections
+
+import kafka.cluster.{Broker, EndPoint}
+import kafka.utils.TestUtils
+import org.apache.kafka.test.{TestUtils => ClientsTestUtils}
+import org.apache.kafka.clients.{ManualMetadataUpdater, Metadata, MockClient}
+import org.apache.kafka.common.feature.Features
+import org.apache.kafka.common.feature.Features.emptySupportedFeatures
+import org.apache.kafka.common.utils.SystemTime
+import org.apache.kafka.common.message.MetadataRequestData
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.MetadataRequest
+import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.Test
+import org.mockito.Mockito._
+
+class BrokerToControllerRequestThreadTest {
+
+  @Test
+  def testRequestsSent(): Unit = {
+    // just a simple test that tests whether the request from 1 -> 2 is sent and the response callback is called
+    val time = new SystemTime
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val controllerId = 2
+
+    val metadata = mock(classOf[Metadata])
+    val mockClient = new MockClient(time, metadata)
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val activeController = new Broker(controllerId,
+      Seq(new EndPoint("host", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, emptySupportedFeatures)
+
+    when(metadataCache.getControllerId).thenReturn(Some(controllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
+    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
+
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
+      config, listenerName, time, "")
+    mockClient.prepareResponse(expectedResponse)
+
+    val responseLatch = new CountDownLatch(1)
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response.responseBody())
+        responseLatch.countDown()
+      }, "")
+    requestQueue.put(queueItem)
+    // initialize to the controller
+    testRequestThread.doWork()
+    // send and process the request
+    testRequestThread.doWork()
+
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
+  }
+
+  @Test
+  def testControllerChanged(): Unit = {
+    // in this test the current broker is 1, and the controller changes from 2 -> 3 then back: 3 -> 2
+    val time = new SystemTime
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val oldControllerId = 1
+    val newControllerId = 2
+
+    val metadata = mock(classOf[Metadata])
+    val mockClient = new MockClient(time, metadata)
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val oldController = new Broker(oldControllerId,
+      Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+    val oldControllerNode = oldController.node(listenerName)
+    val newController = new Broker(newControllerId,
+      Seq(new EndPoint("host2", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+
+    when(metadataCache.getControllerId).thenReturn(Some(oldControllerId), Some(newControllerId))
+    when(metadataCache.getAliveBroker(oldControllerId)).thenReturn(Some(oldController))
+    when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
+
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
+      requestQueue, metadataCache, config, listenerName, time, "")
+
+    val responseLatch = new CountDownLatch(1)
+
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response.responseBody())
+        responseLatch.countDown()
+      }, "")
+    requestQueue.put(queueItem)
+    mockClient.prepareResponse(expectedResponse)
+    // initialize the thread with oldController
+    testRequestThread.doWork()
+    // assert queue correctness
+    assertFalse(requestQueue.isEmpty)
+    assertEquals(1, requestQueue.size())
+    assertEquals(queueItem, requestQueue.peek())
+    // disconnect the node
+    mockClient.setUnreachable(oldControllerNode, time.milliseconds() + 5000)
+    // verify that the client closed the connection to the faulty controller
+    testRequestThread.doWork()
+    assertFalse(requestQueue.isEmpty)
+    assertEquals(1, requestQueue.size())
+    // should connect to the new controller
+    testRequestThread.doWork()
+    // should send the request and process the response
+    testRequestThread.doWork()
+
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
+  }
+
+  @Test
+  def testNotController(): Unit = {
+    val time = new SystemTime
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val oldControllerId = 1
+    val newControllerId = 2
+
+    val metadata = mock(classOf[Metadata])
+    val mockClient = new MockClient(time, metadata)
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val oldController = new Broker(oldControllerId,
+      Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+    val newController = new Broker(2,
+      Seq(new EndPoint("host2", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+
+    when(metadataCache.getControllerId).thenReturn(Some(oldControllerId), Some(newControllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
+    when(metadataCache.getAliveBroker(oldControllerId)).thenReturn(Some(oldController))
+    when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
+
+    val responseWithNotControllerError = ClientsTestUtils.metadataUpdateWith("cluster1", 2,
+      Collections.singletonMap("a", Errors.NOT_CONTROLLER),
+      Collections.singletonMap("a", new Integer(2)))
+    val expectedResponse = ClientsTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
+      config, listenerName, time, "")
+
+
+    val responseLatch = new CountDownLatch(1)
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()), response => {
+        assertEquals(expectedResponse, response.responseBody())
+        responseLatch.countDown()
+      }, "")
+    requestQueue.put(queueItem)
+    // initialize to the controller
+    testRequestThread.doWork()
+    // send and process the request
+    mockClient.prepareResponse(responseWithNotControllerError)
+    testRequestThread.doWork()
+    // reinitialize the controller to a different node
+    testRequestThread.doWork()
+    // process the request again
+    mockClient.prepareResponse(expectedResponse)
+    testRequestThread.doWork()
+
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
+  }
+}

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -68,7 +68,7 @@ class BrokerToControllerRequestThreadTest {
       new MetadataRequest.Builder(new MetadataRequestData()), response => {
         assertEquals(expectedResponse, response.responseBody())
         responseLatch.countDown()
-      }, "")
+      })
     requestQueue.put(queueItem)
     // initialize to the controller
     testRequestThread.doWork()
@@ -113,7 +113,7 @@ class BrokerToControllerRequestThreadTest {
       new MetadataRequest.Builder(new MetadataRequestData()), response => {
         assertEquals(expectedResponse, response.responseBody())
         responseLatch.countDown()
-      }, "")
+      })
     requestQueue.put(queueItem)
     mockClient.prepareResponse(expectedResponse)
     // initialize the thread with oldController
@@ -172,7 +172,7 @@ class BrokerToControllerRequestThreadTest {
         .setAllowAutoTopicCreation(true)), response => {
         assertEquals(expectedResponse, response.responseBody())
         responseLatch.countDown()
-      }, "")
+      })
     requestQueue.put(queueItem)
     // initialize to the controller
     testRequestThread.doWork()


### PR DESCRIPTION
Co-authored-by: Viktor Somogyi viktorsomogyi@gmail.com
Co-authored-by: Boyang Chen boyang@confluent.io

Add a broker to controller channel manager for use cases from KIP-590 and KIP-497. Kudos to Viktor, the code template is from https://github.com/apache/kafka/pull/7716/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
