### PR TITLE
KAFKA-10478: Allow duplicated ports in advertised.listeners

### DIFF
--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -250,14 +250,20 @@ object CoreUtils {
   }
 
   def listenerListToEndPoints(listeners: String, securityProtocolMap: Map[ListenerName, SecurityProtocol]): Seq[EndPoint] = {
+    listenerListToEndPoints(listeners, securityProtocolMap, true)
+  }
+
+  def listenerListToEndPoints(listeners: String, securityProtocolMap: Map[ListenerName, SecurityProtocol], requireDistinctPorts: Boolean): Seq[EndPoint] = {
     def validate(endPoints: Seq[EndPoint]): Unit = {
       // filter port 0 for unit tests
       val portsExcludingZero = endPoints.map(_.port).filter(_ != 0)
-      val distinctPorts = portsExcludingZero.distinct
       val distinctListenerNames = endPoints.map(_.listenerName).distinct
 
-      require(distinctPorts.size == portsExcludingZero.size, s"Each listener must have a different port, listeners: $listeners")
       require(distinctListenerNames.size == endPoints.size, s"Each listener must have a different name, listeners: $listeners")
+      if (requireDistinctPorts) {
+        val distinctPorts = portsExcludingZero.distinct
+        require(distinctPorts.size == portsExcludingZero.size, s"Each listener must have a different port, listeners: $listeners")
+      }
     }
 
     val endPoints = try {


### PR DESCRIPTION
Remove the requirement for unique port numbers for the advertised.listener parameters.
This restriction makes for the listeners parameter but there's not reason to apply the
same logic for advertised.listeners.

Being able to do this opens possibilities for some practical applications when using
Kerberos authentication. For example, when configuring Kafka using Kerberos authentication
and a Load Balancer we need to have two SASL_SSL listeners: (A) one running with the
kafka/hostname principal and (B) another using kafka/lb_name, which is necessary for
proper authentication when using the LB FQDN. After bootstrap, though, the client receives
the brokers' addresses with the actual host FQDNs advertised by the brokers. To connect
to the brokerd using the hostnames the client must connect to the listener A to be able to
authenticate successfully with Kerberos.

All unit/integration tests have passed.

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
