### PR TITLE
KAFKA-10584:IndexSearchType should use sealed trait instead of Enumeration

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -24,7 +24,6 @@ import java.nio.{ByteBuffer, MappedByteBuffer}
 import java.util.concurrent.locks.{Lock, ReentrantLock}
 
 import kafka.common.IndexOffsetOverflowException
-import kafka.log.IndexSearchType.IndexSearchEntity
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.{CoreUtils, Logging}
 import org.apache.kafka.common.utils.{ByteBufferUnmapper, OperatingSystem, Utils}
@@ -359,19 +358,19 @@ abstract class AbstractIndex(@volatile private var _file: File, val baseOffset: 
    * @param target The index key to look for
    * @return The slot found or -1 if the least entry in the index is larger than the target key or the index is empty
    */
-  protected def largestLowerBoundSlotFor(idx: ByteBuffer, target: Long, searchEntity: IndexSearchEntity): Int =
+  protected def largestLowerBoundSlotFor(idx: ByteBuffer, target: Long, searchEntity: IndexSearchType): Int =
     indexSlotRangeFor(idx, target, searchEntity)._1
 
   /**
    * Find the smallest entry greater than or equal the target key or value. If none can be found, -1 is returned.
    */
-  protected def smallestUpperBoundSlotFor(idx: ByteBuffer, target: Long, searchEntity: IndexSearchEntity): Int =
+  protected def smallestUpperBoundSlotFor(idx: ByteBuffer, target: Long, searchEntity: IndexSearchType): Int =
     indexSlotRangeFor(idx, target, searchEntity)._2
 
   /**
    * Lookup lower and upper bounds for the given target.
    */
-  private def indexSlotRangeFor(idx: ByteBuffer, target: Long, searchEntity: IndexSearchEntity): (Int, Int) = {
+  private def indexSlotRangeFor(idx: ByteBuffer, target: Long, searchEntity: IndexSearchType): (Int, Int) = {
     // check if the index is empty
     if(_entries == 0)
       return (-1, -1)
@@ -407,7 +406,7 @@ abstract class AbstractIndex(@volatile private var _file: File, val baseOffset: 
     binarySearch(0, firstHotEntry)
   }
 
-  private def compareIndexEntry(indexEntry: IndexEntry, target: Long, searchEntity: IndexSearchEntity): Int = {
+  private def compareIndexEntry(indexEntry: IndexEntry, target: Long, searchEntity: IndexSearchType): Int = {
     searchEntity match {
       case IndexSearchType.KEY => java.lang.Long.compare(indexEntry.indexKey, target)
       case IndexSearchType.VALUE => java.lang.Long.compare(indexEntry.indexValue, target)
@@ -434,7 +433,8 @@ object AbstractIndex extends Logging {
   override val loggerName: String = classOf[AbstractIndex].getName
 }
 
-object IndexSearchType extends Enumeration {
-  type IndexSearchEntity = Value
-  val KEY, VALUE = Value
+sealed trait IndexSearchType
+object IndexSearchType {
+  case object KEY extends IndexSearchType
+  case object VALUE extends IndexSearchType
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10584

In Scala, we prefer sealed traits over Enumeration since the former gives you exhaustiveness checking. With Scala Enumeration, you don't get a warning if you add a new value that is not handled in a given pattern match.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
