### PR TITLE
POC: Allow bypassing the cache layer in IQ

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StoreQueryParameters.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StoreQueryParameters.java
@@ -27,19 +27,21 @@ public class StoreQueryParameters<T> {
 
     private Integer partition;
     private boolean staleStores;
+    private boolean bypassCache;
     private final String storeName;
     private final QueryableStoreType<T> queryableStoreType;
 
-    private StoreQueryParameters(final String storeName, final QueryableStoreType<T>  queryableStoreType, final Integer partition, final boolean staleStores) {
+    private StoreQueryParameters(final String storeName, final QueryableStoreType<T> queryableStoreType, final Integer partition, final boolean staleStores, final boolean bypassCache) {
         this.storeName = storeName;
         this.queryableStoreType = queryableStoreType;
         this.partition = partition;
         this.staleStores = staleStores;
+        this.bypassCache = bypassCache;
     }
 
     public static <T> StoreQueryParameters<T> fromNameAndType(final String storeName,
                                                               final QueryableStoreType<T>  queryableStoreType) {
-        return new StoreQueryParameters<T>(storeName, queryableStoreType, null, false);
+        return new StoreQueryParameters<T>(storeName, queryableStoreType, null, false, false);
     }
 
     /**
@@ -50,7 +52,7 @@ public class StoreQueryParameters<T> {
      * @return StoreQueryParameters a new {@code StoreQueryParameters} instance configured with the specified partition
      */
     public StoreQueryParameters<T> withPartition(final Integer partition) {
-        return new StoreQueryParameters<T>(storeName, queryableStoreType, partition, staleStores);
+        return new StoreQueryParameters<T>(storeName, queryableStoreType, partition, staleStores, bypassCache);
     }
 
     /**
@@ -59,7 +61,11 @@ public class StoreQueryParameters<T> {
      * @return StoreQueryParameters a new {@code StoreQueryParameters} instance configured with serving from stale stores enabled
      */
     public StoreQueryParameters<T> enableStaleStores() {
-        return new StoreQueryParameters<T>(storeName, queryableStoreType, partition, true);
+        return new StoreQueryParameters<T>(storeName, queryableStoreType, partition, true, bypassCache);
+    }
+
+    public StoreQueryParameters<T> enableBypassCache() {
+        return new StoreQueryParameters<>(storeName, queryableStoreType, partition, staleStores, true);
     }
 
     /**
@@ -100,30 +106,35 @@ public class StoreQueryParameters<T> {
         return staleStores;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
-        if (!(obj instanceof StoreQueryParameters)) {
-            return false;
-        }
-        final StoreQueryParameters storeQueryParameters = (StoreQueryParameters) obj;
-        return Objects.equals(storeQueryParameters.partition, partition)
-                && Objects.equals(storeQueryParameters.staleStores, staleStores)
-                && Objects.equals(storeQueryParameters.storeName, storeName)
-                && Objects.equals(storeQueryParameters.queryableStoreType, queryableStoreType);
+    public boolean bypassCacheEnabled() {
+        return bypassCache;
     }
 
     @Override
-    public String toString() {
-        return "StoreQueryParameters {" +
-                "partition=" + partition +
-                ", staleStores=" + staleStores +
-                ", storeName=" + storeName +
-                ", queryableStoreType=" + queryableStoreType +
-                '}';
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final StoreQueryParameters<?> that = (StoreQueryParameters<?>) o;
+        return staleStores == that.staleStores &&
+            bypassCache == that.bypassCache &&
+            Objects.equals(partition, that.partition) &&
+            Objects.equals(storeName, that.storeName) &&
+            Objects.equals(queryableStoreType, that.queryableStoreType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(partition, staleStores, storeName, queryableStoreType);
+        return Objects.hash(partition, staleStores, bypassCache, storeName, queryableStoreType);
+    }
+
+    @Override
+    public String toString() {
+        return "StoreQueryParameters{" +
+            "partition=" + partition +
+            ", staleStores=" + staleStores +
+            ", bypassCache=" + bypassCache +
+            ", storeName='" + storeName + '\'' +
+            ", queryableStoreType=" + queryableStoreType +
+            '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredStore.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.KeyValueStore;
+
+/**
+ * A Metered {@link KeyValueStore} wrapper that is used for recording operation metrics, and hence its
+ * inner KeyValueStore implementation do not need to provide its own metrics collecting functionality.
+ * The inner {@link KeyValueStore} of this class is of type &lt;Bytes,byte[]&gt;, hence we use {@link Serde}s
+ * to convert from &lt;K,V&gt; to &lt;Bytes,byte[]&gt;
+ *
+ * @param <K>
+ * @param <V>
+ */
+public abstract class MeteredStore<K, V, OwnType extends MeteredStore<K, V, OwnType, InnerType>, InnerType extends StateStore>
+    extends WrappedStateStore<InnerType, K, V> {
+
+    public MeteredStore(final InnerType wrapped) {
+        super(wrapped);
+    }
+
+    abstract OwnType reWrap(final InnerType inner);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -39,7 +39,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
  * @param <V>
  */
 public class MeteredTimestampedKeyValueStore<K, V>
-    extends MeteredKeyValueStore<K, ValueAndTimestamp<V>> 
+    extends MeteredKeyValueStore<K, ValueAndTimestamp<V>, MeteredTimestampedKeyValueStore<K, V>>
     implements TimestampedKeyValueStore<K, V> {
 
     MeteredTimestampedKeyValueStore(final KeyValueStore<Bytes, byte[]> inner,
@@ -48,6 +48,31 @@ public class MeteredTimestampedKeyValueStore<K, V>
                                     final Serde<K> keySerde,
                                     final Serde<ValueAndTimestamp<V>> valueSerde) {
         super(inner, metricScope, time, keySerde, valueSerde);
+    }
+
+    private MeteredTimestampedKeyValueStore(final KeyValueStore<Bytes, byte[]> inner,
+                                            final String metricsScope,
+                                            final String threadId,
+                                            final Time time,
+                                            final Serde<K> keySerde,
+                                            final Serde<ValueAndTimestamp<V>> valueSerde) {
+        super(inner, metricsScope, threadId, time, keySerde, valueSerde);
+    }
+
+    @Override
+    public MeteredTimestampedKeyValueStore<K, V> reWrap(final KeyValueStore<Bytes, byte[]> inner) {
+        final MeteredTimestampedKeyValueStore<K, V> reWrapped = new MeteredTimestampedKeyValueStore<>(
+            inner,
+            metricsScope,
+            threadId,
+            time,
+            keySerde,
+            valueSerde
+        );
+
+        copyInit(reWrapped);
+
+        return reWrapped;
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -36,6 +36,12 @@ public abstract class WrappedStateStore<S extends StateStore, K, V> implements S
         }
     }
 
+    public static boolean isCachingLayer(final StateStore stateStore) {
+        return stateStore instanceof CachingKeyValueStore
+            || stateStore instanceof CachingWindowStore
+            || stateStore instanceof CachingSessionStore;
+    }
+
     private final S wrapped;
 
     public WrappedStateStore(final S wrapped) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
@@ -848,8 +849,11 @@ public class EosIntegrationTest {
 
     private void verifyStateStore(final KafkaStreams streams,
                                   final Set<KeyValue<Long, Long>> expectedStoreContent) throws Exception {
-        final ReadOnlyKeyValueStore<Long, Long> store = IntegrationTestUtils
-            .getStore(300_000L, storeName, streams, QueryableStoreTypes.keyValueStore());
+        final ReadOnlyKeyValueStore<Long, Long> store = IntegrationTestUtils.getStore(
+            300_000L,
+            streams,
+            StoreQueryParameters.fromNameAndType(storeName, QueryableStoreTypes.keyValueStore())
+        );
         assertNotNull(store);
 
         final KeyValueIterator<Long, Long> it = store.all();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -228,13 +228,15 @@ public class StoreQueryIntegrationTest {
 
         // Assert that both active and standby are able to query for a key
         TestUtils.waitForCondition(() -> {
-            final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils
-                .getStore(TABLE_NAME, kafkaStreams1, true, queryableStoreType);
+            final StoreQueryParameters<ReadOnlyKeyValueStore<Integer, Integer>> param =
+                StoreQueryParameters.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores();
+            final ReadOnlyKeyValueStore<Integer, Integer> store1 = IntegrationTestUtils.getStore(IntegrationTestUtils.DEFAULT_TIMEOUT, kafkaStreams1, param);
             return store1.get(key) != null;
         }, "store1 cannot find results for key");
         TestUtils.waitForCondition(() -> {
-            final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils
-                .getStore(TABLE_NAME, kafkaStreams2, true, queryableStoreType);
+            final StoreQueryParameters<ReadOnlyKeyValueStore<Integer, Integer>> param =
+                StoreQueryParameters.fromNameAndType(TABLE_NAME, queryableStoreType).enableStaleStores();
+            final ReadOnlyKeyValueStore<Integer, Integer> store2 = IntegrationTestUtils.getStore(IntegrationTestUtils.DEFAULT_TIMEOUT, kafkaStreams2, param);
             return store2.get(key) != null;
         }, "store2 cannot find results for key");
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1190,32 +1190,7 @@ public class IntegrationTestUtils {
     public static <S> S getStore(final String storeName,
                                  final KafkaStreams streams,
                                  final QueryableStoreType<S> storeType) throws Exception {
-        return getStore(DEFAULT_TIMEOUT, storeName, streams, storeType);
-    }
-
-    public static <S> S getStore(final String storeName,
-                                 final KafkaStreams streams,
-                                 final boolean enableStaleQuery,
-                                 final QueryableStoreType<S> storeType) throws Exception {
-        return getStore(DEFAULT_TIMEOUT, storeName, streams, enableStaleQuery, storeType);
-    }
-
-    public static <S> S getStore(final long waitTime,
-                                 final String storeName,
-                                 final KafkaStreams streams,
-                                 final QueryableStoreType<S> storeType) throws Exception {
-        return getStore(waitTime, storeName, streams, false, storeType);
-    }
-
-    public static <S> S getStore(final long waitTime,
-                                 final String storeName,
-                                 final KafkaStreams streams,
-                                 final boolean enableStaleQuery,
-                                 final QueryableStoreType<S> storeType) throws Exception {
-        final StoreQueryParameters<S> param = enableStaleQuery ?
-            StoreQueryParameters.fromNameAndType(storeName, storeType).enableStaleStores() :
-            StoreQueryParameters.fromNameAndType(storeName, storeType);
-        return getStore(waitTime, streams, param);
+        return getStore(DEFAULT_TIMEOUT, streams, StoreQueryParameters.fromNameAndType(storeName, storeType));
     }
 
     public static <S> S getStore(final KafkaStreams streams,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -106,7 +106,7 @@ public class MeteredKeyValueStoreTest {
     @Mock(type = MockType.NICE)
     private InternalProcessorContext context;
 
-    private MeteredKeyValueStore<String, String> metered;
+    private MeteredKeyValueStore<String, String, ?> metered;
     private final Metrics metrics = new Metrics();
     private String storeLevelGroup;
     private String threadIdTagKey;


### PR DESCRIPTION
Just a quick POC of how we can optionally bypass the caching layer in IQ. Some queries that are common in IQ but rare in the PAPI perform really poorly with the caching layer involved. We should have a comprehensive solution to this in the future, but for now it seems worth considering just giving a way to bypass it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
