### PR TITLE
MINOR: fix potential NPE in PartitionData.equals

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -91,10 +91,10 @@ public class OffsetFetchResponse extends AbstractResponse {
             if (!(other instanceof PartitionData))
                 return false;
             PartitionData otherPartition = (PartitionData) other;
-            return this.offset == otherPartition.offset
-                       && this.leaderEpoch.equals(otherPartition.leaderEpoch)
-                       && this.metadata.equals(otherPartition.metadata)
-                       && this.error.equals(otherPartition.error);
+            return Objects.equals(this.offset, otherPartition.offset)
+                   && Objects.equals(this.leaderEpoch, otherPartition.leaderEpoch)
+                   && Objects.equals(this.metadata, otherPartition.metadata)
+                   && Objects.equals(this.error, otherPartition.error);
         }
 
         @Override

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -159,14 +159,14 @@ public class OffsetFetchResponseTest {
 
     @Test
     public void testNullableMetadata() {
+        PartitionData pd = new PartitionData(
+            offset,
+            leaderEpochOne,
+            null,
+            Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        assertEquals(pd, pd);
         partitionDataMap.clear();
-        partitionDataMap.put(new TopicPartition(topicOne, partitionOne),
-                             new PartitionData(
-                                 offset,
-                                 leaderEpochOne,
-                                 null,
-                                 Errors.UNKNOWN_TOPIC_OR_PARTITION)
-        );
+        partitionDataMap.put(new TopicPartition(topicOne, partitionOne), pd);
 
         OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.GROUP_AUTHORIZATION_FAILED, partitionDataMap);
         OffsetFetchResponseData expectedData =

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -164,6 +164,7 @@ public class OffsetFetchResponseTest {
             leaderEpochOne,
             null,
             Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        // test PartitionData.equals with null metadata
         assertEquals(pd, pd);
         partitionDataMap.clear();
         partitionDataMap.put(new TopicPartition(topicOne, partitionOne), pd);


### PR DESCRIPTION
the field ```metadata``` is nullable (see https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/OffsetFetchResponse.json#L50)

the method ```equals``` is not used in production and ```PartitionData``` is not exposed to client so this issue is minor :)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
