### PR TITLE
sync docs for list of emitted metrics by MirrorMetrics

### DIFF
--- a/connect/mirror/README.md
+++ b/connect/mirror/README.md
@@ -199,6 +199,7 @@ The following metrics are emitted:
     # MBean: kafka.connect.mirror:type=MirrorSourceConnector,target=([-.w]+),topic=([-.w]+),partition=([0-9]+)
 
     record-count            # number of records replicated source -> target
+    record-rate
     record-age-ms           # age of records when they are replicated
     record-age-ms-min
     record-age-ms-max
@@ -207,6 +208,7 @@ The following metrics are emitted:
     replication-latency-ms-min
     replication-latency-ms-max
     replication-latency-ms-avg
+    byte-count
     byte-rate               # average number of bytes/sec in replicated records
 
 


### PR DESCRIPTION
these metrics `record-rate` and `byte-count` are not listed here according to the MirrorMetrics source file:

https://github.com/apache/kafka/blob/3df5464fca06d36b806e50c9d6db047d9d612651/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMetrics.java#L47-L95