### PR TITLE
KAFKA-10390: Remove ignore case option when grep process info to be more specific

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -21,7 +21,7 @@ if [[ $(uname -s) == "OS/390" ]]; then
     fi
     PIDS=$(ps -A -o pid,jobname,comm | grep -i $JOBNAME | grep java | grep -v grep | awk '{print $1}')
 else
-    PIDS=$(ps ax | grep 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
+    PIDS=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk '{print $1}')
 fi
 
 if [ -z "$PIDS" ]; then

--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -21,7 +21,7 @@ if [[ $(uname -s) == "OS/390" ]]; then
     fi
     PIDS=$(ps -A -o pid,jobname,comm | grep -i $JOBNAME | grep java | grep -v grep | awk '{print $1}')
 else
-    PIDS=$(ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
+    PIDS=$(ps ax | grep 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
 fi
 
 if [ -z "$PIDS" ]; then


### PR DESCRIPTION
Remove ignore case option when grep process info to be more specific since our entry point is definitely `kafka.Kafka`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
