### PR TITLE
KAFKA-10515: Properly initialize nullable Serdes with default values

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableSerde.java
@@ -30,6 +30,8 @@ public abstract class WrappingNullableSerde<T, InnerK, InnerV> implements Serde<
 
     protected WrappingNullableSerde(final WrappingNullableSerializer<T, InnerK, InnerV> serializer,
                                     final WrappingNullableDeserializer<T, InnerK, InnerV> deserializer) {
+        Objects.requireNonNull(serializer, "serializer can't be null");
+        Objects.requireNonNull(deserializer, "deserializer can't be null");
         this.serializer = serializer;
         this.deserializer = deserializer;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableSerde.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+public interface WrappingNullableSerde<T, InnerK, InnerV> extends Serde<T> {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    default void setIfUnset(final Serde<InnerK> defaultKeySerde, final Serde<InnerV> defaultValueSerde) {
+        final Serializer<T> serializer = this.serializer();
+        if (serializer instanceof WrappingNullableSerializer) {
+            ((WrappingNullableSerializer) serializer).setIfUnset(defaultKeySerde != null ? defaultKeySerde.serializer() : null, defaultValueSerde != null ? defaultValueSerde.serializer() : null);
+        }
+        final Deserializer<T> deserializer = this.deserializer();
+        if (deserializer instanceof WrappingNullableDeserializer) {
+            ((WrappingNullableDeserializer) deserializer).setIfUnset(defaultKeySerde != null ? defaultKeySerde.deserializer() : null, defaultValueSerde != null ? defaultValueSerde.deserializer() : null);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
@@ -26,24 +26,23 @@ import org.apache.kafka.common.serialization.Serializer;
  */
 public class WrappingNullableUtils {
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public static <T> Deserializer<T> prepareDeserializer(final Deserializer<T> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer, final boolean isKey) {
+    @SuppressWarnings("unchecked")
+    private static <T> Deserializer<T> prepareDeserializer(final Deserializer<T> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer, final boolean isKey) {
         Deserializer<T> deserializerToUse = specificDeserializer;
         if (deserializerToUse == null) {
             deserializerToUse = (Deserializer<T>) (isKey ? contextKeyDeserializer : contextValueDeserializer);
-        } else if (deserializerToUse instanceof WrappingNullableDeserializer) {
-            ((WrappingNullableDeserializer) deserializerToUse).setIfUnset(contextKeyDeserializer, contextValueDeserializer);
+        } else {
+            initNullableDeserializer(deserializerToUse, contextKeyDeserializer, contextValueDeserializer);
         }
         return deserializerToUse;
     }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer, final boolean isKey) {
+    @SuppressWarnings("unchecked")
+    private static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer, final boolean isKey) {
         Serializer<T> serializerToUse = specificSerializer;
         if (serializerToUse == null) {
             serializerToUse = (Serializer<T>) (isKey ? contextKeySerializer : contextValueSerializer);
-        } else if (serializerToUse instanceof WrappingNullableSerializer) {
-            ((WrappingNullableSerializer) serializerToUse).setIfUnset(contextKeySerializer, contextValueSerializer);
+        } else {
+            initNullableSerializer(serializerToUse, contextKeySerializer, contextValueSerializer);
         }
         return serializerToUse;
     }
@@ -81,6 +80,18 @@ public class WrappingNullableUtils {
 
     public static <V> Serde<V> prepareValueSerde(final Serde<V> specificSerde, final Serde<?> keySerde, final Serde<?> valueSerde) {
         return prepareSerde(specificSerde, keySerde, valueSerde, false);
+    }
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static <T> void initNullableSerializer(final Serializer<T> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer) {
+        if (specificSerializer instanceof WrappingNullableSerializer) {
+            ((WrappingNullableSerializer) specificSerializer).setIfUnset(contextKeySerializer, contextValueSerializer);
+        }
+    }
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static <T> void initNullableDeserializer(final Deserializer<T> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer) {
+        if (specificDeserializer instanceof WrappingNullableDeserializer) {
+            ((WrappingNullableDeserializer) specificDeserializer).setIfUnset(contextKeyDeserializer, contextValueDeserializer);
+        }
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
@@ -21,12 +21,13 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 
 /**
- * A utility class to easier handle the initialization of serdes
+ * If a component's serdes are Wrapping serdes, then they require a little extra setup
+ * to be fully initialized at run time.
  */
 public class WrappingNullableUtils {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static <T> Deserializer<T> prepareDeserializer(final Deserializer<T> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer, final boolean isKey) {
+    public static <T> Deserializer<T> prepareDeserializer(final Deserializer<T> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer, final boolean isKey) {
         Deserializer<T> deserializerToUse = specificDeserializer;
         if (deserializerToUse == null) {
             deserializerToUse = (Deserializer<T>) (isKey ? contextKeyDeserializer : contextValueDeserializer);
@@ -37,7 +38,7 @@ public class WrappingNullableUtils {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer, final boolean isKey) {
+    public static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer, final boolean isKey) {
         Serializer<T> serializerToUse = specificSerializer;
         if (serializerToUse == null) {
             serializerToUse = (Serializer<T>) (isKey ? contextKeySerializer : contextValueSerializer);
@@ -81,4 +82,5 @@ public class WrappingNullableUtils {
     public static <V> Serde<V> prepareValueSerde(final Serde<V> specificSerde, final Serde<?> keySerde, final Serde<?> valueSerde) {
         return prepareSerde(specificSerde, keySerde, valueSerde, false);
     }
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WrappingNullableUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * A utility class to easier handle the initialization of serdes
+ */
+public class WrappingNullableUtils {
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <T> Deserializer<T> prepareDeserializer(final Deserializer<T> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer, final boolean isKey) {
+        Deserializer<T> deserializerToUse = specificDeserializer;
+        if (deserializerToUse == null) {
+            deserializerToUse = (Deserializer<T>) (isKey ? contextKeyDeserializer : contextValueDeserializer);
+        } else if (deserializerToUse instanceof WrappingNullableDeserializer) {
+            ((WrappingNullableDeserializer) deserializerToUse).setIfUnset(contextKeyDeserializer, contextValueDeserializer);
+        }
+        return deserializerToUse;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <T> Serializer<T> prepareSerializer(final Serializer<T> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer, final boolean isKey) {
+        Serializer<T> serializerToUse = specificSerializer;
+        if (serializerToUse == null) {
+            serializerToUse = (Serializer<T>) (isKey ? contextKeySerializer : contextValueSerializer);
+        } else if (serializerToUse instanceof WrappingNullableSerializer) {
+            ((WrappingNullableSerializer) serializerToUse).setIfUnset(contextKeySerializer, contextValueSerializer);
+        }
+        return serializerToUse;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static <T> Serde<T> prepareSerde(final Serde<T> specificSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde, final boolean isKey) {
+        Serde<T> serdeToUse = specificSerde;
+        if (serdeToUse == null) {
+            serdeToUse = (Serde<T>) (isKey ?  contextKeySerde : contextValueSerde);
+        } else if (serdeToUse instanceof WrappingNullableSerde) {
+            ((WrappingNullableSerde) serdeToUse).setIfUnset(contextKeySerde, contextValueSerde);
+        }
+        return serdeToUse;
+    }
+
+    public static <K> Deserializer<K> prepareKeyDeserializer(final Deserializer<K> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer) {
+        return prepareDeserializer(specificDeserializer, contextKeyDeserializer, contextValueDeserializer, true);
+    }
+
+    public static <V> Deserializer<V> prepareValueDeserializer(final Deserializer<V> specificDeserializer, final Deserializer<?> contextKeyDeserializer, final Deserializer<?> contextValueDeserializer) {
+        return prepareDeserializer(specificDeserializer, contextKeyDeserializer, contextValueDeserializer, false);
+    }
+
+    public static <K> Serializer<K> prepareKeySerializer(final Serializer<K> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer) {
+        return prepareSerializer(specificSerializer, contextKeySerializer, contextValueSerializer, true);
+    }
+
+    public static <V> Serializer<V> prepareValueSerializer(final Serializer<V> specificSerializer, final Serializer<?> contextKeySerializer, final Serializer<?> contextValueSerializer) {
+        return prepareSerializer(specificSerializer, contextKeySerializer, contextValueSerializer, false);
+    }
+
+    public static <K> Serde<K> prepareKeySerde(final Serde<K> specificSerde, final Serde<?> keySerde, final Serde<?> valueSerde) {
+        return prepareSerde(specificSerde, keySerde, valueSerde, true);
+    }
+
+    public static <V> Serde<V> prepareValueSerde(final Serde<V> specificSerde, final Serde<?> keySerde, final Serde<?> valueSerde) {
+        return prepareSerde(specificSerde, keySerde, valueSerde, false);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerde.java
@@ -28,26 +28,15 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class SubscriptionWrapperSerde<K> implements WrappingNullableSerde<SubscriptionWrapper<K>, K, Void> {
-    private final SubscriptionWrapperSerializer<K> serializer;
-    private final SubscriptionWrapperDeserializer<K> deserializer;
-
+public class SubscriptionWrapperSerde<K> extends WrappingNullableSerde<SubscriptionWrapper<K>, K, Void> {
     public SubscriptionWrapperSerde(final Supplier<String> primaryKeySerializationPseudoTopicSupplier,
                                     final Serde<K> primaryKeySerde) {
-        serializer = new SubscriptionWrapperSerializer<>(primaryKeySerializationPseudoTopicSupplier,
-                                                         primaryKeySerde == null ? null : primaryKeySerde.serializer());
-        deserializer = new SubscriptionWrapperDeserializer<>(primaryKeySerializationPseudoTopicSupplier,
-                                                             primaryKeySerde == null ? null : primaryKeySerde.deserializer());
-    }
-
-    @Override
-    public Serializer<SubscriptionWrapper<K>> serializer() {
-        return serializer;
-    }
-
-    @Override
-    public Deserializer<SubscriptionWrapper<K>> deserializer() {
-        return deserializer;
+        super(
+            new SubscriptionWrapperSerializer<>(primaryKeySerializationPseudoTopicSupplier,
+                                                primaryKeySerde == null ? null : primaryKeySerde.serializer()),
+            new SubscriptionWrapperDeserializer<>(primaryKeySerializationPseudoTopicSupplier,
+                                                  primaryKeySerde == null ? null : primaryKeySerde.deserializer())
+        );
     }
 
     private static class SubscriptionWrapperSerializer<K>

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerde.java
@@ -21,13 +21,14 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableDeserializer;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerde;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class SubscriptionWrapperSerde<K> implements Serde<SubscriptionWrapper<K>> {
+public class SubscriptionWrapperSerde<K> implements WrappingNullableSerde<SubscriptionWrapper<K>, K, Void> {
     private final SubscriptionWrapperSerializer<K> serializer;
     private final SubscriptionWrapperDeserializer<K> deserializer;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextUtils.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -85,5 +88,26 @@ public final class ProcessorContextUtils {
                 "This component requires internal features of Kafka Streams and must be disabled for unit tests."
             );
         }
+    }
+
+    public static Serializer<?> getKeySerializer(final ProcessorContext processorContext) {
+        return getSerializer(processorContext, true);
+    }
+    public static Serializer<?> getValueSerializer(final ProcessorContext processorContext) {
+        return getSerializer(processorContext, false);
+    }
+    private static Serializer<?> getSerializer(final ProcessorContext processorContext, final boolean key) {
+        final Serde<?> serde = key ? processorContext.keySerde() : processorContext.valueSerde();
+        return serde == null ? null : serde.serializer();
+    }
+    public static Deserializer<?> getKeyDeserializer(final ProcessorContext processorContext) {
+        return getDeserializer(processorContext, true);
+    }
+    public static Deserializer<?> getValueDeserializer(final ProcessorContext processorContext) {
+        return getDeserializer(processorContext, false);
+    }
+    private static Deserializer<?> getDeserializer(final ProcessorContext processorContext, final boolean key) {
+        final Serde<?> serde = key ? processorContext.keySerde() : processorContext.valueSerde();
+        return serde == null ? null : serde.deserializer();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -17,10 +17,12 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.api.Record;
+
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerializer;
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareValueSerializer;
 
 public class SinkNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, VIn, KOut, VOut> {
 
@@ -58,8 +60,8 @@ public class SinkNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, VIn, KOut
         this.context = context;
         final Serializer<?> contextKeySerializer = ProcessorContextUtils.getKeySerializer(context);
         final Serializer<?> contextValueSerializer = ProcessorContextUtils.getValueSerializer(context);
-        this.keySerializer = WrappingNullableUtils.prepareKeySerializer(this.keySerializer, contextKeySerializer, contextValueSerializer);
-        valSerializer = WrappingNullableUtils.prepareValueSerializer(valSerializer, contextKeySerializer, contextValueSerializer);
+        keySerializer = prepareKeySerializer(keySerializer, contextKeySerializer, contextValueSerializer);
+        valSerializer = prepareValueSerializer(valSerializer, contextKeySerializer, contextValueSerializer);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.api.Record;
@@ -52,28 +52,14 @@ public class SinkNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, VIn, KOut
         throw new UnsupportedOperationException("sink node does not allow addChild");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void init(final InternalProcessorContext context) {
         super.init(context);
         this.context = context;
-
-        // if serializers are null, get the default ones from the context
-        if (keySerializer == null) {
-            keySerializer = (Serializer<KIn>) context.keySerde().serializer();
-        }
-        if (valSerializer == null) {
-            valSerializer = (Serializer<VIn>) context.valueSerde().serializer();
-        }
-
-        // if serializers are internal wrapping serializers that may need to be given the default serializer
-        // then pass it the default one from the context
-        if (valSerializer instanceof WrappingNullableSerializer) {
-            ((WrappingNullableSerializer) valSerializer).setIfUnset(
-                context.keySerde().serializer(),
-                context.valueSerde().serializer()
-            );
-        }
+        final Serializer<?> contextKeySerializer = ProcessorContextUtils.getKeySerializer(context);
+        final Serializer<?> contextValueSerializer = ProcessorContextUtils.getValueSerializer(context);
+        this.keySerializer = WrappingNullableUtils.prepareKeySerializer(this.keySerializer, contextKeySerializer, contextValueSerializer);
+        valSerializer = WrappingNullableUtils.prepareValueSerializer(valSerializer, contextKeySerializer, contextValueSerializer);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -19,10 +19,12 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics;
+
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeyDeserializer;
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareValueDeserializer;
 
 public class SourceNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, VIn, KOut, VOut> {
 
@@ -74,8 +76,8 @@ public class SourceNode<KIn, VIn, KOut, VOut> extends ProcessorNode<KIn, VIn, KO
 
         final Deserializer<?> contextKeyDeserializer = ProcessorContextUtils.getKeyDeserializer(context);
         final Deserializer<?> contextValueDeserializer = ProcessorContextUtils.getValueDeserializer(context);
-        this.keyDeserializer = WrappingNullableUtils.prepareKeyDeserializer(this.keyDeserializer, contextKeyDeserializer, contextValueDeserializer);
-        this.valDeserializer = WrappingNullableUtils.prepareValueDeserializer(this.valDeserializer, contextKeyDeserializer, contextValueDeserializer);
+        keyDeserializer = prepareKeyDeserializer(keyDeserializer, contextKeyDeserializer, contextValueDeserializer);
+        valDeserializer = prepareValueDeserializer(valDeserializer, contextKeyDeserializer, contextValueDeserializer);
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -38,6 +38,7 @@ import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerde;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 /**
@@ -131,17 +132,13 @@ public class MeteredKeyValueStore<K, V>
         e2eLatencySensor = StateStoreMetrics.e2ELatencySensor(taskId, metricsScope, name(), streamsMetrics);
     }
 
-    protected Serde<K> prepareKeySerde(final Serde<K> keySerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
-        return WrappingNullableUtils.prepareKeySerde(keySerde, contextKeySerde, contextValueSerde);
-    }
-
-    protected Serde<V> prepareValueSerde(final Serde<V> valueSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
+    protected Serde<V> prepareValueSerdeForStore(final Serde<V> valueSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
         return WrappingNullableUtils.prepareValueSerde(valueSerde, contextKeySerde, contextValueSerde);
     }
 
 
     @Deprecated
-    void initStoreSerde(final ProcessorContext context) {
+    private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
         serdes = new StateSerdes<>(
@@ -149,18 +146,20 @@ public class MeteredKeyValueStore<K, V>
                 changelogTopic :
                 ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName),
             prepareKeySerde(keySerde, context.keySerde(), context.valueSerde()),
-            prepareValueSerde(valueSerde, context.keySerde(), context.valueSerde()));
+            prepareValueSerdeForStore(valueSerde, context.keySerde(), context.valueSerde())
+        );
     }
 
-    void initStoreSerde(final StateStoreContext context) {
+    private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
         serdes = new StateSerdes<>(
-             changelogTopic != null ?
+            changelogTopic != null ?
                 changelogTopic :
                 ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName),
             prepareKeySerde(keySerde, context.keySerde(), context.valueSerde()),
-            prepareValueSerde(valueSerde, context.keySerde(), context.valueSerde()));
+            prepareValueSerdeForStore(valueSerde, context.keySerde(), context.valueSerde())
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableUtils;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -111,7 +112,7 @@ public class MeteredSessionStore<K, V>
         e2eLatencySensor = StateStoreMetrics.e2ELatencySensor(taskId, metricsScope, name(), streamsMetrics);
     }
 
-    @SuppressWarnings("unchecked")
+
     private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
@@ -119,12 +120,11 @@ public class MeteredSessionStore<K, V>
             changelogTopic != null ?
                 changelogTopic :
                 ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName),
-            keySerde == null ? (Serde<K>) context.keySerde() : keySerde,
-            valueSerde == null ? (Serde<V>) context.valueSerde() : valueSerde
+                WrappingNullableUtils.prepareKeySerde(keySerde, context.keySerde(), context.valueSerde()),
+                WrappingNullableUtils.prepareValueSerde(valueSerde, context.keySerde(), context.valueSerde())
         );
     }
 
-    @SuppressWarnings("unchecked")
     private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
@@ -132,8 +132,8 @@ public class MeteredSessionStore<K, V>
             changelogTopic != null ?
                 changelogTopic :
                 ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName),
-            keySerde == null ? (Serde<K>) context.keySerde() : keySerde,
-            valueSerde == null ? (Serde<V>) context.valueSerde() : valueSerde
+                WrappingNullableUtils.prepareKeySerde(keySerde, context.keySerde(), context.valueSerde()),
+                WrappingNullableUtils.prepareValueSerde(valueSerde, context.keySerde(), context.valueSerde())
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -22,12 +22,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
-import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
@@ -51,30 +46,17 @@ public class MeteredTimestampedKeyValueStore<K, V>
         super(inner, metricScope, time, keySerde, valueSerde);
     }
 
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    void initStoreSerde(final ProcessorContext context) {
-        final String storeName = name();
-        final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
-        serdes = new StateSerdes<>(
-            changelogTopic != null ?
-                changelogTopic :
-                ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName),
-            keySerde == null ? (Serde<K>) context.keySerde() : keySerde,
-            valueSerde == null ? new ValueAndTimestampSerde<>((Serde<V>) context.valueSerde()) : valueSerde);
-    }
 
     @SuppressWarnings("unchecked")
-    void initStoreSerde(final StateStoreContext context) {
-        final String storeName = name();
-        final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
-        serdes = new StateSerdes<>(
-            changelogTopic != null ?
-                changelogTopic :
-                ProcessorStateManager.storeChangelogTopic(context.applicationId(), storeName),
-            keySerde == null ? (Serde<K>) context.keySerde() : keySerde,
-            valueSerde == null ? new ValueAndTimestampSerde<>((Serde<V>) context.valueSerde()) : valueSerde);
+    @Override
+    protected Serde<ValueAndTimestamp<V>> prepareValueSerde(final Serde<ValueAndTimestamp<V>> valueSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
+        if (valueSerde == null) {
+            return new ValueAndTimestampSerde<>((Serde<V>) contextValueSerde);
+        } else {
+            return super.prepareValueSerde(valueSerde, contextKeySerde, contextValueSerde);
+        }
     }
+
 
     public RawAndDeserializedValue<V> getWithBinary(final K key) {
         try {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredTimestampedKeyValueStore.java
@@ -49,11 +49,11 @@ public class MeteredTimestampedKeyValueStore<K, V>
 
     @SuppressWarnings("unchecked")
     @Override
-    protected Serde<ValueAndTimestamp<V>> prepareValueSerde(final Serde<ValueAndTimestamp<V>> valueSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
+    protected Serde<ValueAndTimestamp<V>> prepareValueSerdeForStore(final Serde<ValueAndTimestamp<V>> valueSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
         if (valueSerde == null) {
             return new ValueAndTimestampSerde<>((Serde<V>) contextValueSerde);
         } else {
-            return super.prepareValueSerde(valueSerde, contextKeySerde, contextValueSerde);
+            return super.prepareValueSerdeForStore(valueSerde, contextKeySerde, contextValueSerde);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -36,6 +36,7 @@ import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareKeySerde;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.maybeMeasureLatency;
 
 public class MeteredWindowStore<K, V>
@@ -104,10 +105,6 @@ public class MeteredWindowStore<K, V>
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
     }
-    protected Serde<K> prepareKeySerde(final Serde<K> keySerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
-        return WrappingNullableUtils.prepareKeySerde(keySerde, contextKeySerde, contextValueSerde);
-    }
-
     protected Serde<V> prepareValueSerde(final Serde<V> valueSerde, final Serde<?> contextKeySerde, final Serde<?> contextValueSerde) {
         return WrappingNullableUtils.prepareValueSerde(valueSerde, contextKeySerde, contextValueSerde);
     }
@@ -120,7 +117,7 @@ public class MeteredWindowStore<K, V>
     }
 
     @Deprecated
-    void initStoreSerde(final ProcessorContext context) {
+    private void initStoreSerde(final ProcessorContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
         serdes = new StateSerdes<>(
@@ -131,7 +128,7 @@ public class MeteredWindowStore<K, V>
             prepareValueSerde(valueSerde, context.keySerde(), context.valueSerde()));
     }
 
-    void initStoreSerde(final StateStoreContext context) {
+    private void initStoreSerde(final StateStoreContext context) {
         final String storeName = name();
         final String changelogTopic = ProcessorContextUtils.changelogFor(context, storeName);
         serdes = new StateSerdes<>(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
@@ -25,14 +25,13 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareDeserializer;
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.initNullableDeserializer;
 
 class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<ValueAndTimestamp<V>, Void, V> {
     private final static LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
 
     public final Deserializer<V> valueDeserializer;
     private final Deserializer<Long> timestampDeserializer;
-    private boolean isKey;
 
     ValueAndTimestampDeserializer(final Deserializer<V> valueDeserializer) {
         Objects.requireNonNull(valueDeserializer);
@@ -45,7 +44,6 @@ class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<V
                           final boolean isKey) {
         valueDeserializer.configure(configs, isKey);
         timestampDeserializer.configure(configs, isKey);
-        this.isKey = isKey;
     }
 
     @Override
@@ -86,11 +84,10 @@ class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<V
         return LONG_DESERIALIZER.deserialize(null, rawTimestamp(rawValueAndTimestamp));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void setIfUnset(final Deserializer<Void> defaultKeyDeserializer, final Deserializer<V> defaultValueDeserializer) {
         // ValueAndTimestampDeserializer never wraps a null deserializer (or configure would throw),
         // but it may wrap a deserializer that itself wraps a null deserializer.
-        prepareDeserializer(valueDeserializer, defaultKeyDeserializer, defaultValueDeserializer, isKey);
+        initNullableDeserializer(valueDeserializer, defaultKeyDeserializer, defaultValueDeserializer);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
@@ -25,11 +25,14 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareDeserializer;
+
 class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<ValueAndTimestamp<V>, Void, V> {
     private final static LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
 
     public final Deserializer<V> valueDeserializer;
     private final Deserializer<Long> timestampDeserializer;
+    private boolean isKey;
 
     ValueAndTimestampDeserializer(final Deserializer<V> valueDeserializer) {
         Objects.requireNonNull(valueDeserializer);
@@ -42,6 +45,7 @@ class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<V
                           final boolean isKey) {
         valueDeserializer.configure(configs, isKey);
         timestampDeserializer.configure(configs, isKey);
+        this.isKey = isKey;
     }
 
     @Override
@@ -85,8 +89,8 @@ class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<V
     @SuppressWarnings("unchecked")
     @Override
     public void setIfUnset(final Deserializer<Void> defaultKeyDeserializer, final Deserializer<V> defaultValueDeserializer) {
-        if (this.valueDeserializer instanceof WrappingNullableDeserializer) {
-            ((WrappingNullableDeserializer<?, Void, V>) this.valueDeserializer).setIfUnset(defaultKeyDeserializer, defaultValueDeserializer);
-        }
+        // ValueAndTimestampDeserializer never wraps a null deserializer (or configure would throw),
+        // but it may wrap a deserializer that itself wraps a null deserializer.
+        prepareDeserializer(valueDeserializer, defaultKeyDeserializer, defaultValueDeserializer, isKey);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampDeserializer.java
@@ -18,13 +18,14 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableDeserializer;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
-class ValueAndTimestampDeserializer<V> implements Deserializer<ValueAndTimestamp<V>> {
+class ValueAndTimestampDeserializer<V> implements WrappingNullableDeserializer<ValueAndTimestamp<V>, Void, V> {
     private final static LongDeserializer LONG_DESERIALIZER = new LongDeserializer();
 
     public final Deserializer<V> valueDeserializer;
@@ -81,4 +82,11 @@ class ValueAndTimestampDeserializer<V> implements Deserializer<ValueAndTimestamp
         return LONG_DESERIALIZER.deserialize(null, rawTimestamp(rawValueAndTimestamp));
     }
 
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setIfUnset(final Deserializer<Void> defaultKeyDeserializer, final Deserializer<V> defaultValueDeserializer) {
+        if (this.valueDeserializer instanceof WrappingNullableDeserializer) {
+            ((WrappingNullableDeserializer<?, Void, V>) this.valueDeserializer).setIfUnset(defaultKeyDeserializer, defaultValueDeserializer);
+        }
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
@@ -16,45 +16,17 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.kstream.internals.WrappingNullableSerde;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
-import java.util.Map;
-import java.util.Objects;
+import static java.util.Objects.requireNonNull;
 
-public class ValueAndTimestampSerde<V> implements WrappingNullableSerde<ValueAndTimestamp<V>, Void, V> {
-    private final ValueAndTimestampSerializer<V> valueAndTimestampSerializer;
-    private final ValueAndTimestampDeserializer<V> valueAndTimestampDeserializer;
-
+public class ValueAndTimestampSerde<V> extends WrappingNullableSerde<ValueAndTimestamp<V>, Void, V> {
     public ValueAndTimestampSerde(final Serde<V> valueSerde) {
-        Objects.requireNonNull(valueSerde);
-        valueAndTimestampSerializer = new ValueAndTimestampSerializer<>(valueSerde.serializer());
-        valueAndTimestampDeserializer = new ValueAndTimestampDeserializer<>(valueSerde.deserializer());
-    }
-
-    @Override
-    public void configure(final Map<String, ?> configs,
-                          final boolean isKey) {
-        valueAndTimestampSerializer.configure(configs, isKey);
-        valueAndTimestampDeserializer.configure(configs, isKey);
-    }
-
-    @Override
-    public void close() {
-        valueAndTimestampSerializer.close();
-        valueAndTimestampDeserializer.close();
-    }
-
-    @Override
-    public Serializer<ValueAndTimestamp<V>> serializer() {
-        return valueAndTimestampSerializer;
-    }
-
-    @Override
-    public Deserializer<ValueAndTimestamp<V>> deserializer() {
-        return valueAndTimestampDeserializer;
+        super(
+            new ValueAndTimestampSerializer<>(requireNonNull(valueSerde, "valueSerde was null").serializer()),
+            new ValueAndTimestampDeserializer<>(requireNonNull(valueSerde, "valueSerde was null").deserializer())
+        );
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerde.java
@@ -19,12 +19,13 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerde;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.util.Map;
 import java.util.Objects;
 
-public class ValueAndTimestampSerde<V> implements Serde<ValueAndTimestamp<V>> {
+public class ValueAndTimestampSerde<V> implements WrappingNullableSerde<ValueAndTimestamp<V>, Void, V> {
     private final ValueAndTimestampSerializer<V> valueAndTimestampSerializer;
     private final ValueAndTimestampDeserializer<V> valueAndTimestampDeserializer;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
@@ -25,12 +25,11 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.prepareSerializer;
+import static org.apache.kafka.streams.kstream.internals.WrappingNullableUtils.initNullableSerializer;
 
 public class ValueAndTimestampSerializer<V> implements WrappingNullableSerializer<ValueAndTimestamp<V>, Void, V> {
     public final Serializer<V> valueSerializer;
     private final Serializer<Long> timestampSerializer;
-    private boolean isKey;
 
     ValueAndTimestampSerializer(final Serializer<V> valueSerializer) {
         Objects.requireNonNull(valueSerializer);
@@ -63,7 +62,6 @@ public class ValueAndTimestampSerializer<V> implements WrappingNullableSerialize
                           final boolean isKey) {
         valueSerializer.configure(configs, isKey);
         timestampSerializer.configure(configs, isKey);
-        this.isKey = isKey;
     }
 
     @Override
@@ -125,11 +123,10 @@ public class ValueAndTimestampSerializer<V> implements WrappingNullableSerialize
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void setIfUnset(final Serializer<Void> defaultKeySerializer, final Serializer<V> defaultValueSerializer) {
         // ValueAndTimestampSerializer never wraps a null serializer (or configure would throw),
         // but it may wrap a serializer that itself wraps a null serializer.
-        prepareSerializer(valueSerializer, defaultKeySerializer, defaultValueSerializer, isKey);
+        initNullableSerializer(valueSerializer, defaultKeySerializer, defaultValueSerializer);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ValueAndTimestampSerializer.java
@@ -18,13 +18,14 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.kstream.internals.WrappingNullableSerializer;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Objects;
 
-public class ValueAndTimestampSerializer<V> implements Serializer<ValueAndTimestamp<V>> {
+public class ValueAndTimestampSerializer<V> implements WrappingNullableSerializer<ValueAndTimestamp<V>, Void, V> {
     public final Serializer<V> valueSerializer;
     private final Serializer<Long> timestampSerializer;
 
@@ -118,5 +119,12 @@ public class ValueAndTimestampSerializer<V> implements Serializer<ValueAndTimest
             }
         }
         return true;
+    }
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setIfUnset(final Serializer<Void> defaultKeySerializer, final Serializer<V> defaultValueSerializer) {
+        if (this.valueSerializer instanceof WrappingNullableSerializer) {
+            ((WrappingNullableSerializer<?, Void, V>) this.valueSerializer).setIfUnset(defaultKeySerializer, defaultValueSerializer);
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDistributedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDistributedTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.processor.ThreadMetadata;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+import static org.junit.Assert.assertEquals;
+
+@Category({IntegrationTest.class})
+public class KTableKTableForeignKeyJoinDistributedTest {
+    private static final int NUM_BROKERS = 1;
+    private static final String LEFT_TABLE = "left_table";
+    private static final String RIGHT_TABLE = "right_table";
+    private static final String OUTPUT = "output-topic";
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    private static final Properties CONSUMER_CONFIG = new Properties();
+
+    @Rule
+    public TestName testName = new TestName();
+
+
+    private static final String INPUT_TOPIC = "input-topic";
+
+    private KafkaStreams client1;
+    private KafkaStreams client2;
+
+    private volatile boolean client1IsOk = false;
+    private volatile boolean client2IsOk = false;
+
+    @BeforeClass
+    public static void createTopics() throws InterruptedException {
+        CLUSTER.createTopic(INPUT_TOPIC, 2, 1);
+    }
+
+    @Before
+    public void setupTopics() throws InterruptedException {
+        CLUSTER.createTopic(LEFT_TABLE, 1, 1);
+        CLUSTER.createTopic(RIGHT_TABLE, 1, 1);
+        CLUSTER.createTopic(OUTPUT, 11, 1);
+
+        //Fill test tables
+        final Properties producerConfig = new Properties();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        final List<KeyValue<String, String>> leftTable = Arrays.asList(
+                new KeyValue<>("lhsValue1", "lhsValue1|rhs1"),
+                new KeyValue<>("lhsValue2", "lhsValue2|rhs2"),
+                new KeyValue<>("lhsValue3", "lhsValue3|rhs3"),
+                new KeyValue<>("lhsValue4", "lhsValue4|rhs4")
+        );
+        final List<KeyValue<String, String>> rightTable = Arrays.asList(
+                new KeyValue<>("rhs1", "rhsValue1"),
+                new KeyValue<>("rhs2", "rhsValue2"),
+                new KeyValue<>("rhs3", "rhsValue3")
+        );
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(LEFT_TABLE, leftTable, producerConfig, CLUSTER.time);
+        IntegrationTestUtils.produceKeyValuesSynchronously(RIGHT_TABLE, rightTable, producerConfig, CLUSTER.time);
+
+        CONSUMER_CONFIG.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        CONSUMER_CONFIG.put(ConsumerConfig.GROUP_ID_CONFIG, "ktable-ktable-distributed-consumer");
+        CONSUMER_CONFIG.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        CONSUMER_CONFIG.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    }
+
+    @After
+    public void after() {
+        client1.close();
+        client2.close();
+    }
+
+    public Properties getStreamsConfiguration() {
+        final String safeTestName = safeUniqueTestName(getClass(), testName);
+        final Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-" + safeTestName);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsConfiguration.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+        return streamsConfiguration;
+    }
+
+
+    private void configureBuilder(final StreamsBuilder builder) {
+        final KTable<String, String> left = builder.table(
+                LEFT_TABLE
+        );
+        final KTable<String, String> right = builder.table(
+                RIGHT_TABLE
+        );
+
+        final Function<String, String> extractor = value -> value.split("\\|")[1];
+        final ValueJoiner<String, String, String> joiner = (value1, value2) -> "(" + value1 + "," + value2 + ")";
+
+        final KTable<String, String> fkJoin = left.join(right, extractor, joiner);
+        fkJoin
+                .toStream()
+                .to(OUTPUT);
+    }
+
+    @Test
+    public void shouldBeInitializedWithDefaultSerde() throws Exception {
+        final Properties streamsConfiguration1 = getStreamsConfiguration();
+        final Properties streamsConfiguration2 = getStreamsConfiguration();
+
+        //Each streams client needs to have it's own StreamsBuilder in order to simulate
+        //a truly distributed run
+        final StreamsBuilder builder1 = new StreamsBuilder();
+        configureBuilder(builder1);
+        final StreamsBuilder builder2 = new StreamsBuilder();
+        configureBuilder(builder2);
+
+
+        createClients(
+                builder1.build(streamsConfiguration1),
+                streamsConfiguration1,
+                builder2.build(streamsConfiguration2),
+                streamsConfiguration2
+        );
+
+        setStateListenersForVerification(thread -> !thread.activeTasks().isEmpty());
+
+        startClients();
+
+        waitUntilBothClientAreOK(
+                "At least one client did not reach state RUNNING with active tasks"
+        );
+        final Set<KeyValue<String, String>> expectedResult = new HashSet<>();
+        expectedResult.add(new KeyValue<>("lhsValue1", "(lhsValue1|rhs1,rhsValue1)"));
+        expectedResult.add(new KeyValue<>("lhsValue2", "(lhsValue2|rhs2,rhsValue2)"));
+        expectedResult.add(new KeyValue<>("lhsValue3", "(lhsValue3|rhs3,rhsValue3)"));
+        final Set<KeyValue<String, String>> result = new HashSet<>(IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(
+                CONSUMER_CONFIG,
+                OUTPUT,
+                expectedResult.size()));
+
+        assertEquals(expectedResult, result);
+        //Check that both clients are still running
+        assertEquals(KafkaStreams.State.RUNNING, client1.state());
+        assertEquals(KafkaStreams.State.RUNNING, client2.state());
+    }
+
+    private void createClients(final Topology topology1,
+                               final Properties streamsConfiguration1,
+                               final Topology topology2,
+                               final Properties streamsConfiguration2) {
+
+        client1 = new KafkaStreams(topology1, streamsConfiguration1);
+        client2 = new KafkaStreams(topology2, streamsConfiguration2);
+    }
+
+    private void setStateListenersForVerification(final Predicate<ThreadMetadata> taskCondition) {
+        client1.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING &&
+                    client1.localThreadsMetadata().stream().allMatch(taskCondition)) {
+                client1IsOk = true;
+            }
+        });
+        client2.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING &&
+                    client2.localThreadsMetadata().stream().allMatch(taskCondition)) {
+                client2IsOk = true;
+            }
+        });
+    }
+
+    private void startClients() {
+        client1.start();
+        client2.start();
+    }
+
+    private void waitUntilBothClientAreOK(final String message) throws Exception {
+        TestUtils.waitForCondition(() -> client1IsOk && client2IsOk,
+                30 * 1000,
+                message + ": "
+                        + "Client 1 is " + (!client1IsOk ? "NOT " : "") + "OK, "
+                        + "client 2 is " + (!client2IsOk ? "NOT " : "") + "OK."
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDistributedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDistributedTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.quietlyCleanStateAfterTest;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.junit.Assert.assertEquals;
 
@@ -118,6 +119,8 @@ public class KTableKTableForeignKeyJoinDistributedTest {
     public void after() {
         client1.close();
         client2.close();
+        quietlyCleanStateAfterTest(CLUSTER, client1);
+        quietlyCleanStateAfterTest(CLUSTER, client2);
     }
 
     public Properties getStreamsConfiguration() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
@@ -108,10 +109,17 @@ public class GlobalStateStoreProviderTest {
             );
         expect(mockContext.taskId()).andStubReturn(new TaskId(0, 0));
         expect(mockContext.recordCollector()).andStubReturn(null);
+        expectSerdes(mockContext);
         replay(mockContext);
         for (final StateStore store : stores.values()) {
             store.init((StateStoreContext) mockContext, null);
         }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void expectSerdes(final ProcessorContextImpl context) {
+        expect(context.keySerde()).andStubReturn((Serde) Serdes.String());
+        expect(context.valueSerde()).andStubReturn((Serde) Serdes.Long());
     }
 
     @Test


### PR DESCRIPTION
Also introduced the notion of WrappingNullableSerdes (aligned to the concept of WrappingNullableSerializer and WrappingNullableDeserializer) and centralized initialization in WrappingNullables.

The added integeration test KTableKTableForeignKeyJoinDistributedTest tests wether all serdes are now correctly set on all stream clients.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
