### PR TITLE
MINOR: Replace Java 14 with Java 15 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See our [web site](https://kafka.apache.org) for details on the project.
 
 You need to have [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-We build and test Apache Kafka with Java 8, 11 and 14. We set the `release` parameter in javac and scalac
+We build and test Apache Kafka with Java 8, 11 and 15. We set the `release` parameter in javac and scalac
 to `8` to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
 used for compilation).
 


### PR DESCRIPTION
We have been testing with the Java 15 release candidate for a few weeks and
it has now been declared final.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
