### PR TITLE
KAFKA-10047: Unnecessary widening of (int to long) scope in FloatSerializer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/FloatSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/FloatSerializer.java
@@ -22,7 +22,7 @@ public class FloatSerializer implements Serializer<Float> {
         if (data == null)
             return null;
 
-        long bits = Float.floatToRawIntBits(data);
+        int bits = Float.floatToRawIntBits(data);
         return new byte[] {
             (byte) (bits >>> 24),
             (byte) (bits >>> 16),


### PR DESCRIPTION
There is a JIRA ticket requesting this small change (https://issues.apache.org/jira/browse/KAFKA-10047)

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
