### PR TITLE
MINOR: Ensure a single version of scala-library is used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,10 @@ allprojects {
       runtime {
         resolutionStrategy {
           force(
-            // ensure we have a single scala-library version since we inline it (the core dependency is not mean to be used as a library)
+            // ensure we have a single version of scala jars in the classpath, we enable inlining
+            // in the scala compiler for the `core` module so binary compatibility is only
+            // guaranteed if the exact same version of the scala jars is used for compilation
+            // and at runtime
             libs.scalaLibrary
             // ensures we have a single version of jackson-annotations in the classpath even if
             // some modules only have a transitive reference to an older version

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,8 @@ allprojects {
         resolutionStrategy {
           force(
             // ensure we have a single scala-library version since we inline it (the core dependency is not mean to be used as a library)
-            libs.scalaLibrary
+            libs.scalaLibrary,
+            libs.scalaReflect,
             // ensures we have a single version of jackson-annotations in the classpath even if
             // some modules only have a transitive reference to an older version
             libs.jacksonAnnotations,

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ allprojects {
       runtime {
         resolutionStrategy {
           force(
+            // ensure we have a single scala-library version since we inline it (the core dependency is not mean to be used as a library)
+            libs.scalaLibrary
             // ensures we have a single version of jackson-annotations in the classpath even if
             // some modules only have a transitive reference to an older version
             libs.jacksonAnnotations,


### PR DESCRIPTION
This patch ensures we use a force resolution strategy for the scala-library dependency

I've tested this locally and saw a difference in the output:
With the change (using 2.4 and the jackson library **2.10.5**):
```
./core/build/dependant-libs-2.12.10/scala-java8-compat_2.12-0.9.0.jar
./core/build/dependant-libs-2.12.10/scala-collection-compat_2.12-2.1.2.jar
./core/build/dependant-libs-2.12.10/scala-reflect-2.12.10.jar
./core/build/dependant-libs-2.12.10/scala-logging_2.12-3.9.2.jar
./core/build/dependant-libs-2.12.10/scala-library-2.12.10.jar
```
Without (using 2.4 and the jackson library **2.10.5**):
```
 find . -name 'scala*.jar'
./core/build/dependant-libs-2.12.10/scala-java8-compat_2.12-0.9.0.jar
./core/build/dependant-libs-2.12.10/scala-collection-compat_2.12-2.1.2.jar
./core/build/dependant-libs-2.12.10/scala-reflect-2.12.10.jar
./core/build/dependant-libs-2.12.10/scala-logging_2.12-3.9.2.jar
./core/build/dependant-libs-2.12.10/scala-library-2.12.12.jar
```