### PR TITLE
MINOR: Ensure same version of scala library is used for compile and at runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,10 @@ allprojects {
         }
       }
     }
-    configurations {
-      runtime {
+    configurations.all {
+      // zinc is the Scala incremental compiler, it has a configuration for its own dependencies
+      // that are unrelated to the project dependencies, we should not change them
+      if (name != "zinc") {
         resolutionStrategy {
           force(
             // ensure we have a single version of scala jars in the classpath, we enable inlining
@@ -716,9 +718,7 @@ project(':core') {
   dependencies {
     compile project(':clients')
     compile libs.jacksonDatabind
-    compile(libs.jacksonModuleScala) {
-      exclude module: 'scala-library'
-    }
+    compile libs.jacksonModuleScala
     compile libs.jacksonDataformatCsv
     compile libs.jacksonJDK8Datatypes
     compile libs.joptSimple

--- a/build.gradle
+++ b/build.gradle
@@ -716,7 +716,9 @@ project(':core') {
   dependencies {
     compile project(':clients')
     compile libs.jacksonDatabind
-    compile libs.jacksonModuleScala
+    compile(libs.jacksonModuleScala) {
+      exclude module: 'scala-library'
+    }
     compile libs.jacksonDataformatCsv
     compile libs.jacksonJDK8Datatypes
     compile libs.joptSimple


### PR DESCRIPTION
We are forcing runtime scala-library dependency to be the one used by Kafka in https://github.com/apache/kafka/commit/3fdf1523a369e9e2f03e215f39c0ed987b2a16c5, but we still seem to include the version in jackson for compile. This PR explicitly excludes it. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
