### PR TITLE
MINOR: Ensure a reason is logged for all segment deletion operations

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2219,7 +2219,7 @@ class Log(@volatile private var _dir: File,
         // removing the deleted segment, we should force materialization of the iterator here, so that results of the
         // iteration remain valid and deterministic.
         val toDelete = segments.toList
-        info(s"${reason.logReason(this, toDelete)}")
+        reason.logReason(this, toDelete)
         toDelete.foreach { segment =>
           this.segments.remove(segment.baseOffset)
         }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2219,7 +2219,7 @@ class Log(@volatile private var _dir: File,
         // removing the deleted segment, we should force materialization of the iterator here, so that results of the
         // iteration remain valid and deterministic.
         val toDelete = segments.toList
-        println(s"${reason.reasonString(this, toDelete)}")
+        info(s"${reason.reasonString(this, toDelete)}")
         toDelete.foreach { segment =>
           this.segments.remove(segment.baseOffset)
         }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2242,18 +2242,16 @@ class Log(@volatile private var _dir: File,
     segments.foreach(_.changeFileSuffixes("", Log.DeletedFileSuffix))
 
     def deleteSegments(): Unit = {
-      info(s"Deleting segments ${segments.mkString(",")}")
+      info(s"Deleting segment files ${segments.mkString(",")}")
       maybeHandleIOException(s"Error while deleting segments for $topicPartition in dir ${dir.getParent}") {
         segments.foreach(_.deleteIfExists())
       }
     }
 
-    if (asyncDelete) {
-      info(s"Scheduling segments for deletion ${segments.mkString(",")}")
+    if (asyncDelete)
       scheduler.schedule("delete-file", () => deleteSegments(), delay = config.fileDeleteDelayMs)
-    } else {
+    else
       deleteSegments()
-    }
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -413,7 +413,7 @@ class LogSegment private[log] (val log: FileRecords,
   override def toString: String = "LogSegment(baseOffset=" + baseOffset +
     ", size=" + size +
     ", lastModifiedTime=" + lastModified +
-    ", largestTime=" + largestTimestamp +
+    ", largestRecordTimestamp=" + largestRecordTimestamp +
     ")"
 
   /**


### PR DESCRIPTION
This PR improves the logging for segment deletion to ensure that a reason is logged for segment deletions via all code paths. It also updates the logging so we can log a reason for an entire batch of deletions instead of logging one message per segment.

Sample log output:
```
[2020-08-05 11:56:35,826] INFO [Log partition=foo-0, dir=/tmp/kafka-logs] Deleting segment LogSegment(baseOffset=219030, size=1042252, lastModifiedTime=1596653795000, largestRecordTimestamp=Some(1596653795374)) due to retention time 1ms breach based on the largest record timestamp in the segment (kafka.log.Log)
[2020-08-05 11:56:35,826] INFO [Log partition=foo-0, dir=/tmp/kafka-logs] Deleting segment LogSegment(baseOffset=220035, size=1042252, lastModifiedTime=1596653795000, largestRecordTimestamp=Some(1596653795384)) due to retention time 1ms breach based on the largest record timestamp in the segment (kafka.log.Log)
...
```