### PR TITLE
KAFKA-4715: Ignore case of CompressionType and OffsetResetStrategy

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -432,7 +432,7 @@ public class ConsumerConfig extends AbstractConfig {
                                 .define(AUTO_OFFSET_RESET_CONFIG,
                                         Type.STRING,
                                         "latest",
-                                        in("latest", "earliest", "none"),
+                                        ConfigDef.CaseInsensitiveValidString.in("latest", "earliest", "none"),
                                         Importance.MEDIUM,
                                         AUTO_OFFSET_RESET_DOC)
                                 .define(CHECK_CRCS_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -716,7 +716,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 config.ignore(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
                 this.valueDeserializer = valueDeserializer;
             }
-            OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
+            OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.forName(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
             this.subscriptions = new SubscriptionState(logContext, offsetResetStrategy);
             ClusterResourceListeners clusterResourceListeners = configureClusterResourceListeners(keyDeserializer,
                     valueDeserializer, metrics.reporters(), interceptorList);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
@@ -17,5 +17,15 @@
 package org.apache.kafka.clients.consumer;
 
 public enum OffsetResetStrategy {
-    LATEST, EARLIEST, NONE
+    LATEST, EARLIEST, NONE;
+
+    public static OffsetResetStrategy forName(final String name) {
+        for (final OffsetResetStrategy value : values()) {
+            if (value.name().equalsIgnoreCase(name)) {
+                return value;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown offset reset strategy: " + name);
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
@@ -16,10 +16,29 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * @see ConsumerConfig#AUTO_OFFSET_RESET_CONFIG
+ * @see ConsumerConfig#AUTO_OFFSET_RESET_DOC
+ */
 public enum OffsetResetStrategy {
     LATEST, EARLIEST, NONE;
 
+    // Enums are singletons, this means that this conversion happens once the
+    // first time a variant is actually used, and never again.
+    private final String id = name().toLowerCase(Locale.ROOT);
+
+    /**
+     * Get the {@link OffsetResetStrategy} for the given {@code name}.
+     *
+     * @throws IllegalArgumentException if the given {@code name} does not match any {@link OffsetResetStrategy}.
+     * @throws NullPointerException     if the given {@code name} is null.
+     */
     public static OffsetResetStrategy forName(final String name) {
+        Objects.requireNonNull(name, "name must not be null");
+
         for (final OffsetResetStrategy value : values()) {
             if (value.name().equalsIgnoreCase(name)) {
                 return value;
@@ -27,5 +46,10 @@ public enum OffsetResetStrategy {
         }
 
         throw new IllegalArgumentException("Unknown offset reset strategy: " + name);
+    }
+
+    @Override
+    public String toString() {
+        return id;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -183,19 +183,14 @@ public enum CompressionType {
         }
     }
 
-    public static CompressionType forName(String name) {
-        if (NONE.name.equals(name))
-            return NONE;
-        else if (GZIP.name.equals(name))
-            return GZIP;
-        else if (SNAPPY.name.equals(name))
-            return SNAPPY;
-        else if (LZ4.name.equals(name))
-            return LZ4;
-        else if (ZSTD.name.equals(name))
-            return ZSTD;
-        else
-            throw new IllegalArgumentException("Unknown compression name: " + name);
+    public static CompressionType forName(final String name) {
+        for (final CompressionType value : values()) {
+            if (value.name.equalsIgnoreCase(name)) {
+                return value;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown compression name: " + name);
     }
 
     // We should only have a runtime dependency on compression algorithms in case the native libraries don't support

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -25,9 +25,12 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 
-import static org.junit.Assert.assertFalse;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class ConsumerConfigTest {
@@ -129,5 +132,27 @@ public class ConsumerConfigTest {
         properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClassName);
         properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClassName);
         assertFalse(new ConsumerConfig(properties).getBoolean(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED));
+    }
+
+    @Test
+    public void testOffsetResetStrategy() {
+        assertThrows(NullPointerException.class, () -> OffsetResetStrategy.forName(null));
+
+        assertEquals("earliest", OffsetResetStrategy.EARLIEST.toString());
+        assertEquals("latest", OffsetResetStrategy.LATEST.toString());
+        assertEquals("none", OffsetResetStrategy.NONE.toString());
+
+        final Function<String, OffsetResetStrategy> config = (value) -> {
+            final Properties properties = new Properties();
+            properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClassName);
+            properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClassName);
+            properties.setProperty(AUTO_OFFSET_RESET_CONFIG, value);
+            return OffsetResetStrategy.forName(
+                new ConsumerConfig(properties).getString(AUTO_OFFSET_RESET_CONFIG)
+            );
+        };
+        assertEquals(OffsetResetStrategy.EARLIEST, config.apply("earliest"));
+        assertEquals(OffsetResetStrategy.LATEST, config.apply("LATEST"));
+        assertEquals(OffsetResetStrategy.NONE, config.apply("NoNe"));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -52,5 +53,12 @@ public class CompressionTypeTest {
         KafkaLZ4BlockInputStream in = (KafkaLZ4BlockInputStream) CompressionType.LZ4.wrapForInput(
                 buffer, RecordBatch.MAGIC_VALUE_V1, BufferSupplier.create());
         assertFalse(in.ignoreFlagDescriptorChecksum());
+    }
+
+    @Test
+    public void testFromName() {
+        assertEquals(CompressionType.NONE, CompressionType.forName("none"));
+        assertEquals(CompressionType.GZIP, CompressionType.forName("GZIP"));
+        assertEquals(CompressionType.SNAPPY, CompressionType.forName("SnApPy"));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -362,7 +363,7 @@ public class StreamThread extends Thread {
         final Map<String, Object> consumerConfigs = config.getMainConsumerConfigs(applicationId, getConsumerClientId(threadId), threadIdx);
         consumerConfigs.put(StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
 
-        final String originalReset = ((String) consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).toLowerCase(Locale.ROOT);
+        final String originalReset = OffsetResetStrategy.forName((String) consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).toString();
         // If there are any overrides, we never fall through to the consumer, but only handle offset management ourselves.
         if (!builder.latestResetTopicsPattern().pattern().isEmpty() || !builder.earliestResetTopicsPattern().pattern().isEmpty()) {
             consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -52,6 +52,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -361,7 +362,7 @@ public class StreamThread extends Thread {
         final Map<String, Object> consumerConfigs = config.getMainConsumerConfigs(applicationId, getConsumerClientId(threadId), threadIdx);
         consumerConfigs.put(StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
 
-        final String originalReset = (String) consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+        final String originalReset = ((String) consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).toLowerCase(Locale.ROOT);
         // If there are any overrides, we never fall through to the consumer, but only handle offset management ourselves.
         if (!builder.latestResetTopicsPattern().pattern().isEmpty() || !builder.earliestResetTopicsPattern().pattern().isEmpty()) {
             consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");


### PR DESCRIPTION
This allows the configuration values for CompressionType in the ProducerConfig and the OffsetResetStrategy in the ConsumerConfig to be specified regardless of their case.