### PR TITLE
KAFKA-10516; Disable automatic retry of `THROTTLING_QUOTA_EXCEEDED` errors in the `kafka-topics` command (KIP-599)

### DIFF
--- a/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+++ b/clients/src/main/resources/common/message/DeleteTopicsResponse.json
@@ -38,7 +38,7 @@
         "about": "The topic name" },
       { "name": "ErrorCode", "type": "int16", "versions": "0+",
         "about": "The deletion error, or 0 if the deletion succeeded." },
-      { "name": "ErrorMessage", "type": "string", "versions": "5+", "nullableVersions": "5+", "ignorable": true,
+      { "name": "ErrorMessage", "type": "string", "versions": "5+", "nullableVersions": "5+", "ignorable": true, "default": "null",
         "about": "The error message, or null if there was no error." }
     ]}
   ]

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
@@ -17,10 +17,8 @@
 package org.apache.kafka.clients.admin;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.admin.CreateTopicsResult.TopicMetadataAndConfig;
-import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
@@ -16,7 +16,11 @@
  */
 package org.apache.kafka.clients.admin;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.clients.admin.CreateTopicsResult.TopicMetadataAndConfig;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
@@ -31,5 +35,60 @@ public class AdminClientTestUtils {
         KafkaFutureImpl<Map<TopicPartition, PartitionReassignment>> future = new KafkaFutureImpl<>();
         future.completeExceptionally(t);
         return new ListPartitionReassignmentsResult(future);
+    }
+
+    /**
+     * Helper to create a CreateTopicsResult instance for a given Throwable.
+     * CreateTopicsResult's constructor is only accessible from within the
+     * admin package.
+     */
+    public static CreateTopicsResult createTopicsResult(String topic, Throwable t) {
+        KafkaFutureImpl<TopicMetadataAndConfig> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(t);
+        return new CreateTopicsResult(Collections.singletonMap(topic, future));
+    }
+
+    /**
+     * Helper to create a DeleteTopicsResult instance for a given Throwable.
+     * DeleteTopicsResult's constructor is only accessible from within the
+     * admin package.
+     */
+    public static DeleteTopicsResult deleteTopicsResult(String topic, Throwable t) {
+        KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(t);
+        return new DeleteTopicsResult(Collections.singletonMap(topic, future));
+    }
+
+    /**
+     * Helper to create a ListTopicsResult instance for a given topic.
+     * ListTopicsResult's constructor is only accessible from within the
+     * admin package.
+     */
+    public static ListTopicsResult listTopicsResult(String topic) {
+        KafkaFutureImpl<Map<String, TopicListing>> future = new KafkaFutureImpl<>();
+        future.complete(Collections.singletonMap(topic, new TopicListing(topic, false)));
+        return new ListTopicsResult(future);
+    }
+
+    /**
+     * Helper to create a CreatePartitionsResult instance for a given Throwable.
+     * CreatePartitionsResult's constructor is only accessible from within the
+     * admin package.
+     */
+    public static CreatePartitionsResult createPartitionsResult(String topic, Throwable t) {
+        KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+        future.completeExceptionally(t);
+        return new CreatePartitionsResult(Collections.singletonMap(topic, future));
+    }
+
+    /**
+     * Helper to create a DescribeTopicsResult instance for a given topic.
+     * DescribeTopicsResult's constructor is only accessible from within the
+     * admin package.
+     */
+    public static DescribeTopicsResult describeTopicsResult(String topic, TopicDescription description) {
+        KafkaFutureImpl<TopicDescription> future = new KafkaFutureImpl<>();
+        future.complete(description);
+        return new DescribeTopicsResult(Collections.singletonMap(topic, future));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -197,6 +197,7 @@ import static org.apache.kafka.test.TestUtils.toBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -964,6 +965,17 @@ public class RequestResponseTest {
         bld.build((short) 3);
     }
 
+    @Test
+    public void testDeletableTopicResultErrorMessageIsNullByDefault() {
+        DeletableTopicResult result = new DeletableTopicResult()
+            .setName("topic")
+            .setErrorCode(Errors.THROTTLING_QUOTA_EXCEEDED.code());
+
+        assertEquals("topic", result.name());
+        assertEquals(Errors.THROTTLING_QUOTA_EXCEEDED.code(), result.errorCode());
+        assertNull(result.errorMessage());
+    }
+
     private ResponseHeader createResponseHeader(short headerVersion) {
         return new ResponseHeader(10, headerVersion);
     }
@@ -1680,6 +1692,9 @@ public class RequestResponseTest {
             .setName("t2")
             .setErrorCode(Errors.TOPIC_AUTHORIZATION_FAILED.code())
             .setErrorMessage("Error Message"));
+        data.responses().add(new DeletableTopicResult()
+            .setName("t3")
+            .setErrorCode(Errors.NOT_CONTROLLER.code()));
         return new DeleteTopicsResponse(data);
     }
 


### PR DESCRIPTION
This PR does two things:
* As stated in KIP-599, we'd like to disable the automatic retry of `THROTTLING_QUOTA_EXCEEDED` errors in order to avoid letting the command hangs until `default.api.timeout.ms` is reached.
* Change the default value of `ErrorMessage` to `null` in the `DeleteTopicsResponse`. I have noted that it defaults to an empty string at the moment. The Admin client only uses the default message when the `ErrorMessage` is `null` so we end up with an empty message provided back to the user when `ErrorMessage` is not explicitly set by the broker.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
