### PR TITLE
KAFKA-10156 [WIP] Fix flaky testCloseOldestConnection

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -463,8 +463,13 @@ public class SelectorTest {
         time.sleep(6000); // The max idle time is 5000ms
         selector.poll(0);
 
-        assertTrue("The idle connection should have been closed", selector.disconnected().containsKey(id));
-        assertEquals(ChannelState.EXPIRED, selector.disconnected().get(id));
+        assertTrue("The idle connection should have been closed or be in closing state",
+                selector.disconnected().get(id) != null || selector.closingChannel(id) != null);
+        if (selector.disconnected().get(id) != null) {
+            assertEquals(ChannelState.EXPIRED, selector.disconnected().get(id));
+        } else {
+            assertEquals(ChannelState.EXPIRED, selector.closingChannel(id).state());
+        }
     }
 
     @Test


### PR DESCRIPTION
In `testCloseOldestConnection` flaky behavior can be caused by the code path when in `selector.poll(0)` the connection is not closed immediately. This can be due to `Selector#maybeReadFromClosingChannel` returning `true`. To avoid this, also check `selector.closingChannel(id)` in addition to `selector.disconnected().containsKey(id)`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
