### PR TITLE
FIX: Remove staticmethod tag to be able to use logger of instance

### DIFF
--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -95,8 +95,7 @@ class BaseStreamsTest(KafkaTest):
                    timeout_sec=60,
                    err_msg="Did expect to read '%s' from %s" % (message, processor.node.account))
 
-    @staticmethod
-    def verify_from_file(processor, message, file):
+    def verify_from_file(self, processor, message, file):
         result = processor.node.account.ssh_output("grep -E '%s' %s | wc -l" % (message, file), allow_fail=False)
         try:
           return int(result)


### PR DESCRIPTION
A system test failed with the following error

global name 'self' is not defined

The reason was that self was accessed in a static
method to log a message.

This commit makes the method an instance method.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
