### PR TITLE
KAFKA-9274: Remove `retries` from InternalTopicManager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -25,12 +25,11 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.JmxReporter;
-import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
@@ -1249,11 +1248,7 @@ public class KafkaStreams implements AutoCloseable {
 
         log.debug("Current changelog positions: {}", allChangelogPositions);
         final Map<TopicPartition, ListOffsetsResultInfo> allEndOffsets;
-        try {
-            allEndOffsets = fetchEndOffsets(allPartitions, adminClient);
-        } catch (final TimeoutException e) {
-            throw new StreamsException("Timed out obtaining end offsets from kafka", e);
-        }
+        allEndOffsets = fetchEndOffsets(allPartitions, adminClient);
         log.debug("Current end offsets :{}", allEndOffsets);
 
         for (final Map.Entry<TopicPartition, ListOffsetsResultInfo> entry : allEndOffsets.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1193,11 +1193,6 @@ public class StreamsConfig extends AbstractConfig {
         // disable auto topic creation
         consumerProps.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
 
-        // add admin retries configs for creating topics
-        final AdminClientConfig adminClientDefaultConfig = new AdminClientConfig(getClientPropsWithPrefix(ADMIN_CLIENT_PREFIX, AdminClientConfig.configNames()));
-        consumerProps.put(adminClientPrefix(AdminClientConfig.RETRIES_CONFIG), adminClientDefaultConfig.getInt(AdminClientConfig.RETRIES_CONFIG));
-        consumerProps.put(adminClientPrefix(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG), adminClientDefaultConfig.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG));
-
         // verify that producer batch config is no larger than segment size, then add topic configs required for creating topics
         final Map<String, Object> topicProps = originalsWithPrefix(TOPIC_PREFIX, false);
         final Map<String, Object> producerProps = getClientPropsWithPrefix(PRODUCER_PREFIX, ProducerConfig.configNames());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -28,7 +27,6 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;
@@ -46,24 +44,18 @@ import java.util.stream.Collectors;
 public class ClientUtils {
     private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
 
-    public static class QuietStreamsConfig extends StreamsConfig {
+    public static final class QuietStreamsConfig extends StreamsConfig {
         public QuietStreamsConfig(final Map<?, ?> props) {
             super(props, false);
         }
     }
 
-    public static class QuietConsumerConfig extends ConsumerConfig {
+    public static final class QuietConsumerConfig extends ConsumerConfig {
         public QuietConsumerConfig(final Map<String, Object> props) {
             super(props, false);
         }
     }
 
-    public static final class QuietAdminClientConfig extends AdminClientConfig {
-        QuietAdminClientConfig(final StreamsConfig streamsConfig) {
-            // If you just want to look up admin configs, you don't care about the clientId
-            super(streamsConfig.getAdminConfigs("dummy"), false);
-        }
-    }
 
     // currently admin client is shared among all threads
     public static String getSharedAdminClientId(final String clientId) {
@@ -141,8 +133,8 @@ public class ClientUtils {
     public static KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> fetchEndOffsetsFuture(final Collection<TopicPartition> partitions,
                                                                                                 final Admin adminClient) {
         return adminClient.listOffsets(
-            partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest())))
-            .all();
+            partitions.stream().collect(Collectors.toMap(Function.identity(), tp -> OffsetSpec.latest()))
+        ).all();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ClientUtils.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
+import org.apache.kafka.streams.processor.internals.ClientUtils.QuietConsumerConfig;
 import org.slf4j.Logger;
 
 import java.util.HashMap;
@@ -98,7 +100,7 @@ public class InternalTopicManager {
      * If a topic exists already but has different number of partitions we fail and throw exception requesting user to reset the app before restarting again.
      * @return the set of topics which had to be newly created
      */
-    public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) {
+    public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) throws TaskAssignmentException {
         // we will do the validation / topic-creation in a loop, until we have confirmed all topics
         // have existed with the expected number of partitions, or some create topic returns fatal errors.
         log.debug("Starting to validate internal topics {} in partition assignor.", topics);
@@ -178,9 +180,7 @@ public class InternalTopicManager {
                     final String timeoutError = String.format("Could not create topics within %d milliseconds. " +
                         "This can happen if the Kafka cluster is temporary not available.", retryTimeoutMs);
                     log.error(timeoutError);
-                    // TODO: should we throw a different exception instead and catch it, to return a `INCOMPLETE_SOURCE_TOPIC_METADATA` error code
-                    throw new StreamsException(timeoutError);
-
+                    throw new TaskAssignmentException(timeoutError);
                 }
                 log.info(
                     "Topics {} could not be made ready. Will retry in {} milliseconds. Remaining time in milliseconds: {}",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.internals.ClientUtils.QuietConsumerConfig;
 import org.slf4j.Logger;
 
@@ -100,7 +99,7 @@ public class InternalTopicManager {
      * If a topic exists already but has different number of partitions we fail and throw exception requesting user to reset the app before restarting again.
      * @return the set of topics which had to be newly created
      */
-    public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) throws TaskAssignmentException {
+    public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) {
         // we will do the validation / topic-creation in a loop, until we have confirmed all topics
         // have existed with the expected number of partitions, or some create topic returns fatal errors.
         log.debug("Starting to validate internal topics {} in partition assignor.", topics);
@@ -178,9 +177,9 @@ public class InternalTopicManager {
 
                 if (currentWallClockMs >= deadlineMs) {
                     final String timeoutError = String.format("Could not create topics within %d milliseconds. " +
-                        "This can happen if the Kafka cluster is temporary not available.", retryTimeoutMs);
+                        "This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs);
                     log.error(timeoutError);
-                    throw new TaskAssignmentException(timeoutError);
+                    throw new TimeoutException(timeoutError);
                 }
                 log.info(
                     "Topics {} could not be made ready. Will retry in {} milliseconds. Remaining time in milliseconds: {}",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -17,16 +17,19 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -45,17 +48,21 @@ public class InternalTopicManager {
         "Please report at https://issues.apache.org/jira/projects/KAFKA or dev-mailing list (https://kafka.apache.org/contact).";
 
     private final Logger log;
-    private final long windowChangeLogAdditionalRetention;
-    private final Map<String, String> defaultTopicConfigs = new HashMap<>();
 
-    private final short replicationFactor;
+    private final Time time;
     private final Admin adminClient;
 
-    private final int retries;
+    private final short replicationFactor;
+    private final long windowChangeLogAdditionalRetention;
     private final long retryBackOffMs;
+    private final long retryTimeoutMs;
 
-    @SuppressWarnings("deprecation") // TODO: remove in follow up PR when `RETRIES` is removed
-    public InternalTopicManager(final Admin adminClient, final StreamsConfig streamsConfig) {
+    private final Map<String, String> defaultTopicConfigs = new HashMap<>();
+
+    public InternalTopicManager(final Time time,
+                                final Admin adminClient,
+                                final StreamsConfig streamsConfig) {
+        this.time = time;
         this.adminClient = adminClient;
 
         final LogContext logContext = new LogContext(String.format("stream-thread [%s] ", Thread.currentThread().getName()));
@@ -63,15 +70,16 @@ public class InternalTopicManager {
 
         replicationFactor = streamsConfig.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG).shortValue();
         windowChangeLogAdditionalRetention = streamsConfig.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG);
-        final AdminClientConfig adminConfigs = new ClientUtils.QuietAdminClientConfig(streamsConfig);
-        retries = adminConfigs.getInt(AdminClientConfig.RETRIES_CONFIG);
-        retryBackOffMs = adminConfigs.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG);
+        retryBackOffMs = streamsConfig.getLong(StreamsConfig.RETRY_BACKOFF_MS_CONFIG);
+        final Map<String, Object> consumerConfig = streamsConfig.getMainConsumerConfigs("dummy", "dummy", -1);
+        // need to add mandatory configs; otherwise `QuietConsumerConfig` throws
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+        retryTimeoutMs = new QuietConsumerConfig(consumerConfig).getInt(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG) / 2L;
 
         log.debug("Configs:" + Utils.NL +
             "\t{} = {}" + Utils.NL +
-            "\t{} = {}" + Utils.NL +
             "\t{} = {}",
-            AdminClientConfig.RETRIES_CONFIG, retries,
             StreamsConfig.REPLICATION_FACTOR_CONFIG, replicationFactor,
             StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, windowChangeLogAdditionalRetention);
 
@@ -95,13 +103,15 @@ public class InternalTopicManager {
         // have existed with the expected number of partitions, or some create topic returns fatal errors.
         log.debug("Starting to validate internal topics {} in partition assignor.", topics);
 
-        int remainingRetries = retries;
+        long currentWallClockMs = time.milliseconds();
+        final long deadlineMs = currentWallClockMs + retryTimeoutMs;
+
         Set<String> topicsNotReady = new HashSet<>(topics.keySet());
         final Set<String> newlyCreatedTopics = new HashSet<>();
 
-        while (!topicsNotReady.isEmpty() && remainingRetries >= 0) {
+        while (!topicsNotReady.isEmpty()) {
             final Set<String> tempUnknownTopics = new HashSet<>();
-            topicsNotReady = validateTopics(topicsNotReady, topics, tempUnknownTopics, remainingRetries);
+            topicsNotReady = validateTopics(topicsNotReady, topics, tempUnknownTopics);
             newlyCreatedTopics.addAll(topicsNotReady);
 
             if (!topicsNotReady.isEmpty()) {
@@ -153,26 +163,33 @@ public class InternalTopicManager {
                                 "Error message was: {}", topicName, cause.toString());
                             throw new StreamsException(String.format("Could not create topic %s.", topicName), cause);
                         }
+                    } catch (final TimeoutException retryableException) {
+                        log.error("Creating topic {} timed out.\n" +
+                            "Error message was: {}", topicName, retryableException.toString());
                     }
                 }
             }
 
 
             if (!topicsNotReady.isEmpty()) {
-                log.info("Topics {} can not be made ready with {} retries left", topicsNotReady, remainingRetries);
+                currentWallClockMs = time.milliseconds();
 
+                if (currentWallClockMs >= deadlineMs) {
+                    final String timeoutError = String.format("Could not create topics within %d milliseconds. " +
+                        "This can happen if the Kafka cluster is temporary not available.", retryTimeoutMs);
+                    log.error(timeoutError);
+                    // TODO: should we throw a different exception instead and catch it, to return a `INCOMPLETE_SOURCE_TOPIC_METADATA` error code
+                    throw new StreamsException(timeoutError);
+
+                }
+                log.info(
+                    "Topics {} could not be made ready. Will retry in {} milliseconds. Remaining time in milliseconds: {}",
+                    topicsNotReady,
+                    retryBackOffMs,
+                    deadlineMs - currentWallClockMs
+                );
                 Utils.sleep(retryBackOffMs);
-
-                remainingRetries--;
             }
-        }
-
-        if (!topicsNotReady.isEmpty()) {
-            final String timeoutAndRetryError = String.format("Could not create topics after %d retries. " +
-                "This can happen if the Kafka cluster is temporary not available. " +
-                "You can increase admin client config `retries` to be resilient against this error.", retries);
-            log.error(timeoutAndRetryError);
-            throw new StreamsException(timeoutAndRetryError);
         }
         log.debug("Completed validating internal topics and created {}", newlyCreatedTopics);
 
@@ -186,8 +203,7 @@ public class InternalTopicManager {
      */
     // visible for testing
     protected Map<String, Integer> getNumPartitions(final Set<String> topics,
-                                                    final Set<String> tempUnknownTopics,
-                                                    final boolean hasRemainingRetries) {
+                                                    final Set<String> tempUnknownTopics) {
         log.debug("Trying to check if topics {} have been created with expected number of partitions.", topics);
 
         final DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(topics);
@@ -212,18 +228,17 @@ public class InternalTopicManager {
                         "Error message was: {}", topicName, cause.toString());
                 } else if (cause instanceof LeaderNotAvailableException) {
                     tempUnknownTopics.add(topicName);
-                    if (!hasRemainingRetries) {
-                        // run out of retries, throw exception directly
-                        throw new StreamsException(
-                            String.format("The leader of the Topic %s is not available.", topicName), cause);
-                    }
-                    log.info("The leader of the Topic {} is not available.\n" +
+                    log.debug("The leader of topic {} is not available.\n" +
                         "Error message was: {}", topicName, cause.toString());
                 } else {
                     log.error("Unexpected error during topic description for {}.\n" +
                         "Error message was: {}", topicName, cause.toString());
                     throw new StreamsException(String.format("Could not create topic %s.", topicName), cause);
                 }
+            } catch (final TimeoutException retryableException) {
+                tempUnknownTopics.add(topicName);
+                log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
+                    "Error message was: {}", topicName, retryableException.toString());
             }
         }
 
@@ -235,15 +250,13 @@ public class InternalTopicManager {
      */
     private Set<String> validateTopics(final Set<String> topicsToValidate,
                                        final Map<String, InternalTopicConfig> topicsMap,
-                                       final Set<String> tempUnknownTopics,
-                                       final int remainingRetries) {
+                                       final Set<String> tempUnknownTopics) {
         if (!topicsMap.keySet().containsAll(topicsToValidate)) {
             throw new IllegalStateException("The topics map " + topicsMap.keySet() + " does not contain all the topics " +
                 topicsToValidate + " trying to validate.");
         }
 
-        final Map<String, Integer> existedTopicPartition =
-            getNumPartitions(topicsToValidate, tempUnknownTopics, remainingRetries > 0);
+        final Map<String, Integer> existedTopicPartition = getNumPartitions(topicsToValidate, tempUnknownTopics);
 
         final Set<String> topicsToCreate = new HashSet<>();
         for (final String topicName : topicsToValidate) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignorConfiguration.java
@@ -296,7 +296,7 @@ public final class AssignorConfiguration {
     }
 
     public InternalTopicManager internalTopicManager() {
-        return new InternalTopicManager(adminClient, streamsConfig);
+        return new InternalTopicManager(time(), adminClient, streamsConfig);
     }
 
     public CopartitionedTopicsEnforcer copartitionedTopicsEnforcer() {

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -159,7 +159,6 @@ public class StreamsConfigTest {
         assertNull(returnedProps.get(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG));
     }
 
-    @SuppressWarnings("deprecation") // TODO revisit in follow up PR
     @Test
     public void consumerConfigMustContainStreamPartitionAssignorConfig() {
         props.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 42);
@@ -169,8 +168,6 @@ public class StreamsConfigTest {
         props.put(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, 99_999L);
         props.put(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, 7L);
         props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, "dummy:host");
-        props.put(StreamsConfig.RETRIES_CONFIG, 10);
-        props.put(StreamsConfig.adminClientPrefix(StreamsConfig.RETRIES_CONFIG), 5);
         props.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_BYTES_CONFIG), 100);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
         final Map<String, Object> returnedProps = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
@@ -186,23 +183,7 @@ public class StreamsConfigTest {
         );
         assertEquals(7L, returnedProps.get(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));
         assertEquals("dummy:host", returnedProps.get(StreamsConfig.APPLICATION_SERVER_CONFIG));
-        assertNull(returnedProps.get(StreamsConfig.RETRIES_CONFIG));
-        assertEquals(5, returnedProps.get(StreamsConfig.adminClientPrefix(StreamsConfig.RETRIES_CONFIG)));
         assertEquals(100, returnedProps.get(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_BYTES_CONFIG)));
-    }
-
-    @SuppressWarnings("deprecation") // TODO revisit in follow up PR
-    @Test
-    public void consumerConfigShouldContainAdminClientConfigsForRetriesAndRetryBackOffMsWithAdminPrefix() {
-        props.put(StreamsConfig.adminClientPrefix(StreamsConfig.RETRIES_CONFIG), 20);
-        props.put(StreamsConfig.adminClientPrefix(StreamsConfig.RETRY_BACKOFF_MS_CONFIG), 200L);
-        props.put(StreamsConfig.RETRIES_CONFIG, 10);
-        props.put(StreamsConfig.RETRY_BACKOFF_MS_CONFIG, 100L);
-        final StreamsConfig streamsConfig = new StreamsConfig(props);
-        final Map<String, Object> returnedProps = streamsConfig.getMainConsumerConfigs(groupId, clientId, threadIdx);
-
-        assertEquals(20, returnedProps.get(StreamsConfig.adminClientPrefix(StreamsConfig.RETRIES_CONFIG)));
-        assertEquals(200L, returnedProps.get(StreamsConfig.adminClientPrefix(StreamsConfig.RETRY_BACKOFF_MS_CONFIG)));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
@@ -180,9 +180,11 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
 
     private void overwriteInternalTopicManagerWithMock() {
         final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
+            time,
             streamsConfig,
             mockClientSupplier.restoreConsumer,
-            false);
+            false
+        );
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -413,9 +414,15 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
 
-        assertThrows(
-            StreamsException.class,
+        final TaskAssignmentException exception = assertThrows(
+            TaskAssignmentException.class,
             () -> topicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig))
+        );
+        assertNull(exception.getCause());
+        assertThat(
+            exception.getMessage(),
+            equalTo("Could not create topics within 50 milliseconds." +
+                " This can happen if the Kafka cluster is temporary not available.")
         );
 
         EasyMock.verify(admin);
@@ -433,8 +440,8 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
 
-        final StreamsException exception = assertThrows(
-            StreamsException.class,
+        final TaskAssignmentException exception = assertThrows(
+            TaskAssignmentException.class,
             () -> internalTopicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig))
         );
         assertNull(exception.getCause());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -39,7 +39,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -414,15 +413,15 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
 
-        final TaskAssignmentException exception = assertThrows(
-            TaskAssignmentException.class,
+        final TimeoutException exception = assertThrows(
+            TimeoutException.class,
             () -> topicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig))
         );
         assertNull(exception.getCause());
         assertThat(
             exception.getMessage(),
             equalTo("Could not create topics within 50 milliseconds." +
-                " This can happen if the Kafka cluster is temporary not available.")
+                " This can happen if the Kafka cluster is temporarily not available.")
         );
 
         EasyMock.verify(admin);
@@ -440,15 +439,15 @@ public class InternalTopicManagerTest {
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
 
-        final TaskAssignmentException exception = assertThrows(
-            TaskAssignmentException.class,
+        final TimeoutException exception = assertThrows(
+            TimeoutException.class,
             () -> internalTopicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig))
         );
         assertNull(exception.getCause());
         assertThat(
             exception.getMessage(),
             equalTo("Could not create topics within 50 milliseconds." +
-                " This can happen if the Kafka cluster is temporary not available.")
+                " This can happen if the Kafka cluster is temporarily not available.")
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -23,17 +23,19 @@ import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -51,10 +53,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
@@ -71,21 +73,20 @@ public class InternalTopicManagerTest {
     private final String topic2 = "test_topic_2";
     private final String topic3 = "test_topic_3";
     private final List<Node> singleReplica = Collections.singletonList(broker1);
-    private final int numRetries = 1;
 
     private String threadName;
 
     private MockAdminClient mockAdminClient;
     private InternalTopicManager internalTopicManager;
 
-    @SuppressWarnings("deprecation") // TODO revisit in follow up PR
     private final Map<String, Object> config = new HashMap<String, Object>() {
         {
             put(StreamsConfig.APPLICATION_ID_CONFIG, "app-id");
             put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, broker1.host() + ":" + broker1.port());
             put(StreamsConfig.REPLICATION_FACTOR_CONFIG, 1);
             put(StreamsConfig.producerPrefix(ProducerConfig.BATCH_SIZE_CONFIG), 16384);
-            put(StreamsConfig.adminClientPrefix(StreamsConfig.RETRIES_CONFIG), numRetries);
+            put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), 100);
+            put(StreamsConfig.RETRY_BACKOFF_MS_CONFIG, 50);
         }
     };
 
@@ -95,8 +96,10 @@ public class InternalTopicManagerTest {
 
         mockAdminClient = new MockAdminClient(cluster, broker1);
         internalTopicManager = new InternalTopicManager(
+            Time.SYSTEM,
             mockAdminClient,
-            new StreamsConfig(config));
+            new StreamsConfig(config)
+        );
     }
 
     @After
@@ -112,7 +115,7 @@ public class InternalTopicManagerTest {
             Collections.singletonList(new TopicPartitionInfo(0, broker1, singleReplica, Collections.emptyList())),
             null);
         assertEquals(Collections.singletonMap(topic, 1),
-            internalTopicManager.getNumPartitions(Collections.singleton(topic), Collections.emptySet(), true));
+            internalTopicManager.getNumPartitions(Collections.singleton(topic), Collections.emptySet()));
     }
 
     @Test
@@ -166,7 +169,11 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldCompleteTopicValidationOnRetry() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
-        final InternalTopicManager topicManager = new InternalTopicManager(admin, new StreamsConfig(config));
+        final InternalTopicManager topicManager = new InternalTopicManager(
+            Time.SYSTEM,
+            admin,
+            new StreamsConfig(config)
+        );
         final TopicPartitionInfo partitionInfo = new TopicPartitionInfo(0, broker1,
             Collections.singletonList(broker1), Collections.singletonList(broker1));
 
@@ -239,8 +246,10 @@ public class InternalTopicManagerTest {
 
         // attempt to create it again with replication 1
         final InternalTopicManager internalTopicManager2 = new InternalTopicManager(
+            Time.SYSTEM,
             mockAdminClient,
-            new StreamsConfig(config));
+            new StreamsConfig(config)
+        );
 
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
@@ -300,7 +309,11 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldCreateTopicWhenTopicLeaderNotAvailableAndThenTopicNotFound() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
-        final InternalTopicManager topicManager = new InternalTopicManager(admin, new StreamsConfig(config));
+        final InternalTopicManager topicManager = new InternalTopicManager(
+            Time.SYSTEM,
+            admin,
+            new StreamsConfig(config)
+        );
 
         final KafkaFutureImpl<TopicDescription> topicDescriptionLeaderNotAvailableFuture = new KafkaFutureImpl<>();
         topicDescriptionLeaderNotAvailableFuture.completeExceptionally(new LeaderNotAvailableException("Leader Not Available!"));
@@ -340,7 +353,11 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldCompleteValidateWhenTopicLeaderNotAvailableAndThenDescribeSuccess() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
-        final InternalTopicManager topicManager = new InternalTopicManager(admin, new StreamsConfig(config));
+        final InternalTopicManager topicManager = new InternalTopicManager(
+            Time.SYSTEM,
+            admin,
+            new StreamsConfig(config)
+        );
         final TopicPartitionInfo partitionInfo = new TopicPartitionInfo(0, broker1,
                 Collections.singletonList(broker1), Collections.singletonList(broker1));
 
@@ -374,7 +391,11 @@ public class InternalTopicManagerTest {
     @Test
     public void shouldThrowExceptionWhenKeepsTopicLeaderNotAvailable() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
-        final InternalTopicManager topicManager = new InternalTopicManager(admin, new StreamsConfig(config));
+        final InternalTopicManager topicManager = new InternalTopicManager(
+            Time.SYSTEM,
+            admin,
+            new StreamsConfig(config)
+        );
 
         final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
         topicDescriptionFailFuture.completeExceptionally(new LeaderNotAvailableException("Leader Not Available!"));
@@ -383,9 +404,9 @@ public class InternalTopicManagerTest {
         EasyMock.expect(admin.describeTopics(Collections.singleton(topic)))
             .andReturn(new MockDescribeTopicsResult(
                 Collections.singletonMap(topic, topicDescriptionFailFuture)))
-            .times(numRetries + 1);
+            .anyTimes();
         EasyMock.expect(admin.createTopics(Collections.emptySet()))
-            .andReturn(new MockCreateTopicsResult(Collections.emptyMap())).once();
+            .andReturn(new MockCreateTopicsResult(Collections.emptyMap())).anyTimes();
 
         EasyMock.replay(admin);
 
@@ -394,7 +415,8 @@ public class InternalTopicManagerTest {
 
         assertThrows(
             StreamsException.class,
-            () -> topicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig)));
+            () -> topicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig))
+        );
 
         EasyMock.verify(admin);
     }
@@ -410,13 +432,17 @@ public class InternalTopicManagerTest {
 
         final InternalTopicConfig internalTopicConfig = new RepartitionTopicConfig(topic, Collections.emptyMap());
         internalTopicConfig.setNumberOfPartitions(1);
-        try {
-            internalTopicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig));
-            fail("Should have thrown StreamsException.");
-        } catch (final StreamsException expected) {
-            assertNull(expected.getCause());
-            assertTrue(expected.getMessage().startsWith("Could not create topics after 1 retries"));
-        }
+
+        final StreamsException exception = assertThrows(
+            StreamsException.class,
+            () -> internalTopicManager.makeReady(Collections.singletonMap(topic, internalTopicConfig))
+        );
+        assertNull(exception.getCause());
+        assertThat(
+            exception.getMessage(),
+            equalTo("Could not create topics within 50 milliseconds." +
+                " This can happen if the Kafka cluster is temporary not available.")
+        );
     }
 
     private static class MockCreateTopicsResult extends CreateTopicsResult {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.TopologyWrapper;
+import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -49,6 +50,7 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
+import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ClientState;
 import org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor;
@@ -125,7 +127,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@SuppressWarnings("unchecked")
 @RunWith(value = Parameterized.class)
 public class StreamsPartitionAssignorTest {
     private static final String CONSUMER_1 = "consumer1";
@@ -492,7 +493,7 @@ public class StreamsPartitionAssignorTest {
     public void testEagerSubscription() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1", "source2");
 
         final Set<TaskId> prevTasks = mkSet(
             new TaskId(0, 1), new TaskId(1, 1), new TaskId(2, 1)
@@ -519,7 +520,7 @@ public class StreamsPartitionAssignorTest {
     public void testCooperativeSubscription() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1", "source2");
 
         final Set<TaskId> prevTasks = mkSet(
             new TaskId(0, 1), new TaskId(1, 1), new TaskId(2, 1));
@@ -545,7 +546,7 @@ public class StreamsPartitionAssignorTest {
     public void testAssignBasic() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1", "source2");
         builder.addStateStore(new MockKeyValueStoreBuilder("store", false), "processor");
         final List<String> topics = asList("topic1", "topic2");
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
@@ -616,8 +617,8 @@ public class StreamsPartitionAssignorTest {
     public void shouldAssignEvenlyAcrossConsumersOneClientMultipleThreads() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1");
-        builder.addProcessor("processorII", new MockProcessorSupplier(), "source2");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1");
+        builder.addProcessor("processorII", new MockProcessorSupplier<>(), "source2");
 
         final List<PartitionInfo> localInfos = asList(
             new PartitionInfo("topic1", 0, Node.noNode(), new Node[0], new Node[0]),
@@ -675,10 +676,10 @@ public class StreamsPartitionAssignorTest {
     @Test
     public void testAssignWithPartialTopology() {
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor2", new MockProcessorSupplier(), "source2");
+        builder.addProcessor("processor2", new MockProcessorSupplier<>(), "source2");
         builder.addStateStore(new MockKeyValueStoreBuilder("store2", false), "processor2");
         final List<String> topics = asList("topic1", "topic2");
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
@@ -710,7 +711,7 @@ public class StreamsPartitionAssignorTest {
     public void testAssignEmptyMetadata() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1", "source2");
         final List<String> topics = asList("topic1", "topic2");
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
 
@@ -766,7 +767,7 @@ public class StreamsPartitionAssignorTest {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addSource(null, "source3", null, null, null, "topic3");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2", "source3");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1", "source2", "source3");
         final List<String> topics = asList("topic1", "topic2", "topic3");
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2, TASK_0_3);
 
@@ -817,10 +818,10 @@ public class StreamsPartitionAssignorTest {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
 
-        builder.addProcessor("processor-1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor-1", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor-1");
 
-        builder.addProcessor("processor-2", new MockProcessorSupplier(), "source2");
+        builder.addProcessor("processor-2", new MockProcessorSupplier<>(), "source2");
         builder.addStateStore(new MockKeyValueStoreBuilder("store2", false), "processor-2");
         builder.addStateStore(new MockKeyValueStoreBuilder("store3", false), "processor-2");
 
@@ -895,7 +896,7 @@ public class StreamsPartitionAssignorTest {
     @Test
     public void testAssignWithStandbyReplicasAndStatelessTasks() {
         builder.addSource(null, "source1", null, null, null, "topic1", "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1");
 
         final List<String> topics = asList("topic1", "topic2");
 
@@ -924,7 +925,7 @@ public class StreamsPartitionAssignorTest {
     @Test
     public void testAssignWithStandbyReplicasAndLoggingDisabled() {
         builder.addSource(null, "source1", null, null, null, "topic1", "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false).withLoggingDisabled(), "processor");
 
         final List<String> topics = asList("topic1", "topic2");
@@ -955,7 +956,7 @@ public class StreamsPartitionAssignorTest {
     public void testAssignWithStandbyReplicas() {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source1", "source2");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor");
 
         final List<String> topics = asList("topic1", "topic2");
@@ -1088,10 +1089,10 @@ public class StreamsPartitionAssignorTest {
     public void testAssignWithInternalTopics() {
         builder.addInternalTopic("topicX", InternalTopicProperties.empty());
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addSink("sink1", "topicX", null, null, null, "processor1");
         builder.addSource(null, "source2", null, null, null, "topicX");
-        builder.addProcessor("processor2", new MockProcessorSupplier(), "source2");
+        builder.addProcessor("processor2", new MockProcessorSupplier<>(), "source2");
         final List<String> topics = asList("topic1", APPLICATION_ID + "-topicX");
         final Set<TaskId> allTasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
 
@@ -1113,11 +1114,11 @@ public class StreamsPartitionAssignorTest {
     public void testAssignWithInternalTopicThatsSourceIsAnotherInternalTopic() {
         builder.addInternalTopic("topicX", InternalTopicProperties.empty());
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addSink("sink1", "topicX", null, null, null, "processor1");
         builder.addSource(null, "source2", null, null, null, "topicX");
         builder.addInternalTopic("topicZ", InternalTopicProperties.empty());
-        builder.addProcessor("processor2", new MockProcessorSupplier(), "source2");
+        builder.addProcessor("processor2", new MockProcessorSupplier<>(), "source2");
         builder.addSink("sink2", "topicZ", null, null, null, "processor2");
         builder.addSource(null, "source3", null, null, null, "topicZ");
         final List<String> topics = asList("topic1", APPLICATION_ID + "-topicX", APPLICATION_ID + "-topicZ");
@@ -1212,9 +1213,92 @@ public class StreamsPartitionAssignorTest {
     }
 
     @Test
+    public void shouldReturnShutdownErrorCodeWhenCreatingRepartitionTopicsTimesOut() {
+        final StreamsBuilder streamsBuilder = new StreamsBuilder();
+        streamsBuilder.stream("topic1").repartition();
+
+        final String client = "client1";
+        builder = TopologyWrapper.getInternalTopologyBuilder(streamsBuilder.build());
+
+        createDefaultMockTaskManager();
+        EasyMock.replay(taskManager);
+        partitionAssignor.configure(configProps());
+        final MockInternalTopicManager mockInternalTopicManager =  new MockInternalTopicManager(
+            time,
+            new StreamsConfig(configProps()),
+            mockClientSupplier.restoreConsumer,
+            false
+        ) {
+            @Override
+            public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) throws TaskAssignmentException {
+                throw new TaskAssignmentException("KABOOM!");
+            }
+        };
+        partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
+
+        subscriptions.put(client,
+            new Subscription(
+                singletonList("topic1"),
+                defaultSubscriptionInfo.encode()
+            )
+        );
+        final Map<String, Assignment> assignment =
+            partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
+
+        // check if we created a task for all expected topicPartitions.
+        assertThat(
+            AssignmentInfo.decode(assignment.get(client).userData()).errCode(),
+            equalTo(AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code())
+        );
+    }
+
+    @Test
+    public void shouldReturnShutdownErrorCodeWhenCreatingChangelogTopicsTimesOut() {
+        final StreamsBuilder streamsBuilder = new StreamsBuilder();
+        streamsBuilder.table("topic1", Materialized.as("store"));
+
+        final String client = "client1";
+        builder = TopologyWrapper.getInternalTopologyBuilder(streamsBuilder.build());
+
+        createDefaultMockTaskManager();
+        EasyMock.replay(taskManager);
+        partitionAssignor.configure(configProps());
+        final MockInternalTopicManager mockInternalTopicManager =  new MockInternalTopicManager(
+            time,
+            new StreamsConfig(configProps()),
+            mockClientSupplier.restoreConsumer,
+            false
+        ) {
+            @Override
+            public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) throws TaskAssignmentException {
+                if (topics.isEmpty()) {
+                    return emptySet();
+                }
+                throw new TaskAssignmentException("KABOOM!");
+            }
+        };
+        partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
+
+        subscriptions.put(client,
+            new Subscription(
+                singletonList("topic1"),
+                defaultSubscriptionInfo.encode()
+            )
+        );
+        final Map<String, Assignment> assignment =
+            partitionAssignor.assign(metadata, new GroupSubscription(subscriptions)).groupAssignment();
+
+        // check if we created a task for all expected topicPartitions.
+        assertThat(
+            AssignmentInfo.decode(assignment.get(client).userData()).errCode(),
+            equalTo(AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code())
+        );
+    }
+
+    @Test
     public void shouldAddUserDefinedEndPointToSubscription() {
         builder.addSource(null, "source", null, null, null, "input");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source");
         builder.addSink("sink", "output", null, null, null, "processor");
 
         createDefaultMockTaskManager();
@@ -1231,7 +1315,7 @@ public class StreamsPartitionAssignorTest {
     @Test
     public void shouldMapUserEndPointToTopicPartitions() {
         builder.addSource(null, "source", null, null, null, "topic1");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addProcessor("processor", new MockProcessorSupplier<>(), "source");
         builder.addSink("sink", "output", null, null, null, "processor");
 
         final List<String> topics = Collections.singletonList("topic1");
@@ -1705,46 +1789,46 @@ public class StreamsPartitionAssignorTest {
         //  The traversal path 0 -> 1 -> 2 -> 3 hits the case where sub-topology 2 will be initialized while its
         //  parent 3 hasn't been initialized yet.
         builder.addSource(null, "KSTREAM-SOURCE-0000000000",  null, null, null, "input-stream");
-        builder.addProcessor("KSTREAM-FLATMAPVALUES-0000000001", new MockProcessorSupplier(), "KSTREAM-SOURCE-0000000000");
-        builder.addProcessor("KSTREAM-BRANCH-0000000002", new MockProcessorSupplier(), "KSTREAM-FLATMAPVALUES-0000000001");
-        builder.addProcessor("KSTREAM-BRANCHCHILD-0000000003", new MockProcessorSupplier(), "KSTREAM-BRANCH-0000000002");
-        builder.addProcessor("KSTREAM-BRANCHCHILD-0000000004", new MockProcessorSupplier(), "KSTREAM-BRANCH-0000000002");
-        builder.addProcessor("KSTREAM-MAP-0000000005", new MockProcessorSupplier(), "KSTREAM-BRANCHCHILD-0000000003");
+        builder.addProcessor("KSTREAM-FLATMAPVALUES-0000000001", new MockProcessorSupplier<>(), "KSTREAM-SOURCE-0000000000");
+        builder.addProcessor("KSTREAM-BRANCH-0000000002", new MockProcessorSupplier<>(), "KSTREAM-FLATMAPVALUES-0000000001");
+        builder.addProcessor("KSTREAM-BRANCHCHILD-0000000003", new MockProcessorSupplier<>(), "KSTREAM-BRANCH-0000000002");
+        builder.addProcessor("KSTREAM-BRANCHCHILD-0000000004", new MockProcessorSupplier<>(), "KSTREAM-BRANCH-0000000002");
+        builder.addProcessor("KSTREAM-MAP-0000000005", new MockProcessorSupplier<>(), "KSTREAM-BRANCHCHILD-0000000003");
 
         builder.addInternalTopic("odd_store-repartition", InternalTopicProperties.empty());
-        builder.addProcessor("odd_store-repartition-filter", new MockProcessorSupplier(), "KSTREAM-MAP-0000000005");
+        builder.addProcessor("odd_store-repartition-filter", new MockProcessorSupplier<>(), "KSTREAM-MAP-0000000005");
         builder.addSink("odd_store-repartition-sink", "odd_store-repartition", null, null, null, "odd_store-repartition-filter");
         builder.addSource(null, "odd_store-repartition-source", null, null, null, "odd_store-repartition");
-        builder.addProcessor("KSTREAM-REDUCE-0000000006", new MockProcessorSupplier(), "odd_store-repartition-source");
-        builder.addProcessor("KTABLE-TOSTREAM-0000000010", new MockProcessorSupplier(), "KSTREAM-REDUCE-0000000006");
-        builder.addProcessor("KSTREAM-PEEK-0000000011", new MockProcessorSupplier(), "KTABLE-TOSTREAM-0000000010");
-        builder.addProcessor("KSTREAM-MAP-0000000012", new MockProcessorSupplier(), "KSTREAM-PEEK-0000000011");
+        builder.addProcessor("KSTREAM-REDUCE-0000000006", new MockProcessorSupplier<>(), "odd_store-repartition-source");
+        builder.addProcessor("KTABLE-TOSTREAM-0000000010", new MockProcessorSupplier<>(), "KSTREAM-REDUCE-0000000006");
+        builder.addProcessor("KSTREAM-PEEK-0000000011", new MockProcessorSupplier<>(), "KTABLE-TOSTREAM-0000000010");
+        builder.addProcessor("KSTREAM-MAP-0000000012", new MockProcessorSupplier<>(), "KSTREAM-PEEK-0000000011");
 
         builder.addInternalTopic("odd_store_2-repartition", InternalTopicProperties.empty());
-        builder.addProcessor("odd_store_2-repartition-filter", new MockProcessorSupplier(), "KSTREAM-MAP-0000000012");
+        builder.addProcessor("odd_store_2-repartition-filter", new MockProcessorSupplier<>(), "KSTREAM-MAP-0000000012");
         builder.addSink("odd_store_2-repartition-sink", "odd_store_2-repartition", null, null, null, "odd_store_2-repartition-filter");
         builder.addSource(null, "odd_store_2-repartition-source", null, null, null, "odd_store_2-repartition");
-        builder.addProcessor("KSTREAM-REDUCE-0000000013", new MockProcessorSupplier(), "odd_store_2-repartition-source");
-        builder.addProcessor("KSTREAM-MAP-0000000017", new MockProcessorSupplier(), "KSTREAM-BRANCHCHILD-0000000004");
+        builder.addProcessor("KSTREAM-REDUCE-0000000013", new MockProcessorSupplier<>(), "odd_store_2-repartition-source");
+        builder.addProcessor("KSTREAM-MAP-0000000017", new MockProcessorSupplier<>(), "KSTREAM-BRANCHCHILD-0000000004");
 
         builder.addInternalTopic("even_store-repartition", InternalTopicProperties.empty());
-        builder.addProcessor("even_store-repartition-filter", new MockProcessorSupplier(), "KSTREAM-MAP-0000000017");
+        builder.addProcessor("even_store-repartition-filter", new MockProcessorSupplier<>(), "KSTREAM-MAP-0000000017");
         builder.addSink("even_store-repartition-sink", "even_store-repartition", null, null, null, "even_store-repartition-filter");
         builder.addSource(null, "even_store-repartition-source", null, null, null, "even_store-repartition");
-        builder.addProcessor("KSTREAM-REDUCE-0000000018", new MockProcessorSupplier(), "even_store-repartition-source");
-        builder.addProcessor("KTABLE-TOSTREAM-0000000022", new MockProcessorSupplier(), "KSTREAM-REDUCE-0000000018");
-        builder.addProcessor("KSTREAM-PEEK-0000000023", new MockProcessorSupplier(), "KTABLE-TOSTREAM-0000000022");
-        builder.addProcessor("KSTREAM-MAP-0000000024", new MockProcessorSupplier(), "KSTREAM-PEEK-0000000023");
+        builder.addProcessor("KSTREAM-REDUCE-0000000018", new MockProcessorSupplier<>(), "even_store-repartition-source");
+        builder.addProcessor("KTABLE-TOSTREAM-0000000022", new MockProcessorSupplier<>(), "KSTREAM-REDUCE-0000000018");
+        builder.addProcessor("KSTREAM-PEEK-0000000023", new MockProcessorSupplier<>(), "KTABLE-TOSTREAM-0000000022");
+        builder.addProcessor("KSTREAM-MAP-0000000024", new MockProcessorSupplier<>(), "KSTREAM-PEEK-0000000023");
 
         builder.addInternalTopic("even_store_2-repartition", InternalTopicProperties.empty());
-        builder.addProcessor("even_store_2-repartition-filter", new MockProcessorSupplier(), "KSTREAM-MAP-0000000024");
+        builder.addProcessor("even_store_2-repartition-filter", new MockProcessorSupplier<>(), "KSTREAM-MAP-0000000024");
         builder.addSink("even_store_2-repartition-sink", "even_store_2-repartition", null, null, null, "even_store_2-repartition-filter");
         builder.addSource(null, "even_store_2-repartition-source", null, null, null, "even_store_2-repartition");
-        builder.addProcessor("KSTREAM-REDUCE-0000000025", new MockProcessorSupplier(), "even_store_2-repartition-source");
-        builder.addProcessor("KTABLE-JOINTHIS-0000000030", new MockProcessorSupplier(), "KSTREAM-REDUCE-0000000013");
-        builder.addProcessor("KTABLE-JOINOTHER-0000000031", new MockProcessorSupplier(), "KSTREAM-REDUCE-0000000025");
-        builder.addProcessor("KTABLE-MERGE-0000000029", new MockProcessorSupplier(), "KTABLE-JOINTHIS-0000000030", "KTABLE-JOINOTHER-0000000031");
-        builder.addProcessor("KTABLE-TOSTREAM-0000000032", new MockProcessorSupplier(), "KTABLE-MERGE-0000000029");
+        builder.addProcessor("KSTREAM-REDUCE-0000000025", new MockProcessorSupplier<>(), "even_store_2-repartition-source");
+        builder.addProcessor("KTABLE-JOINTHIS-0000000030", new MockProcessorSupplier<>(), "KSTREAM-REDUCE-0000000013");
+        builder.addProcessor("KTABLE-JOINOTHER-0000000031", new MockProcessorSupplier<>(), "KSTREAM-REDUCE-0000000025");
+        builder.addProcessor("KTABLE-MERGE-0000000029", new MockProcessorSupplier<>(), "KTABLE-JOINTHIS-0000000030", "KTABLE-JOINOTHER-0000000031");
+        builder.addProcessor("KTABLE-TOSTREAM-0000000032", new MockProcessorSupplier<>(), "KTABLE-MERGE-0000000029");
 
         final List<String> topics = asList("input-stream", "test-even_store-repartition", "test-even_store_2-repartition", "test-odd_store-repartition", "test-odd_store_2-repartition");
 
@@ -1811,7 +1895,7 @@ public class StreamsPartitionAssignorTest {
     public void shouldThrowIllegalStateExceptionIfAnyPartitionsMissingFromChangelogEndOffsets() {
         final int changelogNumPartitions = 3;
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor1");
 
         createMockAdminClient(getTopicPartitionOffsetsMap(
@@ -1832,7 +1916,7 @@ public class StreamsPartitionAssignorTest {
     @Test
     public void shouldThrowIllegalStateExceptionIfAnyTopicsMissingFromChangelogEndOffsets() {
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store2", false), "processor1");
 
@@ -1862,7 +1946,7 @@ public class StreamsPartitionAssignorTest {
         expect(result.all()).andReturn(allFuture);
 
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store1", false), "processor1");
 
         subscriptions.put("consumer10",
@@ -1905,7 +1989,7 @@ public class StreamsPartitionAssignorTest {
         expect(result.all()).andReturn(allFuture);
 
         builder.addSource(null, "source1", null, null, null, "topic1");
-        builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processor1", new MockProcessorSupplier<>(), "source1");
         builder.addStateStore(new MockKeyValueStoreBuilder("store", false), "processor1");
 
         subscriptions.put("consumer10",

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.SortedSet;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListOffsetsResult;
@@ -51,8 +50,8 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorConfiguration;
 import org.apache.kafka.streams.processor.internals.assignment.ClientState;
-import org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.FallbackPriorTaskAssignor;
+import org.apache.kafka.streams.processor.internals.assignment.HighAvailabilityTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
 import org.apache.kafka.streams.processor.internals.assignment.TaskAssignor;
@@ -77,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -269,9 +269,11 @@ public class StreamsPartitionAssignorTest {
     // topics and we will skip the listOffsets request for these changelogs
     private MockInternalTopicManager overwriteInternalTopicManagerWithMock(final boolean mockCreateInternalTopics) {
         final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
+            time,
             new StreamsConfig(configProps()),
             mockClientSupplier.restoreConsumer,
-            mockCreateInternalTopics);
+            mockCreateInternalTopics
+        );
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
         return mockInternalTopicManager;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.KeyValue;
@@ -1231,7 +1232,7 @@ public class StreamsPartitionAssignorTest {
         ) {
             @Override
             public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) throws TaskAssignmentException {
-                throw new TaskAssignmentException("KABOOM!");
+                throw new TimeoutException("KABOOM!");
             }
         };
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
@@ -1274,7 +1275,7 @@ public class StreamsPartitionAssignorTest {
                 if (topics.isEmpty()) {
                     return emptySet();
                 }
-                throw new TaskAssignmentException("KABOOM!");
+                throw new TimeoutException("KABOOM!");
             }
         };
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
@@ -16,15 +16,16 @@
  */
 package org.apache.kafka.test;
 
-import java.util.Collections;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopicConfig;
 import org.apache.kafka.streams.processor.internals.InternalTopicManager;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,10 +37,11 @@ public class MockInternalTopicManager extends InternalTopicManager {
     private final MockConsumer<byte[], byte[]> restoreConsumer;
     private final boolean mockCreateInternalTopics;
 
-    public MockInternalTopicManager(final StreamsConfig streamsConfig,
+    public MockInternalTopicManager(final Time time,
+                                    final StreamsConfig streamsConfig,
                                     final MockConsumer<byte[], byte[]> restoreConsumer,
                                     final boolean mockCreateInternalTopics) {
-        super(Admin.create(streamsConfig.originals()), streamsConfig);
+        super(time, Admin.create(streamsConfig.originals()), streamsConfig);
 
         this.restoreConsumer = restoreConsumer;
         this.mockCreateInternalTopics = mockCreateInternalTopics;
@@ -64,8 +66,7 @@ public class MockInternalTopicManager extends InternalTopicManager {
 
     @Override
     protected Map<String, Integer> getNumPartitions(final Set<String> topics,
-                                                    final Set<String> tempUnknownTopics,
-                                                    final boolean hasRemainingRetries) {
+                                                    final Set<String> tempUnknownTopics) {
         final Map<String, Integer> partitions = new HashMap<>();
         for (final String topic : topics) {
             partitions.put(topic, restoreConsumer.partitionsFor(topic) == null ?  null : restoreConsumer.partitionsFor(topic).size());


### PR DESCRIPTION
 - part of KIP-572
 - replace `retries` in InternalTopicManager with infinite retires plus
   a new timeout, based on consumer config MAX_POLL_INTERVAL_MS
- if the new timeout hits, we don't throw `StreamsException` any longer (as we did when exceeding retries), but send `INCOMPLETE_SOURCE_TOPIC_METADATA` error code to let all instances shut down

Third PR for KIP-572 (cf #8864 and #9047)

Call for review @vvcephei