### PR TITLE
KAFKA-10444: Jenkinsfile testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,16 +34,12 @@ void setBuildStatus(String context, String message, String state) {
     ]);
 }
 
-void doValidation(String scalaVersion) {
-  echo "Scala Version: ${scalaVersion}"
-  environment {
-    SCALA_VERSION = scalaVersion
-  }
+def doValidation() {
   sh '''
     ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-      spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-      --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \
-      || { echo 'Validation steps failed'; exit 1; }
+        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+        --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \
+        || { echo 'Validation steps failed'; exit 1; }
   '''
 }
 
@@ -56,9 +52,12 @@ pipeline {
 	  tools {
 	    jdk 'JDK 1.8 (latest)'
 	  }
+          environment {
+            SCALA_VERSION=2.12
+          }
 	  steps {
 	    sh 'gradle -version'
-	    doValidation('2.12')
+	    doValidation()
 	  }
 	}
 
@@ -66,9 +65,12 @@ pipeline {
 	  tools {
 	    jdk 'JDK 11 (latest)'
 	  }
+          environment {
+            SCALA_VERSION=2.13
+          }
 	  steps {
 	    sh 'gradle -version'
-	    doValidation('2.13')
+	    doValidation()
 	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
 	  }
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,34 +80,32 @@ pipeline {
     stage('Build') {
       parallel {
 	stage('JDK 8') {
-          node {
-	    ools {
-	      jdk 'JDK 1.8 (latest)'
-	    }
-	    environment {
-	      SCALA_VERSION=2.12
-	    }
-	    steps {
-	      sh 'gradle -version'
-	      doValidation()
-	    }
-          }
+          agent { label 'ubuntu' }
+	  tools {
+	    jdk 'JDK 1.8 (latest)'
+	  }
+	  environment {
+	    SCALA_VERSION=2.12
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    doValidation()
+	  }
 	}
 
 	stage('JDK 11') {
-          node {
-	    tools {
-	      jdk 'JDK 11 (latest)'
-	    }
-	    environment {
-	      SCALA_VERSION=2.13
-	    }
-	    steps {
-	      sh 'gradle -version'
-	      doValidation()
-	      // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
-	    }
-          }
+          agent { label 'ubuntu' }
+	  tools {
+	    jdk 'JDK 11 (latest)'
+	  }
+	  environment {
+	    SCALA_VERSION=2.13
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    doValidation()
+	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
+	  }
 	}
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,6 +90,7 @@ pipeline {
 	  steps {
 	    sh 'gradle -version'
 	    doValidation()
+            doTest()
 	  }
 	  post {
 	    always {
@@ -109,6 +110,7 @@ pipeline {
 	  steps {
 	    sh 'gradle -version'
 	    doValidation()
+            doTest()
 	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
 	  }
 	  post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
-            pullRequest.createStatus status: 'SUCCESS', context: 'JDK 11 build', description: 'Does this work?'
+            pullRequest.createStatus('SUCCESS', 'JDK 11 build', 'Does this work?')
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
       matrix {
         agent { label 'ubuntu' }
         tools {
-          jdk "$JDK (latest)"
+          jdk "${JDK} (latest)"
         }
 	environment {
 	  SCALA_VERSION = "$SCALA"
@@ -105,6 +105,16 @@ pipeline {
             axis {
               name 'SCALA'
               values '2.12'
+            }
+          }
+          exclude {
+            axis {
+              name 'JDK'
+              values 'JDK 1.8'
+            }
+            axis {
+              name 'SCALA'
+              values '2.13'
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
 	  }
 	  steps {
             setupGradle()
-	    doValidation()
+            doValidation()
             doTest()
             tryStreamsArchetype()
 	  }
@@ -153,7 +153,7 @@ pipeline {
 	  }
 	  steps {
             setupGradle()
-	    doValidation()
+            doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 11'
 	  }
@@ -181,7 +181,7 @@ pipeline {
 	  }
 	  steps {
             setupGradle()
-	    doValidation()
+            doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 14'
 	  }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,30 @@ pipeline {
   agent { label 'ubuntu' }
   stages {
     stage('build') {
+      // First step
       steps {
-        sh 'gradle -version' 
+        echo 'start'
+      }
+
+      // Do some parallel stuff
+      parallel {
+        stage('JDK 8') {
+          tools {
+	    jdk 'JDK 1.8 (latest)'
+	  }
+	  steps {
+            sh 'gradle -version'
+          }
+        }
+
+        stage('JDK 11') {
+          tools {
+	    jdk 'JDK 1.11 (latest)'
+	  }
+	  steps {
+            sh 'gradle -version'
+          }
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,9 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
-            pullRequest.createStatus('SUCCESS', 'JDK 11 build', 'Does this work?')
+            script {
+              pullRequest.createStatus('SUCCESS', 'JDK 11 build', 'Does this work?')
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,31 +74,6 @@ def doTest() {
   '''
 }
 
-
-def makeStage(String jdk, String scala) {
-  return {
-    stage(jdk) {
-      agent { label 'ubuntu' }
-      tools {
-	jdk '${jdk} (latest)'
-      }
-      environment {
-	SCALA_VERSION=scala
-      }
-      steps {
-	sh 'gradle -version'
-	doValidation()
-	doTest()
-      }
-      post {
-	always {
-	  junit '**/build/test-results/**/TEST-*.xml'
-	}
-      }
-    }
-  }
-}
-
 pipeline {
   agent none
   stages {
@@ -136,7 +111,6 @@ pipeline {
 	    sh 'gradle -version'
 	    doValidation()
             doTest()
-	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
 	  }
 	  post {
 	    always {
@@ -145,7 +119,25 @@ pipeline {
 	  }
 	}
        
-        makeStage("JDK 14", "2.13")
+	stage('JDK 14') {
+          agent { label 'ubuntu' }
+	  tools {
+	    jdk 'JDK 14 (latest)'
+	  }
+	  environment {
+	    SCALA_VERSION=2.13
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    doValidation()
+            doTest()
+	  }
+	  post {
+	    always {
+	      junit '**/build/test-results/**/TEST-*.xml'
+	    }
+	  }
+	}
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,8 +59,8 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
+	    setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
           }
-	  setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ def doValidation() {
   try {
     sh '''
       ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-        --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\"
+          spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+          --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\"
     '''
   } catch(err) {
     error('Validation checks failed, aborting this build')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
       matrix {
         agent { label 'ubuntu' }
         tools {
-          jdk "${JDK} (latest)"
+          jdk "$JDK (latest)"
         }
 	environment {
 	  SCALA_VERSION = "$SCALA"
@@ -105,16 +105,6 @@ pipeline {
             axis {
               name 'SCALA'
               values '2.12'
-            }
-          }
-          exclude {
-            axis {
-              name 'JDK'
-              values 'JDK 1.8'
-            }
-            axis {
-              name 'SCALA'
-              values '2.13'
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@
 def setupGradle() {
   // Delete gradle cache to workaround cache corruption bugs, see KAFKA-3167
   dir('.gradle') {
-    deleteDir
+    deleteDir()
   }
   sh './gradlew -version'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,9 @@ pipeline {
   agent { label 'ubuntu' }
   stages {
     stage('build') {
-      sh 'gradle -version' 
+      steps {
+        sh 'gradle -version' 
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,12 @@
 pipeline {
   agent { label 'ubuntu' }
   stages {
-    stage('build') {
-      // First step
+    stage('pre') {
       steps {
         echo 'start'
       }
-
-      // Do some parallel stuff
+    }
+    stage('build') {
       parallel {
         stage('JDK 8') {
           tools {
@@ -20,12 +19,17 @@ pipeline {
 
         stage('JDK 11') {
           tools {
-	    jdk 'JDK 1.11 (latest)'
+	    jdk 'JDK 11 (latest)'
 	  }
 	  steps {
             sh 'gradle -version'
           }
         }
+      }
+    }
+    stage('post') {
+      steps {
+        echo 'finish'
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ def doValidation() {
   try {
     sh '''
       ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-	  spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-	  --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\"
+        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+        --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\"
     '''
   } catch(err) {
     error('Validation checks failed, aborting this build')
@@ -41,7 +41,7 @@ def doTest() {
   try {
     sh '''
       ./gradlew -PscalaVersion=$SCALA_VERSION unitTest integrationTest \
-	  --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@"
+          --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@"
     '''
   } catch(err) {
     echo 'Some tests failed, marking this build UNSTABLE'
@@ -65,31 +65,31 @@ def doStreamsArchetype() {
   dir('streams/quickstart') {
     sh '''
       mvn clean install -Dgpg.skip  \
-	  || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
+          || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
     '''
 
     sh '''
       mkdir test-streams-archetype && cd test-streams-archetype \
-	  || { echo 'Could not create test directory for stream quickstart archetype'; exit 1; }
+          || { echo 'Could not create test directory for stream quickstart archetype'; exit 1; }
     '''
 
     sh '''
       echo "Y" | mvn archetype:generate \
-	  -DarchetypeCatalog=local \
-	  -DarchetypeGroupId=org.apache.kafka \
-	  -DarchetypeArtifactId=streams-quickstart-java \
-	  -DarchetypeVersion=$version \
-	  -DgroupId=streams.examples \
-	  -DartifactId=streams.examples \
-	  -Dversion=0.1 \
-	  -Dpackage=myapps \
-	  || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
+          -DarchetypeCatalog=local \
+          -DarchetypeGroupId=org.apache.kafka \
+          -DarchetypeArtifactId=streams-quickstart-java \
+          -DarchetypeVersion=$version \
+          -DgroupId=streams.examples \
+          -DartifactId=streams.examples \
+          -Dversion=0.1 \
+          -Dpackage=myapps \
+          || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
     '''
 
     dir('streams.examples') {
       sh '''
-	mvn compile \
-	    || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
+        mvn compile \
+            || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
       '''
     }
   }
@@ -110,90 +110,90 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-	stage('JDK 8') {
+        stage('JDK 8') {
           agent { label 'ubuntu' }
-	  tools {
-	    jdk 'JDK 1.8 (latest)'
+          tools {
+            jdk 'JDK 1.8 (latest)'
             maven 'Maven 3.6.3'
-	  }
+          }
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
           }
-	  environment {
-	    SCALA_VERSION=2.12
-	  }
-	  steps {
+          environment {
+            SCALA_VERSION=2.12
+          }
+          steps {
             setupGradle()
             doValidation()
             doTest()
             tryStreamsArchetype()
-	  }
-	  post {
-	    success {
-	      junit '**/build/test-results/**/TEST-*.xml'
-	    }
-	    unstable {
-	      junit '**/build/test-results/**/TEST-*.xml'
-	    }
-	  }
-	}
+          }
+          post {
+            success {
+              junit '**/build/test-results/**/TEST-*.xml'
+            }
+            unstable {
+              junit '**/build/test-results/**/TEST-*.xml'
+            }
+          }
+        }
 
-	stage('JDK 11') {
+        stage('JDK 11') {
           agent { label 'ubuntu' }
-	  tools {
-	    jdk 'JDK 11 (latest)'
-	  }
+          tools {
+            jdk 'JDK 11 (latest)'
+          }
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
           }
-	  environment {
-	    SCALA_VERSION=2.13
-	  }
-	  steps {
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
             setupGradle()
             doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 11'
-	  }
-	  post {
-	    success {
-	      junit '**/build/test-results/**/TEST-*.xml'
-	    }
-	    unstable {
-	      junit '**/build/test-results/**/TEST-*.xml'
-	    }
-	  }
-	}
+          }
+          post {
+            success {
+              junit '**/build/test-results/**/TEST-*.xml'
+            }
+            unstable {
+              junit '**/build/test-results/**/TEST-*.xml'
+            }
+          }
+        }
        
-	stage('JDK 14') {
+        stage('JDK 14') {
           agent { label 'ubuntu' }
-	  tools {
-	    jdk 'JDK 14 (latest)'
-	  }
+          tools {
+            jdk 'JDK 14 (latest)'
+          }
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
           }
-	  environment {
-	    SCALA_VERSION=2.13
-	  }
-	  steps {
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
             setupGradle()
             doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 14'
-	  }
-	  post {
-	    success {
-	      junit '**/build/test-results/**/TEST-*.xml'
-	    }
-	    unstable {
-	      junit '**/build/test-results/**/TEST-*.xml'
-	    }
-	  }
-	}
+          }
+          post {
+            success {
+              junit '**/build/test-results/**/TEST-*.xml'
+            }
+            unstable {
+              junit '**/build/test-results/**/TEST-*.xml'
+            }
+          }
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,8 +74,10 @@ def doTest() {
   '''
 }
 
-def doStreamsTests() {
+def doStreamsArchetype() {
   // Verify that Kafka Streams archetype compiles
+  echo 'Verify that Kafka Streams archetype compiles'
+
   sh '''
     ./gradlew streams:install clients:install connect:json:install connect:api:install \
          || { echo 'Could not install kafka-streams.jar (and dependencies) locally`'; exit 1; }
@@ -109,15 +111,15 @@ def doStreamsTests() {
 	  -Dpackage=myapps \
 	  || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
     '''
+
+    dir('streams.examples') {
+      sh '''
+	mvn compile \
+	    || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
+      '''
+    }
   }
   
-  dir('streams.examples') {
-    sh '''
-      mvn compile \
-          || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
-    '''
-
-  }
 }
 
 pipeline {
@@ -141,7 +143,7 @@ pipeline {
 	    sh 'gradle -version'
 	    //doValidation()
             //doTest()
-            doStreamsTests()
+            doStreamsArchetype()
 	  }
 	  post {
 	    always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,12 +54,16 @@ void setBuildStatus(String context, String message, String state) {
 }
 
 def doValidation() {
-  sh '''
-    ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-        --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \
-        || { echo 'Validation steps failed'; exit 1; }
-  '''
+  try {
+    sh '''
+      ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
+	  spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+	  --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \
+	  || { echo 'Validation steps failed'; exit 1; }
+    '''
+  } catch(err) {
+    error('Validation checks failed')
+  }
 }
 
 def doTest() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
 	  }
 	  steps {
 	    sh 'gradle -version'
-	    validation('2.12')
+	    doValidation('2.12')
 	  }
 	}
 
@@ -68,7 +68,7 @@ pipeline {
 	  }
 	  steps {
 	    sh 'gradle -version'
-	    validation('2.13')
+	    doValidation('2.13')
 	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
 	  }
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,14 @@
  *
  */
 
+def setupGradle() {
+  // Delete gradle cache to workaround cache corruption bugs, see KAFKA-3167
+  dir('.gradle') {
+    deleteDir
+  }
+  sh './gradlew -version'
+}
+
 def doValidation() {
   try {
     sh '''
@@ -116,7 +124,7 @@ pipeline {
 	    SCALA_VERSION=2.12
 	  }
 	  steps {
-	    sh 'gradle -version'
+            setupGradle()
 	    doValidation()
             doTest()
             tryStreamsArchetype()
@@ -144,7 +152,7 @@ pipeline {
 	    SCALA_VERSION=2.13
 	  }
 	  steps {
-	    sh 'gradle -version'
+            setupGradle()
 	    doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 11'
@@ -172,7 +180,7 @@ pipeline {
 	    SCALA_VERSION=2.13
 	  }
 	  steps {
-	    sh 'gradle -version'
+            setupGradle()
 	    doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 14'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,25 +49,29 @@ void doValidation(String scalaVersion) {
 
 pipeline {
   agent { label 'ubuntu' }
-  parallel {
-    stage('JDK 8') {
-      tools {
-	jdk 'JDK 1.8 (latest)'
-      }
-      steps {
-	sh 'gradle -version'
-	validation('2.12')
-      }
-    }
+  stages {
+    stage('Build') {
+      parallel {
+	stage('JDK 8') {
+	  tools {
+	    jdk 'JDK 1.8 (latest)'
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    validation('2.12')
+	  }
+	}
 
-    stage('JDK 11') {
-      tools {
-	jdk 'JDK 11 (latest)'
-      }
-      steps {
-	sh 'gradle -version'
-	validation('2.13')
-	// setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
+	stage('JDK 11') {
+	  tools {
+	    jdk 'JDK 11 (latest)'
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    validation('2.13')
+	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
+	  }
+	}
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,8 @@
+pipeline {
+  agent { label 'ubuntu' }
+  stages {
+    stage('build') {
+      sh 'gradle -version' 
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,30 +80,34 @@ pipeline {
     stage('Build') {
       parallel {
 	stage('JDK 8') {
-	  tools {
-	    jdk 'JDK 1.8 (latest)'
-	  }
-          environment {
-            SCALA_VERSION=2.12
+          node {
+	    ools {
+	      jdk 'JDK 1.8 (latest)'
+	    }
+	    environment {
+	      SCALA_VERSION=2.12
+	    }
+	    steps {
+	      sh 'gradle -version'
+	      doValidation()
+	    }
           }
-	  steps {
-	    sh 'gradle -version'
-	    doValidation()
-	  }
 	}
 
 	stage('JDK 11') {
-	  tools {
-	    jdk 'JDK 11 (latest)'
-	  }
-          environment {
-            SCALA_VERSION=2.13
+          node {
+	    tools {
+	      jdk 'JDK 11 (latest)'
+	    }
+	    environment {
+	      SCALA_VERSION=2.13
+	    }
+	    steps {
+	      sh 'gradle -version'
+	      doValidation()
+	      // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
+	    }
           }
-	  steps {
-	    sh 'gradle -version'
-	    doValidation()
-	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
-	  }
 	}
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,6 +135,8 @@ pipeline {
 	  }
           options {
             timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+            ansiColor('xterm')
           }
 	  environment {
 	    SCALA_VERSION=2.12
@@ -166,7 +168,7 @@ pipeline {
 	  steps {
 	    sh 'gradle -version'
 	    doValidation()
-            doTest()
+            //doTest()
             echo 'Skipping Kafka Streams archetype test for Java 11'
 	  }
 	  post {
@@ -190,7 +192,7 @@ pipeline {
 	  steps {
 	    sh 'gradle -version'
 	    doValidation()
-            doTest()
+            //doTest()
             echo 'Skipping Kafka Streams archetype test for Java 14'
 	  }
 	  post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,31 +26,18 @@ def setupGradle() {
 }
 
 def doValidation() {
-  def ret = sh script: '''
-      ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
-          spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-          --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\"
-    ''', returnStatus: true
-  if (ret == 143) {
-    echo 'Got a SIGTERM'
-    currentBuild.result = 'ABORTED'
-  } else if (ret != 0) {
-    echo 'Validation checks failed, aborting this build'
-    currentBuild.result = 'FAILURE'
-  }
-  sh 'exit ${ret}'
+  sh '''
+    ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
+        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+        --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\"
+  '''
 }
 
 def doTest() {
-  try {
-    sh '''
-      ./gradlew -PscalaVersion=$SCALA_VERSION unitTest integrationTest \
-          --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@"
-    '''
-  } catch(err) {
-    echo 'Some tests failed, marking this build UNSTABLE'
-    currentBuild.result = 'UNSTABLE'
-  }
+  sh '''
+    ./gradlew -PscalaVersion=$SCALA_VERSION unitTest integrationTest \
+        --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed -PignoreFailures=true "$@"
+  '''
 }
 
 def doStreamsArchetype() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
-            githubNotify context: 'JDK 11 build', description: 'Does this work?',  status: 'SUCCESS'
+            setGitHubPullRequestStatus context: 'JDK 11 build', message: 'Does this work?', state: 'SUCCESS'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
+            githubNotify context: 'JDK 11 build', description: 'Does this work?',  status: 'SUCCESS'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ def doTest() {
     ./gradlew -PscalaVersion=$SCALA_VERSION unitTest integrationTest \
         --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed -PignoreFailures=true "$@"
   '''
+  junit '**/build/test-results/**/TEST-*.xml'
 }
 
 def doStreamsArchetype() {
@@ -120,14 +121,6 @@ pipeline {
             doTest()
             tryStreamsArchetype()
           }
-          post {
-            success {
-              junit '**/build/test-results/**/TEST-*.xml'
-            }
-            unstable {
-              junit '**/build/test-results/**/TEST-*.xml'
-            }
-          }
         }
 
         stage('JDK 11') {
@@ -148,14 +141,6 @@ pipeline {
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 11'
           }
-          post {
-            success {
-              junit '**/build/test-results/**/TEST-*.xml'
-            }
-            unstable {
-              junit '**/build/test-results/**/TEST-*.xml'
-            }
-          }
         }
        
         stage('JDK 14') {
@@ -175,14 +160,6 @@ pipeline {
             doValidation()
             doTest()
             echo 'Skipping Kafka Streams archetype test for Java 14'
-          }
-          post {
-            success {
-              junit '**/build/test-results/**/TEST-*.xml'
-            }
-            unstable {
-              junit '**/build/test-results/**/TEST-*.xml'
-            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,9 @@ pipeline {
 	    jdk 'JDK 1.8 (latest)'
             maven 'Maven 3.6.3'
 	  }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+          }
 	  environment {
 	    SCALA_VERSION=2.12
 	  }
@@ -152,6 +155,9 @@ pipeline {
 	  tools {
 	    jdk 'JDK 11 (latest)'
 	  }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+          }
 	  environment {
 	    SCALA_VERSION=2.13
 	  }
@@ -173,6 +179,9 @@ pipeline {
 	  tools {
 	    jdk 'JDK 14 (latest)'
 	  }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+          }
 	  environment {
 	    SCALA_VERSION=2.13
 	  }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,23 +75,25 @@ def doTest() {
 }
 
 
-def buildStage(String jdk, String scala) {
-  stage(jdk) {
-    agent { label 'ubuntu' }
-    tools {
-      jdk '${jdk} (latest)'
-    }
-    environment {
-      SCALA_VERSION=scala
-    }
-    steps {
-      sh 'gradle -version'
-      doValidation()
-      doTest()
-    }
-    post {
-      always {
-	junit '**/build/test-results/**/TEST-*.xml'
+def makeStage(String jdk, String scala) {
+  return {
+    stage(jdk) {
+      agent { label 'ubuntu' }
+      tools {
+	jdk '${jdk} (latest)'
+      }
+      environment {
+	SCALA_VERSION=scala
+      }
+      steps {
+	sh 'gradle -version'
+	doValidation()
+	doTest()
+      }
+      post {
+	always {
+	  junit '**/build/test-results/**/TEST-*.xml'
+	}
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
-            setGitHubPullRequestStatus context: 'JDK 11 build', message: 'Does this work?', state: 'SUCCESS'
+            pullRequest.createStatus status: 'SUCCESS', context: 'JDK 11 build', description: 'Does this work?'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,11 +91,9 @@ def doStreamsTests() {
         || { echo 'Could not change into directory `streams/quickstart`'; exit 1; }
   '''
 
-  // variable $MAVEN_LATEST__HOME is provided by Jenkins (see build configuration)
-  sh 'mvn=$MAVEN_LATEST__HOME/bin/mvn'
 
   sh '''
-    $mvn clean install -Dgpg.skip  \
+    mvn clean install -Dgpg.skip  \
         || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
   '''
 
@@ -105,7 +103,7 @@ def doStreamsTests() {
   '''
 
   sh '''
-    echo "Y" | $mvn archetype:generate \
+    echo "Y" | mvn archetype:generate \
 	-DarchetypeCatalog=local \
 	-DarchetypeGroupId=org.apache.kafka \
 	-DarchetypeArtifactId=streams-quickstart-java \
@@ -123,7 +121,7 @@ def doStreamsTests() {
   '''
 
   sh '''
-    $mvn compile \
+    mvn compile \
         || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
   '''
 }
@@ -137,14 +135,15 @@ pipeline {
           agent { label 'ubuntu' }
 	  tools {
 	    jdk 'JDK 1.8 (latest)'
+            maven 'Maven 3.6.3'
 	  }
 	  environment {
 	    SCALA_VERSION=2.12
 	  }
 	  steps {
 	    sh 'gradle -version'
-	    doValidation()
-            doTest()
+	    //doValidation()
+            //doTest()
             doStreamsTests()
 	  }
 	  post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
 	  steps {
 	    sh 'gradle -version'
 	    doValidation()
-            //doTest()
+            doTest()
             doStreamsTests()
 	  }
 	  post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,51 +78,47 @@ pipeline {
   agent none
   stages {
     stage('Build') {
-      matrix {
-        agent { label 'ubuntu' }
-        tools {
-          jdk "$JDK (latest)"
-        }
-	environment {
-	  SCALA_VERSION = "$SCALA"
+      parallel {
+	stage('JDK 8') {
+          agent { label 'ubuntu' }
+	  tools {
+	    jdk 'JDK 1.8 (latest)'
+	  }
+	  environment {
+	    SCALA_VERSION=2.12
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    doValidation()
+            doTest()
+	  }
+	  post {
+	    always {
+	      junit '**/build/test-results/**/TEST-*.xml'
+	    }
+	  }
 	}
-        axes {
-          axis {
-            name 'JDK'
-            values 'JDK 1.8', 'JDK 11', 'JDK 14'
-          }
-          axis {
-            name 'SCALA'
-            values '2.12', '2.13'
-          }
-        }
-        excludes {
-          exclude {
-            axis {
-              name 'JDK'
-              values 'JDK 11', 'JDK 14'
-            }
-            axis {
-              name 'SCALA'
-              values '2.12'
-            }
-          }
-        }
-        stages {
-          stage("BuildVersion") {
-	    steps {
-	      sh 'gradle -version'
-	      doValidation()
-	      doTest()
-	      // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
+
+	stage('JDK 11') {
+          agent { label 'ubuntu' }
+	  tools {
+	    jdk 'JDK 11 (latest)'
+	  }
+	  environment {
+	    SCALA_VERSION=2.13
+	  }
+	  steps {
+	    sh 'gradle -version'
+	    doValidation()
+            doTest()
+	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
+	  }
+	  post {
+	    always {
+	      junit '**/build/test-results/**/TEST-*.xml'
 	    }
-	    post {
-	      always {
-		junit '**/build/test-results/**/TEST-*.xml'
-	      }
-	    }
-          }
-        }
+	  }
+	}
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,39 @@
+def getRepoURL() {
+  sh "git config --get remote.origin.url > .git/remote-url"
+  return readFile(".git/remote-url").trim()
+}
+
+def getCommitSha() {
+  sh "git rev-parse HEAD > .git/current-commit"
+  return readFile(".git/current-commit").trim()
+}
+
+void setBuildStatus(String context, String message, String state) {
+    // workaround https://issues.jenkins-ci.org/browse/JENKINS-38674
+    repoUrl = getRepoURL()
+    commitSha = getCommitSha()
+
+    echo "Setting status ${repoUrl}:${commitSha} :: ${context} -> ${state} -- ${message}"
+    echo "scm.branches: ${scm.branches}"
+    echo "scm: ${scm}"
+    step([
+        $class: "GitHubCommitStatusSetter",
+        // Repo needs to be manually specified because it tries to set
+        // status on jenkins-common as well -- anything in context --
+        // if we aren't specific
+        reposSource: [$class: "ManuallyEnteredRepositorySource", url: repoUrl],
+        // SHA needs to be manually specified because git commit info
+        // isn't available via standard env vars, and statuses might
+        // be set before we do the Jenkinsfile-based SCM checkout step
+        // that gets commit info.
+        commitShaSource: [$class: "ManuallyEnteredShaSource", sha: commitSha],
+        // Log errors, default just swallows without logging anything
+        errorHandlers: [[$class: 'ShallowAnyErrorHandler']],
+        contextSource: [$class: "ManuallyEnteredCommitContextSource", context: context],
+        statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
 pipeline {
   agent { label 'ubuntu' }
   stages {
@@ -23,10 +59,8 @@ pipeline {
 	  }
 	  steps {
             sh 'gradle -version'
-            script {
-              pullRequest.createStatus('SUCCESS', 'JDK 11 build', 'Does this work?')
-            }
           }
+	  setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,10 +36,15 @@ void setBuildStatus(String context, String message, String state) {
 
 void doValidation(String scalaVersion) {
   echo "Scala Version: ${scalaVersion}"
-  sh "./gradlew -PscalaVersion=${scalaVersion} clean compileJava compileScala compileTestJava compileTestScala \
-    spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
-    --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \
-    || { echo 'Validation steps failed'; exit 1; }"
+  environment {
+    SCALA_VERSION = scalaVersion
+  }
+  sh '''
+    ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
+      spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+      --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \
+      || { echo 'Validation steps failed'; exit 1; }
+  '''
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,29 @@ def doTest() {
   '''
 }
 
+
+def buildStage(String jdk, String scala) {
+  stage(jdk) {
+    agent { label 'ubuntu' }
+    tools {
+      jdk '${jdk} (latest)'
+    }
+    environment {
+      SCALA_VERSION=scala
+    }
+    steps {
+      sh 'gradle -version'
+      doValidation()
+      doTest()
+    }
+    post {
+      always {
+	junit '**/build/test-results/**/TEST-*.xml'
+      }
+    }
+  }
+}
+
 pipeline {
   agent none
   stages {
@@ -119,6 +142,8 @@ pipeline {
 	    }
 	  }
 	}
+       
+        makeStage("JDK 14", "2.13")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,8 @@ void setBuildStatus(String context, String message, String state) {
     ]);
 }
 
-def validation(String scalaVersion) {
+void doValidation(String scalaVersion) {
+  echo "Scala Version: ${scalaVersion}"
   sh "./gradlew -PscalaVersion=${scalaVersion} clean compileJava compileScala compileTestJava compileTestScala \
     spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
     --profile --no-daemon --continue -PxmlSpotBugsReport=true \"$@\" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,29 +49,25 @@ void doValidation(String scalaVersion) {
 
 pipeline {
   agent { label 'ubuntu' }
-  stages {
-    stage {
-      parallel {
-        stage('JDK 8') {
-          tools {
-	    jdk 'JDK 1.8 (latest)'
-	  }
-	  steps {
-            sh 'gradle -version'
-            validation('2.12')
-          }
-        }
+  parallel {
+    stage('JDK 8') {
+      tools {
+	jdk 'JDK 1.8 (latest)'
+      }
+      steps {
+	sh 'gradle -version'
+	validation('2.12')
+      }
+    }
 
-        stage('JDK 11') {
-          tools {
-	    jdk 'JDK 11 (latest)'
-	  }
-	  steps {
-            sh 'gradle -version'
-            validation('2.13')
-	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
-          }
-        }
+    stage('JDK 11') {
+      tools {
+	jdk 'JDK 11 (latest)'
+      }
+      steps {
+	sh 'gradle -version'
+	validation('2.13')
+	// setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,44 +86,38 @@ def doStreamsTests() {
         || { echo 'Could not get version from `gradle.properties`'; exit 1; }
   '''
 
-  sh '''
-    cd streams/quickstart \
-        || { echo 'Could not change into directory `streams/quickstart`'; exit 1; }
-  '''
+  dir('streams/quickstart') {
+    sh '''
+      mvn clean install -Dgpg.skip  \
+	  || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
+    '''
 
+    sh '''
+      mkdir test-streams-archetype && cd test-streams-archetype \
+	  || { echo 'Could not create test directory for stream quickstart archetype'; exit 1; }
+    '''
 
-  sh '''
-    mvn clean install -Dgpg.skip  \
-        || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
-  '''
+    sh '''
+      echo "Y" | mvn archetype:generate \
+	  -DarchetypeCatalog=local \
+	  -DarchetypeGroupId=org.apache.kafka \
+	  -DarchetypeArtifactId=streams-quickstart-java \
+	  -DarchetypeVersion=$version \
+	  -DgroupId=streams.examples \
+	  -DartifactId=streams.examples \
+	  -Dversion=0.1 \
+	  -Dpackage=myapps \
+	  || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
+    '''
+  }
+  
+  dir('streams.examples') {
+    sh '''
+      mvn compile \
+          || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
+    '''
 
-  sh '''
-    mkdir test-streams-archetype && cd test-streams-archetype \
-        || { echo 'Could not create test directory for stream quickstart archetype'; exit 1; }
-  '''
-
-  sh '''
-    echo "Y" | mvn archetype:generate \
-	-DarchetypeCatalog=local \
-	-DarchetypeGroupId=org.apache.kafka \
-	-DarchetypeArtifactId=streams-quickstart-java \
-	-DarchetypeVersion=$version \
-	-DgroupId=streams.examples \
-	-DartifactId=streams.examples \
-	-Dversion=0.1 \
-	-Dpackage=myapps \
-	|| { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
-  '''
-
-  sh '''
-    cd streams.examples \
-        || { echo 'Could not change into directory `streams.examples`'; exit 1; }
-  '''
-
-  sh '''
-    mvn compile \
-        || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
-  '''
+  }
 }
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ def doTest() {
 }
 
 pipeline {
-  agent { label 'ubuntu' }
+  agent none
   stages {
     stage('Build') {
       parallel {
@@ -90,6 +90,11 @@ pipeline {
 	  steps {
 	    sh 'gradle -version'
 	    doValidation()
+	  }
+	  post {
+	    always {
+	      junit '**/build/test-results/**/TEST-*.xml'
+	    }
 	  }
 	}
 
@@ -106,13 +111,13 @@ pipeline {
 	    doValidation()
 	    // setBuildStatus("continuous-integration/jenkins/test-check-1", "Check is running", "PENDING")
 	  }
+	  post {
+	    always {
+	      junit '**/build/test-results/**/TEST-*.xml'
+	    }
+	  }
 	}
       }
-    }
-  }
-  post {
-    always {
-      junit '**/build/test-results/**/TEST-*.xml'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,22 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
 def getRepoURL() {
   sh "git config --get remote.origin.url > .git/remote-url"
   return readFile(".git/remote-url").trim()
@@ -43,6 +62,14 @@ def doValidation() {
   '''
 }
 
+def doTest() {
+  sh '''
+    ./gradlew -PscalaVersion=$SCALA_VERSION unitTest integrationTest \
+        --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed "$@" \
+        || { echo 'Test steps failed'; exit 1; }
+  '''
+}
+
 pipeline {
   agent { label 'ubuntu' }
   stages {
@@ -75,6 +102,11 @@ pipeline {
 	  }
 	}
       }
+    }
+  }
+  post {
+    always {
+      junit '**/build/test-results/**/TEST-*.xml'
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The following options should be set with a `-P` switch, for example `./gradlew -
 * `commitId`: sets the build commit ID as .git/HEAD might not be correct if there are local commits added for build purposes.
 * `mavenUrl`: sets the URL of the maven deployment repository (`file://path/to/repo` can be used to point to a local repository).
 * `maxParallelForks`: limits the maximum number of processes for each task.
+* `ignoreFailures`: ignore test failures from junit
 * `showStandardStreams`: shows standard out and standard error of the test JVM(s) on the console.
 * `skipSigning`: skips signing of artifacts.
 * `testLoggingEvents`: unit test events to be logged, separated by comma. For example `./gradlew -PtestLoggingEvents=started,passed,skipped,failed test`.

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ ext {
   defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC"]
 
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
+  userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false
 
   userMaxTestRetries = project.hasProperty('maxTestRetries') ? maxTestRetries.toInteger() : 0
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
@@ -336,6 +337,7 @@ subprojects {
 
   task integrationTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs
@@ -364,6 +366,7 @@ subprojects {
 
   task unitTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package kafka.server
+kafka.server
 
 import java.io.{File, IOException}
 import java.net.{InetAddress, SocketTimeoutException}

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -1,19 +1,3 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 package kafka.server
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package kafka.server
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-kafka.server
+package kafka.server
 
 import java.io.{File, IOException}
 import java.net.{InetAddress, SocketTimeoutException}


### PR DESCRIPTION
This PR adds a Jenkinsfile to the build to replace the existing jenkins.sh script.

The build makes use of the `parallel` directive to run the JDK 8, 11, and 14 builds in parallel. Each build will report separate statuses here in Github like:

![image](https://user-images.githubusercontent.com/55116/91722487-51d10380-eb68-11ea-9c09-26736bcf8cd1.png)

Only users with write access to the repository (i.e., committers) will be able to modify Jenkinsfile through pull requests, otherwise the build will use the Jenkinsfile on the target branch.

Here's a build result showing our typical flaky tests https://ci-builds.apache.org/job/Kafka/job/kafka-pr/view/change-requests/job/PR-9226/57/#showFailuresLink