### PR TITLE
KAFKA-9432:(follow-up) Set `configKeys` to null in `describeConfigs()` to make it backward compatible with older Kafka versions.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1949,7 +1949,8 @@ public class KafkaAdminClient extends AdminClient {
                             .map(config ->
                                 new DescribeConfigsRequestData.DescribeConfigsResource()
                                     .setResourceName(config.name())
-                                    .setResourceType(config.type().id()))
+                                    .setResourceType(config.type().id())
+                                    .setConfigurationKeys(null))
                             .collect(Collectors.toList()))
                         .setIncludeSynonyms(options.includeSynonyms())
                         .setIncludeDocumentation(options.includeDocumentation()));

--- a/core/src/test/scala/unit/kafka/server/AdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AdminManagerTest.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.protocol.Errors
 
 import org.junit.{After, Test}
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 
 class AdminManagerTest {
 
@@ -60,6 +61,23 @@ class AdminManagerTest {
       .setConfigurationKeys(null))
     val adminManager = createAdminManager()
     val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = adminManager.describeConfigs(resources, true, true)
-    assertEquals(results.head.errorCode(), Errors.NONE.code)
+    assertEquals(Errors.NONE.code, results.head.errorCode())
+    assertFalse("Should return configs", results.head.configs().isEmpty)
+  }
+
+  @Test
+  def testDescribeConfigsWithEmptyConfigurationKeys(): Unit = {
+    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
+    EasyMock.expect(metadataCache.contains(topic)).andReturn(true)
+
+    EasyMock.replay(zkClient, metadataCache)
+
+    val resources = List(new DescribeConfigsRequestData.DescribeConfigsResource()
+      .setResourceName(topic)
+      .setResourceType(ConfigResource.Type.TOPIC.id))
+    val adminManager = createAdminManager()
+    val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = adminManager.describeConfigs(resources, true, true)
+    assertEquals(Errors.NONE.code, results.head.errorCode())
+    assertFalse("Should return configs", results.head.configs().isEmpty)
   }
 }

--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -39,8 +39,10 @@ def get_broker_features(broker_version):
         features["expect-record-too-large-exception"] = False
     if broker_version < V_0_11_0_0:
         features["describe-acls-supported"] = False
+        features["describe-configs-supported"] = False
     else:
         features["describe-acls-supported"] = True
+        features["describe-configs-supported"] = True
     return features
 
 def run_command(node, cmd, ssh_log_file):

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -22,6 +22,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -40,6 +41,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -85,6 +87,7 @@ public class ClientCompatibilityTest {
         final int numClusterNodes;
         final boolean createTopicsSupported;
         final boolean describeAclsSupported;
+        final boolean describeConfigsSupported;
 
         TestConfig(Namespace res) {
             this.bootstrapServer = res.getString("bootstrapServer");
@@ -95,6 +98,7 @@ public class ClientCompatibilityTest {
             this.numClusterNodes = res.getInt("numClusterNodes");
             this.createTopicsSupported = res.getBoolean("createTopicsSupported");
             this.describeAclsSupported = res.getBoolean("describeAclsSupported");
+            this.describeConfigsSupported = res.getBoolean("describeConfigsSupported");
         }
     }
 
@@ -161,6 +165,13 @@ public class ClientCompatibilityTest {
             .dest("describeAclsSupported")
             .metavar("DESCRIBE_ACLS_SUPPORTED")
             .help("Whether describeAcls is supported in the AdminClient.");
+        parser.addArgument("--describe-configs-supported")
+            .action(store())
+            .required(true)
+            .type(Boolean.class)
+            .dest("describeConfigsSupported")
+            .metavar("DESCRIBE_CONFIGS_SUPPORTED")
+            .help("Whether describeConfigs is supported in the AdminClient.");
 
         Namespace res = null;
         try {
@@ -260,6 +271,9 @@ public class ClientCompatibilityTest {
                 log.info("Saw only {} cluster nodes.  Waiting to see {}.",
                     nodes.size(), testConfig.numClusterNodes);
             }
+
+            testDescribeConfigsMethod(client);
+
             tryFeature("createTopics", testConfig.createTopicsSupported,
                 () -> {
                     try {
@@ -295,6 +309,29 @@ public class ClientCompatibilityTest {
                     }
                 });
         }
+    }
+
+    private void testDescribeConfigsMethod(final Admin client) throws Throwable {
+        tryFeature("describeConfigsSupported", testConfig.describeConfigsSupported,
+            () -> {
+                try {
+                    Collection<Node> nodes = client.describeCluster().nodes().get();
+
+                    final ConfigResource configResource = new ConfigResource(
+                        ConfigResource.Type.BROKER,
+                        nodes.iterator().next().idString()
+                    );
+
+                    Map<ConfigResource, Config> brokerConfig =
+                        client.describeConfigs(Collections.singleton(configResource)).all().get();
+
+                    if (brokerConfig.get(configResource).entries().isEmpty()) {
+                        throw new KafkaException("Expected to see config entries, but got zero entries");
+                    }
+                } catch (ExecutionException e) {
+                    throw e.getCause();
+                }
+            });
     }
 
     private void createTopicsResultTest(Admin client, Collection<String> topics)


### PR DESCRIPTION
- After #8312, older brokers are returning empty configs,  with latest `adminClient.describeConfigs`.  Old brokers  are receiving empty configNames in `AdminManageer.describeConfigs()` method. Older brokers does not handle empty configKeys. Due to this old brokers are filtering all the configs.
- Update ClientCompatibilityTest to verify describe configs
- Add test case to test describe configs with empty configuration Keys

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
