### PR TITLE
MINOR: Fix KStreamKTableJoinTest and StreamTaskTest

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -208,6 +208,9 @@
     <suppress checks="MethodLength"
               files="KStreamSlidingWindowAggregateTest.java"/>
 
+    <suppress checks="ClassFanOutComplexity"
+              files="StreamTaskTest.java"/>
+
     <!-- Streams test-utils -->
     <suppress checks="ClassFanOutComplexity"
               files="TopologyTestDriver.java"/>

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -255,7 +255,7 @@ public class KStreamKTableJoinTest {
             }
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record due to null key or value. key=[null] value=[A] topic=[streamTopic] partition=[0] "
+                hasItem("Skipping record due to null join key or value. key=[null] value=[A] topic=[streamTopic] partition=[0] "
                     + "offset=[0]"));
         }
     }
@@ -282,7 +282,7 @@ public class KStreamKTableJoinTest {
 
             assertThat(
                 appender.getMessages(),
-                hasItem("Skipping record due to null key or value. key=[1] value=[null] topic=[streamTopic] partition=[0] "
+                hasItem("Skipping record due to null join key or value. key=[1] value=[null] topic=[streamTopic] partition=[0] "
                     + "offset=[0]")
             );
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2050,22 +2050,22 @@ public class StreamTaskTest {
         final ProcessorTopology topology = withSources(asList(), mkMap());
 
         final TopologyException  exception = assertThrows(
-                TopologyException.class,
-                () -> new StreamTask(
-                        taskId,
-                        partitions,
-                        topology,
-                        consumer,
-                        createConfig(false, "100"),
-                        metrics,
-                        stateDirectory,
-                        cache,
-                        time,
-                        stateManager,
-                        recordCollector,
-                        context
-                )
-            );
+            TopologyException.class,
+            () -> new StreamTask(
+                taskId,
+                partitions,
+                topology,
+                consumer,
+                createConfig(false, "100"),
+                metrics,
+                stateDirectory,
+                cache,
+                time,
+                stateManager,
+                recordCollector,
+                context
+            )
+        );
 
         assertThat(exception.getMessage(), equalTo("Invalid topology: " +
                 "Topic is unkown to the topology. This may happen if different KafkaStreams instances of the same " +


### PR DESCRIPTION
Quick fixes for checkstyle issues in StreamTaskTest and updated syntax for tests in KSTreamKTableJoinTest based on changes from https://github.com/apache/kafka/pull/9186

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
