### PR TITLE
[mm2] Fix consumer/producer properties override

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -199,6 +199,8 @@ public class MirrorConnectorConfig extends AbstractConfig {
 
     protected static final String SOURCE_CLUSTER_PREFIX = MirrorMakerConfig.SOURCE_CLUSTER_PREFIX;
     protected static final String TARGET_CLUSTER_PREFIX = MirrorMakerConfig.TARGET_CLUSTER_PREFIX;
+    protected static final String SOURCE_PREFIX = MirrorMakerConfig.SOURCE_PREFIX;
+    protected static final String TARGET_PREFIX = MirrorMakerConfig.TARGET_PREFIX;
     protected static final String PRODUCER_CLIENT_PREFIX = "producer.";
     protected static final String CONSUMER_CLIENT_PREFIX = "consumer.";
     protected static final String ADMIN_CLIENT_PREFIX = "admin.";
@@ -234,7 +236,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(PRODUCER_CLIENT_PREFIX));
-        props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX + PRODUCER_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(SOURCE_PREFIX + PRODUCER_CLIENT_PREFIX));
         return props;
     }
 
@@ -243,7 +245,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
-        props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX + CONSUMER_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(SOURCE_PREFIX + CONSUMER_CLIENT_PREFIX));
         props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
         props.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
         return props;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -199,8 +199,8 @@ public class MirrorConnectorConfig extends AbstractConfig {
 
     protected static final String SOURCE_CLUSTER_PREFIX = MirrorMakerConfig.SOURCE_CLUSTER_PREFIX;
     protected static final String TARGET_CLUSTER_PREFIX = MirrorMakerConfig.TARGET_CLUSTER_PREFIX;
-    protected static final String PRODUCER_CLIENT_PREFIX = "producer.";
-    protected static final String CONSUMER_CLIENT_PREFIX = "consumer.";
+    protected static final String PRODUCER_CLIENT_PREFIX = SOURCE_CLUSTER_PREFIX + "producer.";
+    protected static final String CONSUMER_CLIENT_PREFIX = SOURCE_CLUSTER_PREFIX + "consumer.";
     protected static final String ADMIN_CLIENT_PREFIX = "admin.";
     protected static final String SOURCE_ADMIN_CLIENT_PREFIX = "source.admin.";
     protected static final String TARGET_ADMIN_CLIENT_PREFIX = "target.admin.";
@@ -243,7 +243,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
         props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
-        props.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
         return props;
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -204,8 +204,6 @@ public class MirrorConnectorConfig extends AbstractConfig {
     protected static final String PRODUCER_CLIENT_PREFIX = "producer.";
     protected static final String CONSUMER_CLIENT_PREFIX = "consumer.";
     protected static final String ADMIN_CLIENT_PREFIX = "admin.";
-    protected static final String SOURCE_ADMIN_CLIENT_PREFIX = "source.admin.";
-    protected static final String TARGET_ADMIN_CLIENT_PREFIX = "target.admin.";
 
     public MirrorConnectorConfig(Map<String, String> props) {
         this(CONNECTOR_CONFIG_DEF, props);
@@ -271,7 +269,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(ADMIN_CLIENT_PREFIX));
-        props.putAll(originalsWithPrefix(TARGET_ADMIN_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(TARGET_PREFIX + ADMIN_CLIENT_PREFIX));
         return props;
     }
 
@@ -280,7 +278,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(ADMIN_CLIENT_PREFIX));
-        props.putAll(originalsWithPrefix(SOURCE_ADMIN_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(SOURCE_PREFIX + ADMIN_CLIENT_PREFIX));
         return props;
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -199,8 +199,8 @@ public class MirrorConnectorConfig extends AbstractConfig {
 
     protected static final String SOURCE_CLUSTER_PREFIX = MirrorMakerConfig.SOURCE_CLUSTER_PREFIX;
     protected static final String TARGET_CLUSTER_PREFIX = MirrorMakerConfig.TARGET_CLUSTER_PREFIX;
-    protected static final String PRODUCER_CLIENT_PREFIX = SOURCE_CLUSTER_PREFIX + "producer.";
-    protected static final String CONSUMER_CLIENT_PREFIX = SOURCE_CLUSTER_PREFIX + "consumer.";
+    protected static final String PRODUCER_CLIENT_PREFIX = "producer.";
+    protected static final String CONSUMER_CLIENT_PREFIX = "consumer.";
     protected static final String ADMIN_CLIENT_PREFIX = "admin.";
     protected static final String SOURCE_ADMIN_CLIENT_PREFIX = "source.admin.";
     protected static final String TARGET_ADMIN_CLIENT_PREFIX = "target.admin.";
@@ -234,6 +234,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(PRODUCER_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX + PRODUCER_CLIENT_PREFIX));
         return props;
     }
 
@@ -242,6 +243,7 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX));
         props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
         props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(SOURCE_CLUSTER_PREFIX + CONSUMER_CLIENT_PREFIX));
         props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
         props.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
         return props;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -186,13 +186,13 @@ public class MirrorMakerConfig extends AbstractConfig {
 
         Map<String, String> sourceClusterProps = clusterProps(sourceAndTarget.source());
         // attrs non prefixed with producer|consumer|admin
-        props.putAll(prefixForGeneralAttrs(SOURCE_CLUSTER_PREFIX, sourceClusterProps));
+        props.putAll(clusterConfigsWithPrefix(SOURCE_CLUSTER_PREFIX, sourceClusterProps));
         // attrs prefixed with producer|consumer|admin
-        props.putAll(prefixForProducerConsumerAdminAttrs(SOURCE_PREFIX, sourceClusterProps));
+        props.putAll(clientConfigsWithPrefix(SOURCE_PREFIX, sourceClusterProps));
 
         Map<String, String> targetClusterProps = clusterProps(sourceAndTarget.target());
-        props.putAll(prefixForGeneralAttrs(TARGET_CLUSTER_PREFIX, targetClusterProps));
-        props.putAll(prefixForProducerConsumerAdminAttrs(TARGET_PREFIX, targetClusterProps));
+        props.putAll(clusterConfigsWithPrefix(TARGET_CLUSTER_PREFIX, targetClusterProps));
+        props.putAll(clientConfigsWithPrefix(TARGET_PREFIX, targetClusterProps));
 
         props.putIfAbsent(NAME, connectorClass.getSimpleName());
         props.putIfAbsent(CONNECTOR_CLASS, connectorClass.getName());
@@ -256,13 +256,13 @@ public class MirrorMakerConfig extends AbstractConfig {
         return strings;
     }
 
-    static Map<String, String> prefixForGeneralAttrs(String prefix, Map<String, String> props) {
+    static Map<String, String> clusterConfigsWithPrefix(String prefix, Map<String, String> props) {
         return props.entrySet().stream()
                 .filter(x -> !x.getKey().matches("(^consumer.*|^producer.*|^admin.*)"))
                 .collect(Collectors.toMap(x -> prefix + x.getKey(), x -> x.getValue()));
     }
 
-    static Map<String, String> prefixForProducerConsumerAdminAttrs(String prefix, Map<String, String> props) {
+    static Map<String, String> clientConfigsWithPrefix(String prefix, Map<String, String> props) {
         return props.entrySet().stream()
                 .filter(x -> x.getKey().matches("(^consumer.*|^producer.*|^admin.*)"))
                 .collect(Collectors.toMap(x -> prefix + x.getKey(), x -> x.getValue()));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -70,8 +70,8 @@ public class MirrorMakerConfig extends AbstractConfig {
     private static final String BYTE_ARRAY_CONVERTER_CLASS =
         "org.apache.kafka.connect.converters.ByteArrayConverter";
 
-    static final String SOURCE_CLUSTER_PREFIX = "source.cluster.";
-    static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
+    static final String SOURCE_CLUSTER_PREFIX = "source.";
+    static final String TARGET_CLUSTER_PREFIX = "target.";
 
     private final Plugins plugins;
    

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -70,8 +70,10 @@ public class MirrorMakerConfig extends AbstractConfig {
     private static final String BYTE_ARRAY_CONVERTER_CLASS =
         "org.apache.kafka.connect.converters.ByteArrayConverter";
 
-    static final String SOURCE_CLUSTER_PREFIX = "source.";
-    static final String TARGET_CLUSTER_PREFIX = "target.";
+    static final String SOURCE_CLUSTER_PREFIX = "source.cluster.";
+    static final String TARGET_CLUSTER_PREFIX = "target.cluster.";
+    static final String SOURCE_PREFIX = "source.";
+    static final String TARGET_PREFIX = "target.";
 
     private final Plugins plugins;
    
@@ -181,9 +183,16 @@ public class MirrorMakerConfig extends AbstractConfig {
         props.keySet().retainAll(MirrorConnectorConfig.CONNECTOR_CONFIG_DEF.names());
         
         props.putAll(stringsWithPrefix(CONFIG_PROVIDERS_CONFIG));
-        
-        props.putAll(withPrefix(SOURCE_CLUSTER_PREFIX, clusterProps(sourceAndTarget.source())));
-        props.putAll(withPrefix(TARGET_CLUSTER_PREFIX, clusterProps(sourceAndTarget.target())));
+
+        Map<String, String> sourceClusterProps = clusterProps(sourceAndTarget.source());
+        // attrs non prefixed with producer|consumer|admin
+        props.putAll(prefixForGeneralAttrs(SOURCE_CLUSTER_PREFIX, sourceClusterProps));
+        // attrs prefixed with producer|consumer|admin
+        props.putAll(prefixForProducerConsumerAdminAttrs(SOURCE_PREFIX, sourceClusterProps));
+
+        Map<String, String> targetClusterProps = clusterProps(sourceAndTarget.target());
+        props.putAll(prefixForGeneralAttrs(TARGET_CLUSTER_PREFIX, targetClusterProps));
+        props.putAll(prefixForProducerConsumerAdminAttrs(TARGET_PREFIX, targetClusterProps));
 
         props.putIfAbsent(NAME, connectorClass.getSimpleName());
         props.putIfAbsent(CONNECTOR_CLASS, connectorClass.getName());
@@ -245,10 +254,17 @@ public class MirrorMakerConfig extends AbstractConfig {
         Map<String, String> strings = originalsStrings();
         strings.keySet().removeIf(x -> !x.startsWith(prefix));
         return strings;
-    } 
+    }
 
-    static Map<String, String> withPrefix(String prefix, Map<String, String> props) {
+    static Map<String, String> prefixForGeneralAttrs(String prefix, Map<String, String> props) {
         return props.entrySet().stream()
-            .collect(Collectors.toMap(x -> prefix + x.getKey(), x -> x.getValue()));
+                .filter(x -> !x.getKey().matches("(^consumer.*|^producer.*|^admin.*)"))
+                .collect(Collectors.toMap(x -> prefix + x.getKey(), x -> x.getValue()));
+    }
+
+    static Map<String, String> prefixForProducerConsumerAdminAttrs(String prefix, Map<String, String> props) {
+        return props.entrySet().stream()
+                .filter(x -> x.getKey().matches("(^consumer.*|^producer.*|^admin.*)"))
+                .collect(Collectors.toMap(x -> prefix + x.getKey(), x -> x.getValue()));
     }
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -199,10 +199,8 @@ public class MirrorConnectorConfigTest {
 
     @Test
     public void testSourceAdminConfigWithSourcePrefix() {
-        Map<String, String> connectorProps = makeProps(
-                MirrorConnectorConfig.SOURCE_ADMIN_CLIENT_PREFIX +
-                        "connections.max.idle.ms", "10000"
-        );
+        String prefix = MirrorConnectorConfig.SOURCE_PREFIX + MirrorConnectorConfig.ADMIN_CLIENT_PREFIX;
+        Map<String, String> connectorProps = makeProps(prefix + "connections.max.idle.ms", "10000");
         MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorAdminProps = config.sourceAdminConfig();
         Map<String, Object> expectedAdminProps = new HashMap<>();
@@ -225,10 +223,8 @@ public class MirrorConnectorConfigTest {
 
     @Test
     public void testTargetAdminConfigWithSourcePrefix() {
-        Map<String, String> connectorProps = makeProps(
-                MirrorConnectorConfig.TARGET_ADMIN_CLIENT_PREFIX +
-                        "connections.max.idle.ms", "10000"
-        );
+        String prefix = MirrorConnectorConfig.TARGET_PREFIX + MirrorConnectorConfig.ADMIN_CLIENT_PREFIX;
+        Map<String, String> connectorProps = makeProps(prefix + "connections.max.idle.ms", "10000");
         MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorAdminProps = config.targetAdminConfig();
         Map<String, Object> expectedAdminProps = new HashMap<>();

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -146,10 +146,37 @@ public class MirrorConnectorConfigTest {
     }
 
     @Test
+    public void testSourceConsumerConfigWithSourcePrefix() {
+        String prefix = MirrorConnectorConfig.SOURCE_CLUSTER_PREFIX + MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX;
+        Map<String, String> connectorProps = makeProps(
+                prefix + "auto.offset.reset", "latest",
+                prefix + "max.poll.interval.ms", "100"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorConsumerProps = config.sourceConsumerConfig();
+        Map<String, Object> expectedConsumerProps = new HashMap<>();
+        expectedConsumerProps.put("enable.auto.commit", "false");
+        expectedConsumerProps.put("auto.offset.reset", "latest");
+        expectedConsumerProps.put("max.poll.interval.ms", "100");
+        assertEquals(expectedConsumerProps, connectorConsumerProps);
+    }
+
+    @Test
     public void testSourceProducerConfig() {
         Map<String, String> connectorProps = makeProps(
                 MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX + "acks", "1"
         );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorProducerProps = config.sourceProducerConfig();
+        Map<String, Object> expectedProducerProps = new HashMap<>();
+        expectedProducerProps.put("acks", "1");
+        assertEquals(expectedProducerProps, connectorProducerProps);
+    }
+
+    @Test
+    public void testSourceProducerConfigWithSourcePrefix() {
+        String prefix = MirrorConnectorConfig.SOURCE_CLUSTER_PREFIX + MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX;
+        Map<String, String> connectorProps = makeProps(prefix + "acks", "1");
         MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorProducerProps = config.sourceProducerConfig();
         Map<String, Object> expectedProducerProps = new HashMap<>();

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.HashSet;
 
 import static org.apache.kafka.connect.mirror.TestUtils.makeProps;
@@ -119,4 +120,41 @@ public class MirrorConnectorConfigTest {
             connectorConfigDef.names().contains(taskSpecificProperty)
         ));
     }
+
+    @Test
+    public void testSourceConsumerConfig() {
+        Map<String, String> connectorProps = makeProps(
+                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "max.poll.interval.ms", "120000"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorConsumerProps = config.sourceConsumerConfig();
+        Map<String, Object> expectedConsumerProps = new HashMap<>();
+        expectedConsumerProps.put("enable.auto.commit", "false");
+        expectedConsumerProps.put("auto.offset.reset", "earliest");
+        expectedConsumerProps.put("max.poll.interval.ms", "120000");
+        assertEquals(expectedConsumerProps, connectorConsumerProps);
+
+        // checking auto.offset.reset override works
+        connectorProps = makeProps(
+                MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX + "auto.offset.reset", "latest"
+        );
+        config = new MirrorConnectorConfig(connectorProps);
+        connectorConsumerProps = config.sourceConsumerConfig();
+        expectedConsumerProps.put("auto.offset.reset", "latest");
+        expectedConsumerProps.remove("max.poll.interval.ms");
+        assertEquals(expectedConsumerProps, connectorConsumerProps);
+    }
+
+    @Test
+    public void testSourceProducerConfig() {
+        Map<String, String> connectorProps = makeProps(
+                MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX + "acks", "1"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorProducerProps = config.sourceProducerConfig();
+        Map<String, Object> expectedProducerProps = new HashMap<>();
+        expectedProducerProps.put("acks", "1");
+        assertEquals(expectedProducerProps, connectorProducerProps);
+    }
+
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -184,4 +184,56 @@ public class MirrorConnectorConfigTest {
         assertEquals(expectedProducerProps, connectorProducerProps);
     }
 
+    @Test
+    public void testSourceAdminConfig() {
+        Map<String, String> connectorProps = makeProps(
+                MirrorConnectorConfig.ADMIN_CLIENT_PREFIX +
+                        "connections.max.idle.ms", "10000"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorAdminProps = config.sourceAdminConfig();
+        Map<String, Object> expectedAdminProps = new HashMap<>();
+        expectedAdminProps.put("connections.max.idle.ms", "10000");
+        assertEquals(expectedAdminProps, connectorAdminProps);
+    }
+
+    @Test
+    public void testSourceAdminConfigWithSourcePrefix() {
+        Map<String, String> connectorProps = makeProps(
+                MirrorConnectorConfig.SOURCE_ADMIN_CLIENT_PREFIX +
+                        "connections.max.idle.ms", "10000"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorAdminProps = config.sourceAdminConfig();
+        Map<String, Object> expectedAdminProps = new HashMap<>();
+        expectedAdminProps.put("connections.max.idle.ms", "10000");
+        assertEquals(expectedAdminProps, connectorAdminProps);
+    }
+
+    @Test
+    public void testTargetAdminConfig() {
+        Map<String, String> connectorProps = makeProps(
+                MirrorConnectorConfig.ADMIN_CLIENT_PREFIX +
+                        "connections.max.idle.ms", "10000"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorAdminProps = config.targetAdminConfig();
+        Map<String, Object> expectedAdminProps = new HashMap<>();
+        expectedAdminProps.put("connections.max.idle.ms", "10000");
+        assertEquals(expectedAdminProps, connectorAdminProps);
+    }
+
+    @Test
+    public void testTargetAdminConfigWithSourcePrefix() {
+        Map<String, String> connectorProps = makeProps(
+                MirrorConnectorConfig.TARGET_ADMIN_CLIENT_PREFIX +
+                        "connections.max.idle.ms", "10000"
+        );
+        MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
+        Map<String, Object> connectorAdminProps = config.targetAdminConfig();
+        Map<String, Object> expectedAdminProps = new HashMap<>();
+        expectedAdminProps.put("connections.max.idle.ms", "10000");
+        assertEquals(expectedAdminProps, connectorAdminProps);
+    }
+
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorConfigTest.java
@@ -147,7 +147,7 @@ public class MirrorConnectorConfigTest {
 
     @Test
     public void testSourceConsumerConfigWithSourcePrefix() {
-        String prefix = MirrorConnectorConfig.SOURCE_CLUSTER_PREFIX + MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX;
+        String prefix = MirrorConnectorConfig.SOURCE_PREFIX + MirrorConnectorConfig.CONSUMER_CLIENT_PREFIX;
         Map<String, String> connectorProps = makeProps(
                 prefix + "auto.offset.reset", "latest",
                 prefix + "max.poll.interval.ms", "100"
@@ -175,7 +175,7 @@ public class MirrorConnectorConfigTest {
 
     @Test
     public void testSourceProducerConfigWithSourcePrefix() {
-        String prefix = MirrorConnectorConfig.SOURCE_CLUSTER_PREFIX + MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX;
+        String prefix = MirrorConnectorConfig.SOURCE_PREFIX + MirrorConnectorConfig.PRODUCER_CLIENT_PREFIX;
         Map<String, String> connectorProps = makeProps(prefix + "acks", "1");
         MirrorConnectorConfig config = new MirrorConnectorConfig(connectorProps);
         Map<String, Object> connectorProducerProps = config.sourceProducerConfig();

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
@@ -52,10 +52,10 @@ public class MirrorMakerConfigTest {
             "replication.factor", "4"));
         Map<String, String> connectorProps = mirrorConfig.connectorBaseConfig(new SourceAndTarget("a", "b"),
             MirrorSourceConnector.class);
-        assertEquals("source.cluster.bootstrap.servers is set",
-            "servers-one", connectorProps.get("source.cluster.bootstrap.servers"));
-        assertEquals("target.cluster.bootstrap.servers is set",
-            "servers-two", connectorProps.get("target.cluster.bootstrap.servers"));
+        assertEquals("source.bootstrap.servers is set",
+            "servers-one", connectorProps.get("source.bootstrap.servers"));
+        assertEquals("target.bootstrap.servers is set",
+            "servers-two", connectorProps.get("target.bootstrap.servers"));
         assertEquals("top-level security.protocol is passed through to connector config",
             "SASL", connectorProps.get("security.protocol"));
     }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorMakerConfigTest.java
@@ -52,10 +52,10 @@ public class MirrorMakerConfigTest {
             "replication.factor", "4"));
         Map<String, String> connectorProps = mirrorConfig.connectorBaseConfig(new SourceAndTarget("a", "b"),
             MirrorSourceConnector.class);
-        assertEquals("source.bootstrap.servers is set",
-            "servers-one", connectorProps.get("source.bootstrap.servers"));
-        assertEquals("target.bootstrap.servers is set",
-            "servers-two", connectorProps.get("target.bootstrap.servers"));
+        assertEquals("source.cluster.bootstrap.servers is set",
+            "servers-one", connectorProps.get("source.cluster.bootstrap.servers"));
+        assertEquals("target.cluster.bootstrap.servers is set",
+            "servers-two", connectorProps.get("target.cluster.bootstrap.servers"));
         assertEquals("top-level security.protocol is passed through to connector config",
             "SASL", connectorProps.get("security.protocol"));
     }


### PR DESCRIPTION
Currently the producer/consumer properties override for the MirrorSourceTask and OffsetSyncStore do not work. This is due the props stored into MirrorConnectorConfig have a `target.cluster` or `source.cluster` prefix. For example:
```
source.cluster.producer.bootstrap.servers -> localhost:9092
target.cluster.consumer.max.poll.interval.ms -> 120000
target.cluster.consumer.auto.offset.reset -> latest
source.cluster.admin.bootstrap.servers -> localhost:9092
```

The [sourceConsumerConfig](https://github.com/apache/kafka/blob/aa0cd667bcd5c4025e84097192030b59165ac9d0/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java#L240) will strip this prefix and store all props as:

```
producer.bootstrap.servers -> localhost:9092
consumer.auto.offset.reset -> latest
consumer.max.poll.interval.ms -> 120000
alias -> A
bootstrap.servers -> localhost:9092
admin.bootstrap.servers -> localhost:9092
consumer.bootstrap.servers -> localhost:9092
```

The next line `props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());` will strip all the props not defined in this common CLIENT_CONFIG_DEF definition. Not relevant but can be confusing if you think the next line will filter on the current values in props.

Finally, the `props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));` is based on the on the `originals` variable that have the `target.cluster` or `source.cluster` prefix. There's no single property with the "consumer." prefix. This patterns repeats with the producer config.

This PR also allows to override the hardcoded `auto.offset.reset` value.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
