### PR TITLE
KAFKA-10378: change jacksonDatabind as compile dependency for clients project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1002,8 +1002,8 @@ project(':clients') {
     compile libs.lz4
     compile libs.snappy
     compile libs.slf4jApi
+    compile libs.jacksonDatabind // for SASL/OAUTHBEARER bearer token parsing
 
-    compileOnly libs.jacksonDatabind // for SASL/OAUTHBEARER bearer token parsing
     compileOnly libs.jacksonJDK8Datatypes
 
     jacksonDatabindConfig libs.jacksonDatabind // to publish as provided scope dependency.


### PR DESCRIPTION
change `jacksonDatabind` as `compile` dependency for clients project

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
