### PR TITLE
Fix typo in name of output topic

### DIFF
--- a/docs/streams/developer-guide/testing.html
+++ b/docs/streams/developer-guide/testing.html
@@ -78,11 +78,11 @@
 Topology topology = new Topology();
 topology.addSource("sourceProcessor", "input-topic");
 topology.addProcessor("processor", ..., "sourceProcessor");
-topology.addSink("sinkProcessor", "output-topic", "processor");
+topology.addSink("sinkProcessor", "result-topic", "processor");
 // or
 // using DSL
 StreamsBuilder builder = new StreamsBuilder();
-builder.stream("input-topic").filter(...).to("output-topic");
+builder.stream("input-topic").filter(...).to("result-topic");
 Topology topology = builder.build();
 
 // setup test driver


### PR DESCRIPTION
This change fixes inconsistent naming for the output topic in the documentation.

