### PR TITLE
KAFKA-10385 - Remove no print stat when on detailed stat mode on Consumer Perf

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -63,21 +63,20 @@ object ConsumerPerformance extends LazyLogging {
     consumer.close()
     val elapsedSecs = (endMs - startMs) / 1000.0
     val fetchTimeInMs = (endMs - startMs) - joinGroupTimeInMs.get
-    if (!config.showDetailedStats) {
-      val totalMBRead = (totalBytesRead.get * 1.0) / (1024 * 1024)
-      println("%s, %s, %.4f, %.4f, %d, %.4f, %d, %d, %.4f, %.4f".format(
-        config.dateFormat.format(startMs),
-        config.dateFormat.format(endMs),
-        totalMBRead,
-        totalMBRead / elapsedSecs,
-        totalMessagesRead.get,
-        totalMessagesRead.get / elapsedSecs,
-        joinGroupTimeInMs.get,
-        fetchTimeInMs,
-        totalMBRead / (fetchTimeInMs / 1000.0),
-        totalMessagesRead.get / (fetchTimeInMs / 1000.0)
-      ))
-    }
+    
+    val totalMBRead = (totalBytesRead.get * 1.0) / (1024 * 1024)
+    println("%s, %s, %.4f, %.4f, %d, %.4f, %d, %d, %.4f, %.4f".format(
+      config.dateFormat.format(startMs),
+      config.dateFormat.format(endMs),
+      totalMBRead,
+      totalMBRead / elapsedSecs,
+      totalMessagesRead.get,
+      totalMessagesRead.get / elapsedSecs,
+      joinGroupTimeInMs.get,
+      fetchTimeInMs,
+      totalMBRead / (fetchTimeInMs / 1000.0),
+      totalMessagesRead.get / (fetchTimeInMs / 1000.0)
+    ))
 
     if (metrics != null) {
       ToolsUtils.printMetrics(metrics)


### PR DESCRIPTION
The condition to see a detailed stats is conditionned by the time.
     if (currentTimeMillis - lastReportTime >= config.reportingInterval)
       if (config.showDetailedStats)

But when you finish the loop, you haven t the last stats of the performance tests. Just the previous status exists.

 

I propose just to remove the condition to show the final statistic result.
