### PR TITLE
KAFKA-10509: Added throttle connection accept rate metric (KIP-612)

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1252,6 +1252,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
         maxConnectionsPerListener.put(listenerName, newListenerQuota)
         listenerCounts.put(listenerName, 0)
         config.addReconfigurable(newListenerQuota)
+        newListenerQuota.configure(config.valuesWithPrefixOverride(listenerName.configPrefix))
       }
       counts.notifyAll()
     }

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -338,9 +338,9 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
    * is at least certain value. Note that throttling is tested and verified more accurately in ConnectionQuotasTest
    */
   private def verifyConnectionRate(minConnectionRate: Int, maxConnectionRate: Int, listener: String): Unit = {
-    // duration such that the maximum rate should be at most 10% higher than the rate limit. Since all connections
+    // duration such that the maximum rate should be at most 20% higher than the rate limit. Since all connections
     // can fall in the beginning of quota window, it is OK to create extra 2 seconds (window size) worth of connections
-    val runTimeMs = TimeUnit.SECONDS.toMillis(25)
+    val runTimeMs = TimeUnit.SECONDS.toMillis(13)
     val startTimeMs = System.currentTimeMillis
     val endTimeMs = startTimeMs + runTimeMs
 
@@ -351,7 +351,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     }
     val elapsedMs = System.currentTimeMillis - startTimeMs
     val actualRate = (connCount.toDouble / elapsedMs) * 1000
-    val rateCap = if (maxConnectionRate < Int.MaxValue) 1.1 * maxConnectionRate.toDouble else Int.MaxValue.toDouble
+    val rateCap = if (maxConnectionRate < Int.MaxValue) 1.2 * maxConnectionRate.toDouble else Int.MaxValue.toDouble
     assertTrue(s"Listener $listener connection rate $actualRate must be below $rateCap", actualRate <= rateCap)
     assertTrue(s"Listener $listener connection rate $actualRate must be above $minConnectionRate", actualRate >= minConnectionRate)
   }


### PR DESCRIPTION
This PR adds metric to track throttle time of connection accept rate (when hitting connection attempt rate quota), which is a part of KIP-612:
> kafka.network:type=socket-server-metrics,name=connection-accept-throttle-time,listener={listenerName}
> Type: SampledStat.Avg
> Description: Average throttle time due to violating per-listener or broker-wide connection acceptance rate quota on a given listener.

This PR also does 2 fixes:
* Ensures that per-listener connection quotas are configured on broker startup (from static broker config, if one is set). 
* Reduces quota values used in testDynamicListenerConnectionCreationRateQuota test, and the duration of `verifyConnectionRate` (that creates connections and verifies rate). We observed once that this test exhausted ephemeral port count. I reduced quotas used in this test by half, since this does not change the correctness of the test, while it also reduces the number of connections made by this test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
