### PR TITLE
KAFKA-10482: increase the connection close waiting time

### DIFF
--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -347,6 +347,6 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
 
     // make sure the state is the same as before the method call
     TestUtils.waitUntilTrue(() => initialConnectionCount == connectionCount,
-      s"Connections not closed (initial = $initialConnectionCount current = $connectionCount)")
+      s"Connections not closed (initial = $initialConnectionCount current = $connectionCount)", waitTimeMs = runTimeMs)
   }
 }


### PR DESCRIPTION
Increase the connection close waiting time to make the test more reliable. It waits for 15 secs for now, which causes the test failed frequently. Increase the waiting time to 25 secs. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
