### PR TITLE
KAFKA-10455: Ensure that probing rebalances always occur

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -236,7 +236,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // Adds the following information to subscription
         // 1. Client UUID (a unique id assigned to an instance of KafkaStreams)
         // 2. Map from task id to its overall lag
-        // 3. Unique Field to ensure a rebalance when a thread rejoins
+        // 3. Unique Field to ensure a rebalance when a thread rejoins by forcing the user data to be different
 
         handleRebalanceStart(topics);
         if (usedSubscriptionMetadataVersion >= 8) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -182,7 +182,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private AssignmentListener assignmentListener;
 
     private Supplier<TaskAssignor> taskAssignorSupplier;
-
     private byte[] uniqueField;
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -215,7 +215,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         taskAssignorSupplier = assignorConfiguration::taskAssignor;
         assignmentListener = assignorConfiguration.assignmentListener();
         uniqueField = usedSubscriptionMetadataVersion >= 8 ? new byte[1] : new byte[0];
-
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -1590,6 +1590,10 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         return taskManager;
     }
 
+    protected byte[] uniqueField() {
+        return uniqueField;
+    }
+
     protected void handleRebalanceStart(final Set<String> topics) {
         taskManager.handleRebalanceStart(topics);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -213,7 +213,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         rebalanceProtocol = assignorConfiguration.rebalanceProtocol();
         taskAssignorSupplier = assignorConfiguration::taskAssignor;
         assignmentListener = assignorConfiguration.assignmentListener();
-        uniqueField = usedSubscriptionMetadataVersion >= 8 ? new byte[1] : new byte[0];
+        uniqueField = new byte[1];
     }
 
     @Override
@@ -239,9 +239,8 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // 3. Unique Field to ensure a rebalance when a thread rejoins by forcing the user data to be different
 
         handleRebalanceStart(topics);
-        if (usedSubscriptionMetadataVersion >= 8) {
-            uniqueField[0]++;
-        }
+        uniqueField[0]++;
+
 
         return new SubscriptionInfo(
             usedSubscriptionMetadataVersion,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -241,7 +241,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         handleRebalanceStart(topics);
         uniqueField[0]++;
 
-
         return new SubscriptionInfo(
             usedSubscriptionMetadataVersion,
             LATEST_SUPPORTED_VERSION,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -182,7 +182,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private AssignmentListener assignmentListener;
 
     private Supplier<TaskAssignor> taskAssignorSupplier;
-    private byte[] uniqueField;
+    private byte uniqueField;
 
     /**
      * We need to have the PartitionAssignor and its StreamThread to be mutually accessible since the former needs
@@ -213,7 +213,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         rebalanceProtocol = assignorConfiguration.rebalanceProtocol();
         taskAssignorSupplier = assignorConfiguration::taskAssignor;
         assignmentListener = assignorConfiguration.assignmentListener();
-        uniqueField = new byte[1];
+        uniqueField = 0;
     }
 
     @Override
@@ -239,7 +239,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // 3. Unique Field to ensure a rebalance when a thread rejoins by forcing the user data to be different
 
         handleRebalanceStart(topics);
-        uniqueField[0]++;
+        uniqueField++;
 
         return new SubscriptionInfo(
             usedSubscriptionMetadataVersion,
@@ -1590,7 +1590,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         return taskManager;
     }
 
-    protected byte[] uniqueField() {
+    protected byte uniqueField() {
         return uniqueField;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -179,6 +179,7 @@ public class AssignmentInfo {
                     out.writeInt(errCode);
                     break;
                 case 7:
+                case 8:
                     out.writeInt(usedVersion);
                     out.writeInt(commonlySupportedVersion);
                     encodeActiveAndStandbyTaskAssignment(out);
@@ -352,6 +353,7 @@ public class AssignmentInfo {
                     assignmentInfo.errCode = in.readInt();
                     break;
                 case 7:
+                case 8:
                     commonlySupportedVersion = in.readInt();
                     assignmentInfo = new AssignmentInfo(usedVersion, commonlySupportedVersion);
                     decodeActiveTasks(assignmentInfo, in);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StreamsAssignmentProtocolVersions.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StreamsAssignmentProtocolVersions.java
@@ -19,7 +19,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 public final class StreamsAssignmentProtocolVersions {
     public static final int UNKNOWN = -1;
     public static final int EARLIEST_PROBEABLE_VERSION = 3;
-    public static final int LATEST_SUPPORTED_VERSION = 7;
+    public static final int LATEST_SUPPORTED_VERSION = 8;
 
     private StreamsAssignmentProtocolVersions() {}
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -87,7 +87,6 @@ public class SubscriptionInfo {
         final SubscriptionInfoData data = new SubscriptionInfoData();
         data.setVersion(version);
         data.setProcessId(processId);
-
         data.setUniqueField(uniqueField);
 
         if (version >= 2) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -82,7 +82,7 @@ public class SubscriptionInfo {
                             final UUID processId,
                             final String userEndPoint,
                             final Map<TaskId, Long> taskOffsetSums,
-                            final byte[] uniqueField) {
+                            final byte uniqueField) {
         validateVersions(version, latestSupportedVersion);
         final SubscriptionInfoData data = new SubscriptionInfoData();
         data.setVersion(version);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -52,7 +52,6 @@ public class SubscriptionInfo {
     private Set<TaskId> prevTasksCache = null;
     private Set<TaskId> standbyTasksCache = null;
     private Map<TaskId, Long> taskOffsetSumsCache = null;
-    private byte uniqueField;
 
     static {
         // Just statically check to make sure that the generated code always stays in sync with the overall protocol

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -52,6 +52,7 @@ public class SubscriptionInfo {
     private Set<TaskId> prevTasksCache = null;
     private Set<TaskId> standbyTasksCache = null;
     private Map<TaskId, Long> taskOffsetSumsCache = null;
+    private byte uniqueField;
 
     static {
         // Just statically check to make sure that the generated code always stays in sync with the overall protocol
@@ -81,11 +82,14 @@ public class SubscriptionInfo {
                             final int latestSupportedVersion,
                             final UUID processId,
                             final String userEndPoint,
-                            final Map<TaskId, Long> taskOffsetSums) {
+                            final Map<TaskId, Long> taskOffsetSums,
+                            final byte[] uniqueField) {
         validateVersions(version, latestSupportedVersion);
         final SubscriptionInfoData data = new SubscriptionInfoData();
         data.setVersion(version);
         data.setProcessId(processId);
+
+        data.setUniqueField(uniqueField);
 
         if (version >= 2) {
             data.setUserEndPoint(userEndPoint == null

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfo.java
@@ -87,7 +87,6 @@ public class SubscriptionInfo {
         final SubscriptionInfoData data = new SubscriptionInfoData();
         data.setVersion(version);
         data.setProcessId(processId);
-        data.setUniqueField(uniqueField);
 
         if (version >= 2) {
             data.setUserEndPoint(userEndPoint == null
@@ -96,6 +95,9 @@ public class SubscriptionInfo {
         }
         if (version >= 3) {
             data.setLatestSupportedVersion(latestSupportedVersion);
+        }
+        if (version >= 8) {
+            data.setUniqueField(uniqueField);
         }
 
         this.data = data;

--- a/streams/src/main/resources/common/message/SubscriptionInfoData.json
+++ b/streams/src/main/resources/common/message/SubscriptionInfoData.json
@@ -56,7 +56,7 @@
     {
       "name": "uniqueField",
       "versions": "8+",
-      "type": "bytes"
+      "type": "int8"
     }
   ],
   "commonStructs": [

--- a/streams/src/main/resources/common/message/SubscriptionInfoData.json
+++ b/streams/src/main/resources/common/message/SubscriptionInfoData.json
@@ -15,7 +15,7 @@
 
 {
   "name": "SubscriptionInfoData",
-  "validVersions": "1-7",
+  "validVersions": "1-8",
   "fields": [
     {
       "name": "version",
@@ -52,6 +52,11 @@
       "name": "taskOffsetSums",
       "versions": "7+",
       "type": "[]TaskOffsetSum"
+    },
+    {
+      "name": "uniqueField",
+      "versions": "8+",
+      "type": "bytes"
     }
   ],
   "commonStructs": [

--- a/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -287,6 +287,7 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
                 mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
                 mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100"),
                 mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
+                // Increasing the number of threads to ensure that a rebalance happens each time a consumer sends a rejoin
                 mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 40)
             )
         );

--- a/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -286,7 +286,8 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
                 mkEntry(StreamsConfig.PROBING_REBALANCE_INTERVAL_MS_CONFIG, "60000"),
                 mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
                 mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100"),
-                mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName())
+                mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
+                mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 40)
             )
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -287,7 +287,7 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
                 mkEntry(StreamsConfig.InternalConfig.ASSIGNMENT_LISTENER, configuredAssignmentListener),
                 mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100"),
                 mkEntry(StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS, HighAvailabilityTaskAssignor.class.getName()),
-                // Increasing the number of threads to ensure that a rebalance happens each time a consumer sends a rejoin
+                // Increasing the number of threads to ensure that a rebalance happens each time a consumer sends a rejoin (KAFKA-10455)
                 mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 40)
             )
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
@@ -325,7 +324,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
     private static SubscriptionInfo getInfo(final UUID processId,
                                             final Set<TaskId> prevTasks) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks), Bytes.EMPTY);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks), (byte) 0);
     }
 
     // Stub offset sums for when we only care about the prev/standby task sets, not the actual offsets

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HighAvailabilityStreamsPartitionAssignorTest.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsConfig.InternalConfig;
@@ -324,7 +325,7 @@ public class HighAvailabilityStreamsPartitionAssignorTest {
     private static SubscriptionInfo getInfo(final UUID processId,
                                             final Set<TaskId> prevTasks) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks));
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks), Bytes.EMPTY);
     }
 
     // Stub offset sums for when we only care about the prev/standby task sets, not the actual offsets

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2041,9 +2041,7 @@ public class StreamsPartitionAssignorTest {
 
         for (int i = 0; i < 127; i++) {
             partitionAssignor.subscriptionUserData(topics);
-            System.out.println("HERE " + partitionAssignor.uniqueField()[0]);
         }
-        System.out.println(partitionAssignor.uniqueField()[0]);
         assertEquals(127, partitionAssignor.uniqueField()[0]);
         partitionAssignor.subscriptionUserData(topics);
         assertEquals(-128, partitionAssignor.uniqueField()[0]);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -188,7 +188,6 @@ public class StreamsPartitionAssignorTest {
     private final AtomicInteger assignmentError = new AtomicInteger();
     private final AtomicLong nextScheduledRebalanceMs = new AtomicLong(Long.MAX_VALUE);
     private final MockTime time = new MockTime();
-
     private final byte[] uniqueField = {1};
 
     private Map<String, Object> configProps() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2023,18 +2023,12 @@ public class StreamsPartitionAssignorTest {
         configureDefaultPartitionAssignor();
         final Set<String> topics = mkSet("input");
 
-        final Subscription subscription = new Subscription(new ArrayList<>(topics), partitionAssignor.subscriptionUserData(topics));
-
-        final SubscriptionInfo info1 = new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, UUID_1, "", getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS), uniqueField);
-        assertEquals(info1, SubscriptionInfo.decode(subscription.userData()));
-
-        uniqueField[0]++;
-        final SubscriptionInfo info2 = new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, UUID_1, "", getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS), uniqueField);
-        assertEquals(info2, SubscriptionInfo.decode(partitionAssignor.subscriptionUserData(topics)));
-
-        uniqueField[0]++;
-        final SubscriptionInfo info3 = new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, UUID_1, "", getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS), uniqueField);
-        assertEquals(info3, SubscriptionInfo.decode(partitionAssignor.subscriptionUserData(topics)));
+        final Subscription subscription = new Subscription(new ArrayList<>(topics), defaultSubscriptionInfo.encode());
+        assertEquals(0, partitionAssignor.uniqueField()[0]);
+        partitionAssignor.subscriptionUserData(topics);
+        assertEquals(1, partitionAssignor.uniqueField()[0]);
+        partitionAssignor.subscriptionUserData(topics);
+        assertEquals(2, partitionAssignor.uniqueField()[0]);
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -2131,7 +2132,7 @@ public class StreamsPartitionAssignorTest {
                                                            final Set<TaskId> prevTasks,
                                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(
-            version, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks));
+            version, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
     }
 
     // Stub offset sums for when we only care about the prev/standby task sets, not the actual offsets

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2022,13 +2022,11 @@ public class StreamsPartitionAssignorTest {
         configureDefaultPartitionAssignor();
         final Set<String> topics = mkSet("input");
 
-        //assertEquals(1, partitionAssignor.uniqueField().length);
         assertEquals(0, partitionAssignor.uniqueField());
         partitionAssignor.subscriptionUserData(topics);
         assertEquals(1, partitionAssignor.uniqueField());
         partitionAssignor.subscriptionUserData(topics);
         assertEquals(2, partitionAssignor.uniqueField());
-        //assertEquals(1, partitionAssignor.uniqueField().length);
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -189,6 +189,8 @@ public class StreamsPartitionAssignorTest {
     private final AtomicLong nextScheduledRebalanceMs = new AtomicLong(Long.MAX_VALUE);
     private final MockTime time = new MockTime();
 
+    private final byte[] uniqueField = {1};
+
     private Map<String, Object> configProps() {
         final Map<String, Object> configurationMap = new HashMap<>();
         configurationMap.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
@@ -483,8 +485,7 @@ public class StreamsPartitionAssignorTest {
 
         Collections.sort(subscription.topics());
         assertEquals(asList("topic1", "topic2"), subscription.topics());
-
-        final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks);
+        final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks, uniqueField);
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
     }
 
@@ -510,7 +511,7 @@ public class StreamsPartitionAssignorTest {
         Collections.sort(subscription.topics());
         assertEquals(asList("topic1", "topic2"), subscription.topics());
 
-        final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks);
+        final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks, uniqueField);
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -485,6 +485,7 @@ public class StreamsPartitionAssignorTest {
 
         Collections.sort(subscription.topics());
         assertEquals(asList("topic1", "topic2"), subscription.topics());
+
         final SubscriptionInfo info = getInfo(UUID_1, prevTasks, standbyTasks, uniqueField);
         assertEquals(info, SubscriptionInfo.decode(subscription.userData()));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -36,7 +36,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -188,7 +187,7 @@ public class StreamsPartitionAssignorTest {
     private final AtomicInteger assignmentError = new AtomicInteger();
     private final AtomicLong nextScheduledRebalanceMs = new AtomicLong(Long.MAX_VALUE);
     private final MockTime time = new MockTime();
-    private final byte[] uniqueField = {1};
+    private final byte uniqueField = 1;
 
     private Map<String, Object> configProps() {
         final Map<String, Object> configurationMap = new HashMap<>();
@@ -2023,13 +2022,13 @@ public class StreamsPartitionAssignorTest {
         configureDefaultPartitionAssignor();
         final Set<String> topics = mkSet("input");
 
-        assertEquals(1, partitionAssignor.uniqueField().length);
-        assertEquals(0, partitionAssignor.uniqueField()[0]);
+        //assertEquals(1, partitionAssignor.uniqueField().length);
+        assertEquals(0, partitionAssignor.uniqueField());
         partitionAssignor.subscriptionUserData(topics);
-        assertEquals(1, partitionAssignor.uniqueField()[0]);
+        assertEquals(1, partitionAssignor.uniqueField());
         partitionAssignor.subscriptionUserData(topics);
-        assertEquals(2, partitionAssignor.uniqueField()[0]);
-        assertEquals(1, partitionAssignor.uniqueField().length);
+        assertEquals(2, partitionAssignor.uniqueField());
+        //assertEquals(1, partitionAssignor.uniqueField().length);
 
     }
 
@@ -2042,9 +2041,9 @@ public class StreamsPartitionAssignorTest {
         for (int i = 0; i < 127; i++) {
             partitionAssignor.subscriptionUserData(topics);
         }
-        assertEquals(127, partitionAssignor.uniqueField()[0]);
+        assertEquals(127, partitionAssignor.uniqueField());
         partitionAssignor.subscriptionUserData(topics);
-        assertEquals(-128, partitionAssignor.uniqueField()[0]);
+        assertEquals(-128, partitionAssignor.uniqueField());
     }
 
     private static ByteBuffer encodeFutureSubscription() {
@@ -2163,7 +2162,7 @@ public class StreamsPartitionAssignorTest {
                                                            final Set<TaskId> prevTasks,
                                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(
-            version, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
+            version, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), (byte) 0);
     }
 
     // Stub offset sums for when we only care about the prev/standby task sets, not the actual offsets

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2023,13 +2023,30 @@ public class StreamsPartitionAssignorTest {
         configureDefaultPartitionAssignor();
         final Set<String> topics = mkSet("input");
 
-        final Subscription subscription = new Subscription(new ArrayList<>(topics), defaultSubscriptionInfo.encode());
+        assertEquals(1, partitionAssignor.uniqueField().length);
         assertEquals(0, partitionAssignor.uniqueField()[0]);
         partitionAssignor.subscriptionUserData(topics);
         assertEquals(1, partitionAssignor.uniqueField()[0]);
         partitionAssignor.subscriptionUserData(topics);
         assertEquals(2, partitionAssignor.uniqueField()[0]);
+        assertEquals(1, partitionAssignor.uniqueField().length);
 
+    }
+
+    @Test
+    public void testUniqueFieldOverflow() {
+        createDefaultMockTaskManager();
+        configureDefaultPartitionAssignor();
+        final Set<String> topics = mkSet("input");
+
+        for (int i = 0; i < 127; i++) {
+            partitionAssignor.subscriptionUserData(topics);
+            System.out.println("HERE " + partitionAssignor.uniqueField()[0]);
+        }
+        System.out.println(partitionAssignor.uniqueField()[0]);
+        assertEquals(127, partitionAssignor.uniqueField()[0]);
+        partitionAssignor.subscriptionUserData(topics);
+        assertEquals(-128, partitionAssignor.uniqueField()[0]);
     }
 
     private static ByteBuffer encodeFutureSubscription() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -2017,6 +2017,27 @@ public class StreamsPartitionAssignorTest {
         EasyMock.verify(consumerClient);
     }
 
+    @Test
+    public void testUniqueField() {
+        createDefaultMockTaskManager();
+        configureDefaultPartitionAssignor();
+        final Set<String> topics = mkSet("input");
+
+        final Subscription subscription = new Subscription(new ArrayList<>(topics), partitionAssignor.subscriptionUserData(topics));
+
+        final SubscriptionInfo info1 = new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, UUID_1, "", getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS), uniqueField);
+        assertEquals(info1, SubscriptionInfo.decode(subscription.userData()));
+
+        uniqueField[0]++;
+        final SubscriptionInfo info2 = new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, UUID_1, "", getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS), uniqueField);
+        assertEquals(info2, SubscriptionInfo.decode(partitionAssignor.subscriptionUserData(topics)));
+
+        uniqueField[0]++;
+        final SubscriptionInfo info3 = new SubscriptionInfo(LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, UUID_1, "", getTaskOffsetSums(EMPTY_TASKS, EMPTY_TASKS), uniqueField);
+        assertEquals(info3, SubscriptionInfo.decode(partitionAssignor.subscriptionUserData(topics)));
+
+    }
+
     private static ByteBuffer encodeFutureSubscription() {
         final ByteBuffer buf = ByteBuffer.allocate(4 /* used version */ + 4 /* supported version */);
         buf.putInt(LATEST_SUPPORTED_VERSION + 1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.easymock.EasyMock;
@@ -128,7 +129,7 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> prevTasks,
                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks));
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
     }
 
     public static SubscriptionInfo getInfo(final UUID processId,
@@ -136,7 +137,7 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> standbyTasks,
                                            final String userEndPoint) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks));
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
     }
 
     // Stub offset sums for when we only care about the prev/standby task sets, not the actual offsets

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.easymock.EasyMock;
@@ -129,7 +128,7 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> prevTasks,
                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), (byte) 0);
     }
 
     public static SubscriptionInfo getInfo(final UUID processId,
@@ -137,13 +136,13 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> standbyTasks,
                                            final String userEndPoint) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), (byte) 0);
     }
 
     public static SubscriptionInfo getInfo(final UUID processId,
                                            final Set<TaskId> prevTasks,
                                            final Set<TaskId> standbyTasks,
-                                           final byte[] uniqueField) {
+                                           final byte uniqueField) {
         return new SubscriptionInfo(
             LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), uniqueField);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.easymock.EasyMock;
@@ -129,7 +128,7 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> prevTasks,
                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), new byte[1]);
     }
 
     public static SubscriptionInfo getInfo(final UUID processId,
@@ -137,7 +136,15 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> standbyTasks,
                                            final String userEndPoint) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), new byte[1]);
+    }
+
+    public static SubscriptionInfo getInfo(final UUID processId,
+                                           final Set<TaskId> prevTasks,
+                                           final Set<TaskId> standbyTasks,
+                                           final byte[] uniqueField) {
+        return new SubscriptionInfo(
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), uniqueField);
     }
 
     // Stub offset sums for when we only care about the prev/standby task sets, not the actual offsets

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.admin.ListOffsetsResult;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.easymock.EasyMock;
@@ -128,7 +129,7 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> prevTasks,
                                            final Set<TaskId> standbyTasks) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), new byte[1]);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, null, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
     }
 
     public static SubscriptionInfo getInfo(final UUID processId,
@@ -136,7 +137,7 @@ public final class AssignmentTestUtils {
                                            final Set<TaskId> standbyTasks,
                                            final String userEndPoint) {
         return new SubscriptionInfo(
-            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), new byte[1]);
+            LATEST_SUPPORTED_VERSION, LATEST_SUPPORTED_VERSION, processId, userEndPoint, getTaskOffsetSums(prevTasks, standbyTasks), Bytes.EMPTY);
     }
 
     public static SubscriptionInfo getInfo(final UUID processId,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import java.util.Map;
+
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.junit.Test;
@@ -60,6 +62,8 @@ public class SubscriptionInfoTest {
 
     private final static String IGNORED_USER_ENDPOINT = "ignoredUserEndpoint:80";
 
+    private static final byte[] IGNORED_UNIQUE_FIELD = Bytes.EMPTY;
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {
         new SubscriptionInfo(
@@ -67,7 +71,8 @@ public class SubscriptionInfoTest {
             LATEST_SUPPORTED_VERSION,
             UUID_1,
             "localhost:80",
-            TASK_OFFSET_SUMS
+            TASK_OFFSET_SUMS,
+            IGNORED_UNIQUE_FIELD
         );
     }
 
@@ -78,7 +83,8 @@ public class SubscriptionInfoTest {
             LATEST_SUPPORTED_VERSION,
             UUID_1,
             "localhost:80",
-            TASK_OFFSET_SUMS
+            TASK_OFFSET_SUMS,
+            IGNORED_UNIQUE_FIELD
         );
     }
 
@@ -89,7 +95,8 @@ public class SubscriptionInfoTest {
             LATEST_SUPPORTED_VERSION,
             UUID_1,
             IGNORED_USER_ENDPOINT,
-            TASK_OFFSET_SUMS
+            TASK_OFFSET_SUMS,
+            IGNORED_UNIQUE_FIELD
         );
         final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
         assertEquals(1, decoded.version());
@@ -107,7 +114,8 @@ public class SubscriptionInfoTest {
             1234,
             UUID_1,
             "ignoreme",
-            TASK_OFFSET_SUMS
+            TASK_OFFSET_SUMS,
+            IGNORED_UNIQUE_FIELD
         );
         final ByteBuffer buffer = info.encode();
 
@@ -148,7 +156,8 @@ public class SubscriptionInfoTest {
             LATEST_SUPPORTED_VERSION,
             UUID_1,
             "localhost:80",
-            TASK_OFFSET_SUMS
+            TASK_OFFSET_SUMS,
+            IGNORED_UNIQUE_FIELD
         );
         final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
         assertEquals(2, decoded.version());
@@ -166,7 +175,8 @@ public class SubscriptionInfoTest {
             LATEST_SUPPORTED_VERSION,
             UUID_1,
             "localhost:80",
-            TASK_OFFSET_SUMS
+            TASK_OFFSET_SUMS,
+            IGNORED_UNIQUE_FIELD
         );
         final ByteBuffer buffer = info.encode();
 
@@ -208,7 +218,8 @@ public class SubscriptionInfoTest {
                 LATEST_SUPPORTED_VERSION,
                 UUID_1,
                 "localhost:80",
-                TASK_OFFSET_SUMS
+                TASK_OFFSET_SUMS,
+                IGNORED_UNIQUE_FIELD
             );
             final SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
             assertEquals(version, decoded.version());
@@ -228,7 +239,8 @@ public class SubscriptionInfoTest {
                 LATEST_SUPPORTED_VERSION,
                 UUID_1,
                 "localhost:80",
-                TASK_OFFSET_SUMS
+                TASK_OFFSET_SUMS,
+                IGNORED_UNIQUE_FIELD
             );
             final ByteBuffer buffer = info.encode();
 
@@ -269,7 +281,7 @@ public class SubscriptionInfoTest {
     @Test
     public void shouldEncodeAndDecodeVersion5() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(5, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS);
+            new SubscriptionInfo(5, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD);
         assertEquals(info, SubscriptionInfo.decode(info.encode()));
     }
 
@@ -286,23 +298,23 @@ public class SubscriptionInfoTest {
         final int latestSupportedVersion = LATEST_SUPPORTED_VERSION - 1;
 
         final SubscriptionInfo info =
-            new SubscriptionInfo(usedVersion, latestSupportedVersion, UUID_1, "localhost:80", TASK_OFFSET_SUMS);
+            new SubscriptionInfo(usedVersion, latestSupportedVersion, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD);
         final SubscriptionInfo expectedInfo =
-            new SubscriptionInfo(usedVersion, latestSupportedVersion, UUID_1, "localhost:80", TASK_OFFSET_SUMS);
+            new SubscriptionInfo(usedVersion, latestSupportedVersion, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD);
         assertEquals(expectedInfo, SubscriptionInfo.decode(info.encode()));
     }
 
     @Test
     public void shouldEncodeAndDecodeVersion7() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS);
+            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD);
         assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     @Test
     public void shouldConvertTaskOffsetSumMapToTaskSets() {
         final SubscriptionInfo info =
-            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS);
+            new SubscriptionInfo(7, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD);
         assertThat(info.prevTasks(), is(ACTIVE_TASKS));
         assertThat(info.standbyTasks(), is(STANDBY_TASKS));
     }
@@ -313,7 +325,8 @@ public class SubscriptionInfoTest {
             new SubscriptionInfo(MIN_VERSION_OFFSET_SUM_SUBSCRIPTION,
                                  LATEST_SUPPORTED_VERSION, UUID_1,
                                  "localhost:80",
-                                 TASK_OFFSET_SUMS)
+                                 TASK_OFFSET_SUMS,
+                                 IGNORED_UNIQUE_FIELD)
                 .encode());
         assertThat(info.taskOffsetSums(), is(TASK_OFFSET_SUMS));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -59,7 +59,7 @@ public class SubscriptionInfoTest {
     );
 
     private final static String IGNORED_USER_ENDPOINT = "ignoredUserEndpoint:80";
-    private static final byte[] IGNORED_UNIQUE_FIELD = new byte[1];
+    private static final byte IGNORED_UNIQUE_FIELD = (byte) 0;
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import java.util.Map;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.junit.Test;
@@ -60,7 +59,7 @@ public class SubscriptionInfoTest {
     );
 
     private final static String IGNORED_USER_ENDPOINT = "ignoredUserEndpoint:80";
-    private static final byte[] IGNORED_UNIQUE_FIELD = Bytes.EMPTY;
+    private static final byte[] IGNORED_UNIQUE_FIELD = new byte[1];
 
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowForUnknownVersion1() {
@@ -350,6 +349,13 @@ public class SubscriptionInfoTest {
             .encode());
 
         assertThat(info.taskOffsetSums(), is(expectedOffsetSumsMap));
+    }
+
+    @Test
+    public void shouldEncodeAndDecodeVersion8() {
+        final SubscriptionInfo info =
+            new SubscriptionInfo(8, LATEST_SUPPORTED_VERSION, UUID_1, "localhost:80", TASK_OFFSET_SUMS, IGNORED_UNIQUE_FIELD);
+        assertThat(info, is(SubscriptionInfo.decode(info.encode())));
     }
 
     private static ByteBuffer encodeFutureVersion() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.processor.internals.assignment;
 
 import java.util.Map;
-
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
@@ -61,7 +60,6 @@ public class SubscriptionInfoTest {
     );
 
     private final static String IGNORED_USER_ENDPOINT = "ignoredUserEndpoint:80";
-
     private static final byte[] IGNORED_UNIQUE_FIELD = Bytes.EMPTY;
 
     @Test(expected = IllegalArgumentException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -158,7 +159,8 @@ public class StreamsUpgradeTest {
                     LATEST_SUPPORTED_VERSION + 1,
                     taskManager.processId(),
                     userEndPoint(),
-                    taskManager.getTaskOffsetSums()
+                    taskManager.getTaskOffsetSums(),
+                    Bytes.EMPTY
                 ).encode();
             } else {
                 return new FutureSubscriptionInfo(
@@ -257,7 +259,8 @@ public class StreamsUpgradeTest {
                                 LATEST_SUPPORTED_VERSION,
                                 info.processId(),
                                 info.userEndPoint(),
-                                taskManager().getTaskOffsetSums())
+                                taskManager().getTaskOffsetSums(),
+                                Bytes.EMPTY)
                                 .encode(),
                             subscription.ownedPartitions()
                         ));

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -152,7 +152,7 @@ public class StreamsUpgradeTest {
             // 3. Task ids of valid local states on the client's state directory.
             final TaskManager taskManager = taskManager();
             handleRebalanceStart(topics);
-
+            final byte[] uniqueField = new byte[1];
             if (usedSubscriptionMetadataVersion <= LATEST_SUPPORTED_VERSION) {
                 return new SubscriptionInfo(
                     usedSubscriptionMetadataVersion,
@@ -160,7 +160,7 @@ public class StreamsUpgradeTest {
                     taskManager.processId(),
                     userEndPoint(),
                     taskManager.getTaskOffsetSums(),
-                    Bytes.EMPTY
+                    uniqueField
                 ).encode();
             } else {
                 return new FutureSubscriptionInfo(

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -154,6 +154,7 @@ public class StreamsUpgradeTest {
             handleRebalanceStart(topics);
             final byte[] uniqueField = new byte[1];
             if (usedSubscriptionMetadataVersion <= LATEST_SUPPORTED_VERSION) {
+                uniqueField[0]++;
                 return new SubscriptionInfo(
                     usedSubscriptionMetadataVersion,
                     LATEST_SUPPORTED_VERSION + 1,

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -152,9 +151,9 @@ public class StreamsUpgradeTest {
             // 3. Task ids of valid local states on the client's state directory.
             final TaskManager taskManager = taskManager();
             handleRebalanceStart(topics);
-            final byte[] uniqueField = new byte[1];
+            byte uniqueField = 0;
             if (usedSubscriptionMetadataVersion <= LATEST_SUPPORTED_VERSION) {
-                uniqueField[0]++;
+                uniqueField++;
                 return new SubscriptionInfo(
                     usedSubscriptionMetadataVersion,
                     LATEST_SUPPORTED_VERSION + 1,
@@ -261,7 +260,7 @@ public class StreamsUpgradeTest {
                                 info.processId(),
                                 info.userEndPoint(),
                                 taskManager().getTaskOffsetSums(),
-                                Bytes.EMPTY)
+                                (byte) 0)
                                 .encode(),
                             subscription.ownedPartitions()
                         ));


### PR DESCRIPTION
Add data to subscriptionUserData to make sure that it's different each time a consumer rejoins
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
