### PR TITLE
MINOR: set initial capacity for all array buffers in converting produ…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceResponse.java
@@ -258,7 +258,7 @@ public class ProduceResponse extends AbstractResponse {
         for (Map.Entry<String, Map<Integer, PartitionResponse>> entry : responseByTopic.entrySet()) {
             Struct topicData = struct.instance(RESPONSES_KEY_NAME);
             topicData.set(TOPIC_NAME, entry.getKey());
-            List<Struct> partitionArray = new ArrayList<>();
+            List<Struct> partitionArray = new ArrayList<>(entry.getValue().size());
             for (Map.Entry<Integer, PartitionResponse> partitionEntry : entry.getValue().entrySet()) {
                 PartitionResponse part = partitionEntry.getValue();
                 short errorCode = part.error.code();
@@ -278,7 +278,7 @@ public class ProduceResponse extends AbstractResponse {
                 if (partStruct.hasField(RECORD_ERRORS_KEY_NAME)) {
                     List<Struct> recordErrors = Collections.emptyList();
                     if (!part.recordErrors.isEmpty()) {
-                        recordErrors = new ArrayList<>();
+                        recordErrors = new ArrayList<>(part.recordErrors.size());
                         for (RecordError indexAndMessage : part.recordErrors) {
                             Struct indexAndMessageStruct = partStruct.instance(RECORD_ERRORS_KEY_NAME)
                                     .set(BATCH_INDEX_KEY_NAME, indexAndMessage.batchIndex)


### PR DESCRIPTION
this is a bit optimization of converting producer responses. Those array buffers need initial capacity to avoid growing continually if the request carries a bunch of small messages and those messages are sent to different partitions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
