### PR TITLE
MINOR: Fix log message when tasks directory is cleaned manually

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -282,7 +282,6 @@ public class StateDirectory {
         try {
             cleanRemovedTasksCalledByUser();
         } catch (final Exception e) {
-            // this is already logged within cleanRemovedTasks
             throw new StreamsException(e);
         }
         // remove global dir
@@ -327,16 +326,16 @@ public class StateDirectory {
                             Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
                         }
                     }
-                } catch (final OverlappingFileLockException | IOException e) {
+                } catch (final OverlappingFileLockException | IOException exception) {
                     log.warn("{} Swallowed the following exception during deletion of obsolete state directory {} for task {}: {}",
-                        logPrefix(), dirName, id, e);
+                        logPrefix(), dirName, id, exception);
                 } finally {
                     try {
                         unlock(id);
-                    } catch (final IOException e) {
+                    } catch (final IOException exception) {
                         log.warn("{} Swallowed the following exception during unlocking after " +
                                 "deletion of obsolete state directory for task {}: {}",
-                            logPrefix(), dirName, e);
+                            logPrefix(), dirName, exception);
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -289,10 +289,13 @@ public class StateDirectory {
             if (stateDir.exists()) {
                 Utils.delete(globalStateDir().getAbsoluteFile());
             }
-        } catch (final IOException e) {
-            log.error("{} Failed to delete global state directory of {} due to an unexpected exception",
-                logPrefix(), appId, e);
-            throw new StreamsException(e);
+        } catch (final IOException exception) {
+            log.error(
+                String.format("%s Failed to delete global state directory of %s due to an unexpected exception",
+                    logPrefix(), appId),
+                exception
+            );
+            throw new StreamsException(exception);
         }
     }
 
@@ -327,15 +330,20 @@ public class StateDirectory {
                         }
                     }
                 } catch (final OverlappingFileLockException | IOException exception) {
-                    log.warn("{} Swallowed the following exception during deletion of obsolete state directory {} for task {}: {}",
-                        logPrefix(), dirName, id, exception);
+                    log.warn(
+                        String.format("%s Swallowed the following exception during deletion of obsolete state directory %s for task %s:",
+                            logPrefix(), dirName, id),
+                        exception
+                    );
                 } finally {
                     try {
                         unlock(id);
                     } catch (final IOException exception) {
-                        log.warn("{} Swallowed the following exception during unlocking after " +
-                                "deletion of obsolete state directory for task {}: {}",
-                            logPrefix(), dirName, exception);
+                        log.warn(
+                            String.format("%s Swallowed the following exception during unlocking after deletion of obsolete " +
+                                "state directory %s for task %s:", logPrefix(), dirName, id),
+                            exception
+                        );
                     }
                 }
             }
@@ -352,10 +360,16 @@ public class StateDirectory {
                         log.info("{} Deleting state directory {} for task {} as user calling cleanup.",
                             logPrefix(), dirName, id);
                         Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
+                    } else {
+                        log.warn("{} Could not get lock for state directory {} for task {} as user calling cleanup.",
+                            logPrefix(), dirName, id);
                     }
                 } catch (final OverlappingFileLockException | IOException exception) {
-                    log.error("{} Failed to delete state directory {} for task {} with exception: {}",
-                        logPrefix(), dirName, id, exception);
+                    log.error(
+                        String.format("%s Failed to delete state directory %s for task %s with exception:",
+                            logPrefix(), dirName, id),
+                        exception
+                    );
                     throw exception;
                 } finally {
                     try {
@@ -364,8 +378,11 @@ public class StateDirectory {
                         // the whole directory
                         Utils.delete(taskDir);
                     } catch (final IOException exception) {
-                        log.error("{} Failed to release lock on state directory {} for task {} with exception: {}",
-                            logPrefix(), dirName, id, exception);
+                        log.error(
+                            String.format("%s Failed to release lock on state directory %s for task %s with exception:",
+                                logPrefix(), dirName, id),
+                            exception
+                        );
                         throw exception;
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -328,14 +328,14 @@ public class StateDirectory {
                     if (lock(id)) {
                         final long now = time.milliseconds();
                         final long lastModifiedMs = taskDir.lastModified();
-                        if (now > lastModifiedMs + cleanupDelayMs) {
-                            log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).",
-                                logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
-
-                            Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
-                        } else if (manualUserCall) {
+                        if (manualUserCall) {
                             log.info("{} Deleting state directory {} for task {} as user calling cleanup.",
                                 logPrefix(), dirName, id);
+
+                            Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
+                        } else if (now > lastModifiedMs + cleanupDelayMs) {
+                            log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).",
+                                logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
 
                             Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
                         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -323,17 +323,20 @@ public class StateDirectory {
                         final long lastModifiedMs = taskDir.lastModified();
                         if (now > lastModifiedMs + cleanupDelayMs) {
                             log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).",
-                                    logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
+                                logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
                             Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
                         }
                     }
                 } catch (final OverlappingFileLockException | IOException e) {
-                    // do nothing
+                    log.warn("{} Swallowed the following exception during deletion of obsolete state directory {} for task {}: {}",
+                        logPrefix(), dirName, id, e);
                 } finally {
                     try {
                         unlock(id);
                     } catch (final IOException e) {
-                        // do nothing
+                        log.warn("{} Swallowed the following exception during unlocking after " +
+                                "deletion of obsolete state directory for task {}: {}",
+                            logPrefix(), dirName, e);
                     }
                 }
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -49,6 +50,10 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.streams.processor.internals.StateDirectory.LOCK_FILE_NAME;
 import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHECKPOINT_FILE_NAME;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -531,6 +536,38 @@ public class StateDirectoryTest {
         assertTrue(passed.get());
         assertTrue(runner.taskDirectory.exists());
         assertTrue(runner.taskDirectory.isDirectory());
+    }
+
+    @Test
+    public void shouldLogManualUserCallMessage() {
+        final TaskId taskId = new TaskId(0, 0);
+        final File taskDirectory = directory.directoryForTask(taskId);
+        final File testFile = new File(taskDirectory, "testFile");
+        assertThat(testFile.mkdir(), is(true));
+        assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
+            directory.clean();
+            assertThat(
+                appender.getMessages(),
+                hasItem(endsWith("as user calling cleanup."))
+            );
+        }
+    }
+
+    @Test
+    public void shouldLogStateDirCleanerMessage() {
+        final TaskId taskId = new TaskId(0, 0);
+        final File taskDirectory = directory.directoryForTask(taskId);
+        final File testFile = new File(taskDirectory, "testFile");
+        assertThat(testFile.mkdir(), is(true));
+        assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
+            final long cleanupDelayMs = 0;
+            directory.cleanRemovedTasks(cleanupDelayMs);
+            assertThat(appender.getMessages(), hasItem(endsWith("ms has elapsed (cleanup delay is " +  cleanupDelayMs + "ms).")));
+        }
     }
 
     private static class CreateTaskDirRunner implements Runnable {


### PR DESCRIPTION
Currently when a task directory is cleaned manually the message
for the state dir cleaner is logged instead of the message for
the manual cleanup. This is because the code checks the elapsed
time since the last update before it checks whether the cleanup
is a manual call. This commit changes the order of the checks.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
