### PR TITLE
KAFKA-10428: Fix schema for header conversion in MirrorSourceTask.

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -117,14 +117,14 @@ public class MirrorSourceTask extends SourceTask {
         try {
             consumerAccess.acquire();
         } catch (InterruptedException e) {
-            log.warn("Interrupted waiting for access to consumer. Will try closing anyway.");
+            log.warn("Interrupted waiting for access to consumer. Will try closing anyway."); 
         }
         Utils.closeQuietly(consumer, "source consumer");
         Utils.closeQuietly(offsetProducer, "offset producer");
         Utils.closeQuietly(metrics, "metrics");
         log.info("Stopping {} took {} ms.", Thread.currentThread().getName(), System.currentTimeMillis() - start);
     }
-
+   
     @Override
     public String version() {
         return "1";
@@ -222,7 +222,7 @@ public class MirrorSourceTask extends SourceTask {
             outstandingOffsetSyncs.release();
         });
     }
-
+ 
     private Map<TopicPartition, Long> loadOffsets(Set<TopicPartition> topicPartitions) {
         return topicPartitions.stream().collect(Collectors.toMap(x -> x, x -> loadOffset(x)));
     }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import org.junit.Test;
@@ -38,6 +39,7 @@ public class MirrorSourceTaskTest {
         Headers headers = new RecordHeaders();
         headers.add("header1", new byte[]{'l', 'm', 'n', 'o'});
         headers.add("header2", new byte[]{'p', 'q', 'r', 's', 't'});
+        headers.add("header3", new byte[]{'1', '8'});
         ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>("topic1", 2, 3L, 4L,
             TimestampType.CREATE_TIME, 0L, 5, 6, key, value, headers);
         MirrorSourceTask mirrorSourceTask = new MirrorSourceTask("cluster7",
@@ -52,6 +54,9 @@ public class MirrorSourceTaskTest {
         assertEquals(value, sourceRecord.value());
         assertEquals(headers.lastHeader("header1").value(), sourceRecord.headers().lastWithName("header1").value());
         assertEquals(headers.lastHeader("header2").value(), sourceRecord.headers().lastWithName("header2").value());
+        assertEquals(Schema.STRING_SCHEMA, sourceRecord.headers().lastWithName("header1").schema());
+        assertEquals(Schema.STRING_SCHEMA, sourceRecord.headers().lastWithName("header2").schema());
+        assertEquals(Schema.INT8_SCHEMA, sourceRecord.headers().lastWithName("header3").schema());
     }
 
     @Test


### PR DESCRIPTION
The addBytes method adds the header using Schema.BYTES, which results in base64 encoding when the record is stored.  SimpleHeaderConverter#toConnectHeader implements schema inference which we can use here, as the ConsumerRecord does not have header schema information.

Testing: I added schema verification to the existing MirrorSourceTaskTest#testSerde, with a string and int example.
