### PR TITLE
MINOR: Fix common struct `JsonConverter` and `Schema` generation

### DIFF
--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -49,6 +49,14 @@
       "taggedVersions": "2+", "tag": 8,
       "fields": [
         { "name": "structId", "type": "string", "versions": "2+", "about": "String field in struct"}
+    ]},
+    { "name":  "myCommonStruct", "type": "TestCommonStruct", "versions": "0+"},
+    { "name":  "myOtherCommonStruct", "type": "TestCommonStruct", "versions": "0+"}
+  ],
+  "commonStructs": [
+    { "name": "TestCommonStruct", "versions": "0+", "fields": [
+      { "name": "foo", "type": "int32", "default": "123", "versions": "0+" },
+      { "name": "bar", "type": "int32", "default": "123", "versions": "0+" }
     ]}
   ]
 }

--- a/generator/src/main/java/org/apache/kafka/message/FieldType.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldType.java
@@ -282,6 +282,10 @@ public interface FieldType {
             return true;
         }
 
+        public String typeName() {
+            return type;
+        }
+
         @Override
         public String toString() {
             return type;

--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -53,32 +53,23 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
         buffer.incrementIndent();
         generateConverters(message.dataClassName(), message.struct(),
             message.validVersions());
-
         for (Iterator<StructRegistry.StructInfo> iter = structRegistry.structs();
                 iter.hasNext(); ) {
             StructRegistry.StructInfo info = iter.next();
-            if (!info.isCommonStructReference) {
-                generateStructClass(info.spec(), info.parentVersions());
-            }
+            buffer.printf("%n");
+            buffer.printf("public static class %s {%n",
+                MessageGenerator.capitalizeFirst(info.spec().name() + SUFFIX));
+            buffer.incrementIndent();
+            generateConverters(MessageGenerator.capitalizeFirst(info.spec().name()),
+                info.spec(), info.parentVersions());
+            buffer.decrementIndent();
+            buffer.printf("}%n");
         }
         buffer.decrementIndent();
         buffer.printf("}%n");
         headerGenerator.generate();
         headerGenerator.buffer().write(writer);
         buffer.write(writer);
-    }
-
-    private void generateStructClass(
-        StructSpec spec,
-        Versions versions
-    ) {
-        buffer.printf("%n");
-        buffer.printf("public static class %s {%n",
-            MessageGenerator.capitalizeFirst(spec.name() + SUFFIX));
-        buffer.incrementIndent();
-        generateConverters(MessageGenerator.capitalizeFirst(spec.name()), spec, versions);
-        buffer.decrementIndent();
-        buffer.printf("}%n");
     }
 
     private void generateConverters(String name,

--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -53,23 +53,36 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
         buffer.incrementIndent();
         generateConverters(message.dataClassName(), message.struct(),
             message.validVersions());
+
+        for (Iterator<StructSpec> iter = structRegistry.commonStructs(); iter.hasNext(); ) {
+            generateStructClass(iter.next(), message.validVersions());
+        }
+
         for (Iterator<StructRegistry.StructInfo> iter = structRegistry.structs();
                 iter.hasNext(); ) {
             StructRegistry.StructInfo info = iter.next();
-            buffer.printf("%n");
-            buffer.printf("public static class %s {%n",
-                MessageGenerator.capitalizeFirst(info.spec().name() + SUFFIX));
-            buffer.incrementIndent();
-            generateConverters(MessageGenerator.capitalizeFirst(info.spec().name()),
-                info.spec(), info.parentVersions());
-            buffer.decrementIndent();
-            buffer.printf("}%n");
+            if (!structRegistry.commonStructNames().contains(info.spec().name())) {
+                generateStructClass(info.spec(), info.parentVersions());
+            }
         }
         buffer.decrementIndent();
         buffer.printf("}%n");
         headerGenerator.generate();
         headerGenerator.buffer().write(writer);
         buffer.write(writer);
+    }
+
+    private void generateStructClass(
+        StructSpec spec,
+        Versions versions
+    ) {
+        buffer.printf("%n");
+        buffer.printf("public static class %s {%n",
+            MessageGenerator.capitalizeFirst(spec.name() + SUFFIX));
+        buffer.incrementIndent();
+        generateConverters(MessageGenerator.capitalizeFirst(spec.name()), spec, versions);
+        buffer.decrementIndent();
+        buffer.printf("}%n");
     }
 
     private void generateConverters(String name,

--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -54,14 +54,10 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
         generateConverters(message.dataClassName(), message.struct(),
             message.validVersions());
 
-        for (Iterator<StructSpec> iter = structRegistry.commonStructs(); iter.hasNext(); ) {
-            generateStructClass(iter.next(), message.validVersions());
-        }
-
         for (Iterator<StructRegistry.StructInfo> iter = structRegistry.structs();
                 iter.hasNext(); ) {
             StructRegistry.StructInfo info = iter.next();
-            if (!structRegistry.commonStructNames().contains(info.spec().name())) {
+            if (!info.isCommonStructReference) {
                 generateStructClass(info.spec(), info.parentVersions());
             }
         }

--- a/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageDataGenerator.java
@@ -182,9 +182,9 @@ public final class MessageDataGenerator implements MessageClassGenerator {
                             parentVersions.intersect(struct.versions()));
                 }
             } else if (field.type().isStruct()) {
-                if (!structRegistry.commonStructNames().contains(field.name())) {
+                if (!structRegistry.commonStructNames().contains(field.typeString())) {
                     generateClass(Optional.empty(),
-                            field.type().toString(),
+                            field.typeString(),
                             structRegistry.findStruct(field),
                             parentVersions.intersect(struct.versions()));
                 }

--- a/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/SchemaGenerator.java
@@ -81,15 +81,17 @@ final class SchemaGenerator {
 
     void generateSchemas(MessageSpec message) throws Exception {
         this.messageFlexibleVersions = message.flexibleVersions();
+
+        // First generate schemas for common structures so that they are
+        // available when we generate the inline structures
+        for (Iterator<StructSpec> iter = structRegistry.commonStructs(); iter.hasNext(); ) {
+            StructSpec struct = iter.next();
+            generateSchemas(struct.name(), struct, message.struct().versions());
+        }
+
         // Generate schemas for inline structures
         generateSchemas(message.dataClassName(), message.struct(),
             message.struct().versions());
-
-        // Generate schemas for common structures
-        for (Iterator<StructSpec> iter = structRegistry.commonStructs(); iter.hasNext(); ) {
-            StructSpec struct = iter.next();
-            generateSchemas(struct.name(), struct, struct.versions());
-        }
     }
 
     void generateSchemas(String className, StructSpec struct,


### PR DESCRIPTION
This patch fixes a couple problems with the use of the `StructRegistry`. First, it fixes registration so that it is consistently based on the typename of the struct. Previously structs were registered under the field name which meant that fields which referred to common structs resulted in multiple entries. Second, the patch fixes `SchemaGenerator` so that common structs are considered first.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
