### PR TITLE
KAFKA-10321: fix infinite blocking for global stream thread startup

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -107,8 +107,8 @@ public class GlobalStreamThread extends Thread {
             return equals(RUNNING);
         }
 
-        public boolean isDead() {
-            return equals(DEAD);
+        public boolean inErrorState() {
+            return equals(DEAD) || equals(PENDING_SHUTDOWN);
         }
 
         @Override
@@ -178,9 +178,15 @@ public class GlobalStreamThread extends Thread {
         }
     }
 
+    public boolean inErrorState() {
+        synchronized (stateLock) {
+            return state.inErrorState();
+        }
+    }
+
     public boolean stillInitializing() {
         synchronized (stateLock) {
-            return !state.isRunning() && !state.isDead();
+            return !state.isRunning() && !state.inErrorState();
         }
     }
 
@@ -400,6 +406,10 @@ public class GlobalStreamThread extends Thread {
             if (startupException != null) {
                 throw startupException;
             }
+        }
+
+        if (inErrorState()) {
+            throw new IllegalStateException("Initialization for the global stream thread failed");
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.CREATED;
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.DEAD;
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.PENDING_SHUTDOWN;
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.RUNNING;
@@ -186,7 +187,7 @@ public class GlobalStreamThread extends Thread {
 
     public boolean stillInitializing() {
         synchronized (stateLock) {
-            return !state.isRunning() && !state.inErrorState();
+            return state.equals(CREATED);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -163,14 +163,14 @@ public class GlobalStreamThreadTest {
     @Test
     public void shouldBeRunningAfterSuccessfulStart() {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
         assertTrue(globalStreamThread.stillRunning());
     }
 
     @Test(timeout = 30000)
     public void shouldStopRunningWhenClosedByUser() throws Exception {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
         globalStreamThread.shutdown();
         globalStreamThread.join();
         assertEquals(GlobalStreamThread.State.DEAD, globalStreamThread.state());
@@ -179,7 +179,7 @@ public class GlobalStreamThreadTest {
     @Test
     public void shouldCloseStateStoresOnClose() throws Exception {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
         final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
         assertTrue(globalStore.isOpen());
         globalStreamThread.shutdown();
@@ -190,7 +190,7 @@ public class GlobalStreamThreadTest {
     @Test
     public void shouldTransitionToDeadOnClose() throws Exception {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
         globalStreamThread.shutdown();
         globalStreamThread.join();
 
@@ -200,7 +200,7 @@ public class GlobalStreamThreadTest {
     @Test
     public void shouldStayDeadAfterTwoCloses() throws Exception {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
         globalStreamThread.shutdown();
         globalStreamThread.join();
         globalStreamThread.shutdown();
@@ -211,7 +211,7 @@ public class GlobalStreamThreadTest {
     @Test
     public void shouldTransitionToRunningOnStart() throws Exception {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
 
         TestUtils.waitForCondition(
             () -> globalStreamThread.state() == RUNNING,
@@ -231,7 +231,7 @@ public class GlobalStreamThreadTest {
             }
         });
 
-        globalStreamThread.start();
+        startAndSwallowError();
 
         TestUtils.waitForCondition(
             () -> globalStreamThread.state() == DEAD,
@@ -245,7 +245,7 @@ public class GlobalStreamThreadTest {
     @Test
     public void shouldDieOnInvalidOffsetExceptionWhileRunning() throws Exception {
         initializeConsumer();
-        globalStreamThread.start();
+        startAndSwallowError();
 
         TestUtils.waitForCondition(
             () -> globalStreamThread.state() == RUNNING,
@@ -288,5 +288,12 @@ public class GlobalStreamThreadTest {
         mockConsumer.updateBeginningOffsets(Collections.singletonMap(topicPartition, 0L));
         mockConsumer.updateEndOffsets(Collections.singletonMap(topicPartition, 0L));
         mockConsumer.assign(Collections.singleton(topicPartition));
+    }
+
+    private void startAndSwallowError() {
+        try {
+            globalStreamThread.start();
+        } catch (IllegalStateException ignored) {
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -293,7 +293,7 @@ public class GlobalStreamThreadTest {
     private void startAndSwallowError() {
         try {
             globalStreamThread.start();
-        } catch (IllegalStateException ignored) {
+        } catch (final IllegalStateException ignored) {
         }
     }
 }


### PR DESCRIPTION
In the unit test `shouldDieOnInvalidOffsetExceptionDuringStartup` for JDK 11, we spotted a case where a global stream thread startup would stall if it fails immediately upon the first poll. The reason is that `start()` function only checks whether the thread is *not running*, as it needs to block until it finishes the initialization. However, if the thread transits to `DEAD` immediately, the `start()` call would block forever.

Use the failed unit test to verify it works.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
