### PR TITLE
KAFKA-10566: Fix erroneous config usage warnings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/ConfigUsageRecording.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/ConfigUsageRecording.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.internals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AbstractConfig tracks and can log warnings about non-use of config parameters.
+ * In places, copies of the results of methods like AbstractConfig.values() get made
+ * and then mutated, but use of config parameters from those copies don't record use.
+ * This class provides an API for creating copies of the RecordingMaps returned by
+ * AbstractConfig.values() which will cause use to be tracked, but without needing
+ * a public API.
+ */
+public class ConfigUsageRecording extends HashMap<String, Object> {
+
+    private final Map<? extends String, ? extends Object> tracking;
+
+    private ConfigUsageRecording(Map<? extends String, ? extends Object> tracking, Map<? extends String, ? extends Object> copy) {
+        super(copy);
+        this.tracking = tracking;
+    }
+
+    public static ConfigUsageRecording copyOf(Map<? extends String, ? extends Object> configs) {
+        return new ConfigUsageRecording(configs, configs);
+    }
+
+    @Override
+    public Object get(Object key) {
+        // Intentionally ignore the result; call just to mark the original entry as used
+        tracking.get(key);
+        return super.get(key);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.internals.ConfigUsageRecording;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
@@ -167,7 +168,7 @@ public class ChannelBuilders {
             parsedConfigs = config.valuesWithPrefixOverride(listenerName.configPrefix());
 
         // include any custom configs from original configs
-        Map<String, Object> configs = new HashMap<>(parsedConfigs);
+        Map<String, Object> configs = ConfigUsageRecording.copyOf(parsedConfigs);
         config.originals().entrySet().stream()
             .filter(e -> !parsedConfigs.containsKey(e.getKey())) // exclude already parsed configs
             // exclude already parsed listener prefix configs

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Reconfigurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.internals.ConfigUsageRecording;
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.auth.SslEngineFactory;
 import org.apache.kafka.common.utils.Utils;
@@ -86,7 +87,7 @@ public class SslFactory implements Reconfigurable, Closeable {
         }
         this.endpointIdentification = (String) configs.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
 
-        Map<String, Object> nextConfigs = new HashMap<>(configs);
+        Map<String, Object> nextConfigs = ConfigUsageRecording.copyOf(configs);
         if (clientAuthConfigOverride != null) {
             nextConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, clientAuthConfigOverride);
         }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -449,8 +449,8 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     <!-- END Suppress warnings for unused members that are undetectably used by Jackson -->
 
     <Match>
-        <!-- Suppress a warning about ignoring return value because this is intentional. -->
-        <Class name="org.apache.kafka.common.config.AbstractConfig$ResolvingMap"/>
+        <!-- Suppress a warning about ignoring return value because these are intentional. -->
+        <Class name="~org\.apache\.kafka\.common\.(config\.AbstractConfig\$ResolvingMap|internals\.ConfigUsageRecording)"/>
         <Method name="get"/>
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>


### PR DESCRIPTION
Fix warn log messages caused by making HashMap copies of configs prior to using. This is not an ideal solution, but because the `Map`s are passed through `Configurable.configure(Map)` it's not possible to use another type (such as the `RecordingMap` type) directly.