### PR TITLE
MINOR: Fix typo in example

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -78,7 +78,7 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
 test [test-name(s)]
     Run a test or set of tests inside the currently active Ducker nodes.
     For example, to run the system test produce_bench_test, you would run:
-        ./tests/docker/ducker-ak test ./tests/kafkatest/test/core/produce_bench_test.py
+        ./tests/docker/ducker-ak test ./tests/kafkatest/tests/core/produce_bench_test.py
 
 ssh [node-name|user-name@node-name] [command]
     Log in to a running ducker container.  If node-name is not given, it prints


### PR DESCRIPTION
The ducker-ak test example includes a file path that does not exist. I fixed to be the correct path.