### PR TITLE
KAFKA-10257 system test kafkatest.tests.core.security_rolling_upgrade…

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -226,9 +226,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                                     interbroker_sasl_mechanism=self.interbroker_sasl_mechanism,
                                     listener_security_config=self.listener_security_config,
                                     tls_version=self.tls_version)
-            for port in self.port_mappings.values():
-                if port.open:
-                    self._security_config.enable_security_protocol(port.security_protocol)
+        for port in self.port_mappings.values():
+            if port.open:
+                self._security_config.enable_security_protocol(port.security_protocol)
         if self.zk.zk_sasl:
             self._security_config.enable_sasl()
             self._security_config.zk_sasl = self.zk.zk_sasl


### PR DESCRIPTION
```security_rolling_upgrade_test``` may change the security listener and then restart Kafka servers. ```has_sasl``` and ```has_ssl``` get out-of-date due to cached ```_security_config```. This PR offers a simple fix that we always check the changes of port mapping and then update the sasl/ssl flag.

issue: https://issues.apache.org/jira/browse/KAFKA-10257



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
