### PR TITLE
MINOR: the scheduler used to perform rebalance should have thread prefix

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -92,7 +92,7 @@ class KafkaController(val config: KafkaConfig,
 
   // have a separate scheduler for the controller to be able to start and stop independently of the kafka server
   // visible for testing
-  private[controller] val kafkaScheduler = new KafkaScheduler(1)
+  private[controller] val kafkaScheduler = new KafkaScheduler(1, threadNamePrefix = "auto-leader-rebalancer-")
 
   // visible for testing
   private[controller] val eventManager = new ControllerEventManager(config.brokerId, this, time,


### PR DESCRIPTION
There is already a scheduler (see https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/KafkaServer.scala#L264) using default thread prefix so the others should define different thread name. Otherwise, it is hard to distinguish them by JVM profiler.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
