### PR TITLE
KAFKA-10246 : AbstractProcessorContext topic() throws NPE

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -123,7 +123,7 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
 
         final String topic = recordContext.topic();
 
-        if (topic.equals(NONEXIST_TOPIC)) {
+        if (NONEXIST_TOPIC.equals(topic)) {
             return null;
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -92,6 +92,12 @@ public class AbstractProcessorContextTest {
     }
 
     @Test
+    public void shouldNotThrowNullPointerExceptionOnTopicIfRecordContextTopicIsNull() {
+        context.setRecordContext(new ProcessorRecordContext(0, 0, 0, null, null));
+        assertThat(context.topic(), nullValue());
+    }
+
+    @Test
     public void shouldReturnTopicFromRecordContext() {
         assertThat(context.topic(), equalTo(recordContext.topic()));
     }


### PR DESCRIPTION
AbstractProcessorContext topic() throws NullPointerException when modifying a state store within the DSL from a punctuator

