### PR TITLE
MINOR: Fix typos in DefaultSslEngineFactory javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -549,7 +549,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
      *   -----BEGIN ENCRYPTED PRIVATE KEY-----
      *   Base64 private key
      *   -----END ENCRYPTED PRIVATE KEY-----
-     *   Additional data may be included before headers, so we match all entres within the PEM.
+     *   Additional data may be included before headers, so we match all entries within the PEM.
      */
     static class PemParser {
         private final String name;

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactory.java
@@ -548,7 +548,7 @@ public final class DefaultSslEngineFactory implements SslEngineFactory {
      *
      *   -----BEGIN ENCRYPTED PRIVATE KEY-----
      *   Base64 private key
-     *   -----BEGIN ENCRYPTED PRIVATE KEY-----
+     *   -----END ENCRYPTED PRIVATE KEY-----
      *   Additional data may be included before headers, so we match all entres within the PEM.
      */
     static class PemParser {


### PR DESCRIPTION
This PR fixes two typos in the Javadoc for `DefaultSslEngineFactory.PemParser` class.