### PR TITLE
KAFKA-10445: Align IQ SessionStore API with Instant-based methods as ReadOnlyWindowStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadOnlyDecorator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadOnlyDecorator.java
@@ -246,8 +246,8 @@ abstract class AbstractReadOnlyDecorator<T extends StateStore, K, V> extends Wra
         }
 
         @Override
-        public AGG fetchSession(final K key, final long startTime, final long endTime) {
-            return wrapped().fetchSession(key, startTime, endTime);
+        public AGG fetchSession(final K key, final long sessionStartTime, final long sessionEndTime) {
+            return wrapped().fetchSession(key, sessionStartTime, sessionEndTime);
         }
 
         @Override
@@ -256,9 +256,9 @@ abstract class AbstractReadOnlyDecorator<T extends StateStore, K, V> extends Wra
         }
 
         @Override
-        public KeyValueIterator<Windowed<K>, AGG> fetch(final K from,
-                                                        final K to) {
-            return wrapped().fetch(from, to);
+        public KeyValueIterator<Windowed<K>, AGG> fetch(final K keyFrom,
+                                                        final K keyTo) {
+            return wrapped().fetch(keyFrom, keyTo);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractReadWriteDecorator.java
@@ -240,9 +240,9 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
 
         @Override
         public AGG fetchSession(final K key,
-                                final long startTime,
-                                final long endTime) {
-            return wrapped().fetchSession(key, startTime, endTime);
+                                final long sessionStartTime,
+                                final long sessionEndTime) {
+            return wrapped().fetchSession(key, sessionStartTime, sessionEndTime);
         }
 
         @Override
@@ -251,9 +251,9 @@ abstract class AbstractReadWriteDecorator<T extends StateStore, K, V> extends Wr
         }
 
         @Override
-        public KeyValueIterator<Windowed<K>, AGG> fetch(final K from,
-                                                        final K to) {
-            return wrapped().fetch(from, to);
+        public KeyValueIterator<Windowed<K>, AGG> fetch(final K keyFrom,
+                                                        final K keyTo) {
+            return wrapped().fetch(keyFrom, keyTo);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlySessionStore.java
@@ -40,7 +40,7 @@ public interface ReadOnlySessionStore<K, AGG> {
      * @param earliestSessionEndTime the end timestamp of the earliest session to search for
      * @param latestSessionStartTime the end timestamp of the latest session to search for
      * @return iterator of sessions with the matching key and aggregated values
-     * @throws NullPointerException If null is used for key.
+     * @throws NullPointerException if null is used for key.
      */
     KeyValueIterator<Windowed<K>, AGG> findSessions(final K key,
                                                     final Instant earliestSessionEndTime,
@@ -57,7 +57,7 @@ public interface ReadOnlySessionStore<K, AGG> {
      * @param earliestSessionEndTime the end timestamp of the earliest session to search for
      * @param latestSessionStartTime the end timestamp of the latest session to search for
      * @return iterator of sessions with the matching keys and aggregated values
-     * @throws NullPointerException If null is used for any key.
+     * @throws NullPointerException if null is used for any key.
      */
     KeyValueIterator<Windowed<K>, AGG> findSessions(final K keyFrom,
                                                     final K keyTo,
@@ -71,7 +71,7 @@ public interface ReadOnlySessionStore<K, AGG> {
      * @param sessionStartTime start timestamp of the session
      * @param sessionEndTime   end timestamp of the session
      * @return The value or {@code null} if no session associated with the key can be found
-     * @throws NullPointerException If {@code null} is used for any key.
+     * @throws NullPointerException if {@code null} is used for any key.
      */
     AGG fetchSession(final K key, final Instant sessionStartTime, final Instant sessionEndTime);
 
@@ -84,7 +84,7 @@ public interface ReadOnlySessionStore<K, AGG> {
      *
      * @param key record key to find aggregated session values for
      * @return KeyValueIterator containing all sessions for the provided key.
-     * @throws NullPointerException If null is used for key.
+     * @throws NullPointerException if null is used for key.
      */
     KeyValueIterator<Windowed<K>, AGG> fetch(final K key);
 
@@ -98,7 +98,7 @@ public interface ReadOnlySessionStore<K, AGG> {
      * @param keyFrom first key in the range to find aggregated session values for
      * @param keyTo   last key in the range to find aggregated session values for
      * @return KeyValueIterator containing all sessions for the provided key.
-     * @throws NullPointerException If null is used for any of the keys.
+     * @throws NullPointerException if null is used for any of the keys.
      */
     KeyValueIterator<Windowed<K>, AGG> fetch(final K keyFrom, final K keyTo);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/SessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/SessionStore.java
@@ -86,6 +86,7 @@ public interface SessionStore<K, AGG> extends StateStore, ReadOnlySessionStore<K
                                                     final long earliestSessionEndTime,
                                                     final long latestSessionStartTime);
 
+    @Override
     default KeyValueIterator<Windowed<K>, AGG> findSessions(final K keyFrom,
                                                             final K keyTo,
                                                             final Instant earliestSessionEndTime,
@@ -104,10 +105,11 @@ public interface SessionStore<K, AGG> extends StateStore, ReadOnlySessionStore<K
      * @param sessionStartTime start timestamp of the session
      * @param sessionEndTime   end timestamp of the session
      * @return The value or {@code null} if no session associated with the key can be found
-     * @throws NullPointerException If {@code null} is used for any key.
+     * @throws NullPointerException if {@code null} is used for any key.
      */
     AGG fetchSession(final K key, final long sessionStartTime, final long sessionEndTime);
 
+    @Override
     default AGG fetchSession(final K key, final Instant sessionStartTime, final Instant sessionEndTime) {
         return fetchSession(
             key,
@@ -119,7 +121,7 @@ public interface SessionStore<K, AGG> extends StateStore, ReadOnlySessionStore<K
      * Remove the session aggregated with provided {@link Windowed} key from the store
      *
      * @param sessionKey key of the session to remove
-     * @throws NullPointerException If null is used for sessionKey.
+     * @throws NullPointerException if null is used for sessionKey.
      */
     void remove(final Windowed<K> sessionKey);
 
@@ -129,7 +131,7 @@ public interface SessionStore<K, AGG> extends StateStore, ReadOnlySessionStore<K
      * @param sessionKey key of the session to write
      * @param aggregate  the aggregated value for the session, it can be null;
      *                   if the serialized bytes are also null it is interpreted as deletes
-     * @throws NullPointerException If null is used for sessionKey.
+     * @throws NullPointerException if null is used for sessionKey.
      */
     void put(final Windowed<K> sessionKey, final AGG aggregate);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingSessionStore.java
@@ -200,17 +200,17 @@ class CachingSessionStore
     }
 
     @Override
-    public byte[] fetchSession(final Bytes key, final long startTime, final long endTime) {
+    public byte[] fetchSession(final Bytes key, final long sessionStartTime, final long sessionEndTime) {
         Objects.requireNonNull(key, "key cannot be null");
         validateStoreOpen();
         if (context.cache() == null) {
-            return wrapped().fetchSession(key, startTime, endTime);
+            return wrapped().fetchSession(key, sessionStartTime, sessionEndTime);
         } else {
-            final Bytes bytesKey = SessionKeySchema.toBinary(key, startTime, endTime);
+            final Bytes bytesKey = SessionKeySchema.toBinary(key, sessionStartTime, sessionEndTime);
             final Bytes cacheKey = cacheFunction.cacheKey(bytesKey);
             final LRUCacheEntry entry = context.cache().get(cacheName, cacheKey);
             if (entry == null) {
-                return wrapped().fetchSession(key, startTime, endTime);
+                return wrapped().fetchSession(key, sessionStartTime, sessionEndTime);
             } else {
                 return entry.value();
             }
@@ -224,11 +224,11 @@ class CachingSessionStore
     }
 
     @Override
-    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes from,
-                                                           final Bytes to) {
-        Objects.requireNonNull(from, "from cannot be null");
-        Objects.requireNonNull(to, "to cannot be null");
-        return findSessions(from, to, 0, Long.MAX_VALUE);
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom,
+                                                           final Bytes keyTo) {
+        Objects.requireNonNull(keyFrom, "from cannot be null");
+        Objects.requireNonNull(keyTo, "to cannot be null");
+        return findSessions(keyFrom, keyTo, 0, Long.MAX_VALUE);
     }
 
     public void flush() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
@@ -67,8 +67,8 @@ class ChangeLoggingSessionBytesStore
     }
 
     @Override
-    public byte[] fetchSession(final Bytes key, final long startTime, final long endTime) {
-        return wrapped().fetchSession(key, startTime, endTime);
+    public byte[] fetchSession(final Bytes key, final long sessionStartTime, final long sessionEndTime) {
+        return wrapped().fetchSession(key, sessionStartTime, sessionEndTime);
     }
 
     @Override
@@ -77,7 +77,7 @@ class ChangeLoggingSessionBytesStore
     }
 
     @Override
-    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes from, final Bytes to) {
-        return wrapped().fetch(from, to);
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
+        return wrapped().fetch(keyFrom, keyTo);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStore.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 
@@ -43,6 +44,73 @@ public class CompositeReadOnlySessionStore<K, V> implements ReadOnlySessionStore
     }
 
     @Override
+    public KeyValueIterator<Windowed<K>, V> findSessions(final K key,
+                                                         final Instant earliestSessionEndTime,
+                                                         final Instant latestSessionStartTime) {
+        Objects.requireNonNull(key, "key can't be null");
+        final List<ReadOnlySessionStore<K, V>> stores = storeProvider.stores(storeName, queryableStoreType);
+        for (final ReadOnlySessionStore<K, V> store : stores) {
+            try {
+                final KeyValueIterator<Windowed<K>, V> result = store.findSessions(key, earliestSessionEndTime, latestSessionStartTime);
+                if (!result.hasNext()) {
+                    result.close();
+                } else {
+                    return result;
+                }
+            } catch (final InvalidStateStoreException ise) {
+                throw new InvalidStateStoreException("State store  [" + storeName + "] is not available anymore" +
+                    " and may have been migrated to another instance; " +
+                    "please re-discover its location from the state metadata. " +
+                    "Original error message: " + ise.toString());
+            }
+        }
+        return KeyValueIterators.emptyIterator();
+    }
+
+    @Override
+    public KeyValueIterator<Windowed<K>, V> findSessions(final K keyFrom,
+                                                         final K keyTo,
+                                                         final Instant earliestSessionEndTime,
+                                                         final Instant latestSessionStartTime) {
+        Objects.requireNonNull(keyFrom, "keyFrom can't be null");
+        Objects.requireNonNull(keyTo, "keyTo can't be null");
+        final List<ReadOnlySessionStore<K, V>> stores = storeProvider.stores(storeName, queryableStoreType);
+        for (final ReadOnlySessionStore<K, V> store : stores) {
+            try {
+                final KeyValueIterator<Windowed<K>, V> result = store.findSessions(keyFrom, keyTo, earliestSessionEndTime, latestSessionStartTime);
+                if (!result.hasNext()) {
+                    result.close();
+                } else {
+                    return result;
+                }
+            } catch (final InvalidStateStoreException ise) {
+                throw new InvalidStateStoreException("State store  [" + storeName + "] is not available anymore" +
+                    " and may have been migrated to another instance; " +
+                    "please re-discover its location from the state metadata. " +
+                    "Original error message: " + ise.toString());
+            }
+        }
+        return KeyValueIterators.emptyIterator();
+    }
+
+    @Override
+    public V fetchSession(final K key, final Instant sessionStartTime, final Instant sessionEndTime) {
+        Objects.requireNonNull(key, "key can't be null");
+        final List<ReadOnlySessionStore<K, V>> stores = storeProvider.stores(storeName, queryableStoreType);
+        for (final ReadOnlySessionStore<K, V> store : stores) {
+            try {
+                return store.fetchSession(key, sessionStartTime, sessionEndTime);
+            } catch (final InvalidStateStoreException ise) {
+                throw new InvalidStateStoreException("State store  [" + storeName + "] is not available anymore" +
+                    " and may have been migrated to another instance; " +
+                    "please re-discover its location from the state metadata. " +
+                    "Original error message: " + ise.toString());
+            }
+        }
+        return null;
+    }
+
+    @Override
     public KeyValueIterator<Windowed<K>, V> fetch(final K key) {
         Objects.requireNonNull(key, "key can't be null");
         final List<ReadOnlySessionStore<K, V>> stores = storeProvider.stores(storeName, queryableStoreType);
@@ -56,22 +124,22 @@ public class CompositeReadOnlySessionStore<K, V> implements ReadOnlySessionStore
                 }
             } catch (final InvalidStateStoreException ise) {
                 throw new InvalidStateStoreException("State store  [" + storeName + "] is not available anymore" +
-                                                             " and may have been migrated to another instance; " +
-                                                             "please re-discover its location from the state metadata. " +
-                                                             "Original error message: " + ise.toString());
+                    " and may have been migrated to another instance; " +
+                    "please re-discover its location from the state metadata. " +
+                    "Original error message: " + ise.toString());
             }
         }
         return KeyValueIterators.emptyIterator();
     }
 
     @Override
-    public KeyValueIterator<Windowed<K>, V> fetch(final K from, final K to) {
-        Objects.requireNonNull(from, "from can't be null");
-        Objects.requireNonNull(to, "to can't be null");
-        final NextIteratorFunction<Windowed<K>, V, ReadOnlySessionStore<K, V>> nextIteratorFunction = store -> store.fetch(from, to);
+    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom, final K keyTo) {
+        Objects.requireNonNull(keyFrom, "from can't be null");
+        Objects.requireNonNull(keyTo, "to can't be null");
+        final NextIteratorFunction<Windowed<K>, V, ReadOnlySessionStore<K, V>> nextIteratorFunction = store -> store.fetch(keyFrom, keyTo);
         return new DelegatingPeekingKeyValueIterator<>(storeName,
-                                                       new CompositeKeyValueIterator<>(
-                                                               storeProvider.stores(storeName, queryableStoreType).iterator(),
-                                                               nextIteratorFunction));
+            new CompositeKeyValueIterator<>(
+                storeProvider.stores(storeName, queryableStoreType).iterator(),
+                nextIteratorFunction));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -138,18 +138,18 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     }
 
     @Override
-    public byte[] fetchSession(final Bytes key, final long startTime, final long endTime) {
+    public byte[] fetchSession(final Bytes key, final long sessionStartTime, final long sessionEndTime) {
         removeExpiredSegments();
 
         Objects.requireNonNull(key, "key cannot be null");
 
         // Only need to search if the record hasn't expired yet
-        if (endTime > observedStreamTime - retentionPeriod) {
-            final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(endTime);
+        if (sessionEndTime > observedStreamTime - retentionPeriod) {
+            final ConcurrentNavigableMap<Bytes, ConcurrentNavigableMap<Long, byte[]>> keyMap = endTimeMap.get(sessionEndTime);
             if (keyMap != null) {
                 final ConcurrentNavigableMap<Long, byte[]> startTimeMap = keyMap.get(key);
                 if (startTimeMap != null) {
-                    return startTimeMap.get(startTime);
+                    return startTimeMap.get(sessionStartTime);
                 }
             }
         }
@@ -205,15 +205,15 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
     }
 
     @Override
-    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes from, final Bytes to) {
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
 
-        Objects.requireNonNull(from, "from key cannot be null");
-        Objects.requireNonNull(to, "to key cannot be null");
+        Objects.requireNonNull(keyFrom, "from key cannot be null");
+        Objects.requireNonNull(keyTo, "to key cannot be null");
 
         removeExpiredSegments();
 
 
-        return registerNewIterator(from, to, Long.MAX_VALUE, endTimeMap.entrySet().iterator());
+        return registerNewIterator(keyFrom, keyTo, Long.MAX_VALUE, endTimeMap.entrySet().iterator());
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -158,12 +158,12 @@ public class MeteredSessionStore<K, V>
     }
 
     @Override
-    public V fetchSession(final K key, final long startTime, final long endTime) {
+    public V fetchSession(final K key, final long sessionStartTime, final long sessionEndTime) {
         Objects.requireNonNull(key, "key cannot be null");
         return maybeMeasureLatency(
             () -> {
                 final Bytes bytesKey = keyBytes(key);
-                final byte[] result = wrapped().fetchSession(bytesKey, startTime, endTime);
+                final byte[] result = wrapped().fetchSession(bytesKey, sessionStartTime, sessionEndTime);
                 if (result == null) {
                     return null;
                 }
@@ -186,12 +186,12 @@ public class MeteredSessionStore<K, V>
     }
 
     @Override
-    public KeyValueIterator<Windowed<K>, V> fetch(final K from,
-                                                  final K to) {
-        Objects.requireNonNull(from, "from cannot be null");
-        Objects.requireNonNull(to, "to cannot be null");
+    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom,
+                                                  final K keyTo) {
+        Objects.requireNonNull(keyFrom, "from cannot be null");
+        Objects.requireNonNull(keyTo, "to cannot be null");
         return new MeteredWindowedKeyValueIterator<>(
-            wrapped().fetch(keyBytes(from), keyBytes(to)),
+            wrapped().fetch(keyBytes(keyFrom), keyBytes(keyTo)),
             fetchSensor,
             streamsMetrics,
             serdes,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -57,8 +57,8 @@ public class RocksDBSessionStore
     }
 
     @Override
-    public byte[] fetchSession(final Bytes key, final long startTime, final long endTime) {
-        return wrapped().get(SessionKeySchema.toBinary(key, startTime, endTime));
+    public byte[] fetchSession(final Bytes key, final long sessionStartTime, final long sessionEndTime) {
+        return wrapped().get(SessionKeySchema.toBinary(key, sessionStartTime, sessionEndTime));
     }
 
     @Override
@@ -67,8 +67,8 @@ public class RocksDBSessionStore
     }
 
     @Override
-    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes from, final Bytes to) {
-        return findSessions(from, to, 0, Long.MAX_VALUE);
+    public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(final Bytes keyFrom, final Bytes keyTo) {
+        return findSessions(keyFrom, keyTo, 0, Long.MAX_VALUE);
     }
 
     @Override


### PR DESCRIPTION
[KIP-666](https://cwiki.apache.org/confluence/display/KAFKA/KIP-666%3A+Add+Instant-based+methods+to+ReadOnlySessionStore) proposal

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
