### PR TITLE
KAFKA-8582 [WIP] Add ability to handle late messages in streams-aggregation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -421,6 +421,70 @@ public interface TimeWindowedKStream<K, V> {
                                            final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized);
 
     /**
+     * Aggregate the values of records in this stream by the grouped key and defined windows.
+     * Records with {@code null} key or value are ignored.
+     * Aggregating is a generalization of {@link #reduce(Reducer) combining via reduce(...)} as it, for example,
+     * allows the result to have a different type than the input values.
+     * The result is written into a local {@link WindowStore} (which is basically an ever-updating materialized view)
+     * that can be queried using the store name as provided with {@link Materialized}.
+     * Furthermore, updates to the store are sent downstream into a {@link KTable} changelog stream.
+     * <p>
+     * The specified {@link Initializer} is applied directly before the first input record (per key) in each window is
+     * processed to provide an initial intermediate aggregation result that is used to process the first record for
+     * the window (per key).
+     * The specified {@link Aggregator} is applied for each input record and computes a new aggregate using the current
+     * aggregate (or for the very first record using the intermediate aggregation result provided via the
+     * {@link Initializer}) and the record's value.
+     * Thus, {@code aggregate()} can be used to compute aggregate functions like count (c.f. {@link #count()}).
+     * <p>
+     * Not all updates might get sent downstream, as an internal cache will be used to deduplicate consecutive updates
+     * to the same window and key if caching is enabled on the {@link Materialized} instance.
+     * When caching is enabled the rate of propagated updates depends on your input data rate, the number of distinct
+     * keys, the number of parallel running Kafka Streams instances, and the {@link StreamsConfig configuration}
+     * parameters for {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG cache size}, and
+     * {@link StreamsConfig#COMMIT_INTERVAL_MS_CONFIG commit intervall}
+     * <p>
+     * To query the local {@link ReadOnlyWindowStore} it must be obtained via
+     * {@link KafkaStreams#store(StoreQueryParameters) KafkaStreams#store(...)}:
+     * <pre>{@code
+     * KafkaStreams streams = ... // counting words
+     * Store queryableStoreName = ... // the queryableStoreName should be the name of the store as defined by the Materialized instance
+     * ReadOnlyWindowStore<K, ValueAndTimestamp<VR>> localWindowStore = streams.store(queryableStoreName, QueryableStoreTypes.<K, ValueAndTimestamp<VR>>timestampedWindowStore());
+     *
+     * K key = "some-word";
+     * long fromTime = ...;
+     * long toTime = ...;
+     * WindowStoreIterator<ValueAndTimestamp<VR>> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
+     * }</pre>
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * query the value of the key on a parallel running instance of your Kafka Streams application.
+     * <p>
+     * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
+     * Therefore, the store name defined by the {@link Materialized} instance must be a valid Kafka topic name and
+     * cannot contain characters other than ASCII alphanumerics, '.', '_' and '-'.
+     * The changelog topic will be named "${applicationId}-${storeName}-changelog", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is the
+     * provide store name defined in {@link Materialized}, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result. Cannot be {@code null}.
+     * @param aggregator    an {@link Aggregator} that computes a new aggregate result. Cannot be {@code null}.
+     * @param named         a {@link Named} config used to name the processor in the topology. Cannot be {@code null}.
+     * @param materialized  a {@link Materialized} config used to materialize a state store. Cannot be {@code null}.
+     * @param deadLetterTopic  a topic name to produce messages coming outside of time-window and grace-period.
+     * @param <VR>          the value type of the resulting {@link KTable}
+     * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
+     * the latest (rolling) aggregate for each key within a window
+     */
+    <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
+                                           final Aggregator<? super K, ? super V, VR> aggregator,
+                                           final Named named,
+                                           final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized,
+                                           final String deadLetterTopic);
+
+    /**
      * Combine the values of records in this stream by the grouped key and defined windows.
      * Records with {@code null} key or value are ignored.
      * Combining implies that the type of the aggregate result is the same as the type of the input value

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -115,7 +115,7 @@ class GroupedStreamAggregateBuilder<K, V> {
 
         builder.addGraphNode(parentNode, statefulProcessorNode);
 
-        if(lateMessagesSinkNode != null){
+        if (lateMessagesSinkNode != null) {
             builder.addGraphNode(statefulProcessorNode, lateMessagesSinkNode);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -18,7 +18,11 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.streams.kstream.*;
+import org.apache.kafka.streams.kstream.Aggregator;
+import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -18,14 +18,11 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.streams.kstream.Aggregator;
-import org.apache.kafka.streams.kstream.Initializer;
-import org.apache.kafka.streams.kstream.Window;
-import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.Windows;
+import org.apache.kafka.streams.kstream.*;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -33,6 +30,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrLateRecordDropSensor;
@@ -46,6 +44,7 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
     private final Windows<W> windows;
     private final Initializer<Agg> initializer;
     private final Aggregator<? super K, ? super V, Agg> aggregator;
+    private final String deadLetterNodeName;
 
     private boolean sendOldValues = false;
 
@@ -53,10 +52,21 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
                                   final String storeName,
                                   final Initializer<Agg> initializer,
                                   final Aggregator<? super K, ? super V, Agg> aggregator) {
+        this(windows, storeName, initializer, aggregator, null);
+    }
+
+    public KStreamWindowAggregate(
+        final Windows<W> windows,
+        final String storeName,
+        final Initializer<Agg> initializer,
+        final Aggregator<? super K, ? super V, Agg> aggregator,
+        final String deadLetterNodeName
+    ) {
         this.windows = windows;
         this.storeName = storeName;
         this.initializer = initializer;
         this.aggregator = aggregator;
+        this.deadLetterNodeName = deadLetterNodeName;
     }
 
     @Override
@@ -149,7 +159,10 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
                         new Windowed<>(key, entry.getValue()),
                         newAgg,
                         sendOldValues ? oldAgg : null,
-                        newTimestamp);
+                        To.all()
+                            .withTimestamp(newTimestamp)
+                            .withExclusions(deadLetterNodeName == null ? Collections.emptySet() : Collections.singleton(deadLetterNodeName))
+                    );
                 } else {
                     log.warn(
                         "Skipping record for expired window. " +
@@ -170,6 +183,9 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
                         closeTime,
                         observedStreamTime
                     );
+                    if (deadLetterNodeName != null) {
+                        context().forward(key, value, To.child(deadLetterNodeName));
+                    }
                     lateRecordDropSensor.record();
                 }
             }
@@ -186,7 +202,7 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
 
             @Override
             public String[] storeNames() {
-                return new String[] {storeName};
+                return new String[]{storeName};
             }
         };
     }
@@ -210,6 +226,7 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
         }
 
         @Override
-        public void close() {}
+        public void close() {
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -18,11 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.streams.kstream.Aggregator;
-import org.apache.kafka.streams.kstream.Initializer;
-import org.apache.kafka.streams.kstream.Window;
-import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.Windows;
+import org.apache.kafka.streams.kstream.*;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -115,8 +111,9 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
             tupleForwarder = new TimestampedTupleForwarder<>(
                 windowStore,
                 context,
-                new TimestampedCacheFlushListener<>(context),
-                sendOldValues);
+                new TimestampedCacheFlushListener<>(context, deadLetterNodeName == null ? Collections.emptySet() : Collections.singleton(deadLetterNodeName)),
+                sendOldValues
+            );
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -19,17 +19,10 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.kstream.Aggregator;
-import org.apache.kafka.streams.kstream.Initializer;
-import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.Named;
-import org.apache.kafka.streams.kstream.Reducer;
-import org.apache.kafka.streams.kstream.TimeWindowedKStream;
-import org.apache.kafka.streams.kstream.Window;
-import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.Windows;
+import org.apache.kafka.streams.kstream.*;
+import org.apache.kafka.streams.kstream.internals.graph.StreamSinkNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -43,6 +36,7 @@ import java.util.Set;
 
 import static org.apache.kafka.streams.kstream.internals.KGroupedStreamImpl.AGGREGATE_NAME;
 import static org.apache.kafka.streams.kstream.internals.KGroupedStreamImpl.REDUCE_NAME;
+import static org.apache.kafka.streams.kstream.internals.KStreamImpl.SINK_NAME;
 
 public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStream<K, V> implements TimeWindowedKStream<K, V> {
 
@@ -139,6 +133,17 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
                                                   final Aggregator<? super K, ? super V, VR> aggregator,
                                                   final Named named,
                                                   final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized) {
+        return aggregate(initializer, aggregator, named, materialized, null);
+    }
+
+    @Override
+    public <VR> KTable<Windowed<K>, VR> aggregate(
+        final Initializer<VR> initializer,
+        final Aggregator<? super K, ? super V, VR> aggregator,
+        final Named named,
+        final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized,
+        final String deadLetterTopic
+    ) {
         Objects.requireNonNull(initializer, "initializer can't be null");
         Objects.requireNonNull(aggregator, "aggregator can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
@@ -148,14 +153,27 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
             materializedInternal.withKeySerde(keySerde);
         }
 
+        String deadLetterNodeName = null;
+        StreamSinkNode<K, V> lateMessagesSinkNode = null;
+        if(deadLetterTopic != null){
+            deadLetterNodeName = new NamedInternal(named).suffixWithOrElseGet("-lateMessages", builder, AGGREGATE_NAME);
+            lateMessagesSinkNode = new StreamSinkNode<>(
+                deadLetterNodeName,
+                new StaticTopicNameExtractor<>(deadLetterTopic),
+                new ProducedInternal<>(Produced.with(keySerde, valueSerde))
+            );
+        }
+
         final String aggregateName = new NamedInternal(named).orElseGenerateWithPrefix(builder, AGGREGATE_NAME);
         return aggregateBuilder.build(
             new NamedInternal(aggregateName),
             materialize(materializedInternal),
-            new KStreamWindowAggregate<>(windows, materializedInternal.storeName(), initializer, aggregator),
+            new KStreamWindowAggregate<>(windows, materializedInternal.storeName(), initializer, aggregator, deadLetterNodeName),
             materializedInternal.queryableStoreName(),
             materializedInternal.keySerde() != null ? new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.size()) : null,
-            materializedInternal.valueSerde());
+            materializedInternal.valueSerde(),
+            lateMessagesSinkNode
+        );
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -19,7 +19,17 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.kstream.*;
+import org.apache.kafka.streams.kstream.Aggregator;
+import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.kstream.TimeWindowedKStream;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.Windows;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSinkNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
@@ -36,7 +46,6 @@ import java.util.Set;
 
 import static org.apache.kafka.streams.kstream.internals.KGroupedStreamImpl.AGGREGATE_NAME;
 import static org.apache.kafka.streams.kstream.internals.KGroupedStreamImpl.REDUCE_NAME;
-import static org.apache.kafka.streams.kstream.internals.KStreamImpl.SINK_NAME;
 
 public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStream<K, V> implements TimeWindowedKStream<K, V> {
 
@@ -155,7 +164,7 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
 
         String deadLetterNodeName = null;
         StreamSinkNode<K, V> lateMessagesSinkNode = null;
-        if(deadLetterTopic != null){
+        if (deadLetterTopic != null) {
             deadLetterNodeName = new NamedInternal(named).suffixWithOrElseGet("-lateMessages", builder, AGGREGATE_NAME);
             lateMessagesSinkNode = new StreamSinkNode<>(
                 deadLetterNodeName,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedTupleForwarder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimestampedTupleForwarder.java
@@ -60,4 +60,13 @@ class TimestampedTupleForwarder<K, V> {
             context.forward(key, new Change<>(newValue, sendOldValues ? oldValue : null), To.all().withTimestamp(timestamp));
         }
     }
+
+    public void maybeForward(final K key,
+                             final V newValue,
+                             final V oldValue,
+                             final To to) {
+        if (!cachingEnabled) {
+            context.forward(key, new Change<>(newValue, sendOldValues ? oldValue : null), to);
+        }
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/To.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/To.java
@@ -16,7 +16,9 @@
  */
 package org.apache.kafka.streams.processor;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * This class is used to provide the optional parameters when sending output records to downstream processor
@@ -25,20 +27,24 @@ import java.util.Objects;
 public class To {
     protected String childName;
     protected long timestamp;
+    protected Set<String> childExclusions;
 
     private To(final String childName,
-               final long timestamp) {
+               final long timestamp,
+               final Set<String> childExclusions) {
         this.childName = childName;
         this.timestamp = timestamp;
+        this.childExclusions = childExclusions;
     }
 
     protected To(final To to) {
-        this(to.childName, to.timestamp);
+        this(to.childName, to.timestamp, to.childExclusions);
     }
 
     protected void update(final To to) {
         childName = to.childName;
         timestamp = to.timestamp;
+        childExclusions = to.childExclusions;
     }
 
     /**
@@ -47,7 +53,7 @@ public class To {
      * @return a new {@link To} instance configured with {@code childName}
      */
     public static To child(final String childName) {
-        return new To(childName, -1);
+        return new To(childName, -1, Collections.emptySet());
     }
 
     /**
@@ -55,7 +61,7 @@ public class To {
      * @return a new {@link To} instance configured for all downstream processor
      */
     public static To all() {
-        return new To(null, -1);
+        return new To(null, -1,  Collections.emptySet());
     }
 
     /**
@@ -65,6 +71,11 @@ public class To {
      */
     public To withTimestamp(final long timestamp) {
         this.timestamp = timestamp;
+        return this;
+    }
+
+    public To withExclusions(final Set<String> childExclusions) {
+        this.childExclusions = childExclusions;
         return this;
     }
 
@@ -78,7 +89,8 @@ public class To {
         }
         final To to = (To) o;
         return timestamp == to.timestamp &&
-            Objects.equals(childName, to.childName);
+            Objects.equals(childName, to.childName) &&
+            Objects.equals(childExclusions, to.childExclusions);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -214,7 +214,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
             if (sendTo == null) {
                 final List<ProcessorNode<?, ?>> children = currentNode().children();
                 for (final ProcessorNode<?, ?> child : children) {
-                    if(!toInternal.isChildExcluded(child.name())) {
+                    if (!toInternal.isChildExcluded(child.name())) {
                         forward((ProcessorNode<K, V>) child, key, value);
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -214,7 +214,9 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
             if (sendTo == null) {
                 final List<ProcessorNode<?, ?>> children = currentNode().children();
                 for (final ProcessorNode<?, ?> child : children) {
-                    forward((ProcessorNode<K, V>) child, key, value);
+                    if(!toInternal.isChildExcluded(child.name())) {
+                        forward((ProcessorNode<K, V>) child, key, value);
+                    }
                 }
             } else {
                 final ProcessorNode<K, V> child = currentNode().getChild(sendTo);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ToInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ToInternal.java
@@ -39,7 +39,7 @@ public class ToInternal extends To {
         return childName;
     }
 
-    public boolean isChildExcluded(String child){
+    public boolean isChildExcluded(final String child) {
         return childExclusions.contains(child);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ToInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ToInternal.java
@@ -38,4 +38,9 @@ public class ToInternal extends To {
     public String child() {
         return childName;
     }
+
+    public boolean isChildExcluded(String child){
+        return childExclusions.contains(child);
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/WindowedSuppressionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/WindowedSuppressionIntegrationTest.java
@@ -198,7 +198,7 @@ public class WindowedSuppressionIntegrationTest {
 
     private List<ConsumerRecord<Object, Object>> waitForRecords(final Consumer<Object, Object> consumer) {
         final long start = System.currentTimeMillis();
-        List<ConsumerRecord<Object, Object>> result = new ArrayList<>();
+        final List<ConsumerRecord<Object, Object>> result = new ArrayList<>();
         while ((System.currentTimeMillis() - start) < DEFAULT_TIMEOUT) {
             final ConsumerRecords<Object, Object> records = consumer.poll(ofMillis(500));
             if (!records.isEmpty()) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/WindowedSuppressionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/WindowedSuppressionIntegrationTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValueTimestamp;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.*;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import static java.time.Duration.ofMillis;
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.*;
+import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.*;
+import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Category(IntegrationTest.class)
+public class WindowedSuppressionIntegrationTest {
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
+        1,
+        mkProperties(mkMap()),
+        0L
+    );
+    private static final StringSerializer STRING_SERIALIZER = new StringSerializer();
+    private static final int COMMIT_INTERVAL = 100;
+
+    final Properties producerConfig = mkProperties(mkMap(
+        mkEntry(ProducerConfig.CLIENT_ID_CONFIG, "anything"),
+        mkEntry(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+        mkEntry(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ((Serializer<String>) STRING_SERIALIZER).getClass().getName()),
+        mkEntry(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers())
+    ));
+
+    final Properties consumerConfig = mkProperties(mkMap(
+        mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+        mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()),
+        mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName()),
+        mkEntry(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+    ));
+
+    final Producer<String, String> producer = new KafkaProducer<>(producerConfig);
+    final Consumer<Object, Object> outputConsumer = new KafkaConsumer<>(consumerConfig);
+    final Consumer<Object, Object> lateArrivedConsumer = new KafkaConsumer<>(consumerConfig);
+
+    private final String inputTopic = "inputTopic-" + WindowedSuppressionIntegrationTest.class.getSimpleName();
+    private final String outputTopic = "outputTopic-" + WindowedSuppressionIntegrationTest.class.getSimpleName();
+    private final String lateArrived = "lateArrived-" + WindowedSuppressionIntegrationTest.class.getSimpleName();
+
+    @Before
+    public void setUp() {
+        initConsumer(outputConsumer, outputTopic);
+        initConsumer(lateArrivedConsumer, lateArrived);
+        cleanStateBeforeTest(CLUSTER, inputTopic, outputTopic, lateArrived);
+    }
+
+    private void initConsumer(Consumer<Object, Object> consumer, String topic) {
+        final List<TopicPartition> partitions =
+            consumer.partitionsFor(topic)
+                .stream()
+                .map(pi -> new TopicPartition(pi.topic(), pi.partition()))
+                .collect(Collectors.toList());
+        consumer.assign(partitions);
+        consumer.seekToBeginning(partitions);
+    }
+
+
+    @Test
+    public void shouldEmitRecordAfterWindowClose() {
+        final String testId = "-shouldEmitRecordAfterWindowClose";
+        final String appId = getClass().getSimpleName().toLowerCase(Locale.getDefault()) + testId;
+        final long windowSize = 1000L;
+
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, String> inputStream = builder.stream(inputTopic);
+
+        inputStream
+            .groupByKey()
+            .windowedBy(TimeWindows.of(ofMillis(windowSize)).grace(ofMillis(windowSize)))
+            .aggregate(
+                () -> "",
+                (key, value, aggregate) -> value,
+                Named.as("aggregation"+appId),
+                Materialized.<String, String>as(Stores.inMemoryWindowStore("store" + appId, Duration.ofMillis(windowSize), Duration.ofMillis(windowSize), true))
+                    .withKeySerde(Serdes.String())
+                    .withValueSerde(Serdes.String()),
+                lateArrived
+            )
+            .suppress(untilWindowCloses(Suppressed.BufferConfig.unbounded()))
+            .toStream()
+            .selectKey((k, v) -> k.key())
+            .to(outputTopic);
+
+        final Properties streamsConfig = getStreamsConfig(appId);
+        streamsConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+        streamsConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+
+        final KafkaStreams driver = IntegrationTestUtils.getStartedStreams(streamsConfig, builder, true);
+        try {
+            produceSynchronously(
+                inputTopic,
+                asList(
+                    new KeyValueTimestamp<>("k1", "v0", 0L),
+                    new KeyValueTimestamp<>("k1", "v/3", windowSize / 3),
+                    new KeyValueTimestamp<>("k1", "v/2", windowSize / 2),
+                    new KeyValueTimestamp<>("k1", "v-1", windowSize - 1),
+                    new KeyValueTimestamp<>("k1", "v1.5", windowSize + windowSize / 2),
+                    new KeyValueTimestamp<>("k1", "v2", windowSize * 2),
+                    new KeyValueTimestamp<>("k1", "v3", windowSize * 3)
+                )
+            );
+
+            final List<ConsumerRecord<Object, Object>> windows01And12 = waitForRecords(outputConsumer);
+            assertThat(windows01And12.size(), is(2));
+            assertThat(windows01And12.get(0).value(), is("v-1"));
+            assertThat(windows01And12.get(1).value(), is("v1.5"));
+
+            produceSynchronously(
+                inputTopic,
+                asList(
+                    new KeyValueTimestamp<>("k1", "v/2+1", windowSize / 2 + 1), //late
+                    new KeyValueTimestamp<>("k1", "v4", windowSize * 4)
+                )
+            );
+            final List<ConsumerRecord<Object, Object>> windows23 = waitForRecords(outputConsumer);
+            assertThat(windows23.size(), is(1));
+            assertThat(windows23.get(0).value(), is("v2"));
+
+            final List<ConsumerRecord<Object, Object>> lateArrival = waitForRecords(lateArrivedConsumer);
+            assertThat(lateArrival.size(), is(1));
+            assertThat(lateArrival.get(0).value(), is("v/2+1"));
+
+        } finally {
+            driver.close();
+            quietlyCleanStateAfterTest(CLUSTER, driver);
+        }
+    }
+
+    private List<ConsumerRecord<Object, Object>> waitForRecords(Consumer<Object, Object> consumer) {
+        final long start = System.currentTimeMillis();
+        List<ConsumerRecord<Object, Object>> result = new ArrayList<>();
+        while ((System.currentTimeMillis() - start) < DEFAULT_TIMEOUT) {
+            final ConsumerRecords<Object, Object> records = consumer.poll(ofMillis(500));
+            if (!records.isEmpty()) {
+                records.iterator().forEachRemaining(result::add);
+            }
+        }
+        return result;
+    }
+
+    private void produceSynchronously(final String topic, final List<KeyValueTimestamp<String, String>> toProduce) {
+        for (final KeyValueTimestamp<String, String> record : toProduce) {
+            final Future<RecordMetadata> future = producer.send(
+                new ProducerRecord<>(
+                    topic,
+                    null,
+                    record.timestamp(),
+                    record.key(),
+                    record.value(),
+                    null
+                )
+            );
+            producer.flush();
+            try {
+                future.get();
+            } catch (final InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private Properties getStreamsConfig(final String appId) {
+        return mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+            mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            mkEntry(StreamsConfig.POLL_MS_CONFIG, Integer.toString(COMMIT_INTERVAL)),
+            mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Integer.toString(COMMIT_INTERVAL)),
+            mkEntry(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, AT_LEAST_ONCE),
+            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
+        ));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        outputConsumer.close();
+        lateArrivedConsumer.close();
+        producer.close();
+    }
+}


### PR DESCRIPTION
KAFKA-8582 Indicates that there is a need to handle *late* messages, which arrive when respective aggregation window (including grace period) is already closed.
There is also related [SO question](https://stackoverflow.com/questions/62370180/kafka-stream-time-and-window-expire-kstreamsessionwindowaggregate-skipping-rec), where @mjsax mentions following options for handling late messages:
- start new app to reset stream time
- fall back to the Processor API and basically re-implement aggregation logic manually.

This PR tries to add an ability to forward such *late* messages to a configurable deadLetterTopic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
