### PR TITLE
KAFKA-10404; Use higher poll timeout to avoid rebalance in testCoordinatorFailover

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -52,7 +52,9 @@ abstract class BaseConsumerTest extends AbstractConsumerTest {
   def testCoordinatorFailover(): Unit = {
     val listener = new TestConsumerReassignmentListener()
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "5001")
-    this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "2000")
+    this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "1000")
+    // Use higher poll timeout to avoid consumer leaving the group due to timeout
+    this.consumerConfig.setProperty(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "15000")
     val consumer = createConsumer()
 
     consumer.subscribe(List(topic).asJava, listener)


### PR DESCRIPTION
Tests use 6s poll timeout, which isn't sufficient to ensure that clients don't leave the group due to poll timeout. The PR increases poll timeout to 15s. Session timeout of 5s is also low, but leaving it as-is for now with lower heartbeat timeout to make sure we catch unexpected rebalances during the failover.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
