### PR TITLE
KAFKA-10482: Fix flaky testDynamicListenerConnectionCreationRateQuota

### DIFF
--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -179,8 +179,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     reconfigureServers(props, perBrokerConfig = true, (KafkaConfig.ListenersProp, newListeners))
     waitForListener("EXTERNAL")
 
-    // we need to set the initialConnectionCount earlier and pass to verifyConnectionRate method
-    // so that the race condition won't occur for the following multi-thread test cases
+    // The expected connection count after each test run
     val initialConnectionCount = connectionCount
 
     // new broker-wide connection rate limit
@@ -325,7 +324,6 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     }
   }
 
-  // make sure the connection count state is the same as the expectedConnectionCount
   private def waitForConnectionCount(expectedConnectionCount: Int): Unit = {
     TestUtils.waitUntilTrue(() => expectedConnectionCount == connectionCount,
       s"Connections not closed (expected = $expectedConnectionCount current = $connectionCount)")


### PR DESCRIPTION
The flaky test is because we have race condition in `testDynamicListenerConnectionCreationRateQuota`. We set the `initialConnectionCount` with the global shared `connectionCount` in the `verifyConnectionRate` method, but we have multi-thread test cases, which might get the wrong `initialConnectionCount`. And later the waiting close will never complete since the expected initialConnectionCount is wrong.

Ex:
![image](https://user-images.githubusercontent.com/43372967/93566080-0bc8cc00-f9bf-11ea-9aa7-9bc651f5ede2.png)

The error message is:
```
kafka.network.DynamicConnectionQuotaTest > testDynamicListenerConnectionCreationRateQuota FAILED
java.util.concurrent.ExecutionException: org.scalatest.exceptions.TestFailedException: Connections not closed (initial = 2 current = 1)
at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
at kafka.network.DynamicConnectionQuotaTest.testDynamicListenerConnectionCreationRateQuota(DynamicConnectionQuotaTest.scala:219)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
