### PR TITLE
MINOR: Remove `TargetVoters` from `DescribeQuorum`

### DIFF
--- a/clients/src/main/resources/common/message/DescribeQuorumResponse.json
+++ b/clients/src/main/resources/common/message/DescribeQuorumResponse.json
@@ -37,7 +37,6 @@
           "about": "The latest known leader epoch"},
         { "name": "HighWatermark", "type": "int64", "versions": "0+"},
         { "name": "CurrentVoters", "type": "[]ReplicaState", "versions": "0+" },
-        { "name": "TargetVoters", "type": "[]ReplicaState", "versions": "0+" },
         { "name": "Observers", "type": "[]ReplicaState", "versions": "0+" }
       ]}
     ]}],


### PR DESCRIPTION
This field is leftover from the early days of the KIP when it covered reassignment. Since the API is not exposed yet, should be no harm updating the first version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
