### PR TITLE
KAFKA-10361: Windows batch files that use /bin/windows/kafka-run-class.bat fail with a class path error on fresh installation

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -171,6 +171,11 @@ IF ["%KAFKA_JVM_PERFORMANCE_OPTS%"] EQU [""] (
 	set KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true
 )
 
+rem classpath addition for LSB style path
+if exist %BASE_DIR%\share\java\kafka\* (
+call:concat %BASE_DIR%\share\java\kafka\*
+)
+
 IF not defined CLASSPATH (
 	echo Classpath is empty. Please build the project first e.g. by running 'gradlew jarAll'
 	EXIT /B 2

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -94,6 +94,11 @@ for %%i in ("%BASE_DIR%\libs\*") do (
 	call :concat "%%i"
 )
 
+rem classpath addition for LSB style path
+if exist %BASE_DIR%\share\java\kafka\* (
+	call:concat %BASE_DIR%\share\java\kafka\*
+)
+
 rem Classpath addition for core
 for %%i in ("%BASE_DIR%\core\build\libs\kafka_%SCALA_BINARY_VERSION%*.jar") do (
 	call :concat "%%i"
@@ -171,10 +176,7 @@ IF ["%KAFKA_JVM_PERFORMANCE_OPTS%"] EQU [""] (
 	set KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true
 )
 
-rem classpath addition for LSB style path
-if exist %BASE_DIR%\share\java\kafka\* (
-call:concat %BASE_DIR%\share\java\kafka\*
-)
+
 
 IF not defined CLASSPATH (
 	echo Classpath is empty. Please build the project first e.g. by running 'gradlew jarAll'


### PR DESCRIPTION
This contribution is based on public information from https://medium.com/@praveenkumarsingh/confluent-kafka-on-windows-how-to-fix-classpath-is-empty-cf7c31d9c787 

I license my version of the work to the project under the project's open source license.

