### PR TITLE
KAFKA-10574: Fix infinite loop in Values::parseString

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
@@ -1193,7 +1193,7 @@ public class Values {
             boolean escaped = false;
             int start = iter.getIndex();
             char c = iter.current();
-            while (c != CharacterIterator.DONE) {
+            while (canConsumeNextToken()) {
                 switch (c) {
                     case '\\':
                         escaped = !escaped;

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -24,9 +24,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.text.CharacterIterator;
 import java.text.SimpleDateFormat;
-import java.text.StringCharacterIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,7 +78,10 @@ public class ValuesTest {
 
     @Test(timeout = 5000)
     public void shouldNotEncounterInfiniteLoop() {
-        byte[] bytes = new byte[] { -17, -65,  -65 };
+        // This byte sequence gets parsed as CharacterIterator.DONE and can cause issues if
+        // comparisons to that character are done to check if the end of a string has been reached.
+        // For more information, see https://issues.apache.org/jira/browse/KAFKA-10574
+        byte[] bytes = new byte[] {-17, -65,  -65};
         String str = new String(bytes, StandardCharsets.UTF_8);
         SchemaAndValue schemaAndValue = Values.parseString(str);
         assertEquals(Type.STRING, schemaAndValue.schema().type());

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -23,7 +23,10 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.text.CharacterIterator;
 import java.text.SimpleDateFormat;
+import java.text.StringCharacterIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,6 +76,15 @@ public class ValuesTest {
         STRING_LIST.add("bar");
         INT_LIST.add(1234567890);
         INT_LIST.add(-987654321);
+    }
+
+    @Test(timeout = 5000)
+    public void shouldNotEncounterInfiniteLoop() {
+        byte[] bytes = new byte[] { -17, -65,  -65 };
+        String str = new String(bytes, StandardCharsets.UTF_8);
+        SchemaAndValue schemaAndValue = Values.parseString(str);
+        assertEquals(Type.STRING, schemaAndValue.schema().type());
+        assertEquals(str, schemaAndValue.value());
     }
 
     @Test


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-10574)

The special byte sequence `0xEF, 0xBF, 0xBF`, when parsed as a UTF-8 string, causes the `StringCharacterIterator` to return `CharacterIterator.DONE` from its `next()`, `current()`, and other similar methods. This caused an infinite loop in the `Values` class whenever that byte sequence was encountered.

The fix is pretty simple. To see if we're at the end of a string, we compare `StandardCharacterIterator::getIndex` to `StandardCharacterIterator::getEndIndex`, instead of comparing the last-read character to `CharacterIterator.DONE` (since that character may occur in strings that we're parsing).

I've added a unit test that replicates this bug (when the fix in the `Values` class is not present). I gave it a timeout of five seconds in case someone accidentally re-creates the infinite loop in order to save some time and potential confusion.

All existing unit tests for the `Values` class pass with this change.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
