### PR TITLE
MINOR: update required MacOS version

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -74,7 +74,7 @@
         For Kafka Streams 0.10.0, broker version 0.10.0 or higher is required.
     </p>
 
-    <p>Since 2.6.0 release, Kafka Streams depends on a RocksDBs version that requires MacOS 10.14 or higher.</p>
+    <p>Since 2.6.0 release, Kafka Streams depends on a RocksDB version that requires MacOS 10.14 or higher.</p>
 
     <p>
         Another important thing to keep in mind: in deprecated <code>KStreamBuilder</code> class, when a <code>KTable</code> is created from a source topic via <code>KStreamBuilder.table()</code>, its materialized state store

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -74,7 +74,7 @@
         For Kafka Streams 0.10.0, broker version 0.10.0 or higher is required.
     </p>
 
-    <p>Since 2.6.0 release, Kafka Streams depends on a RocksDBs version that requires MacOS 10.15 or higher.</p>
+    <p>Since 2.6.0 release, Kafka Streams depends on a RocksDBs version that requires MacOS 10.14 or higher.</p>
 
     <p>
         Another important thing to keep in mind: in deprecated <code>KStreamBuilder</code> class, when a <code>KTable</code> is created from a source topic via <code>KStreamBuilder.table()</code>, its materialized state store


### PR DESCRIPTION
MacOS 10.14 should actually work, too. At least our tests passed while they fail on 10.13.

This PR should be cherry-picked to `2.6` branch.

Call for review @vvcephei 