### PR TITLE
KAFKA-9516; Increase timeout in testNonBlockingProducer to make it more reliable

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -144,7 +144,7 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
     }
 
     def verifySendSuccess(future: Future[RecordMetadata]): Unit = {
-      val recordMetadata = future.get(10, TimeUnit.SECONDS)
+      val recordMetadata = future.get(30, TimeUnit.SECONDS)
       assertEquals(topic, recordMetadata.topic)
       assertEquals(0, recordMetadata.partition)
       assertTrue(s"Invalid offset $recordMetadata", recordMetadata.offset >= 0)


### PR DESCRIPTION
The test has been timing out occasionally and it is on the first send on a producer, so increasing timeout to 30s similar to some of the other timeouts in BaseProducerSendTest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
