### PR TITLE
KAFKA-10186: Abort transaction with pending data with TransactionAbortedException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClientUtils;
 import org.apache.kafka.clients.RequestCompletionHandler;
 import org.apache.kafka.common.Cluster;
-import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -425,7 +425,6 @@ public class Sender implements Runnable {
                 if (exception == null) {
                     exception = new TransactionAbortedException();
                 }
-                // Since the transaction is aborted / being aborted, abort all the undrained batches.
                 accumulator.abortUndrainedBatches(exception);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors.InvalidMetadataException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.errors.TransactionAbortedException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
@@ -418,10 +419,14 @@ public class Sender implements Runnable {
 
         if (transactionManager.hasAbortableError() || transactionManager.isAborting()) {
             if (accumulator.hasIncomplete()) {
+                // Attempt to get the last error that caused this abort.
                 RuntimeException exception = transactionManager.lastError();
+                // If there was no error, but we are still aborting,
+                // then this is most likely a case where there was no fatal error.
                 if (exception == null) {
-                    exception = new KafkaException("Failing batch since transaction was aborted");
+                    exception = new TransactionAbortedException();
                 }
+                // Since the transaction is aborted / being aborted, abort all the undrained batches.
                 accumulator.abortUndrainedBatches(exception);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/common/errors/TransactionAbortedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/TransactionAbortedException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+/**
+ * This is the Exception thrown when we are aborting any undrained batches during
+ * a transaction which is aborted without any underlying cause - which likely means that the user chose to abort.
+ */
+public class TransactionAbortedException extends ApiException {
+
+    private final static long serialVersionUID = 1L;
+
+    public TransactionAbortedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TransactionAbortedException(String message) {
+        super(message);
+    }
+
+    public TransactionAbortedException() {
+        super("Failing batch since transaction was aborted");
+    }
+}


### PR DESCRIPTION
KAFKA-10186: Abort transaction with pending data with TransactionAbortedException

If a transaction is aborted with no underlying exception, throw
a new kind of exception - `TransactionAbortedException` to
distinguish this from other fatal exceptions.

This is part of KIP-654 and resolves KAFKA-10186

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
