### PR TITLE
[DO NOT MERGE] POC: unify all jvm cache pools

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/MemoryBudget.java
+++ b/streams/src/main/java/org/apache/kafka/streams/MemoryBudget.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class MemoryBudget {
+
+    public enum AllocationType {
+        SOFT, HARD
+    }
+
+    private static final ThreadLocal<Boolean> OVER_CAPACITY = ThreadLocal.withInitial(() -> false);
+    private static final ThreadLocal<Long> THREAD_RESERVED = ThreadLocal.withInitial(() -> 0L);
+    private static final ThreadLocal<Long> THREAD_FREE = ThreadLocal.withInitial(() -> 0L);
+
+    // Allocate 16 times the amount we need (the power of two is to make it a shift)
+    public static final int ALLOCATION_BLOCK = 16;
+
+    // Free twice an allocation block (the power of two is to make it a shift)
+    public static final int FREE_BLOCK = ALLOCATION_BLOCK * 2;
+
+    private final AtomicLong totalBudget;
+    private final AtomicLong hardAllocation;
+    private final AtomicLong softAllocation;
+
+    public MemoryBudget(final AtomicLong totalBudget) {
+        this.totalBudget = totalBudget;
+        hardAllocation = new AtomicLong(0);
+        softAllocation = new AtomicLong(0);
+    }
+
+    public void transact(final AllocationType allocationType, final long sizeDelta) {
+        switch (allocationType) {
+            case HARD:
+                hardTransact(sizeDelta);
+                break;
+            case SOFT:
+                softTransact(sizeDelta);
+                break;
+        }
+    }
+
+    public void hardTransact(final long sizeDelta) {
+        if (sizeDelta > 0) {
+            hardAllocate(sizeDelta);
+        } else if (sizeDelta < 0) {
+            hardFree(-1 * sizeDelta);
+        }
+    }
+
+    public void softTransact(final long sizeDelta) {
+        if (sizeDelta > 0) {
+            softAllocate(sizeDelta);
+        } else if (sizeDelta < 0) {
+            softFree(-1 * sizeDelta);
+        }
+    }
+
+    private void softAllocate(final long size) {
+        // should assert size is positive if this becomes pubic
+        final long reserved = THREAD_RESERVED.get();
+        final long free = THREAD_FREE.get();
+        if (size <= free) {
+            // If we have already requested enough memory, then just use some.
+            THREAD_FREE.set(free - size);
+        } else {
+            // If we need more memory than this thread has requested,
+            // then request an extra allocation block
+            final long blockToReserve = size * ALLOCATION_BLOCK;
+            final long soft = softAllocation.addAndGet(blockToReserve);
+            final long hard = hardAllocation.get();
+            final long totalBudget = this.totalBudget.get();
+            OVER_CAPACITY.set((soft + hard) > totalBudget);
+
+            THREAD_RESERVED.set(reserved + blockToReserve);
+            // don't forget to take out the bite we need from the
+            // block we requested
+            THREAD_FREE.set(free + blockToReserve - size);
+        }
+    }
+
+    private void hardAllocate(final long size) {
+        // should assert size is positive if this becomes pubic
+        final long reserved = THREAD_RESERVED.get();
+        final long free = THREAD_FREE.get();
+        if (size <= free) {
+            // If we have already requested enough memory, then just use some.
+            THREAD_FREE.set(free - size);
+        } else {
+            // If we need more memory than this thread has requested,
+            // then request an extra allocation block
+            final long blockToReserve = size * ALLOCATION_BLOCK;
+
+            final long soft = softAllocation.get();
+            final long hard = hardAllocation.addAndGet(blockToReserve);
+            final long totalBudget = this.totalBudget.get();
+            OVER_CAPACITY.set((soft + hard) > totalBudget);
+
+            THREAD_RESERVED.set(reserved + blockToReserve);
+            // don't forget to take out the bite we need from the
+            // block we requested
+            THREAD_FREE.set(free + blockToReserve - size);
+        }
+    }
+
+    public void softFree(final long size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Nonsense free: " + size);
+        }
+        final Long reserved = THREAD_RESERVED.get();
+        final Long free = THREAD_FREE.get();
+
+        // If we can afford to give up a whole free block, then do it.
+        final long blockToFree = size * FREE_BLOCK;
+        if (blockToFree < free) {
+            // release the block from the shared pool
+            softAllocation.addAndGet(-1 * blockToFree);
+
+            // reduce the reservation size
+            THREAD_RESERVED.set(reserved - blockToFree);
+
+            // reduce the size of the free pool
+            THREAD_FREE.set(free - blockToFree);
+        } else {
+            // Otherwise, just free up the requested size
+            THREAD_FREE.set(free + size);
+        }
+    }
+
+    public void hardFree(final long size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Nonsense free: " + size);
+        }
+        final Long reserved = THREAD_RESERVED.get();
+        final Long free = THREAD_FREE.get();
+
+        // If we can afford to give up a whole free block, then do it.
+        final long blockToFree = size * FREE_BLOCK;
+        if (blockToFree < free) {
+            // release the block from the shared pool
+            hardAllocation.addAndGet(-1 * blockToFree);
+
+            // reduce the reservation size
+            THREAD_RESERVED.set(reserved - blockToFree);
+
+            // reduce the size of the free pool
+            THREAD_FREE.set(free - blockToFree);
+        } else {
+            // Otherwise, just free up the requested size
+            THREAD_FREE.set(free + size);
+        }
+    }
+
+
+    public void free(final AllocationType allocationType, final long size) {
+        switch (allocationType) {
+            case SOFT:
+                softFree(size);
+                break;
+            case HARD:
+                hardFree(size);
+                break;
+        }
+    }
+
+    public boolean overHardBudget() {
+        return hardAllocation.get() > totalBudget.get();
+    }
+
+    public long targetSoftReservation() {
+        final long hard = hardAllocation.get();
+        final long soft = softAllocation.get();
+        final long consumed = hard + soft;
+        final long total = totalBudget.get();
+        final long needToFree = consumed - total;
+        if (needToFree <= 0L) {
+            // If we don't need to free anything, then the target is the current reservation
+            return THREAD_RESERVED.get();
+        } else {
+            // If we need to free some amount, we can free at most the soft reservation
+            final Long reserved = THREAD_RESERVED.get();
+            final long target = reserved - needToFree;
+            return Math.max(target, 0L);
+        }
+    }
+
+    public long softReservation() {
+        return THREAD_RESERVED.get();
+    }
+
+    @Override
+    public String toString() {
+        return "MemoryBudget{" +
+            "totalBudget=" + totalBudget +
+            ", hardAllocation=" + hardAllocation +
+            ", softAllocation=" + softAllocation +
+            '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Suppressed.java
@@ -69,6 +69,11 @@ public interface Suppressed<K> extends NamedOperation<Suppressed<K>> {
         BC withMaxBytes(final long byteLimit);
 
         /**
+         *
+         */
+        BC usingCacheBytes();
+
+        /**
          * Create a buffer unconstrained by size (either keys or bytes).
          *
          * As a result, the buffer will consume as much memory as it needs, dictated by the time bound.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferConfigInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferConfigInternal.java
@@ -27,6 +27,8 @@ public abstract class BufferConfigInternal<BC extends Suppressed.BufferConfig<BC
 
     public abstract long maxBytes();
 
+    public abstract boolean useRecordCacheBytes();
+
     @SuppressWarnings("unused")
     public abstract BufferFullStrategy bufferFullStrategy();
 
@@ -41,12 +43,12 @@ public abstract class BufferConfigInternal<BC extends Suppressed.BufferConfig<BC
 
     @Override
     public Suppressed.StrictBufferConfig shutDownWhenFull() {
-        return new StrictBufferConfigImpl(maxRecords(), maxBytes(), SHUT_DOWN);
+        return new StrictBufferConfigImpl(maxRecords(), maxBytes(), useRecordCacheBytes(), SHUT_DOWN, getLogConfig());
     }
 
     @Override
     public Suppressed.EagerBufferConfig emitEarlyWhenFull() {
-        return new EagerBufferConfigImpl(maxRecords(), maxBytes());
+        return new EagerBufferConfigImpl(maxRecords(), maxBytes(), useRecordCacheBytes(), getLogConfig());
     }
 
     public abstract boolean isLoggingEnabled();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferFullStrategy.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferFullStrategy.java
@@ -17,7 +17,5 @@
 package org.apache.kafka.streams.kstream.internals.suppress;
 
 public enum BufferFullStrategy {
-    EMIT,
-    SPILL_TO_DISK,
-    SHUT_DOWN
+    EMIT, SHUT_DOWN
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/EagerBufferConfigImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/EagerBufferConfigImpl.java
@@ -26,30 +26,39 @@ public class EagerBufferConfigImpl extends BufferConfigInternal<Suppressed.Eager
 
     private final long maxRecords;
     private final long maxBytes;
+    private final boolean useRecordCacheBytes;
     private final Map<String, String> logConfig;
 
     public EagerBufferConfigImpl(final long maxRecords, final long maxBytes) {
         this.maxRecords = maxRecords;
         this.maxBytes = maxBytes;
+        this.useRecordCacheBytes = false;
         this.logConfig = Collections.emptyMap();
     }
 
-    private EagerBufferConfigImpl(final long maxRecords,
+    public EagerBufferConfigImpl(final long maxRecords,
                                   final long maxBytes,
+                                  final boolean useRecordCacheBytes,
                                   final Map<String, String> logConfig) {
         this.maxRecords = maxRecords;
         this.maxBytes = maxBytes;
+        this.useRecordCacheBytes = useRecordCacheBytes;
         this.logConfig = logConfig;
     }
 
     @Override
     public Suppressed.EagerBufferConfig withMaxRecords(final long recordLimit) {
-        return new EagerBufferConfigImpl(recordLimit, maxBytes, logConfig);
+        return new EagerBufferConfigImpl(recordLimit, maxBytes, useRecordCacheBytes, logConfig);
     }
 
     @Override
     public Suppressed.EagerBufferConfig withMaxBytes(final long byteLimit) {
-        return new EagerBufferConfigImpl(maxRecords, byteLimit, logConfig);
+        return new EagerBufferConfigImpl(maxRecords, byteLimit, useRecordCacheBytes, logConfig);
+    }
+
+    @Override
+    public Suppressed.EagerBufferConfig usingCacheBytes() {
+        return new EagerBufferConfigImpl(maxRecords, maxBytes, true, logConfig);
     }
 
     @Override
@@ -63,18 +72,23 @@ public class EagerBufferConfigImpl extends BufferConfigInternal<Suppressed.Eager
     }
 
     @Override
+    public boolean useRecordCacheBytes() {
+        return useRecordCacheBytes;
+    }
+
+    @Override
     public BufferFullStrategy bufferFullStrategy() {
         return BufferFullStrategy.EMIT;
     }
 
     @Override
     public Suppressed.EagerBufferConfig withLoggingDisabled() {
-        return new EagerBufferConfigImpl(maxRecords, maxBytes, null);
+        return new EagerBufferConfigImpl(maxRecords, maxBytes, useRecordCacheBytes, null);
     }
 
     @Override
     public Suppressed.EagerBufferConfig withLoggingEnabled(final Map<String, String> config) {
-        return new EagerBufferConfigImpl(maxRecords, maxBytes, config);
+        return new EagerBufferConfigImpl(maxRecords, maxBytes, useRecordCacheBytes, config);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/StrictBufferConfigImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/StrictBufferConfigImpl.java
@@ -28,15 +28,18 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
 
     private final long maxRecords;
     private final long maxBytes;
+    private final boolean useRecordCacheBytes;
     private final BufferFullStrategy bufferFullStrategy;
     private final Map<String, String> logConfig;
 
     public StrictBufferConfigImpl(final long maxRecords,
                                   final long maxBytes,
+                                  final boolean useRecordCacheBytes,
                                   final BufferFullStrategy bufferFullStrategy,
                                   final Map<String, String> logConfig) {
         this.maxRecords = maxRecords;
         this.maxBytes = maxBytes;
+        this.useRecordCacheBytes = useRecordCacheBytes;
         this.bufferFullStrategy = bufferFullStrategy;
         this.logConfig = logConfig;
     }
@@ -46,6 +49,7 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
                                   final BufferFullStrategy bufferFullStrategy) {
         this.maxRecords = maxRecords;
         this.maxBytes = maxBytes;
+        this.useRecordCacheBytes = false;
         this.bufferFullStrategy = bufferFullStrategy;
         this.logConfig = Collections.emptyMap();
     }
@@ -53,6 +57,7 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
     public StrictBufferConfigImpl() {
         this.maxRecords = Long.MAX_VALUE;
         this.maxBytes = Long.MAX_VALUE;
+        this.useRecordCacheBytes = false;
         this.bufferFullStrategy = SHUT_DOWN;
         this.logConfig = Collections.emptyMap();
     }
@@ -68,6 +73,11 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
     }
 
     @Override
+    public Suppressed.StrictBufferConfig usingCacheBytes() {
+        return new StrictBufferConfigImpl(maxRecords, maxBytes, true, bufferFullStrategy, logConfig);
+    }
+
+    @Override
     public long maxRecords() {
         return maxRecords;
     }
@@ -78,18 +88,23 @@ public class StrictBufferConfigImpl extends BufferConfigInternal<Suppressed.Stri
     }
 
     @Override
+    public boolean useRecordCacheBytes() {
+        return useRecordCacheBytes;
+    }
+
+    @Override
     public BufferFullStrategy bufferFullStrategy() {
         return bufferFullStrategy;
     }
 
     @Override
     public Suppressed.StrictBufferConfig withLoggingDisabled() {
-        return new StrictBufferConfigImpl(maxRecords, maxBytes, bufferFullStrategy, null);
+        return new StrictBufferConfigImpl(maxRecords, maxBytes, useRecordCacheBytes, bufferFullStrategy, null);
     }
 
     @Override
     public Suppressed.StrictBufferConfig withLoggingEnabled(final Map<String, String> config) {
-        return new StrictBufferConfigImpl(maxRecords, maxBytes, bufferFullStrategy, config);
+        return new StrictBufferConfigImpl(maxRecords, maxBytes, useRecordCacheBytes, bufferFullStrategy, config);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractProcessorContext implements InternalProcessorContext {
 
@@ -40,11 +41,12 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
     private final StreamsMetricsImpl metrics;
     private final Serde<?> keySerde;
     private final Serde<?> valueSerde;
+    private final AtomicLong recordCacheRemaining;
+
     private boolean initialized;
     protected ProcessorRecordContext recordContext;
     protected ProcessorNode<?, ?, ?, ?> currentNode;
     private long currentSystemTimeMs;
-
     protected ThreadCache cache;
 
     public AbstractProcessorContext(final TaskId taskId,
@@ -58,6 +60,7 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
         valueSerde = config.defaultValueSerde();
         keySerde = config.defaultKeySerde();
         this.cache = cache;
+        this.recordCacheRemaining = cache == null ? null : cache.getRecordCacheRemaining();
     }
 
     protected abstract StateManager stateManager();
@@ -228,5 +231,10 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
     @Override
     public String changelogFor(final String storeName) {
         return stateManager().changelogFor(storeName);
+    }
+
+    @Override
+    public AtomicLong getRecordCacheRemaining() {
+        return recordCacheRemaining;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -30,7 +31,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class AbstractProcessorContext implements InternalProcessorContext {
 
@@ -41,7 +41,7 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
     private final StreamsMetricsImpl metrics;
     private final Serde<?> keySerde;
     private final Serde<?> valueSerde;
-    private final AtomicLong recordCacheRemaining;
+    private final MemoryBudget memoryBudget;
 
     private boolean initialized;
     protected ProcessorRecordContext recordContext;
@@ -60,7 +60,7 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
         valueSerde = config.defaultValueSerde();
         keySerde = config.defaultKeySerde();
         this.cache = cache;
-        this.recordCacheRemaining = cache == null ? null : cache.getRecordCacheRemaining();
+        this.memoryBudget = cache == null ? null : cache.memoryBudget();
     }
 
     protected abstract StateManager stateManager();
@@ -234,7 +234,7 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
     }
 
     @Override
-    public AtomicLong getRecordCacheRemaining() {
-        return recordCacheRemaining;
+    public MemoryBudget getMemoryBudget() {
+        return memoryBudget;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getTaskProducerClientId;
@@ -55,6 +56,7 @@ class ActiveTaskCreator {
     private final StateDirectory stateDirectory;
     private final ChangelogReader storeChangelogReader;
     private final ThreadCache cache;
+    private final AtomicLong recordCacheRemaining;
     private final Time time;
     private final KafkaClientSupplier clientSupplier;
     private final String threadId;
@@ -81,6 +83,7 @@ class ActiveTaskCreator {
         this.stateDirectory = stateDirectory;
         this.storeChangelogReader = storeChangelogReader;
         this.cache = cache;
+        this.recordCacheRemaining = cache.getRecordCacheRemaining();
         this.time = time;
         this.clientSupplier = clientSupplier;
         this.threadId = threadId;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
@@ -41,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static org.apache.kafka.streams.processor.internals.ClientUtils.getTaskProducerClientId;
@@ -56,7 +56,7 @@ class ActiveTaskCreator {
     private final StateDirectory stateDirectory;
     private final ChangelogReader storeChangelogReader;
     private final ThreadCache cache;
-    private final AtomicLong recordCacheRemaining;
+    private final MemoryBudget memoryBudget;
     private final Time time;
     private final KafkaClientSupplier clientSupplier;
     private final String threadId;
@@ -83,7 +83,7 @@ class ActiveTaskCreator {
         this.stateDirectory = stateDirectory;
         this.storeChangelogReader = storeChangelogReader;
         this.cache = cache;
-        this.recordCacheRemaining = cache.getRecordCacheRemaining();
+        this.memoryBudget = cache.memoryBudget();
         this.time = time;
         this.clientSupplier = clientSupplier;
         this.threadId = threadId;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import static org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.getReadWriteStore;
-
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.Cancellable;
@@ -28,9 +26,11 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
 import java.time.Duration;
-import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
+
+import static org.apache.kafka.streams.processor.internals.AbstractReadWriteDecorator.getReadWriteStore;
 
 public class GlobalProcessorContextImpl extends AbstractProcessorContext {
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.StreamsException;
@@ -63,7 +64,7 @@ public class GlobalStreamThread extends Thread {
     private final ThreadCache cache;
     private final StreamsMetricsImpl streamsMetrics;
     private final ProcessorTopology topology;
-    private final AtomicLong recordCacheRemaining;
+    private final MemoryBudget memoryBudget;
     private volatile StreamsException startupException;
 
     /**
@@ -207,7 +208,7 @@ public class GlobalStreamThread extends Thread {
             config,
             globalConsumer,
             stateDirectory,
-            new AtomicLong(cacheSizeBytes),
+            new MemoryBudget(new AtomicLong(cacheSizeBytes)),
             streamsMetrics,
             time,
             threadClientId,
@@ -219,7 +220,7 @@ public class GlobalStreamThread extends Thread {
                               final StreamsConfig config,
                               final Consumer<byte[], byte[]> globalConsumer,
                               final StateDirectory stateDirectory,
-                              final AtomicLong recordCacheRemaining,
+                              final MemoryBudget memoryBudget,
                               final StreamsMetricsImpl streamsMetrics,
                               final Time time,
                               final String threadClientId,
@@ -234,8 +235,8 @@ public class GlobalStreamThread extends Thread {
         this.logPrefix = String.format("global-stream-thread [%s] ", threadClientId);
         this.logContext = new LogContext(logPrefix);
         this.log = logContext.logger(getClass());
-        this.cache = new ThreadCache(logContext, recordCacheRemaining, this.streamsMetrics);
-        this.recordCacheRemaining = recordCacheRemaining;
+        this.cache = new ThreadCache(logContext, memoryBudget, this.streamsMetrics);
+        this.memoryBudget = memoryBudget;
         this.stateRestoreListener = stateRestoreListener;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalApiProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalApiProcessorContext.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.processor.RecordContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -25,8 +26,6 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * For internal use so we can update the {@link RecordContext} and current
@@ -119,5 +118,5 @@ public interface InternalApiProcessorContext<KForward, VForward> extends Process
 
     String changelogFor(final String storeName);
 
-    AtomicLong getRecordCacheRemaining();
+    MemoryBudget getMemoryBudget();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalApiProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalApiProcessorContext.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * For internal use so we can update the {@link RecordContext} and current
  * {@link ProcessorNode} when we are forwarding items that have been evicted or flushed from
@@ -116,4 +118,6 @@ public interface InternalApiProcessorContext<KForward, VForward> extends Process
                    final long timestamp);
 
     String changelogFor(final String storeName);
+
+    AtomicLong getRecordCacheRemaining();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.RecordContext;
 import org.apache.kafka.streams.processor.StateStore;
@@ -27,8 +28,6 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * For internal use so we can update the {@link RecordContext} and current
@@ -123,5 +122,5 @@ public interface InternalProcessorContext extends ProcessorContext {
 
     String changelogFor(final String storeName);
 
-    AtomicLong getRecordCacheRemaining();
+    MemoryBudget getMemoryBudget();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -28,6 +28,8 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * For internal use so we can update the {@link RecordContext} and current
  * {@link ProcessorNode} when we are forwarding items that have been evicted or flushed from
@@ -120,4 +122,6 @@ public interface InternalProcessorContext extends ProcessorContext {
                    final long timestamp);
 
     String changelogFor(final String storeName);
+
+    AtomicLong getRecordCacheRemaining();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextAdapter.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -34,7 +35,6 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 import java.io.File;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 public final class ProcessorContextAdapter<KForward, VForward>
     implements ProcessorContext<KForward, VForward>, InternalApiProcessorContext<KForward, VForward> {
@@ -165,8 +165,8 @@ public final class ProcessorContextAdapter<KForward, VForward>
     }
 
     @Override
-    public AtomicLong getRecordCacheRemaining() {
-        return delegate.getRecordCacheRemaining();
+    public MemoryBudget getMemoryBudget() {
+        return delegate.getMemoryBudget();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextAdapter.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 import java.io.File;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class ProcessorContextAdapter<KForward, VForward>
     implements ProcessorContext<KForward, VForward>, InternalApiProcessorContext<KForward, VForward> {
@@ -161,6 +162,11 @@ public final class ProcessorContextAdapter<KForward, VForward>
     @Override
     public String changelogFor(final String storeName) {
         return delegate.changelogFor(storeName);
+    }
+
+    @Override
+    public AtomicLong getRecordCacheRemaining() {
+        return delegate.getRecordCacheRemaining();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -16,9 +16,6 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
@@ -33,10 +30,12 @@ import org.apache.kafka.streams.processor.To;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
-import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
+import java.util.Map;
 
 import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFailMsgPrefix;
 import static org.apache.kafka.streams.processor.internals.AbstractReadOnlyDecorator.getReadOnlyStore;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextReverseAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextReverseAdapter.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -33,7 +34,6 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 import java.io.File;
 import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 public final class ProcessorContextReverseAdapter implements InternalProcessorContext {
     private final InternalApiProcessorContext<Object, Object> delegate;
@@ -161,8 +161,8 @@ public final class ProcessorContextReverseAdapter implements InternalProcessorCo
     }
 
     @Override
-    public AtomicLong getRecordCacheRemaining() {
-        return delegate.getRecordCacheRemaining();
+    public MemoryBudget getMemoryBudget() {
+        return delegate.getMemoryBudget();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextReverseAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextReverseAdapter.java
@@ -33,6 +33,7 @@ import org.apache.kafka.streams.state.internals.ThreadCache;
 import java.io.File;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class ProcessorContextReverseAdapter implements InternalProcessorContext {
     private final InternalApiProcessorContext<Object, Object> delegate;
@@ -157,6 +158,11 @@ public final class ProcessorContextReverseAdapter implements InternalProcessorCo
     @Override
     public String changelogFor(final String storeName) {
         return delegate.changelogFor(storeName);
+    }
+
+    @Override
+    public AtomicLong getRecordCacheRemaining() {
+        return delegate.getRecordCacheRemaining();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 class StandbyTaskCreator {
     private final InternalTopologyBuilder builder;
@@ -62,7 +61,6 @@ class StandbyTaskCreator {
 
         dummyCache = new ThreadCache(
             new LogContext(String.format("stream-thread [%s] ", Thread.currentThread().getName())),
-            new AtomicLong(0),
             streamsMetrics
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTaskCreator.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 class StandbyTaskCreator {
     private final InternalTopologyBuilder builder;
@@ -61,7 +62,7 @@ class StandbyTaskCreator {
 
         dummyCache = new ThreadCache(
             new LogContext(String.format("stream-thread [%s] ", Thread.currentThread().getName())),
-            0,
+            new AtomicLong(0),
             streamsMetrics
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
@@ -23,10 +23,13 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
+
+    void setRecordCacheRemaining(AtomicLong recordCacheRemaining);
 
     final class Eviction<K, V> {
         private final K key;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/TimeOrderedKeyValueBuffer.java
@@ -17,19 +17,21 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public interface TimeOrderedKeyValueBuffer<K, V> extends StateStore {
 
-    void setRecordCacheRemaining(AtomicLong recordCacheRemaining);
+    void setMemoryBudget(MemoryBudget memoryBudget, MemoryBudget.AllocationType allocationType);
+
+    boolean nonEmpty();
 
     final class Eviction<K, V> {
         private final K key;

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -81,7 +81,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
@@ -212,7 +211,7 @@ public class KafkaStreamsTest {
             anyObject(StreamsMetricsImpl.class),
             anyObject(Time.class),
             anyObject(StreamsMetadataState.class),
-            anyObject(AtomicLong.class),
+            anyObject(MemoryBudget.class),
             anyObject(StateDirectory.class),
             anyObject(StateRestoreListener.class),
             anyInt()

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -81,6 +81,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyList;
@@ -211,7 +212,7 @@ public class KafkaStreamsTest {
             anyObject(StreamsMetricsImpl.class),
             anyObject(Time.class),
             anyObject(StreamsMetadataState.class),
-            anyLong(),
+            anyObject(AtomicLong.class),
             anyObject(StateDirectory.class),
             anyObject(StateRestoreListener.class),
             anyInt()

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -473,8 +473,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        );
+            new AtomicLong(Long.MAX_VALUE),
+            null);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
         mockTime.sleep(commitInterval - 10L);
@@ -701,8 +701,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        );
+            new AtomicLong(Long.MAX_VALUE),
+            null);
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
         mockTime.sleep(commitInterval - 10L);
@@ -739,8 +739,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        );
+            new AtomicLong(Long.MAX_VALUE),
+            null);
 
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
@@ -930,8 +930,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
+            new AtomicLong(Long.MAX_VALUE),
+            null).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.setStateListener(
             (t, newState, oldState) -> {
                 if (oldState == StreamThread.State.CREATED && newState == StreamThread.State.STARTING) {
@@ -989,8 +989,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
+            new AtomicLong(Long.MAX_VALUE),
+            null).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         final IllegalStateException thrown = assertThrows(
             IllegalStateException.class, thread::run);
@@ -1026,8 +1026,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
+            new AtomicLong(Long.MAX_VALUE),
+            null).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.shutdown();
         verify(taskManager);
     }
@@ -1056,8 +1056,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
+            new AtomicLong(Long.MAX_VALUE),
+            null).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.shutdown();
         // Execute the run method. Verification of the mock will check that shutdown was only done once
         thread.run();
@@ -1971,8 +1971,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
+            new AtomicLong(Long.MAX_VALUE),
+            null).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         consumer.schedulePollTask(() -> {
             thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -2015,8 +2015,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
+            new AtomicLong(Long.MAX_VALUE),
+            null).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         consumer.schedulePollTask(() -> {
             thread.setState(StreamThread.State.PARTITIONS_REVOKED);
@@ -2065,8 +2065,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ) {
+            new AtomicLong(Long.MAX_VALUE),
+            null) {
             @Override
             void runOnce() {
                 setState(State.PENDING_SHUTDOWN);
@@ -2123,8 +2123,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        ) {
+            new AtomicLong(Long.MAX_VALUE),
+            null) {
             @Override
             void runOnce() {
                 setState(State.PENDING_SHUTDOWN);
@@ -2182,8 +2182,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        );
+            new AtomicLong(Long.MAX_VALUE),
+            null);
 
         EasyMock.replay(task1, task2, task3, taskManager);
 
@@ -2348,8 +2348,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        );
+            new AtomicLong(Long.MAX_VALUE),
+            null);
 
         assertThat(dummyProducerMetrics, is(thread.producerMetrics()));
     }
@@ -2382,8 +2382,8 @@ public class StreamThreadTest {
             CLIENT_ID,
             new LogContext(""),
             new AtomicInteger(),
-            new AtomicLong(Long.MAX_VALUE)
-        );
+            new AtomicLong(Long.MAX_VALUE),
+            null);
         final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
         final Metric testMetric = new KafkaMetric(
             new Object(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -44,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -176,6 +178,8 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
         EasyMock.replay(underlyingStore);
         store = new CachingKeyValueStore(underlyingStore);
         cache = EasyMock.niceMock(ThreadCache.class);
+        EasyMock.expect(cache.memoryBudget()).andStubReturn(new MemoryBudget(new AtomicLong(Long.MAX_VALUE)));
+        EasyMock.replay(cache);
         context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, TOPIC, null));
         store.init(context, store);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -51,7 +52,7 @@ public class NamedCacheTest {
     public void setUp() {
         innerMetrics = new Metrics();
         metrics = new MockStreamsMetrics(innerMetrics);
-        cache = new NamedCache(taskIDString + "-" + underlyingStoreName, metrics);
+        cache = new NamedCache(taskIDString + "-" + underlyingStoreName, new AtomicLong(Long.MAX_VALUE), metrics);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.junit.Before;
@@ -52,7 +53,7 @@ public class NamedCacheTest {
     public void setUp() {
         innerMetrics = new Metrics();
         metrics = new MockStreamsMetrics(innerMetrics);
-        cache = new NamedCache(taskIDString + "-" + underlyingStoreName, new AtomicLong(Long.MAX_VALUE), metrics);
+        cache = new NamedCache(taskIDString + "-" + underlyingStoreName, new MemoryBudget(new AtomicLong(Long.MAX_VALUE)), metrics);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.MemoryBudget;
 import org.apache.kafka.streams.processor.MockProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -29,14 +30,13 @@ import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
 import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
 public class MockInternalProcessorContext extends MockProcessorContext implements InternalProcessorContext {
 
@@ -154,7 +154,7 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
     }
 
     @Override
-    public AtomicLong getRecordCacheRemaining() {
-        return new AtomicLong(0);
+    public MemoryBudget getMemoryBudget() {
+        return new MemoryBudget(new AtomicLong(Long.MAX_VALUE));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalProcessorContext.java
@@ -34,6 +34,8 @@ import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.kafka.streams.state.internals.ThreadCache.DirtyEntryFlushListener;
 
 public class MockInternalProcessorContext extends MockProcessorContext implements InternalProcessorContext {
@@ -149,5 +151,10 @@ public class MockInternalProcessorContext extends MockProcessorContext implement
     @Override
     public String changelogFor(final String storeName) {
         return "mock-changelog";
+    }
+
+    @Override
+    public AtomicLong getRecordCacheRemaining() {
+        return new AtomicLong(0);
     }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -312,7 +312,7 @@ public class TopologyTestDriver implements Closeable {
         final AtomicLong cacheSizeBytes = new AtomicLong(Math.max(0, streamsConfig.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)));
         final ThreadCache cache = new ThreadCache(
             logContext,
-            cacheSizeBytes,
+            new MemoryBudget(cacheSizeBytes),
             streamsMetrics
         );
 


### PR DESCRIPTION
Currently, users of Suppress in strict mode must either not configure a memory bound or consider a per-operator, per-partition bound. The former would result in the application crashing ungracefully if it needs too much memory, which is sub-optimal for some deployment strategies. The latter is nice for determinism, but is difficult to configure in practice.

In addition to suppress buffers, Streams has a record cache configuration. Currently, we make the assumption that all threads would probably use a uniform amount of cache space, but this assumption is clearly wrong in some cases.

Finally, there are some applications that want to run multiple Streams instances in the same JVM, probably for running different Streams topologies.

In aggregate, there are quite a few "pools" of heap space that users need to configure if they want to avoid an OOME, and the more threads, applications, and Suppress operators there are, the more granular these pools become. Of course, the more granular the pools are, the lower utilization of the available memory we will see. Plus, especially for Suppression, very granular pool configuration means a higher likelihood that the operator will run out of space and shut the app down.

This POC demonstrates the feasibility of unifying all these pools with one logical bound on total memory usage for all caches and suppression buffers, across all operators/tasks and all threads, and even across all Streams instances in the JVM.

Most of the tests pass right now, but not all of them. I also need to clean up a few more things before really starting a discussion.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
