### PR TITLE
[KAFKA-10422] [WIP] Introduce `timesForOffsets` in `KafkaConsumer`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -224,6 +224,16 @@ public interface Consumer<K, V> extends Closeable {
     Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch, Duration timeout);
 
     /**
+     * @see KafkaConsumer#timesForOffsets(Map)
+     */
+    Map<TopicPartition, OffsetAndTimestamp> timesForOffsets(Map<TopicPartition, Long> offsetsToSearch);
+
+    /**
+     * @see KafkaConsumer#timesForOffsets(Map, Duration)
+     */
+    Map<TopicPartition, OffsetAndTimestamp> timesForOffsets(Map<TopicPartition, Long> offsetsToSearch, Duration timeout);
+
+    /**
      * @see KafkaConsumer#beginningOffsets(Collection)
      */
     Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -410,6 +410,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
+    public synchronized Map<TopicPartition, OffsetAndTimestamp> timesForOffsets(Map<TopicPartition, Long> offsetsToSearch) {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @Override
     public synchronized Map<TopicPartition, Long> beginningOffsets(Collection<TopicPartition> partitions) {
         if (offsetsException != null) {
             RuntimeException exception = this.offsetsException;
@@ -529,6 +534,12 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(Map<TopicPartition, Long> timestampsToSearch,
             Duration timeout) {
         return offsetsForTimes(timestampsToSearch);
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndTimestamp> timesForOffsets(Map<TopicPartition, Long> offsetsToSearch,
+            Duration timeout) {
+        return timesForOffsets(offsetsToSearch);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetRequest.java
@@ -221,13 +221,12 @@ public class ListOffsetRequest extends AbstractRequest {
             this(timestamp, maxNumOffsets, Optional.empty(), ANY_OFFSET);
         }
 
-        // For V6
-        public PartitionData(long offset) {
-            this(EARLIEST_TIMESTAMP, 1, Optional.empty(), offset);
-        }
-
         public PartitionData(long timestamp, Optional<Integer> currentLeaderEpoch) {
             this(timestamp, 1, currentLeaderEpoch, ANY_OFFSET);
+        }
+
+        public PartitionData(long timestamp, long offset, Optional<Integer> currentLeaderEpoch) {
+            this(timestamp, 1, currentLeaderEpoch, offset);
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -129,9 +129,11 @@ public class ListOffsetResponse extends AbstractResponse {
 
     private static final Schema LIST_OFFSET_RESPONSE_V5 = LIST_OFFSET_RESPONSE_V4;
 
+    private static final Schema LIST_OFFSET_RESPONSE_V6 = LIST_OFFSET_RESPONSE_V5;
+
     public static Schema[] schemaVersions() {
         return new Schema[] {LIST_OFFSET_RESPONSE_V0, LIST_OFFSET_RESPONSE_V1, LIST_OFFSET_RESPONSE_V2,
-            LIST_OFFSET_RESPONSE_V3, LIST_OFFSET_RESPONSE_V4, LIST_OFFSET_RESPONSE_V5};
+            LIST_OFFSET_RESPONSE_V3, LIST_OFFSET_RESPONSE_V4, LIST_OFFSET_RESPONSE_V5, LIST_OFFSET_RESPONSE_V6};
     }
 
     public static final class PartitionData {

--- a/clients/src/main/resources/common/message/ListOffsetRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetRequest.json
@@ -26,15 +26,17 @@
   //
   // Version 4 adds the current leader epoch, which is used for fencing.
   //
-  // Version 5 is the same as version 5.
-  "validVersions": "0-5",
+  // Version 5 is the same as version 4.
+  //
+  // Version 6 adds offset.
+  "validVersions": "0-6",
   "flexibleVersions": "none",
   "fields": [
     { "name": "ReplicaId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The broker ID of the requestor, or -1 if this request is being made by a normal consumer." },
     { "name": "IsolationLevel", "type": "int8", "versions": "2+",
       "about": "This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allows consumers to discard ABORTED transactional records" },
-    { "name": "Topics", "type": "[]ListOffsetTopic", "versions": "0+", 
+    { "name": "Topics", "type": "[]ListOffsetTopic", "versions": "0+",
       "about": "Each topic in the request.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
         "about": "The topic name." },
@@ -47,7 +49,9 @@
         { "name": "Timestamp", "type": "int64", "versions": "0+",
           "about": "The current timestamp." },
         { "name": "MaxNumOffsets", "type": "int32", "versions": "0",
-          "about": "The maximum number of offsets to report." }
+          "about": "The maximum number of offsets to report." },
+        { "name": "Offset", "type": "int64", "versions": "6+",
+          "about": "The target offset." }
       ]}
     ]}
   ]

--- a/clients/src/main/resources/common/message/ListOffsetResponse.json
+++ b/clients/src/main/resources/common/message/ListOffsetResponse.json
@@ -27,7 +27,9 @@
   // Version 4 adds the leader epoch, which is used for fencing.
   //
   // Version 5 adds a new error code, OFFSET_NOT_AVAILABLE.
-  "validVersions": "0-5",
+  //
+  // Version 6 is the same as version 5.
+  "validVersions": "0-6",
   "flexibleVersions": "none",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "2+", "ignorable": true,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -587,7 +587,7 @@ public class KafkaConsumerTest {
         client.prepareResponse(
             body -> {
                 ListOffsetRequest request = (ListOffsetRequest) body;
-                Map<TopicPartition, ListOffsetRequest.PartitionData> timestamps = request.partitionTimestamps();
+                Map<TopicPartition, ListOffsetRequest.PartitionData> timestamps = request.partitionsData();
                 return timestamps.get(tp0).timestamp == ListOffsetRequest.LATEST_TIMESTAMP &&
                         timestamps.get(tp1).timestamp == ListOffsetRequest.EARLIEST_TIMESTAMP;
             }, listOffsetsResponse(Collections.singletonMap(tp0, 50L),

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1767,6 +1767,12 @@ public class KafkaConsumerTest {
     }
 
     @Test(expected = AuthenticationException.class)
+    public void testTimesForOffsetsAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
+        consumer.timesForOffsets(singletonMap(tp0, 0L));
+    }
+
+    @Test(expected = AuthenticationException.class)
     public void testCommitSyncAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -2510,7 +2510,7 @@ public class FetcherTest {
                     expectedTopicPartitions.put(tp1, new ListOffsetRequest.PartitionData(
                         fetchTimestamp, Optional.empty()));
 
-                    return request.partitionTimestamps().equals(expectedTopicPartitions);
+                    return request.partitionsData().equals(expectedTopicPartitions);
                 } else {
                     return false;
                 }
@@ -2531,7 +2531,7 @@ public class FetcherTest {
                 if (isListOffsetRequest) {
                     ListOffsetRequest request = (ListOffsetRequest) body;
 
-                    return request.partitionTimestamps().equals(
+                    return request.partitionsData().equals(
                         Collections.singletonMap(tp1, new ListOffsetRequest.PartitionData(
                             fetchTimestamp, Optional.of(newLeaderEpoch))));
                 } else {
@@ -2592,7 +2592,7 @@ public class FetcherTest {
         MockClient.RequestMatcher matcher = body -> {
             if (body instanceof ListOffsetRequest) {
                 ListOffsetRequest offsetRequest = (ListOffsetRequest) body;
-                Optional<Integer> epoch = offsetRequest.partitionTimestamps().get(tp0).currentLeaderEpoch;
+                Optional<Integer> epoch = offsetRequest.partitionsData().get(tp0).currentLeaderEpoch;
                 assertTrue("Expected Fetcher to set leader epoch in request", epoch.isPresent());
                 assertEquals("Expected leader epoch to match epoch from metadata update", epoch.get().longValue(), 99);
                 return true;
@@ -4280,7 +4280,7 @@ public class FetcherTest {
         // matches any list offset request with the provided timestamp
         return body -> {
             ListOffsetRequest req = (ListOffsetRequest) body;
-            return req.partitionTimestamps().equals(Collections.singletonMap(
+            return req.partitionsData().equals(Collections.singletonMap(
                 tp0, new ListOffsetRequest.PartitionData(timestamp, leaderEpoch)));
         };
     }
@@ -4289,7 +4289,7 @@ public class FetcherTest {
         // matches any list offset request with the provided timestamp
         return body -> {
             ListOffsetRequest req = (ListOffsetRequest) body;
-            return req.partitionTimestamps().equals(Collections.singletonMap(
+            return req.partitionsData().equals(Collections.singletonMap(
                     tp0, new ListOffsetRequest.PartitionData(timestamp, Optional.of(leaderEpoch))));
         };
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -2426,33 +2426,33 @@ public class FetcherTest {
     }
 
     @Test
-    public void testGetOffsetsForTimesTimeout() {
+    public void testGetOffsetsTimeout() {
         buildFetcher();
         assertThrows(TimeoutException.class, () -> fetcher.offsetsForTimes(
             Collections.singletonMap(new TopicPartition(topicName, 2), 1000L), time.timer(100L)));
     }
 
     @Test
-    public void testGetOffsetsForTimes() {
+    public void testGetOffsets() {
         buildFetcher();
 
         // Empty map
         assertTrue(fetcher.offsetsForTimes(new HashMap<>(), time.timer(100L)).isEmpty());
         // Unknown Offset
-        testGetOffsetsForTimesWithUnknownOffset();
+        testGetOffsetsWithUnknownOffset();
         // Error code none with unknown offset
-        testGetOffsetsForTimesWithError(Errors.NONE, Errors.NONE, -1L, 100L, null, 100L);
+        testGetOffsetsWithError(Errors.NONE, Errors.NONE, -1L, 100L, null, 100L);
         // Error code none with known offset
-        testGetOffsetsForTimesWithError(Errors.NONE, Errors.NONE, 10L, 100L, 10L, 100L);
+        testGetOffsetsWithError(Errors.NONE, Errors.NONE, 10L, 100L, 10L, 100L);
         // Test both of partition has error.
-        testGetOffsetsForTimesWithError(Errors.NOT_LEADER_OR_FOLLOWER, Errors.INVALID_REQUEST, 10L, 100L, 10L, 100L);
+        testGetOffsetsWithError(Errors.NOT_LEADER_OR_FOLLOWER, Errors.INVALID_REQUEST, 10L, 100L, 10L, 100L);
         // Test the second partition has error.
-        testGetOffsetsForTimesWithError(Errors.NONE, Errors.NOT_LEADER_OR_FOLLOWER, 10L, 100L, 10L, 100L);
+        testGetOffsetsWithError(Errors.NONE, Errors.NOT_LEADER_OR_FOLLOWER, 10L, 100L, 10L, 100L);
         // Test different errors.
-        testGetOffsetsForTimesWithError(Errors.NOT_LEADER_OR_FOLLOWER, Errors.NONE, 10L, 100L, 10L, 100L);
-        testGetOffsetsForTimesWithError(Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.NONE, 10L, 100L, 10L, 100L);
-        testGetOffsetsForTimesWithError(Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT, Errors.NONE, 10L, 100L, null, 100L);
-        testGetOffsetsForTimesWithError(Errors.BROKER_NOT_AVAILABLE, Errors.NONE, 10L, 100L, 10L, 100L);
+        testGetOffsetsWithError(Errors.NOT_LEADER_OR_FOLLOWER, Errors.NONE, 10L, 100L, 10L, 100L);
+        testGetOffsetsWithError(Errors.UNKNOWN_TOPIC_OR_PARTITION, Errors.NONE, 10L, 100L, 10L, 100L);
+        testGetOffsetsWithError(Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT, Errors.NONE, 10L, 100L, null, 100L);
+        testGetOffsetsWithError(Errors.BROKER_NOT_AVAILABLE, Errors.NONE, 10L, 100L, 10L, 100L);
     }
 
     @Test
@@ -2607,7 +2607,7 @@ public class FetcherTest {
     }
 
     @Test
-    public void testGetOffsetsForTimesWhenSomeTopicPartitionLeadersNotKnownInitially() {
+    public void testGetOffsetsWhenSomeTopicPartitionLeadersNotKnownInitially() {
         buildFetcher();
 
         subscriptions.assignFromUser(Utils.mkSet(tp0, tp1));
@@ -2655,7 +2655,7 @@ public class FetcherTest {
     }
 
     @Test
-    public void testGetOffsetsForTimesWhenSomeTopicPartitionLeadersDisconnectException() {
+    public void testGetOffsetsWhenSomeTopicPartitionLeadersDisconnectException() {
         buildFetcher();
         final String anotherTopic = "another-topic";
         final TopicPartition t2p0 = new TopicPartition(anotherTopic, 0);
@@ -3486,12 +3486,12 @@ public class FetcherTest {
         return 1;
     }
 
-    private void testGetOffsetsForTimesWithError(Errors errorForP0,
-                                                 Errors errorForP1,
-                                                 long offsetForP0,
-                                                 long offsetForP1,
-                                                 Long expectedOffsetForP0,
-                                                 Long expectedOffsetForP1) {
+    private void testGetOffsetsWithError(Errors errorForP0,
+                                         Errors errorForP1,
+                                         long offsetForP0,
+                                         long offsetForP1,
+                                         Long expectedOffsetForP0,
+                                         Long expectedOffsetForP1) {
         client.reset();
         String topicName2 = "topic2";
         TopicPartition t2p0 = new TopicPartition(topicName2, 0);
@@ -3540,7 +3540,7 @@ public class FetcherTest {
         }
     }
 
-    private void testGetOffsetsForTimesWithUnknownOffset() {
+    private void testGetOffsetsWithUnknownOffset() {
         client.reset();
         // Ensure metadata has both partition.
         MetadataResponse initialMetadataUpdate = TestUtils.metadataUpdateWith(1, singletonMap(topicName, 1));

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -100,7 +100,9 @@ object ApiVersion {
     // Introduced StopReplicaRequest V3 containing the leader epoch for each partition (KIP-570)
     KAFKA_2_6_IV0,
     // Introduced feature versioning support (KIP-584)
-    KAFKA_2_7_IV0
+    KAFKA_2_7_IV0,
+    // New ListOffsets schema
+    KAFKA_2_8_IV0
   )
 
   // Map keys are the union of the short and full versions
@@ -359,6 +361,13 @@ case object KAFKA_2_7_IV0 extends DefaultApiVersion {
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
   val id: Int = 28
+}
+
+case object KAFKA_2_8_IV0 extends DefaultApiVersion {
+  val shortVersion: String = "2.8"
+  val subVersion = "IV0"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 29
 }
 
 object ApiVersionValidator extends Validator {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1090,7 +1090,7 @@ class Partition(val topicPartition: TopicPartition,
         getOffsetByTimestamp(timestamp).filter(timestampAndOffset => timestampAndOffset.offset < lastFetchableOffset)
           .orElse(maybeOffsetsError.map(e => throw e))
       case Left(offset) =>
-        logManager.getLog(topicPartition).flatMap(log => log.fetchOffset(offset))
+        logManager.getLog(topicPartition).flatMap(log => log.fetchTimestampByOffset(offset))
     }
   }
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1639,9 +1639,14 @@ class Log(@volatile private var _dir: File,
    * @return The offset and timestamp of the message at this offset.
    *         None if no such message is found.
    */
-  def fetchOffset(targetOffset: Long): Option[TimestampAndOffset] = {
+  def fetchTimestampByOffset(targetOffset: Long): Option[TimestampAndOffset] = {
     maybeHandleIOException(s"Error while fetching offset for $topicPartition in dir ${dir.getParent}") {
       debug(s"Searching offset $targetOffset")
+
+      if (config.messageFormatVersion < KAFKA_0_10_0_IV0)
+        throw new UnsupportedForMessageFormatException(s"Cannot retrieve timestamp for offset because message format version " +
+          s"for partition $topicPartition is ${config.messageFormatVersion} which is earlier than the minimum " +
+          s"required version $KAFKA_0_10_0_IV0")
 
       // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
       // constant time access while being safe to use with concurrent collections unlike `toArray`.

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -582,6 +582,18 @@ class LogSegment private[log] (val log: FileRecords,
   }
 
   /**
+   * Search the message offset and timestamp based on offset.
+   *
+   * This method returns an option of TimestampOffset. If no message at this offset is found, return None
+   *
+   * @param offset The offset to search for.
+   * @return the timestamp and offset of the message at this offset. None will be returned if there is no such message.
+   */
+  def findOffset(offset: Long): Option[TimestampAndOffset] = {
+    Option(log.searchForOffset(offset, offsetIndex.lookup(offset).position))
+  }
+
+  /**
    * Close this log segment
    */
   def close(): Unit = {
@@ -642,6 +654,11 @@ class LogSegment private[log] (val log: FileRecords,
    * The largest timestamp this segment contains.
    */
   def largestTimestamp = if (maxTimestampSoFar >= 0) maxTimestampSoFar else lastModified
+
+  /**
+   * The largest offset this segment contains.
+   */
+  def largestOffset = offsetIndex.lastOffset
 
   /**
    * Change the last modified time for this log segment

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -658,7 +658,7 @@ class LogSegment private[log] (val log: FileRecords,
   /**
    * The largest offset this segment contains.
    */
-  def largestOffset = offsetIndex.lastOffset
+  def largestOffset = offsetOfMaxTimestampSoFar
 
   /**
    * Change the last modified time for this log segment

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -923,9 +923,9 @@ class KafkaApis(val requestChannel: RequestChannel,
     val clientId = request.header.clientId
     val offsetRequest = request.body[ListOffsetRequest]
 
-    val partitionTimestamps = offsetRequest.partitionTimestamps.asScala
+    val partitionsData = offsetRequest.partitionsData.asScala
     val (authorizedRequestInfo, unauthorizedRequestInfo) = partitionMapByAuthorized(request.context,
-      DESCRIBE, TOPIC, partitionTimestamps)(_.topic)
+      DESCRIBE, TOPIC, partitionsData)(_.topic)
 
     val unauthorizedResponseStatus = unauthorizedRequestInfo.map { case (k, _) =>
       k -> new ListOffsetResponse.PartitionData(Errors.TOPIC_AUTHORIZATION_FAILED, Seq.empty[JLong].asJava)
@@ -963,7 +963,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val offsetRequest = request.body[ListOffsetRequest]
 
     val (authorizedRequestInfo, unauthorizedRequestInfo) = partitionMapByAuthorized(request.context,
-      DESCRIBE, TOPIC, offsetRequest.partitionTimestamps.asScala)(_.topic)
+      DESCRIBE, TOPIC, offsetRequest.partitionsData.asScala)(_.topic)
 
     val unauthorizedResponseStatus = unauthorizedRequestInfo.map { case (k, _) =>
       k -> new ListOffsetResponse.PartitionData(Errors.TOPIC_AUTHORIZATION_FAILED,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -86,7 +86,8 @@ class ReplicaFetcherThread(name: String,
 
   // Visible for testing
   private[server] val listOffsetRequestVersion: Short =
-    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_2_IV1) 5
+    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_8_IV0) 6
+    else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_2_IV1) 5
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_1_IV1) 4
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_0_IV1) 3
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_0_11_0_IV0) 2

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -915,13 +915,13 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  def fetchOffsetForTimestamp(topicPartition: TopicPartition,
-                              timestamp: Long,
-                              isolationLevel: Option[IsolationLevel],
-                              currentLeaderEpoch: Optional[Integer],
-                              fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
+  def fetchOffset(topicPartition: TopicPartition,
+                  eitherOffsetOrTimestamp: Either[Long,Long],
+                  isolationLevel: Option[IsolationLevel],
+                  currentLeaderEpoch: Optional[Integer],
+                  fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
     val partition = getPartitionOrException(topicPartition)
-    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
+    partition.fetchOffset(eitherOffsetOrTimestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
   }
 
   def legacyFetchOffsetsForTimestamp(topicPartition: TopicPartition,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -386,7 +386,8 @@ class PartitionTest extends AbstractPartitionTest {
     def assertFetchOffsetError(error: Errors,
                                currentLeaderEpochOpt: Optional[Integer]): Unit = {
       try {
-        partition.fetchOffsetForTimestamp(0L,
+        partition.fetchOffset(
+          eitherOffsetOrTimestamp = Right(0L),
           isolationLevel = None,
           currentLeaderEpoch = currentLeaderEpochOpt,
           fetchOnlyFromLeader = true)
@@ -413,7 +414,8 @@ class PartitionTest extends AbstractPartitionTest {
                                currentLeaderEpochOpt: Optional[Integer],
                                fetchOnlyLeader: Boolean): Unit = {
       try {
-        partition.fetchOffsetForTimestamp(0L,
+        partition.fetchOffset(
+          eitherOffsetOrTimestamp = Right(0L),
           isolationLevel = None,
           currentLeaderEpoch = currentLeaderEpochOpt,
           fetchOnlyFromLeader = fetchOnlyLeader)
@@ -441,7 +443,8 @@ class PartitionTest extends AbstractPartitionTest {
     val leaderEpoch = 5
     val partition = setupPartitionWithMocks(leaderEpoch, isLeader = true)
 
-    val timestampAndOffsetOpt = partition.fetchOffsetForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP,
+    val timestampAndOffsetOpt = partition.fetchOffset(
+      eitherOffsetOrTimestamp = Right(ListOffsetRequest.LATEST_TIMESTAMP),
       isolationLevel = None,
       currentLeaderEpoch = Optional.empty(),
       fetchOnlyFromLeader = true)
@@ -508,8 +511,8 @@ class PartitionTest extends AbstractPartitionTest {
 
     def fetchOffsetsForTimestamp(timestamp: Long, isolation: Option[IsolationLevel]): Either[ApiException, Option[TimestampAndOffset]] = {
       try {
-        Right(partition.fetchOffsetForTimestamp(
-          timestamp = timestamp,
+        Right(partition.fetchOffset(
+          eitherOffsetOrTimestamp = Right(timestamp),
           isolationLevel = isolation,
           currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
           fetchOnlyFromLeader = true
@@ -748,7 +751,8 @@ class PartitionTest extends AbstractPartitionTest {
     partition.appendRecordsToLeader(records, origin = AppendOrigin.Client, requiredAcks = 0)
 
     def fetchLatestOffset(isolationLevel: Option[IsolationLevel]): TimestampAndOffset = {
-      val res = partition.fetchOffsetForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP,
+      val res = partition.fetchOffset(
+        eitherOffsetOrTimestamp = Right(ListOffsetRequest.LATEST_TIMESTAMP),
         isolationLevel = isolationLevel,
         currentLeaderEpoch = Optional.empty(),
         fetchOnlyFromLeader = true)
@@ -757,7 +761,8 @@ class PartitionTest extends AbstractPartitionTest {
     }
 
     def fetchEarliestOffset(isolationLevel: Option[IsolationLevel]): TimestampAndOffset = {
-      val res = partition.fetchOffsetForTimestamp(ListOffsetRequest.EARLIEST_TIMESTAMP,
+      val res = partition.fetchOffset(
+        eitherOffsetOrTimestamp = Right(ListOffsetRequest.EARLIEST_TIMESTAMP),
         isolationLevel = isolationLevel,
         currentLeaderEpoch = Optional.empty(),
         fetchOnlyFromLeader = true)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -961,9 +961,9 @@ class KafkaApisTest {
     val isolationLevel = IsolationLevel.READ_UNCOMMITTED
     val currentLeaderEpoch = Optional.of[Integer](15)
 
-    EasyMock.expect(replicaManager.fetchOffsetForTimestamp(
+    EasyMock.expect(replicaManager.fetchOffset(
       EasyMock.eq(tp),
-      EasyMock.eq(ListOffsetRequest.EARLIEST_TIMESTAMP),
+      EasyMock.eq(Right(ListOffsetRequest.EARLIEST_TIMESTAMP)),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
       fetchOnlyFromLeader = EasyMock.eq(true))
@@ -1964,9 +1964,9 @@ class KafkaApisTest {
     val latestOffset = 15L
     val currentLeaderEpoch = Optional.empty[Integer]()
 
-    EasyMock.expect(replicaManager.fetchOffsetForTimestamp(
+    EasyMock.expect(replicaManager.fetchOffset(
       EasyMock.eq(tp),
-      EasyMock.eq(ListOffsetRequest.LATEST_TIMESTAMP),
+      EasyMock.eq(Right(ListOffsetRequest.LATEST_TIMESTAMP)),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
       fetchOnlyFromLeader = EasyMock.eq(true))

--- a/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ListOffsetsRequestTest.scala
@@ -157,7 +157,7 @@ class ListOffsetsRequestTest extends BaseRequestTest {
 
   private def assertResponseError(error: Errors, brokerId: Int, request: ListOffsetRequest): Unit = {
     val response = sendRequest(brokerId, request)
-    assertEquals(request.partitionTimestamps.size, response.responseData.size)
+    assertEquals(request.partitionsData.size, response.responseData.size)
     response.responseData.asScala.values.foreach { partitionData =>
       assertEquals(error, partitionData.error)
     }


### PR DESCRIPTION
The kafka consumer already provides an operation to quickly lookup the offsets by timestamp by using the `offsetsForTimes` operation.

However there are use cases where the inverse operation would be useful: having a set of offsets, I would like to lookup the ingestion timestamps for all these messages. Currently it would require fetching all these message by random access to retrieve the timestamps.

This add the `timesForOffsets` operation to the kafka consumer. The operation signature is equivalent to `offsetsForTimes`: given a mapping from partition to the offset to look up, it returns a mapping from partition to the timestamp and offset of the message at the requested offset. null is returned for the partition if there is no message at this offset.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
