### PR TITLE
KAFKA-10505: Fix parsing of generation log string.

### DIFF
--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -18,7 +18,7 @@ from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StaticMemberTestService
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.tests.streams.utils import verify_stopped, stop_processors, verify_running, extract_generation_from_logs
+from kafkatest.tests.streams.utils import verify_stopped, stop_processors, verify_running, extract_generation_from_logs, extract_generation_id
 
 class StreamsStaticMembershipTest(Test):
     """
@@ -83,7 +83,7 @@ class StreamsStaticMembershipTest(Test):
                 "Smaller than minimum expected %d generation messages, actual %d" % (num_bounce_generations, len(generations))
 
             for generation in generations[-num_bounce_generations:]:
-                generation = int(generation)
+                generation = extract_generation_id(generation)
                 if stable_generation == -1:
                     stable_generation = generation
                 assert stable_generation == generation, \

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService, \
     StreamsUpgradeTestJobRunnerService
 from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.tests.streams.utils import extract_generation_from_logs
+from kafkatest.tests.streams.utils import extract_generation_from_logs, extract_generation_id
 from kafkatest.version import LATEST_0_10_0, LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, LATEST_1_0, LATEST_1_1, \
     LATEST_2_0, LATEST_2_1, LATEST_2_2, LATEST_2_3, LATEST_2_4, LATEST_2_5, LATEST_2_6, DEV_BRANCH, DEV_VERSION, KafkaVersion
 
@@ -530,7 +530,7 @@ class StreamsUpgradeTest(Test):
         return current_generation
 
     def extract_highest_generation(self, found_generations):
-        return int(found_generations[-1])
+        return extract_generation_id(found_generations[-1])
 
     def verify_metadata_no_upgraded_yet(self):
         for p in self.processors:

--- a/tests/kafkatest/tests/streams/utils/__init__.py
+++ b/tests/kafkatest/tests/streams/utils/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from util import verify_running, verify_stopped, stop_processors, extract_generation_from_logs
+from util import verify_running, verify_stopped, stop_processors, extract_generation_from_logs, extract_generation_id

--- a/tests/kafkatest/tests/streams/utils/util.py
+++ b/tests/kafkatest/tests/streams/utils/util.py
@@ -41,5 +41,5 @@ def extract_generation_id(generation):
     # Generation string looks like
     # "Generation{generationId=5,memberId='consumer-A-3-72d7be15-bcdd-4032-b247-784e648d4dd8',protocol='stream'} "
     # Extracting generationId from it.
-    m = re.search(r'Generation{generationId=(\d),.*', generation)
+    m = re.search(r'Generation{generationId=(\d+),.*', generation)
     return int(m.group(1))

--- a/tests/kafkatest/tests/streams/utils/util.py
+++ b/tests/kafkatest/tests/streams/utils/util.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import re
+
 
 def verify_running(processor, message):
     node = processor.node
@@ -34,3 +36,10 @@ def stop_processors(processors, stopped_message):
 
 def extract_generation_from_logs(processor):
     return list(processor.node.account.ssh_capture("grep \"Successfully joined group with generation\" %s| awk \'{for(i=1;i<=NF;i++) {if ($i == \"generation\") beginning=i+1; if($i== \"(org.apache.kafka.clients.consumer.internals.AbstractCoordinator)\") ending=i }; for (j=beginning;j<ending;j++) printf $j; printf \"\\n\"}\'" % processor.LOG_FILE, allow_fail=True))
+
+def extract_generation_id(generation):
+    # Generation string looks like
+    # "Generation{generationId=5,memberId='consumer-A-3-72d7be15-bcdd-4032-b247-784e648d4dd8',protocol='stream'} "
+    # Extracting generationId from it.
+    m = re.search(r'Generation{generationId=(\d),.*', generation)
+    return int(m.group(1))


### PR DESCRIPTION
Two tests fails with the same reason:
```
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_upgrade_test.py", line 533, in extract_highest_generation
    return int(found_generations[-1])
ValueError: invalid literal for int() with base 10: "Generation{generationId=6,memberId='StreamsUpgradeTest-8a6ac110-1c65-40eb-af05-8bee270f1701-StreamThread-1-consumer-207de872-6588-407a-8485-101a19ba2bf0',protocol='stream'}\n"
```
```
  File "/opt/kafka-dev/tests/kafkatest/tests/streams/streams_static_membership_test.py", line 86, in test_rolling_bounces_will_not_trigger_rebalance_under_static_membership
    generation = int(generation)
ValueError: invalid literal for int() with base 10: "Generation{generationId=5,memberId='consumer-A-2-3e9cc50c-9835-4772-b282-29e07b2f9ad6',protocol='stream'}\n"
```

This PR fix the above errors by extracting the correct number from the log string.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
