### PR TITLE
MINOR: use the link of JDK 11 to replace the dynamic url when buildin…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1649,7 +1649,7 @@ project(':connect:api') {
     include "**/org/apache/kafka/connect/**" // needed for the `aggregatedJavadoc` task
     // The URL structure was changed to include the locale after Java 8
     if (JavaVersion.current().isJava11Compatible())
-      options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
+      options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
     else
       options.links "https://docs.oracle.com/javase/8/docs/api/"
   }
@@ -2019,7 +2019,7 @@ task aggregatedJavadoc(type: Javadoc) {
   excludes = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
   // The URL structure was changed to include the locale after Java 8
   if (JavaVersion.current().isJava11Compatible())
-    options.links "https://docs.oracle.com/en/java/javase/${JavaVersion.current().majorVersion}/docs/api/"
+    options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
   else
     options.links "https://docs.oracle.com/javase/8/docs/api/"
 }


### PR DESCRIPTION
The official supported JDKs are 8 and 11 so we should only expose static API link of either JDK 8 or JDK 11. For example, the exposed API link is JDK 11 even if the JDK version used to build kafka is 11+

This PR also fix current broken QA of JDK 15 (the API web-site of JDK 15 is not ready)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
