### PR TITLE
KAFKA-9679: Make MockConsumer.poll() consistent with KafkaConsumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -196,7 +196,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         final List<TopicPartition> toClear = new ArrayList<>();
 
         for (Map.Entry<TopicPartition, List<ConsumerRecord<K, V>>> entry : this.records.entrySet()) {
-            if (!subscriptions.isPaused(entry.getKey())) {
+            if (!subscriptions.isPaused(entry.getKey()) && subscriptions.hasValidPosition(entry.getKey())) {
                 final List<ConsumerRecord<K, V>> recs = entry.getValue();
                 for (final ConsumerRecord<K, V> rec : recs) {
                     long position = subscriptions.position(entry.getKey()).offset;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1001,7 +1001,7 @@ public class StreamThreadTest {
         verify(taskManager);
 
         // The Mock consumer shall throw as the assignment has been wiped out, but records are assigned.
-        assertEquals("No current assignment for partition topic1-1", thrown.getMessage());
+        assertEquals("Cannot add records for a partition that is not assigned to the consumer", thrown.getMessage());
         assertFalse(consumer.shouldRebalance());
     }
 


### PR DESCRIPTION
MockConsumer should filter records from unassigned partitions instead of throwing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
