### PR TITLE
MINOR: Fix flaky system test assertion after static member fencing

### DIFF
--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -254,7 +254,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
             self.await_members(conflict_consumer, num_conflict_consumers)
             self.await_members(consumer, len(consumer.nodes) - num_conflict_consumers)
 
-            assert len(consumer.dead_nodes()) == num_conflict_consumers
+            wait_until(lambda: len(consumer.dead_nodes()) == num_conflict_consumers,
+                       timeout_sec=10,
+                       err_msg("Timed out waiting for the fenced consumers to stop"))
         else:
             consumer.start()
             conflict_consumer.start()

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -256,7 +256,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
 
             wait_until(lambda: len(consumer.dead_nodes()) == num_conflict_consumers,
                        timeout_sec=10,
-                       err_msg("Timed out waiting for the fenced consumers to stop"))
+                       err_msg="Timed out waiting for the fenced consumers to stop")
         else:
             consumer.start()
             conflict_consumer.start()


### PR DESCRIPTION
We see the test case `OffsetValidationTest.test_fencing_static_consumer` failing periodically due to this error:
```
Traceback (most recent call last):
  File "/home/jenkins/workspace/system-test-kafka_2.6/kafka/venv/lib/python2.7/site-packages/ducktape-0.7.8-py2.7.egg/ducktape/tests/runner_client.py", line 134, in run
    data = self.run_test()
  File "/home/jenkins/workspace/system-test-kafka_2.6/kafka/venv/lib/python2.7/site-packages/ducktape-0.7.8-py2.7.egg/ducktape/tests/runner_client.py", line 192, in run_test
    return self.test_context.function(self.test)
  File "/home/jenkins/workspace/system-test-kafka_2.6/kafka/venv/lib/python2.7/site-packages/ducktape-0.7.8-py2.7.egg/ducktape/mark/_mark.py", line 429, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/home/jenkins/workspace/system-test-kafka_2.6/kafka/tests/kafkatest/tests/client/consumer_test.py", line 257, in test_fencing_static_consumer
    assert len(consumer.dead_nodes()) == num_conflict_consumers
AssertionError
```
When a consumer stops, there is some latency between when the shutdown is observed by the service and when the node is actually added to the dead nodes. This patch fixes the problem by giving some time for the assertion to be satisfied.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
