### PR TITLE
KAFKA-10459: Document IQ APIs where order does not hold between stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -25,7 +25,7 @@ import java.time.Instant;
  * A window store that only supports read operations.
  * Implementations should be thread-safe as concurrent reads and writes are expected.
  *
- * Note: The current implementation of either forward or backward fetches on range-key-range-time does not
+ * <p>Note: The current implementation of either forward or backward fetches on range-key-range-time does not
  * obey the ordering when there are multiple local stores hosted on that instance. For example,
  * if there are two stores from two tasks hosting keys {1,3} and {2,4}, then a range query of key [1,4]
  * would return in the order of [1,3,2,4] but not [1,2,3,4] since it is just looping over the stores only.

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -25,6 +25,11 @@ import java.time.Instant;
  * A window store that only supports read operations.
  * Implementations should be thread-safe as concurrent reads and writes are expected.
  *
+ * Note: The current implementation of either forward or backward fetches on range-key-range-time does not
+ * obey the ordering when there are multiple local stores hosted on that instance. For example,
+ * if there are two stores from two tasks hosting keys {1,3} and {2,4}, then a range query of key [1,4]
+ * would return in the order of [1,3,2,4] but not [1,2,3,4] since it is just looping over the stores only.
+ *
  * @param <K> Type of keys
  * @param <V> Type of values
  */


### PR DESCRIPTION
Referring to https://github.com/apache/kafka/pull/9138#discussion_r480469688 , documented on the `ReadOnlyWindowStore` class. Thanks.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
