### PR TITLE
toString pattern change like ProducerRecord.java

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -275,15 +275,15 @@ public class ConsumerRecord<K, V> {
 
     @Override
     public String toString() {
-        return "ConsumerRecord(topic = " + topic
-               + ", partition = " + partition
-               + ", leaderEpoch = " + leaderEpoch.orElse(null)
-               + ", offset = " + offset
-               + ", " + timestampType + " = " + timestamp
-               + ", serialized key size = "  + serializedKeySize
-               + ", serialized value size = " + serializedValueSize
-               + ", headers = " + headers
-               + ", key = " + key
-               + ", value = " + value + ")";
+        return "ConsumerRecord(topic=" + topic
+               + ", partition=" + partition
+               + ", leaderEpoch=" + leaderEpoch.orElse(null)
+               + ", offset=" + offset
+               + ", " + timestampType + "=" + timestamp
+               + ", serializedKeySize=" + serializedKeySize
+               + ", serializedValueSize=" + serializedValueSize
+               + ", headers=" + headers
+               + ", key=" + key
+               + ", value=" + value + ")";
     }
 }


### PR DESCRIPTION
In most of 'toString()' methods,'=' is used instead of ' = ', so I followed the convention.
Actually, if you print 'ProducerRecord' and 'ConsumerRecord', the pattern looks different and looks strange.
---------------------------------
producerRecord: ProducerRecord(topic=xxxx, partition=null, headers= ...)
consumerRecord: ConsumerRecord(topic = xxxx, partition = 0, ..., headers = ...)
