### PR TITLE
MINOR KAFKA-10382 - MockProducer is not ThreadSafe, ideally it should be as the implementation it mocks is

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -145,7 +145,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void initTransactions() {
+    public synchronized void initTransactions() {
         verifyProducerState();
         if (this.transactionInitialized) {
             throw new IllegalStateException("MockProducer has already been initialized for transactions.");
@@ -161,7 +161,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void beginTransaction() throws ProducerFencedException {
+    public synchronized void beginTransaction() throws ProducerFencedException {
         verifyProducerState();
         verifyTransactionsInitialized();
 
@@ -180,7 +180,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+    public synchronized void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                          String consumerGroupId) throws ProducerFencedException {
         Objects.requireNonNull(consumerGroupId);
         verifyProducerState();
@@ -201,7 +201,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+    public synchronized void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
                                          ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
         Objects.requireNonNull(groupMetadata);
         sendOffsetsToTransaction(offsets, groupMetadata.groupId());
@@ -233,7 +233,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void abortTransaction() throws ProducerFencedException {
+    public synchronized void abortTransaction() throws ProducerFencedException {
         verifyProducerState();
         verifyTransactionsInitialized();
         verifyTransactionInFlight();
@@ -369,12 +369,12 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         close(Duration.ofMillis(0));
     }
 
     @Override
-    public void close(Duration timeout) {
+    public synchronized void close(Duration timeout) {
         if (this.closeException != null) {
             throw this.closeException;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -208,7 +208,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     @Override
-    public void commitTransaction() throws ProducerFencedException {
+    public synchronized void commitTransaction() throws ProducerFencedException {
         verifyProducerState();
         verifyTransactionsInitialized();
         verifyTransactionInFlight();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10382

Copied from the jira:

In testing my project, I discovered that the MockProducer is not thread safe as I thought. It doesn't use thread safe libraries for it's underlying stores, and only some of it’s methods are synchronised.
 
As performance isn’t an issue for this, I would propose simply synchronising all public methods in the class, as some already are.
 
In my project, send is synchronised and commit transactions isn’t. This was causing weird collection manipulation and messages going missing. My lolcat only solution was simply to synchronise on the MockProducer instance before calling commit.
 
See my workaround: https://github.com/astubbs/async-consumer/pull/13/files#diff-8e93aa2a2003be7436f94956cf809b2eR558
