### PR TITLE
KAFKA-10092 Remove unnecessary enum modifier in NioEchoServer

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -60,11 +60,7 @@ public class NioEchoServer extends Thread {
     public enum MetricType {
         TOTAL, RATE, AVG, MAX;
 
-        private final String metricNameSuffix;
-
-        private MetricType() {
-            metricNameSuffix = "-" + name().toLowerCase(Locale.ROOT);
-        }
+        private final String metricNameSuffix = "-" + name().toLowerCase(Locale.ROOT);
 
         public String metricNameSuffix() {
             return metricNameSuffix;


### PR DESCRIPTION
Newbie: 

In NioEchoServer the enum has its constructor declared as private, which is redundant. We can remove this.

public class NioEchoServer extends Thread {
    public enum MetricType {
        TOTAL, RATE, AVG, MAX;
        private final String metricNameSuffix;

        private MetricType() {
            metricNameSuffix = "-" + name().toLowerCase(Locale.ROOT);
        }}} 

Removed the MetricType constructor for the MetricType Enum