### PR TITLE
KAFKA-10413: Allow for even distribution of lost/new tasks when multiple Connect workers join at the same time

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -571,7 +571,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         log.debug("Previous rounded down (floor) average number of connectors per worker {}", totalActiveConnectorsNum / existingWorkersNum);
         int floorConnectors = totalActiveConnectorsNum / totalWorkersNum;
         int ceilConnectors = (int) Math.ceil((float) totalActiveConnectorsNum / totalWorkersNum);
-        log.debug("New rounded down (floor) average number of connectors per worker floor connectors {} ciel connectors ", floorConnectors,ceilConnectors);
+        log.debug("New rounded down (floor) average number of connectors per worker floor connectors {} ciel connectors ", floorConnectors, ceilConnectors);
 
 
         log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -471,7 +471,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                     WorkerLoad worker = candidateWorkerIterator.next();
                     log.debug("Assigning task id {} to member {}", task, worker.worker());
                     worker.assign(task);
-                    log.debug("Assigned task id {} to member {}", task, worker.worker());
                 }
             } else {
                 log.debug("No single candidate worker was found to assign lost tasks. Treating lost tasks as new tasks");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -577,9 +577,8 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
         log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);
         int floorTasks = totalActiveTasksNum / totalWorkersNum;
-        log.debug("New rounded down (floor) average number of tasks per worker {}", floorTasks);
         int ceilTasks = (int) Math.ceil((float) totalActiveTasksNum / totalWorkersNum);
-        log.debug("New rounded down (ceil) average number of tasks per worker {}", ceilTasks);
+        log.debug("New average number of tasks per worker: floor={}, ceiling={}", floorTasks, ceilTasks);
 
         int numToRevoke = floorConnectors;
         for (WorkerLoad existing : existingWorkers) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -450,7 +450,9 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
             }
 
             if (!candidateWorkerLoad.isEmpty()) {
-                log.debug("A list of candidate workers has been found to assign lost tasks: {}", candidateWorkerLoad.stream().map(WorkerLoad::worker).collect(Collectors.joining(",")));
+                log.debug("Assigning lost tasks to {} candidate workers: {}", 
+                        candidateWorkerLoad.size(),
+                        candidateWorkerLoad.stream().map(WorkerLoad::worker).collect(Collectors.joining(",")));
                 Iterator<WorkerLoad> candidateWorkerIterator = candidateWorkerLoad.iterator();
                 for (String connector : lostAssignments.connectors()) {
                     // Loop over the the candidate workers as many times as it takes

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -259,7 +259,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         // Do not revoke resources for re-assignment while a delayed rebalance is active
         // Also we do not revoke in two consecutive rebalances by the same leader
         canRevoke = delay == 0 && canRevoke;
-        log.debug("Connector and task to revoke assgn post lb calculation: {}", toRevoke);
+        log.debug("Connector and task to revoke assignment post load balancer calculation: {}", toRevoke);
         // Compute the connectors-and-tasks to be revoked for load balancing without taking into
         // account the deleted ones.
         log.debug("Can leader revoke tasks in this assignment? {} (delay: {})", canRevoke, delay);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -597,7 +597,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         for (WorkerLoad existing : existingWorkers) {
             Iterator<ConnectorTaskId> tasks = existing.tasks().iterator();
             numToRevoke = existing.tasksSize() - ceilTasks;
-            log.debug("revoke number of tasks per worker {}", numToRevoke);
+            log.debug("Tasks on worker {} is higher than ceiling, so revoking {} tasks", existing, numToRevoke);
             for (int i = existing.tasksSize(); i > floorTasks && numToRevoke > 0; --i, --numToRevoke) {
                 ConnectorsAndTasks resources = revoking.computeIfAbsent(
                     existing.worker(),

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -462,7 +462,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                     WorkerLoad worker = candidateWorkerIterator.next();
                     log.debug("Assigning connector id {} to member {}", connector, worker.worker());
                     worker.assign(connector);
-                    log.debug("Assigned connector id {} to member {}", connector, worker.worker());
                 }
                 candidateWorkerIterator = candidateWorkerLoad.iterator();
                 for (ConnectorTaskId task : lostAssignments.tasks()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -34,7 +34,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -604,20 +603,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                     existing.worker(),
                     w -> new ConnectorsAndTasks.Builder().build());
                 resources.tasks().add(tasks.next());
-            }
-        }
-
-        numToRevoke = floorTasks;
-        for (WorkerLoad existing : existingWorkers) {
-            Iterator<ConnectorTaskId> tasks = existing.tasks().iterator();
-            for (int i = existing.tasksSize(); i > floorTasks && numToRevoke > 0; --i, --numToRevoke) {
-                ConnectorsAndTasks resources = revoking.computeIfAbsent(
-                    existing.worker(),
-                    w -> new ConnectorsAndTasks.Builder().build());
-                resources.tasks().add(tasks.next());
-            }
-            if (numToRevoke == 0) {
-                break;
             }
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -577,7 +577,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);
         int floorTasks = totalActiveTasksNum / totalWorkersNum;
         int ceilTasks = floorTasks + ((totalActiveTasksNum % totalWorkersNum == 0) ? 0 : 1);
-        log.debug("New average number of tasks per worker: floor= {}, ceiling= {}", floorTasks, ceilTasks);
+        log.debug("New average number of tasks per worker rounded down (floor) {} and rounded up (ceil) {}", floorTasks, ceilTasks);
         int numToRevoke;
 
         for (WorkerLoad existing : existingWorkers) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -577,7 +577,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);
         int floorTasks = totalActiveTasksNum / totalWorkersNum;
         int ceilTasks = (int) Math.ceil((float) totalActiveTasksNum / totalWorkersNum);
-        log.debug("New average number of tasks per worker: floor={}, ceiling={}", floorTasks, ceilTasks);
+        log.debug("New average number of tasks per worker: floor= {}, ceiling= {}", floorTasks, ceilTasks);
         int numToRevoke;
 
         for (WorkerLoad existing : existingWorkers) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -576,7 +576,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
 
         log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);
         int floorTasks = totalActiveTasksNum / totalWorkersNum;
-        int ceilTasks = (int) Math.ceil((float) totalActiveTasksNum / totalWorkersNum);
+        int ceilTasks = floorTasks + ((totalActiveTasksNum % totalWorkersNum == 0) ? 0 : 1);
         log.debug("New average number of tasks per worker: floor= {}, ceiling= {}", floorTasks, ceilTasks);
         int numToRevoke;
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -570,7 +570,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         // We have at least one worker assignment (the leader itself) so totalWorkersNum can't be 0
         log.debug("Previous rounded down (floor) average number of connectors per worker {}", totalActiveConnectorsNum / existingWorkersNum);
         int floorConnectors = totalActiveConnectorsNum / totalWorkersNum;
-        int ceilConnectors = (int) Math.ceil((float) totalActiveConnectorsNum / totalWorkersNum);
+        int ceilConnectors = floorConnectors + ((totalActiveConnectorsNum % totalWorkersNum == 0) ? 0 : 1);
         log.debug("New average number of connectors per worker rounded down (floor) {} and rounded up (ceil) {}", floorConnectors, ceilConnectors);
 
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -571,7 +571,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         log.debug("Previous rounded down (floor) average number of connectors per worker {}", totalActiveConnectorsNum / existingWorkersNum);
         int floorConnectors = totalActiveConnectorsNum / totalWorkersNum;
         int ceilConnectors = (int) Math.ceil((float) totalActiveConnectorsNum / totalWorkersNum);
-        log.debug("New rounded down (floor) average number of connectors per worker floor connectors {} ciel connectors ", floorConnectors, ceilConnectors);
+        log.debug("New average number of connectors per worker rounded down (floor) {} and rounded up (ceil) {}", floorConnectors, ceilConnectors);
 
 
         log.debug("Previous rounded down (floor) average number of tasks per worker {}", totalActiveTasksNum / existingWorkersNum);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -259,6 +259,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         // Do not revoke resources for re-assignment while a delayed rebalance is active
         // Also we do not revoke in two consecutive rebalances by the same leader
         canRevoke = delay == 0 && canRevoke;
+
         // Compute the connectors-and-tasks to be revoked for load balancing without taking into
         // account the deleted ones.
         log.debug("Can leader revoke tasks in this assignment? {} (delay: {})", canRevoke, delay);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -589,9 +589,6 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                     w -> new ConnectorsAndTasks.Builder().build());
                 resources.connectors().add(connectors.next());
             }
-            if (numToRevoke == 0) {
-                break;
-            }
         }
 
         for (WorkerLoad existing : existingWorkers) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -208,7 +209,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         connect.assertions().assertConnectorAndTasksAreStopped(CONNECTOR_NAME + 3,
                 "Connector tasks did not stop in time.");
 
-        waitForCondition(this::assertConnectorAndTasksAreUnique,
+        waitForCondition(this::assertConnectorAndTasksAreUniqueAndBalanced,
                 WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");
     }
 
@@ -237,7 +238,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME + 3, NUM_TASKS,
                 "Connector tasks did not start in time.");
 
-        waitForCondition(this::assertConnectorAndTasksAreUnique,
+        waitForCondition(this::assertConnectorAndTasksAreUniqueAndBalanced,
                 WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");
     }
 
@@ -263,7 +264,53 @@ public class RebalanceSourceConnectorsIntegrationTest {
         connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS - 1,
                 "Connect workers did not start in time.");
 
-        waitForCondition(this::assertConnectorAndTasksAreUnique,
+        waitForCondition(this::assertConnectorAndTasksAreUniqueAndBalanced,
+                WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");
+    }
+
+    @Test
+    public void testMultipleWorkersRejoining() throws Exception {
+        // create test topic
+        connect.kafka().createTopic(TOPIC_NAME, NUM_TOPIC_PARTITIONS);
+
+        // setup up props for the source connector
+        Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
+
+        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
+                "Connect workers did not start in time.");
+
+        // start a source connector
+        IntStream.range(0, 4).forEachOrdered(i -> connect.configureConnector(CONNECTOR_NAME + i, props));
+
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME + 3, NUM_TASKS,
+                "Connector tasks did not start in time.");
+
+        waitForCondition(this::assertConnectorAndTasksAreUniqueAndBalanced,
+                WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+
+        connect.removeWorker();
+        connect.removeWorker();
+
+        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS - 2,
+                "Connect workers did not stop in time.");
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+
+        connect.addWorker();
+        connect.addWorker();
+
+        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
+                "Connect workers did not start in time.");
+
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+
+        for (int i = 0; i < 4; ++i) {
+            connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME + i, NUM_TASKS, "Connector tasks did not start in time.");
+        }
+
+        waitForCondition(this::assertConnectorAndTasksAreUniqueAndBalanced,
                 WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");
     }
 
@@ -282,7 +329,7 @@ public class RebalanceSourceConnectorsIntegrationTest {
         return props;
     }
 
-    private boolean assertConnectorAndTasksAreUnique() {
+    private boolean assertConnectorAndTasksAreUniqueAndBalanced() {
         try {
             Map<String, Collection<String>> connectors = new HashMap<>();
             Map<String, Collection<String>> tasks = new HashMap<>();
@@ -296,7 +343,12 @@ public class RebalanceSourceConnectorsIntegrationTest {
             }
 
             int maxConnectors = connectors.values().stream().mapToInt(Collection::size).max().orElse(0);
+            int minConnectors = connectors.values().stream().mapToInt(Collection::size).min().orElse(0);
             int maxTasks = tasks.values().stream().mapToInt(Collection::size).max().orElse(0);
+            int minTasks = tasks.values().stream().mapToInt(Collection::size).min().orElse(0);
+
+            log.debug("Connector balance: {}", formatAssignment(connectors));
+            log.debug("Task balance: {}", formatAssignment(tasks));
 
             assertNotEquals("Found no connectors running!", maxConnectors, 0);
             assertNotEquals("Found no tasks running!", maxTasks, 0);
@@ -306,11 +358,22 @@ public class RebalanceSourceConnectorsIntegrationTest {
             assertEquals("Task assignments are not unique: " + tasks,
                     tasks.values().size(),
                     tasks.values().stream().distinct().collect(Collectors.toList()).size());
+            assertTrue("Connectors are imbalanced: " + formatAssignment(connectors), maxConnectors - minConnectors < 2);
+            assertTrue("Tasks are imbalanced: " + formatAssignment(tasks), maxTasks - minTasks < 2);
             return true;
         } catch (Exception e) {
             log.error("Could not check connector state info.", e);
             return false;
         }
+    }
+
+    private static String formatAssignment(Map<String, Collection<String>> assignment) {
+        StringBuilder result = new StringBuilder();
+        for (String worker : assignment.keySet().stream().sorted().collect(Collectors.toList())) {
+            result.append(String.format("\n%s=%s", worker, assignment.getOrDefault(worker,
+                    Collections.emptyList())));
+        }
+        return result.toString();
     }
 
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignorTest.java
@@ -989,18 +989,24 @@ public class IncrementalCooperativeAssignorTest {
         assignor.handleLostAssignments(lostAssignments, newSubmissions,
                 new ArrayList<>(configuredAssignment.values()), memberConfigs);
 
-        // newWorker joined first, so should be picked up first as a candidate for reassignment
+        // both the newWorkers would need to be considered for re assignment of connectors and tasks
+        List<String> listOfConnectorsInLast2Workers = new ArrayList<>();
+        listOfConnectorsInLast2Workers.addAll(configuredAssignment.getOrDefault(newWorker, new WorkerLoad.Builder(flakyWorker).build())
+            .connectors());
+        listOfConnectorsInLast2Workers.addAll(configuredAssignment.getOrDefault(flakyWorker, new WorkerLoad.Builder(flakyWorker).build())
+            .connectors());
+        List<ConnectorTaskId> listOfTasksInLast2Workers = new ArrayList<>();
+        listOfTasksInLast2Workers.addAll(configuredAssignment.getOrDefault(newWorker, new WorkerLoad.Builder(flakyWorker).build())
+            .tasks());
+        listOfTasksInLast2Workers.addAll(configuredAssignment.getOrDefault(flakyWorker, new WorkerLoad.Builder(flakyWorker).build())
+            .tasks());
         assertTrue("Wrong assignment of lost connectors",
-                configuredAssignment.getOrDefault(newWorker, new WorkerLoad.Builder(flakyWorker).build())
-                        .connectors()
-                        .containsAll(lostAssignments.connectors()));
+            listOfConnectorsInLast2Workers.containsAll(lostAssignments.connectors()));
         assertTrue("Wrong assignment of lost tasks",
-                configuredAssignment.getOrDefault(newWorker, new WorkerLoad.Builder(flakyWorker).build())
-                        .tasks()
-                        .containsAll(lostAssignments.tasks()));
+            listOfTasksInLast2Workers.containsAll(lostAssignments.tasks()));
         assertThat("Wrong set of workers for reassignments",
-                Collections.emptySet(),
-                is(assignor.candidateWorkersForReassignment));
+            Collections.emptySet(),
+            is(assignor.candidateWorkersForReassignment));
         assertEquals(0, assignor.scheduledRebalance);
         assertEquals(0, assignor.delay);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorIncrementalTest.java
@@ -302,23 +302,24 @@ public class WorkerCoordinatorIncrementalTest {
 
         result = coordinator.performAssignment(leaderId, compatibility.protocol(), responseMembers);
 
+        //Equally distributing tasks across member
         leaderAssignment = deserializeAssignment(result, leaderId);
         assertAssignment(leaderId, offset,
-                Collections.emptyList(), 0,
-                Collections.emptyList(), 2,
-                leaderAssignment);
+            Collections.emptyList(), 0,
+            Collections.emptyList(), 1,
+            leaderAssignment);
 
         memberAssignment = deserializeAssignment(result, memberId);
         assertAssignment(leaderId, offset,
-                Collections.emptyList(), 0,
-                Collections.emptyList(), 0,
-                memberAssignment);
+            Collections.emptyList(), 0,
+            Collections.emptyList(), 1,
+            memberAssignment);
 
         ExtendedAssignment anotherMemberAssignment = deserializeAssignment(result, anotherMemberId);
         assertAssignment(leaderId, offset,
-                Collections.emptyList(), 0,
-                Collections.emptyList(), 0,
-                anotherMemberAssignment);
+            Collections.emptyList(), 0,
+            Collections.emptyList(), 0,
+            anotherMemberAssignment);
 
         verify(configStorage, times(configStorageCalls)).snapshot();
     }


### PR DESCRIPTION
Allow even distribution of lost/new tasks when more than one worker joins the group at the same time

Issue description:
Existing issue 1 description : When more than one worker joins the consumer group the incremental co operative assignor revokes and re assigns atmost average number of tasks per worker.

Issue: This results in the additional workers joining the group stay idle and would require more future rebalances to happen to have even distribution of tasks.

Fix: As part of task assignment calculation following a deployment, the reassignment of tasks are calculated by revoking all the tasks above ceil(average) number of tasks.

Existing issue 2 description: When more than one worker is lost and rejoins the group at most one worker will be re assigned with the lost tasks from all the workers that left the group.

Issue: In scenarios where more than one worker is lost and rejoins the group only one among them gets assigned all the partitions that were lost in the past. The additional workers that have joined would not get any task assigned to them until a rebalance that happens in future.

Fix: As part fo lost task re assignment all the new workers that have joined the group would be considered for task assignment and would be assigned in a round robin fashion with the new tasks.

Testing strategy : System testing in a Kube environment completed.
UT : updated to UT