### PR TITLE
KAFKA-10444: Configure PR builds via Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,169 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+def setupGradle() {
+  // Delete gradle cache to workaround cache corruption bugs, see KAFKA-3167
+  dir('.gradle') {
+    deleteDir()
+  }
+  sh './gradlew -version'
+}
+
+def doValidation() {
+  sh '''
+    ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
+        spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
+        --profile --no-daemon --continue -PxmlSpotBugsReport=true
+  '''
+}
+
+def doTest() {
+  sh '''
+    ./gradlew -PscalaVersion=$SCALA_VERSION unitTest integrationTest \
+        --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed \
+        -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=5
+  '''
+  junit '**/build/test-results/**/TEST-*.xml'
+}
+
+def doStreamsArchetype() {
+  echo 'Verify that Kafka Streams archetype compiles'
+
+  sh '''
+    ./gradlew streams:install clients:install connect:json:install connect:api:install \
+         || { echo 'Could not install kafka-streams.jar (and dependencies) locally`'; exit 1; }
+  '''
+
+  sh '''
+    version=`grep "^version=" gradle.properties | cut -d= -f 2` \
+        || { echo 'Could not get version from `gradle.properties`'; exit 1; }
+  '''
+
+  dir('streams/quickstart') {
+    sh '''
+      mvn clean install -Dgpg.skip  \
+          || { echo 'Could not `mvn install` streams quickstart archetype'; exit 1; }
+    '''
+
+    sh '''
+      mkdir test-streams-archetype && cd test-streams-archetype \
+          || { echo 'Could not create test directory for stream quickstart archetype'; exit 1; }
+    '''
+
+    sh '''
+      echo "Y" | mvn archetype:generate \
+          -DarchetypeCatalog=local \
+          -DarchetypeGroupId=org.apache.kafka \
+          -DarchetypeArtifactId=streams-quickstart-java \
+          -DarchetypeVersion=$version \
+          -DgroupId=streams.examples \
+          -DartifactId=streams.examples \
+          -Dversion=0.1 \
+          -Dpackage=myapps \
+          || { echo 'Could not create new project using streams quickstart archetype'; exit 1; }
+    '''
+
+    dir('streams.examples') {
+      sh '''
+        mvn compile \
+            || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
+      '''
+    }
+  }
+}
+
+def tryStreamsArchetype() {
+  try {
+    doStreamsArchetype()
+  } catch(err) {
+    echo 'Failed to build Kafka Streams archetype, marking this build UNSTABLE'
+    currentBuild.result = 'UNSTABLE'
+  }
+}
+
+
+pipeline {
+  agent none
+  stages {
+    stage('Build') {
+      parallel {
+        stage('JDK 8') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'JDK 1.8 (latest)'
+            maven 'Maven 3.6.3'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.12
+          }
+          steps {
+            setupGradle()
+            doValidation()
+            doTest()
+            tryStreamsArchetype()
+          }
+        }
+
+        stage('JDK 11') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'JDK 11 (latest)'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            setupGradle()
+            doValidation()
+            doTest()
+            echo 'Skipping Kafka Streams archetype test for Java 11'
+          }
+        }
+       
+        stage('JDK 15') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'JDK 15 (latest)'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            setupGradle()
+            doValidation()
+            doTest()
+            echo 'Skipping Kafka Streams archetype test for Java 14'
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ pipeline {
             setupGradle()
             doValidation()
             doTest()
-            echo 'Skipping Kafka Streams archetype test for Java 14'
+            echo 'Skipping Kafka Streams archetype test for Java 15'
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The following options should be set with a `-P` switch, for example `./gradlew -
 * `commitId`: sets the build commit ID as .git/HEAD might not be correct if there are local commits added for build purposes.
 * `mavenUrl`: sets the URL of the maven deployment repository (`file://path/to/repo` can be used to point to a local repository).
 * `maxParallelForks`: limits the maximum number of processes for each task.
+* `ignoreFailures`: ignore test failures from junit
 * `showStandardStreams`: shows standard out and standard error of the test JVM(s) on the console.
 * `skipSigning`: skips signing of artifacts.
 * `testLoggingEvents`: unit test events to be logged, separated by comma. For example `./gradlew -PtestLoggingEvents=started,passed,skipped,failed test`.

--- a/build.gradle
+++ b/build.gradle
@@ -314,6 +314,7 @@ subprojects {
 
   test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ ext {
   defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC"]
 
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
+  userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false
 
   userMaxTestRetries = project.hasProperty('maxTestRetries') ? maxTestRetries.toInteger() : 0
   userMaxTestRetryFailures = project.hasProperty('maxTestRetryFailures') ? maxTestRetryFailures.toInteger() : 0
@@ -336,6 +337,7 @@ subprojects {
 
   task integrationTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs
@@ -364,6 +366,7 @@ subprojects {
 
   task unitTest(type: Test, dependsOn: compileJava) {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    ignoreFailures = userIgnoreFailures
 
     maxHeapSize = defaultMaxHeapSize
     jvmArgs = defaultJvmArgs


### PR DESCRIPTION
This PR adds a Jenkinsfile to the build to replace the existing jenkins.sh script.

The build makes use of the parallel directive to run the JDK 8, 11, and 15 builds in parallel. Each build will report status to PRs in Github including which tests failed.

Only users with write access to the repository (i.e., committers) will be able to modify Jenkinsfile through pull requests, otherwise the build will use the Jenkinsfile on the target branch.