### PR TITLE
KAFKA-8033; Wait for NoOffsetForPartitionException in testFetchInvalidOffset

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -678,9 +678,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     sendRecords(producer, totalRecords, tp)
     consumer.assign(List(tp).asJava)
 
-    // poll should fail because there is no offset reset strategy set
+    // poll should fail because there is no offset reset strategy set.
+    // we fail only when resetting positions after coordinator is known, so using a long timeout.
     intercept[NoOffsetForPartitionException] {
-      consumer.poll(Duration.ofMillis(50))
+      consumer.poll(Duration.ofMillis(15000))
     }
 
     // seek to out of range position


### PR DESCRIPTION
We wait only 50ms in consumer.poll() and expect NoOffsetForPartitionException, but the exception is thrown only when initializing partition offsets after coordinator is known. Increased poll timeout to make test reliable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
