### PR TITLE
Allow replace all for RegexRouter

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/RegexRouter.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/RegexRouter.java
@@ -29,33 +29,43 @@ public class RegexRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     public static final String OVERVIEW_DOC = "Update the record topic using the configured regular expression and replacement string."
             + "<p/>Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>. "
-            + "If the pattern matches the input topic, <code>java.util.regex.Matcher#replaceFirst()</code> is used with the replacement string to obtain the new topic.";
+            + "If the pattern matches the input topic, <code>java.util.regex.Matcher#replaceFirst()</code> is used with the replacement string to obtain the new topic."
+            + "<p/>If you need to replace all occurrences you can use flag replaceAll.";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(ConfigName.REGEX, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, new RegexValidator(), ConfigDef.Importance.HIGH,
                     "Regular expression to use for matching.")
             .define(ConfigName.REPLACEMENT, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.HIGH,
-                    "Replacement string.");
+                    "Replacement string.")
+            .define(ConfigName.REPLACE_ALL, ConfigDef.Type.BOOLEAN, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.LOW,
+                    "Replace all flag.");
 
     private interface ConfigName {
         String REGEX = "regex";
         String REPLACEMENT = "replacement";
+        String REPLACE_ALL = "replaceAll";
     }
 
     private Pattern regex;
     private String replacement;
+    private Boolean replaceAll;
 
     @Override
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         regex = Pattern.compile(config.getString(ConfigName.REGEX));
         replacement = config.getString(ConfigName.REPLACEMENT);
+        replaceAll = config.getBoolean(ConfigName.REPLACE_ALL);
     }
 
     @Override
     public R apply(R record) {
         final Matcher matcher = regex.matcher(record.topic());
-        if (matcher.matches()) {
+
+        if (replaceAll) {
+            final String topic = record.topic().replaceAll(regex.pattern(), replacement);
+            return record.newRecord(topic, record.kafkaPartition(), record.keySchema(), record.key(), record.valueSchema(), record.value(), record.timestamp());
+        } else if (matcher.matches()) {
             final String topic = matcher.replaceFirst(replacement);
             return record.newRecord(topic, record.kafkaPartition(), record.keySchema(), record.key(), record.valueSchema(), record.value(), record.timestamp());
         }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/RegexRouterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/RegexRouterTest.java
@@ -27,9 +27,14 @@ import static org.junit.Assert.assertEquals;
 public class RegexRouterTest {
 
     private static String apply(String regex, String replacement, String topic) {
+        return apply(regex, replacement, topic, false);
+    }
+
+    private static String apply(String regex, String replacement, String topic, Boolean replaceAll) {
         final Map<String, String> props = new HashMap<>();
         props.put("regex", regex);
         props.put("replacement", replacement);
+        props.put("replaceAll", replaceAll.toString());
         final RegexRouter<SinkRecord> router = new RegexRouter<>();
         router.configure(props);
         String sinkTopic = router.apply(new SinkRecord(topic, 0, null, null, null, null, 0)).topic();
@@ -65,6 +70,16 @@ public class RegexRouterTest {
     @Test
     public void slice() {
         assertEquals("index", apply("(.*)-(\\d\\d\\d\\d\\d\\d\\d\\d)", "$1", "index-20160117"));
+    }
+
+    @Test
+    public void replaceFirstDash() {
+        assertEquals("sample-table_name", apply("([^\\_]*)_(.*)", "$1-$2", "sample_table_name"));
+    }
+
+    @Test
+    public void replaceAllDashes() {
+        assertEquals("sample-table-name", apply("_", "-", "sample_table_name", true));
     }
 
 }


### PR DESCRIPTION
### Context 
I need to create topics on the fly from database table names (cdc) and I'm replacing all `_` with `-`.
With current RegexRouter I can't do this in one call (actually if I don't know the number of `_` I don't know how many times I need to call the transformer).

That's the reason why I implemented a new flag to allow replaceAll on RegexRouter.

### Change applied
I added a new flag `replaceAll` of type `Boolean` with default value `false` which allows to apply a regex replacement in all occurencces of the topic name.
I updated the description of the transformer and added 2 tests to cover previous and new behaviour.

### Testing strategy (Unit test)
I created a new topic name with two `_` symbols (`sample_table_name`).
I called a regex with current implementation expecting only the first `_` to be substituted.
I called a regex with new flag expecting all `_` to be replaced with `-`.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
