### PR TITLE
KAFKA-10272: Add IBM i support to "stop" scripts

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -15,11 +15,14 @@
 # limitations under the License.
 SIGNAL=${SIGNAL:-TERM}
 
-if [[ $(uname -s) == "OS/390" ]]; then
+OSNAME=$(uname -s)
+if [[ "$OSNAME" == "OS/390" ]]; then
     if [ -z $JOBNAME ]; then
         JOBNAME="KAFKSTRT"
     fi
     PIDS=$(ps -A -o pid,jobname,comm | grep -i $JOBNAME | grep java | grep -v grep | awk '{print $1}')
+elif [[ "$OSNAME" == "OS400" ]]; then
+    PIDS=$(ps -af | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $2}')
 else
     PIDS=$(ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
 fi

--- a/bin/zookeeper-server-stop.sh
+++ b/bin/zookeeper-server-stop.sh
@@ -15,11 +15,14 @@
 # limitations under the License.
 SIGNAL=${SIGNAL:-TERM}
 
-if [[ $(uname -s) == "OS/390" ]]; then
+OSNAME=$(uname -s)
+if [[ "$OSNAME" == "OS/390" ]]; then
     if [ -z $JOBNAME ]; then
         JOBNAME="ZKEESTRT"
     fi
     PIDS=$(ps -A -o pid,jobname,comm | grep -i $JOBNAME | grep java | grep -v grep | awk '{print $1}')
+elif [[ "$OSNAME" == "OS400" ]]; then
+    PIDS=$(ps -af | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $2}')
 else
     PIDS=$(ps ax | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $1}')
 fi


### PR DESCRIPTION
Details are documented in jira issue [KAFKA-10272](https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-10272).

Turns out a similar issue was fixed for IBM z/OS earlier this year, as part of PR #7913.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] ~~Verify test coverage and CI build status~~  N/A
- [x] ~~Verify documentation (including upgrade notes)~~ N/A


