### PR TITLE
MINOR: Improve checks for CogroupedStreamAggregateBuilder

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -122,16 +122,13 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,
                                         final NamedInternal named,
                                         final MaterializedInternal<K, VOut, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-        return aggregateBuilder.build(
+        return aggregateBuilder.buildNotWindowed(
             groupPatterns,
             initializer,
             named,
             new TimestampedKeyValueStoreMaterializer<>(materializedInternal).materialize(),
             materializedInternal.keySerde(),
             materializedInternal.valueSerde(),
-            materializedInternal.queryableStoreName(),
-            null,
-            null,
-            null);
+            materializedInternal.queryableStoreName());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -122,13 +122,13 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,
                                         final NamedInternal named,
                                         final MaterializedInternal<K, VOut, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-        return aggregateBuilder.processRepartitions(
-            groupPatterns,
-            initializer,
-            named,
-            new TimestampedKeyValueStoreMaterializer<>(materializedInternal).materialize(),
-            materializedInternal.keySerde(),
-            materializedInternal.valueSerde(),
-            materializedInternal.queryableStoreName());
+        return aggregateBuilder.build(
+                groupPatterns,
+                initializer,
+                named,
+                new TimestampedKeyValueStoreMaterializer<>(materializedInternal).materialize(),
+                materializedInternal.keySerde(),
+                materializedInternal.valueSerde(),
+                materializedInternal.queryableStoreName());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -122,7 +122,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,
                                         final NamedInternal named,
                                         final MaterializedInternal<K, VOut, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-        return aggregateBuilder.processRepartitions(
+        return aggregateBuilder.build(
             groupPatterns,
             initializer,
             named,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -122,7 +122,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
     private KTable<K, VOut> doAggregate(final Initializer<VOut> initializer,
                                         final NamedInternal named,
                                         final MaterializedInternal<K, VOut, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-        return aggregateBuilder.buildNotWindowed(
+        return aggregateBuilder.processRepartitions(
             groupPatterns,
             initializer,
             named,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -47,20 +47,19 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     CogroupedStreamAggregateBuilder(final InternalStreamsBuilder builder) {
         this.builder = builder;
     }
-    <KR, VIn, W extends Window> KTable<KR, VOut> buildNotWindowed(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                                       final Initializer<VOut> initializer,
-                                                       final NamedInternal named,
-                                                       final StoreBuilder<?> storeBuilder,
-                                                       final Serde<KR> keySerde,
-                                                       final Serde<VOut> valueSerde,
-                                                       final String queryableName) {
-        build(groupPatterns, storeBuilder);
+    <KR> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                              final Initializer<VOut> initializer,
+                                              final NamedInternal named,
+                                              final StoreBuilder<?> storeBuilder,
+                                              final Serde<KR> keySerde,
+                                              final Serde<VOut> valueSerde,
+                                              final String queryableName) {
+        processRepartitions(groupPatterns, storeBuilder);
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
-                    initializer,
                     named.suffixWithOrElseGet(
                             "-cogroup-agg-" + counter++,
                             builder,
@@ -75,22 +74,21 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    <KR, VIn, W extends Window> KTable<KR, VOut> buildTimeWindows(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                                              final Initializer<VOut> initializer,
-                                                              final NamedInternal named,
-                                                              final StoreBuilder<?> storeBuilder,
-                                                              final Serde<KR> keySerde,
-                                                              final Serde<VOut> valueSerde,
-                                                              final String queryableName,
-                                                                  final Windows<W> windows) {
-        build(groupPatterns, storeBuilder);
+    <KR, W extends Window> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                                                final Initializer<VOut> initializer,
+                                                                final NamedInternal named,
+                                                                final StoreBuilder<?> storeBuilder,
+                                                                final Serde<KR> keySerde,
+                                                                final Serde<VOut> valueSerde,
+                                                                final String queryableName,
+                                                                final Windows<W> windows) {
+        processRepartitions(groupPatterns, storeBuilder);
 
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
-                    initializer,
                     named.suffixWithOrElseGet(
                             "-cogroup-agg-" + counter++,
                             builder,
@@ -105,22 +103,21 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    <KR, VIn, W extends Window> KTable<KR, VOut> buildSessionWindows(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                                                  final Initializer<VOut> initializer,
-                                                                  final NamedInternal named,
-                                                                  final StoreBuilder<?> storeBuilder,
-                                                                  final Serde<KR> keySerde,
-                                                                  final Serde<VOut> valueSerde,
-                                                                  final String queryableName,
-                                                                  final SessionWindows sessionWindows,
-                                                                     final Merger<? super K, VOut> sessionMerger) {
-        build(groupPatterns, storeBuilder);
+    <KR> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                              final Initializer<VOut> initializer,
+                                              final NamedInternal named,
+                                              final StoreBuilder<?> storeBuilder,
+                                              final Serde<KR> keySerde,
+                                              final Serde<VOut> valueSerde,
+                                              final String queryableName,
+                                              final SessionWindows sessionWindows,
+                                              final Merger<? super K, VOut> sessionMerger) {
+        processRepartitions(groupPatterns, storeBuilder);
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
-                    initializer,
                     named.suffixWithOrElseGet(
                             "-cogroup-agg-" + counter++,
                             builder,
@@ -135,8 +132,8 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    private void build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                                       final StoreBuilder<?> storeBuilder) {
+    private void processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                     final StoreBuilder<?> storeBuilder) {
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
             if (repartitionReqs.repartitionRequired) {
@@ -165,11 +162,11 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     }
 
-    <KR, VIn, W extends Window> KTable<KR, VOut> createTable(final Collection<StreamsGraphNode> processors,
-                                                             final NamedInternal named,
-                                                             final Serde<KR> keySerde,
-                                                             final Serde<VOut> valueSerde,
-                                                             final String queryableName) {
+    <KR, VIn> KTable<KR, VOut> createTable(final Collection<StreamsGraphNode> processors,
+                                           final NamedInternal named,
+                                           final Serde<KR> keySerde,
+                                           final Serde<VOut> valueSerde,
+                                           final String queryableName) {
         final String mergeProcessorName = named.suffixWithOrElseGet(
                 "-cogroup-merge",
                 builder,
@@ -191,11 +188,10 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                 builder);
     }
 
-    private <W extends Window> StatefulProcessorNode<K, ?> getStatefulProcessorNode(final Initializer<VOut> initializer,
-                                                                                    final String processorName,
-                                                                                    final boolean stateCreated,
-                                                                                    final StoreBuilder<?> storeBuilder,
-                                                                                    final ProcessorSupplier<K, ?> kStreamAggregate) {
+    private StatefulProcessorNode<K, ?> getStatefulProcessorNode(final String processorName,
+                                                                 final boolean stateCreated,
+                                                                 final StoreBuilder<?> storeBuilder,
+                                                                 final ProcessorSupplier<K, ?> kStreamAggregate) {
         final StatefulProcessorNode<K, ?> statefulProcessorNode;
         if (!stateCreated) {
             statefulProcessorNode =
@@ -218,9 +214,9 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     @SuppressWarnings("unchecked")
     private <VIn> void createRepartitionSource(final String repartitionTopicNamePrefix,
-                                                 final OptimizableRepartitionNodeBuilder<K, ?> optimizableRepartitionNodeBuilder,
-                                                 final Serde<K> keySerde,
-                                                 final Serde<?> valueSerde) {
+                                               final OptimizableRepartitionNodeBuilder<K, ?> optimizableRepartitionNodeBuilder,
+                                               final Serde<K> keySerde,
+                                               final Serde<?> valueSerde) {
 
         KStreamImpl.createRepartitionedSource(builder,
                 keySerde,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -61,9 +61,9 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                     named.suffixWithOrElseGet(
-                            "-cogroup-agg-" + counter++,
-                            builder,
-                            CogroupedKStreamImpl.AGGREGATE_NAME),
+                        "-cogroup-agg-" + counter++,
+                        builder,
+                        CogroupedKStreamImpl.AGGREGATE_NAME),
                     stateCreated,
                     storeBuilder,
                     new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue()));
@@ -89,13 +89,13 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
-                    named.suffixWithOrElseGet(
-                            "-cogroup-agg-" + counter++,
-                            builder,
-                            CogroupedKStreamImpl.AGGREGATE_NAME),
-                    stateCreated,
-                    storeBuilder,
-                    new KStreamWindowAggregate<>(windows, storeBuilder.name(), initializer, kGroupedStream.getValue()));
+                named.suffixWithOrElseGet(
+                    "-cogroup-agg-" + counter++,
+                    builder,
+                    CogroupedKStreamImpl.AGGREGATE_NAME),
+                stateCreated,
+                storeBuilder,
+                new KStreamWindowAggregate<>(windows, storeBuilder.name(), initializer, kGroupedStream.getValue()));
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
@@ -118,13 +118,13 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
-                    named.suffixWithOrElseGet(
-                            "-cogroup-agg-" + counter++,
-                            builder,
-                            CogroupedKStreamImpl.AGGREGATE_NAME),
-                    stateCreated,
-                    storeBuilder,
-                    new KStreamSessionWindowAggregate<>(sessionWindows, storeBuilder.name(), initializer, kGroupedStream.getValue(), sessionMerger));
+                named.suffixWithOrElseGet(
+                    "-cogroup-agg-" + counter++,
+                    builder,
+                    CogroupedKStreamImpl.AGGREGATE_NAME),
+                stateCreated,
+                storeBuilder,
+                new KStreamSessionWindowAggregate<>(sessionWindows, storeBuilder.name(), initializer, kGroupedStream.getValue(), sessionMerger));
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
@@ -141,7 +141,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                 final OptimizableRepartitionNodeBuilder<K, ?> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
 
                 final String repartionNamePrefix = repartitionReqs.userProvidedRepartitionTopicName != null ?
-                        repartitionReqs.userProvidedRepartitionTopicName : storeBuilder.name();
+                    repartitionReqs.userProvidedRepartitionTopicName : storeBuilder.name();
 
                 createRepartitionSource(repartionNamePrefix, repartitionNodeBuilder, repartitionReqs.keySerde, repartitionReqs.valueSerde);
 
@@ -167,10 +167,11 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                            final Serde<KR> keySerde,
                                            final Serde<VOut> valueSerde,
                                            final String queryableName) {
+
         final String mergeProcessorName = named.suffixWithOrElseGet(
-                "-cogroup-merge",
-                builder,
-                CogroupedKStreamImpl.MERGE_NAME);
+            "-cogroup-merge",
+            builder,
+            CogroupedKStreamImpl.MERGE_NAME);
         final ProcessorSupplier<K, VOut> passThrough = new PassThrough<>();
         final ProcessorGraphNode<K, VOut> mergeNode =
                 new ProcessorGraphNode<>(mergeProcessorName, new ProcessorParameters<>(passThrough, mergeProcessorName));
@@ -178,14 +179,14 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         builder.addGraphNode(processors, mergeNode);
 
         return new KTableImpl<KR, VIn, VOut>(
-                mergeProcessorName,
-                keySerde,
-                valueSerde,
-                Collections.singleton(mergeNode.nodeName()),
-                queryableName,
-                passThrough,
-                mergeNode,
-                builder);
+            mergeProcessorName,
+            keySerde,
+            valueSerde,
+            Collections.singleton(mergeNode.nodeName()),
+            queryableName,
+            passThrough,
+            mergeNode,
+            builder);
     }
 
     private StatefulProcessorNode<K, ?> getStatefulProcessorNode(final String processorName,
@@ -196,16 +197,16 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         if (!stateCreated) {
             statefulProcessorNode =
                     new StatefulProcessorNode<>(
-                            processorName,
-                            new ProcessorParameters<>(kStreamAggregate, processorName),
-                            storeBuilder
+                        processorName,
+                        new ProcessorParameters<>(kStreamAggregate, processorName),
+                        storeBuilder
                     );
         } else {
             statefulProcessorNode =
                     new StatefulProcessorNode<>(
-                            processorName,
-                            new ProcessorParameters<>(kStreamAggregate, processorName),
-                            new String[]{storeBuilder.name()}
+                        processorName,
+                        new ProcessorParameters<>(kStreamAggregate, processorName),
+                        new String[]{storeBuilder.name()}
                     );
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -47,7 +47,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     CogroupedStreamAggregateBuilder(final InternalStreamsBuilder builder) {
         this.builder = builder;
     }
-    <KR> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+    <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                               final Initializer<VOut> initializer,
                                               final NamedInternal named,
                                               final StoreBuilder<?> storeBuilder,
@@ -74,7 +74,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    <KR, W extends Window> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+    <KR, W extends Window> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                                                 final Initializer<VOut> initializer,
                                                                 final NamedInternal named,
                                                                 final StoreBuilder<?> storeBuilder,
@@ -103,7 +103,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    <KR> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+    <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                               final Initializer<VOut> initializer,
                                               final NamedInternal named,
                                               final StoreBuilder<?> storeBuilder,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -47,13 +47,13 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     CogroupedStreamAggregateBuilder(final InternalStreamsBuilder builder) {
         this.builder = builder;
     }
-    <KR> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                              final Initializer<VOut> initializer,
-                                              final NamedInternal named,
-                                              final StoreBuilder<?> storeBuilder,
-                                              final Serde<KR> keySerde,
-                                              final Serde<VOut> valueSerde,
-                                              final String queryableName) {
+    <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                final Initializer<VOut> initializer,
+                                final NamedInternal named,
+                                final StoreBuilder<?> storeBuilder,
+                                final Serde<KR> keySerde,
+                                final Serde<VOut> valueSerde,
+                                final String queryableName) {
         processRepartitions(groupPatterns, storeBuilder);
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
@@ -74,14 +74,14 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    <KR, W extends Window> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                                                final Initializer<VOut> initializer,
-                                                                final NamedInternal named,
-                                                                final StoreBuilder<?> storeBuilder,
-                                                                final Serde<KR> keySerde,
-                                                                final Serde<VOut> valueSerde,
-                                                                final String queryableName,
-                                                                final Windows<W> windows) {
+    <KR, W extends Window> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                                  final Initializer<VOut> initializer,
+                                                  final NamedInternal named,
+                                                  final StoreBuilder<?> storeBuilder,
+                                                  final Serde<KR> keySerde,
+                                                  final Serde<VOut> valueSerde,
+                                                  final String queryableName,
+                                                  final Windows<W> windows) {
         processRepartitions(groupPatterns, storeBuilder);
 
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
@@ -103,15 +103,15 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
-    <KR> KTable<KR, VOut> processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
-                                              final Initializer<VOut> initializer,
-                                              final NamedInternal named,
-                                              final StoreBuilder<?> storeBuilder,
-                                              final Serde<KR> keySerde,
-                                              final Serde<VOut> valueSerde,
-                                              final String queryableName,
-                                              final SessionWindows sessionWindows,
-                                              final Merger<? super K, VOut> sessionMerger) {
+    <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
+                                final Initializer<VOut> initializer,
+                                final NamedInternal named,
+                                final StoreBuilder<?> storeBuilder,
+                                final Serde<KR> keySerde,
+                                final Serde<VOut> valueSerde,
+                                final String queryableName,
+                                final SessionWindows sessionWindows,
+                                final Merger<? super K, VOut> sessionMerger) {
         processRepartitions(groupPatterns, storeBuilder);
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -72,9 +72,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-
         return createTable(processors, named, keySerde, valueSerde, queryableName);
-
     }
 
     <KR, VIn, W extends Window> KTable<KR, VOut> buildTimeWindows(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
@@ -104,7 +102,6 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-
         return createTable(processors, named, keySerde, valueSerde, queryableName);
     }
 
@@ -118,7 +115,6 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                                                   final SessionWindows sessionWindows,
                                                                      final Merger<? super K, VOut> sessionMerger) {
         build(groupPatterns, storeBuilder);
-
         final Collection<StreamsGraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
@@ -136,14 +132,11 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-
         return createTable(processors, named, keySerde, valueSerde, queryableName);
-
     }
 
     private void build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                                        final StoreBuilder<?> storeBuilder) {
-
         for (final KGroupedStreamImpl<K, ?> repartitionReqs : groupPatterns.keySet()) {
 
             if (repartitionReqs.repartitionRequired) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
@@ -91,7 +91,7 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
                 materialized,
                 builder,
                 CogroupedKStreamImpl.AGGREGATE_NAME);
-        return aggregateBuilder.processRepartitions(
+        return aggregateBuilder.build(
                 groupPatterns,
                 initializer,
                 new NamedInternal(named),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
@@ -91,7 +91,8 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
                 materialized,
                 builder,
                 CogroupedKStreamImpl.AGGREGATE_NAME);
-        return aggregateBuilder.buildSessionWindows(groupPatterns,
+        return aggregateBuilder.processRepartitions(
+                groupPatterns,
                 initializer,
                 new NamedInternal(named),
                 materialize(materializedInternal),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
@@ -91,7 +91,7 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
                 materialized,
                 builder,
                 CogroupedKStreamImpl.AGGREGATE_NAME);
-        return aggregateBuilder.build(groupPatterns,
+        return aggregateBuilder.buildSessionWindows(groupPatterns,
                 initializer,
                 new NamedInternal(named),
                 materialize(materializedInternal),
@@ -101,7 +101,6 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
                         null,
                 materializedInternal.valueSerde(),
                 materializedInternal.queryableStoreName(),
-                null,
                 sessionWindows,
                 sessionMerger);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -90,7 +90,7 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
             materialized,
             builder,
             CogroupedKStreamImpl.AGGREGATE_NAME);
-        return aggregateBuilder.build(
+        return aggregateBuilder.buildTimeWindows(
             groupPatterns,
             initializer,
             new NamedInternal(named),
@@ -100,9 +100,7 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
                     : null,
             materializedInternal.valueSerde(),
             materializedInternal.queryableStoreName(),
-            windows,
-            null,
-            null);
+            windows);
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -90,17 +90,17 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
             materialized,
             builder,
             CogroupedKStreamImpl.AGGREGATE_NAME);
-        return aggregateBuilder.buildTimeWindows(
-            groupPatterns,
-            initializer,
-            new NamedInternal(named),
-            materialize(materializedInternal),
-            materializedInternal.keySerde() != null ?
-                    new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.size())
-                    : null,
-            materializedInternal.valueSerde(),
-            materializedInternal.queryableStoreName(),
-            windows);
+        return aggregateBuilder.processRepartitions(
+                groupPatterns,
+                initializer,
+                new NamedInternal(named),
+                materialize(materializedInternal),
+                materializedInternal.keySerde() != null ?
+                        new FullTimeWindowedSerde<>(materializedInternal.keySerde(), windows.size())
+                        : null,
+                materializedInternal.valueSerde(),
+                materializedInternal.queryableStoreName(),
+                windows);
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -90,7 +90,7 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
             materialized,
             builder,
             CogroupedKStreamImpl.AGGREGATE_NAME);
-        return aggregateBuilder.processRepartitions(
+        return aggregateBuilder.build(
                 groupPatterns,
                 initializer,
                 new NamedInternal(named),


### PR DESCRIPTION
Updated `CogroupedStreamAggregateBuilder` to have individual builders depending on the windowed aggregation, or lack thereof. This replaced passing in all options into the builder, with all but the current type of aggregation set to null and then checking to see which value was not null.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
