### PR TITLE
KAFKA-7334: Suggest changing config for state.dir in case of FileNotF…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -446,7 +446,9 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         try {
             checkpointFile.write(filteredOffsets);
         } catch (final IOException e) {
-            log.warn("Failed to write offset checkpoint file to {} for global stores: {}", checkpointFile, e);
+            log.warn("Failed to write offset checkpoint file to {} for global stores: {}." +
+                " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
+                " You can change location for state.dir to resolve problem", checkpointFile, e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -447,8 +447,8 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
             checkpointFile.write(filteredOffsets);
         } catch (final IOException e) {
             log.warn("Failed to write offset checkpoint file to {} for global stores: {}." +
-                " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
-                " You can change location for state.dir to resolve problem", checkpointFile, e);
+                " This may occur if OS cleaned the state.dir in case when it is located in the (default) /tmp/kafka-streams directory." +
+                " Changing the location of state.dir may resolve the problem", checkpointFile, e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -605,7 +605,9 @@ public class ProcessorStateManager implements StateManager {
         } catch (final IOException e) {
             log.warn("Failed to write offset checkpoint file to [{}]." +
                 " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
-                " You can change location for state.dir to resolve problem", checkpointFile, e);
+                " You can change location for state.dir to resolve problem." +
+                " This can also occur due to running multiple instances on the same machine using the same state dir.",
+                checkpointFile, e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -605,8 +605,8 @@ public class ProcessorStateManager implements StateManager {
         } catch (final IOException e) {
             log.warn("Failed to write offset checkpoint file to [{}]." +
                 " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
-                " You can change location for state.dir to resolve problem." +
-                " This can also occur due to running multiple instances on the same machine using the same state dir.",
+                " This may also occur due to running multiple instances on the same machine using the same state dir." +
+                " Changing the location of state.dir may resolve the problem.",
                 checkpointFile, e);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -603,7 +603,9 @@ public class ProcessorStateManager implements StateManager {
         try {
             checkpointFile.write(checkpointingOffsets);
         } catch (final IOException e) {
-            log.warn("Failed to write offset checkpoint file to [{}]", checkpointFile, e);
+            log.warn("Failed to write offset checkpoint file to [{}]." +
+                " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
+                " You can change location for state.dir to resolve problem", checkpointFile, e);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -98,6 +98,10 @@ public class StateDirectory {
             throw new ProcessorStateException(
                 String.format("state directory [%s] doesn't exist and couldn't be created", stateDir.getPath()));
         }
+        if (stateDirName.startsWith("/tmp")) {
+            log.warn("Using /tmp directory in the state.dir property can cause failures with writing the checkpoint file" +
+                " due to the fact that this directory can be cleared by the OS");
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -98,7 +98,7 @@ public class StateDirectory {
             throw new ProcessorStateException(
                 String.format("state directory [%s] doesn't exist and couldn't be created", stateDir.getPath()));
         }
-        if (stateDirName.startsWith("/tmp")) {
+        if (hasPersistentStores && stateDirName.startsWith("/tmp")) {
             log.warn("Using /tmp directory in the state.dir property can cause failures with writing the checkpoint file" +
                 " due to the fact that this directory can be cleared by the OS");
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -776,7 +776,9 @@ public class ProcessorStateManagerTest {
             for (final LogCaptureAppender.Event event : appender.getEvents()) {
                 if ("WARN".equals(event.getLevel())
                     && event.getMessage().startsWith("process-state-manager-test Failed to write offset checkpoint file to [")
-                    && event.getMessage().endsWith(".checkpoint]")
+                    && event.getMessage().endsWith(".checkpoint]." +
+                        " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
+                        " You can change location for state.dir to resolve problem")
                     && event.getThrowableInfo().get().startsWith("java.io.FileNotFoundException: ")) {
 
                     foundExpectedLogMessage = true;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -778,8 +778,8 @@ public class ProcessorStateManagerTest {
                     && event.getMessage().startsWith("process-state-manager-test Failed to write offset checkpoint file to [")
                     && event.getMessage().endsWith(".checkpoint]." +
                         " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
-                        " You can change location for state.dir to resolve problem." +
-                        " This can also occur due to running multiple instances on the same machine using the same state dir.")
+                        " This may also occur due to running multiple instances on the same machine using the same state dir." +
+                        " Changing the location of state.dir may resolve the problem.")
                     && event.getThrowableInfo().get().startsWith("java.io.FileNotFoundException: ")) {
 
                     foundExpectedLogMessage = true;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -778,7 +778,8 @@ public class ProcessorStateManagerTest {
                     && event.getMessage().startsWith("process-state-manager-test Failed to write offset checkpoint file to [")
                     && event.getMessage().endsWith(".checkpoint]." +
                         " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
-                        " You can change location for state.dir to resolve problem")
+                        " You can change location for state.dir to resolve problem." +
+                        " This can also occur due to running multiple instances on the same machine using the same state dir.")
                     && event.getThrowableInfo().get().startsWith("java.io.FileNotFoundException: ")) {
 
                     foundExpectedLogMessage = true;


### PR DESCRIPTION
When state.dir is left at default configuration, there is a chance that certain files under the state directory are cleaned by OS since the default dir starts with /tmp/kafka-streams.

I've added suggestion to change state.dir config in the exception message.
(https://issues.apache.org/jira/browse/KAFKA-7334)