### PR TITLE
KAFKA-10131: Remove use_zk_connection flag

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -254,7 +254,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def alive(self, node):
         return len(self.pids(node)) > 0
 
-    def start(self, add_principals="", use_zk_to_create_topic=True):
+    def start(self, add_principals=""):
         if self.zk_client_secure and not self.zk.zk_client_secure_port:
             raise Exception("Unable to start Kafka: TLS to Zookeeper requested but Zookeeper secure port not enabled")
         self.open_port(self.security_protocol)
@@ -281,7 +281,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                     topic_cfg = {}
 
                 topic_cfg["topic"] = topic
-                self.create_topic(topic_cfg, use_zk_to_create_topic=use_zk_to_create_topic)
+                self.create_topic(topic_cfg)
 
     def _ensure_zk_chroot(self):
         self.logger.info("Ensuring zk_chroot %s exists", self.zk_chroot)
@@ -445,25 +445,25 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                                          clean_shutdown=False, allow_fail=True)
         node.account.ssh("sudo rm -rf -- %s" % KafkaService.PERSISTENT_ROOT, allow_fail=False)
 
-    def _kafka_topics_cmd(self, node, use_zk_connection=True):
+    def _kafka_topics_cmd(self, node, force_use_zk_connection):
         """
         Returns kafka-topics.sh command path with jaas configuration and krb5 environment variable
         set. If Admin client is not going to be used, don't set the environment variable.
         """
         kafka_topic_script = self.path.script("kafka-topics.sh", node)
-        skip_security_settings = use_zk_connection or not node.version.topic_command_supports_bootstrap_server()
+        skip_security_settings = force_use_zk_connection or not node.version.topic_command_supports_bootstrap_server()
         return kafka_topic_script if skip_security_settings else \
             "KAFKA_OPTS='-D%s -D%s' %s" % (KafkaService.JAAS_CONF_PROPERTY, KafkaService.KRB5_CONF, kafka_topic_script)
 
-    def _kafka_topics_cmd_config(self, node, use_zk_connection=True):
+    def _kafka_topics_cmd_config(self, node, force_use_zk_connection):
         """
         Return --command-config parameter to the kafka-topics.sh command. The config parameter specifies
         the security settings that AdminClient uses to connect to a secure kafka server.
         """
-        skip_command_config = use_zk_connection or not node.version.topic_command_supports_bootstrap_server()
+        skip_command_config = force_use_zk_connection or not node.version.topic_command_supports_bootstrap_server()
         return "" if skip_command_config else " --command-config <(echo '%s')" % (self.security_config.client_config())
 
-    def create_topic(self, topic_cfg, node=None, use_zk_to_create_topic=True):
+    def create_topic(self, topic_cfg, node=None):
         """Run the admin tool create topic command.
         Specifying node is optional, and may be done if for different kafka nodes have different versions,
         and we care where command gets run.
@@ -475,12 +475,13 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Creating topic %s with settings %s",
                          topic_cfg["topic"], topic_cfg)
 
-        use_zk_connection = topic_cfg.get('if-not-exists', False) or use_zk_to_create_topic
+        force_use_zk_connection = not node.version.topic_command_supports_bootstrap_server() or\
+                            (topic_cfg.get('if-not-exists', False) and not node.version.topic_command_supports_if_not_exists_with_bootstrap_server())
 
         cmd = fix_opts_for_new_jvm(node)
         cmd += "%(kafka_topics_cmd)s %(connection_string)s --create --topic %(topic)s " % {
-            'kafka_topics_cmd': self._kafka_topics_cmd(node, use_zk_connection),
-            'connection_string': self._topic_command_connect_setting(node, use_zk_connection),
+            'kafka_topics_cmd': self._kafka_topics_cmd(node, force_use_zk_connection),
+            'connection_string': self._topic_command_connect_setting(node, force_use_zk_connection),
             'topic': topic_cfg.get("topic"),
         }
         if 'replica-assignment' in topic_cfg:
@@ -500,12 +501,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             for config_name, config_value in topic_cfg["configs"].items():
                 cmd += " --config %s=%s" % (config_name, str(config_value))
 
-        cmd += self._kafka_topics_cmd_config(node, use_zk_connection)
+        cmd += self._kafka_topics_cmd_config(node, force_use_zk_connection)
 
         self.logger.info("Running topic creation command...\n%s" % cmd)
         node.account.ssh(cmd)
 
-    def delete_topic(self, topic, node=None, use_zk_to_delete_topic=False):
+    def delete_topic(self, topic, node=None):
         """
         Delete a topic with the topics command
         :param topic:
@@ -516,22 +517,27 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             node = self.nodes[0]
         self.logger.info("Deleting topic %s" % topic)
 
+        force_use_zk_connection = not node.version.topic_command_supports_bootstrap_server()
+
         cmd = fix_opts_for_new_jvm(node)
         cmd += "%s %s --topic %s --delete %s" % \
-               (self._kafka_topics_cmd(node=node, use_zk_connection=use_zk_to_delete_topic),
-                self._topic_command_connect_setting(node=node, use_zk_connection=use_zk_to_delete_topic),
-                topic, self._kafka_topics_cmd_config(node=node, use_zk_connection=use_zk_to_delete_topic))
+               (self._kafka_topics_cmd(node, force_use_zk_connection),
+                self._topic_command_connect_setting(node, force_use_zk_connection),
+                topic, self._kafka_topics_cmd_config(node, force_use_zk_connection))
         self.logger.info("Running topic delete command...\n%s" % cmd)
         node.account.ssh(cmd)
 
-    def describe_topic(self, topic, node=None, use_zk_to_describe_topic=True):
+    def describe_topic(self, topic, node=None):
         if node is None:
             node = self.nodes[0]
+
+        force_use_zk_connection = not node.version.topic_command_supports_bootstrap_server()
+
         cmd = fix_opts_for_new_jvm(node)
         cmd += "%s %s --topic %s --describe %s" % \
-              (self._kafka_topics_cmd(node=node, use_zk_connection=use_zk_to_describe_topic),
-               self._topic_command_connect_setting(node=node, use_zk_connection=use_zk_to_describe_topic),
-               topic, self._kafka_topics_cmd_config(node=node, use_zk_connection=use_zk_to_describe_topic))
+              (self._kafka_topics_cmd(node, force_use_zk_connection),
+               self._topic_command_connect_setting(node, force_use_zk_connection),
+               topic, self._kafka_topics_cmd_config(node, force_use_zk_connection))
 
         self.logger.info("Running topic describe command...\n%s" % cmd)
         output = ""
@@ -539,17 +545,156 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             output += line
         return output
 
-    def list_topics(self, node=None, use_zk_to_list_topic=True):
+    def list_topics(self, node=None):
         if node is None:
             node = self.nodes[0]
 
+        force_use_zk_connection = not node.version.topic_command_supports_bootstrap_server()
+
         cmd = fix_opts_for_new_jvm(node)
-        cmd += "%s %s --list %s" % (self._kafka_topics_cmd(node, use_zk_to_list_topic),
-                                   self._topic_command_connect_setting(node, use_zk_to_list_topic),
-                                   self._kafka_topics_cmd_config(node, use_zk_to_list_topic))
+        cmd += "%s %s --list %s" % (self._kafka_topics_cmd(node, force_use_zk_connection),
+                                   self._topic_command_connect_setting(node, force_use_zk_connection),
+                                   self._kafka_topics_cmd_config(node, force_use_zk_connection))
         for line in node.account.ssh_capture(cmd):
             if not line.startswith("SLF4J"):
                 yield line.rstrip()
+
+    def _acl_command_connect_setting(self, node, force_use_zk_connection):
+        """
+        Checks if --bootstrap-server config is supported, if yes then returns a string with
+        bootstrap server, otherwise returns authorizer properties for zookeeper connection.
+        """
+        if not force_use_zk_connection and node.version.acl_command_supports_bootstrap_server():
+            connection_setting = "--bootstrap-server %s" % (self.bootstrap_servers(self.security_protocol))
+        else:
+            connection_setting = "--authorizer-properties zookeeper.connect=%s" % (self.zk_connect_setting())
+
+        return connection_setting
+
+    def _kafka_acls_cmd(self, node, force_use_zk_connection):
+        """
+        Returns kafka-acls.sh command path with jaas configuration and krb5 environment variable
+        set. If Admin client is not going to be used, don't set the environment variable.
+        """
+        kafka_acl_script = self.path.script("kafka-acls.sh", node)
+        skip_security_settings = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        return kafka_acl_script if skip_security_settings else \
+            "KAFKA_OPTS='-D%s -D%s' %s" % (KafkaService.JAAS_CONF_PROPERTY, KafkaService.KRB5_CONF, kafka_acl_script)
+
+    def _kafka_acls_cmd_config(self, node, force_use_zk_connection):
+        """
+        Return --command-config parameter to the kafka-acls.sh command. The config parameter specifies
+        the security settings that AdminClient uses to connect to a secure kafka server.
+        """
+        skip_command_config = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        return "" if skip_command_config else " --command-config <(echo '%s')" % (self.security_config.client_config())
+
+    def _acl_cmd_prefix(self, node, force_use_zk_connection):
+        """
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available
+        :return command prefix for running kafka-acls
+        """
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s %s %s" % (
+            self._kafka_acls_cmd(node, force_use_zk_connection),
+            self._acl_command_connect_setting(node, force_use_zk_connection),
+            self._kafka_acls_cmd_config(node, force_use_zk_connection))
+        return cmd
+
+    def _run_acl_command(self, node, cmd):
+        output = ""
+        self.logger.debug(cmd)
+        for line in node.account.ssh_capture(cmd):
+            if not line.startswith("SLF4J"):
+                output += line
+        self.logger.debug(output)
+
+    def _add_acl_on_topic(self, principal, topic, operation_flag, node, force_use_zk_connection):
+        """
+        :param principal: principal for which ACL is created
+        :param topic: topic for which ACL is created
+        :param operation_flag: type of ACL created (e.g. --producer, --consumer, --operation=Read)
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available
+        """
+        cmd = "%(cmd_prefix)s --add --topic=%(topic)s %(operation_flag)s --allow-principal=%(principal)s" % {
+            'cmd_prefix': self._acl_cmd_prefix(node, force_use_zk_connection),
+            'topic': topic,
+            'operation_flag': operation_flag,
+            'principal': principal
+        }
+        self._run_acl_command(node, cmd)
+
+    def add_cluster_acl(self, principal, node=None, force_use_zk_connection=False):
+        """
+        :param principal: principal for which ClusterAction ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        if node is None:
+            node = self.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        cmd = "%(cmd_prefix)s --add --cluster --operation=ClusterAction --allow-principal=%(principal)s" % {
+            'cmd_prefix': self._acl_cmd_prefix(node, force_use_zk_connection),
+            'principal': principal
+        }
+        self._run_acl_command(node, cmd)
+
+    def add_read_acl(self, principal, topic, node=None, force_use_zk_connection=False):
+        """
+        :param principal: principal for which Read ACL is created
+        :param topic: topic for which Read ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        if node is None:
+            node = self.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        self._add_acl_on_topic(principal, topic, "--operation=Read", node, force_use_zk_connection)
+
+    def add_produce_acl(self, principal, topic, node=None, force_use_zk_connection=False):
+        """
+        :param principal: principal for which Producer ACL is created
+        :param topic: topic for which Producer ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        if node is None:
+            node = self.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        self._add_acl_on_topic(principal, topic, "--producer", node, force_use_zk_connection)
+
+    def add_consume_acl(self, principal, topic, group, node=None, force_use_zk_connection=False):
+        """
+        :param principal: principal for which Consumer ACL is created
+        :param topic: topic for which Consumer ACL is created
+        :param group: consumewr group for which Consumer ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        if node is None:
+            node = self.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        cmd = "%(cmd_prefix)s --add --topic=%(topic)s --group=%(group)s --consumer --allow-principal=%(principal)s" % {
+            'cmd_prefix': self._acl_cmd_prefix(node, force_use_zk_connection),
+            'topic': topic,
+            'group': group,
+            'principal': principal
+        }
+        self._run_acl_command(node, cmd)
 
     def alter_message_format(self, topic, msg_format_version, node=None):
         if node is None:
@@ -748,37 +893,68 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.stop_node(node, clean_shutdown, timeout_sec)
         self.start_node(node, timeout_sec)
 
+    def _describe_topic_line_for_partition(self, partition, describe_topic_output):
+        # Lines look like this: Topic: test_topic	Partition: 0	Leader: 3	Replicas: 3,2	Isr: 3,2
+        grep_for = "Partition: %i\t" % (partition) # be sure to include trailing tab, otherwise 1 might match 10 (for example)
+        found_lines = [line for line in describe_topic_output.splitlines() if grep_for in line]
+        return None if not found_lines else found_lines[0]
+
     def isr_idx_list(self, topic, partition=0):
         """ Get in-sync replica list the given topic and partition.
         """
-        self.logger.debug("Querying zookeeper to find in-sync replicas for topic %s and partition %d" % (topic, partition))
-        zk_path = "/brokers/topics/%s/partitions/%d/state" % (topic, partition)
-        partition_state = self.zk.query(zk_path, chroot=self.zk_chroot)
+        node = self.nodes[0]
+        if not node.version.topic_command_supports_bootstrap_server():
+            self.logger.debug("Querying zookeeper to find in-sync replicas for topic %s and partition %d" % (topic, partition))
+            zk_path = "/brokers/topics/%s/partitions/%d/state" % (topic, partition)
+            partition_state = self.zk.query(zk_path, chroot=self.zk_chroot)
 
-        if partition_state is None:
-            raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
+            if partition_state is None:
+                raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
 
-        partition_state = json.loads(partition_state)
-        self.logger.info(partition_state)
+            partition_state = json.loads(partition_state)
+            self.logger.info(partition_state)
 
-        isr_idx_list = partition_state["isr"]
+            isr_idx_list = partition_state["isr"]
+        else:
+            self.logger.debug("Querying Kafka Admin API to find in-sync replicas for topic %s and partition %d" % (topic, partition))
+            describe_output = self.describe_topic(topic, node)
+            self.logger.debug(describe_output)
+            requested_partition_line = self._describe_topic_line_for_partition(partition, describe_output)
+            # e.g. Topic: test_topic	Partition: 0	Leader: 3	Replicas: 3,2	Isr: 3,2
+            if not requested_partition_line:
+                raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
+            isr_csv = requested_partition_line.split()[9] # 10th column from above
+            isr_idx_list = [int(i) for i in isr_csv.split(",")]
+
         self.logger.info("Isr for topic %s and partition %d is now: %s" % (topic, partition, isr_idx_list))
         return isr_idx_list
 
     def replicas(self, topic, partition=0):
         """ Get the assigned replicas for the given topic and partition.
         """
-        self.logger.debug("Querying zookeeper to find assigned replicas for topic %s and partition %d" % (topic, partition))
-        zk_path = "/brokers/topics/%s" % (topic)
-        assignment = self.zk.query(zk_path, chroot=self.zk_chroot)
+        node = self.nodes[0]
+        if not node.version.topic_command_supports_bootstrap_server():
+            self.logger.debug("Querying zookeeper to find assigned replicas for topic %s and partition %d" % (topic, partition))
+            zk_path = "/brokers/topics/%s" % (topic)
+            assignment = self.zk.query(zk_path, chroot=self.zk_chroot)
 
-        if assignment is None:
-            raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
+            if assignment is None:
+                raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
 
-        assignment = json.loads(assignment)
-        self.logger.info(assignment)
+            assignment = json.loads(assignment)
+            self.logger.info(assignment)
 
-        replicas = assignment["partitions"][str(partition)]
+            replicas = assignment["partitions"][str(partition)]
+        else:
+            self.logger.debug("Querying Kafka Admin API to find replicas for topic %s and partition %d" % (topic, partition))
+            describe_output = self.describe_topic(topic, node)
+            self.logger.debug(describe_output)
+            requested_partition_line = self._describe_topic_line_for_partition(partition, describe_output)
+            # e.g. Topic: test_topic	Partition: 0	Leader: 3	Replicas: 3,2	Isr: 3,2
+            if not requested_partition_line:
+                raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
+            isr_csv = requested_partition_line.split()[7] # 8th column from above
+            replicas = [int(i) for i in isr_csv.split(",")]
 
         self.logger.info("Assigned replicas for topic %s and partition %d is now: %s" % (topic, partition, replicas))
         return [self.get_node(replica) for replica in replicas]
@@ -786,17 +962,29 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def leader(self, topic, partition=0):
         """ Get the leader replica for the given topic and partition.
         """
-        self.logger.debug("Querying zookeeper to find leader replica for topic %s and partition %d" % (topic, partition))
-        zk_path = "/brokers/topics/%s/partitions/%d/state" % (topic, partition)
-        partition_state = self.zk.query(zk_path, chroot=self.zk_chroot)
+        node = self.nodes[0]
+        if not node.version.topic_command_supports_bootstrap_server():
+            self.logger.debug("Querying zookeeper to find leader replica for topic %s and partition %d" % (topic, partition))
+            zk_path = "/brokers/topics/%s/partitions/%d/state" % (topic, partition)
+            partition_state = self.zk.query(zk_path, chroot=self.zk_chroot)
 
-        if partition_state is None:
-            raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
+            if partition_state is None:
+                raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
 
-        partition_state = json.loads(partition_state)
-        self.logger.info(partition_state)
+            partition_state = json.loads(partition_state)
+            self.logger.info(partition_state)
 
-        leader_idx = int(partition_state["leader"])
+            leader_idx = int(partition_state["leader"])
+        else:
+            self.logger.debug("Querying Kafka Admin API to find leader for topic %s and partition %d" % (topic, partition))
+            describe_output = self.describe_topic(topic, node)
+            self.logger.debug(describe_output)
+            requested_partition_line = self._describe_topic_line_for_partition(partition, describe_output)
+            # e.g. Topic: test_topic	Partition: 0	Leader: 3	Replicas: 3,2	Isr: 3,2
+            if not requested_partition_line:
+                raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
+            leader_idx = int(requested_partition_line.split()[5]) # 6th column from above
+
         self.logger.info("Leader for topic %s and partition %d is now: %d" % (topic, partition, leader_idx))
         return self.get_node(leader_idx)
 
@@ -877,12 +1065,12 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
     def zk_connect_setting(self):
         return self.zk.connect_setting(self.zk_chroot, self.zk_client_secure)
 
-    def _topic_command_connect_setting(self, node, use_zk_connection=True):
+    def _topic_command_connect_setting(self, node, force_use_zk_connection):
         """
         Checks if --bootstrap-server config is supported, if yes then returns a string with
         bootstrap server, otherwise returns zookeeper connection string.
         """
-        if node.version.topic_command_supports_bootstrap_server() and not use_zk_connection:
+        if node.version.topic_command_supports_bootstrap_server() and not force_use_zk_connection:
             connection_setting = "--bootstrap-server %s" % (self.bootstrap_servers(self.security_protocol))
         else:
             connection_setting = "--zookeeper %s" % (self.zk_connect_setting())

--- a/tests/kafkatest/services/security/kafka_acls.py
+++ b/tests/kafkatest/services/security/kafka_acls.py
@@ -37,7 +37,7 @@ class ACLs(KafkaPathResolverMixin):
         Checks if --bootstrap-server config is supported, if yes then returns a string with
         bootstrap server, otherwise returns authorizer properties for zookeeper connection.
         """
-        if not force_use_zk_connection and node.version.acl_command_supports_bootstrap_server():
+        if not force_use_zk_connection and kafka.all_nodes_acl_command_supports_bootstrap_server():
             connection_setting = "--bootstrap-server %s" % (kafka.bootstrap_servers(kafka.security_protocol))
         else:
             connection_setting = "--authorizer-properties zookeeper.connect=%s" % (kafka.zk_connect_setting())
@@ -49,7 +49,7 @@ class ACLs(KafkaPathResolverMixin):
         Return --command-config parameter to the kafka-acls.sh command. The config parameter specifies
         the security settings that AdminClient uses to connect to a secure kafka server.
         """
-        skip_command_config = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        skip_command_config = force_use_zk_connection or not kafka.all_nodes_acl_command_supports_bootstrap_server()
         return "" if skip_command_config else " --command-config <(echo '%s')" % (kafka.security_config.client_config())
 
     def _acl_cmd_prefix(self, kafka, node, force_use_zk_connection):
@@ -91,7 +91,7 @@ class ACLs(KafkaPathResolverMixin):
         """
         node = kafka.nodes[0]
 
-        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        force_use_zk_connection = force_use_zk_connection or not kafka.all_nodes_acl_command_supports_bootstrap_server()
 
         cmd = "%(cmd_prefix)s --add --cluster --operation=ClusterAction --allow-principal=%(principal)s" % {
             'cmd_prefix': self._acl_cmd_prefix(kafka, node, force_use_zk_connection),
@@ -110,7 +110,7 @@ class ACLs(KafkaPathResolverMixin):
         """
         node = kafka.nodes[0]
 
-        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        force_use_zk_connection = force_use_zk_connection or not kafka.all_nodes_acl_command_supports_bootstrap_server()
 
         self._add_acl_on_topic(kafka, principal, topic, "--operation=Read", node, force_use_zk_connection)
 
@@ -125,7 +125,7 @@ class ACLs(KafkaPathResolverMixin):
         """
         node = kafka.nodes[0]
 
-        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        force_use_zk_connection = force_use_zk_connection or not kafka.all_nodes_acl_command_supports_bootstrap_server()
 
         self._add_acl_on_topic(kafka, principal, topic, "--producer", node, force_use_zk_connection)
 
@@ -141,7 +141,7 @@ class ACLs(KafkaPathResolverMixin):
         """
         node = kafka.nodes[0]
 
-        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        force_use_zk_connection = force_use_zk_connection or not kafka.all_nodes_acl_command_supports_bootstrap_server()
 
         cmd = "%(cmd_prefix)s --add --topic=%(topic)s --group=%(group)s --consumer --allow-principal=%(principal)s" % {
             'cmd_prefix': self._acl_cmd_prefix(kafka, node, force_use_zk_connection),

--- a/tests/kafkatest/services/security/kafka_acls.py
+++ b/tests/kafkatest/services/security/kafka_acls.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
+from kafkatest.services.kafka.util import fix_opts_for_new_jvm
 
 
 class ACLs(KafkaPathResolverMixin):
@@ -23,10 +24,130 @@ class ACLs(KafkaPathResolverMixin):
     def set_acls(self, protocol, kafka, topic, group, force_use_zk_connection=False):
         # Set server ACLs
         kafka_principal = "User:CN=systemtest" if protocol == "SSL" else "User:kafka"
-        kafka.add_cluster_acl(kafka_principal, force_use_zk_connection=force_use_zk_connection)
-        kafka.add_read_acl(kafka_principal, "*", force_use_zk_connection=force_use_zk_connection)
+        self.add_cluster_acl(kafka, kafka_principal, force_use_zk_connection=force_use_zk_connection)
+        self.add_read_acl(kafka, kafka_principal, "*", force_use_zk_connection=force_use_zk_connection)
 
         # Set client ACLs
         client_principal = "User:CN=systemtest" if protocol == "SSL" else "User:client"
-        kafka.add_produce_acl(client_principal, topic, force_use_zk_connection=force_use_zk_connection)
-        kafka.add_consume_acl(client_principal, topic, group, force_use_zk_connection=force_use_zk_connection)
+        self.add_produce_acl(kafka, client_principal, topic, force_use_zk_connection=force_use_zk_connection)
+        self.add_consume_acl(kafka, client_principal, topic, group, force_use_zk_connection=force_use_zk_connection)
+
+    def _acl_command_connect_setting(self, kafka, node, force_use_zk_connection):
+        """
+        Checks if --bootstrap-server config is supported, if yes then returns a string with
+        bootstrap server, otherwise returns authorizer properties for zookeeper connection.
+        """
+        if not force_use_zk_connection and node.version.acl_command_supports_bootstrap_server():
+            connection_setting = "--bootstrap-server %s" % (kafka.bootstrap_servers(kafka.security_protocol))
+        else:
+            connection_setting = "--authorizer-properties zookeeper.connect=%s" % (kafka.zk_connect_setting())
+
+        return connection_setting
+
+    def _kafka_acls_cmd_config(self, kafka, node, force_use_zk_connection):
+        """
+        Return --command-config parameter to the kafka-acls.sh command. The config parameter specifies
+        the security settings that AdminClient uses to connect to a secure kafka server.
+        """
+        skip_command_config = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+        return "" if skip_command_config else " --command-config <(echo '%s')" % (kafka.security_config.client_config())
+
+    def _acl_cmd_prefix(self, kafka, node, force_use_zk_connection):
+        """
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available
+        :return command prefix for running kafka-acls
+        """
+        cmd = fix_opts_for_new_jvm(node)
+        cmd += "%s %s %s" % (
+            kafka.kafka_acls_cmd(node, force_use_zk_connection),
+            self._acl_command_connect_setting(kafka, node, force_use_zk_connection),
+            self._kafka_acls_cmd_config(kafka, node, force_use_zk_connection))
+        return cmd
+
+    def _add_acl_on_topic(self, kafka, principal, topic, operation_flag, node, force_use_zk_connection):
+        """
+        :param principal: principal for which ACL is created
+        :param topic: topic for which ACL is created
+        :param operation_flag: type of ACL created (e.g. --producer, --consumer, --operation=Read)
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available
+        """
+        cmd = "%(cmd_prefix)s --add --topic=%(topic)s %(operation_flag)s --allow-principal=%(principal)s" % {
+            'cmd_prefix': self._acl_cmd_prefix(kafka, node, force_use_zk_connection),
+            'topic': topic,
+            'operation_flag': operation_flag,
+            'principal': principal
+        }
+        kafka.run_cli_tool(node, cmd)
+
+    def add_cluster_acl(self, kafka, principal, force_use_zk_connection=False):
+        """
+        :param kafka: Kafka cluster upon which ClusterAction ACL is created
+        :param principal: principal for which ClusterAction ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        node = kafka.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        cmd = "%(cmd_prefix)s --add --cluster --operation=ClusterAction --allow-principal=%(principal)s" % {
+            'cmd_prefix': self._acl_cmd_prefix(kafka, node, force_use_zk_connection),
+            'principal': principal
+        }
+        kafka.run_cli_tool(node, cmd)
+
+    def add_read_acl(self, kafka, principal, topic, force_use_zk_connection=False):
+        """
+        :param kafka: Kafka cluster upon which Read ACL is created
+        :param principal: principal for which Read ACL is created
+        :param topic: topic for which Read ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        node = kafka.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        self._add_acl_on_topic(kafka, principal, topic, "--operation=Read", node, force_use_zk_connection)
+
+    def add_produce_acl(self, kafka, principal, topic, force_use_zk_connection=False):
+        """
+        :param kafka: Kafka cluster upon which Producer ACL is created
+        :param principal: principal for which Producer ACL is created
+        :param topic: topic for which Producer ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        node = kafka.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        self._add_acl_on_topic(kafka, principal, topic, "--producer", node, force_use_zk_connection)
+
+    def add_consume_acl(self, kafka, principal, topic, group, force_use_zk_connection=False):
+        """
+        :param kafka: Kafka cluster upon which Consumer ACL is created
+        :param principal: principal for which Consumer ACL is created
+        :param topic: topic for which Consumer ACL is created
+        :param group: consumewr group for which Consumer ACL is created
+        :param node: Node to use when determining connection settings
+        :param force_use_zk_connection: forces the use of ZooKeeper when true, otherwise AdminClient is used when available.
+               This is necessary for the case where we are bootstrapping ACLs before Kafka is started or before authorizer is enabled
+        """
+        node = kafka.nodes[0]
+
+        force_use_zk_connection = force_use_zk_connection or not node.version.acl_command_supports_bootstrap_server()
+
+        cmd = "%(cmd_prefix)s --add --topic=%(topic)s --group=%(group)s --consumer --allow-principal=%(principal)s" % {
+            'cmd_prefix': self._acl_cmd_prefix(kafka, node, force_use_zk_connection),
+            'topic': topic,
+            'group': group,
+            'principal': principal
+        }
+        kafka.run_cli_tool(node, cmd)
+

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -72,9 +72,10 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
 
     def set_authorizer_and_bounce(self, client_protocol, broker_protocol, authorizer_class_name = KafkaService.ACL_AUTHORIZER):
         self.kafka.authorizer_class_name = authorizer_class_name
-        self.acls.set_acls(client_protocol, self.kafka, self.topic, self.group)
-        self.acls.set_acls(broker_protocol, self.kafka, self.topic, self.group)
-        self.bounce()
+        # Force use of direct ZooKeeper access due to SecurityDisabledException: No Authorizer is configured on the broker.
+        self.acls.set_acls(client_protocol, self.kafka, self.topic, self.group, force_use_zk_connection=True)
+        self.acls.set_acls(broker_protocol, self.kafka, self.topic, self.group, force_use_zk_connection=True)
+        self.bounce() # enables the authorizer
 
     def open_secured_port(self, client_protocol):
         self.kafka.security_protocol = client_protocol

--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -67,8 +67,9 @@ class SecurityTest(EndToEndTest):
         with hostname verification failure. Hence clients are expected to fail with LEADER_NOT_AVAILABLE.
         """
 
+        # Start Kafka with valid hostnames in the certs' SANs so that we can create the test topic via the admin client
         SecurityConfig.ssl_stores = TestSslStores(self.test_context.local_scratch_dir,
-                                                  valid_hostname=False)
+                                                  valid_hostname=True)
 
         self.create_zookeeper()
         self.zk.start()
@@ -76,6 +77,10 @@ class SecurityTest(EndToEndTest):
         self.create_kafka(security_protocol=security_protocol,
                           interbroker_security_protocol=interbroker_security_protocol)
         self.kafka.start()
+
+        # now set the certs to have invalid hostnames so we can run the actual test
+        SecurityConfig.ssl_stores.valid_hostname = False
+        self.kafka.restart_cluster()
 
         # We need more verbose logging to catch the expected errors
         self.create_and_start_clients(log_level="DEBUG")

--- a/tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_security_upgrade_test.py
@@ -96,7 +96,8 @@ class ZooKeeperSecurityUpgradeTest(ProduceConsumeValidateTest):
         # set acls
         if self.is_secure:
             self.kafka.authorizer_class_name = KafkaService.ACL_AUTHORIZER
-            self.acls.set_acls(security_protocol, self.kafka, self.topic, self.group)
+            # Force use of direct ZooKeeper access because Kafka is not yet started
+            self.acls.set_acls(security_protocol, self.kafka, self.topic, self.group, force_use_zk_connection=True)
 
         if self.no_sasl:
             self.kafka.start()

--- a/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
+++ b/tests/kafkatest/tests/core/zookeeper_tls_encrypt_only_test.py
@@ -69,9 +69,7 @@ class ZookeeperTlsEncryptOnlyTest(ProduceConsumeValidateTest):
         self.zk.start()
         self.kafka.security_protocol = self.kafka.interbroker_security_protocol = "PLAINTEXT"
 
-        # Cannot use --zookeeper because kafka-topics.sh is unable to connect to a TLS-enabled ZooKeeper quorum,
-        # so indicate that topics should be created via the Admin client
-        self.kafka.start(use_zk_to_create_topic=False)
+        self.kafka.start()
 
         self.perform_produce_consume_validation()
 

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -51,9 +51,16 @@ class KafkaVersion(LooseVersion):
 
     def supports_named_listeners(self):
         return self >= V_0_10_2_0
+        return self >= V_0_10_2_02_1_0
+
+    def acl_command_supports_bootstrap_server(self):
+        return self >= V_2_1_0
 
     def topic_command_supports_bootstrap_server(self):
         return self >= V_2_3_0
+
+    def topic_command_supports_if_not_exists_with_bootstrap_server(self):
+        return self >= V_2_6_0
 
     def supports_tls_to_zookeeper(self):
         # indicate if KIP-515 is available

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -51,7 +51,6 @@ class KafkaVersion(LooseVersion):
 
     def supports_named_listeners(self):
         return self >= V_0_10_2_0
-        return self >= V_0_10_2_02_1_0
 
     def acl_command_supports_bootstrap_server(self):
         return self >= V_2_1_0


### PR DESCRIPTION
Eliminate "use_zk_connection" and similarly-named flags in public system test methods.  System tests should always use admin client when the broker supports it.  We do need to bootstrap ACLs prior to Kafka starting or prior to enabling the
authorizer, so the ability to force the use of a direct ZooKeeper connection rather than the admin client still exists for this case.

This PR also converts a few methods in kafka.py that were connecting directly to ZooKeeper for leader and replica/ISR lists
to use the admin client when the broker version supports it.  It also adds support for using the admin client when
performing "kafka-topics.sh ... -if-not-exists" which was added via KIP-604 in v2.6.
