### PR TITLE
KAFKA-10035: Safer conversion of consumer timeout parameters

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -150,7 +150,7 @@ public abstract class AbstractResetIntegrationTest {
         streamsConfig.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
         streamsConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         streamsConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + STREAMS_CONSUMER_TIMEOUT);
+        streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(STREAMS_CONSUMER_TIMEOUT));
         streamsConfig.putAll(commonClientConfig);
     }
 
@@ -164,8 +164,8 @@ public abstract class AbstractResetIntegrationTest {
     private static final String INTERMEDIATE_USER_TOPIC = "userTopic";
     private static final String NON_EXISTING_TOPIC = "nonExistingTopic";
 
-    private static final long STREAMS_CONSUMER_TIMEOUT = 2000L;
-    private static final long CLEANUP_CONSUMER_TIMEOUT = 2000L;
+    private static final int STREAMS_CONSUMER_TIMEOUT = 2000;
+    private static final int CLEANUP_CONSUMER_TIMEOUT = 2000;
     private static final int TIMEOUT_MULTIPLIER = 15;
 
     void prepareTest() throws Exception {
@@ -215,7 +215,7 @@ public abstract class AbstractResetIntegrationTest {
         };
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
 
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
@@ -239,7 +239,7 @@ public abstract class AbstractResetIntegrationTest {
         };
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
 
         final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
         Assert.assertEquals(1, exitCode);
@@ -255,7 +255,7 @@ public abstract class AbstractResetIntegrationTest {
         };
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
 
         final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
         Assert.assertEquals(1, exitCode);
@@ -264,7 +264,7 @@ public abstract class AbstractResetIntegrationTest {
     public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
         appID = testId + "-with-force-option";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
-        streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + STREAMS_CONSUMER_TIMEOUT * 100);
+        streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(STREAMS_CONSUMER_TIMEOUT * 100));
 
         // Run
         streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
@@ -594,7 +594,7 @@ public abstract class AbstractResetIntegrationTest {
 
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
 
         return new StreamsResetter().run(parameters, cleanUpConfig) == 0;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -330,6 +330,16 @@ public abstract class AbstractResetIntegrationTest {
         cleanGlobal(false, null, null);
     }
 
+    @Test
+    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
+        testReprocessingFromScratchAfterResetWithIntermediateUserTopic(false);
+    }
+
+    @Test
+    public void testReprocessingFromScratchAfterResetWithIntermediateInternalTopic() throws Exception {
+        testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
+    }
+
     public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic(final boolean useRepartitioned) throws Exception {
         if (!useRepartitioned) {
             cluster.createTopic(INTERMEDIATE_USER_TOPIC);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -52,18 +52,15 @@ import org.junit.rules.TemporaryFolder;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
-import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import static java.time.Duration.ofMillis;
-import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.isEmptyConsumerGroup;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -74,8 +71,8 @@ public abstract class AbstractResetIntegrationTest {
     static EmbeddedKafkaCluster cluster;
 
     private static MockTime mockTime;
-    private static KafkaStreams streams;
-    private static Admin adminClient = null;
+    protected static KafkaStreams streams;
+    protected static Admin adminClient = null;
 
     abstract Map<String, Object> getClientSslConfig();
 
@@ -87,11 +84,11 @@ public abstract class AbstractResetIntegrationTest {
         }
     }
 
-    private String appID = "abstract-reset-integration-test";
-    private Properties commonClientConfig;
-    private Properties streamsConfig;
+    protected String appID = "abstract-reset-integration-test";
+    protected Properties commonClientConfig;
+    protected Properties streamsConfig;
     private Properties producerConfig;
-    private Properties resultConsumerConfig;
+    protected Properties resultConsumerConfig;
 
     private void prepareEnvironment() {
         if (adminClient == null) {
@@ -158,16 +155,15 @@ public abstract class AbstractResetIntegrationTest {
     @Rule
     public final TemporaryFolder testFolder = new TemporaryFolder(TestUtils.tempDirectory());
 
-    private static final String INPUT_TOPIC = "inputTopic";
-    private static final String OUTPUT_TOPIC = "outputTopic";
+    protected static final String INPUT_TOPIC = "inputTopic";
+    protected static final String OUTPUT_TOPIC = "outputTopic";
     private static final String OUTPUT_TOPIC_2 = "outputTopic2";
     private static final String OUTPUT_TOPIC_2_RERUN = "outputTopic2_rerun";
     private static final String INTERMEDIATE_USER_TOPIC = "userTopic";
-    private static final String NON_EXISTING_TOPIC = "nonExistingTopic";
 
-    private static final int STREAMS_CONSUMER_TIMEOUT = 2000;
-    private static final int CLEANUP_CONSUMER_TIMEOUT = 2000;
-    private static final int TIMEOUT_MULTIPLIER = 15;
+    protected static final int STREAMS_CONSUMER_TIMEOUT = 2000;
+    protected static final int CLEANUP_CONSUMER_TIMEOUT = 2000;
+    protected static final int TIMEOUT_MULTIPLIER = 15;
 
     void prepareTest() throws Exception {
         prepareConfigs();
@@ -204,98 +200,6 @@ public abstract class AbstractResetIntegrationTest {
             mockTime.sleep(10);
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(INPUT_TOPIC, Collections.singleton(record), producerConfig, mockTime.milliseconds());
         }
-    }
- 
-    public void shouldNotAllowToResetWhileStreamsIsRunning() {
-        appID = testId + "-not-reset-during-runtime";
-        final String[] parameters = new String[] {
-            "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
-            "--input-topics", NON_EXISTING_TOPIC,
-            "--execute"
-        };
-        final Properties cleanUpConfig = new Properties();
-        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
-
-        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
-
-        // RUN
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.start();
-
-        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
-        Assert.assertEquals(1, exitCode);
-
-        streams.close();
-    }
-
-    public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
-        appID = testId + "-not-reset-without-input-topic";
-        final String[] parameters = new String[] {
-            "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
-            "--input-topics", NON_EXISTING_TOPIC,
-            "--execute"
-        };
-        final Properties cleanUpConfig = new Properties();
-        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
-
-        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
-        Assert.assertEquals(1, exitCode);
-    }
-
-    public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
-        appID = testId + "-not-reset-without-intermediate-topic";
-        final String[] parameters = new String[] {
-            "--application-id", appID,
-            "--bootstrap-servers", cluster.bootstrapServers(),
-            "--intermediate-topics", NON_EXISTING_TOPIC,
-            "--execute"
-        };
-        final Properties cleanUpConfig = new Properties();
-        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
-
-        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
-        Assert.assertEquals(1, exitCode);
-    }
-
-    @Test
-    public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
-        appID = testId + "-with-force-option";
-        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
-        streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(STREAMS_CONSUMER_TIMEOUT * 100));
-
-        // Run
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-
-        streams.close();
-
-        // RESET
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.cleanUp();
-
-        // Reset would fail since long session timeout has been configured
-        final boolean cleanResult = tryCleanGlobal(false, null, null);
-        Assert.assertFalse(cleanResult);
-
-        // Reset will success with --force, it will force delete active members on broker side
-        cleanGlobal(false, "--force", null);
-        assertThat("Group is not empty after cleanGlobal", isEmptyConsumerGroup(adminClient, appID));
-
-        assertInternalTopicsGotDeleted(null);
-
-        // RE-RUN
-        streams.start();
-        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-        streams.close();
-
-        assertThat(resultRerun, equalTo(result));
-        cleanGlobal(false, "--force", null);
     }
 
     @Test
@@ -340,7 +244,7 @@ public abstract class AbstractResetIntegrationTest {
         testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
     }
 
-    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic(final boolean useRepartitioned) throws Exception {
+    private void testReprocessingFromScratchAfterResetWithIntermediateUserTopic(final boolean useRepartitioned) throws Exception {
         if (!useRepartitioned) {
             cluster.createTopic(INTERMEDIATE_USER_TOPIC);
         }
@@ -405,132 +309,6 @@ public abstract class AbstractResetIntegrationTest {
         }
     }
 
-    @Test
-    public void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
-        appID = testId + "-from-file";
-        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
-
-        // RUN
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-
-        streams.close();
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-
-        // RESET
-        final File resetFile = File.createTempFile("reset", ".csv");
-        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
-            writer.write(INPUT_TOPIC + ",0,1");
-        }
-
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.cleanUp();
-
-        cleanGlobal(false, "--from-file", resetFile.getAbsolutePath());
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-
-        assertInternalTopicsGotDeleted(null);
-
-        resetFile.deleteOnExit();
-
-        // RE-RUN
-        streams.start();
-        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 5);
-        streams.close();
-
-        result.remove(0);
-        assertThat(resultRerun, equalTo(result));
-
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-        cleanGlobal(false, null, null);
-    }
-
-    @Test
-    public void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
-        appID = testId + "-from-datetime";
-        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
-
-        // RUN
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-
-        streams.close();
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-
-        // RESET
-        final File resetFile = File.createTempFile("reset", ".csv");
-        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
-            writer.write(INPUT_TOPIC + ",0,1");
-        }
-
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.cleanUp();
-
-
-        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
-        final Calendar calendar = Calendar.getInstance();
-        calendar.add(Calendar.DATE, -1);
-
-        cleanGlobal(false, "--to-datetime", format.format(calendar.getTime()));
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-
-        assertInternalTopicsGotDeleted(null);
-
-        resetFile.deleteOnExit();
-
-        // RE-RUN
-        streams.start();
-        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-        streams.close();
-
-        assertThat(resultRerun, equalTo(result));
-
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-        cleanGlobal(false, null, null);
-    }
-
-    @Test
-    public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
-        appID = testId + "-from-duration";
-        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
-
-        // RUN
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-
-        streams.close();
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-
-        // RESET
-        final File resetFile = File.createTempFile("reset", ".csv");
-        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
-            writer.write(INPUT_TOPIC + ",0,1");
-        }
-
-        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
-        streams.cleanUp();
-        cleanGlobal(false, "--by-duration", "PT1M");
-
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-
-        assertInternalTopicsGotDeleted(null);
-
-        resetFile.deleteOnExit();
-
-        // RE-RUN
-        streams.start();
-        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
-        streams.close();
-
-        assertThat(resultRerun, equalTo(result));
-
-        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-        cleanGlobal(false, null, null);
-    }
-
     private Topology setupTopologyWithIntermediateTopic(final boolean useRepartitioned,
                                                         final String outputTopic2) {
         final StreamsBuilder builder = new StreamsBuilder();
@@ -561,7 +339,7 @@ public abstract class AbstractResetIntegrationTest {
         return builder.build();
     }
 
-    private Topology setupTopologyWithoutIntermediateUserTopic() {
+    protected Topology setupTopologyWithoutIntermediateUserTopic() {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final KStream<Long, String> input = builder.stream(INPUT_TOPIC);
@@ -573,7 +351,7 @@ public abstract class AbstractResetIntegrationTest {
         return builder.build();
     }
 
-    private boolean tryCleanGlobal(final boolean withIntermediateTopics,
+    protected boolean tryCleanGlobal(final boolean withIntermediateTopics,
                                    final String resetScenario,
                                    final String resetScenarioArg) throws Exception {
         // leaving --zookeeper arg here to ensure tool works if users add it
@@ -615,14 +393,14 @@ public abstract class AbstractResetIntegrationTest {
         return new StreamsResetter().run(parameters, cleanUpConfig) == 0;
     }
 
-    private void cleanGlobal(final boolean withIntermediateTopics,
+    protected void cleanGlobal(final boolean withIntermediateTopics,
                              final String resetScenario,
                              final String resetScenarioArg) throws Exception {
         final boolean cleanResult = tryCleanGlobal(withIntermediateTopics, resetScenario, resetScenarioArg);
         Assert.assertTrue(cleanResult);
     }
 
-    private void assertInternalTopicsGotDeleted(final String intermediateUserTopic) throws Exception {
+    protected void assertInternalTopicsGotDeleted(final String intermediateUserTopic) throws Exception {
         // do not use list topics request, but read from the embedded cluster's zookeeper path directly to confirm
         if (intermediateUserTopic != null) {
             cluster.waitForRemainingTopics(30000, INPUT_TOPIC, OUTPUT_TOPIC, OUTPUT_TOPIC_2, OUTPUT_TOPIC_2_RERUN,

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -45,6 +45,7 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
@@ -204,8 +205,8 @@ public abstract class AbstractResetIntegrationTest {
             IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(INPUT_TOPIC, Collections.singleton(record), producerConfig, mockTime.milliseconds());
         }
     }
-
-    void shouldNotAllowToResetWhileStreamsIsRunning() {
+ 
+    public void shouldNotAllowToResetWhileStreamsIsRunning() {
         appID = testId + "-not-reset-during-runtime";
         final String[] parameters = new String[] {
             "--application-id", appID,
@@ -261,6 +262,7 @@ public abstract class AbstractResetIntegrationTest {
         Assert.assertEquals(1, exitCode);
     }
 
+    @Test
     public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
         appID = testId + "-with-force-option";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
@@ -296,7 +298,8 @@ public abstract class AbstractResetIntegrationTest {
         cleanGlobal(false, "--force", null);
     }
 
-    void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
+    @Test
+    public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
         appID = testId + "-from-scratch";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
@@ -327,7 +330,7 @@ public abstract class AbstractResetIntegrationTest {
         cleanGlobal(false, null, null);
     }
 
-    void testReprocessingFromScratchAfterResetWithIntermediateUserTopic(final boolean useRepartitioned) throws Exception {
+    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic(final boolean useRepartitioned) throws Exception {
         if (!useRepartitioned) {
             cluster.createTopic(INTERMEDIATE_USER_TOPIC);
         }
@@ -392,7 +395,8 @@ public abstract class AbstractResetIntegrationTest {
         }
     }
 
-    void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
+    @Test
+    public void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
         appID = testId + "-from-file";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
@@ -432,7 +436,8 @@ public abstract class AbstractResetIntegrationTest {
         cleanGlobal(false, null, null);
     }
 
-    void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
+    @Test
+    public void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
         appID = testId + "-from-datetime";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
@@ -476,7 +481,8 @@ public abstract class AbstractResetIntegrationTest {
         cleanGlobal(false, null, null);
     }
 
-    void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
+    @Test
+    public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
         appID = testId + "-from-duration";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -68,42 +68,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     }
 
     @Test
-    public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic();
-    }
-
-    @Test
-    public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
-        super.testResetWhenLongSessionTimeoutConfiguredWithForceOption();
-    }
-
-    @Test
-    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(false);
-    }
-
-    @Test
-    public void testReprocessingFromScratchAfterResetWithIntermediateInternalTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
-    }
-
-    @Test
-    public void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromFileAfterResetWithoutIntermediateUserTopic();
-    }
-
-    @Test
-    public void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic();
-    }
-
-    @Test
-    public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
-        super.testReprocessingByDurationAfterResetWithoutIntermediateUserTopic();
-    }
-
-    @Test
-    public void shouldNotAllowToResetWhileStreamsRunning() {
+    public void shouldNotAllowToResetWhileStreamsIsRunning() {
         super.shouldNotAllowToResetWhileStreamsIsRunning();
     }
 
@@ -116,4 +81,15 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
         super.shouldNotAllowToResetWhenIntermediateTopicAbsent();
     }
+
+    @Test
+    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
+        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(false);
+    }
+
+    @Test
+    public void testReprocessingFromScratchAfterResetWithIntermediateInternalTopic() throws Exception {
+        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -82,14 +82,4 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         super.shouldNotAllowToResetWhenIntermediateTopicAbsent();
     }
 
-    @Test
-    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(false);
-    }
-
-    @Test
-    public void testReprocessingFromScratchAfterResetWithIntermediateInternalTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
-    }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -17,24 +17,44 @@
 package org.apache.kafka.streams.integration;
 
 import kafka.server.KafkaConfig$;
+import kafka.tools.StreamsResetter;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.test.IntegrationTest;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.isEmptyConsumerGroup;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.waitForEmptyConsumerGroup;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests local state store and global application cleanup.
  */
 @Category({IntegrationTest.class})
 public class ResetIntegrationTest extends AbstractResetIntegrationTest {
+
+    private static final String NON_EXISTING_TOPIC = "nonExistingTopic";
 
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER;
@@ -69,17 +89,223 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhileStreamsIsRunning() {
-        super.shouldNotAllowToResetWhileStreamsIsRunning();
+        appID = testId + "-not-reset-during-runtime";
+        final String[] parameters = new String[] {
+            "--application-id", appID,
+            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--input-topics", NON_EXISTING_TOPIC,
+            "--execute"
+        };
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
+
+        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+        // RUN
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.start();
+
+        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
+        Assert.assertEquals(1, exitCode);
+
+        streams.close();
     }
 
     @Test
     public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
-        super.shouldNotAllowToResetWhenInputTopicAbsent();
+        appID = testId + "-not-reset-without-input-topic";
+        final String[] parameters = new String[] {
+            "--application-id", appID,
+            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--input-topics", NON_EXISTING_TOPIC,
+            "--execute"
+        };
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
+
+        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
+        Assert.assertEquals(1, exitCode);
     }
 
     @Test
     public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
-        super.shouldNotAllowToResetWhenIntermediateTopicAbsent();
+        appID = testId + "-not-reset-without-intermediate-topic";
+        final String[] parameters = new String[] {
+            "--application-id", appID,
+            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--intermediate-topics", NON_EXISTING_TOPIC,
+            "--execute"
+        };
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(CLEANUP_CONSUMER_TIMEOUT));
+
+        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
+        Assert.assertEquals(1, exitCode);
+    }
+
+    @Test
+    public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
+        appID = testId + "-with-force-option";
+        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+        streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(STREAMS_CONSUMER_TIMEOUT * 100));
+
+        // Run
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.start();
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+
+        streams.close();
+
+        // RESET
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.cleanUp();
+
+        // Reset would fail since long session timeout has been configured
+        final boolean cleanResult = tryCleanGlobal(false, null, null);
+        Assert.assertFalse(cleanResult);
+
+        // Reset will success with --force, it will force delete active members on broker side
+        cleanGlobal(false, "--force", null);
+        assertThat("Group is not empty after cleanGlobal", isEmptyConsumerGroup(adminClient, appID));
+
+        assertInternalTopicsGotDeleted(null);
+
+        // RE-RUN
+        streams.start();
+        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+        streams.close();
+
+        assertThat(resultRerun, equalTo(result));
+        cleanGlobal(false, "--force", null);
+    }
+
+    @Test
+    public void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
+        appID = testId + "-from-file";
+        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+        // RUN
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.start();
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+
+        streams.close();
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+
+        // RESET
+        final File resetFile = File.createTempFile("reset", ".csv");
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
+            writer.write(INPUT_TOPIC + ",0,1");
+        }
+
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.cleanUp();
+
+        cleanGlobal(false, "--from-file", resetFile.getAbsolutePath());
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+
+        assertInternalTopicsGotDeleted(null);
+
+        resetFile.deleteOnExit();
+
+        // RE-RUN
+        streams.start();
+        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 5);
+        streams.close();
+
+        result.remove(0);
+        assertThat(resultRerun, equalTo(result));
+
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+        cleanGlobal(false, null, null);
+    }
+
+    @Test
+    public void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
+        appID = testId + "-from-datetime";
+        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+        // RUN
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.start();
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+
+        streams.close();
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+
+        // RESET
+        final File resetFile = File.createTempFile("reset", ".csv");
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
+            writer.write(INPUT_TOPIC + ",0,1");
+        }
+
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.cleanUp();
+
+
+        final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        final Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.DATE, -1);
+
+        cleanGlobal(false, "--to-datetime", format.format(calendar.getTime()));
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+
+        assertInternalTopicsGotDeleted(null);
+
+        resetFile.deleteOnExit();
+
+        // RE-RUN
+        streams.start();
+        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+        streams.close();
+
+        assertThat(resultRerun, equalTo(result));
+
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+        cleanGlobal(false, null, null);
+    }
+
+    @Test
+    public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
+        appID = testId + "-from-duration";
+        streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+        // RUN
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.start();
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+
+        streams.close();
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+
+        // RESET
+        final File resetFile = File.createTempFile("reset", ".csv");
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(resetFile))) {
+            writer.write(INPUT_TOPIC + ",0,1");
+        }
+
+        streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
+        streams.cleanUp();
+        cleanGlobal(false, "--by-duration", "PT1M");
+
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+
+        assertInternalTopicsGotDeleted(null);
+
+        resetFile.deleteOnExit();
+
+        // RE-RUN
+        streams.start();
+        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(resultConsumerConfig, OUTPUT_TOPIC, 10);
+        streams.close();
+
+        assertThat(resultRerun, equalTo(result));
+
+        waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
+        cleanGlobal(false, null, null);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -71,13 +71,17 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     }
 
     @Override
+    protected String getTestId() {
+        return TEST_ID;
+    }
+
+    @Override
     Map<String, Object> getClientSslConfig() {
         return null;
     }
 
     @Before
     public void before() throws Exception {
-        testId = TEST_ID;
         cluster = CLUSTER;
         prepareTest();
     }
@@ -89,7 +93,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhileStreamsIsRunning() {
-        appID = testId + "-not-reset-during-runtime";
+        final String appID = getTestId() + "-not-reset-during-runtime";
         final String[] parameters = new String[] {
             "--application-id", appID,
             "--bootstrap-servers", cluster.bootstrapServers(),
@@ -114,7 +118,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
-        appID = testId + "-not-reset-without-input-topic";
+        final String appID = getTestId() + "-not-reset-without-input-topic";
         final String[] parameters = new String[] {
             "--application-id", appID,
             "--bootstrap-servers", cluster.bootstrapServers(),
@@ -131,7 +135,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
-        appID = testId + "-not-reset-without-intermediate-topic";
+        final String appID = getTestId() + "-not-reset-without-intermediate-topic";
         final String[] parameters = new String[] {
             "--application-id", appID,
             "--bootstrap-servers", cluster.bootstrapServers(),
@@ -148,7 +152,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
-        appID = testId + "-with-force-option";
+        final String appID = getTestId() + "-with-force-option";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
         streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(STREAMS_CONSUMER_TIMEOUT * 100));
 
@@ -164,11 +168,11 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         streams.cleanUp();
 
         // Reset would fail since long session timeout has been configured
-        final boolean cleanResult = tryCleanGlobal(false, null, null);
+        final boolean cleanResult = tryCleanGlobal(false, null, null, appID);
         Assert.assertFalse(cleanResult);
 
         // Reset will success with --force, it will force delete active members on broker side
-        cleanGlobal(false, "--force", null);
+        cleanGlobal(false, "--force", null, appID);
         assertThat("Group is not empty after cleanGlobal", isEmptyConsumerGroup(adminClient, appID));
 
         assertInternalTopicsGotDeleted(null);
@@ -179,12 +183,12 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         streams.close();
 
         assertThat(resultRerun, equalTo(result));
-        cleanGlobal(false, "--force", null);
+        cleanGlobal(false, "--force", null, appID);
     }
 
     @Test
     public void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
-        appID = testId + "-from-file";
+        final String appID = getTestId() + "-from-file";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
         // RUN
@@ -204,7 +208,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
         streams.cleanUp();
 
-        cleanGlobal(false, "--from-file", resetFile.getAbsolutePath());
+        cleanGlobal(false, "--from-file", resetFile.getAbsolutePath(), appID);
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
 
         assertInternalTopicsGotDeleted(null);
@@ -220,12 +224,12 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         assertThat(resultRerun, equalTo(result));
 
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-        cleanGlobal(false, null, null);
+        cleanGlobal(false, null, null, appID);
     }
 
     @Test
     public void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
-        appID = testId + "-from-datetime";
+        final String appID = getTestId() + "-from-datetime";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
         // RUN
@@ -250,7 +254,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         final Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DATE, -1);
 
-        cleanGlobal(false, "--to-datetime", format.format(calendar.getTime()));
+        cleanGlobal(false, "--to-datetime", format.format(calendar.getTime()), appID);
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
 
         assertInternalTopicsGotDeleted(null);
@@ -265,12 +269,12 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         assertThat(resultRerun, equalTo(result));
 
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-        cleanGlobal(false, null, null);
+        cleanGlobal(false, null, null, appID);
     }
 
     @Test
     public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
-        appID = testId + "-from-duration";
+        final String appID = getTestId() + "-from-duration";
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
         // RUN
@@ -289,7 +293,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
         streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfig);
         streams.cleanUp();
-        cleanGlobal(false, "--by-duration", "PT1M");
+        cleanGlobal(false, "--by-duration", "PT1M", appID);
 
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
 
@@ -305,7 +309,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         assertThat(resultRerun, equalTo(result));
 
         waitForEmptyConsumerGroup(adminClient, appID, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT);
-        cleanGlobal(false, null, null);
+        cleanGlobal(false, null, null, appID);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -59,8 +59,6 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER;
 
-    private static final String TEST_ID = "reset-integration-test";
-
     static {
         final Properties brokerProps = new Properties();
         // we double the value passed to `time.sleep` in each iteration in one of the map functions, so we disable
@@ -68,11 +66,6 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         // very long sleep times
         brokerProps.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
         CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
-    }
-
-    @Override
-    protected String getTestId() {
-        return TEST_ID;
     }
 
     @Override
@@ -93,7 +86,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhileStreamsIsRunning() {
-        final String appID = getTestId() + "-not-reset-during-runtime";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
             "--bootstrap-servers", cluster.bootstrapServers(),
@@ -118,7 +111,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
-        final String appID = getTestId() + "-not-reset-without-input-topic";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
             "--bootstrap-servers", cluster.bootstrapServers(),
@@ -135,7 +128,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
-        final String appID = getTestId() + "-not-reset-without-intermediate-topic";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         final String[] parameters = new String[] {
             "--application-id", appID,
             "--bootstrap-servers", cluster.bootstrapServers(),
@@ -152,7 +145,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void testResetWhenLongSessionTimeoutConfiguredWithForceOption() throws Exception {
-        final String appID = getTestId() + "-with-force-option";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
         streamsConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(STREAMS_CONSUMER_TIMEOUT * 100));
 
@@ -188,7 +181,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void testReprocessingFromFileAfterResetWithoutIntermediateUserTopic() throws Exception {
-        final String appID = getTestId() + "-from-file";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
         // RUN
@@ -229,7 +222,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void testReprocessingFromDateTimeAfterResetWithoutIntermediateUserTopic() throws Exception {
-        final String appID = getTestId() + "-from-datetime";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
         // RUN
@@ -274,7 +267,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
-        final String appID = getTestId() + "-from-duration";
+        final String appID = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
         streamsConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
 
         // RUN

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.util.Map;
@@ -79,16 +78,6 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
     @After 
     public void after() throws Exception {
         cleanupTest();
-    }
-
-    @Test
-    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(false);
-    }
-
-    @Test
-    public void testReprocessingFromScratchAfterResetWithIntermediateInternalTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -64,13 +64,17 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
     }
 
     @Override
+    protected String getTestId() {
+        return TEST_ID;
+    }
+
+    @Override
     Map<String, Object> getClientSslConfig() {
         return SSL_CONFIG;
     }
 
     @Before
     public void before() throws Exception {
-        testId = TEST_ID;
         cluster = CLUSTER;
         prepareTest();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -39,8 +39,6 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER;
 
-    private static final String TEST_ID = "reset-with-ssl-integration-test";
-
     private static final Map<String, Object> SSL_CONFIG;
 
     static {
@@ -61,11 +59,6 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         }
 
         CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
-    }
-
-    @Override
-    protected String getTestId() {
-        return TEST_ID;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -76,14 +76,9 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         prepareTest();
     }
 
-    @After
+    @After 
     public void after() throws Exception {
         cleanupTest();
-    }
-
-    @Test
-    public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
-        super.testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic();
     }
 
     @Test
@@ -95,4 +90,5 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
     public void testReprocessingFromScratchAfterResetWithIntermediateInternalTopic() throws Exception {
         super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic(true);
     }
+
 }


### PR DESCRIPTION
In `org.apache.kafka.streams.integration.AbstractResetIntegrationTest`:

- Corrected types of consumer timeout params: `STREAMS_CONSUMER_TIMEOUT ` and `CLEANUP_CONSUMER_TIMEOUT ` from `long` to `int`
- Type-safe conversion from `int` to `String`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
