### PR TITLE
KAFKA-10162; Make the rate based quota behave more like a Token Bucket (KIP-599, Part III)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/SampledStat.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/SampledStat.java
@@ -34,8 +34,8 @@ import org.apache.kafka.common.metrics.MetricConfig;
  */
 public abstract class SampledStat implements MeasurableStat {
 
-    private double initialValue;
-    private int current = 0;
+    protected double initialValue;
+    protected int current = 0;
     protected List<Sample> samples;
 
     public SampledStat(double initialValue) {
@@ -52,7 +52,7 @@ public abstract class SampledStat implements MeasurableStat {
         sample.eventCount += 1;
     }
 
-    private Sample advance(MetricConfig config, long timeMs) {
+    protected Sample advance(MetricConfig config, long timeMs) {
         this.current = (this.current + 1) % config.samples();
         if (this.current >= samples.size()) {
             Sample sample = newSample(timeMs);

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/TokenBucket.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/TokenBucket.java
@@ -22,14 +22,44 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.metrics.MetricConfig;
 
+/**
+ * The {@link TokenBucket} is a {@link SampledStat} implementing a token bucket that can be used
+ * in conjunction with a {@link Rate} to enforce a quota.
+ *
+ * A token bucket accumulates tokens with a constant rate R, one token per 1/R second, up to a
+ * maximum burst size B. The burst size essentially means that we keep permission to do a unit of
+ * work for up to B / R seconds.
+ *
+ * The {@link TokenBucket} adapts this to fit within a {@link SampledStat}. It accumulates tokens
+ * in chunks of Q units by default (sample length * quota) instead of one token every 1/R second
+ * and expires in chunks of Q units too (when the oldest sample is expired).
+ *
+ * Internally, we achieve this behavior by not completing the current sample until we fill that
+ * sample up to Q (used all credits). Samples are filled up one after the others until the maximum
+ * number of samples is reached. If it is not possible to created a new sample, we accumulate in
+ * the last one until a new one can be created. The over used credits are spilled over to the new
+ * sample at when it is created. Every time a sample is purged, Q credits are made available.
+ *
+ * It is important to note that the maximum burst is not enforced in the class and depends on
+ * how the quota is enforced in the {@link Rate}.
+ */
 public class TokenBucket extends SampledStat {
 
     private final TimeUnit unit;
 
+    /**
+     * Instantiates a new TokenBucket that works by default with a Quota {@link MetricConfig#quota()}
+     * in {@link TimeUnit#SECONDS}.
+     */
     public TokenBucket() {
         this(TimeUnit.SECONDS);
     }
 
+    /**
+     * Instantiates a new TokenBucket that works with the provided time unit.
+     *
+     * @param unit The time unit of the Quota {@link MetricConfig#quota()}
+     */
     public TokenBucket(TimeUnit unit) {
         super(0);
         this.unit = unit;
@@ -42,19 +72,19 @@ public class TokenBucket extends SampledStat {
             return;
         }
 
-        final double quota = quota(config);
+        final double sampleWindowQuota = sampleWindowQuota(config);
         final long firstTimeWindowMs = firstTimeWindowMs(config, timeMs);
 
-        // Get current sample or create one if empty
+        // Get current sample or create one if empty.
         Sample sample = current(firstTimeWindowMs);
 
         // Verify that the current sample was not reinitialized. If it was the case,
-        // restart from the first time window
+        // restart from the first time window.
         if (sample.eventCount == 0) {
             sample.reset(firstTimeWindowMs);
         }
 
-        // Add the value to the current sample
+        // Add the value to the current sample.
         sample.value += value;
         sample.eventCount += 1;
 
@@ -63,8 +93,8 @@ public class TokenBucket extends SampledStat {
         // new sample. Repeat until either the sample is not complete
         // or no new sample can be created.
         while (sample.isComplete(timeMs, config)) {
-            double extra = sample.value - quota;
-            sample.value = quota;
+            double extra = sample.value - sampleWindowQuota;
+            sample.value = sampleWindowQuota;
 
             sample = advance(config, sample.lastWindowMs + config.timeWindowMs());
             sample.value = extra;
@@ -73,38 +103,41 @@ public class TokenBucket extends SampledStat {
     }
 
     private void unrecord(MetricConfig config, double value, long timeMs) {
-        final double quota = quota(config);
         final long firstTimeWindowMs = firstTimeWindowMs(config, timeMs);
 
         // Rewind
         while (value > 0) {
-            // Get current sample or create one if empty
+            // Get current sample or create one if empty.
             Sample sample = current(firstTimeWindowMs);
 
-            // If the current sample has been purged, we can't unrecord anything
+            // If the current sample has been purged, we can't unrecord anything.
             if (sample.eventCount == 0) {
                 return;
             }
 
+            // If the value to unrecord is smaller than the current sample, we
+            // deduct it and return.
             if (value <= sample.value) {
                 sample.value -= value;
                 return;
             }
 
+            // The value of the current sample is removed, and the current sample
+            // is reset.
+            value -= sample.value;
             sample.reset(timeMs);
-            value -= quota;
 
             this.current = this.current - 1;
-            if (this.current <= 0)
+            if (this.current < 0)
                 this.current = this.samples.size() - 1;
         }
     }
 
-    private static double quota(MetricConfig config) {
+    private double sampleWindowQuota(MetricConfig config) {
         if (config.quota() == null)
             throw new IllegalStateException("TokenBucket can't be used without a quota.");
 
-        return config.quota().bound();
+        return config.quota().bound() * unit.convert(config.timeWindowMs(), MILLISECONDS);
     }
 
     private long firstTimeWindowMs(MetricConfig config, long timeMs) {
@@ -113,7 +146,7 @@ public class TokenBucket extends SampledStat {
 
     @Override
     protected void update(final Sample sample, final MetricConfig config, final double value, final long timeMs) {
-        // Nothing
+        // Unused.
     }
 
     @Override
@@ -139,12 +172,8 @@ public class TokenBucket extends SampledStat {
 
         public boolean isComplete(long timeMs, MetricConfig config) {
             final double quota = config.quota().bound();
-            return value >= quota * convert(config.timeWindowMs())
+            return value >= quota * unit.convert(config.timeWindowMs(), MILLISECONDS)
                 && lastWindowMs + config.timeWindowMs() <= timeMs;
-        }
-
-        private double convert(long timeMs) {
-            return unit.convert(timeMs, MILLISECONDS);
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/TokenBucket.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/TokenBucket.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics.stats;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.metrics.MetricConfig;
+
+public class TokenBucket extends SampledStat {
+
+    private final TimeUnit unit;
+
+    public TokenBucket() {
+        this(TimeUnit.SECONDS);
+    }
+
+    public TokenBucket(TimeUnit unit) {
+        super(0);
+        this.unit = unit;
+    }
+
+    @Override
+    public void record(MetricConfig config, double value, long timeMs) {
+        if (value < 0) {
+            unrecord(config, -value, timeMs);
+            return;
+        }
+
+        final double quota = quota(config);
+        final long firstTimeWindowMs = firstTimeWindowMs(config, timeMs);
+
+        // Get current sample or create one if empty
+        Sample sample = current(firstTimeWindowMs);
+
+        // Verify that the current sample was not reinitialized. If it was the case,
+        // restart from the first time window
+        if (sample.eventCount == 0) {
+            sample.reset(firstTimeWindowMs);
+        }
+
+        // Add the value to the current sample
+        sample.value += value;
+        sample.eventCount += 1;
+
+        // If current sample is completed AND a new one can be created,
+        // create one and spill over the amount above the quota to the
+        // new sample. Repeat until either the sample is not complete
+        // or no new sample can be created.
+        while (sample.isComplete(timeMs, config)) {
+            double extra = sample.value - quota;
+            sample.value = quota;
+
+            sample = advance(config, sample.lastWindowMs + config.timeWindowMs());
+            sample.value = extra;
+            sample.eventCount += 1;
+        }
+    }
+
+    private void unrecord(MetricConfig config, double value, long timeMs) {
+        final double quota = quota(config);
+        final long firstTimeWindowMs = firstTimeWindowMs(config, timeMs);
+
+        // Rewind
+        while (value > 0) {
+            // Get current sample or create one if empty
+            Sample sample = current(firstTimeWindowMs);
+
+            // If the current sample has been purged, we can't unrecord anything
+            if (sample.eventCount == 0) {
+                return;
+            }
+
+            if (value <= sample.value) {
+                sample.value -= value;
+                return;
+            }
+
+            sample.reset(timeMs);
+            value -= quota;
+
+            this.current = this.current - 1;
+            if (this.current <= 0)
+                this.current = this.samples.size() - 1;
+        }
+    }
+
+    private static double quota(MetricConfig config) {
+        if (config.quota() == null)
+            throw new IllegalStateException("TokenBucket can't be used without a quota.");
+
+        return config.quota().bound();
+    }
+
+    private long firstTimeWindowMs(MetricConfig config, long timeMs) {
+        return timeMs - config.timeWindowMs() * (config.samples() - 1);
+    }
+
+    @Override
+    protected void update(final Sample sample, final MetricConfig config, final double value, final long timeMs) {
+        // Nothing
+    }
+
+    @Override
+    public double combine(final List<Sample> samples, final MetricConfig config, final long now) {
+        double total = 0.0;
+        for (Sample sample : samples) {
+            total += sample.value;
+        }
+        return total;
+    }
+
+    protected Sample newSample(long timeMs) {
+        return new TokenBucketSample(this.initialValue, timeMs, this.unit);
+    }
+
+    private static class TokenBucketSample extends SampledStat.Sample {
+        private final TimeUnit unit;
+
+        public TokenBucketSample(double initialValue, long now, TimeUnit unit) {
+            super(initialValue, now);
+            this.unit = unit;
+        }
+
+        public boolean isComplete(long timeMs, MetricConfig config) {
+            final double quota = config.quota().bound();
+            return value >= quota * convert(config.timeWindowMs())
+                && lastWindowMs + config.timeWindowMs() <= timeMs;
+        }
+
+        private double convert(long timeMs) {
+            return unit.convert(timeMs, MILLISECONDS);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/TokenBucketTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/TokenBucketTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics.stats;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Quota;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TokenBucketTest {
+    Time time;
+
+    @Before
+    public void setup() {
+        time = new MockTime(0, 0, 0);
+    }
+
+    @Test
+    public void testOneSampleIsDecreasedCorrectly() {
+        MetricConfig config = new MetricConfig()
+            .quota(Quota.upperBound(1))
+            .timeWindow(1, TimeUnit.SECONDS)
+            .samples(11);
+
+        TokenBucket tk = new TokenBucket();
+
+        // Record 6 at T
+        tk.record(config, 6, time.milliseconds());
+
+        // Expect 6 at T
+        assertEquals(6, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 4 at T+2s
+        time.sleep(2000);
+        assertEquals(4, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 2 at T+4s
+        time.sleep(2000);
+        assertEquals(2, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 0 at T+6s
+        time.sleep(2000);
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+    }
+
+    @Test
+    public void testOneSampleIsDecreasedCorrectlyAndThenDropped() {
+        MetricConfig config = new MetricConfig()
+            .quota(Quota.upperBound(1))
+            .timeWindow(1, TimeUnit.SECONDS)
+            .samples(11);
+
+        TokenBucket tk = new TokenBucket();
+
+        // Record 20 at T
+        tk.record(config, 20, time.milliseconds());
+
+        // Expect 10 at T+10s
+        time.sleep(10000);
+        assertEquals(10, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 0 at T+11s -> The sample has been dropped
+        time.sleep(1000);
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+    }
+
+    @Test
+    public void testMultipleSamples() {
+        MetricConfig config = new MetricConfig()
+            .quota(Quota.upperBound(5))
+            .timeWindow(1, TimeUnit.SECONDS)
+            .samples(11);
+
+        TokenBucket tk = new TokenBucket();
+
+        // Record 50 (S1) at T
+        // [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]
+        tk.record(config, 50, time.milliseconds());
+
+        // Expect 50 at T
+        assertEquals(50, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Record 50 (S2) at T+5s
+        // [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 25]
+        time.sleep(5000);
+        tk.record(config, 50, time.milliseconds());
+
+        // Expect 75 at T+5s
+        assertEquals(75, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Record 50 (S3) at T+10s
+        // [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 50]
+        time.sleep(5000);
+        tk.record(config, 50, time.milliseconds());
+
+        // Expect 100 at T+10s
+        assertEquals(100, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Record 50 (S4) at T+15s
+        // [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 75]
+        time.sleep(5000);
+        tk.record(config, 50, time.milliseconds());
+
+        // Expect 125 at T+15s
+        assertEquals(125, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 100 at T+20s
+        time.sleep(5000);
+        assertEquals(100, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 75 at T+25s
+        time.sleep(5000);
+        assertEquals(75, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 0 at T+30s -> last sample is expired -> drop to zero
+        time.sleep(5000);
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 0 at T+35s
+        time.sleep(5000);
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 0 at T+40s
+        time.sleep(5000);
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+    }
+
+    @Test
+    public void testUnrecord() {
+        MetricConfig config = new MetricConfig()
+            .quota(Quota.upperBound(5))
+            .timeWindow(1, TimeUnit.SECONDS)
+            .samples(11);
+
+        TokenBucket tk = new TokenBucket();
+
+        // Record 50 at T
+        tk.record(config, 50, time.milliseconds());
+
+        // Expect 50 at T
+        assertEquals(50, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 25 at T+5s
+        time.sleep(5000);
+        assertEquals(25, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Unrecord 5 at T+5s
+        tk.record(config, -5, time.milliseconds());
+
+        // Expect 20 at T+5s
+        assertEquals(20, tk.measure(config, time.milliseconds()), 0.1);
+
+        time.sleep(1000);
+
+        // Expect 0 at T+6s
+        assertEquals(15, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Unrecord 50 at T+6s
+        tk.record(config, -50, time.milliseconds());
+
+        // Expect 0 at T+6s
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/TokenBucketTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/TokenBucketTest.java
@@ -63,6 +63,34 @@ public class TokenBucketTest {
     }
 
     @Test
+    public void testTimeWindowLargerThan1s() {
+        MetricConfig config = new MetricConfig()
+            .quota(Quota.upperBound(2))
+            .timeWindow(5, TimeUnit.SECONDS)
+            .samples(11);
+
+        TokenBucket tk = new TokenBucket();
+
+        // Record 14 at T
+        tk.record(config, 14, time.milliseconds());
+
+        // Expect 14 at T
+        assertEquals(14, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 14 at T+2s
+        time.sleep(2000);
+        assertEquals(14, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 4 at T+5s
+        time.sleep(3000);
+        assertEquals(4, tk.measure(config, time.milliseconds()), 0.1);
+
+        // Expect 4 at T+10s
+        time.sleep(5000);
+        assertEquals(0, tk.measure(config, time.milliseconds()), 0.1);
+    }
+
+    @Test
     public void testOneSampleIsDecreasedCorrectlyAndThenDropped() {
         MetricConfig config = new MetricConfig()
             .quota(Quota.upperBound(1))

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -396,7 +396,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
         ClientQuotaManager.InactiveSensorExpirationTimeSeconds,
         clientRateMetricName(metricTags),
         Some(getQuotaMetricConfig(metricTags)),
-        new Rate
+        getQuotaSensorRate
       ),
       sensorAccessor.getOrCreate(
         getThrottleTimeSensorName(metricTags),
@@ -423,6 +423,8 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
   private def getQuotaMetricConfig(metricTags: Map[String, String]): MetricConfig = {
     getQuotaMetricConfig(quotaLimit(metricTags.asJava))
   }
+
+  protected def getQuotaSensorRate: Rate = new Rate()
 
   private def getQuotaMetricConfig(quotaLimit: Double): MetricConfig = {
     new MetricConfig()

--- a/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
@@ -23,6 +23,8 @@ import org.apache.kafka.common.errors.ThrottlingQuotaExceededException
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.QuotaViolationException
 import org.apache.kafka.common.metrics.Sensor
+import org.apache.kafka.common.metrics.stats.Rate
+import org.apache.kafka.common.metrics.stats.TokenBucket
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.server.quota.ClientQuotaCallback
@@ -151,6 +153,8 @@ class ControllerMutationQuotaManager(private val config: ClientQuotaManagerConfi
       "Tracking mutation-rate per user/client-id",
       quotaMetricTags.asJava)
   }
+
+  override protected def getQuotaSensorRate: Rate = new Rate(new TokenBucket())
 
   /**
    * Records that a user/clientId accumulated or would like to accumulate the provided amount at the


### PR DESCRIPTION
* Introduce a new SampledStat named TokenBucket
* Change the ControllerMutationManager to use it by default

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
