### PR TITLE
KAFKA-10458; Updating controller quota does not work since Token Bucket

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -63,11 +63,11 @@ public final class Sensor {
         }
 
         public Stat stat() {
-            return this.stat;
+            return stat;
         }
 
         public MetricConfig config() {
-            return this.configSupplier.get();
+            return configSupplier.get();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.metrics;
 
+import java.util.function.Supplier;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.CompoundStat.NamedMeasurable;
 import org.apache.kafka.common.metrics.stats.TokenBucket;
@@ -53,12 +54,20 @@ public final class Sensor {
     private final Object metricLock;
 
     private static class StatAndConfig {
-        public final Stat stat;
-        public final MetricConfig config;
+        private final Stat stat;
+        private final Supplier<MetricConfig> configSupplier;
 
-        StatAndConfig(Stat stat, MetricConfig config) {
+        StatAndConfig(Stat stat, Supplier<MetricConfig> configSupplier) {
             this.stat = stat;
-            this.config = config;
+            this.configSupplier = configSupplier;
+        }
+
+        public Stat stat() {
+            return this.stat;
+        }
+
+        public MetricConfig config() {
+            return this.configSupplier.get();
         }
     }
 
@@ -219,7 +228,7 @@ public final class Sensor {
             synchronized (metricLock()) {
                 // increment all the stats
                 for (StatAndConfig statAndConfig : this.stats) {
-                    statAndConfig.stat.record(statAndConfig.config, value, timeMs);
+                    statAndConfig.stat.record(statAndConfig.config(), value, timeMs);
                 }
             }
             if (checkQuotas)
@@ -278,7 +287,7 @@ public final class Sensor {
             return false;
 
         final MetricConfig statConfig = config == null ? this.config : config;
-        stats.add(new StatAndConfig(Objects.requireNonNull(stat), statConfig));
+        stats.add(new StatAndConfig(Objects.requireNonNull(stat), () -> statConfig));
         Object lock = metricLock();
         for (NamedMeasurable m : stat.stats()) {
             final KafkaMetric metric = new KafkaMetric(lock, m.name(), m.stat(), statConfig, time);
@@ -324,7 +333,7 @@ public final class Sensor {
             );
             registry.registerMetric(metric);
             metrics.put(metric.metricName(), metric);
-            stats.add(new StatAndConfig(Objects.requireNonNull(stat), statConfig));
+            stats.add(new StatAndConfig(Objects.requireNonNull(stat), metric::config));
             return true;
         }
     }

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -409,7 +409,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
 
   protected def registerQuotaMetrics(metricTags: Map[String, String])(sensor: Sensor): Unit = {
     sensor.add(
-      clientRateMetricName(metricTags),
+      clientQuotaMetricName(metricTags),
       new Rate,
       getQuotaMetricConfig(metricTags)
     )
@@ -522,7 +522,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
       val clientId = quotaEntity.clientId
       val metricTags = Map(DefaultTags.User -> user, DefaultTags.ClientId -> clientId)
 
-      val quotaMetricName = clientRateMetricName(metricTags)
+      val quotaMetricName = clientQuotaMetricName(metricTags)
       // Change the underlying metric config if the sensor has been created
       val metric = allMetrics.get(quotaMetricName)
       if (metric != null) {
@@ -532,7 +532,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
         }
       }
     } else {
-      val quotaMetricName = clientRateMetricName(Map.empty)
+      val quotaMetricName = clientQuotaMetricName(Map.empty)
       allMetrics.forEach { (metricName, metric) =>
         if (metricName.name == quotaMetricName.name && metricName.group == quotaMetricName.group) {
           val metricTags = metricName.tags
@@ -547,7 +547,11 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     }
   }
 
-  protected def clientRateMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+  /**
+   * Returns the MetricName of the metric used for the quota. The name is used to create the
+   * metric but also to find the metric when the quota is changed.
+   */
+  protected def clientQuotaMetricName(quotaMetricTags: Map[String, String]): MetricName = {
     metrics.metricName("byte-rate", quotaType.toString,
       "Tracking byte-rate per user/client-id",
       quotaMetricTags.asJava)

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -79,7 +79,7 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
     QuotaUtils.boundedThrottleTime(e, maxThrottleTimeMs, timeMs)
   }
 
-  override protected def clientRateMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+  override protected def clientQuotaMetricName(quotaMetricTags: Map[String, String]): MetricName = {
     metrics.metricName("request-time", QuotaType.Request.toString,
       "Tracking request-time per user/client-id",
       quotaMetricTags.asJava)

--- a/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ControllerMutationQuotaManager.scala
@@ -168,15 +168,15 @@ class ControllerMutationQuotaManager(private val config: ClientQuotaManagerConfi
                                      private val quotaCallback: Option[ClientQuotaCallback])
     extends ClientQuotaManager(config, metrics, QuotaType.ControllerMutation, time, threadNamePrefix, quotaCallback) {
 
-  override protected def clientRateMetricName(quotaMetricTags: Map[String, String]): MetricName = {
-    metrics.metricName("mutation-rate", QuotaType.ControllerMutation.toString,
-      "Tracking mutation-rate per user/client-id",
+  override protected def clientQuotaMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+    metrics.metricName("tokens", QuotaType.ControllerMutation.toString,
+      "Tracking remaining tokens in the token bucket per user/client-id",
       quotaMetricTags.asJava)
   }
 
-  private def clientTokenBucketMetricName(quotaMetricTags: Map[String, String]): MetricName = {
-    metrics.metricName("tokens", QuotaType.ControllerMutation.toString,
-      "Tracking remaining tokens in the token bucket per user/client-id",
+  private def clientRateMetricName(quotaMetricTags: Map[String, String]): MetricName = {
+    metrics.metricName("mutation-rate", QuotaType.ControllerMutation.toString,
+      "Tracking mutation-rate per user/client-id",
       quotaMetricTags.asJava)
   }
 
@@ -186,7 +186,7 @@ class ControllerMutationQuotaManager(private val config: ClientQuotaManagerConfi
       new Rate
     )
     sensor.add(
-      clientTokenBucketMetricName(metricTags),
+      clientQuotaMetricName(metricTags),
       new TokenBucket,
       getQuotaMetricConfig(metricTags)
     )


### PR DESCRIPTION
This PR fixes two issues that have been introduced by https://github.com/apache/kafka/pull/9114.

* When I switched the metric from `Rate` to `TokenBucket` in the `ControllerMutationQuotaManager`, I have mixed up the metrics. That broke the quota update path.

* When a quota is updated, the `ClientQuotaManager` updates the `MetricConfig` of the `KafkaMetric`. That update was not reflected into the `Sensor` so the `Sensor` was still using the `MetricConfig` that it has been created with.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
