### PR TITLE
MINOR: Record all poll invocations

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -636,8 +636,8 @@ public class StreamThread extends Thread {
 
         final long pollLatency = advanceNowAndComputeLatency();
 
+        pollSensor.record(pollLatency, now);
         if (records != null && !records.isEmpty()) {
-            pollSensor.record(pollLatency, now);
             pollRecordsSensor.record(records.count(), now);
             taskManager.addRecordsToTasks(records);
         }


### PR DESCRIPTION
Record the `pollSensor` after every invocation to poll, rather than just when we get records back so that we can accurately gauge how often we're invoking Consumer#poll.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
