### PR TITLE
KAFKA-10386; Fix flexible version support for `records` type

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -73,6 +73,7 @@
       <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.protocol.types" />
       <allow pkg="org.apache.kafka.common.message" />
+      <allow pkg="org.apache.kafka.common.record" />
     </subpackage>
 
     <subpackage name="metrics">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -176,6 +176,7 @@
               files="streams[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <suppress checks="ImportControl" files="FetchResponseData.java"/>
+    <suppress checks="ImportControl" files="RecordsSerdeTest.java"/>
 
     <!-- Streams tests -->
     <suppress checks="ClassFanOutComplexity"

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -18,7 +18,6 @@ package org.apache.kafka.common.protocol.types;
 
 import org.apache.kafka.common.record.BaseRecords;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.common.utils.Utils;
 
@@ -866,6 +865,69 @@ public abstract class Type {
         }
     };
 
+    public static final DocumentedType COMPACT_RECORDS = new DocumentedType() {
+        @Override
+        public boolean isNullable() {
+            return true;
+        }
+
+        @Override
+        public void write(ByteBuffer buffer, Object o) {
+            if (o == null) {
+                COMPACT_NULLABLE_BYTES.write(buffer, null);
+            } else if (o instanceof MemoryRecords) {
+                MemoryRecords records = (MemoryRecords) o;
+                COMPACT_NULLABLE_BYTES.write(buffer, records.buffer().duplicate());
+            } else {
+                throw new IllegalArgumentException("Unexpected record type: " + o.getClass());
+            }
+        }
+
+        @Override
+        public MemoryRecords read(ByteBuffer buffer) {
+            ByteBuffer recordsBuffer = (ByteBuffer) COMPACT_NULLABLE_BYTES.read(buffer);
+            if (recordsBuffer == null) {
+                return null;
+            } else {
+                return MemoryRecords.readableRecords(recordsBuffer);
+            }
+        }
+
+        @Override
+        public int sizeOf(Object o) {
+            if (o == null) {
+                return 1;
+            }
+
+            BaseRecords records = (BaseRecords) o;
+            int recordsSize = records.sizeInBytes();
+            return ByteUtils.sizeOfUnsignedVarint(recordsSize + 1) + recordsSize;
+        }
+
+        @Override
+        public String typeName() {
+            return "COMPACT_RECORDS";
+        }
+
+        @Override
+        public BaseRecords validate(Object item) {
+            if (item == null)
+                return null;
+
+            if (item instanceof BaseRecords)
+                return (BaseRecords) item;
+
+            throw new SchemaException(item + " is not an instance of " + BaseRecords.class.getName());
+        }
+
+        @Override
+        public String documentation() {
+            return "Represents a sequence of Kafka records as " + COMPACT_NULLABLE_BYTES + ". " +
+                "For a detailed description of records see " +
+                "<a href=\"/documentation/#messageformat\">Message Sets</a>.";
+        }
+    };
+
     public static final DocumentedType RECORDS = new DocumentedType() {
         @Override
         public boolean isNullable() {
@@ -874,16 +936,24 @@ public abstract class Type {
 
         @Override
         public void write(ByteBuffer buffer, Object o) {
-            if (!(o instanceof MemoryRecords))
+            if (o == null) {
+                NULLABLE_BYTES.write(buffer, null);
+            } else if (o instanceof MemoryRecords) {
+                MemoryRecords records = (MemoryRecords) o;
+                NULLABLE_BYTES.write(buffer, records.buffer().duplicate());
+            } else {
                 throw new IllegalArgumentException("Unexpected record type: " + o.getClass());
-            MemoryRecords records = (MemoryRecords) o;
-            NULLABLE_BYTES.write(buffer, records.buffer().duplicate());
+            }
         }
 
         @Override
         public MemoryRecords read(ByteBuffer buffer) {
             ByteBuffer recordsBuffer = (ByteBuffer) NULLABLE_BYTES.read(buffer);
-            return MemoryRecords.readableRecords(recordsBuffer);
+            if (recordsBuffer == null) {
+                return null;
+            } else {
+                return MemoryRecords.readableRecords(recordsBuffer);
+            }
         }
 
         @Override
@@ -908,7 +978,7 @@ public abstract class Type {
             if (item instanceof BaseRecords)
                 return (BaseRecords) item;
 
-            throw new SchemaException(item + " is not an instance of " + Records.class.getName());
+            throw new SchemaException(item + " is not an instance of " + BaseRecords.class.getName());
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.message;
+
+import org.apache.kafka.common.network.Send;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.RecordsReadable;
+import org.apache.kafka.common.protocol.RecordsWritable;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MultiRecordsSend;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.requests.ByteBufferChannel;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RecordsSerdeTest {
+
+    @Test
+    public void testSerde() throws Exception {
+        MemoryRecords records = MemoryRecords.withRecords(CompressionType.NONE,
+            new SimpleRecord("foo".getBytes()),
+            new SimpleRecord("bar".getBytes()));
+
+        SimpleRecordsMessageData message = new SimpleRecordsMessageData()
+            .setTopic("foo")
+            .setRecordSet(records);
+
+        testSerdeAllVerions(message);
+    }
+
+    @Test
+    public void testSerdeNullRecords() throws Exception {
+        SimpleRecordsMessageData message = new SimpleRecordsMessageData()
+            .setTopic("foo");
+        assertNull(message.recordSet());
+
+        testSerdeAllVerions(message);
+    }
+
+    private void testSerdeAllVerions(SimpleRecordsMessageData message) throws Exception {
+        for (short version = SimpleRecordsMessageData.LOWEST_SUPPORTED_VERSION;
+             version <= SimpleRecordsMessageData.HIGHEST_SUPPORTED_VERSION;
+             version++) {
+            ByteBuffer buffer = serialize(message, version);
+            assertEquals(buffer, serializeAsStruct(message, version));
+            assertEquals(message, deserialize(buffer.duplicate(), version));
+            assertEquals(message, deserializeFromStruct(buffer.duplicate(), version));
+        }
+    }
+
+    private SimpleRecordsMessageData deserializeFromStruct(ByteBuffer buffer, short version) {
+        Schema schema = SimpleRecordsMessageData.SCHEMAS[version];
+        Struct struct = schema.read(buffer);
+        return new SimpleRecordsMessageData(struct, version);
+    }
+
+    private SimpleRecordsMessageData deserialize(ByteBuffer buffer, short version) {
+        RecordsReadable readable = new RecordsReadable(buffer);
+        return new SimpleRecordsMessageData(readable, version);
+    }
+
+    private ByteBuffer serializeAsStruct(SimpleRecordsMessageData message, short version) {
+        Struct struct = message.toStruct(version);
+        ByteBuffer buffer = ByteBuffer.allocate(struct.sizeOf());
+        struct.writeTo(buffer);
+        buffer.flip();
+        return buffer;
+    }
+
+    private ByteBuffer serialize(SimpleRecordsMessageData message, short version) throws IOException {
+        ArrayDeque<Send> sends = new ArrayDeque<>();
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        int totalMessageSize = message.size(cache, version);
+
+        int recordsSize = message.recordSet() == null ? 0 : message.recordSet().sizeInBytes();
+        RecordsWritable writer = new RecordsWritable("0",
+            totalMessageSize - recordsSize, sends::add);
+        message.write(writer, cache, version);
+        writer.flush();
+
+        MultiRecordsSend send = new MultiRecordsSend("0", sends);
+        ByteBufferChannel channel = new ByteBufferChannel(send.size());
+        send.writeTo(channel);
+        channel.close();
+        return channel.buffer();
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/TypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/TypeTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.protocol.types;
+
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TypeTest {
+
+    @Test
+    public void testEmptyRecordsSerde() {
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        Type.RECORDS.write(buffer, MemoryRecords.EMPTY);
+        buffer.flip();
+        assertEquals(4, Type.RECORDS.sizeOf(MemoryRecords.EMPTY));
+        assertEquals(4, buffer.limit());
+        assertEquals(MemoryRecords.EMPTY, Type.RECORDS.read(buffer));
+    }
+
+    @Test
+    public void testNullRecordsSerde() {
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        Type.RECORDS.write(buffer, null);
+        buffer.flip();
+        assertEquals(4, Type.RECORDS.sizeOf(MemoryRecords.EMPTY));
+        assertEquals(4, buffer.limit());
+        assertNull(Type.RECORDS.read(buffer));
+    }
+
+    @Test
+    public void testRecordsSerde() {
+        MemoryRecords records = MemoryRecords.withRecords(CompressionType.NONE,
+            new SimpleRecord("foo".getBytes()),
+            new SimpleRecord("bar".getBytes()));
+        ByteBuffer buffer = ByteBuffer.allocate(Type.RECORDS.sizeOf(records));
+        Type.RECORDS.write(buffer, records);
+        buffer.flip();
+        assertEquals(records, Type.RECORDS.read(buffer));
+    }
+
+    @Test
+    public void testEmptyCompactRecordsSerde() {
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        Type.COMPACT_RECORDS.write(buffer, MemoryRecords.EMPTY);
+        buffer.flip();
+        assertEquals(1, Type.COMPACT_RECORDS.sizeOf(MemoryRecords.EMPTY));
+        assertEquals(1, buffer.limit());
+        assertEquals(MemoryRecords.EMPTY, Type.COMPACT_RECORDS.read(buffer));
+    }
+
+    @Test
+    public void testNullCompactRecordsSerde() {
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        Type.COMPACT_RECORDS.write(buffer, null);
+        buffer.flip();
+        assertEquals(1, Type.COMPACT_RECORDS.sizeOf(MemoryRecords.EMPTY));
+        assertEquals(1, buffer.limit());
+        assertNull(Type.COMPACT_RECORDS.read(buffer));
+    }
+
+    @Test
+    public void testCompactRecordsSerde() {
+        MemoryRecords records = MemoryRecords.withRecords(CompressionType.NONE,
+            new SimpleRecord("foo".getBytes()),
+            new SimpleRecord("bar".getBytes()));
+        ByteBuffer buffer = ByteBuffer.allocate(Type.COMPACT_RECORDS.sizeOf(records));
+        Type.COMPACT_RECORDS.write(buffer, records);
+        buffer.flip();
+        assertEquals(records, Type.COMPACT_RECORDS.read(buffer));
+    }
+
+}

--- a/clients/src/test/resources/common/message/SimpleRecordsMessage.json
+++ b/clients/src/test/resources/common/message/SimpleRecordsMessage.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+{
+  "name": "SimpleRecordsMessage",
+  "type": "header",
+  "validVersions": "0-1",
+  "flexibleVersions": "1+",
+  "fields": [
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "RecordSet", "type": "records", "versions": "0+",
+        "nullableVersions": "0+", "about": "The record data." }
+  ]
+}

--- a/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
@@ -281,7 +281,12 @@ final class SchemaGenerator {
                 return nullable ? "Type.NULLABLE_BYTES" : "Type.BYTES";
             }
         } else if (type.isRecords()) {
-            return "Type.RECORDS";
+            headerGenerator.addImport(MessageGenerator.TYPE_CLASS);
+            if (fieldFlexibleVersions.contains(version)) {
+                return "Type.COMPACT_RECORDS";
+            } else {
+                return "Type.RECORDS";
+            }
         } else if (type.isArray()) {
             if (fieldFlexibleVersions.contains(version)) {
                 headerGenerator.addImport(MessageGenerator.COMPACT_ARRAYOF_CLASS);


### PR DESCRIPTION
This patch fixes the generated serde logic for the 'records' type so that it uses the compact byte array representation consistently when flexible versions are enabled.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
