### PR TITLE
KAFKA-10403 Replace scala collection by java collection in generating…

### DIFF
--- a/core/src/main/scala/kafka/utils/Log4jController.scala
+++ b/core/src/main/scala/kafka/utils/Log4jController.scala
@@ -86,11 +86,10 @@ object Log4jController {
  */
 class Log4jController extends Log4jControllerMBean {
 
-  def getLoggers: util.List[String] = {
-    Log4jController.loggers.map {
+  def getLoggers: util.List[String] =
+    new util.ArrayList[String](Log4jController.loggers.map {
       case (logger, level) => s"$logger=$level"
-    }.toList.asJava
-  }
+    }.toSeq.asJava)
 
 
   def getLogLevel(loggerName: String): String = {

--- a/core/src/main/scala/kafka/utils/Log4jController.scala
+++ b/core/src/main/scala/kafka/utils/Log4jController.scala
@@ -87,7 +87,7 @@ object Log4jController {
 class Log4jController extends Log4jControllerMBean {
 
   def getLoggers: util.List[String] = {
-    // we replace scala collection by java collection so mbean client is able to parse it without scala library.
+    // we replace scala collection by java collection so mbean client is able to deserialize it without scala library.
     new util.ArrayList[String](Log4jController.loggers.map {
       case (logger, level) => s"$logger=$level"
     }.toSeq.asJava)

--- a/core/src/main/scala/kafka/utils/Log4jController.scala
+++ b/core/src/main/scala/kafka/utils/Log4jController.scala
@@ -86,10 +86,12 @@ object Log4jController {
  */
 class Log4jController extends Log4jControllerMBean {
 
-  def getLoggers: util.List[String] =
+  def getLoggers: util.List[String] = {
+    // we replace scala collection by java collection so mbean client is able to parse it without scala library.
     new util.ArrayList[String](Log4jController.loggers.map {
       case (logger, level) => s"$logger=$level"
     }.toSeq.asJava)
+  }
 
 
   def getLogLevel(loggerName: String): String = {

--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -27,6 +27,12 @@ import org.junit.Assert.{assertEquals, assertTrue}
 class LoggingTest extends Logging {
 
   @Test
+  def testTypeOfGetLoggers(): Unit = {
+    val log4jController = new Log4jController
+    assertEquals(classOf[java.util.ArrayList[String]], log4jController.getLoggers.getClass)
+  }
+
+  @Test
   def testLog4jControllerIsRegistered(): Unit = {
     val mbs = ManagementFactory.getPlatformMBeanServer()
     val log4jControllerName = ObjectName.getInstance("kafka:type=kafka.Log4jController")

--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -29,6 +29,8 @@ class LoggingTest extends Logging {
   @Test
   def testTypeOfGetLoggers(): Unit = {
     val log4jController = new Log4jController
+    // the return object of getLoggers must be a collection instance from java standard library.
+    // That enables mbean client to deserialize it without extra libraries.
     assertEquals(classOf[java.util.ArrayList[String]], log4jController.getLoggers.getClass)
   }
 


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-10403

It seems to me the metrics is a "kind" of public interface so users should be able to access metrics of kafka server without scala library.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
