### PR TITLE
KAFKA-10611: Merge log error to avoid double error

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -184,7 +184,7 @@ abstract class WorkerTask implements Runnable {
 
             execute();
         } catch (Throwable t) {
-            log.error("{} Task threw an uncaught and unrecoverable exception, task is being killed and will not recover until manually restarted", this, t);
+            log.error("{} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted", this, t);
             throw t;
         } finally {
             doClose();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -184,8 +184,7 @@ abstract class WorkerTask implements Runnable {
 
             execute();
         } catch (Throwable t) {
-            log.error("{} Task threw an uncaught and unrecoverable exception", this, t);
-            log.error("{} Task is being killed and will not recover until manually restarted", this);
+            log.error("{} Task threw an uncaught and unrecoverable exception, task is being killed and will not recover until manually restarted", this, t);
             throw t;
         } finally {
             doClose();


### PR DESCRIPTION
When using an error tracking system, 2 errors means 2 different alerts.
It's best to group the logs and have one error with all information.

For example when using with [Sentry](https://sentry.io/welcome/), this double line of log.error will create 2 different Issues.
One can merge the issues but it will be simpler to have a single error log line

I feel this is a trivial change, so following [Contribution rules](https://cwiki.apache.org/confluence/display/KAFKA/Contributing+Code+Changes#ContributingCodeChanges-PullRequest)
I didn't create a Jira ticket but simply open a pull request

If I'm wrong, please feel free to indicate me the correct process.