### PR TITLE
KAFKA-10264 Flaky Test TransactionsTest.testBumpTransactionalEpoch

### DIFF
--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -652,7 +652,6 @@ class TransactionsTest extends KafkaServerTestHarness {
 
       producer.beginTransaction()
       producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic1, null, "2", "2", willBeCommitted = false))
-      producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "4", "4", willBeCommitted = false))
 
       killBroker(partitionLeader) // kill the partition leader to prevent the batch from being submitted
       val failedFuture = producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(testTopic, 0, "3", "3", willBeCommitted = false))


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-10264

The test case sends two records before killing broker. The failure is caused by that the both records are NOT in a single batch. The failure of first record can abort second batch and then produces KafkaException rather than TimeoutException.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
