### PR TITLE
MINOR: Annotate test BlockingConnectorTest as integration test

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -28,9 +28,11 @@ import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +49,11 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.junit.Assert.assertThrows;
 
+/**
+ * Tests situations during which certain connector operations, such as start, validation,
+ * configuration and others, take longer than expected.
+ */
+@Category(IntegrationTest.class)
 public class BlockingConnectorTest {
 
     private static final Logger log = LoggerFactory.getLogger(BlockingConnectorTest.class);


### PR DESCRIPTION
`BlockingConnectorTest` was incorrectly running as a unit test.
Categorize this test correctly as integration test by adding the appropriate annotation

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
