### PR TITLE
KAFKA-10433 Reuse the ByteBuffer in validating compressed records

### DIFF
--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -398,9 +398,9 @@ private[log] object LogValidator extends Logging {
       // if we are on version 2 and beyond, and we know we are going for in place assignment,
       // then we can optimize the iterator to skip key / value / headers since they would not be used at all
       val recordsIterator = if (inPlaceAssignment && firstBatch.magic >= RecordBatch.MAGIC_VALUE_V2)
-        batch.skipKeyValueIterator(BufferSupplier.NO_CACHING)
+        batch.skipKeyValueIterator(BufferSupplier.SINGLETON)
       else
-        batch.streamingIterator(BufferSupplier.NO_CACHING)
+        batch.streamingIterator(BufferSupplier.SINGLETON)
 
       try {
         val recordErrors = new ArrayBuffer[ApiRecordError](0)


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-10433

It is hot method so reusing the ByteBuffer can reduce a bunch of memory usage if the compression type supports BufferSupplier.

**experiment**
- duration: 1 minute
- compression: LZ4
- workload: 10 producers -> 1 broker 
- memory usage of byte array allocation: 4.52 GB -> 0.68 GB

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
