### PR TITLE
KAFKA-10527; Voters should not reinitialize as leader in same epoch

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -135,11 +135,15 @@ public class QuorumState {
                 randomElectionTimeoutMs()
             );
         } else if (election.isLeader(localId)) {
-            initialState = new LeaderState(
-                localId,
+            // If we were previously a leader, then we will start out as unattached
+            // in the same epoch. This protects the invariant that each record
+            // is uniquely identified by offset and epoch, which might otherwise
+            // be violated if unflushed data is lost after restarting.
+            initialState = new UnattachedState(
+                time,
                 election.epoch,
-                logEndOffsetAndEpoch.offset,
-                voters
+                voters,
+                randomElectionTimeoutMs()
             );
         } else if (election.isCandidate(localId)) {
             initialState = new CandidateState(

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -167,14 +167,23 @@ public class QuorumStateTest {
         Set<Integer> voters = Utils.mkSet(localId, node1, node2);
         store.writeElectionState(ElectionState.withElectedLeader(epoch, localId, voters));
 
+        // If we were previously a leader, we will start as unattached
+        // so that records are always uniquely defined by epoch and offset
+        // even accounting for the loss of unflushed data.
+
+        // The election timeout should be reset after we become a candidate again
+        int jitterMs = 2500;
+        Mockito.doReturn(jitterMs).when(random).nextInt(Mockito.anyInt());
+
         QuorumState state = buildQuorumState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
-        assertTrue(state.isLeader());
+        assertFalse(state.isLeader());
         assertEquals(epoch, state.epoch());
 
-        LeaderState leaderState = state.leaderStateOrThrow();
-        assertEquals(epoch, leaderState.epoch());
-        assertEquals(Utils.mkSet(node1, node2), leaderState.nonEndorsingFollowers());
+        UnattachedState unattachedState = state.unattachedStateOrThrow();
+        assertEquals(epoch, unattachedState.epoch());
+        assertEquals(electionTimeoutMs + jitterMs,
+            unattachedState.remainingElectionTimeMs(time.milliseconds()));
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -100,7 +100,7 @@ public class RaftEventSimulationTest {
             scheduler.schedule(router::deliverAll, 0, 2, 1);
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
             scheduler.runUntil(cluster::hasConsistentLeader);
-            scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
+            scheduler.runUntil(() -> cluster.allReachedHighWatermark(10));
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -98,50 +98,8 @@ public class RaftEventSimulationTest {
             cluster.startAll();
             schedulePolling(scheduler, cluster, 3, 5);
             scheduler.schedule(router::deliverAll, 0, 2, 1);
-            scheduler.runUntil(cluster::hasConsistentLeader);
-        }
-    }
-
-    @Test
-    public void testReplicationNoLeaderChangeQuorumSizeOne() {
-        testReplicationNoLeaderChange(new QuorumConfig(1));
-    }
-
-    @Test
-    public void testReplicationNoLeaderChangeQuorumSizeTwo() {
-        testReplicationNoLeaderChange(new QuorumConfig(2));
-    }
-
-    @Test
-    public void testReplicationNoLeaderChangeQuorumSizeThree() {
-        testReplicationNoLeaderChange(new QuorumConfig(3, 0));
-    }
-
-    @Test
-    public void testReplicationNoLeaderChangeQuorumSizeFour() {
-        testReplicationNoLeaderChange(new QuorumConfig(4));
-    }
-
-    @Test
-    public void testReplicationNoLeaderChangeQuorumSizeFive() {
-        testReplicationNoLeaderChange(new QuorumConfig(5));
-    }
-
-    private void testReplicationNoLeaderChange(QuorumConfig config) {
-        for (int seed = 0; seed < 100; seed++) {
-            Cluster cluster = new Cluster(config, seed);
-            MessageRouter router = new MessageRouter(cluster);
-            EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
-
-            Set<Integer> voters = cluster.voters();
-            // Start with node 0 as the leader
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 0, voters));
-            cluster.startAll();
-            assertTrue(cluster.hasConsistentLeader());
-
-            schedulePolling(scheduler, cluster, 3, 5);
-            scheduler.schedule(router::deliverAll, 0, 2, 0);
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
+            scheduler.runUntil(cluster::hasConsistentLeader);
             scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
         }
     }
@@ -223,21 +181,17 @@ public class RaftEventSimulationTest {
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
-            // Start with node 0 as the leader
-            int leaderId = 0;
-            Set<Integer> voters = cluster.voters();
-            cluster.initializeElection(ElectionState.withElectedLeader(2, leaderId, voters));
-            cluster.startAll();
-            assertTrue(cluster.hasConsistentLeader());
-
             // Seed the cluster with some data
+            cluster.startAll();
             schedulePolling(scheduler, cluster, 3, 5);
             scheduler.schedule(router::deliverAll, 0, 2, 1);
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
+            scheduler.runUntil(cluster::hasConsistentLeader);
             scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
 
             // Shutdown the leader and write some more data. We can verify the new leader has been elected
             // by verifying that the high watermark can still advance.
+            int leaderId = cluster.latestLeader().getAsInt();
             if (isGracefulShutdown) {
                 cluster.shutdown(leaderId);
             } else {
@@ -287,24 +241,21 @@ public class RaftEventSimulationTest {
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
-            // Start with node 1 as the leader
-            Set<Integer> voters = cluster.voters();
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
-            cluster.startAll();
-            assertTrue(cluster.hasConsistentLeader());
-
             // Seed the cluster with some data
+            cluster.startAll();
             schedulePolling(scheduler, cluster, 3, 5);
             scheduler.schedule(router::deliverAll, 0, 2, 2);
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
+            scheduler.runUntil(cluster::hasConsistentLeader);
             scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
 
             // The leader gets partitioned off. We can verify the new leader has been elected
             // by writing some data and ensuring that it gets replicated
-            router.filter(1, new DropAllTraffic());
+            int leaderId = cluster.latestLeader().getAsInt();
+            router.filter(leaderId, new DropAllTraffic());
 
             Set<Integer> nonPartitionedNodes = new HashSet<>(cluster.nodes());
-            nonPartitionedNodes.remove(1);
+            nonPartitionedNodes.remove(leaderId);
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(20, nonPartitionedNodes));
         }
@@ -329,20 +280,17 @@ public class RaftEventSimulationTest {
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
-            // Start with node 1 as the leader
-            Set<Integer> voters = cluster.voters();
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
-            cluster.startAll();
-            assertTrue(cluster.hasConsistentLeader());
-
             // Seed the cluster with some data
+            cluster.startAll();
             schedulePolling(scheduler, cluster, 3, 5);
             scheduler.schedule(router::deliverAll, 0, 2, 2);
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
+            scheduler.runUntil(cluster::hasConsistentLeader);
             scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
 
-            // Partition the nodes into two sets. Nodes are reachable within each set, but the
-            // two sets cannot communicate with each other.
+            // Partition the nodes into two sets. Nodes are reachable within each set,
+            // but the two sets cannot communicate with each other. We should be able
+            // to make progress even if an election is needed in the larger set.
             router.filter(0, new DropOutboundRequestsFrom(Utils.mkSet(2, 3, 4)));
             router.filter(1, new DropOutboundRequestsFrom(Utils.mkSet(2, 3, 4)));
             router.filter(2, new DropOutboundRequestsFrom(Utils.mkSet(0, 1)));
@@ -383,25 +331,21 @@ public class RaftEventSimulationTest {
             MessageRouter router = new MessageRouter(cluster);
             EventScheduler scheduler = schedulerWithDefaultInvariants(cluster);
 
-            // Start with node 1 as the leader
-            Set<Integer> voters = cluster.voters();
-            cluster.initializeElection(ElectionState.withElectedLeader(2, 1, voters));
-            cluster.startAll();
-            assertTrue(cluster.hasConsistentLeader());
-
             // Seed the cluster with some data
+            cluster.startAll();
             schedulePolling(scheduler, cluster, 3, 5);
             scheduler.schedule(router::deliverAll, 0, 2, 5);
             scheduler.schedule(new SequentialAppendAction(cluster), 0, 2, 3);
+            scheduler.runUntil(cluster::hasConsistentLeader);
             scheduler.runUntil(() -> cluster.anyReachedHighWatermark(10));
 
-            // Now partition off node 1 and wait for a new leader
-            router.filter(1, new DropAllTraffic());
-            scheduler.runUntil(() -> cluster.latestLeader().isPresent() && cluster.latestLeader().getAsInt() != 1);
+            int leaderId = cluster.latestLeader().getAsInt();
+            router.filter(leaderId, new DropAllTraffic());
+            scheduler.runUntil(() -> cluster.latestLeader().isPresent() && cluster.latestLeader().getAsInt() != leaderId);
 
-            // As soon as we have a new leader, restore traffic to node 1 and partition the new leader
+            // As soon as we have a new leader, restore traffic to the old leader and partition the new leader
             int newLeaderId = cluster.latestLeader().getAsInt();
-            router.filter(1, new PermitAllTraffic());
+            router.filter(leaderId, new PermitAllTraffic());
             router.filter(newLeaderId, new DropAllTraffic());
 
             // Verify now that we can make progress
@@ -656,6 +600,7 @@ public class RaftEventSimulationTest {
             for (RaftNode node : running.values()) {
                 if (node.quorum.epoch() > latestEpoch) {
                     latestLeader = node.quorum.leaderId();
+                    latestEpoch = node.quorum.epoch();
                 } else if (node.quorum.epoch() == latestEpoch && node.quorum.leaderId().isPresent()) {
                     latestLeader = node.quorum.leaderId();
                 }
@@ -704,15 +649,6 @@ public class RaftEventSimulationTest {
 
         Collection<RaftNode> running() {
             return running.values();
-        }
-
-        void initializeElection(ElectionState election) {
-            if (election.hasLeader() && !voters.contains(election.leaderId()))
-                throw new IllegalArgumentException("Illegal election of observer " + election.leaderId());
-
-            nodes.values().forEach(state -> {
-                state.store.writeElectionState(election);
-            });
         }
 
         void ifRunning(int nodeId, Consumer<RaftNode> action) {


### PR DESCRIPTION
One of the invariants that the raft replication protocol ensures is that each record is uniquely identified by leader epoch and offset. This can be violated if a leader remains elected with the same epoch between restarts since unflushed data could be lost.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
