### PR TITLE
MINOR: Move `RaftRequestHandler` to `tools` package

### DIFF
--- a/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-package kafka.server
+package kafka.tools
 
 import java.util.Collections
 
 import kafka.network.RequestChannel
 import kafka.raft.KafkaNetworkChannel
+import kafka.server.ApiRequestHandler
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.feature.Features
@@ -34,12 +35,16 @@ import org.apache.kafka.raft.{AckMode, RaftClient}
 
 import scala.jdk.CollectionConverters._
 
-class RaftRequestHandler(networkChannel: KafkaNetworkChannel,
-                         requestChannel: RequestChannel,
-                         time: Time,
-                         client: RaftClient,
-                         metadataPartition: TopicPartition)
-  extends ApiRequestHandler with Logging {
+/**
+ * Simple request handler implementation for use by [[TestRaftServer]].
+ */
+class TestRaftRequestHandler(
+  networkChannel: KafkaNetworkChannel,
+  requestChannel: RequestChannel,
+  time: Time,
+  client: RaftClient,
+  metadataPartition: TopicPartition
+) extends ApiRequestHandler with Logging {
 
   override def handle(request: RequestChannel.Request): Unit = {
     try {

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -28,7 +28,7 @@ import kafka.log.{Log, LogConfig, LogManager}
 import kafka.network.{ConnectionQuotas, Processor, RequestChannel, SocketServer}
 import kafka.raft.{KafkaFuturePurgatory, KafkaMetadataLog, KafkaNetworkChannel}
 import kafka.security.CredentialProvider
-import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaRequestHandlerPool, KafkaServer, LogDirFailureChannel, RaftRequestHandler}
+import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaRequestHandlerPool, KafkaServer, LogDirFailureChannel}
 import kafka.utils.timer.SystemTimer
 import kafka.utils.{CommandLineUtils, CoreUtils, Exit, KafkaScheduler, Logging, ShutdownableThread}
 import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient}
@@ -100,7 +100,7 @@ class TestRaftServer(val config: KafkaConfig) extends Logging {
 
     raftClient.initialize()
 
-    val requestHandler = new RaftRequestHandler(
+    val requestHandler = new TestRaftRequestHandler(
       networkChannel,
       socketServer.dataPlaneRequestChannel,
       time,


### PR DESCRIPTION
To avoid confusion since it is only used by `TestRaftServer`, this PR moves `RaftRequestHandler` to the `tools` package and renames it to `TestRaftRequestHandler`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
