### PR TITLE
MINOR: rewrite zipWithIndex by normal foreach to refrain unnecessary …

### DIFF
--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -234,7 +234,7 @@ private[log] object LogValidator extends Logging {
 
     val firstBatch = getFirstBatchAndMaybeValidateNoMoreBatches(records, NoCompressionCodec)
 
-    for (batch <- records.batches.asScala) {
+    records.batches.forEach { batch =>
       validateBatch(topicPartition, firstBatch, batch, origin, toMagicValue, brokerTopicStats)
 
       val recordErrors = new ArrayBuffer[ApiRecordError](0)
@@ -279,7 +279,7 @@ private[log] object LogValidator extends Logging {
 
     val firstBatch = getFirstBatchAndMaybeValidateNoMoreBatches(records, NoCompressionCodec)
 
-    for (batch <- records.batches.asScala) {
+    records.batches.forEach { batch =>
       validateBatch(topicPartition, firstBatch, batch, origin, magic, brokerTopicStats)
 
       var maxBatchTimestamp = RecordBatch.NO_TIMESTAMP
@@ -393,8 +393,7 @@ private[log] object LogValidator extends Logging {
     if (sourceCodec == NoCompressionCodec && firstBatch.isControlBatch)
       inPlaceAssignment = true
 
-    val batches = records.batches.asScala
-    for (batch <- batches) {
+    records.batches.forEach { batch =>
       validateBatch(topicPartition, firstBatch, batch, origin, toMagic, brokerTopicStats)
       uncompressedSizeInBytes += AbstractRecords.recordBatchHeaderSizeInBytes(toMagic, batch.compressionType())
 
@@ -409,7 +408,7 @@ private[log] object LogValidator extends Logging {
         val recordErrors = new ArrayBuffer[ApiRecordError](0)
         // this is a hot path and we want to avoid any unnecessary allocations.
         var batchIndex = 0
-        for (record <- recordsIterator.asScala) {
+        recordsIterator.forEachRemaining { record =>
           val expectedOffset = expectedInnerOffset.getAndIncrement()
           val recordError = validateRecordCompression(batchIndex, record).orElse {
             validateRecord(batch, topicPartition, record, batchIndex, now,


### PR DESCRIPTION
steal some memory back from hot method :)
- improvement: +17%
- garbage allocation: -12 %

**Parameters**
1. bufferSupplierStr = NO_CACHING
1. bytes = RANDOM
1. compressionType = NONE
1. maxBatchSize = 500
1. messageSize = 100000
1. messageVersion = 2

**BEFORE**

```
Benchmark                                                                                                  (bufferSupplierStr)  (bytes)  (maxBatchSize)  (messageSize)  (messageVersion)   Mode  Cnt        Score       Error   Units
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed                                        NO_CACHING   RANDOM             500         100000                 2  thrpt   15  2315566.901 ± 35760.064   ops/s
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.alloc.rate                         NO_CACHING   RANDOM             500         100000                 2  thrpt   15     4004.046 ±    61.825  MB/sec
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.alloc.rate.norm                    NO_CACHING   RANDOM             500         100000                 2  thrpt   15     1904.000 ±     0.001    B/op
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Eden_Space                NO_CACHING   RANDOM             500         100000                 2  thrpt   15     4007.442 ±    80.422  MB/sec
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Eden_Space.norm           NO_CACHING   RANDOM             500         100000                 2  thrpt   15     1905.678 ±    29.493    B/op
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Old_Gen                   NO_CACHING   RANDOM             500         100000                 2  thrpt   15        0.007 ±     0.001  MB/sec
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Old_Gen.norm              NO_CACHING   RANDOM             500         100000                 2  thrpt   15        0.003 ±     0.001    B/op
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.count                              NO_CACHING   RANDOM             500         100000                 2  thrpt   15      516.000              counts
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.time                               NO_CACHING   RANDOM             500         100000                 2  thrpt   15      491.000                  ms
```

**AFTER**

```
Benchmark                                                                                                  (bufferSupplierStr)  (bytes)  (maxBatchSize)  (messageSize)  (messageVersion)   Mode  Cnt        Score      Error   Units
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed                                        NO_CACHING   RANDOM             500         100000                 2  thrpt   15  2715876.329 ± 4288.625   ops/s
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.alloc.rate                         NO_CACHING   RANDOM             500         100000                 2  thrpt   15     4163.501 ±    6.553  MB/sec
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.alloc.rate.norm                    NO_CACHING   RANDOM             500         100000                 2  thrpt   15     1688.000 ±    0.001    B/op
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Eden_Space                NO_CACHING   RANDOM             500         100000                 2  thrpt   15     4164.497 ±   56.694  MB/sec
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Eden_Space.norm           NO_CACHING   RANDOM             500         100000                 2  thrpt   15     1688.397 ±   22.173    B/op
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Old_Gen                   NO_CACHING   RANDOM             500         100000                 2  thrpt   15        0.008 ±    0.002  MB/sec
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.churn.G1_Old_Gen.norm              NO_CACHING   RANDOM             500         100000                 2  thrpt   15        0.003 ±    0.001    B/op
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.count                              NO_CACHING   RANDOM             500         100000                 2  thrpt   15      536.000             counts
UncompressedRecordBatchValidationBenchmark.measureAssignOffsetsNonCompressed:·gc.time                               NO_CACHING   RANDOM             500         100000                 2  thrpt   15      518.000                 ms
```



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
