### PR TITLE
KAFKA-10533; KafkaRaftClient should flush log after appends

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -60,11 +60,11 @@ object RequestChannel extends Logging {
     val sanitizedUser: String = Sanitizer.sanitize(principal.getName)
   }
 
-  class Metrics {
+  class Metrics(allowDisabledApis: Boolean = false) {
 
     private val metricsMap = mutable.Map[String, RequestMetrics]()
 
-    (ApiKeys.enabledApis.asScala.toSeq.map(_.name) ++
+    (ApiKeys.values.toSeq.filter(_.isEnabled || allowDisabledApis).map(_.name) ++
         Seq(RequestMetrics.consumerFetchMetricName, RequestMetrics.followFetchMetricName)).foreach { name =>
       metricsMap.put(name, new RequestMetrics(name))
     }
@@ -311,10 +311,11 @@ object RequestChannel extends Logging {
 }
 
 class RequestChannel(val queueSize: Int,
-                     val metricNamePrefix : String,
-                     time: Time) extends KafkaMetricsGroup {
+                     val metricNamePrefix: String,
+                     time: Time,
+                     allowDisabledApis: Boolean = false) extends KafkaMetricsGroup {
   import RequestChannel._
-  val metrics = new RequestChannel.Metrics
+  val metrics = new RequestChannel.Metrics(allowDisabledApis)
   private val requestQueue = new ArrayBlockingQueue[BaseRequest](queueSize)
   private val processors = new ConcurrentHashMap[Int, Processor]()
   val requestQueueSizeMetricName = metricNamePrefix.concat(RequestQueueSizeMetric)

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -27,9 +27,11 @@ import org.apache.kafka.raft.{LogAppendInfo, LogFetchInfo, LogOffsetMetadata, Is
 
 import scala.compat.java8.OptionConverters._
 
-class KafkaMetadataLog(log: Log,
-                       topicPartition: TopicPartition,
-                       maxFetchSizeInBytes: Int = 1024 * 1024) extends ReplicatedLog {
+class KafkaMetadataLog(
+  log: Log,
+  topicPartition: TopicPartition,
+  maxFetchSizeInBytes: Int = 1024 * 1024
+) extends ReplicatedLog {
 
   override def read(startOffset: Long, readIsolation: Isolation): LogFetchInfo = {
     val isolation = readIsolation match {
@@ -122,6 +124,10 @@ class KafkaMetadataLog(log: Log,
         // FIXME: This API returns the new high watermark, which may be different from the passed offset
         log.updateHighWatermark(offsetMetadata.offset)
     }
+  }
+
+  override def flush(): Unit = {
+    log.flush()
   }
 
   /**

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -130,6 +130,10 @@ class KafkaMetadataLog(
     log.flush()
   }
 
+  override def lastFlushedOffset(): Long = {
+    log.recoveryPoint
+  }
+
   /**
    * Return the topic partition associated with the log.
    */

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -18,14 +18,13 @@
 package kafka.tools
 
 import java.io.File
-import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.util.concurrent.CountDownLatch
 import java.util.{Properties, Random}
 
 import joptsimple.OptionParser
 import kafka.log.{Log, LogConfig, LogManager}
-import kafka.network.{ConnectionQuotas, Processor, RequestChannel, SocketServer}
+import kafka.network.SocketServer
 import kafka.raft.{KafkaFuturePurgatory, KafkaMetadataLog, KafkaNetworkChannel}
 import kafka.security.CredentialProvider
 import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaRequestHandlerPool, KafkaServer, LogDirFailureChannel}
@@ -34,12 +33,9 @@ import kafka.utils.{CommandLineUtils, CoreUtils, Exit, KafkaScheduler, Logging, 
 import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.config.ConfigException
-import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.metrics.Metrics
-import org.apache.kafka.common.network.{ChannelBuilders, ListenerName, NetworkReceive, Selectable, Selector}
-import org.apache.kafka.common.requests.RequestHeader
+import org.apache.kafka.common.network.{ChannelBuilders, NetworkReceive, Selectable, Selector}
 import org.apache.kafka.common.security.JaasContext
-import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.utils.{LogContext, Time, Utils}
@@ -80,7 +76,7 @@ class TestRaftServer(val config: KafkaConfig) extends Logging {
     tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
     credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
 
-    socketServer = new RaftSocketServer(config, metrics, time, credentialProvider, logContext)
+    socketServer = new SocketServer(config, metrics, time, credentialProvider, allowDisabledApis = true)
     socketServer.startup(startProcessingRequests = false)
 
     val logDirName = Log.logDirName(partition)
@@ -302,50 +298,6 @@ class TestRaftServer(val config: KafkaConfig) extends Logging {
   }
 
 }
-
-class RaftSocketServer(
-  config: KafkaConfig,
-  metrics: Metrics,
-  time: Time,
-  credentialProvider: CredentialProvider,
-  logContext: LogContext
-) extends SocketServer(config, metrics, time, credentialProvider) {
-  override def newProcessor(
-    id: Int,
-    requestChannel: RequestChannel,
-    connectionQuotas: ConnectionQuotas,
-    listenerName: ListenerName,
-    securityProtocol: SecurityProtocol,
-    memoryPool: MemoryPool,
-    isPrivilegedListener: Boolean
-  ): Processor = {
-    new Processor(id,
-      time,
-      config.socketRequestMaxBytes,
-      requestChannel,
-      connectionQuotas,
-      config.connectionsMaxIdleMs,
-      config.failedAuthenticationDelayMs,
-      listenerName,
-      securityProtocol,
-      config,
-      metrics,
-      credentialProvider,
-      memoryPool,
-      logContext,
-      isPrivilegedListener = isPrivilegedListener
-    ) {
-      // We extend this API to skip the check for only enabled APIs. This
-      // gets us access to Vote, BeginQuorumEpoch, etc. which are not usable
-      // from the Kafka broker yet.
-      override def parseRequestHeader(buffer: ByteBuffer): RequestHeader = {
-        RequestHeader.parse(buffer)
-      }
-    }
-  }
-
-}
-
 
 object TestRaftServer extends Logging {
   import kafka.utils.Implicits._

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -114,14 +114,6 @@ public class LeaderState implements EpochState {
         return false;
     }
 
-    private OptionalLong quorumMajorityFetchTimestamp() {
-        // Find the latest timestamp which is fetched by a majority of replicas (the leader counts)
-        ArrayList<ReplicaState> followersByDescendingFetchTimestamp = new ArrayList<>(this.voterReplicaStates.values());
-        followersByDescendingFetchTimestamp.sort(FETCH_TIMESTAMP_COMPARATOR);
-        int indexOfTimestamp = voterReplicaStates.size() / 2;
-        return followersByDescendingFetchTimestamp.get(indexOfTimestamp).lastFetchTimestamp;
-    }
-
     /**
      * Update the local replica state.
      *
@@ -271,18 +263,6 @@ public class LeaderState implements EpochState {
             this.hasEndorsedLeader = hasEndorsedLeader;
         }
     }
-
-    private static final Comparator<ReplicaState> FETCH_TIMESTAMP_COMPARATOR = (state, that) -> {
-        if (state.lastFetchTimestamp.equals(that.lastFetchTimestamp))
-            return Integer.compare(state.nodeId, that.nodeId);
-        else if (!state.lastFetchTimestamp.isPresent())
-            return 1;
-        else if (!that.lastFetchTimestamp.isPresent())
-            return -1;
-        else
-            return Long.compare(that.lastFetchTimestamp.getAsLong(), state.lastFetchTimestamp.getAsLong());
-    };
-
 
     @Override
     public String toString() {

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.raft;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -104,6 +104,11 @@ public interface ReplicatedLog extends Closeable {
     void updateHighWatermark(LogOffsetMetadata offsetMetadata);
 
     /**
+     * Flush the current log to disk.
+     */
+    void flush();
+
+    /**
      * Return the topic partition associated with the log.
      */
     TopicPartition topicPartition();

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -109,6 +109,11 @@ public interface ReplicatedLog extends Closeable {
     void flush();
 
     /**
+     * Get the last offset which has been flushed to disk.
+     */
+    long lastFlushedOffset();
+
+    /**
      * Return the topic partition associated with the log.
      */
     TopicPartition topicPartition();

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -215,7 +215,8 @@ public class KafkaRaftClientTest {
         long electionTimestamp = time.milliseconds();
 
         // Leader change record appended
-        assertEquals(1, log.endOffset().offset);
+        assertEquals(1L, log.endOffset().offset);
+        assertEquals(1L, log.lastFlushedOffset());
 
         // Send BeginQuorumEpoch to voters
         client.poll();
@@ -396,6 +397,7 @@ public class KafkaRaftClientTest {
         client.append(MemoryRecords.withRecords(CompressionType.NONE, records), AckMode.LEADER, Integer.MAX_VALUE);
         client.poll();
         assertEquals(3L, log.endOffset().offset);
+        assertEquals(3L, log.lastFlushedOffset());
         assertEquals(OptionalLong.of(1L), client.highWatermark());
 
         validateLocalRead(client, new OffsetAndEpoch(1L, epoch), Isolation.COMMITTED, new SimpleRecord[0]);
@@ -1779,6 +1781,7 @@ public class KafkaRaftClientTest {
 
         client.poll();
         assertEquals(2L, log.endOffset().offset);
+        assertEquals(2L, log.lastFlushedOffset());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -246,6 +246,7 @@ public class MockLog implements ReplicatedLog {
         lastFlushedOffset = endOffset().offset;
     }
 
+    @Override
     public long lastFlushedOffset() {
         return lastFlushedOffset;
     }

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -43,10 +43,11 @@ import java.util.stream.Collectors;
 public class MockLog implements ReplicatedLog {
     private final List<EpochStartOffset> epochStartOffsets = new ArrayList<>();
     private final List<LogBatch> log = new ArrayList<>();
+    private final TopicPartition topicPartition;
 
     private UUID nextId = UUID.randomUUID();
-    private LogOffsetMetadata highWatermark = new LogOffsetMetadata(0L, Optional.of(new MockOffsetMetadata(nextId)));
-    private final TopicPartition topicPartition;
+    private LogOffsetMetadata highWatermark = new LogOffsetMetadata(0L, Optional.empty());
+    private long lastFlushedOffset = 0L;
 
     public MockLog(TopicPartition topicPartition) {
         this.topicPartition = topicPartition;
@@ -238,6 +239,24 @@ public class MockLog implements ReplicatedLog {
             lastOffset = entries.get(entries.size() - 1).offset;
         }
         return new LogAppendInfo(baseOffset, lastOffset);
+    }
+
+    @Override
+    public void flush() {
+        lastFlushedOffset = endOffset().offset;
+    }
+
+    public long lastFlushedOffset() {
+        return lastFlushedOffset;
+    }
+
+    /**
+     * Reopening the log causes all unflushed data to be lost.
+     */
+    public void reopen() {
+        log.removeIf(batch -> batch.firstOffset() >= lastFlushedOffset);
+        epochStartOffsets.removeIf(epochStartOffset -> epochStartOffset.startOffset >= lastFlushedOffset);
+        highWatermark = new LogOffsetMetadata(0L, Optional.empty());
     }
 
     public List<LogBatch> readBatches(long startOffset, OptionalLong maxOffsetOpt) {
@@ -436,10 +455,4 @@ public class MockLog implements ReplicatedLog {
         }
     }
 
-    public void clear() {
-        epochStartOffsets.clear();
-        log.clear();
-        highWatermark = new LogOffsetMetadata(0L);
-    }
 }
-

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -382,6 +382,20 @@ public class MockLogTest {
         assertEquals(Optional.of(new OffsetAndEpoch(5L, 3)), log.endOffsetForEpoch(3));
     }
 
+    @Test
+    public void testUnflushedRecordsLostAfterReopen() {
+        appendBatch(5, 1);
+        appendBatch(10, 2);
+        log.flush();
+
+        appendBatch(5, 3);
+        appendBatch(10, 4);
+        log.reopen();
+
+        assertEquals(15L, log.endOffset().offset);
+        assertEquals(2, log.lastFetchedEpoch());
+    }
+
     private Optional<OffsetRange> readOffsets(long startOffset, Isolation isolation) {
         Records records = log.read(startOffset, isolation).records;
         long firstReadOffset = -1L;


### PR DESCRIPTION
This patch adds missing flush logic to `KafkaRaftClient`. The initial flushing behavior is simplistic. We guarantee that the leader will not replicate above the last flushed offset and we guarantee that the follower will not fetch data above its own flush point. More sophisticated flush behavior is proposed in KAFKA-10526.

We have also extended the simulation test so that it covers flush behavior. When a node is shutdown, all unflushed data is lost. We were able to confirm that the monotonic high watermark invariant fails without the added `flush` calls.

This patch also piggybacks a fix to the `TestRaftServer` implementation. The initial check-in contained a bug which caused `RequestChannel` to fail sending responses because the disabled APIs did not have metrics registered. As a result of this, it is impossible to elect leaders.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
