### PR TITLE
extract common functions from SourceConnector and SourceTask

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorCommon.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorCommon.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AccessControlEntryFilter;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidPartitionsException;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
+
+import java.util.Map;
+import java.util.List;
+import java.util.Set;
+import java.util.Map.Entry;
+import java.util.HashSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** 
+ * The common function of configuration, ACL between clusters
+*/
+class MirrorConnectorCommon {
+
+    private static final Logger log = LoggerFactory.getLogger(MirrorConnectorCommon.class);
+    private static final ResourcePatternFilter ANY_TOPIC = new ResourcePatternFilter(ResourceType.TOPIC,
+        null, PatternType.ANY);
+    private static final AclBindingFilter ANY_TOPIC_ACL = new AclBindingFilter(ANY_TOPIC, AccessControlEntryFilter.ANY);
+
+    private Scheduler scheduler;
+    private SourceAndTarget sourceAndTarget;
+    private String connectorName;
+    private TopicFilter topicFilter;
+    private ConfigPropertyFilter configPropertyFilter;
+    private List<TopicPartition> knownSourceTopicPartitions = Collections.emptyList();
+    private List<TopicPartition> knownTargetTopicPartitions = Collections.emptyList();
+    private ReplicationPolicy replicationPolicy;
+    private int replicationFactor;
+    private AdminClient sourceAdminClient;
+    private AdminClient targetAdminClient;
+    private ConnectorContext context;
+    private MirrorConnectorConfig config;
+    
+    MirrorConnectorCommon(MirrorConnectorConfig config, ConnectorContext context, Scheduler scheduler) {
+        sourceAndTarget = new SourceAndTarget(config.sourceClusterAlias(), config.targetClusterAlias());
+        topicFilter = config.topicFilter();
+        configPropertyFilter = config.configPropertyFilter();
+        replicationPolicy = config.replicationPolicy();
+        replicationFactor = config.replicationFactor();
+        sourceAdminClient = AdminClient.create(config.sourceAdminConfig());
+        targetAdminClient = AdminClient.create(config.targetAdminConfig());
+        this.context = context;
+        this.config = config;
+        this.scheduler = scheduler;
+        scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
+        scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
+        scheduler.execute(this::computeAndCreateTopicPartitions, "creating downstream topic-partitions");
+        scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
+        scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");
+        scheduler.scheduleRepeating(this::syncTopicConfigs, config.syncTopicConfigsInterval(),
+            "syncing topic configs");
+        scheduler.scheduleRepeatingDelayed(this::refreshTopicPartitions, config.refreshTopicsInterval(),
+            "refreshing topics");
+    }
+
+    // visible for testing
+    MirrorConnectorCommon() { // no-op 
+    }
+
+    // visible for testing
+    MirrorConnectorCommon(SourceAndTarget sourceAndTarget, ReplicationPolicy replicationPolicy,
+            TopicFilter topicFilter, ConfigPropertyFilter configPropertyFilter) {
+        this.sourceAndTarget = sourceAndTarget;
+        this.replicationPolicy = replicationPolicy;
+        this.topicFilter = topicFilter;
+        this.configPropertyFilter = configPropertyFilter;
+    }
+    
+    // visible for testing
+    MirrorConnectorCommon(SourceAndTarget sourceAndTarget, ReplicationPolicy replicationPolicy,
+            TopicFilter topicFilter, ConfigPropertyFilter configPropertyFilter, ConnectorContext context) {
+        this.sourceAndTarget = sourceAndTarget;
+        this.replicationPolicy = replicationPolicy;
+        this.topicFilter = topicFilter;
+        this.configPropertyFilter = configPropertyFilter;
+        this.context = context;
+    }
+
+    // visible for testing
+    List<TopicPartition> findSourceTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        Set<String> topics = listTopics(sourceAdminClient).stream()
+            .filter(this::shouldReplicateTopic)
+            .collect(Collectors.toSet());
+        return describeTopics(sourceAdminClient, topics).stream()
+            .flatMap(MirrorConnectorCommon::expandTopicDescription)
+            .collect(Collectors.toList());
+    }
+
+    // visible for testing
+    List<TopicPartition> findTargetTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        Set<String> topics = listTopics(targetAdminClient).stream()
+            .filter(t -> sourceAndTarget.source().equals(replicationPolicy.topicSource(t)))
+            .filter(t -> !t.equals(config.checkpointsTopic()))
+            .collect(Collectors.toSet());
+        return describeTopics(targetAdminClient, topics).stream()
+                .flatMap(MirrorConnectorCommon::expandTopicDescription)
+                .collect(Collectors.toList());
+    }
+
+    // visible for testing
+    void refreshTopicPartitions()
+            throws InterruptedException, ExecutionException {
+
+        List<TopicPartition> sourceTopicPartitions = findSourceTopicPartitions();
+        List<TopicPartition> targetTopicPartitions = findTargetTopicPartitions();
+
+        Set<TopicPartition> sourceTopicPartitionsSet = new HashSet<>(sourceTopicPartitions);
+        Set<TopicPartition> knownSourceTopicPartitionsSet = new HashSet<>(knownSourceTopicPartitions);
+
+        Set<TopicPartition> upstreamTargetTopicPartitions = targetTopicPartitions.stream()
+                .map(x -> new TopicPartition(replicationPolicy.upstreamTopic(x.topic()), x.partition()))
+                .collect(Collectors.toSet());
+
+        Set<TopicPartition> missingInTarget = new HashSet<>(sourceTopicPartitions);
+        missingInTarget.removeAll(upstreamTargetTopicPartitions);
+
+        knownTargetTopicPartitions = targetTopicPartitions;
+
+        // Detect if topic-partitions were added or deleted from the source cluster
+        // or if topic-partitions are missing from the target cluster
+        if (!knownSourceTopicPartitionsSet.equals(sourceTopicPartitionsSet) || !missingInTarget.isEmpty()) {
+
+            Set<TopicPartition> newTopicPartitions = sourceTopicPartitionsSet;
+            newTopicPartitions.removeAll(knownSourceTopicPartitions);
+
+            Set<TopicPartition> deletedTopicPartitions = knownSourceTopicPartitionsSet;
+            deletedTopicPartitions.removeAll(sourceTopicPartitions);
+
+            log.info("Found {} new topic-partitions on {}. " +
+                     "Found {} deleted topic-partitions on {}. " +
+                     "Found {} topic-partitions missing on {}.",
+                     newTopicPartitions.size(), sourceAndTarget.source(),
+                     deletedTopicPartitions.size(), sourceAndTarget.source(),
+                     missingInTarget.size(), sourceAndTarget.target());
+
+            log.trace("Found new topic-partitions on {}: {}", sourceAndTarget.source(), newTopicPartitions);
+            log.trace("Found deleted topic-partitions on {}: {}", sourceAndTarget.source(), deletedTopicPartitions);
+            log.trace("Found missing topic-partitions on {}: {}", sourceAndTarget.target(), missingInTarget);
+
+            knownSourceTopicPartitions = sourceTopicPartitions;
+            computeAndCreateTopicPartitions();
+            context.requestTaskReconfiguration();
+        }
+    }
+
+    private void loadTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findTargetTopicPartitions();
+    }
+
+    private void refreshKnownTargetTopics()
+            throws InterruptedException, ExecutionException {
+        knownTargetTopicPartitions = findTargetTopicPartitions();
+    }
+
+    private Set<String> topicsBeingReplicated() {
+        Set<String> knownTargetTopics = toTopics(knownTargetTopicPartitions);
+        return knownSourceTopicPartitions.stream()
+            .map(TopicPartition::topic)
+            .distinct()
+            .filter(x -> knownTargetTopics.contains(formatRemoteTopic(x)))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<String> toTopics(Collection<TopicPartition> tps) {
+        return tps.stream()
+                .map(TopicPartition::topic)
+                .collect(Collectors.toSet());
+    }
+
+    private void syncTopicAcls()
+            throws InterruptedException, ExecutionException {
+        List<AclBinding> bindings = listTopicAclBindings().stream()
+            .filter(x -> x.pattern().resourceType() == ResourceType.TOPIC)
+            .filter(x -> x.pattern().patternType() == PatternType.LITERAL)
+            .filter(this::shouldReplicateAcl)
+            .filter(x -> shouldReplicateTopic(x.pattern().name()))
+            .map(this::targetAclBinding)
+            .collect(Collectors.toList());
+        updateTopicAcls(bindings);
+    }
+
+    private void syncTopicConfigs()
+            throws InterruptedException, ExecutionException {
+        Map<String, Config> sourceConfigs = describeTopicConfigs(topicsBeingReplicated());
+        Map<String, Config> targetConfigs = sourceConfigs.entrySet().stream()
+            .collect(Collectors.toMap(x -> formatRemoteTopic(x.getKey()), x -> targetConfig(x.getValue())));
+        updateTopicConfigs(targetConfigs);
+    }
+
+    private void createOffsetSyncsTopic() {
+        MirrorUtils.createSinglePartitionCompactedTopic(config.offsetSyncsTopic(), config.offsetSyncsTopicReplicationFactor(), config.sourceAdminConfig());
+    }
+
+    void computeAndCreateTopicPartitions() throws ExecutionException, InterruptedException {
+        // get source and target topics with respective partition counts
+        Map<String, Long> sourceTopicToPartitionCounts = knownSourceTopicPartitions.stream()
+                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting())).entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        Map<String, Long> targetTopicToPartitionCounts = knownTargetTopicPartitions.stream()
+                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting())).entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+        Set<String> knownSourceTopics = sourceTopicToPartitionCounts.keySet();
+        Set<String> knownTargetTopics = targetTopicToPartitionCounts.keySet();
+        Map<String, String> sourceToRemoteTopics = knownSourceTopics.stream()
+                .collect(Collectors.toMap(Function.identity(), sourceTopic -> formatRemoteTopic(sourceTopic)));
+
+        // compute existing and new source topics
+        Map<Boolean, Set<String>> partitionedSourceTopics = knownSourceTopics.stream()
+                .collect(Collectors.partitioningBy(sourceTopic -> knownTargetTopics.contains(sourceToRemoteTopics.get(sourceTopic)),
+                        Collectors.toSet()));
+        Set<String> existingSourceTopics = partitionedSourceTopics.get(true);
+        Set<String> newSourceTopics = partitionedSourceTopics.get(false);
+
+        // create new topics
+        if (!newSourceTopics.isEmpty())
+            createNewTopics(newSourceTopics, sourceTopicToPartitionCounts);
+
+        // compute topics with new partitions
+        Map<String, Long> sourceTopicsWithNewPartitions = existingSourceTopics.stream()
+                .filter(sourceTopic -> {
+                    String targetTopic = sourceToRemoteTopics.get(sourceTopic);
+                    return sourceTopicToPartitionCounts.get(sourceTopic) > targetTopicToPartitionCounts.get(targetTopic);
+                })
+                .collect(Collectors.toMap(Function.identity(), sourceTopicToPartitionCounts::get));
+
+        // create new partitions
+        if (!sourceTopicsWithNewPartitions.isEmpty()) {
+            Map<String, NewPartitions> newTargetPartitions = sourceTopicsWithNewPartitions.entrySet().stream()
+                    .collect(Collectors.toMap(sourceTopicAndPartitionCount -> sourceToRemoteTopics.get(sourceTopicAndPartitionCount.getKey()),
+                        sourceTopicAndPartitionCount -> NewPartitions.increaseTo(sourceTopicAndPartitionCount.getValue().intValue())));
+            createNewPartitions(newTargetPartitions);
+        }
+    }
+
+    private void createNewTopics(Set<String> newSourceTopics, Map<String, Long> sourceTopicToPartitionCounts)
+            throws ExecutionException, InterruptedException {
+        Map<String, Config> sourceTopicToConfig = describeTopicConfigs(newSourceTopics);
+        Map<String, NewTopic> newTopics = newSourceTopics.stream()
+                .map(sourceTopic -> {
+                    String remoteTopic = formatRemoteTopic(sourceTopic);
+                    int partitionCount = sourceTopicToPartitionCounts.get(sourceTopic).intValue();
+                    Map<String, String> configs = configToMap(sourceTopicToConfig.get(sourceTopic));
+                    return new NewTopic(remoteTopic, partitionCount, (short) replicationFactor)
+                            .configs(configs);
+                })
+                .collect(Collectors.toMap(NewTopic::name, Function.identity()));
+        createNewTopics(newTopics);
+    }
+
+    // visible for testing
+    void createNewTopics(Map<String, NewTopic> newTopics) {
+        targetAdminClient.createTopics(newTopics.values(), new CreateTopicsOptions()).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e != null) {
+                log.warn("Could not create topic {}.", k, e);
+            } else {
+                log.info("Created remote topic {} with {} partitions.", k, newTopics.get(k).numPartitions());
+            }
+        }));
+    }
+
+    void createNewPartitions(Map<String, NewPartitions> newPartitions) {
+        targetAdminClient.createPartitions(newPartitions).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e instanceof InvalidPartitionsException) {
+                // swallow, this is normal
+            } else if (e != null) {
+                log.warn("Could not create topic-partitions for {}.", k, e);
+            } else {
+                log.info("Increased size of {} to {} partitions.", k, newPartitions.get(k).totalCount());
+            }
+        }));
+    }
+
+    private Set<String> listTopics(AdminClient adminClient)
+            throws InterruptedException, ExecutionException {
+        return adminClient.listTopics().names().get();
+    }
+
+    private Collection<AclBinding> listTopicAclBindings()
+            throws InterruptedException, ExecutionException {
+        return sourceAdminClient.describeAcls(ANY_TOPIC_ACL).values().get();
+    }
+
+    private static Collection<TopicDescription> describeTopics(AdminClient adminClient, Collection<String> topics)
+            throws InterruptedException, ExecutionException {
+        return adminClient.describeTopics(topics).all().get().values();
+    }
+
+    static Map<String, String> configToMap(Config config) {
+        return config.entries().stream()
+                .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
+    }
+
+    @SuppressWarnings("deprecation")
+    // use deprecated alterConfigs API for broker compatibility back to 0.11.0
+    private void updateTopicConfigs(Map<String, Config> topicConfigs)
+            throws InterruptedException, ExecutionException {
+        Map<ConfigResource, Config> configs = topicConfigs.entrySet().stream()
+            .collect(Collectors.toMap(x ->
+                new ConfigResource(ConfigResource.Type.TOPIC, x.getKey()), Entry::getValue));
+        log.trace("Syncing configs for {} topics.", configs.size());
+        targetAdminClient.alterConfigs(configs).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e != null) {
+                log.warn("Could not alter configuration of topic {}.", k.name(), e);
+            }
+        }));
+    }
+
+    private void updateTopicAcls(List<AclBinding> bindings)
+            throws InterruptedException, ExecutionException {
+        log.trace("Syncing {} topic ACL bindings.", bindings.size());
+        targetAdminClient.createAcls(bindings).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e != null) {
+                log.warn("Could not sync ACL of topic {}.", k.pattern().name(), e);
+            }
+        }));
+    }
+
+    private static Stream<TopicPartition> expandTopicDescription(TopicDescription description) {
+        String topic = description.name();
+        return description.partitions().stream()
+            .map(x -> new TopicPartition(topic, x.partition()));
+    }
+
+    Map<String, Config> describeTopicConfigs(Set<String> topics)
+            throws InterruptedException, ExecutionException {
+        Set<ConfigResource> resources = topics.stream()
+            .map(x -> new ConfigResource(ConfigResource.Type.TOPIC, x))
+            .collect(Collectors.toSet());
+        return sourceAdminClient.describeConfigs(resources).all().get().entrySet().stream()
+            .collect(Collectors.toMap(x -> x.getKey().name(), Entry::getValue));
+    }
+
+    Config targetConfig(Config sourceConfig) {
+        List<ConfigEntry> entries = sourceConfig.entries().stream()
+            .filter(x -> !x.isDefault() && !x.isReadOnly() && !x.isSensitive())
+            .filter(x -> x.source() != ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
+            .filter(x -> shouldReplicateTopicConfigurationProperty(x.name()))
+            .collect(Collectors.toList());
+        return new Config(entries);
+    }
+
+    private static AccessControlEntry downgradeAllowAllACL(AccessControlEntry entry) {
+        return new AccessControlEntry(entry.principal(), entry.host(), AclOperation.READ, entry.permissionType());
+    }
+
+    AclBinding targetAclBinding(AclBinding sourceAclBinding) {
+        String targetTopic = formatRemoteTopic(sourceAclBinding.pattern().name());
+        final AccessControlEntry entry;
+        if (sourceAclBinding.entry().permissionType() == AclPermissionType.ALLOW
+                && sourceAclBinding.entry().operation() == AclOperation.ALL) {
+            entry = downgradeAllowAllACL(sourceAclBinding.entry());
+        } else {
+            entry = sourceAclBinding.entry();
+        }
+        return new AclBinding(new ResourcePattern(ResourceType.TOPIC, targetTopic, PatternType.LITERAL), entry);
+    }
+
+    boolean shouldReplicateTopic(String topic) {
+        return (topicFilter.shouldReplicateTopic(topic) || isHeartbeatTopic(topic))
+            && !replicationPolicy.isInternalTopic(topic) && !isCycle(topic);
+    }
+
+    boolean shouldReplicateAcl(AclBinding aclBinding) {
+        return !(aclBinding.entry().permissionType() == AclPermissionType.ALLOW
+            && aclBinding.entry().operation() == AclOperation.WRITE);
+    }
+
+    boolean shouldReplicateTopicConfigurationProperty(String property) {
+        return configPropertyFilter.shouldReplicateConfigProperty(property);
+    }
+
+    // Recurse upstream to detect cycles, i.e. whether this topic is already on the target cluster
+    boolean isCycle(String topic) {
+        String source = replicationPolicy.topicSource(topic);
+        if (source == null) {
+            return false;
+        } else if (source.equals(sourceAndTarget.target())) {
+            return true;
+        } else {
+            return isCycle(replicationPolicy.upstreamTopic(topic));
+        }
+    }
+
+    // e.g. heartbeats, us-west.heartbeats
+    boolean isHeartbeatTopic(String topic) {
+        return MirrorClientConfig.HEARTBEATS_TOPIC.equals(replicationPolicy.originalTopic(topic));
+    }
+
+    String formatRemoteTopic(String topic) {
+        return replicationPolicy.formatRemoteTopic(sourceAndTarget.source(), topic);
+    }
+    
+    List<TopicPartition> getKnownSourceTopicPartitions() {
+        return knownSourceTopicPartitions;
+    }
+    
+    // visible for testing
+    void setKnownSourceTopicPartitions(List<TopicPartition> knownSourceTopicPartitions) {
+        this.knownSourceTopicPartitions = knownSourceTopicPartitions;
+    }
+    
+    void stop() {
+        Utils.closeQuietly(scheduler, "scheduler");
+        Utils.closeQuietly(topicFilter, "topic filter");
+        Utils.closeQuietly(configPropertyFilter, "config property filter");
+        Utils.closeQuietly(sourceAdminClient, "source admin client");
+        Utils.closeQuietly(targetAdminClient, "target admin client");
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -16,43 +16,16 @@
  */
 package org.apache.kafka.connect.mirror;
 
-import java.util.Map.Entry;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.acl.AclBinding;
-import org.apache.kafka.common.acl.AclBindingFilter;
-import org.apache.kafka.common.acl.AccessControlEntry;
-import org.apache.kafka.common.acl.AccessControlEntryFilter;
-import org.apache.kafka.common.acl.AclPermissionType;
-import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.resource.ResourceType;
-import org.apache.kafka.common.resource.ResourcePattern;
-import org.apache.kafka.common.resource.ResourcePatternFilter;
-import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.InvalidPartitionsException;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
-import org.apache.kafka.clients.admin.NewPartitions;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.CreateTopicsOptions;
 
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,23 +37,12 @@ import org.slf4j.LoggerFactory;
 public class MirrorSourceConnector extends SourceConnector {
 
     private static final Logger log = LoggerFactory.getLogger(MirrorSourceConnector.class);
-    private static final ResourcePatternFilter ANY_TOPIC = new ResourcePatternFilter(ResourceType.TOPIC,
-        null, PatternType.ANY);
-    private static final AclBindingFilter ANY_TOPIC_ACL = new AclBindingFilter(ANY_TOPIC, AccessControlEntryFilter.ANY);
 
     private Scheduler scheduler;
     private MirrorConnectorConfig config;
-    private SourceAndTarget sourceAndTarget;
     private String connectorName;
-    private TopicFilter topicFilter;
-    private ConfigPropertyFilter configPropertyFilter;
     private List<TopicPartition> knownSourceTopicPartitions = Collections.emptyList();
-    private List<TopicPartition> knownTargetTopicPartitions = Collections.emptyList();
-    private ReplicationPolicy replicationPolicy;
-    private int replicationFactor;
-    private AdminClient sourceAdminClient;
-    private AdminClient targetAdminClient;
-
+    private MirrorConnectorCommon connectorCommon;
     public MirrorSourceConnector() {
         // nop
     }
@@ -89,17 +51,11 @@ public class MirrorSourceConnector extends SourceConnector {
     MirrorSourceConnector(List<TopicPartition> knownSourceTopicPartitions, MirrorConnectorConfig config) {
         this.knownSourceTopicPartitions = knownSourceTopicPartitions;
         this.config = config;
+        connectorCommon = new MirrorConnectorCommon();
+        connectorCommon.setKnownSourceTopicPartitions(knownSourceTopicPartitions);
     }
 
-    // visible for testing
-    MirrorSourceConnector(SourceAndTarget sourceAndTarget, ReplicationPolicy replicationPolicy,
-            TopicFilter topicFilter, ConfigPropertyFilter configPropertyFilter) {
-        this.sourceAndTarget = sourceAndTarget;
-        this.replicationPolicy = replicationPolicy;
-        this.topicFilter = topicFilter;
-        this.configPropertyFilter = configPropertyFilter;
-    }
-
+    
     @Override
     public void start(Map<String, String> props) {
         long start = System.currentTimeMillis();
@@ -107,24 +63,10 @@ public class MirrorSourceConnector extends SourceConnector {
         if (!config.enabled()) {
             return;
         }
-        connectorName = config.connectorName();
-        sourceAndTarget = new SourceAndTarget(config.sourceClusterAlias(), config.targetClusterAlias());
-        topicFilter = config.topicFilter();
-        configPropertyFilter = config.configPropertyFilter();
-        replicationPolicy = config.replicationPolicy();
-        replicationFactor = config.replicationFactor();
-        sourceAdminClient = AdminClient.create(config.sourceAdminConfig());
-        targetAdminClient = AdminClient.create(config.targetAdminConfig());
         scheduler = new Scheduler(MirrorSourceConnector.class, config.adminTimeout());
-        scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
-        scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
-        scheduler.execute(this::computeAndCreateTopicPartitions, "creating downstream topic-partitions");
-        scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
-        scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");
-        scheduler.scheduleRepeating(this::syncTopicConfigs, config.syncTopicConfigsInterval(),
-            "syncing topic configs");
-        scheduler.scheduleRepeatingDelayed(this::refreshTopicPartitions, config.refreshTopicsInterval(),
-            "refreshing topics");
+        connectorCommon = new MirrorConnectorCommon(config, context, scheduler);
+        connectorName = config.connectorName();
+        knownSourceTopicPartitions = connectorCommon.getKnownSourceTopicPartitions();
         log.info("Started {} with {} topic-partitions.", connectorName, knownSourceTopicPartitions.size());
         log.info("Starting {} took {} ms.", connectorName, System.currentTimeMillis() - start);
     }
@@ -135,11 +77,7 @@ public class MirrorSourceConnector extends SourceConnector {
         if (!config.enabled()) {
             return;
         }
-        Utils.closeQuietly(scheduler, "scheduler");
-        Utils.closeQuietly(topicFilter, "topic filter");
-        Utils.closeQuietly(configPropertyFilter, "config property filter");
-        Utils.closeQuietly(sourceAdminClient, "source admin client");
-        Utils.closeQuietly(targetAdminClient, "target admin client");
+        connectorCommon.stop();
         log.info("Stopping {} took {} ms.", connectorName, System.currentTimeMillis() - start);
     }
 
@@ -159,6 +97,7 @@ public class MirrorSourceConnector extends SourceConnector {
     // t3 -> [t0p2, t0p5, t1p0, t2p1]
     @Override
     public List<Map<String, String>> taskConfigs(int maxTasks) {
+        knownSourceTopicPartitions = connectorCommon.getKnownSourceTopicPartitions();
         if (!config.enabled() || knownSourceTopicPartitions.isEmpty()) {
             return Collections.emptyList();
         }
@@ -186,324 +125,5 @@ public class MirrorSourceConnector extends SourceConnector {
     @Override
     public String version() {
         return "1";
-    }
-
-    // visible for testing
-    List<TopicPartition> findSourceTopicPartitions()
-            throws InterruptedException, ExecutionException {
-        Set<String> topics = listTopics(sourceAdminClient).stream()
-            .filter(this::shouldReplicateTopic)
-            .collect(Collectors.toSet());
-        return describeTopics(sourceAdminClient, topics).stream()
-            .flatMap(MirrorSourceConnector::expandTopicDescription)
-            .collect(Collectors.toList());
-    }
-
-    // visible for testing
-    List<TopicPartition> findTargetTopicPartitions()
-            throws InterruptedException, ExecutionException {
-        Set<String> topics = listTopics(targetAdminClient).stream()
-            .filter(t -> sourceAndTarget.source().equals(replicationPolicy.topicSource(t)))
-            .filter(t -> !t.equals(config.checkpointsTopic()))
-            .collect(Collectors.toSet());
-        return describeTopics(targetAdminClient, topics).stream()
-                .flatMap(MirrorSourceConnector::expandTopicDescription)
-                .collect(Collectors.toList());
-    }
-
-    // visible for testing
-    void refreshTopicPartitions()
-            throws InterruptedException, ExecutionException {
-
-        List<TopicPartition> sourceTopicPartitions = findSourceTopicPartitions();
-        List<TopicPartition> targetTopicPartitions = findTargetTopicPartitions();
-
-        Set<TopicPartition> sourceTopicPartitionsSet = new HashSet<>(sourceTopicPartitions);
-        Set<TopicPartition> knownSourceTopicPartitionsSet = new HashSet<>(knownSourceTopicPartitions);
-
-        Set<TopicPartition> upstreamTargetTopicPartitions = targetTopicPartitions.stream()
-                .map(x -> new TopicPartition(replicationPolicy.upstreamTopic(x.topic()), x.partition()))
-                .collect(Collectors.toSet());
-
-        Set<TopicPartition> missingInTarget = new HashSet<>(sourceTopicPartitions);
-        missingInTarget.removeAll(upstreamTargetTopicPartitions);
-
-        knownTargetTopicPartitions = targetTopicPartitions;
-
-        // Detect if topic-partitions were added or deleted from the source cluster
-        // or if topic-partitions are missing from the target cluster
-        if (!knownSourceTopicPartitionsSet.equals(sourceTopicPartitionsSet) || !missingInTarget.isEmpty()) {
-
-            Set<TopicPartition> newTopicPartitions = sourceTopicPartitionsSet;
-            newTopicPartitions.removeAll(knownSourceTopicPartitions);
-
-            Set<TopicPartition> deletedTopicPartitions = knownSourceTopicPartitionsSet;
-            deletedTopicPartitions.removeAll(sourceTopicPartitions);
-
-            log.info("Found {} new topic-partitions on {}. " +
-                     "Found {} deleted topic-partitions on {}. " +
-                     "Found {} topic-partitions missing on {}.",
-                     newTopicPartitions.size(), sourceAndTarget.source(),
-                     deletedTopicPartitions.size(), sourceAndTarget.source(),
-                     missingInTarget.size(), sourceAndTarget.target());
-
-            log.trace("Found new topic-partitions on {}: {}", sourceAndTarget.source(), newTopicPartitions);
-            log.trace("Found deleted topic-partitions on {}: {}", sourceAndTarget.source(), deletedTopicPartitions);
-            log.trace("Found missing topic-partitions on {}: {}", sourceAndTarget.target(), missingInTarget);
-
-            knownSourceTopicPartitions = sourceTopicPartitions;
-            computeAndCreateTopicPartitions();
-            context.requestTaskReconfiguration();
-        }
-    }
-
-    private void loadTopicPartitions()
-            throws InterruptedException, ExecutionException {
-        knownSourceTopicPartitions = findSourceTopicPartitions();
-        knownTargetTopicPartitions = findTargetTopicPartitions();
-    }
-
-    private void refreshKnownTargetTopics()
-            throws InterruptedException, ExecutionException {
-        knownTargetTopicPartitions = findTargetTopicPartitions();
-    }
-
-    private Set<String> topicsBeingReplicated() {
-        Set<String> knownTargetTopics = toTopics(knownTargetTopicPartitions);
-        return knownSourceTopicPartitions.stream()
-            .map(TopicPartition::topic)
-            .distinct()
-            .filter(x -> knownTargetTopics.contains(formatRemoteTopic(x)))
-            .collect(Collectors.toSet());
-    }
-
-    private Set<String> toTopics(Collection<TopicPartition> tps) {
-        return tps.stream()
-                .map(TopicPartition::topic)
-                .collect(Collectors.toSet());
-    }
-
-    private void syncTopicAcls()
-            throws InterruptedException, ExecutionException {
-        List<AclBinding> bindings = listTopicAclBindings().stream()
-            .filter(x -> x.pattern().resourceType() == ResourceType.TOPIC)
-            .filter(x -> x.pattern().patternType() == PatternType.LITERAL)
-            .filter(this::shouldReplicateAcl)
-            .filter(x -> shouldReplicateTopic(x.pattern().name()))
-            .map(this::targetAclBinding)
-            .collect(Collectors.toList());
-        updateTopicAcls(bindings);
-    }
-
-    private void syncTopicConfigs()
-            throws InterruptedException, ExecutionException {
-        Map<String, Config> sourceConfigs = describeTopicConfigs(topicsBeingReplicated());
-        Map<String, Config> targetConfigs = sourceConfigs.entrySet().stream()
-            .collect(Collectors.toMap(x -> formatRemoteTopic(x.getKey()), x -> targetConfig(x.getValue())));
-        updateTopicConfigs(targetConfigs);
-    }
-
-    private void createOffsetSyncsTopic() {
-        MirrorUtils.createSinglePartitionCompactedTopic(config.offsetSyncsTopic(), config.offsetSyncsTopicReplicationFactor(), config.sourceAdminConfig());
-    }
-
-    void computeAndCreateTopicPartitions() throws ExecutionException, InterruptedException {
-        // get source and target topics with respective partition counts
-        Map<String, Long> sourceTopicToPartitionCounts = knownSourceTopicPartitions.stream()
-                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting())).entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-        Map<String, Long> targetTopicToPartitionCounts = knownTargetTopicPartitions.stream()
-                .collect(Collectors.groupingBy(TopicPartition::topic, Collectors.counting())).entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-
-        Set<String> knownSourceTopics = sourceTopicToPartitionCounts.keySet();
-        Set<String> knownTargetTopics = targetTopicToPartitionCounts.keySet();
-        Map<String, String> sourceToRemoteTopics = knownSourceTopics.stream()
-                .collect(Collectors.toMap(Function.identity(), sourceTopic -> formatRemoteTopic(sourceTopic)));
-
-        // compute existing and new source topics
-        Map<Boolean, Set<String>> partitionedSourceTopics = knownSourceTopics.stream()
-                .collect(Collectors.partitioningBy(sourceTopic -> knownTargetTopics.contains(sourceToRemoteTopics.get(sourceTopic)),
-                        Collectors.toSet()));
-        Set<String> existingSourceTopics = partitionedSourceTopics.get(true);
-        Set<String> newSourceTopics = partitionedSourceTopics.get(false);
-
-        // create new topics
-        if (!newSourceTopics.isEmpty())
-            createNewTopics(newSourceTopics, sourceTopicToPartitionCounts);
-
-        // compute topics with new partitions
-        Map<String, Long> sourceTopicsWithNewPartitions = existingSourceTopics.stream()
-                .filter(sourceTopic -> {
-                    String targetTopic = sourceToRemoteTopics.get(sourceTopic);
-                    return sourceTopicToPartitionCounts.get(sourceTopic) > targetTopicToPartitionCounts.get(targetTopic);
-                })
-                .collect(Collectors.toMap(Function.identity(), sourceTopicToPartitionCounts::get));
-
-        // create new partitions
-        if (!sourceTopicsWithNewPartitions.isEmpty()) {
-            Map<String, NewPartitions> newTargetPartitions = sourceTopicsWithNewPartitions.entrySet().stream()
-                    .collect(Collectors.toMap(sourceTopicAndPartitionCount -> sourceToRemoteTopics.get(sourceTopicAndPartitionCount.getKey()),
-                        sourceTopicAndPartitionCount -> NewPartitions.increaseTo(sourceTopicAndPartitionCount.getValue().intValue())));
-            createNewPartitions(newTargetPartitions);
-        }
-    }
-
-    private void createNewTopics(Set<String> newSourceTopics, Map<String, Long> sourceTopicToPartitionCounts)
-            throws ExecutionException, InterruptedException {
-        Map<String, Config> sourceTopicToConfig = describeTopicConfigs(newSourceTopics);
-        Map<String, NewTopic> newTopics = newSourceTopics.stream()
-                .map(sourceTopic -> {
-                    String remoteTopic = formatRemoteTopic(sourceTopic);
-                    int partitionCount = sourceTopicToPartitionCounts.get(sourceTopic).intValue();
-                    Map<String, String> configs = configToMap(sourceTopicToConfig.get(sourceTopic));
-                    return new NewTopic(remoteTopic, partitionCount, (short) replicationFactor)
-                            .configs(configs);
-                })
-                .collect(Collectors.toMap(NewTopic::name, Function.identity()));
-        createNewTopics(newTopics);
-    }
-
-    // visible for testing
-    void createNewTopics(Map<String, NewTopic> newTopics) {
-        targetAdminClient.createTopics(newTopics.values(), new CreateTopicsOptions()).values().forEach((k, v) -> v.whenComplete((x, e) -> {
-            if (e != null) {
-                log.warn("Could not create topic {}.", k, e);
-            } else {
-                log.info("Created remote topic {} with {} partitions.", k, newTopics.get(k).numPartitions());
-            }
-        }));
-    }
-
-    void createNewPartitions(Map<String, NewPartitions> newPartitions) {
-        targetAdminClient.createPartitions(newPartitions).values().forEach((k, v) -> v.whenComplete((x, e) -> {
-            if (e instanceof InvalidPartitionsException) {
-                // swallow, this is normal
-            } else if (e != null) {
-                log.warn("Could not create topic-partitions for {}.", k, e);
-            } else {
-                log.info("Increased size of {} to {} partitions.", k, newPartitions.get(k).totalCount());
-            }
-        }));
-    }
-
-    private Set<String> listTopics(AdminClient adminClient)
-            throws InterruptedException, ExecutionException {
-        return adminClient.listTopics().names().get();
-    }
-
-    private Collection<AclBinding> listTopicAclBindings()
-            throws InterruptedException, ExecutionException {
-        return sourceAdminClient.describeAcls(ANY_TOPIC_ACL).values().get();
-    }
-
-    private static Collection<TopicDescription> describeTopics(AdminClient adminClient, Collection<String> topics)
-            throws InterruptedException, ExecutionException {
-        return adminClient.describeTopics(topics).all().get().values();
-    }
-
-    static Map<String, String> configToMap(Config config) {
-        return config.entries().stream()
-                .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
-    }
-
-    @SuppressWarnings("deprecation")
-    // use deprecated alterConfigs API for broker compatibility back to 0.11.0
-    private void updateTopicConfigs(Map<String, Config> topicConfigs)
-            throws InterruptedException, ExecutionException {
-        Map<ConfigResource, Config> configs = topicConfigs.entrySet().stream()
-            .collect(Collectors.toMap(x ->
-                new ConfigResource(ConfigResource.Type.TOPIC, x.getKey()), Entry::getValue));
-        log.trace("Syncing configs for {} topics.", configs.size());
-        targetAdminClient.alterConfigs(configs).values().forEach((k, v) -> v.whenComplete((x, e) -> {
-            if (e != null) {
-                log.warn("Could not alter configuration of topic {}.", k.name(), e);
-            }
-        }));
-    }
-
-    private void updateTopicAcls(List<AclBinding> bindings)
-            throws InterruptedException, ExecutionException {
-        log.trace("Syncing {} topic ACL bindings.", bindings.size());
-        targetAdminClient.createAcls(bindings).values().forEach((k, v) -> v.whenComplete((x, e) -> {
-            if (e != null) {
-                log.warn("Could not sync ACL of topic {}.", k.pattern().name(), e);
-            }
-        }));
-    }
-
-    private static Stream<TopicPartition> expandTopicDescription(TopicDescription description) {
-        String topic = description.name();
-        return description.partitions().stream()
-            .map(x -> new TopicPartition(topic, x.partition()));
-    }
-
-    Map<String, Config> describeTopicConfigs(Set<String> topics)
-            throws InterruptedException, ExecutionException {
-        Set<ConfigResource> resources = topics.stream()
-            .map(x -> new ConfigResource(ConfigResource.Type.TOPIC, x))
-            .collect(Collectors.toSet());
-        return sourceAdminClient.describeConfigs(resources).all().get().entrySet().stream()
-            .collect(Collectors.toMap(x -> x.getKey().name(), Entry::getValue));
-    }
-
-    Config targetConfig(Config sourceConfig) {
-        List<ConfigEntry> entries = sourceConfig.entries().stream()
-            .filter(x -> !x.isDefault() && !x.isReadOnly() && !x.isSensitive())
-            .filter(x -> x.source() != ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
-            .filter(x -> shouldReplicateTopicConfigurationProperty(x.name()))
-            .collect(Collectors.toList());
-        return new Config(entries);
-    }
-
-    private static AccessControlEntry downgradeAllowAllACL(AccessControlEntry entry) {
-        return new AccessControlEntry(entry.principal(), entry.host(), AclOperation.READ, entry.permissionType());
-    }
-
-    AclBinding targetAclBinding(AclBinding sourceAclBinding) {
-        String targetTopic = formatRemoteTopic(sourceAclBinding.pattern().name());
-        final AccessControlEntry entry;
-        if (sourceAclBinding.entry().permissionType() == AclPermissionType.ALLOW
-                && sourceAclBinding.entry().operation() == AclOperation.ALL) {
-            entry = downgradeAllowAllACL(sourceAclBinding.entry());
-        } else {
-            entry = sourceAclBinding.entry();
-        }
-        return new AclBinding(new ResourcePattern(ResourceType.TOPIC, targetTopic, PatternType.LITERAL), entry);
-    }
-
-    boolean shouldReplicateTopic(String topic) {
-        return (topicFilter.shouldReplicateTopic(topic) || isHeartbeatTopic(topic))
-            && !replicationPolicy.isInternalTopic(topic) && !isCycle(topic);
-    }
-
-    boolean shouldReplicateAcl(AclBinding aclBinding) {
-        return !(aclBinding.entry().permissionType() == AclPermissionType.ALLOW
-            && aclBinding.entry().operation() == AclOperation.WRITE);
-    }
-
-    boolean shouldReplicateTopicConfigurationProperty(String property) {
-        return configPropertyFilter.shouldReplicateConfigProperty(property);
-    }
-
-    // Recurse upstream to detect cycles, i.e. whether this topic is already on the target cluster
-    boolean isCycle(String topic) {
-        String source = replicationPolicy.topicSource(topic);
-        if (source == null) {
-            return false;
-        } else if (source.equals(sourceAndTarget.target())) {
-            return true;
-        } else {
-            return isCycle(replicationPolicy.upstreamTopic(topic));
-        }
-    }
-
-    // e.g. heartbeats, us-west.heartbeats
-    boolean isHeartbeatTopic(String topic) {
-        return MirrorClientConfig.HEARTBEATS_TOPIC.equals(replicationPolicy.originalTopic(topic));
-    }
-
-    String formatRemoteTopic(String topic) {
-        return replicationPolicy.formatRemoteTopic(sourceAndTarget.source(), topic);
     }
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceTask.java
@@ -25,8 +25,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.errors.WakeupException;
@@ -37,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.ArrayList;
@@ -50,44 +47,33 @@ public class MirrorSourceTask extends SourceTask {
 
     private static final Logger log = LoggerFactory.getLogger(MirrorSourceTask.class);
 
-    private static final int MAX_OUTSTANDING_OFFSET_SYNCS = 10;
-
     private KafkaConsumer<byte[], byte[]> consumer;
-    private KafkaProducer<byte[], byte[]> offsetProducer;
     private String sourceClusterAlias;
-    private String offsetSyncsTopic;
     private Duration pollTimeout;
-    private long maxOffsetLag;
-    private Map<TopicPartition, PartitionState> partitionStates;
     private ReplicationPolicy replicationPolicy;
     private MirrorMetrics metrics;
     private boolean stopping = false;
-    private Semaphore outstandingOffsetSyncs;
     private Semaphore consumerAccess;
+    private MirrorTaskCommon taskCommon;
 
     public MirrorSourceTask() {}
 
     // for testing
-    MirrorSourceTask(String sourceClusterAlias, ReplicationPolicy replicationPolicy, long maxOffsetLag) {
+    MirrorSourceTask(String sourceClusterAlias, ReplicationPolicy replicationPolicy) {
         this.sourceClusterAlias = sourceClusterAlias;
         this.replicationPolicy = replicationPolicy;
-        this.maxOffsetLag = maxOffsetLag;
     }
 
     @Override
     public void start(Map<String, String> props) {
         MirrorTaskConfig config = new MirrorTaskConfig(props);
-        outstandingOffsetSyncs = new Semaphore(MAX_OUTSTANDING_OFFSET_SYNCS);
         consumerAccess = new Semaphore(1);  // let one thread at a time access the consumer
         sourceClusterAlias = config.sourceClusterAlias();
         metrics = config.metrics();
         pollTimeout = config.consumerPollTimeout();
-        maxOffsetLag = config.maxOffsetLag();
         replicationPolicy = config.replicationPolicy();
-        partitionStates = new HashMap<>();
-        offsetSyncsTopic = config.offsetSyncsTopic();
         consumer = MirrorUtils.newConsumer(config.sourceConsumerConfig());
-        offsetProducer = MirrorUtils.newProducer(config.sourceProducerConfig());
+        taskCommon = new MirrorTaskCommon(config);
         Set<TopicPartition> taskTopicPartitions = config.taskTopicPartitions();
         Map<TopicPartition, Long> topicPartitionOffsets = loadOffsets(taskTopicPartitions);
         consumer.assign(topicPartitionOffsets.keySet());
@@ -114,8 +100,8 @@ public class MirrorSourceTask extends SourceTask {
         } catch (InterruptedException e) {
             log.warn("Interrupted waiting for access to consumer. Will try closing anyway."); 
         }
+        taskCommon.stop();
         Utils.closeQuietly(consumer, "source consumer");
-        Utils.closeQuietly(offsetProducer, "offset producer");
         Utils.closeQuietly(metrics, "metrics");
         log.info("Stopping {} took {} ms.", Thread.currentThread().getName(), System.currentTimeMillis() - start);
     }
@@ -181,41 +167,10 @@ public class MirrorSourceTask extends SourceTask {
             TopicPartition sourceTopicPartition = MirrorUtils.unwrapPartition(record.sourcePartition());
             long upstreamOffset = MirrorUtils.unwrapOffset(record.sourceOffset());
             long downstreamOffset = metadata.offset();
-            maybeSyncOffsets(sourceTopicPartition, upstreamOffset, downstreamOffset);
+            taskCommon.maybeSyncOffsets(sourceTopicPartition, upstreamOffset, downstreamOffset);
         } catch (Throwable e) {
             log.warn("Failure committing record.", e);
         }
-    }
-
-    // updates partition state and sends OffsetSync if necessary
-    private void maybeSyncOffsets(TopicPartition topicPartition, long upstreamOffset,
-            long downstreamOffset) {
-        PartitionState partitionState =
-            partitionStates.computeIfAbsent(topicPartition, x -> new PartitionState(maxOffsetLag));
-        if (partitionState.update(upstreamOffset, downstreamOffset)) {
-            sendOffsetSync(topicPartition, upstreamOffset, downstreamOffset);
-        }
-    }
-
-    // sends OffsetSync record upstream to internal offsets topic
-    private void sendOffsetSync(TopicPartition topicPartition, long upstreamOffset,
-            long downstreamOffset) {
-        if (!outstandingOffsetSyncs.tryAcquire()) {
-            // Too many outstanding offset syncs.
-            return;
-        }
-        OffsetSync offsetSync = new OffsetSync(topicPartition, upstreamOffset, downstreamOffset);
-        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(offsetSyncsTopic, 0,
-                offsetSync.recordKey(), offsetSync.recordValue());
-        offsetProducer.send(record, (x, e) -> {
-            if (e != null) {
-                log.error("Failure sending offset sync.", e);
-            } else {
-                log.trace("Sync'd offsets for {}: {}=={}", topicPartition,
-                    upstreamOffset, downstreamOffset);
-            }
-            outstandingOffsetSyncs.release();
-        });
     }
  
     private Map<TopicPartition, Long> loadOffsets(Set<TopicPartition> topicPartitions) {
@@ -258,36 +213,6 @@ public class MirrorSourceTask extends SourceTask {
             return 0;
         } else {
             return bytes.length;
-        }
-    }
-
-    static class PartitionState {
-        long previousUpstreamOffset = -1L;
-        long previousDownstreamOffset = -1L;
-        long lastSyncUpstreamOffset = -1L;
-        long lastSyncDownstreamOffset = -1L;
-        long maxOffsetLag;
-
-        PartitionState(long maxOffsetLag) {
-            this.maxOffsetLag = maxOffsetLag;
-        }
-
-        // true if we should emit an offset sync
-        boolean update(long upstreamOffset, long downstreamOffset) {
-            boolean shouldSyncOffsets = false;
-            long upstreamStep = upstreamOffset - lastSyncUpstreamOffset;
-            long downstreamTargetOffset = lastSyncDownstreamOffset + upstreamStep;
-            if (lastSyncDownstreamOffset == -1L
-                    || downstreamOffset - downstreamTargetOffset >= maxOffsetLag
-                    || upstreamOffset - previousUpstreamOffset != 1L
-                    || downstreamOffset < previousDownstreamOffset) {
-                lastSyncUpstreamOffset = upstreamOffset;
-                lastSyncDownstreamOffset = downstreamOffset;
-                shouldSyncOffsets = true;
-            }
-            previousUpstreamOffset = upstreamOffset;
-            previousDownstreamOffset = downstreamOffset;
-            return shouldSyncOffsets;
         }
     }
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorTaskCommon.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorTaskCommon.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MirrorTaskCommon {
+
+    private static final Logger log = LoggerFactory.getLogger(MirrorTaskCommon.class);
+    
+    private static final int MAX_OUTSTANDING_OFFSET_SYNCS = 10;
+    
+    private Map<TopicPartition, PartitionState> partitionStates;
+    private Semaphore outstandingOffsetSyncs;
+    private KafkaProducer<byte[], byte[]> offsetProducer;
+    private String offsetSyncsTopic;
+    private long maxOffsetLag;
+    
+    public MirrorTaskCommon(MirrorTaskConfig config) {
+        maxOffsetLag = config.maxOffsetLag();
+        partitionStates = new HashMap<>();
+        offsetSyncsTopic = config.offsetSyncsTopic();
+        offsetProducer = MirrorUtils.newProducer(config.sourceProducerConfig());
+        outstandingOffsetSyncs = new Semaphore(MAX_OUTSTANDING_OFFSET_SYNCS);
+    }
+    
+    // updates partition state and sends OffsetSync if necessary
+    void maybeSyncOffsets(TopicPartition topicPartition, long upstreamOffset,
+            long downstreamOffset) {
+        PartitionState partitionState =
+            partitionStates.computeIfAbsent(topicPartition, x -> new PartitionState(maxOffsetLag));
+        if (partitionState.update(upstreamOffset, downstreamOffset)) {
+            sendOffsetSync(topicPartition, upstreamOffset, downstreamOffset);
+        }
+    }
+
+    // sends OffsetSync record upstream to internal offsets topic
+    private void sendOffsetSync(TopicPartition topicPartition, long upstreamOffset,
+            long downstreamOffset) {
+        if (!outstandingOffsetSyncs.tryAcquire()) {
+            // Too many outstanding offset syncs.
+            return;
+        }
+        OffsetSync offsetSync = new OffsetSync(topicPartition, upstreamOffset, downstreamOffset);
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(offsetSyncsTopic, 0,
+                offsetSync.recordKey(), offsetSync.recordValue());
+        offsetProducer.send(record, (x, e) -> {
+            if (e != null) {
+                log.error("Failure sending offset sync.", e);
+            } else {
+                log.trace("Sync'd offsets for {}: {}=={}", topicPartition,
+                    upstreamOffset, downstreamOffset);
+            }
+            outstandingOffsetSyncs.release();
+        });
+    }
+    
+    void stop() {
+        Utils.closeQuietly(offsetProducer, "offset producer");
+    }
+    
+    static class PartitionState {
+        long previousUpstreamOffset = -1L;
+        long previousDownstreamOffset = -1L;
+        long lastSyncUpstreamOffset = -1L;
+        long lastSyncDownstreamOffset = -1L;
+        long maxOffsetLag;
+
+        PartitionState(long maxOffsetLag) {
+            this.maxOffsetLag = maxOffsetLag;
+        }
+
+        // true if we should emit an offset sync
+        boolean update(long upstreamOffset, long downstreamOffset) {
+            boolean shouldSyncOffsets = false;
+            long upstreamStep = upstreamOffset - lastSyncUpstreamOffset;
+            long downstreamTargetOffset = lastSyncDownstreamOffset + upstreamStep;
+            if (lastSyncDownstreamOffset == -1L
+                    || downstreamOffset - downstreamTargetOffset >= maxOffsetLag
+                    || upstreamOffset - previousUpstreamOffset != 1L
+                    || downstreamOffset < previousDownstreamOffset) {
+                lastSyncUpstreamOffset = upstreamOffset;
+                lastSyncDownstreamOffset = downstreamOffset;
+                shouldSyncOffsets = true;
+            }
+            previousUpstreamOffset = upstreamOffset;
+            previousDownstreamOffset = downstreamOffset;
+            return shouldSyncOffsets;
+        }
+    }
+}

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -56,7 +56,7 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testReplicatesHeartbeatsByDefault() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"), 
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"), 
             new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
         assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
         assertTrue(connector.shouldReplicateTopic("us-west.heartbeats"), "should replicate upstream heartbeats");
@@ -64,7 +64,7 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testReplicatesHeartbeatsDespiteFilter() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
             new DefaultReplicationPolicy(), x -> false, new DefaultConfigPropertyFilter());
         assertTrue(connector.shouldReplicateTopic("heartbeats"), "should replicate heartbeats");
         assertTrue(connector.shouldReplicateTopic("us-west.heartbeats"), "should replicate upstream heartbeats");
@@ -72,7 +72,7 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testNoCycles() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
             new DefaultReplicationPolicy(), x -> true, x -> true);
         assertFalse(connector.shouldReplicateTopic("target.topic1"), "should not allow cycles");
         assertFalse(connector.shouldReplicateTopic("target.source.topic1"), "should not allow cycles");
@@ -83,7 +83,7 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testAclFiltering() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
             new DefaultReplicationPolicy(), x -> true, x -> true);
         assertFalse(connector.shouldReplicateAcl(
             new AclBinding(new ResourcePattern(ResourceType.TOPIC, "test_topic", PatternType.LITERAL),
@@ -95,7 +95,7 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testAclTransformation() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
             new DefaultReplicationPolicy(), x -> true, x -> true);
         AclBinding allowAllAclBinding = new AclBinding(
             new ResourcePattern(ResourceType.TOPIC, "test_topic", PatternType.LITERAL),
@@ -117,7 +117,7 @@ public class MirrorSourceConnectorTest {
     
     @Test
     public void testConfigPropertyFiltering() {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
             new DefaultReplicationPolicy(), x -> true, new DefaultConfigPropertyFilter());
         ArrayList<ConfigEntry> entries = new ArrayList<>();
         entries.add(new ConfigEntry("name-1", "value-1"));
@@ -178,9 +178,9 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testRefreshTopicPartitions() throws Exception {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
-        connector.initialize(mock(ConnectorContext.class));
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
+                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter(), mock(ConnectorContext.class));
+
         connector = spy(connector);
 
         Config topicConfig = new Config(Arrays.asList(
@@ -220,9 +220,9 @@ public class MirrorSourceConnectorTest {
 
     @Test
     public void testRefreshTopicPartitionsTopicOnTargetFirst() throws Exception {
-        MirrorSourceConnector connector = new MirrorSourceConnector(new SourceAndTarget("source", "target"),
-                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter());
-        connector.initialize(mock(ConnectorContext.class));
+        MirrorConnectorCommon connector = new MirrorConnectorCommon(new SourceAndTarget("source", "target"),
+                new DefaultReplicationPolicy(), new DefaultTopicFilter(), new DefaultConfigPropertyFilter(), mock(ConnectorContext.class));
+
         connector = spy(connector);
 
         Config topicConfig = new Config(Arrays.asList(

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceTaskTest.java
@@ -40,8 +40,7 @@ public class MirrorSourceTaskTest {
         headers.add("header2", new byte[]{'p', 'q', 'r', 's', 't'});
         ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecord<>("topic1", 2, 3L, 4L,
             TimestampType.CREATE_TIME, 0L, 5, 6, key, value, headers);
-        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask("cluster7",
-            new DefaultReplicationPolicy(), 50);
+        MirrorSourceTask mirrorSourceTask = new MirrorSourceTask("cluster7", new DefaultReplicationPolicy());
         SourceRecord sourceRecord = mirrorSourceTask.convertRecord(consumerRecord);
         assertEquals("cluster7.topic1", sourceRecord.topic());
         assertEquals(2, sourceRecord.kafkaPartition().intValue());
@@ -56,7 +55,7 @@ public class MirrorSourceTaskTest {
 
     @Test
     public void testOffsetSync() {
-        MirrorSourceTask.PartitionState partitionState = new MirrorSourceTask.PartitionState(50);
+        MirrorTaskCommon.PartitionState partitionState = new MirrorTaskCommon.PartitionState(50);
 
         assertTrue(partitionState.update(0, 100), "always emit offset sync on first update");
         assertTrue(partitionState.update(2, 102), "upstream offset skipped -> resync");
@@ -72,7 +71,7 @@ public class MirrorSourceTaskTest {
 
     @Test
     public void testZeroOffsetSync() {
-        MirrorSourceTask.PartitionState partitionState = new MirrorSourceTask.PartitionState(0);
+        MirrorTaskCommon.PartitionState partitionState = new MirrorTaskCommon.PartitionState(0);
 
         // if max offset lag is zero, should always emit offset syncs
         assertTrue(partitionState.update(0, 100));


### PR DESCRIPTION
The idea is to centralize the common functions of current `MirrorSourceConnector` and `MirrorSourceTask` to prepare for reusing them in new Sink Connector and Sink Task in future (KIP-656 https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=158870065)

Two new files are proposed:
- `MirrorConnectorCommon`: contains the reusable functions extracted from `MirrorSourceConnector`
- `MirrorTaskCommon`: contains the reusable functions extracted from `MirrorSourceTask`

no functional changes to current behaviors