### PR TITLE
MINOR: Fix flaky ControllerMutationQuotaTest.testQuotaMetric

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
@@ -140,14 +140,14 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
       assertEquals(Set(Errors.NONE), errors.values.toSet)
 
       // Metric must be there with the correct config
-      verifyQuotaMetric(principal.getName, ControllerMutationRate)
+      waitQuotaMetric(principal.getName, ControllerMutationRate)
 
       // Update quota
       defineUserQuota(ThrottledPrincipal.getName, Some(ControllerMutationRate * 2))
       waitUserQuota(ThrottledPrincipal.getName, ControllerMutationRate * 2)
 
       // Metric must be there with the updated config
-      verifyQuotaMetric(principal.getName, ControllerMutationRate * 2)
+      waitQuotaMetric(principal.getName, ControllerMutationRate * 2)
     }
   }
 
@@ -381,16 +381,18 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
     Option(servers.head.metrics.metric(metricName))
   }
 
-  private def verifyQuotaMetric(user: String, expectedQuota: Double): Unit = {
-    quotaMetric(user) match {
-      case Some(metric) =>
-        val config = metric.config()
-        assertEquals(expectedQuota, config.quota().bound(), 0.1)
-        assertEquals(ControllerQuotaSamples, config.samples())
-        assertEquals(ControllerQuotaWindowSizeSeconds * 1000, config.timeWindowMs())
+  private def waitQuotaMetric(user: String, expectedQuota: Double): Unit = {
+    TestUtils.retry(200) {
+      quotaMetric(user) match {
+        case Some(metric) =>
+          val config = metric.config()
+          assertEquals(expectedQuota, config.quota().bound(), 0.1)
+          assertEquals(ControllerQuotaSamples, config.samples())
+          assertEquals(ControllerQuotaWindowSizeSeconds * 1000, config.timeWindowMs())
 
-      case None =>
-        fail(s"Quota metric of $user is not defined")
+        case None =>
+          fail(s"Quota metric of $user is not defined")
+      }
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerMutationQuotaTest.scala
@@ -41,6 +41,7 @@ import org.apache.kafka.common.requests.DeleteTopicsResponse
 import org.apache.kafka.common.security.auth.AuthenticationContext
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -382,7 +383,7 @@ class ControllerMutationQuotaTest extends BaseRequestTest {
   }
 
   private def waitQuotaMetric(user: String, expectedQuota: Double): Unit = {
-    TestUtils.retry(200) {
+    TestUtils.retry(JTestUtils.DEFAULT_MAX_WAIT_MS) {
       quotaMetric(user) match {
         case Some(metric) =>
           val config = metric.config()


### PR DESCRIPTION
### What
`ClientQuotaManager.updateQuota` updates `quotaCallback` before updating metric configs.
`ClientQuotaManager.quota()` performs an unlocked call to `quotaLimit()`, so we can run into a case where `quota` returns the updated quota, but the metric config hasn't been updated.

The fix is to acquire the read lock before attempting to read the quota. An alternative would be to have `verifyQuotaMetric` run in a `waitUntilTrue`. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
