### PR TITLE
Performance degradation while fetching a key from a single partition

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -48,7 +48,12 @@ public class WrappingStoreProvider implements StateStoreProvider {
         final List<T> allStores = new ArrayList<>();
         for (final StreamThreadStateStoreProvider provider : storeProviders) {
             final List<T> stores = provider.stores(storeQueryParameters);
-            allStores.addAll(stores);
+            if (!stores.isEmpty()) {
+                allStores.addAll(stores);
+                if (storeQueryParameters.partition() != null) {
+                    break;
+                }
+            }
         }
         if (allStores.isEmpty()) {
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");


### PR DESCRIPTION
WrappingStoreProvider does not take into account withPartition parameter and always return all existing stores, thus causing significant performance degradation to the caller, in case state store has many partitions.

https://issues.apache.org/jira/browse/KAFKA-10271