### PR TITLE
break when dst is full so that unwrap isn't called when appreadbuffer…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -599,11 +599,11 @@ public class SslTransportLayer implements TransportLayer {
                     }
 
                     // appReadBuffer will extended upto currentApplicationBufferSize
-                    // we need to read the existing content into dst before we can do unwrap again. If there are no space in dst
-                    // we can break here.
-                    if (dst.hasRemaining())
-                        read += readFromAppBuffer(dst);
-                    else
+                    // we need to read the existing content into dst before we can do unwrap again.
+                    read += readFromAppBuffer(dst);
+                    // If there are no space in dst we can break here. Any data left in appReadBuffer
+                    // or netReadBuffer will be processed on the next call to the read method.
+                    if (!dst.hasRemaining())
                         break;
                 } else if (unwrapResult.getStatus() == Status.BUFFER_UNDERFLOW) {
                     int currentNetReadBufferSize = netReadBufferSize();


### PR DESCRIPTION
… may have data

There are a couple of different situations which can result in
BUFFER_OVERFLOW on read with the current implementation, due to the
while loop structure (such as TLS compression with identical buffer
sizes, or buffers sizes that differ to optimize modes where the cipher
text is larger than the plain text.)  The JDK documentation indicates
that a buffer of getApplicationBufferSize() bytes will be enough for a
single unwrap operation, but the SslTransportLayer loop may call unwrap
with an application buffer which isn't empty.

The current implementation will check dst for space and then move data
from the application buffer.  It will then continue the loop and may try
to unwrap() again without verifying that there are
getApplicationBufferSize() bytes free in the application buffer. If,
instead, the loop moves data into dst, and then breaks the loop if dst
is full, then unwrap() should never be called with data in the
application buffer.
