### PR TITLE
MINOR: Update dependencies for Kafka 2.7 (part 1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ buildscript {
   }
 }
 
-apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: "com.diffplug.spotless"
 spotless {
   scala {
     target 'streams/**/*.scala'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -105,7 +105,7 @@ versions += [
   scalaJava8Compat : "0.9.1",
   scalatest: "3.0.8",
   scoverage: "1.4.2",
-  scoveragePlugin: "4.0.1",
+  scoveragePlugin: "4.0.2",
   shadowPlugin: "6.0.0",
   slf4j: "1.7.30",
   snappy: "1.1.7.6",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -104,7 +104,7 @@ versions += [
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.1",
   scalatest: "3.0.8",
-  scoverage: "1.4.2",
+  scoverage: "1.4.1",
   scoveragePlugin: "4.0.2",
   shadowPlugin: "6.0.0",
   slf4j: "1.7.30",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,7 +27,7 @@ ext {
 }
 
 // Add Scala version
-def defaultScala212Version = '2.12.11'
+def defaultScala212Version = '2.12.12'
 def defaultScala213Version = '2.13.3'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
@@ -58,13 +58,13 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.64",
+  bcpkix: "1.66",
   checkstyle: "8.20",
   commonsCli: "1.4",
   gradle: "6.5",
-  gradleVersionsPlugin: "0.28.0",
-  grgit: "4.0.1",
-  httpclient: "4.5.11",
+  gradleVersionsPlugin: "0.29.0",
+  grgit: "4.0.2",
+  httpclient: "4.5.12",
   easymock: "4.2",
   jackson: "2.10.2",
   jacoco: "0.8.5",
@@ -94,8 +94,8 @@ versions += [
   lz4: "1.7.1",
   mavenArtifact: "3.6.3",
   metrics: "2.2.0",
-  mockito: "3.3.3",
-  netty: "4.1.50.Final",
+  mockito: "3.4.4",
+  netty: "4.1.51.Final",
   owaspDepCheckPlugin: "5.3.2.1",
   powermock: "2.0.7",
   reflections: "0.9.12",
@@ -104,18 +104,18 @@ versions += [
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.1",
   scalatest: "3.0.8",
-  scoverage: "1.4.1",
+  scoverage: "1.4.2",
   scoveragePlugin: "4.0.1",
-  shadowPlugin: "5.2.0",
+  shadowPlugin: "6.0.0",
   slf4j: "1.7.30",
-  snappy: "1.1.7.3",
-  spotbugs: "4.0.3",
-  spotbugsPlugin: "4.2.4",
-  spotlessPlugin: "3.28.1",
-  testRetryPlugin: "1.1.5",
+  snappy: "1.1.7.6",
+  spotbugs: "4.0.6",
+  spotbugsPlugin: "4.4.4",
+  spotlessPlugin: "5.1.0",
+  testRetryPlugin: "1.1.6",
   zinc: "1.3.5",
   zookeeper: "3.5.8",
-  zstd: "1.4.5-2"
+  zstd: "1.4.5-6"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
I left out updates that could be risky. Preliminary testing indicates
we can build (including spotBugs) and run tests with Java 15 with
these changes. I will do more thorough testing once Java 15 reaches
release candidate stage in a few weeks.

Minor updates with mostly bug fixes:
- Scala: 2.12.11 -> 2.12.12 (compiler and collection performance improvements)
- Bouncy castle: 1.64 -> 1.66 (several bug fixes)
- HttpClient: 4.5.11 -> 4.5.12 (small number of bug fixes)
- Mockito: 3.3.3 -> 3.4.4 (several bug fixes and Java 15 support)
- Netty: 4.5.10 -> 4.5.11 (several bug fixes)
- Snappy: 1.1.7.3 -> 1.1.7.6 (small number of bug fixes)
- Zstd: 1.4.5-2 -> 1.4.5-6 (small number of bug fixes)

Gradle plugin and library upgrades:
- Gradle version plugins: 0.28.0 -> 0.29.0 (small number of bug fixes)
- Git: 4.0.1 -> 4.0.2 (small number of bug fixes)
- Scoverage plugin: 4.0.1 -> 4.0.2 (small number of bug fixes)
- Shadow plugin: 5.2.0 -> 6.0.0 (Java 15 support and require Gradle 6.0)
- Test Retry plugin: 1.1.5 -> 1.1.6 (small number of bug fixes)
- Spotless plugin: 4.4.4 -> 5.1.0 (several internal changes that should not matter to us)
- Spotbugs: 4.0.3 -> 4.0.6 (small number of bug fixes)
- Spotbugs plugin: 4.2.4 -> 4.4.4 (small number of bug fixes)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
