### PR TITLE
KAFKA-10460: ReplicaListValidator format checking is incomplete

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -218,7 +218,7 @@ object ThrottledReplicaListValidator extends Validator {
   override def ensureValid(name: String, value: Any): Unit = {
     def check(proposed: Seq[Any]): Unit = {
       if (!(proposed.forall(_.toString.trim.matches("([0-9]+:[0-9]+)?"))
-        || proposed.headOption.exists(_.toString.trim.equals("*"))))
+        || proposed.toString.trim.equals("*")))
         throw new ConfigException(name, value,
           s"$name must be the literal '*' or a list of replicas in the following format: [partitionId]:[brokerId],[partitionId]:[brokerId],...")
     }

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -218,7 +218,7 @@ object ThrottledReplicaListValidator extends Validator {
   override def ensureValid(name: String, value: Any): Unit = {
     def check(proposed: Seq[Any]): Unit = {
       if (!(proposed.forall(_.toString.trim.matches("([0-9]+:[0-9]+)?"))
-        || proposed.toString.trim.equals("*")))
+        || proposed.mkString.trim.equals("*")))
         throw new ConfigException(name, value,
           s"$name must be the literal '*' or a list of replicas in the following format: [partitionId]:[brokerId],[partitionId]:[brokerId],...")
     }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -113,6 +113,8 @@ class LogConfigTest {
     assertFalse(isValid("100 :0,10:   "))
     assertFalse(isValid("100: 0,10:   "))
     assertFalse(isValid("100:0,10 :   "))
+    assertFalse(isValid("*,100:10"))
+    assertFalse(isValid("* ,100:10"))
   }
 
   /* Sanity check that toHtmlTable produces one of the expected configs */


### PR DESCRIPTION
What? :: See https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/ConfigHandler.scala#L220 . The logic is supposed to accept only two cases:

list of k:v pairs
a single '*'
But in practice, since the disjunction's second part only checks that the head is '*', the case where a k:v list is headed by a star is also accepted (and then later broker dies at startup, refusing the value).

JIRA: https://issues.apache.org/jira/browse/KAFKA-10460

@viktorsomogyi Can you please review this?