### PR TITLE
MINOR: add epoch lineage checks to system tests

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -977,7 +977,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             epochs = [self.replica_leader_epochs(self.get_node(replica), topic, partition, end_offset) for replica in isr]
             for e1 in epochs:
                 for e2 in epochs:
-                    assert e1 == e2, "leader epochs didn't match %s" % str(epochs)
+                    assert e1 == e2, "leader epochs for %s-%d didn't match %s" % (topic, partition, str(epochs))
 
     def java_class_name(self):
         return "kafka.Kafka"

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -939,5 +939,45 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.debug(output)
         return output
 
+    def wait_until_rejoin_isr(self, topic, partitions, replication_factor, timeout_sec=60):
+        for partition in partitions:
+            wait_until(lambda: len(self.isr_idx_list(topic, partition)) == replication_factor, timeout_sec=timeout_sec,
+                    backoff_sec=1, err_msg="Replicas did not rejoin the ISR in a reasonable amount of time")
+
+    def replica_leader_epochs(self, node, topic, partition, end_offset):
+        """
+        Fetch the leader epoch history for a given partition replica
+        :param topic:
+        :param partition:
+        :return leader epochs:
+        """
+        path = next(node.account.ssh_capture("find %s* -regex '.*/%s-%s/leader-epoch-checkpoint'" % \
+             (KafkaService.DATA_LOG_DIR_PREFIX, topic, partition)))
+        output = list(node.account.ssh_capture("cat %s" % path))
+        epochs = {}
+        for line in output[2:]:
+            epoch, offset = line.split()
+            # After a leader election the leader will be stamped with the next offset
+            # but the followers will not be until a new message has been written.
+            # Therefore we strip off the final epoch if the offset matches the exclusive end offset
+            if end_offset != long(offset):
+                epochs[int(epoch)] = long(offset)
+        return epochs
+
+    def replica_leader_epochs_match(self, topic, partitions):
+        """
+        Assert that leader epoch lineages match between replicas
+        :param topic:
+        :param partitions:
+        :return:
+        """
+        for partition in partitions:
+            end_offset = long(self.get_offset_shell(topic, str(partition), 30000, 0, -1).split(':')[2])
+            isr = self.isr_idx_list(topic, partition)
+            epochs = [self.replica_leader_epochs(self.get_node(replica), topic, partition, end_offset) for replica in isr]
+            for e1 in epochs:
+                for e2 in epochs:
+                    assert e1 == e2, "leader epochs didn't match %s" % str(epochs)
+
     def java_class_name(self):
         return "kafka.Kafka"

--- a/tests/kafkatest/tests/core/downgrade_test.py
+++ b/tests/kafkatest/tests/core/downgrade_test.py
@@ -46,7 +46,7 @@ class TestDowngrade(EndToEndTest):
             node.config[config_property.INTER_BROKER_PROTOCOL_VERSION] = str(kafka_version)
             node.config[config_property.MESSAGE_FORMAT_VERSION] = str(kafka_version)
             self.kafka.start_node(node)
-            self.wait_until_rejoin()
+            self.kafka.wait_until_rejoin_isr(self.topic, range(0, self.PARTITIONS), self.REPLICATION_FACTOR)
 
     def downgrade_to(self, kafka_version):
         for node in self.kafka.nodes:
@@ -55,7 +55,7 @@ class TestDowngrade(EndToEndTest):
             del node.config[config_property.INTER_BROKER_PROTOCOL_VERSION]
             del node.config[config_property.MESSAGE_FORMAT_VERSION]
             self.kafka.start_node(node)
-            self.wait_until_rejoin()
+            self.kafka.wait_until_rejoin_isr(self.topic, range(0, self.PARTITIONS), self.REPLICATION_FACTOR)
 
     def setup_services(self, kafka_version, compression_types, security_protocol, static_membership):
         self.create_zookeeper()
@@ -77,11 +77,6 @@ class TestDowngrade(EndToEndTest):
                              static_membership=static_membership)
 
         self.consumer.start()
-
-    def wait_until_rejoin(self):
-        for partition in range(0, self.PARTITIONS):
-            wait_until(lambda: len(self.kafka.isr_idx_list(self.topic, partition)) == self.REPLICATION_FACTOR, 
-                    timeout_sec=60, backoff_sec=1, err_msg="Replicas did not rejoin the ISR in a reasonable amount of time")
 
     @cluster(num_nodes=7)
     @matrix(version=[str(LATEST_2_5)], compression_types=[["none"]], static_membership=[False, True])
@@ -133,3 +128,7 @@ class TestDowngrade(EndToEndTest):
         self.downgrade_to(kafka_version)
         self.run_validation()
         assert self.kafka.check_protocol_errors(self)
+
+        # epoch checks aren't supported with SASL_SSL
+        if security_protocol != "SASL_SSL" and kafka_version >= LATEST_2_2:
+            self.kafka.replica_leader_epochs_match(self.topic, range(0, self.PARTITIONS))

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -158,3 +158,4 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
 
         self.enable_idempotence=True
         self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(bounce_brokers))
+        self.kafka.replica_leader_epochs_match(self.topic, range(0, self.num_partitions))

--- a/tests/kafkatest/tests/core/replication_test.py
+++ b/tests/kafkatest/tests/core/replication_test.py
@@ -93,9 +93,11 @@ class ReplicationTest(EndToEndTest):
     indicator that nothing is left to consume.
     """
 
+    PARTITIONS = 3
+    REPLICATION_FACTOR = 3
     TOPIC_CONFIG = {
-        "partitions": 3,
-        "replication-factor": 3,
+        "partitions": PARTITIONS,
+        "replication-factor": REPLICATION_FACTOR,
         "configs": {"min.insync.replicas": 2}
     }
  
@@ -163,3 +165,6 @@ class ReplicationTest(EndToEndTest):
         self.await_startup()
         failures[failure_mode](self, broker_type)
         self.run_validation(enable_idempotence=enable_idempotence)
+
+        if security_protocol != "SASL_SSL":
+            self.kafka.replica_leader_epochs_match(self.topic, range(0, self.REPLICATION_FACTOR))

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -281,3 +281,6 @@ class TransactionsTest(Test):
             assert input_messages == sorted(input_messages), "The seed messages themselves were not in order"
             assert output_messages == input_messages, "Output messages are not in order"
             assert concurrently_consumed_messages == output_messages, "Concurrently consumed messages are not in order"
+
+        self.kafka.replica_leader_epochs_match(self.input_topic, range(0, self.num_input_partitions))
+        self.kafka.replica_leader_epochs_match(self.output_topic, range(0, self.num_output_partitions))


### PR DESCRIPTION
This adds assertions to check that leader epoch lineages match between
replicas. These have been added to system tests that involve broker
restarts and that wait for replicas to rejoin the ISR by the end of the
test.

I also moved wait_until_rejoin_isr from downgrade_test and upgrade_test
 as the implementation was the same in each.