### PR TITLE
KAFKA-10583: Add documentation on the thread-safety of KafkaAdminClient.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -51,6 +51,9 @@ import org.apache.kafka.common.requests.LeaveGroupResponse;
  * This client was introduced in 0.11.0.0 and the API is still evolving. We will try to evolve the API in a compatible
  * manner, but we reserve the right to make breaking changes in minor releases, if necessary. We will update the
  * {@code InterfaceStability} annotation and this notice once the API is considered stable.
+ * <p>
+ * Instances returned from the {@code create} methods of this interface are guaranteed to be thread safe.
+ * </p>
  */
 @InterfaceStability.Evolving
 public interface Admin extends AutoCloseable {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -287,6 +287,9 @@ import static org.apache.kafka.common.utils.Utils.closeQuietly;
  * The default implementation of {@link Admin}. An instance of this class is created by invoking one of the
  * {@code create()} methods in {@code AdminClient}. Users should not refer to this class directly.
  *
+ * <p>
+ * This class is thread-safe.
+ * </p>
  * The API of this class is evolving, see {@link Admin} for details.
  */
 @InterfaceStability.Evolving


### PR DESCRIPTION
Other than a Stack Overflow comment (see https://stackoverflow.com/a/61738065) by Colin Patrick McCabe (@cmccabe ) and a proposed design note on KIP-117 wiki, there is no source that verifies the thread-safety of `KafkaAdminClient`.

This patch updates JavaDoc of `KafkaAdminClient` to clarify its thread-safety.
