### PR TITLE
HOTFIX: use Exit.exit instead of System.exit

### DIFF
--- a/streams/upgrade-system-tests-22/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
+++ b/streams/upgrade-system-tests-22/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.tests;
 
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 
@@ -40,7 +41,7 @@ public class StreamsSmokeTest {
     public static void main(final String[] args) throws IOException {
         if (args.length < 2) {
             System.err.println("StreamsSmokeTest are expecting two parameters: propFile, command; but only see " + args.length + " parameter");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         final String propFileName = args[0];
@@ -53,7 +54,7 @@ public class StreamsSmokeTest {
 
         if (kafka == null) {
             System.err.println("No bootstrap kafka servers specified in " + StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
-            System.exit(1);
+            Exit.exit(1);
         }
 
         if ("process".equals(command)) {
@@ -63,7 +64,7 @@ public class StreamsSmokeTest {
                 System.err.println("processingGuarantee must be either " + StreamsConfig.AT_LEAST_ONCE + " or " +
                     StreamsConfig.EXACTLY_ONCE);
 
-                System.exit(1);
+                Exit.exit(1);
             }
         }
 

--- a/streams/upgrade-system-tests-23/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
+++ b/streams/upgrade-system-tests-23/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.tests;
 
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 
@@ -40,7 +41,7 @@ public class StreamsSmokeTest {
     public static void main(final String[] args) throws IOException {
         if (args.length < 2) {
             System.err.println("StreamsSmokeTest are expecting two parameters: propFile, command; but only see " + args.length + " parameter");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         final String propFileName = args[0];
@@ -53,7 +54,7 @@ public class StreamsSmokeTest {
 
         if (kafka == null) {
             System.err.println("No bootstrap kafka servers specified in " + StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
-            System.exit(1);
+            Exit.exit(1);
         }
 
         if ("process".equals(command)) {
@@ -63,7 +64,7 @@ public class StreamsSmokeTest {
                 System.err.println("processingGuarantee must be either " + StreamsConfig.AT_LEAST_ONCE + " or " +
                     StreamsConfig.EXACTLY_ONCE);
 
-                System.exit(1);
+                Exit.exit(1);
             }
         }
 

--- a/streams/upgrade-system-tests-24/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
+++ b/streams/upgrade-system-tests-24/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.tests;
 
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 
@@ -40,7 +41,7 @@ public class StreamsSmokeTest {
     public static void main(final String[] args) throws IOException {
         if (args.length < 2) {
             System.err.println("StreamsSmokeTest are expecting two parameters: propFile, command; but only see " + args.length + " parameter");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         final String propFileName = args[0];
@@ -53,7 +54,7 @@ public class StreamsSmokeTest {
 
         if (kafka == null) {
             System.err.println("No bootstrap kafka servers specified in " + StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
-            System.exit(1);
+            Exit.exit(1);
         }
 
         if ("process".equals(command)) {
@@ -63,7 +64,7 @@ public class StreamsSmokeTest {
                 System.err.println("processingGuarantee must be either " + StreamsConfig.AT_LEAST_ONCE + " or " +
                     StreamsConfig.EXACTLY_ONCE);
 
-                System.exit(1);
+                Exit.exit(1);
             }
         }
 

--- a/streams/upgrade-system-tests-25/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
+++ b/streams/upgrade-system-tests-25/src/test/java/org/apache/kafka/streams/tests/StreamsSmokeTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.tests;
 
+import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 
@@ -40,7 +41,7 @@ public class StreamsSmokeTest {
     public static void main(final String[] args) throws IOException {
         if (args.length < 2) {
             System.err.println("StreamsSmokeTest are expecting two parameters: propFile, command; but only see " + args.length + " parameter");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         final String propFileName = args[0];
@@ -53,7 +54,7 @@ public class StreamsSmokeTest {
 
         if (kafka == null) {
             System.err.println("No bootstrap kafka servers specified in " + StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
-            System.exit(1);
+            Exit.exit(1);
         }
 
         if ("process".equals(command)) {
@@ -63,7 +64,7 @@ public class StreamsSmokeTest {
                 System.err.println("processingGuarantee must be either " + StreamsConfig.AT_LEAST_ONCE + " or " +
                     StreamsConfig.EXACTLY_ONCE);
 
-                System.exit(1);
+                Exit.exit(1);
             }
         }
 


### PR DESCRIPTION
Follow up to #9067 -- seems I made an error resolving the unclean cherry-pick from `trunk` to `2.6`.

Call for review @vvcephei @ijuma 