### PR TITLE
KAFKA-8360: Docs do not mention RequestQueueSize JMX metric

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -861,6 +861,11 @@
         <td>Number of records which required message format conversion.</td>
       </tr>
       <tr>
+        <td>Request Queue Size</td>
+        <td>kafka.network:type=RequestChannel,name=RequestQueueSize</td>
+        <td>Size of the request queue.</td>
+      </tr>
+      <tr>
         <td>Byte out rate to clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec</td>
         <td></td>


### PR DESCRIPTION
What? :: Mentioning "Request Queue Size" under Monitoring tab. RequestQueueSize is an important metric to monitor the number of requests in the queue. As a crowded queue might face issue processing incoming or outgoing requests

@viktorsomogyi Can you please review this?

Thanks!!