### PR TITLE
KAFKA-10133: MM2 readme update on config

### DIFF
--- a/connect/mirror/README.md
+++ b/connect/mirror/README.md
@@ -141,7 +141,40 @@ nearby clusters.
 N.B. that the `--clusters` parameter is not technically required here. MM2 will work fine without it; however, throughput may suffer from "producer lag" between
 data centers, and you may incur unnecessary data transfer costs.
 
-## Shared configuration
+## Configuration
+The following sections target for dedicated MM2 cluster. If running MM2 in a Connect cluster, please refer to [KIP-382: MirrorMaker 2.0](https://cwiki.apache.org/confluence/display/KAFKA/KIP-382%3A+MirrorMaker+2.0) for guidance.
+ 
+### General Kafka Connect Config
+All Kafka Connect, Source Connector, Sink Connector configs, as defined in [Kafka official doc](https://kafka.apache.org/documentation/#connectconfigs), can be 
+directly used in MM2 configuration without prefix in the configuration name. As the starting point, most of these default configs may work well with the exception of `tasks.max`.
+
+In order to evenly distribute the workload across more than one MM2 instance, it is advised to set `tasks.max` at least to 2 or even larger depending on the hardware resources
+and the total number partitions to be replicated.
+
+### Kafka Connect Config for a Specific Connector
+If needed, Kafka Connect worker-level configs could be even specified "per connector", which needs to follow the format of `cluster_alias.config_name` in MM2 configuration. For example,
+ 
+    backup.ssl.truststore.location = /usr/lib/jvm/zulu-8-amd64/jre/lib/security/cacerts // SSL cert location
+    backup.security.protocol = SSL // if target cluster needs SSL to send message
+    
+### MM2 Config for a Specific Connector
+MM2 itself has many configs to control how it behaves. To override those default values, add the config name by the format of `source_cluster_alias->target_cluster_alias.config_name` in MM2 configuration. For example,
+    
+    backup->primary.enabled = false // set to false if one-way replication is desired
+    primary->backup.topics.blacklist = topics_to_blacklist
+    primary->backup.emit.heartbeats.enabled = false
+    primary->backup.sync.group.offsets = true 
+
+### Producer / Consumer / Admin Config used by MM2
+In many cases, customized values for producer or consumer configurations are needed. In order to override the default values of producer or consumer used by MM2, 
+`target_cluster_alias.producer.producer_config_name`, `source_cluster_alias.consumer.consumer_config_name` or `cluster_alias.admin.admin_config_name` are the formats to use in MM2 configuration. For example,
+
+     backup.producer.compression.type = gzip
+     backup.producer.buffer.memory = 32768
+     primary.consumer.isolation.level = read_committed
+     primary.admin.bootstrap.servers = localhost:9092
+     
+### Shared configuration
 
 MM2 processes share configuration via their target Kafka clusters. 
 For example, the following two processes would be racy:


### PR DESCRIPTION
Per https://issues.apache.org/jira/browse/KAFKA-10133, MM2 users sometimes confuse on specifying or overriding the default configurations at different levels: connector, MM2, producer/consumers. It may be great if we clarify how to correctly set those configs in README.md, in addition to the example config file.