### PR TITLE
KAFKA-10431: Sequential selection of payload in ProducerPerformance

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -126,6 +126,8 @@ public class ProducerPerformance {
 
             int currentTransactionSize = 0;
             long transactionStartTime = 0;
+            int currentIndex = 0;
+            int totalPayloadSize = payloadByteList.size();
             for (long i = 0; i < numRecords; i++) {
                 if (transactionsEnabled && currentTransactionSize == 0) {
                     producer.beginTransaction();
@@ -134,7 +136,8 @@ public class ProducerPerformance {
 
 
                 if (payloadFilePath != null) {
-                    payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
+                    payload = payloadByteList.get(currentIndex++);
+                    currentIndex = currentIndex == totalPayloadSize ? 0 : currentIndex;
                 }
                 record = new ProducerRecord<>(topicName, payload);
 
@@ -228,7 +231,7 @@ public class ProducerPerformance {
                 .metavar("PAYLOAD-FILE")
                 .dest("payloadFile")
                 .help("file to read the message payloads from. This works only for UTF-8 encoded text files. " +
-                        "Payloads will be read from this file and a payload will be randomly selected when sending messages. " +
+                        "Payloads will be read from this file and be sequentially and circularly selected when sending messages. " +
                         "Note that you must provide exactly one of --record-size or --payload-file.");
 
         parser.addArgument("--payload-delimiter")


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10431

Currently, ProducerPerformance randomly selects a payload from the payload file when sending message. This might cause the some payloads being selected more times than others. It's better to do sequential selection of payloads.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
