### PR TITLE
KAFKA-10496: Removed relying on external DNS servers in tests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -59,7 +59,7 @@ public final class ClientUtils {
                         throw new ConfigException("Invalid url in " + CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG + ": " + url);
 
                     if (clientDnsLookup == ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY) {
-                        InetAddress[] inetAddresses = InetAddress.getAllByName(host);
+                        InetAddress[] inetAddresses = DefaultDnsNameResolver.DEFAULT_DNS_NAME_RESOLVER.resolve(host);
                         for (InetAddress inetAddress : inetAddresses) {
                             String resolvedCanonicalName = inetAddress.getCanonicalHostName();
                             InetSocketAddress address = new InetSocketAddress(resolvedCanonicalName, port);
@@ -106,8 +106,10 @@ public final class ClientUtils {
                 clientSaslMechanism, time, true, logContext);
     }
 
-    static List<InetAddress> resolve(String host, ClientDnsLookup clientDnsLookup) throws UnknownHostException {
-        InetAddress[] addresses = InetAddress.getAllByName(host);
+    static List<InetAddress> resolve(String host,
+                                     DnsNameResolver dnsNameResolver,
+                                     ClientDnsLookup clientDnsLookup) throws UnknownHostException {
+        InetAddress[] addresses = dnsNameResolver.resolve(host);
 
         switch (clientDnsLookup) {
             case DEFAULT:

--- a/clients/src/main/java/org/apache/kafka/clients/DefaultDnsNameResolver.java
+++ b/clients/src/main/java/org/apache/kafka/clients/DefaultDnsNameResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+final class DefaultDnsNameResolver implements DnsNameResolver {
+    static final DefaultDnsNameResolver DEFAULT_DNS_NAME_RESOLVER = new DefaultDnsNameResolver();
+
+    private DefaultDnsNameResolver() {}
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        return InetAddress.getAllByName(host);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/DnsNameResolver.java
+++ b/clients/src/main/java/org/apache/kafka/clients/DnsNameResolver.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+interface DnsNameResolver {
+
+    InetAddress[] resolve(String host) throws UnknownHostException;
+}

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -275,7 +275,8 @@ public class NetworkClient implements KafkaClient {
         this.inFlightRequests = new InFlightRequests(maxInFlightRequestsPerConnection);
         this.connectionStates = new ClusterConnectionStates(
                 reconnectBackoffMs, reconnectBackoffMax,
-                connectionSetupTimeoutMs, connectionSetupTimeoutMaxMs, logContext);
+                connectionSetupTimeoutMs, connectionSetupTimeoutMaxMs, logContext,
+                DefaultDnsNameResolver.DEFAULT_DNS_NAME_RESOLVER);
         this.socketSendBuffer = socketSendBuffer;
         this.socketReceiveBuffer = socketReceiveBuffer;
         this.correlation = 0;

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -97,25 +97,34 @@ public class ClientUtilsTest {
 
     @Test(expected = UnknownHostException.class)
     public void testResolveUnknownHostException() throws UnknownHostException {
-        ClientUtils.resolve("some.invalid.hostname.foo.bar.local", ClientDnsLookup.USE_ALL_DNS_IPS);
+        DnsNameResolver dnsNameResolver = new MockDnsNameResolver.Builder()
+                .withUnknownHostname("some.invalid.hostname.foo.bar.local")
+                .build();
+        ClientUtils.resolve("some.invalid.hostname.foo.bar.local", dnsNameResolver, ClientDnsLookup.USE_ALL_DNS_IPS);
     }
 
     @Test
     public void testResolveDnsLookup() throws UnknownHostException {
-        // Note that kafka.apache.org resolves to at least 2 IP addresses
-        assertEquals(1, ClientUtils.resolve("kafka.apache.org", ClientDnsLookup.DEFAULT).size());
+        DnsNameResolver dnsNameResolver = new MockDnsNameResolver.Builder()
+                .withMapping("kafka.apache.org", InetAddress.getByName("95.216.24.32"), InetAddress.getByName("40.79.78.1"))
+                .build();
+        assertEquals(1, ClientUtils.resolve("kafka.apache.org", dnsNameResolver, ClientDnsLookup.DEFAULT).size());
     }
 
     @Test
     public void testResolveDnsLookupAllIps() throws UnknownHostException {
-        // Note that kafka.apache.org resolves to at least 2 IP addresses
-        assertTrue(ClientUtils.resolve("kafka.apache.org", ClientDnsLookup.USE_ALL_DNS_IPS).size() > 1);
+        DnsNameResolver dnsNameResolver = new MockDnsNameResolver.Builder()
+                .withMapping("kafka.apache.org", InetAddress.getByName("95.216.24.32"), InetAddress.getByName("40.79.78.1"))
+                .build();
+        assertEquals(2, ClientUtils.resolve("kafka.apache.org", dnsNameResolver, ClientDnsLookup.USE_ALL_DNS_IPS).size());
     }
 
     @Test
     public void testResolveDnsLookupResolveCanonicalBootstrapServers() throws UnknownHostException {
-        // Note that kafka.apache.org resolves to at least 2 IP addresses
-        assertTrue(ClientUtils.resolve("kafka.apache.org", ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY).size() > 1);
+        DnsNameResolver dnsNameResolver = new MockDnsNameResolver.Builder()
+                .withMapping("kafka.apache.org", InetAddress.getByName("95.216.24.32"), InetAddress.getByName("40.79.78.1"))
+                .build();
+        assertEquals(2, ClientUtils.resolve("kafka.apache.org", dnsNameResolver, ClientDnsLookup.RESOLVE_CANONICAL_BOOTSTRAP_SERVERS_ONLY).size());
     }
 
     private List<InetSocketAddress> checkWithoutLookup(String... url) {

--- a/clients/src/test/java/org/apache/kafka/clients/MockDnsNameResolver.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockDnsNameResolver.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+class MockDnsNameResolver implements DnsNameResolver {
+    private final Map<String, InetAddress[]> knownMappings;
+    private final Set<String> unknownHostnames;
+
+    private MockDnsNameResolver(Map<String, InetAddress[]> knownMappings, Set<String> unknownHostnames) {
+        this.knownMappings = knownMappings;
+        this.unknownHostnames = unknownHostnames;
+    }
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        if (unknownHostnames.contains(host)) {
+            throw new UnknownHostException(host);
+        }
+        InetAddress[] addresses = knownMappings.get(host);
+        if (addresses == null) {
+            throw new IllegalStateException("Unexpected DnsNameResolver::resolve(" + host + ") call");
+        }
+        return addresses;
+    }
+
+    static class Builder {
+        private final Map<String, InetAddress[]> knownMappings = new HashMap<>();
+        private final Set<String> unknownHostnames = new HashSet<>();
+
+        Builder withMapping(String hostname, InetAddress... addresses) {
+            knownMappings.put(hostname, addresses);
+            return this;
+        }
+
+        Builder withUnknownHostname(String hostname) {
+            unknownHostnames.add(hostname);
+            return this;
+        }
+
+        DnsNameResolver build() {
+            return new MockDnsNameResolver(knownMappings, unknownHostnames);
+        }
+    }
+}


### PR DESCRIPTION
As ticket suggested I’ve tried to introduce an in-memory DNS server for testing purposes, but unfortunately capability to change default DNS provider has been removed in Java 9: https://bugs.openjdk.java.net/browse/JDK-8134577.  There is a request for restoring it: https://bugs.openjdk.java.net/browse/JDK-8192780, but so far has not been implemented.

Therefore this PR decouples DNS resolution from `InetAddress.getAllByName` implementation in order to mock its behavior in tests. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
