### PR TITLE
MINOR: Remove call to Exit.exit() to prevent infinite recursion

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -112,7 +112,6 @@ public class EmbeddedConnectCluster {
             log.warn(exitMessage);
             throw new UngracefulShutdownException(exitMessage);
         }
-        Exit.exit(0, message);
     };
 
     /**
@@ -124,7 +123,6 @@ public class EmbeddedConnectCluster {
             log.warn(haltMessage);
             throw new UngracefulShutdownException(haltMessage);
         }
-        Exit.halt(0, message);
     };
 
     /**


### PR DESCRIPTION
Signed-off-by: Arjun Satish <arjun@confluent.io>

If we call org.apache.kafka.common.utils.Exit#exit(int code) with code=0, the current implementation will go into an infinite recursion and kill the VM with a stack overflow error. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
