### PR TITLE
MINOR: Fix MirrorConnectorsIntegrationTest

### DIFF
--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorConnectorsIntegrationTest.java
@@ -125,7 +125,7 @@ public class MirrorConnectorsIntegrationTest {
         primary.assertions().assertAtLeastNumWorkersAreUp(3,
                 "Workers of primary-connect-cluster did not start in time.");
         backup.start();
-        primary.assertions().assertAtLeastNumWorkersAreUp(3,
+        backup.assertions().assertAtLeastNumWorkersAreUp(3,
                 "Workers of backup-connect-cluster did not start in time.");
 
         // create these topics before starting the connectors so we don't need to wait for discovery


### PR DESCRIPTION
In `setup()`, `primary` was checked to be running twice, instead of `backup`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
