### PR TITLE
KAFKA-10479 Throw exception if users try to update configs of existen…

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -895,13 +895,6 @@ class DynamicListenerConfig(server: KafkaServer) extends BrokerReconfigurable wi
   }
 
   def validateReconfiguration(newConfig: KafkaConfig): Unit = {
-
-    def immutableListenerConfigs(kafkaConfig: KafkaConfig, prefix: String): Map[String, AnyRef] = {
-      newConfig.originals.asScala.filter { case (key, _) =>
-        key.startsWith(prefix) && !DynamicSecurityConfigs.contains(key)
-      }
-    }
-
     val oldConfig = server.config
     val newListeners = listenersToMap(newConfig.listeners)
     val newAdvertisedListeners = listenersToMap(newConfig.advertisedListeners)
@@ -911,6 +904,11 @@ class DynamicListenerConfig(server: KafkaServer) extends BrokerReconfigurable wi
     if (!newListeners.keySet.subsetOf(newConfig.listenerSecurityProtocolMap.keySet))
       throw new ConfigException(s"Listeners '$newListeners' must be subset of listener map '${newConfig.listenerSecurityProtocolMap}'")
     newListeners.keySet.intersect(oldListeners.keySet).foreach { listenerName =>
+      def immutableListenerConfigs(kafkaConfig: KafkaConfig, prefix: String): Map[String, AnyRef] = {
+        kafkaConfig.originals.asScala.filter { case (key, _) =>
+          key.startsWith(prefix) && !DynamicSecurityConfigs.contains(key)
+        }
+      }
       val prefix = listenerName.configPrefix
       val newListenerProps = immutableListenerConfigs(newConfig, prefix)
       val oldListenerProps = immutableListenerConfigs(oldConfig, prefix)

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -327,10 +327,12 @@ class DynamicBrokerConfigTest {
     EasyMock.replay(kafkaServer)
 
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
-    val newConfig = KafkaConfig(props)
+    new DynamicListenerConfig(kafkaServer).validateReconfiguration(KafkaConfig(props))
 
+    // it is illegal to update configs of existent listeners
+    props.put("listener.name.plaintext.you.should.not.pass", "failure")
     val dynamicListenerConfig = new DynamicListenerConfig(kafkaServer)
-    dynamicListenerConfig.validateReconfiguration(newConfig)
+    assertThrows(classOf[ConfigException], () => dynamicListenerConfig.validateReconfiguration(KafkaConfig(props)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -329,7 +329,7 @@ class DynamicBrokerConfigTest {
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://hostname:9092,SASL_PLAINTEXT://hostname:9093")
     new DynamicListenerConfig(kafkaServer).validateReconfiguration(KafkaConfig(props))
 
-    // it is illegal to update configs of existent listeners
+    // it is illegal to update non-reconfiguable configs of existent listeners
     props.put("listener.name.plaintext.you.should.not.pass", "failure")
     val dynamicListenerConfig = new DynamicListenerConfig(kafkaServer)
     assertThrows(classOf[ConfigException], () => dynamicListenerConfig.validateReconfiguration(KafkaConfig(props)))

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -28,11 +28,10 @@
         Note that parameter <code>retry.backoff.ms</code> is not impacted by this change.
     </li>
     <li>Altering non-reconfigurable configs of existent listeners causes <code>InvalidRequestException</code>.
-        By contrast, the previous behavior would have caused the updated configuration to be persisted, but it wouldn't
-        take effect until the broker was restarted. The old behavior is not worth keeping since that behavior is unintended.
-        see <a href="https://github.com/apache/kafka/pull/9284">KAFKA-10479</a> for more discussion.
-        see <code>DynamicBrokerConfig.DynamicSecurityConfigs</code> and <code>SocketServer.ListenerReconfigurableConfigs</code>
-        for reconfigurable configs of existent listeners.
+        By contrast, the previous (unintended) behavior would have caused the updated configuration to be persisted, but it wouldn't
+        take effect until the broker was restarted. See <a href="https://github.com/apache/kafka/pull/9284">KAFKA-10479</a> for more discussion.
+        See <code>DynamicBrokerConfig.DynamicSecurityConfigs</code> and <code>SocketServer.ListenerReconfigurableConfigs</code>
+        for the supported reconfigurable configs of existent listeners.
     </li>
 </ul>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -29,9 +29,8 @@
     </li>
     <li>Altering non-reconfigurable configs of existent listeners causes <code>InvalidRequestException</code>.
         By contrast, the previous behavior would have caused the updated configuration to be persisted, but it wouldn't
-        take effect until the broker was restarted. This change breaks behavior compatibility but the old behavior is not
-        worth keeping since that behavior is unintended. see
-        <a href="https://github.com/apache/kafka/pull/9284">KAFKA-10479</a> for more discussion.
+        take effect until the broker was restarted. The old behavior is not worth keeping since that behavior is unintended.
+        see <a href="https://github.com/apache/kafka/pull/9284">KAFKA-10479</a> for more discussion.
         see <code>DynamicBrokerConfig.DynamicSecurityConfigs</code> and <code>SocketServer.ListenerReconfigurableConfigs</code>
         for reconfigurable configs of existent listeners.
     </li>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -27,6 +27,14 @@
         <code>default.api.timeout.ms</code>, and Kafka Streams' new <code>task.timeout.ms</code> parameters instead.
         Note that parameter <code>retry.backoff.ms</code> is not impacted by this change.
     </li>
+    <li>Altering non-reconfigurable configs of existent listeners causes <code>InvalidRequestException</code>.
+        By contrast, the previous behavior would have caused the updated configuration to be persisted, but it wouldn't
+        take effect until the broker was restarted. This change breaks behavior compatibility but the old behavior is not
+        worth keeping since that behavior is unintended. see
+        <a href="https://github.com/apache/kafka/pull/9284">KAFKA-10479</a> for more discussion.
+        see <code>DynamicBrokerConfig.DynamicSecurityConfigs</code> and <code>SocketServer.ListenerReconfigurableConfigs</code>
+        for reconfigurable configs of existent listeners.
+    </li>
 </ul>
 
 <h5><a id="upgrade_260_notable" href="#upgrade_260_notable">Notable changes in 2.6.0</a></h5>


### PR DESCRIPTION
```scala
def immutableListenerConfigs(kafkaConfig: KafkaConfig, prefix: String): Map[String, AnyRef] = {
      newConfig.originals.asScala.filter { case (key, _) =>
        key.startsWith(prefix) && !DynamicSecurityConfigs.contains(key)
      }
    }
```

We don't actually compare new configs to origin configs so the suitable exception is not thrown.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
