### PR TITLE
MINOR: Remove unneeded FIXME

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -130,8 +130,6 @@ class KafkaNetworkChannel(time: Time,
       val request = pendingOutbound.peek()
       endpoints.get(request.destinationId) match {
         case Some(node) =>
-          // FIXME: This check is broken
-
           if (client.connectionFailed(node)) {
             pendingOutbound.poll()
             val apiKey = ApiKeys.forId(request.data.apiKey)


### PR DESCRIPTION
A previous iteration of the Raft patch had a broken check for disconnects. We had fixed the problem, but forgotten to remove the FIXME.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
