### PR TITLE
MINOR: Install "iproute2" explicitly in Dockerfile

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -32,8 +32,13 @@ ARG ducker_creator=default
 LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
-# we have to install git since it is included in openjdk:8 but not openjdk:11
-RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python-pip python-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
+RUN apt update && apt install -y \
+  sudo \
+  # iproute2 is required by DegradedNetworkFaultWorker (round_trip_fault_test.py) and it is not in openjdk:11
+  iproute2 \
+  # we have to install git since it is included in openjdk:8 but not openjdk:11
+  git \
+  netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python-pip python-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
 RUN python -m pip install -U pip==9.0.3;
 RUN pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.9
 


### PR DESCRIPTION
this patch is similar to https://github.com/apache/kafka/commit/ee68b999c49cbbf514940a81282ff894e6cf50d9

the tool "iproute2" is required by ```round_trip_fault_test.py``` and it is not in openjdk:11

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
