### PR TITLE
MINOR: refactor Log to get rid of "return" in nested anonymous function

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1239,11 +1239,10 @@ class Log(@volatile private var _dir: File,
 
               // update the transaction index with the true last stable offset. The last offset visible
               // to consumers using READ_COMMITTED will be limited by this value and the high watermark.
-              completedTxns.foreach {
-                completedTxn =>
-                  val lastStableOffset = producerStateManager.lastStableOffset(completedTxn)
-                  segment.updateTxnIndex(completedTxn, lastStableOffset)
-                  producerStateManager.completeTxn(completedTxn)
+              completedTxns.foreach { completedTxn =>
+                val lastStableOffset = producerStateManager.lastStableOffset(completedTxn)
+                segment.updateTxnIndex(completedTxn, lastStableOffset)
+                producerStateManager.completeTxn(completedTxn)
               }
 
               // always update the last producer id map offset so that the snapshot reflects the current offset

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2301,7 +2301,7 @@ class Log(@volatile private var _dir: File,
       val newSegmentBaseOffsets = sortedNewSegments.map(_.baseOffset).toSet
 
       // delete the old files
-      for (seg <- sortedOldSegments) {
+      sortedOldSegments.foreach { seg =>
         // remove the index entry
         if (seg.baseOffset != sortedNewSegments.head.baseOffset)
           segments.remove(seg.baseOffset)


### PR DESCRIPTION
scala throws and then catches ```NonLocalReturnException``` to implement the control flow of returning from a nested anonymous function. That is anti-pattern and we should avoid using it in the hot methods.

I run the producer benchmark and the following screen snapshot show the improvement by this patch. The ```NonLocalReturnException``` is gone.

**BEFORE**

<img width="1039" alt="截圖 2020-09-10 上午11 53 30" src="https://user-images.githubusercontent.com/6234750/92679940-5d88ab00-f35c-11ea-96be-73e7e87934ec.png">

**AFTER**

<img width="1039" alt="截圖 2020-09-10 上午11 52 26" src="https://user-images.githubusercontent.com/6234750/92679948-637e8c00-f35c-11ea-9e99-423b82d84c38.png">



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
