### PR TITLE
KAFKA-10255: Fix flaky testOneWayReplicationWithAutoOffsetSync test

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -345,10 +345,10 @@ public class MirrorConnectorsIntegrationTest {
     private void waitForConsumingAllRecords(Consumer<byte[], byte[]> consumer) throws InterruptedException {
         final AtomicInteger totalConsumedRecords = new AtomicInteger(0);
         waitForCondition(() -> {
-            ConsumerRecords records = consumer.poll(Duration.ofMillis(500));
-            consumer.commitSync();
+            ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofMillis(500));
             return NUM_RECORDS_PRODUCED == totalConsumedRecords.addAndGet(records.count());
-        }, RECORD_CONSUME_DURATION_MS, "Consumer cannot consume all the records in time");
+        }, RECORD_CONSUME_DURATION_MS, "Consumer cannot consume all records in time");
+        consumer.commitSync();
     }
 
     @Test
@@ -357,7 +357,7 @@ public class MirrorConnectorsIntegrationTest {
         // create consumers before starting the connectors so we don't need to wait for discovery
         try (Consumer<byte[], byte[]> consumer1 = primary.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
             "group.id", "consumer-group-1"), "test-topic-1")) {
-            // we need to wait for consuming all the records for MM2 replicaing the expected offsets
+            // we need to wait for consuming all the records for MM2 replicating the expected offsets
             waitForConsumingAllRecords(consumer1);
         }
 
@@ -395,7 +395,7 @@ public class MirrorConnectorsIntegrationTest {
         // create a consumer at primary cluster to consume the new topic
         try (Consumer<byte[], byte[]> consumer1 = primary.kafka().createConsumerAndSubscribeTo(Collections.singletonMap(
             "group.id", "consumer-group-1"), "test-topic-2")) {
-            // we need to wait for consuming all the records for MM2 replicaing the expected offsets
+            // we need to wait for consuming all the records for MM2 replicating the expected offsets
             waitForConsumingAllRecords(consumer1);
         }
 

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -323,10 +323,12 @@ public class MirrorConnectorsIntegrationTest {
             throws InterruptedException {
         Admin backupClient = backup.kafka().createAdminClient();
         List<TopicPartition> tps = new ArrayList<>(NUM_PARTITIONS * topics.size());
-        IntStream.range(0, NUM_PARTITIONS).forEach(partitionInd -> {
-            for (String topic: topics) {
-                tps.add(new TopicPartition(topic, partitionInd));
-            }}
+        IntStream.range(0, NUM_PARTITIONS).forEach(
+            partitionInd -> {
+                for (String topic: topics) {
+                    tps.add(new TopicPartition(topic, partitionInd));
+                }
+            }
         );
         long expectedTotalOffsets = NUM_RECORDS_PRODUCED * topics.size();
 
@@ -336,7 +338,7 @@ public class MirrorConnectorsIntegrationTest {
             long consumerGroupOffsetTotal = consumerGroupOffsets.values().stream().mapToLong(metadata -> metadata.offset()).sum();
 
             Map<TopicPartition, Long> offsets = consumer.endOffsets(tps, Duration.ofMillis(500));
-            long totalOffsets = offsets.values().stream().mapToLong(l->l).sum();
+            long totalOffsets = offsets.values().stream().mapToLong(l -> l).sum();
 
             // make sure the consumer group offsets are synced to expected number
             return totalOffsets == expectedTotalOffsets && consumerGroupOffsetTotal > 0;


### PR DESCRIPTION
In the original test, we will sleep for static 5 seconds to ensure the automated group offset sync is complete. It sometimes synced fast (less than 1 sec), and sometimes slow (~ 20 seconds). I rewrite the sleep to wait for specific condition:  
1. `consumer.endOffsets` to make sure the topic partition metadata is synced
2. `backupClient.listConsumerGroupOffsets` to make sure the consumerGroupOffset is also synced

I've tested in my local environment a lot of times. It can make the test more stable.

Thanks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
