### PR TITLE
KAFKA-6181 Examining log messages with {{--deep-iteration}} should show superset of fields

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -258,11 +258,11 @@ object DumpLogSegments {
             }
             lastOffset = record.offset
 
-            print(s"$RecordIndent offset: ${record.offset} isValid: ${record.isValid} crc: ${record.checksumOrNull} "+
-                s" keySize: ${record.keySize} valueSize: ${record.valueSize} ${batch.timestampType}: ${record.timestamp} "+
-                s" baseOffset: ${batch.baseOffset} lastOffset: ${batch.lastOffset} baseSequence: ${batch.baseSequence} " +
-                s" lastSequence: ${batch.lastSequence} producerEpoch: ${batch.producerEpoch} partitionLeaderEpoch: ${batch.partitionLeaderEpoch}  " +
-                s" batchSize: ${batch.sizeInBytes} magic: ${batch.magic} compressType: ${batch.compressionType} position: ${validBytes} ")
+            print(s"$RecordIndent offset: ${record.offset} isValid: ${record.isValid} crc: ${record.checksumOrNull}" +
+                s" keySize: ${record.keySize} valueSize: ${record.valueSize} ${batch.timestampType}: ${record.timestamp}" +
+                s" baseOffset: ${batch.baseOffset} lastOffset: ${batch.lastOffset} baseSequence: ${batch.baseSequence}" +
+                s" lastSequence: ${batch.lastSequence} producerEpoch: ${batch.producerEpoch} partitionLeaderEpoch: ${batch.partitionLeaderEpoch}" +
+                s" batchSize: ${batch.sizeInBytes} magic: ${batch.magic} compressType: ${batch.compressionType} position: ${validBytes}")
 
 
             if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -258,11 +258,12 @@ object DumpLogSegments {
             }
             lastOffset = record.offset
 
-            print(s"$RecordIndent offset: ${record.offset} baseOffset: ${batch.baseOffset} lastOffset: ${batch.lastOffset} baseSequence: ${} ${batch.baseSequence}" +
-             s" lastSequence: ${batch.lastSequence} producerEpoch: ${batch.producerEpoch} partitionLeaderEpoch: ${batch.partitionLeaderEpoch} position: ${validBytes} " +
-             s" ${batch.timestampType}: ${record.timestamp} isvalid: ${record.isValid}"+
-             s" keysize: ${record.keySize} valuesize: ${record.valueSize} size: ${batch.sizeInBytes} magic: ${batch.magic} " +
-             s"compresscodec: ${batch.compressionType} crc: ${record.checksumOrNull}")
+            print(s"$RecordIndent offset: ${record.offset} isValid: ${record.isValid} crc: ${record.checksumOrNull} "+
+                s" keySize: ${record.keySize} valueSize: ${record.valueSize} ${batch.timestampType}: ${record.timestamp} "+
+                s" baseOffset: ${batch.baseOffset} lastOffset: ${batch.lastOffset} baseSequence: ${batch.baseSequence} " +
+                s" lastSequence: ${batch.lastSequence} producerEpoch: ${batch.producerEpoch} partitionLeaderEpoch: ${batch.partitionLeaderEpoch}  " +
+                s" size: ${batch.sizeInBytes} magic: ${batch.magic} compressType: ${batch.compressionType} position: ${validBytes} ")
+
 
             if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
               print(" sequence: " + record.sequence + " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -258,8 +258,11 @@ object DumpLogSegments {
             }
             lastOffset = record.offset
 
-            print(s"$RecordIndent offset: ${record.offset} ${batch.timestampType}: ${record.timestamp} " +
-              s"keysize: ${record.keySize} valuesize: ${record.valueSize}")
+            print(s"$RecordIndent offset: ${record.offset} baseOffset: ${batch.baseOffset} lastOffset: ${batch.lastOffset} baseSequence: ${} ${batch.baseSequence}" +
+             s" lastSequence: ${batch.lastSequence} producerEpoch: ${batch.producerEpoch} partitionLeaderEpoch: ${batch.partitionLeaderEpoch} position: ${validBytes} " +
+             s" ${batch.timestampType}: ${record.timestamp} isvalid: ${record.isValid}"+
+             s" keysize: ${record.keySize} valuesize: ${record.valueSize} size: ${batch.sizeInBytes} magic: ${batch.magic} " +
+             s"compresscodec: ${batch.compressionType} crc: ${record.checksumOrNull}")
 
             if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
               print(" sequence: " + record.sequence + " headerKeys: " + record.headers.map(_.key).mkString("[", ",", "]"))

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -262,7 +262,7 @@ object DumpLogSegments {
                 s" keySize: ${record.keySize} valueSize: ${record.valueSize} ${batch.timestampType}: ${record.timestamp} "+
                 s" baseOffset: ${batch.baseOffset} lastOffset: ${batch.lastOffset} baseSequence: ${batch.baseSequence} " +
                 s" lastSequence: ${batch.lastSequence} producerEpoch: ${batch.producerEpoch} partitionLeaderEpoch: ${batch.partitionLeaderEpoch}  " +
-                s" size: ${batch.sizeInBytes} magic: ${batch.magic} compressType: ${batch.compressionType} position: ${validBytes} ")
+                s" batchSize: ${batch.sizeInBytes} magic: ${batch.magic} compressType: ${batch.compressionType} position: ${validBytes} ")
 
 
             if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {


### PR DESCRIPTION
adding missing fields for --deep-iteration log messages.

Missing fields include : partitionLeaderEpoch, baseSequence, lastSequence, etc.,