### PR TITLE
MINOR: Log warn message with details when there's kerberos login issue

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -238,7 +238,7 @@ public class KerberosLogin extends AbstractLogin {
                             break;
                         } catch (LoginException le) {
                             if (retry > 0) {
-                                log.warn("[Principal={}]: Error when trying to re-Login, but will retry ", principal, e);
+                                log.warn("[Principal={}]: Error when trying to re-Login, but will retry ", principal, le);
                                 --retry;
                                 // sleep for 10 seconds.
                                 try {

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -238,7 +238,7 @@ public class KerberosLogin extends AbstractLogin {
                             break;
                         } catch (LoginException le) {
                             if (retry > 0) {
-                                log.warn("[Principal={}]: Error when trying to  re-Login, but will retry ", principal, e);
+                                log.warn("[Principal={}]: Error when trying to re-Login, but will retry ", principal, e);
                                 --retry;
                                 // sleep for 10 seconds.
                                 try {

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -213,6 +213,7 @@ public class KerberosLogin extends AbstractLogin {
                             break;
                         } catch (Exception e) {
                             if (retry > 0) {
+                                log.warn("[Principal={}]: Error when trying to renew with TicketCache, but will retry ", principal, e);
                                 --retry;
                                 // sleep for 10 seconds
                                 try {
@@ -237,6 +238,7 @@ public class KerberosLogin extends AbstractLogin {
                             break;
                         } catch (LoginException le) {
                             if (retry > 0) {
+                                log.warn("[Principal={}]: Error when trying to  re-Login, but will retry ", principal, e);
                                 --retry;
                                 // sleep for 10 seconds.
                                 try {


### PR DESCRIPTION
…though we will still retry

Currently, we just capture the exception and retry later, we can't figure out what happened at runtime, it would be helpful to log a warn message with details.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
Minor logging change, so no extra test is required. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
