### PR TITLE
KAFKA-10132: Return correct value types for MBean attributes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -272,7 +272,14 @@ public class JmxReporter implements MetricsReporter {
             for (Map.Entry<String, KafkaMetric> entry : this.metrics.entrySet()) {
                 String attribute = entry.getKey();
                 KafkaMetric metric = entry.getValue();
-                String metricType = metric.metricValue() != null ? metric.metricValue().getClass().getName() : null;
+                String metricType = null;
+
+                try {
+                    metricType = metric.metricValue().getClass().getName();
+                } catch (NullPointerException e) {
+                    log.debug("Could not determine metric value type for attribute {}", attribute);
+                }
+
                 attrs[i] = new MBeanAttributeInfo(attribute,
                                                   metricType,
                                                   metric.metricName().description(),

--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -272,7 +272,7 @@ public class JmxReporter implements MetricsReporter {
             for (Map.Entry<String, KafkaMetric> entry : this.metrics.entrySet()) {
                 String attribute = entry.getKey();
                 KafkaMetric metric = entry.getValue();
-                String metricType = metric.metricValue() != null ? metric.metricValue().getClass().getName() : double.class.getName();
+                String metricType = metric.metricValue() != null ? metric.metricValue().getClass().getName() : null;
                 attrs[i] = new MBeanAttributeInfo(attribute,
                                                   metricType,
                                                   metric.metricName().description(),

--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -272,12 +272,12 @@ public class JmxReporter implements MetricsReporter {
             for (Map.Entry<String, KafkaMetric> entry : this.metrics.entrySet()) {
                 String attribute = entry.getKey();
                 KafkaMetric metric = entry.getValue();
-                String metricType = null;
+                String metricType = double.class.getName();
 
                 try {
                     metricType = metric.metricValue().getClass().getName();
                 } catch (NullPointerException e) {
-                    log.debug("Could not determine metric value type for attribute {}", attribute);
+                    log.debug("Could not determine metric value type for attribute {}, falling back to double", attribute);
                 }
 
                 attrs[i] = new MBeanAttributeInfo(attribute,

--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -272,8 +272,9 @@ public class JmxReporter implements MetricsReporter {
             for (Map.Entry<String, KafkaMetric> entry : this.metrics.entrySet()) {
                 String attribute = entry.getKey();
                 KafkaMetric metric = entry.getValue();
+                String metricType = metric.metricValue() != null ? metric.metricValue().getClass().getName() : double.class.getName();
                 attrs[i] = new MBeanAttributeInfo(attribute,
-                                                  double.class.getName(),
+                                                  metricType,
                                                   metric.metricName().description(),
                                                   true,
                                                   false,

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class JmxReporterTest {
@@ -219,7 +218,7 @@ public class JmxReporterTest {
             assertEquals(attributes.length, 3);
             assertEquals(String.class.getName(), attributes[0].getType());
             assertEquals(Double.class.getName(), attributes[1].getType());
-            assertNull(attributes[2].getType());
+            assertEquals(double.class.getName(), attributes[2].getType());
         } finally {
             metrics.close();
         }


### PR DESCRIPTION
Currently, JMX outputs all metrics as having type `double`, even if they are strings or other types of numbers. This PR gets the type from the metric's value if possible, using `double` as a fallback if the type can't be determined.
