### PR TITLE
MINOR: add proper checks to KafkaConsumer.groupMetadata

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -590,8 +590,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     // currentThread holds the threadId of the current thread accessing KafkaConsumer
     // and is used to prevent multi-threaded access
-    // visible for testing
-    final AtomicLong currentThread = new AtomicLong(NO_CURRENT_THREAD);
+    private final AtomicLong currentThread = new AtomicLong(NO_CURRENT_THREAD);
     // refcount is used to allow reentrant access by the thread who has acquired currentThread
     private final AtomicInteger refcount = new AtomicInteger(0);
 


### PR DESCRIPTION
add following checks to ```KafkaConsumer.groupMetadata```

1. null check of coordinator (replace NPE by ```InvalidGroupIdException``` which is same to other methods)
1. concurrent check (```groupMetadata``` is not thread-safe so concurrent check is necessary)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
