### PR TITLE
MINOR: Fix the way total consumed is calculated for verifiable consumer

### DIFF
--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -97,7 +97,7 @@ class ConsumerEventHandler(object):
                     if tp in self.position:
                         self.position[tp] = max_offset + 1
                     logger.warn(msg)
-            self.total_consumed += event["count"]
+        self.total_consumed += event["count"]
 
     def handle_partitions_revoked(self, event):
         self.revoked_count += 1


### PR DESCRIPTION
Currently the way we calculate the number of total consumed messages for the verifiable consumer overcounts the number of actually consumed messages. This PR is to fix that to ensure we count the number of consumed messages correctly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
