### PR TITLE
MINOR: Fix JSON generation of nested structs with non-matching type/name

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -693,7 +693,7 @@ public final class MessageTest {
         message.setMyStruct(new SimpleExampleMessageData.MyStruct().setStructId(25).setArrayInStruct(
             Collections.singletonList(new SimpleExampleMessageData.StructArray().setArrayFieldId(20))
         ));
-        message.setMyTaggedStruct(new SimpleExampleMessageData.MyTaggedStruct().setStructId("abc"));
+        message.setMyTaggedStruct(new SimpleExampleMessageData.TaggedStruct().setStructId("abc"));
 
         message.setProcessId(UUID.randomUUID());
         message.setMyNullableString("notNull");

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -310,8 +310,8 @@ public class SimpleExampleMessageTest {
     @Test
     public void testMyTaggedStruct() {
         // Verify that we can set and retrieve a nullable struct object.
-        SimpleExampleMessageData.MyTaggedStruct myStruct =
-            new SimpleExampleMessageData.MyTaggedStruct().setStructId("abc");
+        SimpleExampleMessageData.TaggedStruct myStruct =
+            new SimpleExampleMessageData.TaggedStruct().setStructId("abc");
         testRoundTrip(new SimpleExampleMessageData().setMyTaggedStruct(myStruct),
             message -> assertEquals(myStruct, message.myTaggedStruct()), (short) 2);
 

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -45,7 +45,7 @@
             { "name": "arrayFieldId", "type": "int32", "versions": "2+"}
           ]}
     ]},
-    { "name": "myTaggedStruct", "type": "MyTaggedStruct", "versions": "2+", "about": "Test Tagged Struct field",
+    { "name": "myTaggedStruct", "type": "TaggedStruct", "versions": "2+", "about": "Test Tagged Struct field",
       "taggedVersions": "2+", "tag": 8,
       "fields": [
         { "name": "structId", "type": "string", "versions": "2+", "about": "String field in struct"}

--- a/generator/src/main/java/org/apache/kafka/message/StructRegistry.java
+++ b/generator/src/main/java/org/apache/kafka/message/StructRegistry.java
@@ -87,11 +87,14 @@ final class StructRegistry {
     private void addStructSpecs(Versions parentVersions, List<FieldSpec> fields) {
         for (FieldSpec field : fields) {
             String elementName = null;
+            String typeName = null;
             if (field.type().isStructArray()) {
                 FieldType.ArrayType arrayType = (FieldType.ArrayType) field.type();
                 elementName = arrayType.elementName();
+                typeName = arrayType.elementName();
             } else if (field.type().isStruct()) {
                 elementName = field.name();
+                typeName = field.typeString();
             }
             if (elementName != null) {
                 if (commonStructNames.contains(elementName)) {
@@ -107,7 +110,7 @@ final class StructRegistry {
                         " was specified twice.");
                 } else {
                     // Synthesize a StructSpec object out of the fields.
-                    StructSpec spec = new StructSpec(elementName,
+                    StructSpec spec = new StructSpec(typeName,
                             field.versions().toString(),
                             field.fields());
                     structs.put(elementName, new StructInfo(spec, parentVersions));

--- a/generator/src/test/java/org/apache/kafka/message/StructRegistryTest.java
+++ b/generator/src/test/java/org/apache/kafka/message/StructRegistryTest.java
@@ -143,8 +143,9 @@ public class StructRegistryTest {
         FieldSpec field2 = testMessageSpec.fields().get(1);
         assertTrue(field2.type().isStruct());
         assertEquals("TestInlineStruct", field2.type().toString());
+        assertEquals("field2", field2.name());
 
-        assertEquals("field2", structRegistry.findStruct(field2).name());
+        assertEquals("TestInlineStruct", structRegistry.findStruct(field2).name());
         assertFalse(structRegistry.isStructArrayWithKeys(field2));
     }
 }


### PR DESCRIPTION
The schema specification allows a struct type name to differ from the field name. This works with the generated `Message` classes, but not with the generated JSON converter. The problem seems to be that the type name gets replaced with the field name when the struct is registered.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
