### PR TITLE
KAFKA-10355: Throw error when source topic was deleted

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/MissingSourceTopicException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/MissingSourceTopicException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class MissingSourceTopicException extends StreamsException {
+
+    private final static long serialVersionUID = 1L;
+
+    public MissingSourceTopicException(final String message) {
+        super(message);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.errors.MissingSourceTopicException;
 import org.apache.kafka.streams.processor.internals.StreamThread.State;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.slf4j.Logger;
@@ -51,8 +52,8 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         // NB: all task management is already handled by:
         // org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor.onAssignment
         if (assignmentErrorCode.get() == AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code()) {
-            log.error("Received error code {} - shutdown", assignmentErrorCode.get());
-            streamThread.shutdown();
+            log.error("Received error code {}", assignmentErrorCode.get());
+            throw new MissingSourceTopicException("One or more source topics were missing during rebalance");
         } else {
             streamThread.setState(State.PARTITIONS_ASSIGNED);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListener.java
@@ -54,10 +54,9 @@ public class StreamsRebalanceListener implements ConsumerRebalanceListener {
         if (assignmentErrorCode.get() == AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code()) {
             log.error("Received error code {}", assignmentErrorCode.get());
             throw new MissingSourceTopicException("One or more source topics were missing during rebalance");
-        } else {
-            streamThread.setState(State.PARTITIONS_ASSIGNED);
         }
 
+        streamThread.setState(State.PARTITIONS_ASSIGNED);
         taskManager.handleRebalanceComplete();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HandlingSourceTopicDeletionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HandlingSourceTopicDeletionTest.java
@@ -67,8 +67,7 @@ public class HandlingSourceTopicDeletionTest {
 
     @Before
     public void before() throws InterruptedException {
-        CLUSTER.createTopic(INPUT_TOPIC, 2, 1);
-        CLUSTER.createTopic(OUTPUT_TOPIC, 2, 1);
+        CLUSTER.createTopics(INPUT_TOPIC, OUTPUT_TOPIC);
 
         final String safeTestName = safeUniqueTestName(getClass(), testName);
         final String appId = "app-" + safeTestName;
@@ -79,6 +78,7 @@ public class HandlingSourceTopicDeletionTest {
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
+        streamsConfiguration.put(StreamsConfig.METADATA_MAX_AGE_CONFIG, 2000);
     }
 
     @After
@@ -93,7 +93,7 @@ public class HandlingSourceTopicDeletionTest {
         startApplication();
     }
 
-    private void startApplication() throws InterruptedException, ExecutionException {
+    private void startApplication() throws InterruptedException {
         final Topology topology = builder.build();
         kafkaStreams = new KafkaStreams(topology, streamsConfiguration);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HandlingSourceTopicDeletionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HandlingSourceTopicDeletionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import java.util.Properties;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+
+@Category({IntegrationTest.class})
+public class HandlingSourceTopicDeletionTest {
+
+    private static final int NUM_BROKERS = 1;
+    private static final int NUM_THREADS = 2;
+    private static final long TIMEOUT = 60000;
+
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+
+    // topic names
+    private static final String INPUT_TOPIC = "inputTopic";
+    private static final String OUTPUT_TOPIC = "outputTopic";
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private final StreamsBuilder builder = new StreamsBuilder();
+    private String appId;
+    private Properties streamsConfiguration;
+    private KafkaStreams kafkaStreams1;
+    private KafkaStreams kafkaStreams2;
+
+    @Before
+    public void before() throws InterruptedException {
+        CLUSTER.createTopic(INPUT_TOPIC, 2, 1);
+        CLUSTER.createTopic(OUTPUT_TOPIC, 2, 1);
+
+        final String safeTestName = safeUniqueTestName(getClass(), testName);
+        appId = "app-" + safeTestName;
+
+        streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, NUM_THREADS);
+    }
+
+    @After
+    public void after() throws InterruptedException {
+        CLUSTER.deleteTopics(INPUT_TOPIC, OUTPUT_TOPIC);
+    }
+
+    @Test
+    public void shouldShutdownAfterSourceTopicDeleted() throws InterruptedException {
+        builder.stream(INPUT_TOPIC, Consumed.with(Serdes.Integer(), Serdes.String()))
+            .to(OUTPUT_TOPIC, Produced.with(Serdes.Integer(), Serdes.String()));
+        startApplication();
+    }
+
+    private void startApplication() throws InterruptedException {
+        final Topology topology = builder.build();
+        kafkaStreams1 = new KafkaStreams(topology, streamsConfiguration);
+
+        kafkaStreams1.start();
+        TestUtils.waitForCondition(
+            () -> kafkaStreams1.state() == State.RUNNING,
+            TIMEOUT,
+            () -> "Kafka Streams application did not reach state RUNNING in " + TIMEOUT + " ms"
+        );
+
+        CLUSTER.deleteTopics(INPUT_TOPIC);
+
+        TestUtils.waitForCondition(
+            () -> kafkaStreams1.state() == State.ERROR,
+            TIMEOUT,
+            () -> "Kafka Streams application did not reach state ERROR in " + TIMEOUT + " ms"
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HandlingSourceTopicDeletionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HandlingSourceTopicDeletionTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -38,7 +37,6 @@ import org.junit.rules.TestName;
 
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.hamcrest.CoreMatchers.is;
@@ -63,7 +61,6 @@ public class HandlingSourceTopicDeletionTest {
     public TestName testName = new TestName();
 
     private final StreamsBuilder builder = new StreamsBuilder();
-    private String appId;
     private Properties streamsConfiguration;
     private KafkaStreams kafkaStreams;
 
@@ -72,7 +69,7 @@ public class HandlingSourceTopicDeletionTest {
         CLUSTER.createTopics(INPUT_TOPIC, OUTPUT_TOPIC);
 
         final String safeTestName = safeUniqueTestName(getClass(), testName);
-        appId = "app-" + safeTestName;
+        final String appId = "app-" + safeTestName;
 
         streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
@@ -111,7 +108,7 @@ public class HandlingSourceTopicDeletionTest {
 
         TestUtils.waitForCondition(
             () -> kafkaStreams.state() == State.ERROR,
-            2*TIMEOUT,
+            2 * TIMEOUT,
             () -> "Kafka Streams application did not reach state ERROR in " + TIMEOUT + " ms"
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsRebalanceListenerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.errors.MissingSourceTopicException;
+import org.apache.kafka.streams.processor.internals.StreamThread.State;
+import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class StreamsRebalanceListenerTest {
+
+    private final TaskManager taskManager = mock(TaskManager.class);
+    private final StreamThread streamThread = mock(StreamThread.class);
+    private final AtomicInteger assignmentErrorCode = new AtomicInteger();
+    private final StreamsRebalanceListener streamsRebalanceListener = new StreamsRebalanceListener(
+        new MockTime(),
+        taskManager,
+        streamThread,
+        LoggerFactory.getLogger(StreamsRebalanceListenerTest.class),
+        assignmentErrorCode
+    );
+
+    @Test
+    public void shouldThrowMissingSourceTopicException() {
+        replay(taskManager, streamThread);
+        assignmentErrorCode.set(AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code());
+
+        final MissingSourceTopicException exception = assertThrows(
+            MissingSourceTopicException.class,
+            () -> streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList())
+        );
+        assertThat(exception.getMessage(), is("One or more source topics were missing during rebalance"));
+        verify(taskManager, streamThread);
+    }
+
+    @Test
+    public void shouldHandleOnPartitionAssigned() {
+        taskManager.handleRebalanceComplete();
+        expect(streamThread.setState(State.PARTITIONS_ASSIGNED)).andStubReturn(null);
+        replay(taskManager, streamThread);
+        assignmentErrorCode.set(AssignorError.NONE.code());
+
+        streamsRebalanceListener.onPartitionsAssigned(Collections.emptyList());
+
+        verify(taskManager, streamThread);
+    }
+}


### PR DESCRIPTION
Before this commit, Kafka Streams would gracefully shut down the whole application when a source topic is deleted. The graceful shutdown does not give the user the possibility to react on the deletion of the source topic in the uncaught exception handler.

This commit changes this behavior and throws an error when a source topic is deleted.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
