### PR TITLE
MINOR: Update jackson to latest 2.10.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,7 +66,7 @@ versions += [
   grgit: "4.0.1",
   httpclient: "4.5.11",
   easymock: "4.2",
-  jackson: "2.10.2",
+  jackson: "2.10.5",
   jacoco: "0.8.5",
   jetty: "9.4.30.v20200611",
   jersey: "2.31",


### PR DESCRIPTION
Jackson 2.10.5 is now available. This pull request is for updating the patch from 2.10.**2** to 2.10.**5**. 

~~This should also be cherry picked to older branches as well (at least 2.5 and above but probably 2.2 and above).~~

- 2.6, 2.5 are on 2.10.2.
- 2.4, 2.3, 2.2 are on 2.10.0.
- 2.1 is on 2.9.8, which is a bit more significant change.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
