### PR TITLE
MINOR: Fix NPE in KafkaAdminClient.describeUserScramCredentials

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -116,6 +116,7 @@ import org.apache.kafka.common.message.DescribeLogDirsRequestData;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData.DescribableLogDirTopic;
 import org.apache.kafka.common.message.DescribeLogDirsResponseData;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData;
+import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData.UserName;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.ExpireDelegationTokenRequestData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
@@ -4166,10 +4167,22 @@ public class KafkaAdminClient extends AdminClient {
         Call call = new Call("describeUserScramCredentials", calcDeadlineMs(now, options.timeoutMs()),
                 new LeastLoadedNodeProvider()) {
             @Override
-            public DescribeUserScramCredentialsRequest.Builder createRequest(int timeoutMs) {
-                return new DescribeUserScramCredentialsRequest.Builder(
-                        new DescribeUserScramCredentialsRequestData().setUsers(users.stream().map(user ->
-                                new DescribeUserScramCredentialsRequestData.UserName().setName(user)).collect(Collectors.toList())));
+            public DescribeUserScramCredentialsRequest.Builder createRequest(final int timeoutMs) {
+                final DescribeUserScramCredentialsRequestData requestData = new DescribeUserScramCredentialsRequestData();
+
+                if (users != null && !users.isEmpty()) {
+                    final List<UserName> userNames = new ArrayList<>(users.size());
+
+                    for (final String user : users) {
+                        if (user != null) {
+                            userNames.add(new UserName().setName(user));
+                        }
+                    }
+
+                    requestData.setUsers(userNames);
+                }
+
+                return new DescribeUserScramCredentialsRequest.Builder(requestData);
             }
 
             @Override

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4492,10 +4492,10 @@ public class KafkaAdminClientTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
 
             final String user0Name = "user0";
-            ScramMechanism user0ScramMechanism0 = ScramMechanism.SCRAM_SHA_256;
-            int user0Iterations0 = 4096;
-            ScramMechanism user0ScramMechanism1 = ScramMechanism.SCRAM_SHA_512;
-            int user0Iterations1 = 8192;
+            final ScramMechanism user0ScramMechanism0 = ScramMechanism.SCRAM_SHA_256;
+            final int user0Iterations0 = 4096;
+            final ScramMechanism user0ScramMechanism1 = ScramMechanism.SCRAM_SHA_512;
+            final int user0Iterations1 = 8192;
 
             final CredentialInfo user0CredentialInfo0 = new CredentialInfo();
             user0CredentialInfo0.setMechanism(user0ScramMechanism0.type());
@@ -4505,50 +4505,57 @@ public class KafkaAdminClientTest {
             user0CredentialInfo1.setIterations(user0Iterations1);
 
             final String user1Name = "user1";
-            ScramMechanism user1ScramMechanism = ScramMechanism.SCRAM_SHA_256;
-            int user1Iterations = 4096;
+            final ScramMechanism user1ScramMechanism = ScramMechanism.SCRAM_SHA_256;
+            final int user1Iterations = 4096;
 
             final CredentialInfo user1CredentialInfo = new CredentialInfo();
             user1CredentialInfo.setMechanism(user1ScramMechanism.type());
             user1CredentialInfo.setIterations(user1Iterations);
 
-            DescribeUserScramCredentialsResponseData responseData = new DescribeUserScramCredentialsResponseData();
+            final DescribeUserScramCredentialsResponseData responseData = new DescribeUserScramCredentialsResponseData();
             responseData.setResults(Arrays.asList(
                     new DescribeUserScramCredentialsResponseData.DescribeUserScramCredentialsResult()
                             .setUser(user0Name)
                             .setCredentialInfos(Arrays.asList(user0CredentialInfo0, user0CredentialInfo1)),
                     new DescribeUserScramCredentialsResponseData.DescribeUserScramCredentialsResult()
                             .setUser(user1Name)
-                            .setCredentialInfos(Arrays.asList(user1CredentialInfo))));
+                            .setCredentialInfos(singletonList(user1CredentialInfo))));
+            final DescribeUserScramCredentialsResponse response = new DescribeUserScramCredentialsResponse(responseData);
 
-            env.kafkaClient().prepareResponse(new DescribeUserScramCredentialsResponse(responseData));
+            final Set<String> usersRequestedSet = new HashSet<>();
+            usersRequestedSet.add(user0Name);
+            usersRequestedSet.add(user1Name);
 
-            List<String> usersRequestedList = asList(user0Name, user1Name);
-            Set<String> usersRequestedSet = usersRequestedList.stream().collect(Collectors.toSet());
-            DescribeUserScramCredentialsResult result = env.adminClient().describeUserScramCredentials(usersRequestedList);
-            Map<String, UserScramCredentialsDescription> descriptionResults = result.all().get();
-            KafkaFuture<UserScramCredentialsDescription> user0DescriptionFuture = result.description(user0Name);
-            KafkaFuture<UserScramCredentialsDescription> user1DescriptionFuture = result.description(user1Name);
-            Set<String> usersDescribedFromUsersSet = result.users().get().stream().collect(Collectors.toSet());
-            assertEquals(usersRequestedSet, usersDescribedFromUsersSet);
-            Set<String> usersDescribedFromMapKeySet = descriptionResults.keySet();
-            assertEquals(usersRequestedSet, usersDescribedFromMapKeySet);
+            for (final List<String> users : asList(null, new ArrayList<String>(), asList(user0Name, null, user1Name))) {
+                env.kafkaClient().prepareResponse(response);
 
-            UserScramCredentialsDescription userScramCredentialsDescription0 = descriptionResults.get(user0Name);
-            assertEquals(user0Name, userScramCredentialsDescription0.name());
-            assertEquals(2, userScramCredentialsDescription0.credentialInfos().size());
-            assertEquals(user0ScramMechanism0, userScramCredentialsDescription0.credentialInfos().get(0).mechanism());
-            assertEquals(user0Iterations0, userScramCredentialsDescription0.credentialInfos().get(0).iterations());
-            assertEquals(user0ScramMechanism1, userScramCredentialsDescription0.credentialInfos().get(1).mechanism());
-            assertEquals(user0Iterations1, userScramCredentialsDescription0.credentialInfos().get(1).iterations());
-            assertEquals(userScramCredentialsDescription0, user0DescriptionFuture.get());
+                final DescribeUserScramCredentialsResult result = env.adminClient().describeUserScramCredentials(users);
+                final Map<String, UserScramCredentialsDescription> descriptionResults = result.all().get();
+                final KafkaFuture<UserScramCredentialsDescription> user0DescriptionFuture = result.description(user0Name);
+                final KafkaFuture<UserScramCredentialsDescription> user1DescriptionFuture = result.description(user1Name);
 
-            UserScramCredentialsDescription userScramCredentialsDescription1 = descriptionResults.get(user1Name);
-            assertEquals(user1Name, userScramCredentialsDescription1.name());
-            assertEquals(1, userScramCredentialsDescription1.credentialInfos().size());
-            assertEquals(user1ScramMechanism, userScramCredentialsDescription1.credentialInfos().get(0).mechanism());
-            assertEquals(user1Iterations, userScramCredentialsDescription1.credentialInfos().get(0).iterations());
-            assertEquals(userScramCredentialsDescription1, user1DescriptionFuture.get());
+                final Set<String> usersDescribedFromUsersSet = new HashSet<>(result.users().get());
+                assertEquals(usersRequestedSet, usersDescribedFromUsersSet);
+
+                final Set<String> usersDescribedFromMapKeySet = descriptionResults.keySet();
+                assertEquals(usersRequestedSet, usersDescribedFromMapKeySet);
+
+                final UserScramCredentialsDescription userScramCredentialsDescription0 = descriptionResults.get(user0Name);
+                assertEquals(user0Name, userScramCredentialsDescription0.name());
+                assertEquals(2, userScramCredentialsDescription0.credentialInfos().size());
+                assertEquals(user0ScramMechanism0, userScramCredentialsDescription0.credentialInfos().get(0).mechanism());
+                assertEquals(user0Iterations0, userScramCredentialsDescription0.credentialInfos().get(0).iterations());
+                assertEquals(user0ScramMechanism1, userScramCredentialsDescription0.credentialInfos().get(1).mechanism());
+                assertEquals(user0Iterations1, userScramCredentialsDescription0.credentialInfos().get(1).iterations());
+                assertEquals(userScramCredentialsDescription0, user0DescriptionFuture.get());
+
+                final UserScramCredentialsDescription userScramCredentialsDescription1 = descriptionResults.get(user1Name);
+                assertEquals(user1Name, userScramCredentialsDescription1.name());
+                assertEquals(1, userScramCredentialsDescription1.credentialInfos().size());
+                assertEquals(user1ScramMechanism, userScramCredentialsDescription1.credentialInfos().get(0).mechanism());
+                assertEquals(user1Iterations, userScramCredentialsDescription1.credentialInfos().get(0).iterations());
+                assertEquals(userScramCredentialsDescription1, user1DescriptionFuture.get());
+            }
         }
     }
 


### PR DESCRIPTION
This bug was detected as part of #9370. @rondagostino and I decided that this should be fixed right away and not until the other PR eventually gets merged (or not). I am not only properly handling `null` everywhere but also rewrote the function to be more readable (and more efficient, but I think this is not important here). I extended the existing test to go through all possible permutations of the users argument to make sure that we never get an NPE.