### PR TITLE
Update quickstart.html

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -73,7 +73,7 @@ test
 Run the producer and then type a few messages into the console to send to the server.</p>
 
 <pre class="brush: bash;">
-&gt; bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic test
+&gt; bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test
 This is a message
 This is another message
 </pre>


### PR DESCRIPTION
i've followed quickstart instructions here https://kafka.apache.org/documentation/#quickstart_send
and when i run:
`bin/kafka-console-producer.sh --topic quickstart-events --bootstrap-server localhost:9092`
i get:
`bootstrap-server is not a recognized option`
the solution was to use:
`bin/kafka-console-producer.sh --topic quickstart-events --broker-list localhost:9092`