### PR TITLE
KAFKA-10418: alter topic configs via kafka-topics error text

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -617,10 +617,13 @@ object TopicCommand extends Logging {
                          .describedAs("topic")
                          .ofType(classOf[String])
     private val nl = System.getProperty("line.separator")
-    private val configOpt = parser.accepts("config", "A topic configuration override for the topic being created or altered."  +
-                                             "The following is a list of valid configurations: " + nl + LogConfig.configNames.map("\t" + _).mkString(nl) + nl +
+    private val kafkaConfigsCanAlterTopicConfigsViaBootstrapServer =
+      " (the kafka-configs CLI supports altering topic configs with a --bootstrap-server option)"
+    private val configOpt = parser.accepts("config", "A topic configuration override for the topic being created or altered." +
+                                             " The following is a list of valid configurations: " + nl + LogConfig.configNames.map("\t" + _).mkString(nl) + nl +
                                              "See the Kafka documentation for full details on the topic configs." +
-                                             "It is supported only in combination with --create if --bootstrap-server option is used.")
+                                             " It is supported only in combination with --create if --bootstrap-server option is used" +
+                                             kafkaConfigsCanAlterTopicConfigsViaBootstrapServer + ".")
                            .withRequiredArg
                            .describedAs("name=value")
                            .ofType(classOf[String])
@@ -729,7 +732,8 @@ object TopicCommand extends Logging {
       if (has(createOpt) && !has(replicaAssignmentOpt) && has(zkConnectOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt, replicationFactorOpt)
       if (has(bootstrapServerOpt) && has(alterOpt)) {
-        CommandLineUtils.checkInvalidArgsSet(parser, options, Set(bootstrapServerOpt, configOpt), Set(alterOpt))
+        CommandLineUtils.checkInvalidArgsSet(parser, options, Set(bootstrapServerOpt, configOpt), Set(alterOpt),
+        Some(kafkaConfigsCanAlterTopicConfigsViaBootstrapServer))
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt)
       }
 

--- a/core/src/main/scala/kafka/utils/CommandLineUtils.scala
+++ b/core/src/main/scala/kafka/utils/CommandLineUtils.scala
@@ -84,11 +84,12 @@ object CommandLineUtils extends Logging {
   /**
     * Check that none of the listed options are present with the combination of used options
     */
-  def checkInvalidArgsSet(parser: OptionParser, options: OptionSet, usedOptions: Set[OptionSpec[_]], invalidOptions: Set[OptionSpec[_]]): Unit = {
+  def checkInvalidArgsSet(parser: OptionParser, options: OptionSet, usedOptions: Set[OptionSpec[_]], invalidOptions: Set[OptionSpec[_]],
+                         trailingAdditionalMessage: Option[String] = None): Unit = {
     if (usedOptions.count(options.has) == usedOptions.size) {
       for (arg <- invalidOptions) {
         if (options.has(arg))
-          printUsageAndDie(parser, "Option combination \"" + usedOptions.mkString(",") + "\" can't be used with option \"" + arg + "\"")
+          printUsageAndDie(parser, "Option combination \"" + usedOptions.mkString(",") + "\" can't be used with option \"" + arg + "\"" + trailingAdditionalMessage.getOrElse(""))
       }
     }
   }


### PR DESCRIPTION
Changing a topic config with the `kafka-topics` command while connecting to Kafka via `--bootstrap-server` (rather than connecting to ZooKeeper via `--zookeeper`) is not supported. The desired functionality is available elsewhere, though: it is possible to change a topic config while connecting to Kafka rather than ZooKeeper via the `kafka-configs` command instead. However, neither the `kafka-topics` error message received nor the `kafka-topics` help information itself indicates this other possibility. For example:

```
$ kafka-topics.sh --bootstrap-server localhost:9092 --alter --topic test --config flush.messages=12345
Option combination "[bootstrap-server],[config]" can't be used with option "[alter]"
```

```
$ kafka-topics.sh
...
--config <String: name=value> A topic configuration override for the topic being created or altered...It is supported only in combination with – create if --bootstrap-server option is used.
```

Rather than simply saying that what you want to do isn't available, it would be better to say also that you can do it with the `kafka-configs` command.