### PR TITLE
KAFKA-10338; Support PEM format for SSL key and trust stores (KIP-651)

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -109,6 +109,9 @@
         <allow pkg="org.apache.kafka.common.requests" />
         <allow pkg="org.apache.kafka.clients" />
       </subpackage>
+      <subpackage name="ssl">
+        <allow pkg="javax.crypto" />
+      </subpackage>
       <subpackage name="scram">
         <allow pkg="javax.crypto" />
       </subpackage>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -63,7 +63,7 @@
               files="(Utils|Topic|KafkaLZ4BlockOutputStream|AclData|JoinGroupRequest).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor).java"/>
+              files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory).java"/>
 
     <suppress checks="JavaNCSS"
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest).java"/>
@@ -96,7 +96,7 @@
               files="RequestResponseTest.java|FetcherTest.java|KafkaAdminClientTest.java"/>
 
     <suppress checks="NPathComplexity"
-              files="MemoryRecordsTest|MetricsTest"/>
+              files="MemoryRecordsTest|MetricsTest|TestSslUtils"/>
 
     <suppress checks="(WhitespaceAround|LocalVariableName|ImportControl|AvoidStarImport)"
               files="Murmur3Test.java"/>

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -97,7 +97,7 @@ public class SslConfigs {
         + "key password must be specified using 'ssl.key.password'";
 
     public static final String SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG = "ssl.keystore.certificate.chain";
-    public static final String SSL_KEYSTORE_CERTIFICATE_DOC = "Certificate chain in the format specified by 'ssl.keystore.type'. "
+    public static final String SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC = "Certificate chain in the format specified by 'ssl.keystore.type'. "
         + "Default SSL engine factory supports only PEM format with a list of X.509 certificates";
 
     public static final String SSL_TRUSTSTORE_CERTIFICATES_CONFIG = "ssl.truststore.certificates";
@@ -170,7 +170,7 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEY_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEY_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_KEY_DOC)
-                .define(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_CERTIFICATE_DOC)
+                .define(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_TRUSTSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.config;
 
+import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.Utils;
@@ -90,17 +91,31 @@ public class SslConfigs {
             + "This is optional for client.";
     public static final String DEFAULT_SSL_KEYSTORE_TYPE = "JKS";
 
+    public static final String SSL_KEYSTORE_KEY_CONFIG = "ssl.keystore.key";
+    public static final String SSL_KEYSTORE_KEY_DOC = "Private key in the format specified by 'ssl.keystore.type'. "
+        + "Default SSL engine factory supports only PEM format with PKCS#8 keys. If the key is encrypted, "
+        + "key password must be specified using 'ssl.key.password'";
+
+    public static final String SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG = "ssl.keystore.certificate.chain";
+    public static final String SSL_KEYSTORE_CERTIFICATE_DOC = "Certificate chain in the format specified by 'ssl.keystore.type'. "
+        + "Default SSL engine factory supports only PEM format with a list of X.509 certificates";
+
+    public static final String SSL_TRUSTSTORE_CERTIFICATES_CONFIG = "ssl.truststore.certificates";
+    public static final String SSL_TRUSTSTORE_CERTIFICATES_DOC = "Trusted certificates in the format specified by 'ssl.truststore.type'. "
+        + "Default SSL engine factory supports only PEM format with X.509 certificates.";
+
     public static final String SSL_KEYSTORE_LOCATION_CONFIG = "ssl.keystore.location";
     public static final String SSL_KEYSTORE_LOCATION_DOC = "The location of the key store file. "
         + "This is optional for client and can be used for two-way authentication for client.";
 
     public static final String SSL_KEYSTORE_PASSWORD_CONFIG = "ssl.keystore.password";
     public static final String SSL_KEYSTORE_PASSWORD_DOC = "The store password for the key store file. "
-        + "This is optional for client and only needed if ssl.keystore.location is configured. ";
+        + "This is optional for client and only needed if 'ssl.keystore.location' is configured. "
+        + " Key store password is not supported for PEM format.";
 
     public static final String SSL_KEY_PASSWORD_CONFIG = "ssl.key.password";
-    public static final String SSL_KEY_PASSWORD_DOC = "The password of the private key in the key store file. "
-            + "This is optional for client.";
+    public static final String SSL_KEY_PASSWORD_DOC = "The password of the private key in the key store file or"
+        + "the PEM key specified in `ssl.keystore.key'. This is required for clients only if two-way authentication is configured.";
 
     public static final String SSL_TRUSTSTORE_TYPE_CONFIG = "ssl.truststore.type";
     public static final String SSL_TRUSTSTORE_TYPE_DOC = "The file format of the trust store file.";
@@ -110,7 +125,9 @@ public class SslConfigs {
     public static final String SSL_TRUSTSTORE_LOCATION_DOC = "The location of the trust store file. ";
 
     public static final String SSL_TRUSTSTORE_PASSWORD_CONFIG = "ssl.truststore.password";
-    public static final String SSL_TRUSTSTORE_PASSWORD_DOC = "The password for the trust store file. If a password is not set access to the truststore is still available, but integrity checking is disabled.";
+    public static final String SSL_TRUSTSTORE_PASSWORD_DOC = "The password for the trust store file. "
+        + "If a password is not set, trust store file configured will still be used, but integrity checking is disabled. "
+        + "Trust store password is not supported for PEM format.";
 
     public static final String SSL_KEYMANAGER_ALGORITHM_CONFIG = "ssl.keymanager.algorithm";
     public static final String SSL_KEYMANAGER_ALGORITHM_DOC = "The algorithm used by key manager factory for SSL connections. "
@@ -152,6 +169,9 @@ public class SslConfigs {
                 .define(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_LOCATION_DOC)
                 .define(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_PASSWORD_DOC)
                 .define(SslConfigs.SSL_KEY_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_KEY_PASSWORD_DOC)
+                .define(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_KEY_DOC)
+                .define(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_KEYSTORE_CERTIFICATE_DOC)
+                .define(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, ConfigDef.Type.PASSWORD, null,  ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, ConfigDef.Type.STRING, SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE, ConfigDef.Importance.MEDIUM, SslConfigs.SSL_TRUSTSTORE_TYPE_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC)
                 .define(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.HIGH, SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC)
@@ -169,7 +189,10 @@ public class SslConfigs {
             SslConfigs.SSL_KEY_PASSWORD_CONFIG,
             SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
             SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
-            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
+            SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG);
 
     public static final Set<String> NON_RECONFIGURABLE_CONFIGS = Utils.mkSet(
             BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -70,6 +70,8 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
                 sslPrincipalMapper = SslPrincipalMapper.fromRules(sslPrincipalMappingRules);
             this.sslFactory = new SslFactory(mode, null, isInterBrokerListener);
             this.sslFactory.configure(this.configs);
+        } catch (KafkaException e) {
+            throw e;
         } catch (Exception e) {
             throw new KafkaException(e);
         }

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -21,36 +21,58 @@ import org.apache.kafka.common.config.SslClientAuth;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
 import org.apache.kafka.common.utils.SecurityUtils;
+import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
-import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyFactory;
 import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import javax.crypto.Cipher;
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.TrustManagerFactory;
 
 public final class DefaultSslEngineFactory implements SslEngineFactory {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultSslEngineFactory.class);
+    public static final String PEM_TYPE = "PEM";
 
     private Map<String, ?> configs;
     private String protocol;
@@ -139,13 +161,16 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
         this.keystore = createKeystore((String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
                 (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
                 (Password) configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
-                (Password) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG));
+                (Password) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG),
+                (Password) configs.get(SslConfigs.SSL_KEYSTORE_KEY_CONFIG),
+                (Password) configs.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG));
 
         this.truststore = createTruststore((String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
                 (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
-                (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+                (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG),
+                (Password) configs.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG));
 
-        this.sslContext = createSSLContext();
+        this.sslContext = createSSLContext(keystore, truststore);
     }
 
     @Override
@@ -209,7 +234,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
         }
     }
 
-    private SSLContext createSSLContext() {
+    private SSLContext createSSLContext(SecurityStore keystore, SecurityStore truststore) {
         try {
             SSLContext sslContext;
             if (provider != null)
@@ -223,9 +248,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
                         this.kmfAlgorithm : KeyManagerFactory.getDefaultAlgorithm();
                 KeyManagerFactory kmf = KeyManagerFactory.getInstance(kmfAlgorithm);
                 if (keystore != null) {
-                    KeyStore ks = keystore.get();
-                    Password keyPassword = keystore.keyPassword != null ? keystore.keyPassword : keystore.password;
-                    kmf.init(ks, keyPassword.value().toCharArray());
+                    kmf.init(keystore.get(), keystore.keyPassword());
                 } else {
                     kmf.init(null, null);
                 }
@@ -246,47 +269,95 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
         }
     }
 
-    private static SecurityStore createKeystore(String type, String path, Password password, Password keyPassword) {
-        if (path == null && password != null) {
-            throw new KafkaException("SSL key store is not specified, but key store password is specified.");
+    // Visibility to override for testing
+    protected SecurityStore createKeystore(String type, String path, Password password, Password keyPassword, Password privateKey, Password certificateChain) {
+        if (privateKey != null) {
+            if (!PEM_TYPE.equals(type))
+                throw new InvalidConfigurationException("SSL private key can be specified only for PEM, but key store type is " + type + ".");
+            else if (certificateChain == null)
+                throw new InvalidConfigurationException("SSL private key is specified, but certificate chain is not specified.");
+            else if (path != null)
+                throw new InvalidConfigurationException("Both SSL key store location and separate private key are specified.");
+            else if (password != null)
+                throw new InvalidConfigurationException("SSL key store password cannot be specified with PEM format, only key password may be specified.");
+            else
+                return new PemStore(certificateChain, privateKey, keyPassword);
+        } else if (certificateChain != null) {
+            throw new InvalidConfigurationException("SSL certificate chain is specified, but private key is not specified");
+        } else if (PEM_TYPE.equals(type) && path != null) {
+            if (password != null)
+                throw new InvalidConfigurationException("SSL key store password cannot be specified with PEM format, only key password may be specified");
+            else if (keyPassword == null)
+                throw new InvalidConfigurationException("SSL PEM key store is specified, but key password is not specified.");
+            else
+                return new FileBasedPemStore(path, keyPassword, true);
+        } else if (path == null && password != null) {
+            throw new InvalidConfigurationException("SSL key store is not specified, but key store password is specified.");
         } else if (path != null && password == null) {
-            throw new KafkaException("SSL key store is specified, but key store password is not specified.");
+            throw new InvalidConfigurationException("SSL key store is specified, but key store password is not specified.");
         } else if (path != null && password != null) {
-            return new SecurityStore(type, path, password, keyPassword);
+            return new FileBasedStore(type, path, password, keyPassword, true);
         } else
             return null; // path == null, clients may use this path with brokers that don't require client auth
     }
 
-    private static SecurityStore createTruststore(String type, String path, Password password) {
-        if (path == null && password != null) {
-            throw new KafkaException("SSL trust store is not specified, but trust store password is specified.");
+    private static SecurityStore createTruststore(String type, String path, Password password, Password trustStoreCerts) {
+        if (trustStoreCerts != null) {
+            if (!PEM_TYPE.equals(type))
+                throw new InvalidConfigurationException("SSL trust store certs can be specified only for PEM, but trust store type is " + type + ".");
+            else if (path != null)
+                throw new InvalidConfigurationException("Both SSL trust store location and separate trust certificates are specified.");
+            else if (password != null)
+                throw new InvalidConfigurationException("SSL trust store password cannot be specified for PEM format.");
+            else
+                return new PemStore(trustStoreCerts);
+        } else if (PEM_TYPE.equals(type) && path != null) {
+            if (password != null)
+                throw new InvalidConfigurationException("SSL trust store password cannot be specified for PEM format.");
+            else
+                return new FileBasedPemStore(path, null, false);
+        } else if (path == null && password != null) {
+            throw new InvalidConfigurationException("SSL trust store is not specified, but trust store password is specified.");
         } else if (path != null) {
-            return new SecurityStore(type, path, password, null);
+            return new FileBasedStore(type, path, password, null, false);
         } else
             return null;
     }
 
+    static interface SecurityStore {
+        KeyStore get();
+        char[] keyPassword();
+        boolean modified();
+    }
+
     // package access for testing
-    static class SecurityStore {
+    static class FileBasedStore implements SecurityStore {
         private final String type;
-        private final String path;
+        protected final String path;
         private final Password password;
-        private final Password keyPassword;
+        protected final Password keyPassword;
         private final Long fileLastModifiedMs;
         private final KeyStore keyStore;
 
-        SecurityStore(String type, String path, Password password, Password keyPassword) {
+        FileBasedStore(String type, String path, Password password, Password keyPassword, boolean isKeyStore) {
             Objects.requireNonNull(type, "type must not be null");
             this.type = type;
             this.path = path;
             this.password = password;
             this.keyPassword = keyPassword;
             fileLastModifiedMs = lastModifiedMs(path);
-            this.keyStore = load();
+            this.keyStore = load(isKeyStore);
         }
 
-        KeyStore get() {
+        @Override
+        public KeyStore get() {
             return keyStore;
+        }
+
+        @Override
+        public char[] keyPassword() {
+            Password passwd = keyPassword != null ? keyPassword : password;
+            return passwd == null ? null : passwd.value().toCharArray();
         }
 
         /**
@@ -295,7 +366,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
          * @throws KafkaException if the file could not be read or if the keystore could not be loaded
          *   using the specified configs (e.g. if the password or keystore type is invalid)
          */
-        private KeyStore load() {
+        protected KeyStore load(boolean isKeyStore) {
             try (InputStream in = Files.newInputStream(Paths.get(path))) {
                 KeyStore ks = KeyStore.getInstance(type);
                 // If a password is not set access to the truststore is still available, but integrity checking is disabled.
@@ -316,7 +387,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
             }
         }
 
-        boolean modified() {
+        public boolean modified() {
             Long modifiedMs = lastModifiedMs(path);
             return modifiedMs != null && !Objects.equals(modifiedMs, this.fileLastModifiedMs);
         }
@@ -326,6 +397,188 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
             return "SecurityStore(" +
                     "path=" + path +
                     ", modificationTime=" + (fileLastModifiedMs == null ? null : new Date(fileLastModifiedMs)) + ")";
+        }
+    }
+
+    static class FileBasedPemStore extends FileBasedStore {
+        FileBasedPemStore(String path, Password keyPassword, boolean isKeyStore) {
+            super(PEM_TYPE, path, null, keyPassword, isKeyStore);
+        }
+
+        @Override
+        protected KeyStore load(boolean isKeyStore) {
+            try {
+                Password storeContents = new Password(Utils.readFileAsString(path));
+                PemStore pemStore = isKeyStore ? new PemStore(storeContents, storeContents, keyPassword) :
+                    new PemStore(storeContents);
+                return pemStore.keyStore;
+            } catch (Exception e) {
+                throw new InvalidConfigurationException("Failed to load PEM SSL keystore " + path, e);
+            }
+        }
+    }
+
+    static class PemStore implements SecurityStore {
+        private static final PemParser CERTIFICATE_PARSER = new PemParser("CERTIFICATE");
+        private static final PemParser PRIVATE_KEY_PARSER = new PemParser("PRIVATE KEY");
+        private static final List<KeyFactory> KEY_FACTORIES = Arrays.asList(
+                keyFactory("RSA"),
+                keyFactory("DSA"),
+                keyFactory("EC")
+        );
+
+        private final char[] keyPassword;
+        private final KeyStore keyStore;
+
+        PemStore(Password certificateChain, Password privateKey, Password keyPassword) {
+            this.keyPassword = keyPassword == null ? null : keyPassword.value().toCharArray();
+            keyStore = createKeyStoreFromPem(privateKey.value(), certificateChain.value(), this.keyPassword);
+        }
+
+        PemStore(Password trustStoreCerts) {
+            this.keyPassword = null;
+            keyStore = createTrustStoreFromPem(trustStoreCerts.value());
+        }
+
+        @Override
+        public KeyStore get() {
+            return keyStore;
+        }
+
+        @Override
+        public char[] keyPassword() {
+            return keyPassword;
+        }
+
+        @Override
+        public boolean modified() {
+            return false;
+        }
+
+        private KeyStore createKeyStoreFromPem(String privateKeyPem, String certChainPem, char[] keyPassword) {
+            try {
+                KeyStore ks = KeyStore.getInstance("PKCS12");
+                ks.load(null, null);
+                Key key = privateKey(privateKeyPem, keyPassword);
+                Certificate[] certChain = certs(certChainPem);
+                ks.setKeyEntry("kafka", key, keyPassword, certChain);
+                return ks;
+            } catch (Exception e) {
+                throw new InvalidConfigurationException("Invalid PEM keystore configs", e);
+            }
+        }
+
+        private KeyStore createTrustStoreFromPem(String trustedCertsPem) {
+            try {
+                KeyStore ts = KeyStore.getInstance("PKCS12");
+                ts.load(null, null);
+                Certificate[] certs = certs(trustedCertsPem);
+                for (int i = 0; i < certs.length; i++) {
+                    ts.setCertificateEntry("kafka" + i, certs[i]);
+                }
+                return ts;
+            } catch (InvalidConfigurationException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new InvalidConfigurationException("Invalid PEM keystore configs", e);
+            }
+        }
+
+        private Certificate[] certs(String pem) throws GeneralSecurityException {
+            List<byte[]> certEntries = CERTIFICATE_PARSER.pemEntries(pem);
+            if (certEntries.isEmpty())
+                throw new InvalidConfigurationException("At least one certificate expected, but none found");
+
+            Certificate[] certs = new Certificate[certEntries.size()];
+            for (int i = 0; i < certs.length; i++) {
+                certs[i] = CertificateFactory.getInstance("X.509")
+                    .generateCertificate(new ByteArrayInputStream(certEntries.get(i)));
+            }
+            return certs;
+        }
+
+        private PrivateKey privateKey(String pem, char[] keyPassword) throws Exception {
+            List<byte[]> keyEntries = PRIVATE_KEY_PARSER.pemEntries(pem);
+            if (keyEntries.isEmpty())
+                throw new InvalidConfigurationException("Private key not provided");
+            if (keyEntries.size() != 1)
+                throw new InvalidConfigurationException("Expected one private key, but found " + keyEntries.size());
+
+            byte[] keyBytes = keyEntries.get(0);
+            PKCS8EncodedKeySpec keySpec;
+            if (keyPassword == null) {
+                keySpec = new PKCS8EncodedKeySpec(keyBytes);
+            } else {
+                EncryptedPrivateKeyInfo keyInfo = new EncryptedPrivateKeyInfo(keyBytes);
+                String algorithm = keyInfo.getAlgName();
+                SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(algorithm);
+                SecretKey pbeKey = keyFactory.generateSecret(new PBEKeySpec(keyPassword));
+                Cipher cipher = Cipher.getInstance(algorithm);
+                cipher.init(Cipher.DECRYPT_MODE, pbeKey, keyInfo.getAlgParameters());
+                keySpec = keyInfo.getKeySpec(cipher);
+            }
+
+            InvalidKeySpecException firstException = null;
+            for (KeyFactory factory : KEY_FACTORIES) {
+                try {
+                    return factory.generatePrivate(keySpec);
+                } catch (InvalidKeySpecException e) {
+                    if (firstException == null)
+                        firstException = e;
+                }
+            }
+            throw new InvalidConfigurationException("Private key could not be loaded", firstException);
+        }
+
+        private static KeyFactory keyFactory(String algorithm) {
+            try {
+                return KeyFactory.getInstance(algorithm);
+            } catch (Exception e) {
+                throw new InvalidConfigurationException("Could not create key factory for algorithm " + algorithm, e);
+            }
+        }
+    }
+
+    /**
+     * Parser to process certificate/private key entries from PEM files
+     * Examples:
+     *   -----BEGIN CERTIFICATE-----
+     *   Base64 cert
+     *   -----END CERTIFICATE-----
+     *
+     *   -----BEGIN ENCRYPTED PRIVATE KEY-----
+     *   Base64 private key
+     *   -----BEGIN ENCRYPTED PRIVATE KEY-----
+     *   Additional data may be included before headers, so we match all entres within the PEM.
+     */
+    static class PemParser {
+        private final String name;
+        private final Pattern pattern;
+
+        PemParser(String name) {
+            this.name = name;
+            String beginOrEndFormat = "-+%s\\s*.*%s[^-]*-+\\s+";
+            String nameIgnoreSpace = name.replace(" ", "\\s+");
+
+            String encodingParams = "\\s*[^\\r\\n]*:[^\\r\\n]*[\\r\\n]+";
+            String base64Pattern = "([a-zA-Z0-9/+=\\s]*)";
+            String patternStr =  String.format(beginOrEndFormat, "BEGIN", nameIgnoreSpace) +
+                String.format("(?:%s)*", encodingParams) +
+                base64Pattern +
+                String.format(beginOrEndFormat, "END", nameIgnoreSpace);
+            pattern = Pattern.compile(patternStr);
+        }
+
+        private List<byte[]> pemEntries(String pem) {
+            Matcher matcher = pattern.matcher(pem + "\n"); // allow last newline to be omitted in value
+            List<byte[]>  entries = new ArrayList<>();
+            while (matcher.find()) {
+                String base64Str = matcher.group(1).replaceAll("\\s", "");
+                entries.add(Base64.getDecoder().decode(base64Str));
+            }
+            if (entries.isEmpty())
+                throw new InvalidConfigurationException("No matching " + name + " entries in PEM file");
+            return entries;
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
@@ -80,10 +80,6 @@ public class CertStores {
 
 
     public Map<String, Object> getTrustingConfig(CertStores truststoreConfig) {
-        return getTrustingConfig(truststoreConfig, false);
-    }
-
-    public Map<String, Object> getTrustingConfig(CertStores truststoreConfig, boolean usePemCerts) {
         Map<String, Object> config = new HashMap<>(sslConfig);
         for (String propName : TRUSTSTORE_PROPS) {
             config.put(propName, truststoreConfig.sslConfig.get(propName));

--- a/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/CertStores.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.network;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
@@ -25,6 +27,7 @@ import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.kafka.test.TestSslUtils.SslConfigsBuilder;
 
 public class CertStores {
 
@@ -32,12 +35,15 @@ public class CertStores {
             SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
             SslConfigs.SSL_KEYSTORE_TYPE_CONFIG,
             SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG,
-            SslConfigs.SSL_KEY_PASSWORD_CONFIG);
+            SslConfigs.SSL_KEY_PASSWORD_CONFIG,
+            SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
+            SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG);
 
     public static final Set<String> TRUSTSTORE_PROPS = Utils.mkSet(
             SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
             SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
-            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+            SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG);
 
     private final Map<String, Object> sslConfig;
 
@@ -54,13 +60,30 @@ public class CertStores {
     }
 
     private CertStores(boolean server, String commonName, TestSslUtils.CertificateBuilder certBuilder) throws Exception {
-        String name = server ? "server" : "client";
-        Mode mode = server ? Mode.SERVER : Mode.CLIENT;
-        File truststoreFile = File.createTempFile(name + "TS", ".jks");
-        sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name, commonName, certBuilder);
+        this(server, commonName, "RSA", certBuilder, false);
     }
 
+    private CertStores(boolean server, String commonName, String keyAlgorithm, TestSslUtils.CertificateBuilder certBuilder, boolean usePem) throws Exception {
+        String name = server ? "server" : "client";
+        Mode mode = server ? Mode.SERVER : Mode.CLIENT;
+        File truststoreFile = usePem ? null : File.createTempFile(name + "TS", ".jks");
+        sslConfig = new SslConfigsBuilder(mode)
+                .useClientCert(!server)
+                .certAlias(name)
+                .cn(commonName)
+                .createNewTrustStore(truststoreFile)
+                .certBuilder(certBuilder)
+                .algorithm(keyAlgorithm)
+                .usePem(usePem)
+                .build();
+    }
+
+
     public Map<String, Object> getTrustingConfig(CertStores truststoreConfig) {
+        return getTrustingConfig(truststoreConfig, false);
+    }
+
+    public Map<String, Object> getTrustingConfig(CertStores truststoreConfig, boolean usePemCerts) {
         Map<String, Object> config = new HashMap<>(sslConfig);
         for (String propName : TRUSTSTORE_PROPS) {
             config.put(propName, truststoreConfig.sslConfig.get(propName));
@@ -86,5 +109,53 @@ public class CertStores {
             props.put(propName, sslConfig.get(propName));
         }
         return props;
+    }
+
+    public static class Builder {
+        private final boolean isServer;
+        private String cn;
+        private List<String> sanDns;
+        private InetAddress sanIp;
+        private String keyAlgorithm;
+        private boolean usePem;
+
+        public Builder(boolean isServer) {
+            this.isServer = isServer;
+            this.sanDns = new ArrayList<>();
+            this.keyAlgorithm = "RSA";
+        }
+
+        public Builder cn(String cn) {
+            this.cn = cn;
+            return this;
+        }
+
+        public Builder addHostName(String hostname) {
+            this.sanDns.add(hostname);
+            return this;
+        }
+
+        public Builder hostAddress(InetAddress hostAddress) {
+            this.sanIp = hostAddress;
+            return this;
+        }
+
+        public Builder keyAlgorithm(String keyAlgorithm) {
+            this.keyAlgorithm = keyAlgorithm;
+            return this;
+        }
+
+        public Builder usePem(boolean usePem) {
+            this.usePem = usePem;
+            return this;
+        }
+
+        public CertStores build() throws Exception {
+            TestSslUtils.CertificateBuilder certBuilder = new TestSslUtils.CertificateBuilder()
+                .sanDnsNames(sanDns.toArray(new String[0]));
+            if (sanIp != null)
+                certBuilder = certBuilder.sanIpAddress(sanIp);
+            return new CertStores(isServer, cn, keyAlgorithm, certBuilder, usePem);
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -180,7 +180,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testValidEndpointIdentificationCN() throws Exception {
-        String node = "0";
         serverCertStores = certBuilder(true, "localhost").build();
         clientCertStores = certBuilder(false, "localhost").build();
         sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
@@ -260,7 +259,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testInvalidEndpointIdentification() throws Exception {
-        String node = "0";
         serverCertStores = certBuilder(true, "server").addHostName("notahost").build();
         clientCertStores = certBuilder(false, "client").addHostName("localhost").build();
         sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
@@ -312,7 +310,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationRequiredValidProvided() throws Exception {
-        String node = "0";
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
         verifySslConfigs();
     }
@@ -361,7 +358,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationRequiredUntrustedProvided() throws Exception {
-        String node = "0";
         sslServerConfigs = serverCertStores.getUntrustingConfig();
         sslServerConfigs.putAll(sslConfigOverrides);
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
@@ -374,7 +370,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationRequiredNotProvided() throws Exception {
-        String node = "0";
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
         CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
         verifySslConfigsWithHandshakeFailure();
@@ -386,7 +381,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationDisabledUntrustedProvided() throws Exception {
-        String node = "0";
         sslServerConfigs = serverCertStores.getUntrustingConfig();
         sslServerConfigs.putAll(sslConfigOverrides);
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
@@ -399,7 +393,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationDisabledNotProvided() throws Exception {
-        String node = "0";
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
 
         CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
@@ -412,7 +405,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationRequestedValidProvided() throws Exception {
-        String node = "0";
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
         verifySslConfigs();
     }
@@ -423,7 +415,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testClientAuthenticationRequestedNotProvided() throws Exception {
-        String node = "0";
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
 
         CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
@@ -506,7 +497,7 @@ public class SslTransportLayerTest {
      * Tests that an invalid SecureRandom implementation cannot be configured
      */
     @Test
-    public void testInvalidSecureRandomImplementation() throws Exception {
+    public void testInvalidSecureRandomImplementation() {
         try (SslChannelBuilder channelBuilder = newClientChannelBuilder()) {
             sslClientConfigs.put(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, "invalid");
             channelBuilder.configure(sslClientConfigs);
@@ -520,7 +511,7 @@ public class SslTransportLayerTest {
      * Tests that channels cannot be created if truststore cannot be loaded
      */
     @Test
-    public void testInvalidTruststorePassword() throws Exception {
+    public void testInvalidTruststorePassword() {
         try (SslChannelBuilder channelBuilder = newClientChannelBuilder()) {
             sslClientConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "invalid");
             channelBuilder.configure(sslClientConfigs);
@@ -534,7 +525,7 @@ public class SslTransportLayerTest {
      * Tests that channels cannot be created if keystore cannot be loaded
      */
     @Test
-    public void testInvalidKeystorePassword() throws Exception {
+    public void testInvalidKeystorePassword() {
         try (SslChannelBuilder channelBuilder = newClientChannelBuilder()) {
             sslClientConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "invalid");
             channelBuilder.configure(sslClientConfigs);
@@ -550,7 +541,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testNullTruststorePassword() throws Exception {
-        String node = "0";
         sslClientConfigs.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
         sslServerConfigs.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
 
@@ -563,7 +553,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testInvalidKeyPassword() throws Exception {
-        String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, new Password("invalid"));
         if (useInlinePem) {
             // We fail fast for PEM
@@ -594,15 +583,15 @@ public class SslTransportLayerTest {
         server.verifyAuthenticationMetrics(1, 0);
         selector.close();
 
-        checkAuthentiationFailed("1", "TLSv1.1");
+        checkAuthenticationFailed("1", "TLSv1.1");
         server.verifyAuthenticationMetrics(1, 1);
 
-        checkAuthentiationFailed("2", "TLSv1");
+        checkAuthenticationFailed("2", "TLSv1");
         server.verifyAuthenticationMetrics(1, 2);
     }
 
     /** Checks connection failed using the specified {@code tlsVersion}. */
-    private void checkAuthentiationFailed(String node, String tlsVersion) throws IOException {
+    private void checkAuthenticationFailed(String node, String tlsVersion) throws IOException {
         sslClientConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList(tlsVersion));
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
@@ -621,7 +610,7 @@ public class SslTransportLayerTest {
         sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
         server = createEchoServer(SecurityProtocol.SSL);
 
-        checkAuthentiationFailed("0", "TLSv1.1");
+        checkAuthenticationFailed("0", "TLSv1.1");
         server.verifyAuthenticationMetrics(0, 1);
     }
 
@@ -639,7 +628,7 @@ public class SslTransportLayerTest {
         sslClientConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[1]));
         createSelector(sslClientConfigs);
 
-        checkAuthentiationFailed("1", tlsProtocol);
+        checkAuthenticationFailed("1", tlsProtocol);
         server.verifyAuthenticationMetrics(0, 1);
     }
 
@@ -1014,7 +1003,7 @@ public class SslTransportLayerTest {
      * fails if certs from keystore are not trusted.
      */
     @Test(expected = KafkaException.class)
-    public void testInterBrokerSslConfigValidationFailure() throws Exception {
+    public void testInterBrokerSslConfigValidationFailure() {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
         TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
@@ -1205,7 +1194,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testCustomClientSslEngineFactory() throws Exception {
-        String node = "0";
         sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
         verifySslConfigs();
     }
@@ -1215,7 +1203,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testCustomServerSslEngineFactory() throws Exception {
-        String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
         verifySslConfigs();
     }
@@ -1225,7 +1212,6 @@ public class SslTransportLayerTest {
      */
     @Test
     public void testCustomClientAndServerSslEngineFactory() throws Exception {
-        String node = "0";
         sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
         sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
         verifySslConfigs();
@@ -1235,7 +1221,7 @@ public class SslTransportLayerTest {
      * Tests invalid ssl.engine.factory plugin class
      */
     @Test(expected = KafkaException.class)
-    public void testInvalidSslEngineFactory() throws Exception {
+    public void testInvalidSslEngineFactory() {
         sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, String.class);
         createSelector(sslClientConfigs);
     }
@@ -1336,8 +1322,7 @@ public class SslTransportLayerTest {
                                                         String host, ChannelMetadataRegistry metadataRegistry) throws IOException {
             SocketChannel socketChannel = (SocketChannel) key.channel();
             SSLEngine sslEngine = sslFactory.createSslEngine(host, socketChannel.socket().getPort());
-            TestSslTransportLayer transportLayer = newTransportLayer(id, key, sslEngine);
-            return transportLayer;
+            return newTransportLayer(id, key, sslEngine);
         }
 
         protected TestSslTransportLayer newTransportLayer(String id, SelectionKey key, SSLEngine sslEngine) throws IOException {
@@ -1363,7 +1348,7 @@ public class SslTransportLayerTest {
             private final AtomicLong numFlushesRemaining;
             private final AtomicInteger numDelayedFlushesRemaining;
 
-            public TestSslTransportLayer(String channelId, SelectionKey key, SSLEngine sslEngine) throws IOException {
+            public TestSslTransportLayer(String channelId, SelectionKey key, SSLEngine sslEngine) {
                 super(channelId, key, sslEngine, new DefaultChannelMetadataRegistry());
                 this.netReadBufSize = new ResizeableBufferSize(netReadBufSizeOverride);
                 this.netWriteBufSize = new ResizeableBufferSize(netWriteBufSizeOverride);

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.security.KeyStore;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+public class DefaultSslEngineFactoryTest {
+
+    /*
+     * Key and certificates were extracted using openssl from a key store file created with 100 years validity using:
+     *
+     * openssl pkcs12 -in server.keystore.p12 -nodes -nocerts -out test.key.pem -passin pass:key-password
+     * openssl pkcs12 -in server.keystore.p12 -nodes -nokeys -out test.certchain.pem  -passin pass:key-password
+     * openssl pkcs12 -in server.keystore.p12 -nodes  -out test.keystore.pem -passin pass:key-password
+     * openssl pkcs8 -topk8 -v1 pbeWithSHA1And3-KeyTripleDES-CBC -in test.key.pem -out test.key.encrypted.pem -passout pass:key-password
+     */
+
+    private static final String CA1 = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIC0zCCAbugAwIBAgIEStdXHTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+            + "ZXN0Q0ExMCAXDTIwMDkyODA5MDI0MFoYDzIxMjAwOTA0MDkwMjQwWjASMRAwDgYD\n"
+            + "VQQDEwdUZXN0Q0ExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo3Gr\n"
+            + "WJAkjnvgcuIfjArDhNdtAlRTt094WMUXhYDibgGtd+CLcWqA+c4PEoK4oybnKZqU\n"
+            + "6MlDfPgesIK2YiNBuSVWMtZ2doageOBnd80Iwbg8DqGtQpUsvw8X5fOmuza+4inv\n"
+            + "/8IpiTizq8YjSMT4nYDmIjyyRCSNY4atjgMnskutJ0v6i69+ZAA520Y6nn2n4RD5\n"
+            + "8Yc+y7yCkbZXnYS5xBOFEExmtc0Xa7S9nM157xqKws9Z+rTKZYLrryaHI9JNcXgG\n"
+            + "kzQEH9fBePASeWfi9AGRvAyS2GMSIBOsihIDIha/mqQcJOGCEqTMtefIj2FaErO2\n"
+            + "bL9yU7OpW53iIC8y0QIDAQABoy8wLTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRf\n"
+            + "svKcoQ9ZBvjwyUSV2uMFzlkOWDANBgkqhkiG9w0BAQsFAAOCAQEAEE1ZG2MGE248\n"
+            + "glO83ROrHbxmnVWSQHt/JZANR1i362sY1ekL83wlhkriuvGVBlHQYWezIfo/4l9y\n"
+            + "JTHNX3Mrs9eWUkaDXADkHWj3AyLXN3nfeU307x1wA7OvI4YKpwvfb4aYS8RTPz9d\n"
+            + "JtrfR0r8aGTgsXvCe4SgwDBKv7bckctOwD3S7D/b6y3w7X0s7JCU5+8ZjgoYfcLE\n"
+            + "gNqQEaOwdT2LHCvxHmGn/2VGs/yatPQIYYuufe5i8yX7pp4Xbd2eD6LULYkHFs3x\n"
+            + "uJzMRI7BukmIIWuBbAkYI0atxLQIysnVFXdL9pBgvgso2nA3FgP/XeORhkyHVvtL\n"
+            + "REH2YTlftQ==\n"
+            + "-----END CERTIFICATE-----";
+
+    private static final String CA2 = "-----BEGIN CERTIFICATE-----\n"
+            + "MIIC0zCCAbugAwIBAgIEfk9e9DANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+            + "ZXN0Q0EyMCAXDTIwMDkyODA5MDI0MVoYDzIxMjAwOTA0MDkwMjQxWjASMRAwDgYD\n"
+            + "VQQDEwdUZXN0Q0EyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvCh0\n"
+            + "UO5op9eHfz7mvZ7IySK7AOCTC56QYFJcU+hD6yk1wKg2qot7naI5ozAc8n7c4pMt\n"
+            + "LjI3D0VtC/oHC29R2HNMSWyHcxIXw8z127XeCLRkCqYWuVAl3nBuWfWVPObjKetH\n"
+            + "TWlQANYWAfk1VbS6wfzgp9cMaK7wQ+VoGEo4x3pjlrdlyg4k4O2yubcpWmJ2TjxS\n"
+            + "gg7TfKGizUVAvF9wUG9Q4AlCg4uuww5RN9w6vnzDKGhWJhkQ6pf/m1xB+WueFOeU\n"
+            + "aASGhGqCTqiz3p3M3M4OZzG3KptjQ/yb67x4T5U5RxqoiN4L57E7ZJLREpa6ZZNs\n"
+            + "ps/gQ8dR9Uo/PRyAkQIDAQABoy8wLTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRg\n"
+            + "IAOVH5LeE6nZmdScEE3JO/AhvTANBgkqhkiG9w0BAQsFAAOCAQEAHkk1iybwy/Lf\n"
+            + "iEQMVRy7XfuC008O7jfCUBMgUvE+oO2RadH5MmsXHG3YerdsDM90dui4JqQNZOUh\n"
+            + "kF8dIWPQHE0xDsR9jiUsemZFpVMN7DcvVZ3eFhbvJA8Q50rxcNGA+tn9xT/xdQ6z\n"
+            + "1eRq9IPoYcRexQ7s9mincM4T4lLm8GGcd7ZPHy8kw0Bp3E/enRHWaF5b8KbXezXD\n"
+            + "I3SEYUyRL2K3px4FImT4X9XQm2EX6EONlu4GRcJpD6RPc0zC7c9dwEnSo+0NnewR\n"
+            + "gjgO34CLzShB/kASLS9VQXcUC6bsggAVK2rWQMmy35SOEUufSuvg8kUFoyuTzfhn\n"
+            + "hL+PVwIu7g==\n"
+            + "-----END CERTIFICATE-----";
+
+    private static final String CERTCHAIN = "Bag Attributes\n"
+            + "    friendlyName: server\n"
+            + "    localKeyID: 54 69 6D 65 20 31 36 30 31 32 38 33 37 36 35 34 32 33 \n"
+            + "subject=/CN=TestBroker\n"
+            + "issuer=/CN=TestCA1\n"
+            + "-----BEGIN CERTIFICATE-----\n"
+            + "MIIC/zCCAeegAwIBAgIEatBnEzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+            + "ZXN0Q0ExMCAXDTIwMDkyODA5MDI0NFoYDzIxMjAwOTA0MDkwMjQ0WjAVMRMwEQYD\n"
+            + "VQQDEwpUZXN0QnJva2VyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n"
+            + "pkw1AS71ej/iOMvzVgVL1dkQOYzI842NcPmx0yFFsue2umL8WVd3085NgWRb3SS1\n"
+            + "4X676t7zxjPGzYi7jwmA8stCrDt0NAPWd/Ko6ErsCs87CUs4u1Cinf+b3o9NF5u0\n"
+            + "UPYBQLF4Ir8T1jQ+tKiqsChGDt6urRAg1Cro5i7r10jN1uofY2tBs+r8mALhJ17c\n"
+            + "T5LKawXeYwNOQ86c5djClbcP0RrfcPyRyj1/Cp1axo28iO0fXFyO2Zf3a4vtt+Ih\n"
+            + "PW+A2tL+t3JTBd8g7Fl3ozzpcotAi7MDcZaYA9GiTP4DOiKUeDt6yMYQQr3VEqGa\n"
+            + "pXp4fKY+t9slqnAmcBZ4kQIDAQABo1gwVjAfBgNVHSMEGDAWgBRfsvKcoQ9ZBvjw\n"
+            + "yUSV2uMFzlkOWDAUBgNVHREEDTALgglsb2NhbGhvc3QwHQYDVR0OBBYEFGWt+27P\n"
+            + "INk/S5X+PRV/jW3WOhtaMA0GCSqGSIb3DQEBCwUAA4IBAQCLHCjFFvqa+0GcG9eq\n"
+            + "v1QWaXDohY5t5CCwD8Z+lT9wcSruTxDPwL7LrR36h++D6xJYfiw4iaRighoA40xP\n"
+            + "W6+0zGK/UtWV4t+ODTDzyAWgls5w+0R5ki6447qGqu5tXlW5DCHkkxWiozMnhNU2\n"
+            + "G3P/Drh7DhmADDBjtVLsu5M1sagF/xwTP/qCLMdChlJNdeqyLnAUa9SYG1eNZS/i\n"
+            + "wrCC8m9RUQb4+OlQuFtr0KhaaCkBXfmhigQAmh44zSyO+oa3qQDEavVFo/Mcui9o\n"
+            + "WBYetcgVbXPNoti+hQEMqmJYBHlLbhxMnkooGn2fa70f453Bdu/Xh6Yphi5NeCHn\n"
+            + "1I+y\n"
+            + "-----END CERTIFICATE-----\n"
+            + "Bag Attributes\n"
+            + "    friendlyName: CN=TestCA1\n"
+            + "subject=/CN=TestCA1\n"
+            + "issuer=/CN=TestCA1\n"
+            + "-----BEGIN CERTIFICATE-----\n"
+            + "MIIC0zCCAbugAwIBAgIEStdXHTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+            + "ZXN0Q0ExMCAXDTIwMDkyODA5MDI0MFoYDzIxMjAwOTA0MDkwMjQwWjASMRAwDgYD\n"
+            + "VQQDEwdUZXN0Q0ExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo3Gr\n"
+            + "WJAkjnvgcuIfjArDhNdtAlRTt094WMUXhYDibgGtd+CLcWqA+c4PEoK4oybnKZqU\n"
+            + "6MlDfPgesIK2YiNBuSVWMtZ2doageOBnd80Iwbg8DqGtQpUsvw8X5fOmuza+4inv\n"
+            + "/8IpiTizq8YjSMT4nYDmIjyyRCSNY4atjgMnskutJ0v6i69+ZAA520Y6nn2n4RD5\n"
+            + "8Yc+y7yCkbZXnYS5xBOFEExmtc0Xa7S9nM157xqKws9Z+rTKZYLrryaHI9JNcXgG\n"
+            + "kzQEH9fBePASeWfi9AGRvAyS2GMSIBOsihIDIha/mqQcJOGCEqTMtefIj2FaErO2\n"
+            + "bL9yU7OpW53iIC8y0QIDAQABoy8wLTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRf\n"
+            + "svKcoQ9ZBvjwyUSV2uMFzlkOWDANBgkqhkiG9w0BAQsFAAOCAQEAEE1ZG2MGE248\n"
+            + "glO83ROrHbxmnVWSQHt/JZANR1i362sY1ekL83wlhkriuvGVBlHQYWezIfo/4l9y\n"
+            + "JTHNX3Mrs9eWUkaDXADkHWj3AyLXN3nfeU307x1wA7OvI4YKpwvfb4aYS8RTPz9d\n"
+            + "JtrfR0r8aGTgsXvCe4SgwDBKv7bckctOwD3S7D/b6y3w7X0s7JCU5+8ZjgoYfcLE\n"
+            + "gNqQEaOwdT2LHCvxHmGn/2VGs/yatPQIYYuufe5i8yX7pp4Xbd2eD6LULYkHFs3x\n"
+            + "uJzMRI7BukmIIWuBbAkYI0atxLQIysnVFXdL9pBgvgso2nA3FgP/XeORhkyHVvtL\n"
+            + "REH2YTlftQ==\n"
+            + "-----END CERTIFICATE-----";
+
+    private static final String KEY =  "Bag Attributes\n"
+            + "    friendlyName: server\n"
+            + "    localKeyID: 54 69 6D 65 20 31 36 30 31 32 38 33 37 36 35 34 32 33\n"
+            + "Key Attributes: <No Attributes>\n"
+            + "-----BEGIN PRIVATE KEY-----\n"
+            + "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCmTDUBLvV6P+I4\n"
+            + "y/NWBUvV2RA5jMjzjY1w+bHTIUWy57a6YvxZV3fTzk2BZFvdJLXhfrvq3vPGM8bN\n"
+            + "iLuPCYDyy0KsO3Q0A9Z38qjoSuwKzzsJSzi7UKKd/5vej00Xm7RQ9gFAsXgivxPW\n"
+            + "ND60qKqwKEYO3q6tECDUKujmLuvXSM3W6h9ja0Gz6vyYAuEnXtxPksprBd5jA05D\n"
+            + "zpzl2MKVtw/RGt9w/JHKPX8KnVrGjbyI7R9cXI7Zl/dri+234iE9b4Da0v63clMF\n"
+            + "3yDsWXejPOlyi0CLswNxlpgD0aJM/gM6IpR4O3rIxhBCvdUSoZqlenh8pj632yWq\n"
+            + "cCZwFniRAgMBAAECggEAOfC/XwQvf0KW3VciF0yNGZshbgvBUCp3p284J+ml0Smu\n"
+            + "ns4yQiaZl3B/zJ9c6nYJ8OEpNDIuGVac46vKPZIAHZf4SO4GFMFpji078IN6LmH5\n"
+            + "nclZoNn9brNKaYbgQ2N6teKgmRu8Uc7laHKXjnZd0jaWAkRP8/h0l7fDob+jaERj\n"
+            + "oJBx4ux2Z62TTCP6W4VY3KZgSL1p6dQswqlukPVytMeI2XEwWnO+w8ED0BxCxM4F\n"
+            + "K//dw7nUMGS9GUNkgyDcH1akYSCDzdBeymQBp2latBotVfGNK1hq9nC1iaxmRkJL\n"
+            + "sYjwVc24n37u+txOovy3daq2ySj9trF7ySAPVYkh4QKBgQDWeN/MR6cy1TLF2j3g\n"
+            + "eMMeM32LxXArIPsar+mft+uisKWk5LDpsKpph93sl0JjFi4x0t1mqw23h23I+B2c\n"
+            + "JWiPAHUG3FGvvkPPcfMUvd7pODyE2XaXi+36UZAH7qc94VZGJEb+sPITckSruREE\n"
+            + "QErWZyrbBRgvQXsmVme5B2/kRQKBgQDGf2HQH0KHl54O2r9vrhiQxWIIMSWlizJC\n"
+            + "hjboY6DkIsAMwnXp3wn3Bk4tSgeLk8DEVlmEaE3gvGpiIp0vQnSOlME2TXfEthdM\n"
+            + "uS3+BFXN4Vxxx/qjKL2WfZloyzdaaaF7s+LIwmXgLsFFCUSq+uLtBqfpH2Qv+paX\n"
+            + "Xqm7LN3V3QKBgH5ssj/Q3RZx5oQKqf7wMNRUteT2dbB2uI56s9SariQwzPPuevrG\n"
+            + "US30ETWt1ExkfsaP7kLfAi71fhnBaHLq+j+RnWp15REbrw1RtmC7q/L+W25UYjvj\n"
+            + "GF0+RxDl9V/cvOaL6+2mkIw2B5TSet1uqK7KEdEZp6/zgYyP0oSXhbWhAoGAdnlZ\n"
+            + "HCtMPjnUcPFHCZVTvDTTSihrW9805FfPNe0g/olvLy5xymEBRZtR1d41mq1ZhNY1\n"
+            + "H75RnS1YIbKfNrHnd6J5n7ulHJfCWFy+grp7rCIyVwcRJYkPf17/zXhdVW1uoLLB\n"
+            + "TSoaPDAr0tSxU4vjHa23UoEV/z0F3Nr3W2xwC1ECgYBHKjv6ekLhx7HbP797+Ai+\n"
+            + "wkHvS2L/MqEBxuHzcQ9G6Mj3ANAeyDB8YSC8qGtDQoEyukv2dO73lpodNgbR8P+Q\n"
+            + "PDBb6eyntAo2sSeo0jZkiXvDOfRaGuGVrxjuTfaqcVB33jC6BYfi61/3Sr5oG9Nd\n"
+            + "tDGh1HlOIRm1jD9KQNVZ/Q==\n"
+            + "-----END PRIVATE KEY-----";
+
+    private static final String ENCRYPTED_KEY =  "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+            + "MIIE6jAcBgoqhkiG9w0BDAEDMA4ECGyAEWAXlaXzAgIIAASCBMgt7QD1Bbz7MAHI\n"
+            + "Ni0eTrwNiuAPluHirLXzsV57d1O9i4EXVp5nzRy6753cjXbGXARbBeaJD+/+jbZp\n"
+            + "CBZTHMG8rTCfbsg5kMqxT6XuuqWlKLKc4gaq+QNgHHleKqnpwZQmOQ+awKWEK/Ow\n"
+            + "Z0KxXqkp+b4/qJK3MqKZDsJtVdyUhO0tLVxd+BHDg9B93oExc87F16h3R0+T4rxE\n"
+            + "Tvz2c2upBqva49AbLDxpWXLCJC8CRkxM+KHrPkYjpNx3jCjtwiiXfzJCWjuCkVrL\n"
+            + "2F4bqvpYPIseoPtMvWaplNtoPwhpzBB/hoJ+R+URr4XHX3Y+bz6k6iQnhoCOIviy\n"
+            + "oEEUvWtKnaEEKSauR+Wyj3MoeB64g9NWMEHv7+SQeA4WqlgV2s4txwRxFGKyKLPq\n"
+            + "caMSpfxvYujtSh0DOv9GI3cVHPM8WsebCz9cNrbKSR8/8JufcoonTitwF/4vm1Et\n"
+            + "AdmCuH9JIYVvmFKFVxY9SvRAvo43OQaPmJQHMUa4yDfMtpTSgmB/7HFgxtksYs++\n"
+            + "Gbrq6F/hon+0bLx+bMz2FK635UU+iVno+qaScKWN3BFqDl+KnZprBhLSXTT3aHmp\n"
+            + "fisQit/HWp71a0Vzq85WwI4ucMKNc8LemlwNBxWLLiJDp7sNPLb5dIl8yIwSEIgd\n"
+            + "vC5px9KWEdt3GxTUEqtIeBmagbBhahcv+c9Dq924DLI+Slv6TJKZpIcMqUECgzvi\n"
+            + "hb8gegyEscBEcDSzl0ojlFVz4Va5eZS/linTjNJhnkx8BKLn/QFco7FpEE6uOmQ3\n"
+            + "0kF64M2Rv67cJbYVrhD46TgIzH3Y/FOMSi1zFHQ14nVXWMu0yAlBX+QGk7Xl+/aF\n"
+            + "BIq+i9WcBqbttR3CwyeTnIFXkdC66iTZYhDl9HT6yMcazql2Or2TjIIWr6tfNWH/\n"
+            + "5dWSEHYM5m8F2/wF0ANWJyR1oPr4ckcUsfl5TfOWVj5wz4QVF6EGV7FxEnQHrdx0\n"
+            + "6rXThRKFjqxUubsNt1yUEwdlTNz2UFhobGF9MmFeB97BZ6T4v8G825de/Caq9FzO\n"
+            + "yMFFCRcGC7gIzMXRPEjHIvBdTThm9rbNzKPXHqw0LHG478yIqzxvraCYTRw/4eWN\n"
+            + "Q+hyOL/5T5QNXHpR8Udp/7sptw7HfRnecQ/Vz9hOKShQq3h4Sz6eQMQm7P9qGo/N\n"
+            + "bltEAIECRVcNYLN8LuEORfeecNcV3BX+4BBniFtdD2bIRsWC0ZUsGf14Yhr4P1OA\n"
+            + "PtMJzy99mrcq3h+o+hEW6bhIj1gA88JSMJ4iRuwTLRKE81w7EyziScDsotYKvDPu\n"
+            + "w4+PFbQO3fr/Zga3LgYis8/DMqZoWjVCjAeVoypuOZreieZYC/BgBS8qSUAmDPKq\n"
+            + "jK+T5pwMMchfXbkV80LTu1kqLfKWdE0AmZfGy8COE/NNZ/FeiWZPdwu2Ix6u/RoY\n"
+            + "LTjNy4YLIBdVELFXaFJF2GfzLpnwrW5tyNPVVrGmUoiyOzgx8gMyCLGavGtduyoY\n"
+            + "tBiUTmd05Ugscn4Rz9X30S4NbnjL/h+bWl1m6/M+9FHEe85FPxmt/GRmJPbFPMR5\n"
+            + "q5EgQGkt4ifiaP6qvyFulwvVwx+m0bf1q6Vb/k3clIyLMcVZWFE1TqNH2Ife46AE\n"
+            + "2I39ZnGTt0mbWskpHBA=\n"
+            + "-----END ENCRYPTED PRIVATE KEY-----";
+
+    private static final Password KEY_PASSWORD = new Password("key-password");
+
+    private DefaultSslEngineFactory factory = new DefaultSslEngineFactory();
+    Map<String, Object> configs = new HashMap<>();
+
+    @Before
+    public void setUp() {
+        factory = new DefaultSslEngineFactory();
+        configs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+    }
+
+    @Test
+    public void testPemTrustStoreConfigWithOneCert() throws Exception {
+        configs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, pemAsConfigValue(CA1));
+        configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore trustStore = factory.truststore();
+        List<String> aliases = Collections.list(trustStore.aliases());
+        assertEquals(Collections.singletonList("kafka0"), aliases);
+        assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka0"));
+        assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+    }
+
+    @Test
+    public void testPemTrustStoreConfigWithMultipleCerts() throws Exception {
+        configs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, pemAsConfigValue(CA1, CA2));
+        configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore trustStore = factory.truststore();
+        List<String> aliases = Collections.list(trustStore.aliases());
+        assertEquals(Arrays.asList("kafka0", "kafka1"), aliases);
+        assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka0"));
+        assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+        assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka1"));
+        assertNull("Unexpected private key", trustStore.getKey("kafka1", null));
+    }
+
+    @Test
+    public void testPemKeyStoreConfigNoPassword() throws Exception {
+        verifyPemKeyStoreConfig(KEY, null);
+    }
+
+    @Test
+    public void testPemKeyStoreConfigWithKeyPassword() throws Exception {
+        verifyPemKeyStoreConfig(ENCRYPTED_KEY, KEY_PASSWORD);
+    }
+
+    @Test
+    public void testTrailingNewLines() throws Exception {
+        verifyPemKeyStoreConfig(ENCRYPTED_KEY + "\n\n", KEY_PASSWORD);
+    }
+
+    @Test
+    public void testLeadingNewLines() throws Exception {
+        verifyPemKeyStoreConfig("\n\n" + ENCRYPTED_KEY, KEY_PASSWORD);
+    }
+
+    @Test
+    public void testCarriageReturnLineFeed() throws Exception {
+        verifyPemKeyStoreConfig(ENCRYPTED_KEY.replaceAll("\n", "\r\n"), KEY_PASSWORD);
+    }
+
+    private void verifyPemKeyStoreConfig(String keyFileName, Password keyPassword) throws Exception {
+        configs.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, pemAsConfigValue(keyFileName));
+        configs.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, pemAsConfigValue(CERTCHAIN));
+        configs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyPassword);
+        configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore keyStore = factory.keystore();
+        List<String> aliases = Collections.list(keyStore.aliases());
+        assertEquals(Collections.singletonList("kafka"), aliases);
+        assertNotNull("Certificate not loaded", keyStore.getCertificate("kafka"));
+        assertNotNull("Private key not loaded",
+                keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()));
+    }
+
+    @Test
+    public void testPemTrustStoreFile() throws Exception {
+        configs.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, pemFilePath(CA1));
+        configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore trustStore = factory.truststore();
+        List<String> aliases = Collections.list(trustStore.aliases());
+        assertEquals(Collections.singletonList("kafka0"), aliases);
+        assertNotNull("Certificate not found", trustStore.getCertificate("kafka0"));
+        assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+    }
+
+    @Test
+    public void testPemKeyStoreFileNoKeyPassword() throws Exception {
+        configs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+                pemFilePath(pemAsConfigValue(KEY, CERTCHAIN).value()));
+        configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        assertThrows(InvalidConfigurationException.class, () -> factory.configure(configs));
+    }
+
+    @Test
+    public void testPemKeyStoreFileWithKeyPassword() throws Exception {
+        configs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+                pemFilePath(pemAsConfigValue(ENCRYPTED_KEY, CERTCHAIN).value()));
+        configs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, KEY_PASSWORD);
+        configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+        factory.configure(configs);
+
+        KeyStore keyStore = factory.keystore();
+        List<String> aliases = Collections.list(keyStore.aliases());
+        assertEquals(Collections.singletonList("kafka"), aliases);
+        assertNotNull("Certificate not found", keyStore.getCertificate("kafka"));
+        assertNotNull("Private key not found", keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()));
+    }
+
+    private String pemFilePath(String pem) throws Exception {
+        return TestUtils.tempFile(pem).getAbsolutePath();
+    }
+
+    private Password pemAsConfigValue(String... pemValues)  throws Exception {
+        StringBuilder builder = new StringBuilder();
+        for (String pem : pemValues) {
+            builder.append(pem);
+            builder.append("\n");
+        }
+        return new Password(builder.toString().trim());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -36,6 +36,9 @@ import org.apache.kafka.common.config.SecurityConfig;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory.FileBasedStore;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory.PemStore;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory.SecurityStore;
 import org.apache.kafka.common.security.ssl.mock.TestKeyManagerFactory;
 import org.apache.kafka.common.security.ssl.mock.TestProviderCreator;
 import org.apache.kafka.common.security.ssl.mock.TestTrustManagerFactory;
@@ -314,6 +317,40 @@ public class SslFactoryTest {
     }
 
     @Test
+    public void testPemReconfiguration() throws Exception {
+        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
+                .createNewTrustStore(null)
+                .usePem(true)
+                .build();
+        SslFactory sslFactory = new SslFactory(Mode.SERVER);
+        sslFactory.configure(sslConfig);
+        SslEngineFactory sslEngineFactory = sslFactory.sslEngineFactory();
+        assertNotNull("SslEngineFactory not created", sslEngineFactory);
+
+        sslConfig.put("some.config", "some.value");
+        sslFactory.reconfigure(sslConfig);
+        assertSame("SslEngineFactory recreated unnecessarily", sslEngineFactory, sslFactory.sslEngineFactory());
+
+        sslConfig.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG,
+                new Password(((Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_KEY_CONFIG)).value() + " "));
+        sslFactory.reconfigure(sslConfig);
+        assertNotSame("SslEngineFactory not recreated", sslEngineFactory, sslFactory.sslEngineFactory());
+        sslEngineFactory = sslFactory.sslEngineFactory();
+
+        sslConfig.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG,
+                new Password(((Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG)).value() + " "));
+        sslFactory.reconfigure(sslConfig);
+        assertNotSame("SslEngineFactory not recreated", sslEngineFactory, sslFactory.sslEngineFactory());
+        sslEngineFactory = sslFactory.sslEngineFactory();
+
+        sslConfig.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG,
+                new Password(((Password) sslConfig.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG)).value() + " "));
+        sslFactory.reconfigure(sslConfig);
+        assertNotSame("SslEngineFactory not recreated", sslEngineFactory, sslFactory.sslEngineFactory());
+        sslEngineFactory = sslFactory.sslEngineFactory();
+    }
+
+    @Test
     public void testKeyStoreTrustStoreValidation() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
@@ -351,16 +388,27 @@ public class SslFactoryTest {
 
     @Test
     public void testKeystoreVerifiableUsingTruststore() throws Exception {
-        File trustStoreFile1 = File.createTempFile("truststore1", ".jks");
+        verifyKeystoreVerifiableUsingTruststore(false);
+    }
+
+    @Test
+    public void testPemKeystoreVerifiableUsingTruststore() throws Exception {
+        verifyKeystoreVerifiableUsingTruststore(true);
+    }
+
+    private void verifyKeystoreVerifiableUsingTruststore(boolean usePem) throws Exception {
+        File trustStoreFile1 = usePem ? null : File.createTempFile("truststore1", ".jks");
         Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile1)
+                .usePem(usePem)
                 .build();
         SslFactory sslFactory = new SslFactory(Mode.SERVER, null, true);
         sslFactory.configure(sslConfig1);
 
-        File trustStoreFile2 = File.createTempFile("truststore2", ".jks");
+        File trustStoreFile2 = usePem ? null : File.createTempFile("truststore2", ".jks");
         Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile2)
+                .usePem(usePem)
                 .build();
         // Verify that `createSSLContext` fails even if certificate from new keystore is trusted by
         // the new truststore, if certificate is not trusted by the existing truststore on the `SslFactory`.
@@ -376,23 +424,35 @@ public class SslFactoryTest {
 
     @Test
     public void testCertificateEntriesValidation() throws Exception {
-        File trustStoreFile = File.createTempFile("truststore", ".jks");
+        verifyCertificateEntriesValidation(false);
+    }
+
+    @Test
+    public void testPemCertificateEntriesValidation() throws Exception {
+        verifyCertificateEntriesValidation(true);
+    }
+
+    private void verifyCertificateEntriesValidation(boolean usePem) throws Exception {
+        File trustStoreFile = usePem ? null : File.createTempFile("truststore", ".jks");
         Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
+                .usePem(usePem)
                 .build();
+        File newTrustStoreFile = usePem ? null : File.createTempFile("truststore", ".jks");
         Map<String, Object> newCnConfig = sslConfigsBuilder(Mode.SERVER)
-                .createNewTrustStore(File.createTempFile("truststore", ".jks"))
+                .createNewTrustStore(newTrustStoreFile)
                 .cn("Another CN")
+                .usePem(usePem)
                 .build();
-        KeyStore ks1 = sslKeyStore(serverSslConfig).get();
-        KeyStore ks2 = sslKeyStore(serverSslConfig).get();
+        KeyStore ks1 = sslKeyStore(serverSslConfig);
+        KeyStore ks2 = sslKeyStore(serverSslConfig);
         assertEquals(SslFactory.CertificateEntries.create(ks1), SslFactory.CertificateEntries.create(ks2));
 
         // Use different alias name, validation should succeed
         ks2.setCertificateEntry("another", ks1.getCertificate("localhost"));
         assertEquals(SslFactory.CertificateEntries.create(ks1), SslFactory.CertificateEntries.create(ks2));
 
-        KeyStore ks3 = sslKeyStore(newCnConfig).get();
+        KeyStore ks3 = sslKeyStore(newCnConfig);
         assertNotEquals(SslFactory.CertificateEntries.create(ks1), SslFactory.CertificateEntries.create(ks3));
     }
 
@@ -461,13 +521,24 @@ public class SslFactoryTest {
         sslFactory.configure(clientSslConfig);
     }
 
-    private DefaultSslEngineFactory.SecurityStore sslKeyStore(Map<String, Object> sslConfig) {
-        return new DefaultSslEngineFactory.SecurityStore(
-                (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
-                (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
-                (Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
-                (Password) sslConfig.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
-        );
+    private KeyStore sslKeyStore(Map<String, Object> sslConfig) {
+        SecurityStore store;
+        if (sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG) != null) {
+            store = new FileBasedStore(
+                    (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
+                    (String) sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
+                    (Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
+                    (Password) sslConfig.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG),
+                    true
+            );
+        } else {
+            store = new PemStore(
+                    (Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG),
+                    (Password) sslConfig.get(SslConfigs.SSL_KEYSTORE_KEY_CONFIG),
+                    (Password) sslConfig.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
+            );
+        }
+        return store.get();
     }
 
     private TestSslUtils.SslConfigsBuilder sslConfigsBuilder(Mode mode) {

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -240,8 +240,6 @@ public class TestSslUtils {
             key = exportPrivateKey(ksPath, ksPassword, keyPassword, ksType, pemKeyPassword);
             if (!encryptPrivateKey)
                 sslProps.remove(SslConfigs.SSL_KEY_PASSWORD_CONFIG);
-        } else if (!encryptPrivateKey) {
-
         }
 
         if (certChain != null) {

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -17,34 +17,8 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.network.Mode;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.EOFException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.math.BigInteger;
-import java.net.InetAddress;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.TrustManagerFactory;
-
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.security.GeneralSecurityException;
-import java.security.Key;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.Security;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
 import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
 import org.bouncycastle.asn1.DEROctetString;
@@ -61,18 +35,60 @@ import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
 import org.bouncycastle.crypto.util.PrivateKeyFactory;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
 import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
+import org.bouncycastle.operator.bc.BcContentSignerBuilder;
+import org.bouncycastle.operator.bc.BcDSAContentSignerBuilder;
+import org.bouncycastle.operator.bc.BcECContentSignerBuilder;
 import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
+import org.bouncycastle.util.io.pem.PemWriter;
 
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManagerFactory;
+
+import static org.apache.kafka.common.security.ssl.DefaultSslEngineFactory.PEM_TYPE;
 
 public class TestSslUtils {
 
@@ -98,7 +114,7 @@ public class TestSslUtils {
 
     public static KeyPair generateKeyPair(String algorithm) throws NoSuchAlgorithmException {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance(algorithm);
-        keyGen.initialize(2048);
+        keyGen.initialize(algorithm.equals("EC") ? 256 : 2048);
         return keyGen.genKeyPair();
     }
 
@@ -113,15 +129,6 @@ public class TestSslUtils {
         try (OutputStream out = Files.newOutputStream(Paths.get(filename))) {
             ks.store(out, password.value().toCharArray());
         }
-    }
-
-    public static void createKeyStore(String filename,
-                                      Password password, String alias,
-                                      Key privateKey, Certificate cert) throws GeneralSecurityException, IOException {
-        KeyStore ks = createEmptyKeyStore();
-        ks.setKeyEntry(alias, privateKey, password.value().toCharArray(),
-                new Certificate[]{cert});
-        saveKeyStore(ks, filename, password);
     }
 
     /**
@@ -199,6 +206,156 @@ public class TestSslUtils {
         return builder.build();
     }
 
+    public static void convertToPem(Map<String, Object> sslProps, boolean writeToFile, boolean encryptPrivateKey) throws Exception {
+        String tsPath = (String) sslProps.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+        String tsType = (String) sslProps.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG);
+        Password tsPassword = (Password) sslProps.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+        Password trustCerts = (Password) sslProps.remove(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG);
+        if (trustCerts == null && tsPath != null) {
+            trustCerts = exportCertificates(tsPath, tsPassword, tsType);
+        }
+        if (trustCerts != null) {
+            if (tsPath == null) {
+                tsPath = File.createTempFile("truststore", ".pem").getPath();
+                sslProps.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, tsPath);
+            }
+            sslProps.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
+            if (writeToFile)
+                writeToFile(tsPath, trustCerts);
+            else {
+                sslProps.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, trustCerts);
+                sslProps.remove(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+            }
+        }
+
+        String ksPath = (String) sslProps.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+        Password certChain = (Password) sslProps.remove(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG);
+        Password key = (Password) sslProps.remove(SslConfigs.SSL_KEYSTORE_KEY_CONFIG);
+        if (certChain == null && ksPath != null) {
+            String ksType = (String) sslProps.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
+            Password ksPassword = (Password) sslProps.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+            Password keyPassword = (Password) sslProps.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG);
+            certChain = exportCertificates(ksPath, ksPassword, ksType);
+            Password pemKeyPassword = encryptPrivateKey ? keyPassword : null;
+            key = exportPrivateKey(ksPath, ksPassword, keyPassword, ksType, pemKeyPassword);
+            if (!encryptPrivateKey)
+                sslProps.remove(SslConfigs.SSL_KEY_PASSWORD_CONFIG);
+        } else if (!encryptPrivateKey) {
+
+        }
+
+        if (certChain != null) {
+            if (ksPath == null) {
+                ksPath = File.createTempFile("keystore", ".pem").getPath();
+                sslProps.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, ksPath);
+            }
+            sslProps.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+            if (writeToFile)
+                writeToFile(ksPath, key, certChain);
+            else {
+                sslProps.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, key);
+                sslProps.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, certChain);
+                sslProps.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+            }
+        }
+    }
+
+    private static void writeToFile(String path, Password... entries) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(path)) {
+            for (Password entry: entries) {
+                out.write(entry.value().getBytes(StandardCharsets.UTF_8));
+            }
+        }
+    }
+
+    public static void convertToPemWithoutFiles(Properties sslProps) throws Exception {
+        String tsPath = sslProps.getProperty(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+        if (tsPath != null) {
+            Password trustCerts = exportCertificates(tsPath,
+                    (Password) sslProps.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG),
+                    sslProps.getProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG));
+            sslProps.remove(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+            sslProps.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+            sslProps.setProperty(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
+            sslProps.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, trustCerts);
+        }
+        String ksPath = sslProps.getProperty(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+        if (ksPath != null) {
+            String ksType = sslProps.getProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
+            Password ksPassword = (Password) sslProps.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+            Password keyPassword = (Password) sslProps.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG);
+            Password certChain = exportCertificates(ksPath, ksPassword, ksType);
+            Password key = exportPrivateKey(ksPath, ksPassword, keyPassword, ksType, keyPassword);
+            sslProps.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
+            sslProps.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
+            sslProps.setProperty(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+            sslProps.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, certChain);
+            sslProps.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, key);
+        }
+    }
+
+    public static Password exportCertificates(String storePath, Password storePassword, String storeType) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        try (FileInputStream in = new FileInputStream(storePath)) {
+            KeyStore ks = KeyStore.getInstance(storeType);
+            ks.load(in, storePassword.value().toCharArray());
+            Enumeration<String> aliases = ks.aliases();
+            if (!aliases.hasMoreElements())
+                throw new IllegalArgumentException("No certificates found in file " + storePath);
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                Certificate[] certs = ks.getCertificateChain(alias);
+                if (certs != null) {
+                    for (Certificate cert : certs) {
+                        builder.append(pem(cert));
+                    }
+                } else {
+                    builder.append(pem(ks.getCertificate(alias)));
+                }
+            }
+        }
+        return new Password(builder.toString());
+    }
+
+    public static Password exportPrivateKey(String storePath,
+                                            Password storePassword,
+                                            Password keyPassword,
+                                            String storeType,
+                                            Password pemKeyPassword) throws Exception {
+        try (FileInputStream in = new FileInputStream(storePath)) {
+            KeyStore ks = KeyStore.getInstance(storeType);
+            ks.load(in, storePassword.value().toCharArray());
+            String alias = ks.aliases().nextElement();
+            return new Password(pem((PrivateKey) ks.getKey(alias, keyPassword.value().toCharArray()), pemKeyPassword));
+        }
+    }
+
+    static String pem(Certificate cert) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (PemWriter pemWriter = new PemWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8.name()))) {
+            pemWriter.writeObject(new JcaMiscPEMGenerator(cert));
+        }
+        return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    static String pem(PrivateKey privateKey, Password password) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (PemWriter pemWriter = new PemWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8.name()))) {
+            if (password == null) {
+                pemWriter.writeObject(new JcaPKCS8Generator(privateKey, null));
+            } else {
+                JceOpenSSLPKCS8EncryptorBuilder encryptorBuilder = new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES);
+                encryptorBuilder.setPasssword(password.value().toCharArray());
+                try {
+                    pemWriter.writeObject(new JcaPKCS8Generator(privateKey, encryptorBuilder.build()));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+
     public static class CertificateBuilder {
         private final int days;
         private final String algorithm;
@@ -233,7 +390,17 @@ public class TestSslUtils {
                 AlgorithmIdentifier digAlgId = new DefaultDigestAlgorithmIdentifierFinder().find(sigAlgId);
                 AsymmetricKeyParameter privateKeyAsymKeyParam = PrivateKeyFactory.createKey(keyPair.getPrivate().getEncoded());
                 SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded());
-                ContentSigner sigGen = new BcRSAContentSignerBuilder(sigAlgId, digAlgId).build(privateKeyAsymKeyParam);
+                BcContentSignerBuilder signerBuilder;
+                String keyAlgorithm = keyPair.getPublic().getAlgorithm();
+                if (keyAlgorithm.equals("RSA"))
+                    signerBuilder = new BcRSAContentSignerBuilder(sigAlgId, digAlgId);
+                else if (keyAlgorithm.equals("DSA"))
+                    signerBuilder = new BcDSAContentSignerBuilder(sigAlgId, digAlgId);
+                else if (keyAlgorithm.equals("EC"))
+                    signerBuilder = new BcECContentSignerBuilder(sigAlgId, digAlgId);
+                else
+                    throw new IllegalArgumentException("Unsupported algorithm " + keyAlgorithm);
+                ContentSigner sigGen = signerBuilder.build(privateKeyAsymKeyParam);
                 X500Name name = new X500Name(dn);
                 Date from = new Date();
                 Date to = new Date(from.getTime() + days * 86400000L);
@@ -259,12 +426,13 @@ public class TestSslUtils {
         boolean createTrustStore;
         File trustStoreFile;
         Password trustStorePassword;
-        File keyStoreFile;
         Password keyStorePassword;
         Password keyPassword;
         String certAlias;
         String cn;
+        String algorithm;
         CertificateBuilder certBuilder;
+        boolean usePem;
 
         public SslConfigsBuilder(Mode mode) {
             this.mode = mode;
@@ -275,6 +443,8 @@ public class TestSslUtils {
             this.certBuilder = new CertificateBuilder();
             this.cn = "localhost";
             this.certAlias = mode.name().toLowerCase(Locale.ROOT);
+            this.algorithm = "RSA";
+            this.createTrustStore = true;
         }
 
         public SslConfigsBuilder tlsProtocol(String tlsProtocol) {
@@ -294,11 +464,6 @@ public class TestSslUtils {
             return this;
         }
 
-        public SslConfigsBuilder createNewKeyStore(File keyStoreFile) {
-            this.keyStoreFile = keyStoreFile;
-            return this;
-        }
-
         public SslConfigsBuilder useClientCert(boolean useClientCert) {
             this.useClientCert = useClientCert;
             return this;
@@ -314,27 +479,43 @@ public class TestSslUtils {
             return this;
         }
 
+        public SslConfigsBuilder algorithm(String algorithm) {
+            this.algorithm = algorithm;
+            return this;
+        }
+
         public SslConfigsBuilder certBuilder(CertificateBuilder certBuilder) {
             this.certBuilder = certBuilder;
             return this;
         }
 
+        public SslConfigsBuilder usePem(boolean usePem) {
+            this.usePem = usePem;
+            return this;
+        }
+
         public  Map<String, Object> build() throws IOException, GeneralSecurityException {
+            if (usePem) {
+                return buildPem();
+            } else
+                return buildJks();
+        }
+
+        private Map<String, Object> buildJks() throws IOException, GeneralSecurityException {
             Map<String, X509Certificate> certs = new HashMap<>();
             File keyStoreFile = null;
 
             if (mode == Mode.CLIENT && useClientCert) {
                 keyStoreFile = File.createTempFile("clientKS", ".jks");
-                KeyPair cKP = generateKeyPair("RSA");
+                KeyPair cKP = generateKeyPair(algorithm);
                 X509Certificate cCert = certBuilder.generate("CN=" + cn + ", O=A client", cKP);
-                createKeyStore(keyStoreFile.getPath(), keyStorePassword, "client", cKP.getPrivate(), cCert);
+                createKeyStore(keyStoreFile.getPath(), keyStorePassword, keyPassword, "client", cKP.getPrivate(), cCert);
                 certs.put(certAlias, cCert);
-                keyStoreFile.deleteOnExit();
             } else if (mode == Mode.SERVER) {
                 keyStoreFile = File.createTempFile("serverKS", ".jks");
-                KeyPair sKP = generateKeyPair("RSA");
+                KeyPair sKP = generateKeyPair(algorithm);
                 X509Certificate sCert = certBuilder.generate("CN=" + cn + ", O=A server", sKP);
-                createKeyStore(keyStoreFile.getPath(), keyStorePassword, keyStorePassword, "server", sKP.getPrivate(), sCert);
+                createKeyStore(keyStoreFile.getPath(), keyStorePassword, keyPassword, "server", sKP.getPrivate(), sCert);
                 certs.put(certAlias, sCert);
                 keyStoreFile.deleteOnExit();
             }
@@ -365,6 +546,31 @@ public class TestSslUtils {
             enabledProtocols.add(tlsProtocol);
             sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, enabledProtocols);
 
+            return sslConfigs;
+        }
+
+        private Map<String, Object> buildPem() throws IOException, GeneralSecurityException {
+            if (!createTrustStore) {
+                throw new IllegalArgumentException("PEM configs cannot be created with existing trust stores");
+            }
+
+            Map<String, Object> sslConfigs = new HashMap<>();
+            sslConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol);
+            sslConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList(tlsProtocol));
+
+            if (mode != Mode.CLIENT || useClientCert) {
+                KeyPair keyPair = generateKeyPair(algorithm);
+                X509Certificate cert = certBuilder.generate("CN=" + cn + ", O=A " + mode.name().toLowerCase(Locale.ROOT), keyPair);
+
+                Password privateKeyPem = new Password(pem(keyPair.getPrivate(), keyPassword));
+                Password certPem = new Password(pem(cert));
+                sslConfigs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+                sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
+                sslConfigs.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, privateKeyPem);
+                sslConfigs.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, certPem);
+                sslConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyPassword);
+                sslConfigs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, certPem);
+            }
             return sslConfigs;
         }
     }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -931,11 +931,11 @@ object KafkaConfig {
   val SslKeystorePasswordDoc = SslConfigs.SSL_KEYSTORE_PASSWORD_DOC
   val SslKeyPasswordDoc = SslConfigs.SSL_KEY_PASSWORD_DOC
   val SslKeystoreKeyDoc = SslConfigs.SSL_KEYSTORE_KEY_DOC
-  val SslKeystoreCertificateChainDoc = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG
+  val SslKeystoreCertificateChainDoc = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_DOC
   val SslTruststoreTypeDoc = SslConfigs.SSL_TRUSTSTORE_TYPE_DOC
   val SslTruststorePasswordDoc = SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC
   val SslTruststoreLocationDoc = SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC
-  val SslTruststoreCertificatesDoc = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG
+  val SslTruststoreCertificatesDoc = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_DOC
   val SslKeyManagerAlgorithmDoc = SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC
   val SslTrustManagerAlgorithmDoc = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC
   val SslEndpointIdentificationAlgorithmDoc = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -522,9 +522,12 @@ object KafkaConfig {
   val SslKeystoreLocationProp = SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG
   val SslKeystorePasswordProp = SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG
   val SslKeyPasswordProp = SslConfigs.SSL_KEY_PASSWORD_CONFIG
+  val SslKeystoreKeyProp = SslConfigs.SSL_KEYSTORE_KEY_CONFIG
+  val SslKeystoreCertificateChainProp = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG
   val SslTruststoreTypeProp = SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG
   val SslTruststoreLocationProp = SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG
   val SslTruststorePasswordProp = SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG
+  val SslTruststoreCertificatesProp = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG
   val SslKeyManagerAlgorithmProp = SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG
   val SslTrustManagerAlgorithmProp = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG
   val SslEndpointIdentificationAlgorithmProp = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG
@@ -927,9 +930,12 @@ object KafkaConfig {
   val SslKeystoreLocationDoc = SslConfigs.SSL_KEYSTORE_LOCATION_DOC
   val SslKeystorePasswordDoc = SslConfigs.SSL_KEYSTORE_PASSWORD_DOC
   val SslKeyPasswordDoc = SslConfigs.SSL_KEY_PASSWORD_DOC
+  val SslKeystoreKeyDoc = SslConfigs.SSL_KEYSTORE_KEY_DOC
+  val SslKeystoreCertificateChainDoc = SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG
   val SslTruststoreTypeDoc = SslConfigs.SSL_TRUSTSTORE_TYPE_DOC
   val SslTruststorePasswordDoc = SslConfigs.SSL_TRUSTSTORE_PASSWORD_DOC
   val SslTruststoreLocationDoc = SslConfigs.SSL_TRUSTSTORE_LOCATION_DOC
+  val SslTruststoreCertificatesDoc = SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG
   val SslKeyManagerAlgorithmDoc = SslConfigs.SSL_KEYMANAGER_ALGORITHM_DOC
   val SslTrustManagerAlgorithmDoc = SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_DOC
   val SslEndpointIdentificationAlgorithmDoc = SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC
@@ -1195,9 +1201,12 @@ object KafkaConfig {
       .define(SslKeystoreLocationProp, STRING, null, MEDIUM, SslKeystoreLocationDoc)
       .define(SslKeystorePasswordProp, PASSWORD, null, MEDIUM, SslKeystorePasswordDoc)
       .define(SslKeyPasswordProp, PASSWORD, null, MEDIUM, SslKeyPasswordDoc)
+      .define(SslKeystoreKeyProp, PASSWORD, null, MEDIUM, SslKeystoreKeyDoc)
+      .define(SslKeystoreCertificateChainProp, PASSWORD, null, MEDIUM, SslKeystoreCertificateChainDoc)
       .define(SslTruststoreTypeProp, STRING, Defaults.SslTruststoreType, MEDIUM, SslTruststoreTypeDoc)
       .define(SslTruststoreLocationProp, STRING, null, MEDIUM, SslTruststoreLocationDoc)
       .define(SslTruststorePasswordProp, PASSWORD, null, MEDIUM, SslTruststorePasswordDoc)
+      .define(SslTruststoreCertificatesProp, PASSWORD, null, MEDIUM, SslTruststoreCertificatesDoc)
       .define(SslKeyManagerAlgorithmProp, STRING, Defaults.SslKeyManagerAlgorithm, MEDIUM, SslKeyManagerAlgorithmDoc)
       .define(SslTrustManagerAlgorithmProp, STRING, Defaults.SslTrustManagerAlgorithm, MEDIUM, SslTrustManagerAlgorithmDoc)
       .define(SslEndpointIdentificationAlgorithmProp, STRING, Defaults.SslEndpointIdentificationAlgorithm, LOW, SslEndpointIdentificationAlgorithmDoc)

--- a/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
@@ -20,6 +20,7 @@ import kafka.utils.JaasTestUtils
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
+import org.apache.kafka.test.TestSslUtils
 
 import scala.jdk.CollectionConverters._
 import org.junit.Before
@@ -36,6 +37,10 @@ class SaslScramSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
     zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
     // Create broker credentials before starting brokers
     createScramCredentials(zkConnect, kafkaPrincipal.getName, kafkaPassword)
+    TestSslUtils.convertToPemWithoutFiles(serverConfig)
+    TestSslUtils.convertToPemWithoutFiles(producerConfig)
+    TestSslUtils.convertToPemWithoutFiles(consumerConfig)
+    TestSslUtils.convertToPemWithoutFiles(consumerConfig)
   }
 
   override def createPrivilegedAdminClient() = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)

--- a/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
@@ -16,6 +16,8 @@
   */
 package kafka.api
 
+import java.util.Properties
+
 import kafka.utils.JaasTestUtils
 import kafka.zk.ConfigEntityChangeNotificationZNode
 import org.apache.kafka.common.security.auth.KafkaPrincipal
@@ -37,10 +39,14 @@ class SaslScramSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
     zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
     // Create broker credentials before starting brokers
     createScramCredentials(zkConnect, kafkaPrincipal.getName, kafkaPassword)
-    TestSslUtils.convertToPemWithoutFiles(serverConfig)
     TestSslUtils.convertToPemWithoutFiles(producerConfig)
     TestSslUtils.convertToPemWithoutFiles(consumerConfig)
-    TestSslUtils.convertToPemWithoutFiles(consumerConfig)
+    TestSslUtils.convertToPemWithoutFiles(adminClientConfig)
+  }
+
+  override def configureListeners(props: collection.Seq[Properties]): Unit = {
+    props.foreach(TestSslUtils.convertToPemWithoutFiles)
+    super.configureListeners(props)
   }
 
   override def createPrivilegedAdminClient() = createScramAdminClient(kafkaClientSaslMechanism, kafkaPrincipal.getName, kafkaPassword)

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -206,7 +206,11 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     }
 
     def verifySslConfig(prefix: String, expectedProps: Properties, configDesc: Config): Unit = {
-      KEYSTORE_PROPS.forEach { configName =>
+      // Validate file-based SSL keystore configs
+      val keyStoreProps = new util.HashSet[String](KEYSTORE_PROPS)
+      keyStoreProps.remove(SSL_KEYSTORE_KEY_CONFIG)
+      keyStoreProps.remove(SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG)
+      keyStoreProps.forEach { configName =>
         val desc = configEntry(configDesc, s"$prefix$configName")
         val isSensitive = configName.contains("password")
         verifyConfig(configName, desc, isSensitive, isReadOnly = prefix.nonEmpty, if (prefix.isEmpty) invalidSslProperties else sslProperties1)

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -84,14 +84,23 @@ class KafkaTest {
     val propertiesFile = prepareDefaultConfig()
     val config = KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "ssl.keystore.password=keystore_password",
                                                                                     "--override", "ssl.key.password=key_password",
-                                                                                    "--override", "ssl.truststore.password=truststore_password")))
+                                                                                    "--override", "ssl.truststore.password=truststore_password",
+                                                                                    "--override", "ssl.keystore.certificate.chain=certificate_chain",
+                                                                                    "--override", "ssl.keystore.key=private_key",
+                                                                                    "--override", "ssl.truststore.certificates=truststore_certificates")))
     assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeyPasswordProp).toString)
     assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystorePasswordProp).toString)
     assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslTruststorePasswordProp).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystoreKeyProp).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslKeystoreCertificateChainProp).toString)
+    assertEquals(Password.HIDDEN, config.getPassword(KafkaConfig.SslTruststoreCertificatesProp).toString)
 
     assertEquals("key_password", config.getPassword(KafkaConfig.SslKeyPasswordProp).value)
     assertEquals("keystore_password", config.getPassword(KafkaConfig.SslKeystorePasswordProp).value)
     assertEquals("truststore_password", config.getPassword(KafkaConfig.SslTruststorePasswordProp).value)
+    assertEquals("private_key", config.getPassword(KafkaConfig.SslKeystoreKeyProp).value)
+    assertEquals("certificate_chain", config.getPassword(KafkaConfig.SslKeystoreCertificateChainProp).value)
+    assertEquals("truststore_certificates", config.getPassword(KafkaConfig.SslTruststoreCertificatesProp).value)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -740,9 +740,12 @@ class KafkaConfigTest {
         case KafkaConfig.SslKeystoreLocationProp => // ignore string
         case KafkaConfig.SslKeystorePasswordProp => // ignore string
         case KafkaConfig.SslKeyPasswordProp => // ignore string
+        case KafkaConfig.SslKeystoreCertificateChainProp => // ignore string
+        case KafkaConfig.SslKeystoreKeyProp => // ignore string
         case KafkaConfig.SslTruststoreTypeProp => // ignore string
         case KafkaConfig.SslTruststorePasswordProp => // ignore string
         case KafkaConfig.SslTruststoreLocationProp => // ignore string
+        case KafkaConfig.SslTruststoreCertificatesProp => // ignore string
         case KafkaConfig.SslKeyManagerAlgorithmProp =>
         case KafkaConfig.SslTrustManagerAlgorithmProp =>
         case KafkaConfig.SslClientAuthProp => // ignore string

--- a/docs/security.html
+++ b/docs/security.html
@@ -282,6 +282,22 @@ keyUsage               = digitalSignature, keyEncipherment
             <p>For some tooling assistance on this topic, please check out the <a href="https://github.com/OpenVPN/easy-rsa">easyRSA</a> project which has
                 extensive scripting in place to help with these steps.</p>
 
+            <h5>SSL key and certificates in PEM format</h5>
+            From 2.7.0 onwards, SSL key and trust stores can be configured for Kafka brokers and clients directly in the configuration in PEM format.
+            This avoids the need to store separate files on the file system and benefits from password protection features of Kafka configuration.
+            PEM may also be used as the store type for file-based key and trust stores in addition to JKS and PKCS12. To configure PEM key store directly in the
+            broker or client configuration, private key in PEM format should be provided in <code>ssl.keystore.key</code> and the certificate chain in PEM format
+            should be provided in <code>ssl.keystore.certificate.chain</code>.  To configure trust store, trust certificates, e.g. public certificate of CA,
+            should be provided in <code>ssl.truststore.certificates</code>. Since PEM is typically stored as multi-line base-64 strings, the configuration value
+            can be included in Kafka configuration as multi-line strings with lines terminating in backslash ('\') for line continuation.
+
+            <p>Store password configs <code>ssl.keystore.password</code> and <code>ssl.truststore.password</code> are not used for PEM. 
+            If private key is encrypted using a password, the key password must be provided in <code>ssl.key.password</code>. Private keys may be provided
+            in unencrypted form without a password when PEM is specified directly in the config value. In production deployments, configs should be encrypted or
+            externalized using password protection feature in Kafka in this case. Note that the default SSL engine factory has limited capabilities for decryption
+            of encrypted private keys when external tools like OpenSSL are used for encryption. Third party libraries like BouncyCastle may be integrated witn a
+            custom <code>SslEngineFactory</code> to support a wider range of encrypted private keys.</p>
+
         </li>
         <li><h4><a id="security_ssl_production" href="#security_ssl_production">Common Pitfalls in Production</a></h4>
             The above paragraphs show the process to create your own CA and use it to sign certificates for your cluster.


### PR DESCRIPTION
Adds support for SSL key and trust stores to be specified in PEM format either as files or directly as configuration values.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
