### PR TITLE
KAFKA-10510: Validate replication factor consistency on reassignment

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1575,6 +1575,11 @@ class KafkaController(val config: KafkaConfig,
         }
       }
 
+      validateReplicationFactors(partitionsToReassign).forKeyValue { (tp, apiError) =>
+        partitionsToReassign.remove(tp)
+        reassignmentResults.put(tp, apiError)
+      }
+
       // The latest reassignment (whether by API or through zk) always takes precedence,
       // so remove from active zk reassignment (if one exists)
       maybeRemoveFromZkReassignment((tp, _) => partitionsToReassign.contains(tp))
@@ -1605,6 +1610,26 @@ class KafkaController(val config: KafkaConfig,
           s"Replica assignment has brokers that are not alive. Replica list: " +
             s"${newAssignment.addingReplicas}, live broker list: ${controllerContext.liveBrokerIds}"))
       else None
+    }
+  }
+
+  private def validateReplicationFactors(partitionsToReassign: Map[TopicPartition, ReplicaAssignment]): Map[TopicPartition, ApiError] = {
+    partitionsToReassign.groupBy(_._1.topic()).flatMap {
+      case (topic, newAssignmentsForTopic) =>
+        val existingAssignmentsForTopic = controllerContext.partitionFullReplicaAssignmentForTopic(topic)
+        val targetAssignmentsForTopic = mutable.Map[TopicPartition, ReplicaAssignment]()
+        targetAssignmentsForTopic ++= existingAssignmentsForTopic
+        targetAssignmentsForTopic ++= newAssignmentsForTopic
+        val targetReplicationFactors = targetAssignmentsForTopic.map(_._2.targetReplicas.size).toSet
+        if (targetReplicationFactors.size > 1) {
+          val sortedPartitions = targetAssignmentsForTopic.toSeq.sortBy { case (tp, _) => tp.partition() }
+          val partitions = sortedPartitions.map { case (tp, _) => tp.partition() }
+          val replicationFactors = sortedPartitions.map { case (_, assignment) => assignment.targetReplicas.size }
+          val error = new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+            s"Inconsistent replication factor between partitions. Partitions [${partitions.mkString(", ")}]" +
+              s" will have replication factors [${replicationFactors.mkString(", ")}] respectively.")
+          newAssignmentsForTopic.map { case (tp, _) => (tp, error) }
+        } else Map.empty
     }
   }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1629,7 +1629,7 @@ class KafkaController(val config: KafkaConfig,
             s"Inconsistent replication factor between partitions. Partitions [${partitions.mkString(", ")}]" +
               s" will have replication factors [${replicationFactors.mkString(", ")}] respectively.")
           newAssignmentsForTopic.map { case (tp, _) => (tp, error) }
-        } else Map.empty
+        } else Map.empty[TopicPartition, ApiError]
     }
   }
 


### PR DESCRIPTION
This patch introduces server-side validation that checks if applying requested reassignment won't lead to a situation where different partitions of the same topic have different replication factors. 

If a given partition has a pending reassignment, then the target replication factor is used by the validator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
