### PR TITLE
MINOR: Add deleteDir for streams quickstart test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ def doStreamsArchetype() {
       }
 
       echo 'Cleaning up test-streams-archetype'
-      deleteDir
+      deleteDir()
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,9 @@ def doStreamsArchetype() {
               || { echo 'Could not compile streams quickstart archetype project'; exit 1; }
         '''
       }
+
+      echo 'Cleaning up test-streams-archetype'
+      deleteDir
     }
   }
 }


### PR DESCRIPTION
Add a `deleteDir` directive to the temporary dir we create during the streams/quickstart archetype test in the Jenkinsfile