### PR TITLE
KAFKA-10268: dynamic config like "--delete-config log.retention.ms" doesn't work

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -653,9 +653,12 @@ class DynamicLogConfig(logManager: LogManager, server: KafkaServer) extends Brok
     val origUncleanLeaderElectionEnable = logManager.currentDefaultConfig.uncleanLeaderElectionEnable
     val newBrokerDefaults = new util.HashMap[String, Object](currentLogConfig.originals)
     newConfig.valuesFromThisConfig.forEach { (k, v) =>
-      if (DynamicLogConfig.ReconfigurableConfigs.contains(k) && v != null) {
+      if (DynamicLogConfig.ReconfigurableConfigs.contains(k)) {
         DynamicLogConfig.KafkaConfigToLogConfigName.get(k).foreach { configName =>
-          newBrokerDefaults.put(configName, v.asInstanceOf[AnyRef])
+          if (v == null)
+             newBrokerDefaults.remove(configName)
+          else
+            newBrokerDefaults.put(configName, v.asInstanceOf[AnyRef])
         }
       }
     }

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -622,12 +622,34 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     // configuration across brokers, they can also be defined at per-broker level for testing
     props.clear()
     props.put(KafkaConfig.LogIndexSizeMaxBytesProp, "500000")
+    props.put(KafkaConfig.LogRetentionTimeMillisProp, TimeUnit.DAYS.toMillis(2).toString)
     alterConfigsOnServer(servers.head, props)
     assertEquals(500000, servers.head.config.values.get(KafkaConfig.LogIndexSizeMaxBytesProp))
-    servers.tail.foreach { server => assertEquals(Defaults.LogIndexSizeMaxBytes, server.config.values.get(KafkaConfig.LogIndexSizeMaxBytesProp)) }
+    assertEquals(TimeUnit.DAYS.toMillis(2), servers.head.config.values.get(KafkaConfig.LogRetentionTimeMillisProp))
+    servers.tail.foreach { server =>
+      assertEquals(Defaults.LogIndexSizeMaxBytes, server.config.values.get(KafkaConfig.LogIndexSizeMaxBytesProp))
+      assertEquals(1680000000L, server.config.values.get(KafkaConfig.LogRetentionTimeMillisProp))
+    }
 
     // Verify that produce/consume worked throughout this test without any retries in producer
     stopAndVerifyProduceConsume(producerThread, consumerThread)
+
+    // Verify that configuration at both per-broker level and default cluster level could be deleted and
+    // the default value should be restored
+    props.clear()
+    props.put(KafkaConfig.LogRetentionTimeMillisProp, "")
+    props.put(KafkaConfig.LogIndexSizeMaxBytesProp, "")
+    TestUtils.incrementalAlterConfigs(servers.take(1), adminClients.head, props, perBrokerConfig = true, opType = OpType.DELETE).all.get
+    TestUtils.incrementalAlterConfigs(servers, adminClients.head, props, perBrokerConfig = false, opType = OpType.DELETE).all.get
+    servers.foreach { server =>
+      waitForConfigOnServer(server, KafkaConfig.LogRetentionTimeMillisProp, 1680000000.toString)
+    }
+    servers.foreach { server =>
+      val log = server.logManager.getLog(new TopicPartition(topic, 0)).getOrElse(throw new IllegalStateException("Log not found"))
+      // Verify default values for these two configurations are restored on all brokers
+      TestUtils.waitUntilTrue(() => log.config.maxIndexSize == Defaults.LogIndexSizeMaxBytes && log.config.retentionMs == 1680000000L,
+        "Existing topic config using defaults not updated")
+    }
   }
 
   @Test
@@ -773,24 +795,6 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
 
     verifyProcessorMetrics()
     verifyMarkPartitionsForTruncation()
-  }
-
-  @Test
-  def testDefaultValueRestoredAfterDeleteDynamicConfig(): Unit = {
-    val newProps = new Properties
-    newProps.put(KafkaConfig.LogRetentionTimeMillisProp, "100000")
-    newProps.put(KafkaConfig.LogFlushIntervalMsProp, "10000")
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, newProps, perBrokerConfig = false).all.get
-    newProps.put(KafkaConfig.LogFlushIntervalMsProp, "20000")
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, newProps, perBrokerConfig = true).all.get
-    waitForConfigOnServer(servers.head, KafkaConfig.LogFlushIntervalMsProp, "20000")
-
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, newProps, perBrokerConfig = true, opType = OpType.DELETE).all.get
-    waitForConfigOnServer(servers.head, KafkaConfig.LogFlushIntervalMsProp, "10000")
-    TestUtils.incrementalAlterConfigs(servers, adminClients.head, newProps, perBrokerConfig = false, opType = OpType.DELETE).all.get
-    waitForConfigOnServer(servers.head, KafkaConfig.LogFlushIntervalMsProp, null)
-    assertEquals(servers.head.logManager.initialDefaultConfig.flushMs, servers.head.logManager.currentDefaultConfig.flushMs)
-    assertEquals(servers.head.logManager.initialDefaultConfig.retentionMs, servers.head.logManager.currentDefaultConfig.retentionMs)
   }
 
   private def isProcessorMetric(metricName: MetricName): Boolean = {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10268

Currently, ConfigCommand's `--delete-config` API does not restore the config to default value, no matter at broker-level or broker-default level. Besides, Admin.incrementalAlterConfigs API also runs into this problem. This patch fixes it by removing the corresponding config from the `newConfig` properties when reconfiguring dynamic broker config.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
