### PR TITLE
MINOR: Update scala default version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fail due to code changes. You can just run:
     ./gradlew clean
 
 ### Running a task with one of the Scala versions available (2.12.x or 2.13.x) ###
-*Note that if building the jars with a version other than 2.12.x, you need to set the `SCALA_VERSION` variable or change it in `bin/kafka-run-class.sh` to run the quick start.*
+*Note that if building the jars with a version other than 2.13.x, you need to set the `SCALA_VERSION` variable or change it in `bin/kafka-run-class.sh` to run the quick start.*
 
 You can pass either the major version (eg 2.12) or the full version (eg 2.12.7):
 


### PR DESCRIPTION
Now, default should be 2.13.x, not 2.12.x. Update it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
