### PR TITLE
KAFKA-10534: change params type to avoid redundant judgments.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -98,12 +98,7 @@ public class AbstractConfig {
      * @param doLog whether the configurations should be logged
      */
     @SuppressWarnings("unchecked")
-    public AbstractConfig(ConfigDef definition, Map<?, ?> originals,  Map<String, ?> configProviderProps, boolean doLog) {
-        /* check that all the keys are really strings */
-        for (Map.Entry<?, ?> entry : originals.entrySet())
-            if (!(entry.getKey() instanceof String))
-                throw new ConfigException(entry.getKey().toString(), entry.getValue(), "Key must be a string.");
-
+    public AbstractConfig(ConfigDef definition, Map<String, ?> originals,  Map<String, ?> configProviderProps, boolean doLog) {
         this.originals = resolveConfigVariables(configProviderProps, (Map<String, Object>) originals);
         this.values = definition.parse(this.originals);
         this.used = Collections.synchronizedSet(new HashSet<>());


### PR DESCRIPTION
Modify the AbstractConfig class, convert params `originals` type from Map<?, ?> to Map<String, ?> to avoid redundant judgments in the code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
