### PR TITLE
KAFKA-10471 Mark broker crash during log loading as unclean shutdown

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -244,7 +244,8 @@ class Log(@volatile private var _dir: File,
           val producerIdExpirationCheckIntervalMs: Int,
           val topicPartition: TopicPartition,
           val producerStateManager: ProducerStateManager,
-          logDirFailureChannel: LogDirFailureChannel) extends Logging with KafkaMetricsGroup {
+          logDirFailureChannel: LogDirFailureChannel,
+          val hadCleanShutdown: Boolean = true) extends Logging with KafkaMetricsGroup {
 
   import kafka.log.Log._
 
@@ -318,7 +319,7 @@ class Log(@volatile private var _dir: File,
     // during log recovery may have deleted some files without the Log.producerStateManager instance witnessing the
     // deletion.
     producerStateManager.removeStraySnapshots(segments.values().asScala.map(_.baseOffset).toSeq)
-    loadProducerState(logEndOffset, reloadFromCleanShutdown = hasCleanShutdownFile)
+    loadProducerState(logEndOffset, reloadFromCleanShutdown = hadCleanShutdown)
   }
 
   def dir: File = _dir
@@ -804,9 +805,9 @@ class Log(@volatile private var _dir: File,
    * logs are loaded.
    * @throws LogSegmentOffsetOverflowException if we encountered a legacy segment with offset overflow
    */
-  private def recoverLog(): Long = {
+  private[log] def recoverLog(): Long = {
     // if we have the clean shutdown marker, skip recovery
-    if (!hasCleanShutdownFile) {
+    if (!hadCleanShutdown) {
       // okay we need to actually recover this log
       val unflushed = logSegments(this.recoveryPoint, Long.MaxValue).iterator
       var truncated = false
@@ -974,11 +975,6 @@ class Log(@volatile private var _dir: File,
       producerId -> lastRecord
     }
   }
-
-  /**
-   * Check if we have the "clean shutdown" file
-   */
-  private def hasCleanShutdownFile: Boolean = new File(dir.getParentFile, CleanShutdownFile).exists()
 
   /**
    * The number of segments in the log.
@@ -2487,11 +2483,12 @@ object Log {
             time: Time = Time.SYSTEM,
             maxProducerIdExpirationMs: Int,
             producerIdExpirationCheckIntervalMs: Int,
-            logDirFailureChannel: LogDirFailureChannel): Log = {
+            logDirFailureChannel: LogDirFailureChannel,
+            lastShutdownClean: Boolean = true): Log = {
     val topicPartition = Log.parseTopicPartitionName(dir)
     val producerStateManager = new ProducerStateManager(topicPartition, dir, maxProducerIdExpirationMs)
     new Log(dir, config, logStartOffset, recoveryPoint, scheduler, brokerTopicStats, time, maxProducerIdExpirationMs,
-      producerIdExpirationCheckIntervalMs, topicPartition, producerStateManager, logDirFailureChannel)
+      producerIdExpirationCheckIntervalMs, topicPartition, producerStateManager, logDirFailureChannel, lastShutdownClean)
   }
 
   /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -231,6 +231,8 @@ case object SegmentDeletion extends LogStartOffsetIncrementReason {
  * @param time The time instance used for checking the clock
  * @param maxProducerIdExpirationMs The maximum amount of time to wait before a producer id is considered expired
  * @param producerIdExpirationCheckIntervalMs How often to check for producer ids which need to be expired
+ * @param hadCleanShutdown boolean flag to indicate if the Log had a clean/graceful shutdown last time. true means
+ *                         clean shutdown whereas false means a crash.
  */
 @threadsafe
 class Log(@volatile private var _dir: File,

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -247,7 +247,7 @@ class Log(@volatile private var _dir: File,
           val topicPartition: TopicPartition,
           val producerStateManager: ProducerStateManager,
           logDirFailureChannel: LogDirFailureChannel,
-          val hadCleanShutdown: Boolean = true) extends Logging with KafkaMetricsGroup {
+          private val hadCleanShutdown: Boolean = true) extends Logging with KafkaMetricsGroup {
 
   import kafka.log.Log._
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -320,13 +320,7 @@ class LogManager(logDirs: Seq[File],
           info(s"Skipping recovery for all logs in $logDirAbsolutePath since clean shutdown file was found")
           // Cache the clean shutdown status and use that for rest of log loading workflow. Delete the CleanShutdownFile
           // so that if broker crashes while loading the log, it is considered hard shutdown during the next boot up. KAFKA-10471
-          try {
-            cleanShutdownFile.delete()
-          } catch {
-            case e: IOException =>
-              error(s"Error while deleting the clean shutdown file $cleanShutdownFile", e)
-              throw e
-          }
+          cleanShutdownFile.delete()
           hadCleanShutdown = true
         } else {
           // log recovery itself is being performed by `Log` class during initialization

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -385,7 +385,7 @@ class LogManager(logDirs: Seq[File],
       }
 
       offlineDirs.foreach { case (dir, e) =>
-        logDirFailureChannel.maybeAddOfflineLogDir(dir, s"Error while deleting the clean shutdown file in dir $dir", e)
+        logDirFailureChannel.maybeAddOfflineLogDir(dir, s"Error while loading log dir $dir", e)
       }
     } catch {
       case e: ExecutionException =>

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -325,7 +325,6 @@ class LogManager(logDirs: Seq[File],
         } else {
           // log recovery itself is being performed by `Log` class during initialization
           info(s"Attempting recovery for all logs in $logDirAbsolutePath since no clean shutdown file was found")
-          hadCleanShutdown = false
           brokerState.newState(RecoveringFromUncleanShutdown)
         }
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -252,7 +252,8 @@ class LogManager(logDirs: Seq[File],
   // Only for testing
   private[log] def hasLogsToBeDeleted: Boolean = !logsToBeDeleted.isEmpty
 
-  private def loadLog(logDir: File,
+  private[log] def loadLog(logDir: File,
+                      hadCleanShutdown: Boolean,
                       recoveryPoints: Map[TopicPartition, Long],
                       logStartOffsets: Map[TopicPartition, Long]): Log = {
     val topicPartition = Log.parseTopicPartitionName(logDir)
@@ -270,7 +271,8 @@ class LogManager(logDirs: Seq[File],
       scheduler = scheduler,
       time = time,
       brokerTopicStats = brokerTopicStats,
-      logDirFailureChannel = logDirFailureChannel)
+      logDirFailureChannel = logDirFailureChannel,
+      lastShutdownClean = hadCleanShutdown)
 
     if (logDir.getName.endsWith(Log.DeleteDirSuffix)) {
       addLogToBeDeleted(log)
@@ -298,16 +300,17 @@ class LogManager(logDirs: Seq[File],
   /**
    * Recover and load all logs in the given data directories
    */
-  private def loadLogs(): Unit = {
+  private[log] def loadLogs(): Unit = {
     info(s"Loading logs from log dirs $liveLogDirs")
     val startMs = time.hiResClockMs()
     val threadPools = ArrayBuffer.empty[ExecutorService]
     val offlineDirs = mutable.Set.empty[(String, IOException)]
-    val jobs = mutable.Map.empty[File, Seq[Future[_]]]
+    val jobs = ArrayBuffer.empty[Seq[Future[_]]]
     var numTotalLogs = 0
 
     for (dir <- liveLogDirs) {
       val logDirAbsolutePath = dir.getAbsolutePath
+      var hadCleanShutdown: Boolean = false
       try {
         val pool = Executors.newFixedThreadPool(numRecoveryThreadsPerDataDir)
         threadPools.append(pool)
@@ -315,9 +318,20 @@ class LogManager(logDirs: Seq[File],
         val cleanShutdownFile = new File(dir, Log.CleanShutdownFile)
         if (cleanShutdownFile.exists) {
           info(s"Skipping recovery for all logs in $logDirAbsolutePath since clean shutdown file was found")
+          // Cache the clean shutdown status and use that for rest of log loading workflow. Delete the CleanShutdownFile
+          // so that if broker crashes while loading the log, it is considered hard shutdown during the next boot up. KAFKA-10471
+          try {
+            cleanShutdownFile.delete()
+          } catch {
+            case e: IOException =>
+              error(s"Error while deleting the clean shutdown file $cleanShutdownFile", e)
+              throw e
+          }
+          hadCleanShutdown = true
         } else {
           // log recovery itself is being performed by `Log` class during initialization
           info(s"Attempting recovery for all logs in $logDirAbsolutePath since no clean shutdown file was found")
+          hadCleanShutdown = false
           brokerState.newState(RecoveringFromUncleanShutdown)
         }
 
@@ -349,7 +363,7 @@ class LogManager(logDirs: Seq[File],
               debug(s"Loading log $logDir")
 
               val logLoadStartMs = time.hiResClockMs()
-              val log = loadLog(logDir, recoveryPoints, logStartOffsets)
+              val log = loadLog(logDir, hadCleanShutdown, recoveryPoints, logStartOffsets)
               val logLoadDurationMs = time.hiResClockMs() - logLoadStartMs
               val currentNumLoaded = numLogsLoaded.incrementAndGet()
 
@@ -364,7 +378,7 @@ class LogManager(logDirs: Seq[File],
           runnable
         }
 
-        jobs(cleanShutdownFile) = jobsForDir.map(pool.submit)
+        jobs += jobsForDir.map(pool.submit)
       } catch {
         case e: IOException =>
           offlineDirs.add((logDirAbsolutePath, e))
@@ -373,15 +387,8 @@ class LogManager(logDirs: Seq[File],
     }
 
     try {
-      for ((cleanShutdownFile, dirJobs) <- jobs) {
+      for (dirJobs <- jobs) {
         dirJobs.foreach(_.get)
-        try {
-          cleanShutdownFile.delete()
-        } catch {
-          case e: IOException =>
-            offlineDirs.add((cleanShutdownFile.getParent, e))
-            error(s"Error while deleting the clean shutdown file $cleanShutdownFile", e)
-        }
       }
 
       offlineDirs.foreach { case (dir, e) =>

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1742,7 +1742,7 @@ class LogCleanerTest {
   private def tombstoneRecord(key: Int): MemoryRecords = record(key, null)
 
   private def recoverAndCheck(config: LogConfig, expectedKeys: Iterable[Long]): Log = {
-    LogTest.recoverAndCheck(dir, config, expectedKeys, new BrokerTopicStats(), time, time.scheduler)
+    LogTest.recoverAndCheck(dir, config, expectedKeys, new BrokerTopicStats(), time, time.scheduler, hadCleanShutdown = false)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1742,7 +1742,7 @@ class LogCleanerTest {
   private def tombstoneRecord(key: Int): MemoryRecords = record(key, null)
 
   private def recoverAndCheck(config: LogConfig, expectedKeys: Iterable[Long]): Log = {
-    LogTest.recoverAndCheck(dir, config, expectedKeys, new BrokerTopicStats(), time, time.scheduler, hadCleanShutdown = false)
+    LogTest.recoverAndCheck(dir, config, expectedKeys, new BrokerTopicStats(), time, time.scheduler)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -1051,8 +1051,7 @@ class LogTest {
       producerIdExpirationCheckIntervalMs = 30000,
       topicPartition = Log.parseTopicPartitionName(logDir),
       producerStateManager = stateManager,
-      logDirFailureChannel = null,
-      hadCleanShutdown = true)
+      logDirFailureChannel = null)
 
     EasyMock.verify(stateManager)
   }
@@ -1092,8 +1091,7 @@ class LogTest {
       producerIdExpirationCheckIntervalMs = 30000,
       topicPartition = Log.parseTopicPartitionName(logDir),
       producerStateManager = stateManager,
-      logDirFailureChannel = null,
-      hadCleanShutdown = true)
+      logDirFailureChannel = null)
 
     EasyMock.verify(stateManager)
   }


### PR DESCRIPTION
LogManager writes a clean shutdown file when the broker shuts down. The
presence of this file indicates that the broker had a clean shutdown and
log recovery is not needed upon the next boot up.

Earlier, LogManager would check for this file at the start of log loading workflow,
and delete it after the log has been loaded. If the broker were to crash
while loading logs, the file would not be deleted and mislead LogManager when it
tries to load logs upon next boot up. Hence, a crash during log loading
will not be considered a hard reset of broker.

As part of this fix, we delete the clean shutdown file as soon as we
look it up, at the start of log loading workflow. Thereafter, we maintain a boolean
flag to indicate if broker underwent clean shutdown or not. So, if the
broker were to crash while logs are being loaded, LogManager will be
able to detect this as a hard reset.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
