### PR TITLE
MINOR: optimize fetchablePartitions check by performing cheap check first

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -423,7 +423,8 @@ public class SubscriptionState {
 
     synchronized List<TopicPartition> fetchablePartitions(Predicate<TopicPartition> isAvailable) {
         return assignment.stream()
-                .filter(tpState -> isAvailable.test(tpState.topicPartition()) && tpState.value().isFetchable())
+                // perform cheaper isFetchable test before more expensive isAvailable test
+                .filter(tpState -> tpState.value().isFetchable() && isAvailable.test(tpState.topicPartition()))
                 .map(PartitionStates.PartitionState::topicPartition)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
When the consumer fetches a lot of partitions at once the isAvailable
check can become expensive due to a high number of contains check. We
might as well perform the isFetchable check first as this is clearly much
cheaper.

This will help most with partitions that are paused or are otherwise not
in a state where they are fetchable.