### PR TITLE
KAFKA-7540 reduce session timeout to evict dead member in time and so…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.TopicPartition
 import kafka.utils.{ShutdownableThread, TestUtils}
+import kafka.utils.Implicits._
 import kafka.server.{BaseRequestTest, KafkaConfig}
 import org.junit.Assert._
 import org.junit.Before
@@ -96,9 +97,11 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
     }
   }
 
-  protected def createConsumerWithGroupId(groupId: String): KafkaConsumer[Array[Byte], Array[Byte]] = {
+  protected def createConsumerWithGroupId(groupId: String,
+                                          configOverrides: Properties = new Properties): KafkaConsumer[Array[Byte], Array[Byte]] = {
     val groupOverrideConfig = new Properties
     groupOverrideConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+    groupOverrideConfig ++= configOverrides
     createConsumer(configOverrides = groupOverrideConfig)
   }
 


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-7540

In short, the LEAVE_GROUP is sent to a shutdown broker so the dead member which is left in the group obstructs broker from completing rebalance.

The test case creates two consumers (with different group) and then shutdown their coordinator (broker). After first coordinator is shutdown, the heartbeat thread of first consumer gets timeout so it sends LEAVE_GROUP request to “next” coordinator. Unfortunately, the LEAVE_GROUP request can’t be processed successfully if the ”next” coordinator is the coordinator of second consumer (yep, it is shutdown also). 

The simple approach is that we can reduce the session timeout so coordinator can evict dead member in time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
