### PR TITLE
KAFKA-10384: Separate converters from generated messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -974,6 +974,7 @@ project(':examples') {
 
 project(':generator') {
   dependencies {
+    compile libs.argparse4j
     compile libs.jacksonDatabind
     compile libs.jacksonJDK8Datatypes
     compile libs.jacksonJaxrsJsonProvider
@@ -1050,10 +1051,12 @@ project(':clients') {
   task processMessages(type:JavaExec) {
     main = "org.apache.kafka.message.MessageGenerator"
     classpath = project(':generator').sourceSets.main.runtimeClasspath
-    args = [ "org.apache.kafka.common.message",
-             "src/generated/java/org/apache/kafka/common/message",
-             "src/main/resources/common/message",
-             "ApiMessageTypeGenerator" ]
+    args = [ "-p", "org.apache.kafka.common.message",
+             "-o", "src/generated/java/org/apache/kafka/common/message",
+             "-i", "src/main/resources/common/message",
+             "-t", "ApiMessageTypeGenerator",
+             "-m", "MessageDataGenerator", "JsonConverterGenerator"
+           ]
     inputs.dir("src/main/resources/common/message")
     outputs.dir("src/generated/java/org/apache/kafka/common/message")
   }
@@ -1061,10 +1064,11 @@ project(':clients') {
   task processTestMessages(type:JavaExec) {
     main = "org.apache.kafka.message.MessageGenerator"
     classpath = project(':generator').sourceSets.main.runtimeClasspath
-    args = [ "org.apache.kafka.common.message",
-             "src/generated-test/java/org/apache/kafka/common/message",
-             "src/test/resources/common/message",
-             "none" ]
+    args = [ "-p", "org.apache.kafka.common.message",
+             "-o", "src/generated-test/java/org/apache/kafka/common/message",
+             "-i", "src/test/resources/common/message",
+             "-m", "MessageDataGenerator", "JsonConverterGenerator"
+           ]
     inputs.dir("src/test/resources/common/message")
     outputs.dir("src/generated-test/java/org/apache/kafka/common/message")
   }
@@ -1199,10 +1203,11 @@ project(':streams') {
   task processMessages(type:JavaExec) {
     main = "org.apache.kafka.message.MessageGenerator"
     classpath = project(':generator').sourceSets.main.runtimeClasspath
-    args = [ "org.apache.kafka.streams.internals.generated",
-             "src/generated/java/org/apache/kafka/streams/internals/generated",
-             "src/main/resources/common/message",
-             "none" ]
+    args = [ "-p", "org.apache.kafka.streams.internals.generated",
+             "-o", "src/generated/java/org/apache/kafka/streams/internals/generated",
+             "-i", "src/main/resources/common/message",
+             "-m", "MessageDataGenerator"
+           ]
     inputs.dir("src/main/resources/common/message")
     outputs.dir("src/generated/java/org/apache/kafka/streams/internals/generated")
   }

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -232,6 +232,8 @@
   <subpackage name="message">
     <allow pkg="com.fasterxml.jackson" />
     <allow pkg="com.fasterxml.jackson.annotation" />
+    <allow pkg="net.sourceforge.argparse4j" />
+    <allow pkg="org.apache.message" />
   </subpackage>
 
   <subpackage name="streams">

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -14,7 +14,7 @@
     <suppress checks="NPathComplexity"
               files="(MessageDataGenerator|FieldSpec|WorkerSinkTask).java"/>
     <suppress checks="JavaNCSS"
-              files="(ApiMessageType).java|MessageDataGenerator.java"/>
+              files="(ApiMessageType|FieldSpec|MessageDataGenerator).java"/>
     <suppress checks="MethodLength"
               files="MessageDataGenerator.java"/>
     <suppress id="dontUseSystemExit"
@@ -76,7 +76,7 @@
     <suppress checks="(UnnecessaryParentheses|BooleanExpressionComplexity|CyclomaticComplexity|WhitespaceAfter|LocalVariableName)"
               files="Murmur3.java"/>
 
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS)"
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
             files="clients[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <suppress checks="NPathComplexity"
@@ -172,7 +172,7 @@
               files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
 
     <!-- Generated code -->
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS)"
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
               files="streams[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <suppress checks="ImportControl" files="FetchResponseData.java"/>

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Message.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Message.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.common.protocol;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
 import org.apache.kafka.common.protocol.types.Struct;
 
@@ -101,46 +99,6 @@ public interface Message {
      *                      by this software.
      */
     Struct toStruct(short version);
-
-    /**
-     * Reads this message from a Jackson JsonNode object.  This will overwrite
-     * all relevant fields with information from the Struct.
-     *
-     * For the most part, we expect every JSON object in the input to be the
-     * correct type.  There is one exception: we will deserialize numbers
-     * represented as strings.  If the numeric string begins with 0x, we will
-     * treat the number as hexadecimal.
-     *
-     * Note that we expect to see NullNode objects created for null entries.
-     * Therefore, please configure your Jackson ObjectMapper with
-     * setSerializationInclusion({@link JsonInclude.Include#ALWAYS}).
-     * Other settings may silently omit the nulls, which is not the
-     * semantic that Kafka RPC uses.  (Including a field and setting it to
-     * null is different than not including the field.)
-     *
-     * @param node          The source node.
-     * @param version       The version to use.
-     *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
-     *                      If the specified JSON can't be processed with the
-     *                      specified message version.
-     */
-    void fromJson(JsonNode node, short version);
-
-    /**
-     * Convert this message to a JsonNode.
-     *
-     * Note that 64-bit numbers will be serialized as strings rather than as integers.
-     * The reason is because JavaScript can't represent numbers above 2**52 accurately.
-     * Therefore, for maximum interoperability, we represent these numbers as strings.
-     *
-     * @param version       The version to use.
-     *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
-     *                      If the specified version is too new to be supported
-     *                      by this software.
-     */
-    JsonNode toJson(short version);
 
     /**
      * Returns a list of tagged fields which this software can't understand.

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 public final class FieldSpec {
@@ -271,5 +272,344 @@ public final class FieldSpec {
     @JsonProperty("zeroCopy")
     public boolean zeroCopy() {
         return zeroCopy;
+    }
+
+    /**
+     * Get a string representation of the field default.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     *
+     * @return                  A string that can be used for the field default in the
+     *                          generated code.
+     */
+    String fieldDefault(HeaderGenerator headerGenerator,
+                        StructRegistry structRegistry) {
+        if (type instanceof FieldType.BoolFieldType) {
+            if (fieldDefault.isEmpty()) {
+                return "false";
+            } else if (fieldDefault.equalsIgnoreCase("true")) {
+                return "true";
+            } else if (fieldDefault.equalsIgnoreCase("false")) {
+                return "false";
+            } else {
+                throw new RuntimeException("Invalid default for boolean field " +
+                    name + ": " + fieldDefault);
+            }
+        } else if ((type instanceof FieldType.Int8FieldType) ||
+            (type instanceof FieldType.Int16FieldType) ||
+            (type instanceof FieldType.Int32FieldType) ||
+            (type instanceof FieldType.Int64FieldType)) {
+            int base = 10;
+            String defaultString = fieldDefault;
+            if (defaultString.startsWith("0x")) {
+                base = 16;
+                defaultString = defaultString.substring(2);
+            }
+            if (type instanceof FieldType.Int8FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "(byte) 0";
+                } else {
+                    try {
+                        Byte.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int8 field " +
+                            name + ": " + defaultString, e);
+                    }
+                    return "(byte) " + fieldDefault;
+                }
+            } else if (type instanceof FieldType.Int16FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "(short) 0";
+                } else {
+                    try {
+                        Short.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int16 field " +
+                            name + ": " + defaultString, e);
+                    }
+                    return "(short) " + fieldDefault;
+                }
+            } else if (type instanceof FieldType.Int32FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0";
+                } else {
+                    try {
+                        Integer.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int32 field " +
+                            name + ": " + defaultString, e);
+                    }
+                    return fieldDefault;
+                }
+            } else if (type instanceof FieldType.Int64FieldType) {
+                if (defaultString.isEmpty()) {
+                    return "0L";
+                } else {
+                    try {
+                        Long.valueOf(defaultString, base);
+                    } catch (NumberFormatException e) {
+                        throw new RuntimeException("Invalid default for int64 field " +
+                            name + ": " + defaultString, e);
+                    }
+                    return fieldDefault + "L";
+                }
+            } else {
+                throw new RuntimeException("Unsupported field type " + type);
+            }
+        } else if (type instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            if (fieldDefault.isEmpty()) {
+                headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+                return "MessageUtil.ZERO_UUID";
+            } else {
+                try {
+                    UUID.fromString(fieldDefault);
+                } catch (IllegalArgumentException e) {
+                    throw new RuntimeException("Invalid default for uuid field " +
+                        name + ": " + fieldDefault, e);
+                }
+                headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+                return "UUID.fromString(\"" + fieldDefault + "\")";
+            }
+        } else if (type instanceof FieldType.Float64FieldType) {
+            if (fieldDefault.isEmpty()) {
+                return "0.0";
+            } else {
+                try {
+                    Double.parseDouble(fieldDefault);
+                } catch (NumberFormatException e) {
+                    throw new RuntimeException("Invalid default for float64 field " +
+                        name + ": " + fieldDefault, e);
+                }
+                return "Double.parseDouble(\"" + fieldDefault + "\")";
+            }
+        } else if (type instanceof FieldType.StringFieldType) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            } else {
+                return "\"" + fieldDefault + "\"";
+            }
+        } else if (type.isBytes()) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            } else if (!fieldDefault.isEmpty()) {
+                throw new RuntimeException("Invalid default for bytes field " +
+                    name + ".  The only valid default for a bytes field " +
+                    "is empty or null.");
+            }
+            if (zeroCopy) {
+                headerGenerator.addImport(MessageGenerator.BYTE_UTILS_CLASS);
+                return "ByteUtils.EMPTY_BUF";
+            } else {
+                headerGenerator.addImport(MessageGenerator.BYTES_CLASS);
+                return "Bytes.EMPTY";
+            }
+        } else if (type.isRecords()) {
+            return "null";
+        } else if (type.isStruct()) {
+            if (!fieldDefault.isEmpty()) {
+                throw new RuntimeException("Invalid default for struct field " +
+                    name + ": custom defaults are not supported for struct fields.");
+            }
+            return "new " + type.toString() + "()";
+        } else if (type.isArray()) {
+            if (fieldDefault.equals("null")) {
+                validateNullDefault();
+                return "null";
+            } else if (!fieldDefault.isEmpty()) {
+                throw new RuntimeException("Invalid default for array field " +
+                    name + ".  The only valid default for an array field " +
+                    "is the empty array or null.");
+            }
+            return String.format("new %s(0)",
+                concreteJavaType(headerGenerator, structRegistry));
+        } else {
+            throw new RuntimeException("Unsupported field type " + type);
+        }
+    }
+
+    private void validateNullDefault() {
+        if (!(nullableVersions().contains(versions))) {
+            throw new RuntimeException("null cannot be the default for field " +
+                name + ", because not all versions of this field are " +
+                "nullable.");
+        }
+    }
+
+    /**
+     * Get the abstract Java type of the field-- for example, List.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     *
+     * @return                  The abstract java type name.
+     */
+    String fieldAbstractJavaType(HeaderGenerator headerGenerator,
+                                 StructRegistry structRegistry) {
+        if (type instanceof FieldType.BoolFieldType) {
+            return "boolean";
+        } else if (type instanceof FieldType.Int8FieldType) {
+            return "byte";
+        } else if (type instanceof FieldType.Int16FieldType) {
+            return "short";
+        } else if (type instanceof FieldType.Int32FieldType) {
+            return "int";
+        } else if (type instanceof FieldType.Int64FieldType) {
+            return "long";
+        } else if (type instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            return "UUID";
+        } else if (type instanceof FieldType.Float64FieldType) {
+            return "double";
+        } else if (type.isString()) {
+            return "String";
+        } else if (type.isBytes()) {
+            if (zeroCopy) {
+                headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+                return "ByteBuffer";
+            } else {
+                return "byte[]";
+            }
+        } else if (type instanceof FieldType.RecordsFieldType) {
+            headerGenerator.addImport(MessageGenerator.BASE_RECORDS_CLASS);
+            return "BaseRecords";
+        } else if (type.isStruct()) {
+            return MessageGenerator.capitalizeFirst(typeString());
+        } else if (type.isArray()) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+            if (structRegistry.isStructArrayWithKeys(this)) {
+                headerGenerator.addImport(MessageGenerator.IMPLICIT_LINKED_HASH_MULTI_COLLECTION_CLASS);
+                return collectionType(arrayType.elementType().toString());
+            } else {
+                headerGenerator.addImport(MessageGenerator.LIST_CLASS);
+                return String.format("List<%s>",
+                    arrayType.elementType().getBoxedJavaType(headerGenerator));
+            }
+        } else {
+            throw new RuntimeException("Unknown field type " + type);
+        }
+    }
+
+    /**
+     * Get the concrete Java type of the field-- for example, ArrayList.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     *
+     * @return                  The abstract java type name.
+     */
+    String concreteJavaType(HeaderGenerator headerGenerator,
+                            StructRegistry structRegistry) {
+        if (type.isArray()) {
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) type;
+            if (structRegistry.isStructArrayWithKeys(this)) {
+                return collectionType(arrayType.elementType().toString());
+            } else {
+                headerGenerator.addImport(MessageGenerator.ARRAYLIST_CLASS);
+                return String.format("ArrayList<%s>",
+                    arrayType.elementType().getBoxedJavaType(headerGenerator));
+            }
+        } else {
+            return fieldAbstractJavaType(headerGenerator, structRegistry);
+        }
+    }
+
+    static String collectionType(String baseType) {
+        return baseType + "Collection";
+    }
+
+    /**
+     * Generate an if statement that checks if this field has a non-default value.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     * @param buffer            The code buffer to write to.
+     * @param fieldPrefix       The prefix to prepend before references to this field.
+     * @param nullableVersions  The nullable versions to use for this field.  This is
+     *                          mainly to let us choose to ignore the possibility of
+     *                          nulls sometimes (like when dealing with array entries
+     *                          that cannot be null).
+     */
+    void generateNonDefaultValueCheck(HeaderGenerator headerGenerator,
+                                      StructRegistry structRegistry,
+                                      CodeBuffer buffer,
+                                      String fieldPrefix,
+                                      Versions nullableVersions) {
+        String fieldDefault = fieldDefault(headerGenerator, structRegistry);
+        if (type().isArray()) {
+            if (fieldDefault.equals("null")) {
+                buffer.printf("if (%s%s != null) {%n", fieldPrefix, camelCaseName());
+            } else if (nullableVersions.empty()) {
+                buffer.printf("if (!%s%s.isEmpty()) {%n", fieldPrefix, camelCaseName());
+            } else {
+                buffer.printf("if (%s%s == null || !%s%s.isEmpty()) {%n",
+                    fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName());
+            }
+        } else if (type().isBytes()) {
+            if (fieldDefault.equals("null")) {
+                buffer.printf("if (%s%s != null) {%n", fieldPrefix, camelCaseName());
+            } else if (nullableVersions.empty()) {
+                if (zeroCopy()) {
+                    buffer.printf("if (%s%s.hasRemaining()) {%n",
+                        fieldPrefix, camelCaseName());
+                } else {
+                    buffer.printf("if (%s%s.length != 0) {%n",
+                        fieldPrefix, camelCaseName());
+                }
+            } else {
+                if (zeroCopy()) {
+                    buffer.printf("if (%s%s == null || %s%s.remaining() > 0) {%n",
+                        fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName());
+                } else {
+                    buffer.printf("if (%s%s == null || %s%s.length != 0) {%n",
+                        fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName());
+                }
+            }
+        } else if (type().isString() || type().isStruct()) {
+            if (fieldDefault.equals("null")) {
+                buffer.printf("if (%s%s != null) {%n", fieldPrefix, camelCaseName());
+            } else if (nullableVersions.empty()) {
+                buffer.printf("if (!%s%s.equals(%s)) {%n",
+                    fieldPrefix, camelCaseName(), fieldDefault);
+            } else {
+                buffer.printf("if (%s%s == null || !%s%s.equals(%s)) {%n",
+                    fieldPrefix, camelCaseName(), fieldPrefix, camelCaseName(),
+                    fieldDefault);
+            }
+        } else if (type() instanceof FieldType.BoolFieldType) {
+            buffer.printf("if (%s%s%s) {%n",
+                fieldDefault.equals("true") ? "!" : "",
+                fieldPrefix, camelCaseName());
+        } else {
+            buffer.printf("if (%s%s != %s) {%n",
+                fieldPrefix, camelCaseName(), fieldDefault);
+        }
+    }
+
+    /**
+     * Generate an if statement that checks if this field is non-default and also
+     * non-ignorable.
+     *
+     * @param headerGenerator   The header generator in case we need to add imports.
+     * @param structRegistry    The struct registry in case we need to look up structs.
+     * @param fieldPrefix       The prefix to prepend before references to this field.
+     * @param buffer            The code buffer to write to.
+     */
+    void generateNonIgnorableFieldCheck(HeaderGenerator headerGenerator,
+                                        StructRegistry structRegistry,
+                                        String fieldPrefix,
+                                        CodeBuffer buffer) {
+        generateNonDefaultValueCheck(headerGenerator, structRegistry,
+            buffer, fieldPrefix, nullableVersions());
+        buffer.incrementIndent();
+        headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+        buffer.printf("throw new UnsupportedVersionException(" +
+                "\"Attempted to write a non-default %s at version \" + _version);%n",
+            camelCaseName());
+        buffer.decrementIndent();
+        buffer.printf("}%n");
     }
 }

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -27,6 +27,11 @@ public interface FieldType {
         private static final String NAME = "bool";
 
         @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Boolean";
+        }
+
+        @Override
         public Optional<Integer> fixedLength() {
             return Optional.of(1);
         }
@@ -40,6 +45,11 @@ public interface FieldType {
     final class Int8FieldType implements FieldType {
         static final Int8FieldType INSTANCE = new Int8FieldType();
         private static final String NAME = "int8";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Byte";
+        }
 
         @Override
         public Optional<Integer> fixedLength() {
@@ -57,6 +67,11 @@ public interface FieldType {
         private static final String NAME = "int16";
 
         @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Short";
+        }
+
+        @Override
         public Optional<Integer> fixedLength() {
             return Optional.of(2);
         }
@@ -70,6 +85,11 @@ public interface FieldType {
     final class Int32FieldType implements FieldType {
         static final Int32FieldType INSTANCE = new Int32FieldType();
         private static final String NAME = "int32";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Integer";
+        }
 
         @Override
         public Optional<Integer> fixedLength() {
@@ -87,6 +107,11 @@ public interface FieldType {
         private static final String NAME = "int64";
 
         @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Long";
+        }
+
+        @Override
         public Optional<Integer> fixedLength() {
             return Optional.of(8);
         }
@@ -100,6 +125,12 @@ public interface FieldType {
     final class UUIDFieldType implements FieldType {
         static final UUIDFieldType INSTANCE = new UUIDFieldType();
         private static final String NAME = "uuid";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            return "UUID";
+        }
 
         @Override
         public Optional<Integer> fixedLength() {
@@ -122,6 +153,11 @@ public interface FieldType {
         }
 
         @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "Double";
+        }
+
+        @Override
         public boolean isFloat() {
             return true;
         }
@@ -135,6 +171,11 @@ public interface FieldType {
     final class StringFieldType implements FieldType {
         static final StringFieldType INSTANCE = new StringFieldType();
         private static final String NAME = "string";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return "String";
+        }
 
         @Override
         public boolean serializationIsDifferentInFlexibleVersions() {
@@ -162,6 +203,12 @@ public interface FieldType {
         private static final String NAME = "bytes";
 
         @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+            return "ByteBuffer";
+        }
+
+        @Override
         public boolean serializationIsDifferentInFlexibleVersions() {
             return true;
         }
@@ -185,6 +232,12 @@ public interface FieldType {
     final class RecordsFieldType implements FieldType {
         static final RecordsFieldType INSTANCE = new RecordsFieldType();
         private static final String NAME = "records";
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            headerGenerator.addImport(MessageGenerator.BASE_RECORDS_CLASS);
+            return "BaseRecords";
+        }
 
         @Override
         public boolean serializationIsDifferentInFlexibleVersions() {
@@ -215,6 +268,11 @@ public interface FieldType {
         }
 
         @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            return type;
+        }
+
+        @Override
         public boolean serializationIsDifferentInFlexibleVersions() {
             return true;
         }
@@ -240,6 +298,11 @@ public interface FieldType {
         @Override
         public boolean serializationIsDifferentInFlexibleVersions() {
             return true;
+        }
+
+        @Override
+        public String getBoxedJavaType(HeaderGenerator headerGenerator) {
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -314,6 +377,8 @@ public interface FieldType {
                 }
         }
     }
+
+    String getBoxedJavaType(HeaderGenerator headerGenerator);
 
     /**
      * Returns true if this is an array type.

--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import java.io.BufferedWriter;
+import java.util.Iterator;
+
+/**
+ * Generates Kafka MessageData classes.
+ */
+public final class JsonConverterGenerator implements MessageClassGenerator {
+    private final static String SUFFIX = "JsonConverter";
+    private final String packageName;
+    private final StructRegistry structRegistry;
+    private final HeaderGenerator headerGenerator;
+    private final CodeBuffer buffer;
+
+    JsonConverterGenerator(String packageName) {
+        this.packageName = packageName;
+        this.structRegistry = new StructRegistry();
+        this.headerGenerator = new HeaderGenerator(packageName);
+        this.buffer = new CodeBuffer();
+    }
+
+    @Override
+    public String outputName(MessageSpec spec) {
+        return spec.dataClassName() + SUFFIX;
+    }
+
+    @Override
+    public void generateAndWrite(MessageSpec message, BufferedWriter writer)
+            throws Exception {
+        structRegistry.register(message);
+        headerGenerator.addStaticImport(String.format("%s.%s.*",
+            packageName, message.dataClassName()));
+        buffer.printf("public class %s {%n",
+            MessageGenerator.capitalizeFirst(outputName(message)));
+        buffer.incrementIndent();
+        generateConverters(message.dataClassName(), message.struct(),
+            message.validVersions());
+        for (Iterator<StructRegistry.StructInfo> iter = structRegistry.structs();
+                iter.hasNext(); ) {
+            StructRegistry.StructInfo info = iter.next();
+            buffer.printf("%n");
+            buffer.printf("public static class %s {%n",
+                MessageGenerator.capitalizeFirst(info.spec().name() + SUFFIX));
+            buffer.incrementIndent();
+            generateConverters(MessageGenerator.capitalizeFirst(info.spec().name()),
+                info.spec(), info.parentVersions());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+        headerGenerator.generate();
+        headerGenerator.buffer().write(writer);
+        buffer.write(writer);
+    }
+
+    private void generateConverters(String name,
+                                    StructSpec spec,
+                                    Versions parentVersions) {
+        generateRead(name, spec, parentVersions);
+        generateWrite(name, spec, parentVersions);
+    }
+
+    private void generateRead(String className,
+                              StructSpec struct,
+                              Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        buffer.printf("public static %s read(JsonNode _node, short _version) {%n",
+            className);
+        buffer.incrementIndent();
+        buffer.printf("%s _object = new %s();%n", className, className);
+        VersionConditional.forVersions(struct.versions(), parentVersions).
+            allowMembershipCheckAlwaysFalse(false).
+            ifNotMember(__ -> {
+                headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+                buffer.printf("throw new UnsupportedVersionException(\"Can't read " +
+                    "version \" + _version + \" of %s\");%n", className);
+            }).
+            generate(buffer);
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        for (FieldSpec field : struct.fields()) {
+            String sourceVariable = String.format("_%sNode", field.camelCaseName());
+            buffer.printf("JsonNode %s = _node.get(\"%s\");%n",
+                sourceVariable,
+                field.camelCaseName());
+            buffer.printf("if (%s == null) {%n", sourceVariable);
+            buffer.incrementIndent();
+            Versions mandatoryVersions = field.versions().subtract(field.taggedVersions());
+            VersionConditional.forVersions(mandatoryVersions, curVersions).
+                ifMember(__ -> {
+                    buffer.printf("throw new RuntimeException(\"%s: unable to locate " +
+                            "field \'%s\', which is mandatory in version \" + _version);%n",
+                        className, field.camelCaseName());
+                }).
+                ifNotMember(__ -> {
+                    buffer.printf("_object.%s = %s;%n", field.camelCaseName(),
+                        field.fieldDefault(headerGenerator, structRegistry));
+                }).
+                generate(buffer);
+            buffer.decrementIndent();
+            buffer.printf("} else {%n");
+            buffer.incrementIndent();
+            VersionConditional.forVersions(struct.versions(), curVersions).
+                ifMember(presentVersions -> {
+                    generateTargetFromJson(new Target(field,
+                            sourceVariable,
+                            className,
+                        input -> String.format("_object.%s = %s", field.camelCaseName(), input)),
+                        curVersions);
+                }).ifNotMember(__ -> {
+                    buffer.printf("throw new RuntimeException(\"%s: field \'%s\' is not " +
+                        "supported in version \" + _version);%n",
+                        className, field.camelCaseName());
+                }).generate(buffer);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        }
+        buffer.printf("return _object;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateTargetFromJson(Target target, Versions curVersions) {
+        if (target.field().type() instanceof FieldType.BoolFieldType) {
+            buffer.printf("if (!%s.isBoolean()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected Boolean type, " +
+                "but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%s;%n", target.assignmentStatement(
+                target.sourceVariable() + ".asBoolean()"));
+        } else if (target.field().type() instanceof FieldType.Int8FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("MessageUtil.jsonNodeToByte(%s, \"%s\")",
+                    target.sourceVariable(), target.humanReadableName())));
+        } else if (target.field().type() instanceof FieldType.Int16FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("MessageUtil.jsonNodeToShort(%s, \"%s\")",
+                    target.sourceVariable(), target.humanReadableName())));
+        } else if (target.field().type() instanceof FieldType.Int32FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("MessageUtil.jsonNodeToInt(%s, \"%s\")",
+                    target.sourceVariable(), target.humanReadableName())));
+        } else if (target.field().type() instanceof FieldType.Int64FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("MessageUtil.jsonNodeToLong(%s, \"%s\")",
+                    target.sourceVariable(), target.humanReadableName())));
+        } else if (target.field().type() instanceof FieldType.UUIDFieldType) {
+            buffer.printf("if (!%s.isTextual()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected a JSON string " +
+                "type, but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            headerGenerator.addImport(MessageGenerator.UUID_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(String.format(
+                "UUID.fromString(%s.asText())", target.sourceVariable())));
+        } else if (target.field().type() instanceof FieldType.Float64FieldType) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("MessageUtil.jsonNodeToDouble(%s, \"%s\")",
+                    target.sourceVariable(), target.humanReadableName())));
+        } else {
+            // Handle the variable length types.  All of them are potentially
+            // nullable, so handle that here.
+            IsNullConditional.forName(target.sourceVariable()).
+                nullableVersions(target.field().nullableVersions()).
+                possibleVersions(curVersions).
+                conditionalGenerator((name, negated) ->
+                    String.format("%s%s.isNull()", negated ? "!" : "", name)).
+                ifNull(() -> {
+                    buffer.printf("%s;%n", target.assignmentStatement("null"));
+                }).
+                ifShouldNotBeNull(() -> {
+                    generateVariableLengthTargetFromJson(target, curVersions);
+                }).
+                generate(buffer);
+        }
+    }
+
+    private void generateVariableLengthTargetFromJson(Target target, Versions curVersions) {
+        if (target.field().type().isString()) {
+            buffer.printf("if (!%s.isTextual()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected a string " +
+                "type, but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("%s.asText()", target.sourceVariable())));
+        } else if (target.field().type().isBytes()) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            if (target.field().zeroCopy()) {
+                headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+                buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("ByteBuffer.wrap(MessageUtil.jsonNodeToBinary(%s, \"%s\"))",
+                        target.sourceVariable(), target.humanReadableName())));
+            } else {
+                buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("MessageUtil.jsonNodeToBinary(%s, \"%s\")",
+                        target.sourceVariable(), target.humanReadableName())));
+            }
+        } else if (target.field().type().isRecords()) {
+            headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+            headerGenerator.addImport(MessageGenerator.BYTE_BUFFER_CLASS);
+            headerGenerator.addImport(MessageGenerator.MEMORY_RECORDS_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("MemoryRecords.readableRecords(ByteBuffer.wrap(MessageUtil.jsonNodeToBinary(%s, \"%s\")))",
+                    target.sourceVariable(), target.humanReadableName())));
+        } else if (target.field().type().isArray()) {
+            buffer.printf("if (!%s.isArray()) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            buffer.printf("throw new RuntimeException(\"%s expected a JSON " +
+                "array, but got \" + _node.getNodeType());%n", target.humanReadableName());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            String type = target.field().concreteJavaType(headerGenerator, structRegistry);
+            buffer.printf("%s _collection = new %s();%n", type, type);
+            buffer.printf("%s;%n", target.assignmentStatement("_collection"));
+            headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+            buffer.printf("for (JsonNode _element : %s) {%n", target.sourceVariable());
+            buffer.incrementIndent();
+            generateTargetFromJson(target.arrayElementTarget(
+                input -> String.format("_collection.add(%s)", input)),
+                curVersions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+        } else if (target.field().type().isStruct()) {
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("%s%s.read(%s, _version)",
+                target.field().type().toString(), SUFFIX, target.sourceVariable())));
+        } else {
+            throw new RuntimeException("Unexpected type " + target.field().type());
+        }
+    }
+
+    private void generateWrite(String className,
+                               StructSpec struct,
+                               Versions parentVersions) {
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
+        buffer.printf("public static JsonNode write(%s _object, short _version) {%n",
+            className);
+        buffer.incrementIndent();
+        VersionConditional.forVersions(struct.versions(), parentVersions).
+            allowMembershipCheckAlwaysFalse(false).
+            ifNotMember(__ -> {
+                headerGenerator.addImport(MessageGenerator.UNSUPPORTED_VERSION_EXCEPTION_CLASS);
+                buffer.printf("throw new UnsupportedVersionException(\"Can't write " +
+                    "version \" + _version + \" of %s\");%n", className);
+            }).
+            generate(buffer);
+        Versions curVersions = parentVersions.intersect(struct.versions());
+        headerGenerator.addImport(MessageGenerator.OBJECT_NODE_CLASS);
+        headerGenerator.addImport(MessageGenerator.JSON_NODE_FACTORY_CLASS);
+        buffer.printf("ObjectNode _node = new ObjectNode(JsonNodeFactory.instance);%n");
+        for (FieldSpec field : struct.fields()) {
+            Target target = new Target(field,
+                String.format("_object.%s", field.camelCaseName()),
+                field.camelCaseName(),
+                input -> String.format("_node.set(\"%s\", %s)", field.camelCaseName(), input));
+            VersionConditional cond = VersionConditional.forVersions(field.versions(), curVersions).
+                ifMember(presentVersions -> {
+                    VersionConditional.forVersions(field.taggedVersions(), presentVersions).
+                        ifMember(presentAndTaggedVersions -> {
+                            field.generateNonDefaultValueCheck(headerGenerator,
+                                structRegistry, buffer, "_object.", field.nullableVersions());
+                            buffer.incrementIndent();
+                            if (field.defaultString().equals("null")) {
+                                // If the default was null, and we already checked that this field was not
+                                // the default, we can omit further null checks.
+                                generateTargetToJson(target.nonNullableCopy(), presentAndTaggedVersions);
+                            } else {
+                                generateTargetToJson(target, presentAndTaggedVersions);
+                            }
+                            buffer.decrementIndent();
+                            buffer.printf("}%n");
+                        }).
+                        ifNotMember(presentAndNotTaggedVersions -> {
+                            generateTargetToJson(target, presentAndNotTaggedVersions);
+                        }).
+                        generate(buffer);
+                });
+            if (!field.ignorable()) {
+                cond.ifNotMember(__ -> {
+                    field.generateNonIgnorableFieldCheck(headerGenerator,
+                        structRegistry, "_object.", buffer);
+                });
+            }
+            cond.generate(buffer);
+        }
+        buffer.printf("return _node;%n");
+        buffer.decrementIndent();
+        buffer.printf("}%n");
+    }
+
+    private void generateTargetToJson(Target target, Versions versions) {
+        if (target.field().type() instanceof FieldType.BoolFieldType) {
+            headerGenerator.addImport(MessageGenerator.BOOLEAN_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("BooleanNode.valueOf(%s)", target.sourceVariable())));
+        } else if ((target.field().type() instanceof FieldType.Int8FieldType) ||
+            (target.field().type() instanceof FieldType.Int16FieldType)) {
+            headerGenerator.addImport(MessageGenerator.SHORT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("new ShortNode(%s)", target.sourceVariable())));
+        } else if (target.field().type() instanceof FieldType.Int32FieldType) {
+            headerGenerator.addImport(MessageGenerator.INT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("new IntNode(%s)", target.sourceVariable())));
+        } else if (target.field().type() instanceof FieldType.Int64FieldType) {
+            headerGenerator.addImport(MessageGenerator.LONG_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("new LongNode(%s)", target.sourceVariable())));
+        } else if (target.field().type() instanceof FieldType.UUIDFieldType) {
+            headerGenerator.addImport(MessageGenerator.TEXT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("new TextNode(%s.toString())", target.sourceVariable())));
+        } else if (target.field().type() instanceof FieldType.Float64FieldType) {
+            headerGenerator.addImport(MessageGenerator.DOUBLE_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("new DoubleNode(%s)", target.sourceVariable())));
+        } else {
+            // Handle the variable length types.  All of them are potentially
+            // nullable, so handle that here.
+            IsNullConditional.forName(target.sourceVariable()).
+                nullableVersions(target.field().nullableVersions()).
+                possibleVersions(versions).
+                conditionalGenerator((name, negated) ->
+                    String.format("%s %s= null", name, negated ? "!" : "=")).
+                ifNull(() -> {
+                    headerGenerator.addImport(MessageGenerator.NULL_NODE_CLASS);
+                    buffer.printf("%s;%n", target.assignmentStatement("NullNode.instance"));
+                }).
+                ifShouldNotBeNull(() -> {
+                    generateVariableLengthTargetToJson(target, versions);
+                }).
+                generate(buffer);
+        }
+    }
+
+    private void generateVariableLengthTargetToJson(Target target, Versions versions) {
+        if (target.field().type().isString()) {
+            headerGenerator.addImport(MessageGenerator.TEXT_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("new TextNode(%s)", target.sourceVariable())));
+        } else if (target.field().type().isBytes()) {
+            headerGenerator.addImport(MessageGenerator.BINARY_NODE_CLASS);
+            if (target.field().zeroCopy()) {
+                headerGenerator.addImport(MessageGenerator.MESSAGE_UTIL_CLASS);
+                buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new BinaryNode(MessageUtil.byteBufferToArray(%s))",
+                        target.sourceVariable())));
+            } else {
+                headerGenerator.addImport(MessageGenerator.ARRAYS_CLASS);
+                buffer.printf("%s;%n", target.assignmentStatement(
+                    String.format("new BinaryNode(Arrays.copyOf(%s, %s.length))",
+                        target.sourceVariable(), target.sourceVariable())));
+            }
+        } else if (target.field().type().isRecords()) {
+            headerGenerator.addImport(MessageGenerator.BINARY_NODE_CLASS);
+            buffer.printf("%s;%n", target.assignmentStatement("new BinaryNode(new byte[]{})"));
+        } else if (target.field().type().isArray()) {
+            headerGenerator.addImport(MessageGenerator.ARRAY_NODE_CLASS);
+            headerGenerator.addImport(MessageGenerator.JSON_NODE_FACTORY_CLASS);
+            FieldType.ArrayType arrayType = (FieldType.ArrayType) target.field().type();
+            FieldType elementType = arrayType.elementType();
+            String arrayInstanceName = String.format("_%sArray",
+                target.field().camelCaseName());
+            buffer.printf("ArrayNode %s = new ArrayNode(JsonNodeFactory.instance);%n",
+                arrayInstanceName);
+            buffer.printf("for (%s _element : %s) {%n",
+                elementType.getBoxedJavaType(headerGenerator), target.sourceVariable());
+            buffer.incrementIndent();
+            generateTargetToJson(target.arrayElementTarget(
+                input -> String.format("%s.add(%s)", arrayInstanceName, input)),
+                versions);
+            buffer.decrementIndent();
+            buffer.printf("}%n");
+            buffer.printf("%s;%n", target.assignmentStatement(arrayInstanceName));
+        } else if (target.field().type().isStruct()) {
+            buffer.printf("%s;%n", target.assignmentStatement(
+                String.format("%sJsonConverter.write(%s, _version)",
+                    target.field().type().toString(), target.sourceVariable())));
+        } else {
+            throw new RuntimeException("unknown type " + target.field().type());
+        }
+    }
+
+}

--- a/generator/src/main/java/org/apache/kafka/message/MessageClassGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageClassGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import java.io.BufferedWriter;
+
+public interface MessageClassGenerator {
+    /**
+     * The short name of the converter class we are generating.  For example,
+     * FetchRequestDataJsonConverter.java.
+     */
+    String outputName(MessageSpec spec);
+
+    /**
+     * Generate the convertere, and then write it out.
+     *
+     * @param spec      The message to generate a converter for.
+     * @param writer    The writer to write out the state to.
+     */
+    void generateAndWrite(MessageSpec spec, BufferedWriter writer) throws Exception;
+}

--- a/generator/src/main/java/org/apache/kafka/message/MessageSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageSpec.java
@@ -106,7 +106,7 @@ public final class MessageSpec {
         return flexibleVersions.toString();
     }
 
-    public String generatedClassName() {
+    public String dataClassName() {
         switch (type) {
             case HEADER:
             case REQUEST:

--- a/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
@@ -82,7 +82,7 @@ final class SchemaGenerator {
     void generateSchemas(MessageSpec message) throws Exception {
         this.messageFlexibleVersions = message.flexibleVersions();
         // Generate schemas for inline structures
-        generateSchemas(message.generatedClassName(), message.struct(),
+        generateSchemas(message.dataClassName(), message.struct(),
             message.struct().versions());
 
         // Generate schemas for common structures

--- a/generator/src/main/java/org/apache/kafka/message/StructRegistry.java
+++ b/generator/src/main/java/org/apache/kafka/message/StructRegistry.java
@@ -28,11 +28,38 @@ import java.util.TreeSet;
  * Contains structure data for Kafka MessageData classes.
  */
 final class StructRegistry {
-    private final Map<String, StructSpec> structSpecs;
+    private final Map<String, StructInfo> structs;
     private final Set<String> commonStructNames;
 
+    static class StructInfo {
+        /**
+         * The specification for this structure.
+         */
+        private final StructSpec spec;
+
+        /**
+         * The versions which the parent(s) of this structure can have.  If this is a
+         * top-level structure, this will be equal to the versions which the
+         * overall message can have.
+         */
+        private final Versions parentVersions;
+
+        StructInfo(StructSpec spec, Versions parentVersions) {
+            this.spec = spec;
+            this.parentVersions = parentVersions;
+        }
+
+        public StructSpec spec() {
+            return spec;
+        }
+
+        public Versions parentVersions() {
+            return parentVersions;
+        }
+    }
+
     StructRegistry() {
-        this.structSpecs = new TreeMap<>();
+        this.structs = new TreeMap<>();
         this.commonStructNames = new TreeSet<>();
     }
 
@@ -46,18 +73,18 @@ final class StructRegistry {
                 throw new RuntimeException("Can't process structure " + struct.name() +
                         ": the first letter of structure names must be capitalized.");
             }
-            if (structSpecs.put(struct.name(), struct) != null) {
+            if (structs.containsKey(struct.name())) {
                 throw new RuntimeException("Common struct " + struct.name() + " was specified twice.");
             }
+            structs.put(struct.name(), new StructInfo(struct, struct.versions()));
             commonStructNames.add(struct.name());
         }
-
         // Register inline structures.
-        addStructSpecs(message.fields());
+        addStructSpecs(message.validVersions(), message.fields());
     }
 
     @SuppressWarnings("unchecked")
-    private void addStructSpecs(List<FieldSpec> fields) {
+    private void addStructSpecs(Versions parentVersions, List<FieldSpec> fields) {
         for (FieldSpec field : fields) {
             String elementName = null;
             if (field.type().isStructArray()) {
@@ -66,7 +93,6 @@ final class StructRegistry {
             } else if (field.type().isStruct()) {
                 elementName = field.name();
             }
-
             if (elementName != null) {
                 if (commonStructNames.contains(elementName)) {
                     // If we're using a common structure, we can't specify its fields.
@@ -75,15 +101,18 @@ final class StructRegistry {
                         throw new RuntimeException("Can't re-specify the common struct " +
                                 elementName + " as an inline struct.");
                     }
-                } else if (structSpecs.put(elementName,
-                        new StructSpec(elementName,
-                                field.versions().toString(),
-                                field.fields())) != null) {
+                } else if (structs.containsKey(elementName)) {
                     // Inline structures should only appear once.
                     throw new RuntimeException("Struct " + elementName +
-                            " was specified twice.");
+                        " was specified twice.");
+                } else {
+                    // Synthesize a StructSpec object out of the fields.
+                    StructSpec spec = new StructSpec(elementName,
+                            field.versions().toString(),
+                            field.fields());
+                    structs.put(elementName, new StructInfo(spec, parentVersions));
                 }
-                addStructSpecs(field.fields());
+                addStructSpecs(parentVersions.intersect(field.versions()), field.fields());
             }
         }
     }
@@ -103,13 +132,12 @@ final class StructRegistry {
             throw new RuntimeException("Field " + field.name() +
                     " cannot be treated as a structure.");
         }
-        StructSpec struct = structSpecs.get(structFieldName);
-
-        if (struct == null) {
+        StructInfo structInfo = structs.get(structFieldName);
+        if (structInfo == null) {
             throw new RuntimeException("Unable to locate a specification for the structure " +
                     structFieldName);
         }
-        return struct;
+        return structInfo.spec;
     }
 
     /**
@@ -124,12 +152,12 @@ final class StructRegistry {
         if (!arrayType.isStructArray()) {
             return false;
         }
-        StructSpec struct = structSpecs.get(arrayType.elementName());
-        if (struct == null) {
+        StructInfo structInfo = structs.get(arrayType.elementName());
+        if (structInfo == null) {
             throw new RuntimeException("Unable to locate a specification for the structure " +
                     arrayType.elementName());
         }
-        return struct.hasKeys();
+        return structInfo.spec.hasKeys();
     }
 
     Set<String> commonStructNames() {
@@ -150,8 +178,12 @@ final class StructRegistry {
 
             @Override
             public StructSpec next() {
-                return structSpecs.get(iter.next());
+                return structs.get(iter.next()).spec;
             }
         };
+    }
+
+    Iterator<StructInfo> structs() {
+        return structs.values().iterator();
     }
 }


### PR DESCRIPTION
For the generated message code, put the JSON conversion functionality
in a separate JsonConverter class.

Make MessageDataGenerator simply another generator class, alongside the
new JsonConverterGenerator class.  Move some of the utility functions
from MessageDataGenerator into FieldSpec and other places, so that they
can be used by other generator classes.

Use argparse4j to support a better command-line for the generator.