### PR TITLE
KAFKA-10561: Timestamp Microseconds support

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -69,6 +69,7 @@ public class ConnectSchema implements Schema {
         LOGICAL_TYPE_CLASSES.put(Date.LOGICAL_NAME, Collections.singletonList((Class) java.util.Date.class));
         LOGICAL_TYPE_CLASSES.put(Time.LOGICAL_NAME, Collections.singletonList((Class) java.util.Date.class));
         LOGICAL_TYPE_CLASSES.put(Timestamp.LOGICAL_NAME, Collections.singletonList((Class) java.util.Date.class));
+        LOGICAL_TYPE_CLASSES.put(TimestampMicros.LOGICAL_NAME, Collections.singletonList((Class) java.time.Instant.class));
         // We don't need to put these into JAVA_CLASS_SCHEMA_TYPES since that's only used to determine schemas for
         // schemaless data and logical types will have ambiguous schemas (e.g. many of them use the same Java class) so
         // they should not be used without schemas.

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/TimestampMicros.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/TimestampMicros.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.data;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * <p>
+ *     A timestamp representing an absolute time, without timezone information. The corresponding Java type is a
+ *     java.util.Date. The underlying representation is a long representing the number of microseconds since Unix epoch.
+ * </p>
+ */
+public class TimestampMicros {
+    public static final String LOGICAL_NAME = "org.apache.kafka.connect.data.TimestampMicros";
+
+    /**
+     * Returns a SchemaBuilder for a TimestampMicros. By returning a SchemaBuilder you can override additional schema settings such
+     * as required/optional, default value, and documentation.
+     * @return a SchemaBuilder
+     */
+    public static SchemaBuilder builder() {
+        return SchemaBuilder.int64()
+                .name(LOGICAL_NAME)
+                .version(1);
+    }
+
+    public static final Schema SCHEMA = builder().schema();
+
+    /**
+     * Convert a value from its logical format (Instant) to it's encoded format.
+     * @param value the logical value
+     * @return the encoded value
+     */
+    public static long fromLogical(Schema schema, java.time.Instant value) {
+        if (!(LOGICAL_NAME.equals(schema.name())))
+            throw new DataException("Requested conversion of TimestampMicros object but the schema does not match.");
+        return ChronoUnit.MICROS.between(Instant.EPOCH, value);
+    }
+
+    public static java.time.Instant toLogical(Schema schema, long value) {
+        if (!(LOGICAL_NAME.equals(schema.name())))
+            throw new DataException("Requested conversion of TimestampMicros object but the schema does not match.");
+        return Instant.EPOCH.plus(value, ChronoUnit.MICROS);
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.TimestampMicros;
 import org.apache.kafka.connect.errors.DataException;
 
 import java.math.BigDecimal;
@@ -219,6 +220,15 @@ public class ConnectHeaders implements Headers {
             Timestamp.fromLogical(Timestamp.SCHEMA, value);
         }
         return addWithoutValidating(key, value, Timestamp.SCHEMA);
+    }
+
+    @Override
+    public Headers addTimestampMicros(String key, java.time.Instant value) {
+        if (value != null) {
+            // Check that this is a timestamp with microseconds precision...
+            TimestampMicros.fromLogical(TimestampMicros.SCHEMA, value);
+        }
+        return addWithoutValidating(key, value, TimestampMicros.SCHEMA);
     }
 
     @Override
@@ -443,6 +453,8 @@ public class ConnectHeaders implements Headers {
                         if (value instanceof Long)
                             return;
                         if (value instanceof java.util.Date && Timestamp.LOGICAL_NAME.equals(schema.name()))
+                            return;
+                        if (value instanceof java.time.Instant && TimestampMicros.LOGICAL_NAME.equals(schema.name()))
                             return;
                         break;
                     case FLOAT32:

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/Headers.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/Headers.java
@@ -238,6 +238,15 @@ public interface Headers extends Iterable<Header> {
     Headers addTimestamp(String key, java.util.Date value);
 
     /**
+     * Add to this collection a {@link Header} with the given key and {@link org.apache.kafka.connect.data.TimestampMicros} value.
+     *
+     * @param key   the header's key; may not be null
+     * @param value the header's {@link org.apache.kafka.connect.data.TimestampMicros} value; may be null
+     * @return this object to facilitate chaining multiple methods; never null
+     */
+    Headers addTimestampMicros(String key, java.time.Instant value);
+
+    /**
      * Removes all {@link Header} objects whose {@link Header#key() key} matches the specified key.
      *
      * @param key the key; may not be null

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -104,6 +105,7 @@ public class ConnectSchemaTest {
         ConnectSchema.validateValue(Date.SCHEMA, new java.util.Date(0));
         ConnectSchema.validateValue(Time.SCHEMA, new java.util.Date(0));
         ConnectSchema.validateValue(Timestamp.SCHEMA, new java.util.Date(0));
+        ConnectSchema.validateValue(TimestampMicros.SCHEMA, Instant.EPOCH);
     }
 
     // To avoid requiring excessive numbers of tests, these checks for invalid types use a similar type where possible
@@ -231,6 +233,11 @@ public class ConnectSchemaTest {
     @Test(expected = DataException.class)
     public void testValidateValueMismatchTimestamp() {
         ConnectSchema.validateValue(Timestamp.SCHEMA, 1000L);
+    }
+
+    @Test(expected = DataException.class)
+    public void testValidateValueMismatchTimestampMicros() {
+        ConnectSchema.validateValue(TimestampMicros.SCHEMA, 1000L);
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
@@ -352,6 +352,9 @@ public class SchemaProjectorTest {
         projected = SchemaProjector.project(Timestamp.SCHEMA, 34567L, Timestamp.SCHEMA);
         assertEquals(34567L, projected);
 
+        projected = SchemaProjector.project(TimestampMicros.SCHEMA, 34567L, TimestampMicros.SCHEMA);
+        assertEquals(34567L, projected);
+
         java.util.Date date = new java.util.Date();
 
         projected = SchemaProjector.project(Date.SCHEMA, date, Date.SCHEMA);
@@ -362,6 +365,9 @@ public class SchemaProjectorTest {
 
         projected = SchemaProjector.project(Timestamp.SCHEMA, date, Timestamp.SCHEMA);
         assertEquals(date, projected);
+
+        projected = SchemaProjector.project(TimestampMicros.SCHEMA, date.toInstant(), TimestampMicros.SCHEMA);
+        assertEquals(date.toInstant(), projected);
 
         Schema namedSchema = SchemaBuilder.int32().name("invalidLogicalTypeName").build();
         for (Schema logicalTypeSchema: logicalTypeSchemas) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampMicrosTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampMicrosTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.data;
+
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimestampMicrosTest {
+
+    @Test
+    public void testBuilder() {
+        Schema plain = TimestampMicros.SCHEMA;
+        assertEquals(TimestampMicros.LOGICAL_NAME, plain.name());
+        assertEquals(1, (Object) plain.version());
+    }
+
+    @Test
+    public void testFromLogical() {
+        assertEquals(0L, TimestampMicros.fromLogical(TimestampMicros.SCHEMA, Instant.EPOCH));
+        assertEquals(100000, TimestampMicros.fromLogical(TimestampMicros.SCHEMA, Instant.EPOCH.plus(100000, ChronoUnit.MICROS)));
+    }
+
+    @Test(expected = DataException.class)
+    public void testFromLogicalInvalidSchema() {
+        TimestampMicros.fromLogical(TimestampMicros.builder().name("invalid").build(), Instant.EPOCH);
+    }
+
+    @Test
+    public void testToLogical() {
+        assertEquals(Instant.EPOCH, TimestampMicros.toLogical(TimestampMicros.SCHEMA, 0L));
+        assertEquals(Instant.EPOCH.plus(100000, ChronoUnit.MICROS), TimestampMicros.toLogical(TimestampMicros.SCHEMA, 100000));
+    }
+
+    @Test(expected = DataException.class)
+    public void testToLogicalInvalidSchema() {
+        TimestampMicros.toLogical(Date.builder().name("invalid").build(), 0);
+    }
+
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -395,6 +396,16 @@ public class ValuesTest {
     }
 
     @Test
+    public void shouldParseTimestampStringAsTimestampMicros() throws Exception {
+        String str = "2019-08-23T14:34:54.346876Z";
+        SchemaAndValue result = Values.parseString(str);
+        assertEquals(Type.INT64, result.schema().type());
+        assertEquals(TimestampMicros.LOGICAL_NAME, result.schema().name());
+        Instant expected = Instant.parse(str);
+        assertEquals(expected, result.value());
+    }
+
+    @Test
     public void shouldParseDateStringAsDate() throws Exception {
         String str = "2019-08-23";
         SchemaAndValue result = Values.parseString(str);
@@ -422,6 +433,17 @@ public class ValuesTest {
         assertEquals(Timestamp.LOGICAL_NAME, result.schema().name());
         String expectedStr = "2019-08-23T14:34:54.346Z";
         java.util.Date expected = new SimpleDateFormat(Values.ISO_8601_TIMESTAMP_FORMAT_PATTERN).parse(expectedStr);
+        assertEquals(expected, result.value());
+    }
+
+    @Test
+    public void shouldParseTimestampMicrosStringWithEscapedColonsAsTimestampMicros() throws Exception {
+        String str = "2019-08-23T14\\:34\\:54.346876Z";
+        SchemaAndValue result = Values.parseString(str);
+        assertEquals(Type.INT64, result.schema().type());
+        assertEquals(TimestampMicros.LOGICAL_NAME, result.schema().name());
+        String expectedStr = "2019-08-23T14:34:54.346876Z";
+        Instant expected = Instant.parse(expectedStr);
         assertEquals(expected, result.value());
     }
 
@@ -476,6 +498,19 @@ public class ValuesTest {
     }
 
     @Test
+    public void shouldParseTimestampMicrosStringAsTimestampMicrosInArray() throws Exception {
+        String tsStr = "2019-08-23T14:34:54.346876Z";
+        String arrayStr = "[" + tsStr + "]";
+        SchemaAndValue result = Values.parseString(arrayStr);
+        assertEquals(Type.ARRAY, result.schema().type());
+        Schema elementSchema = result.schema().valueSchema();
+        assertEquals(Type.INT64, elementSchema.type());
+        assertEquals(TimestampMicros.LOGICAL_NAME, elementSchema.name());
+        Instant expected = Instant.parse(tsStr);
+        assertEquals(Collections.singletonList(expected), result.value());
+    }
+
+    @Test
     public void shouldParseMultipleTimestampStringAsTimestampInArray() throws Exception {
         String tsStr1 = "2019-08-23T14:34:54.346Z";
         String tsStr2 = "2019-01-23T15:12:34.567Z";
@@ -489,6 +524,23 @@ public class ValuesTest {
         java.util.Date expected1 = new SimpleDateFormat(Values.ISO_8601_TIMESTAMP_FORMAT_PATTERN).parse(tsStr1);
         java.util.Date expected2 = new SimpleDateFormat(Values.ISO_8601_TIMESTAMP_FORMAT_PATTERN).parse(tsStr2);
         java.util.Date expected3 = new SimpleDateFormat(Values.ISO_8601_TIMESTAMP_FORMAT_PATTERN).parse(tsStr3);
+        assertEquals(Arrays.asList(expected1, expected2, expected3), result.value());
+    }
+
+    @Test
+    public void shouldParseMultipleTimestampMicrosStringAsTimestampMicrosInArray() throws Exception {
+        String tsStr1 = "2019-08-23T14:34:54.346876Z";
+        String tsStr2 = "2019-01-23T15:12:34.567765Z";
+        String tsStr3 = "2019-04-23T19:12:34.567654Z";
+        String arrayStr = "[" + tsStr1 + "," + tsStr2 + ",   " + tsStr3 + "]";
+        SchemaAndValue result = Values.parseString(arrayStr);
+        assertEquals(Type.ARRAY, result.schema().type());
+        Schema elementSchema = result.schema().valueSchema();
+        assertEquals(Type.INT64, elementSchema.type());
+        assertEquals(TimestampMicros.LOGICAL_NAME, elementSchema.name());
+        Instant expected1 = Instant.parse(tsStr1);
+        Instant expected2 = Instant.parse(tsStr2);
+        Instant expected3 = Instant.parse(tsStr3);
         assertEquals(Arrays.asList(expected1, expected2, expected3), result.value());
     }
 
@@ -665,6 +717,11 @@ public class ValuesTest {
         // Millis as long
         java.util.Date t4 = Values.convertToTime(Time.SCHEMA, currentMillis);
         assertEquals(currentMillis, t4.getTime());
+
+        // Millis as java.time.Instant - discard the date and microseconds and keep just day's milliseconds
+        java.util.Date t5 = Values.convertToTime(TimestampMicros.SCHEMA, current.toInstant());
+        assertEquals(currentMillis, t5.getTime());
+
     }
 
     @Test
@@ -691,6 +748,10 @@ public class ValuesTest {
         // Days as long
         java.util.Date d4 = Values.convertToDate(Date.SCHEMA, days);
         assertEquals(currentDate, d4);
+
+        // Days as java.time.Instant
+        java.util.Date t5 = Values.convertToDate(TimestampMicros.SCHEMA, current.toInstant());
+        assertEquals(current, t5);
     }
 
     @Test
@@ -720,6 +781,10 @@ public class ValuesTest {
         // Millis as long
         java.util.Date ts4 = Values.convertToTimestamp(Timestamp.SCHEMA, current.getTime());
         assertEquals(current, ts4);
+
+        // Millis as java.time.Instant
+        java.util.Date ts5 = Values.convertToTimestamp(TimestampMicros.SCHEMA, current.toInstant());
+        assertEquals(current, ts5);
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.TimestampMicros;
 import org.apache.kafka.connect.data.Values;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.header.Headers.HeaderTransform;
@@ -33,6 +34,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -400,6 +402,7 @@ public class ConnectHeadersTest {
         assertSchemaMatches(Time.SCHEMA, new java.util.Date());
         assertSchemaMatches(Date.SCHEMA, new java.util.Date());
         assertSchemaMatches(Timestamp.SCHEMA, new java.util.Date());
+        assertSchemaMatches(TimestampMicros.SCHEMA, Instant.now());
     }
 
     @Test
@@ -477,6 +480,21 @@ public class ConnectHeadersTest {
         header = headers.lastWithName(other);
         assertEquals(millis, (long) Values.convertToLong(header.schema(), header.value()));
         assertEquals(dateObj, Values.convertToTimestamp(header.schema(), header.value()));
+    }
+
+    @Test
+    public void shouldAddTimestampMicros() {
+        java.time.Instant dateObj = EPOCH_PLUS_TEN_THOUSAND_MILLIS.getTime().toInstant();
+        long micros = TimestampMicros.fromLogical(TimestampMicros.SCHEMA, dateObj);
+        headers.addTimestampMicros(key, dateObj);
+        Header header = headers.lastWithName(key);
+        assertEquals(micros, (long) Values.convertToLong(header.schema(), header.value()));
+        assertSame(dateObj, Values.convertToTimestampMicros(header.schema(), header.value()));
+
+        headers.addLong(other, micros);
+        header = headers.lastWithName(other);
+        assertEquals(micros, (long) Values.convertToLong(header.schema(), header.value()));
+        assertEquals(dateObj, Values.convertToTimestampMicros(header.schema(), header.value()));
     }
 
     @Test

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.TimestampMicros;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Date;
@@ -45,6 +46,7 @@ import org.apache.kafka.connect.storage.StringConverterConfig;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -272,6 +274,23 @@ public class JsonConverter implements Converter, HeaderConverter {
                 if (!(value.isIntegralNumber()))
                     throw new DataException("Invalid type for Timestamp, underlying representation should be integral but was " + value.getNodeType());
                 return Timestamp.toLogical(schema, value.longValue());
+            }
+        });
+
+
+        LOGICAL_CONVERTERS.put(TimestampMicros.LOGICAL_NAME, new LogicalTypeConverter() {
+            @Override
+            public JsonNode toJson(final Schema schema, final Object value, final JsonConverterConfig config) {
+                if (!(value instanceof Instant))
+                    throw new DataException("Invalid type for TimestampMicros, expected Instant but was " + value.getClass());
+                return JSON_NODE_FACTORY.numberNode(TimestampMicros.fromLogical(schema, (Instant) value));
+            }
+
+            @Override
+            public Object toConnect(final Schema schema, final JsonNode value) {
+                if (!(value.isIntegralNumber()))
+                    throw new DataException("Invalid type for TimestampMicros, underlying representation should be integral but was " + value.getNodeType());
+                return TimestampMicros.toLogical(schema, value.longValue());
             }
         });
     }


### PR DESCRIPTION
*More detailed description of your change,
The purpose of this PR is to support microseconds precision when dealing with timestamps.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
