### PR TITLE
KAFKA-10343: Add IBP based ApiVersion tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -2061,6 +2061,7 @@ public class FetcherTest {
         ByteBuffer buffer = ApiVersionsResponse.
             createApiVersionsResponse(
                 400,
+                ApiVersionsResponse.MIN_CONSTRAINT_IBP_VERSION,
                 RecordBatch.CURRENT_MAGIC_VALUE
             ).serialize(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion(), 0);
         selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -268,6 +268,7 @@ public class SenderTest {
 
         ByteBuffer buffer = ApiVersionsResponse.createApiVersionsResponse(
             400,
+            ApiVersionsResponse.MIN_CONSTRAINT_IBP_VERSION,
             RecordBatch.CURRENT_MAGIC_VALUE
         ).serialize(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion(), 0);
         selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -44,6 +44,7 @@ public class ApiVersionsResponseTest {
     public void shouldCreateApiResponseOnlyWithKeysSupportedByMagicValue() {
         final ApiVersionsResponse response = ApiVersionsResponse.apiVersionsResponse(
             10,
+            ApiVersionsResponse.MIN_CONSTRAINT_IBP_VERSION,
             RecordBatch.MAGIC_VALUE_V1,
             Features.emptySupportedFeatures());
         verifyApiKeysForMagic(response, RecordBatch.MAGIC_VALUE_V1);
@@ -64,9 +65,8 @@ public class ApiVersionsResponseTest {
     @Test
     public void shouldReturnAllKeysWhenMagicIsCurrentValueAndThrottleMsIsDefaultThrottle() {
         ApiVersionsResponse response = ApiVersionsResponse.apiVersionsResponse(
-            AbstractResponse.DEFAULT_THROTTLE_TIME,
-            RecordBatch.CURRENT_MAGIC_VALUE,
-            Features.emptySupportedFeatures());
+            AbstractResponse.DEFAULT_THROTTLE_TIME, ApiVersionsResponse.MIN_CONSTRAINT_IBP_VERSION,
+            RecordBatch.CURRENT_MAGIC_VALUE, Features.emptySupportedFeatures());
         assertEquals(new HashSet<>(ApiKeys.enabledApis()), apiKeysInResponse(response));
         assertEquals(AbstractResponse.DEFAULT_THROTTLE_TIME, response.throttleTimeMs());
         assertTrue(response.data.supportedFeatures().isEmpty());
@@ -107,10 +107,12 @@ public class ApiVersionsResponseTest {
     public void shouldReturnFeatureKeysWhenMagicIsCurrentValueAndThrottleMsIsDefaultThrottle() {
         ApiVersionsResponse response = ApiVersionsResponse.apiVersionsResponse(
             10,
+            ApiVersionsResponse.MIN_CONSTRAINT_IBP_VERSION,
             RecordBatch.MAGIC_VALUE_V1,
             Features.supportedFeatures(Utils.mkMap(Utils.mkEntry("feature", new SupportedVersionRange((short) 1, (short) 4)))),
             Features.finalizedFeatures(Utils.mkMap(Utils.mkEntry("feature", new FinalizedVersionRange((short) 2, (short) 3)))),
-            10);
+            10
+        );
         verifyApiKeysForMagic(response, RecordBatch.MAGIC_VALUE_V1);
         assertEquals(10, response.throttleTimeMs());
 

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -104,7 +104,9 @@ object ApiVersion {
     // Bup Fetch protocol for Raft protocol (KIP-595)
     KAFKA_2_7_IV1,
     // Introduced AlterIsr (KIP-497)
-    KAFKA_2_7_IV2
+    KAFKA_2_7_IV2,
+    // Introduced IBP based constraints for ApiVersion (KIP-590)
+    KAFKA_2_8_IV0
   )
 
   // Map keys are the union of the short and full versions
@@ -377,6 +379,13 @@ case object KAFKA_2_7_IV2 extends DefaultApiVersion {
   val subVersion = "IV2"
   val recordVersion = RecordVersion.V2
   val id: Int = 30
+}
+
+case object KAFKA_2_8_IV0 extends DefaultApiVersion {
+  val shortVersion: String = "2.8"
+  val subVersion = "IV0"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 31
 }
 
 object ApiVersionValidator extends Validator {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1739,12 +1739,14 @@ class KafkaApis(val requestChannel: RequestChannel,
         finalizedFeaturesOpt match {
           case Some(finalizedFeatures) => ApiVersionsResponse.apiVersionsResponse(
             requestThrottleMs,
+            config.interBrokerProtocolVersion.id,
             config.interBrokerProtocolVersion.recordVersion.value,
             supportedFeatures,
             finalizedFeatures.features,
             finalizedFeatures.epoch)
           case None => ApiVersionsResponse.apiVersionsResponse(
             requestThrottleMs,
+            config.interBrokerProtocolVersion.id,
             config.interBrokerProtocolVersion.recordVersion.value,
             supportedFeatures)
         }

--- a/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
@@ -62,8 +62,8 @@ class TestRaftRequestHandler(
             response => sendResponse(request, Some(response)))
 
         case ApiKeys.API_VERSIONS =>
-          sendResponse(request, Option(ApiVersionsResponse.apiVersionsResponse(0, 2,
-            Features.emptySupportedFeatures())))
+          sendResponse(request, Option(ApiVersionsResponse.apiVersionsResponse(0,
+            ApiVersionsResponse.MIN_CONSTRAINT_IBP_VERSION, 2, Features.emptySupportedFeatures())))
 
         case ApiKeys.METADATA =>
           val metadataRequest = request.body[MetadataRequest]

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -17,7 +17,10 @@
 
 package kafka.api
 
-import org.apache.kafka.common.record.RecordVersion
+import org.apache.kafka.common.feature.Features
+import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.record.{RecordBatch, RecordVersion}
+import org.apache.kafka.common.requests.ApiVersionsResponse
 import org.junit.Test
 import org.junit.Assert._
 
@@ -96,6 +99,20 @@ class ApiVersionTest {
     assertEquals(KAFKA_2_4_IV1, ApiVersion("2.4"))
     assertEquals(KAFKA_2_4_IV0, ApiVersion("2.4-IV0"))
     assertEquals(KAFKA_2_4_IV1, ApiVersion("2.4-IV1"))
+
+    assertEquals(KAFKA_2_5_IV0, ApiVersion("2.5"))
+    assertEquals(KAFKA_2_5_IV0, ApiVersion("2.5-IV0"))
+
+    assertEquals(KAFKA_2_6_IV0, ApiVersion("2.6"))
+    assertEquals(KAFKA_2_6_IV0, ApiVersion("2.6-IV0"))
+
+    assertEquals(KAFKA_2_7_IV2, ApiVersion("2.7"))
+    assertEquals(KAFKA_2_7_IV0, ApiVersion("2.7-IV0"))
+    assertEquals(KAFKA_2_7_IV1, ApiVersion("2.7-IV1"))
+    assertEquals(KAFKA_2_7_IV2, ApiVersion("2.7-IV2"))
+
+    assertEquals(KAFKA_2_8_IV0, ApiVersion("2.8"))
+    assertEquals(KAFKA_2_8_IV0, ApiVersion("2.8-IV0"))
   }
 
   @Test
@@ -140,6 +157,10 @@ class ApiVersionTest {
     assertEquals("2.3", KAFKA_2_3_IV0.shortVersion)
     assertEquals("2.3", KAFKA_2_3_IV1.shortVersion)
     assertEquals("2.4", KAFKA_2_4_IV0.shortVersion)
+    assertEquals("2.5", KAFKA_2_5_IV0.shortVersion)
+    assertEquals("2.6", KAFKA_2_6_IV0.shortVersion)
+    assertEquals("2.7", KAFKA_2_7_IV2.shortVersion)
+    assertEquals("2.8", KAFKA_2_8_IV0.shortVersion)
   }
 
   @Test
@@ -149,4 +170,97 @@ class ApiVersionTest {
     assertEquals(ApiVersion.allVersions.size, apiVersions.length)
   }
 
+  @Test
+  def testInterBrokerProtocolVersionConstraint(): Unit = {
+    val response = ApiVersionsResponse.apiVersionsResponse(
+      10,
+      ApiVersion.latestVersion.id,
+      RecordBatch.MAGIC_VALUE_V2,
+      Features.emptySupportedFeatures())
+    response.data.apiKeys().forEach(
+      version => {
+        val apiKeys = ApiKeys.forId(version.apiKey())
+        apiKeys match {
+          case ApiKeys.ALTER_CONFIGS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 1)
+            }
+
+          case ApiKeys.INCREMENTAL_ALTER_CONFIGS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 1)
+            }
+
+          case ApiKeys.ALTER_CLIENT_QUOTAS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 0)
+            }
+
+          case ApiKeys.CREATE_ACLS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 2)
+            }
+
+          case ApiKeys.DELETE_ACLS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 2)
+            }
+
+          case ApiKeys.CREATE_DELEGATION_TOKEN =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 2)
+            }
+
+          case ApiKeys.RENEW_DELEGATION_TOKEN =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 2)
+            }
+
+          case ApiKeys.EXPIRE_DELEGATION_TOKEN =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 2)
+            }
+
+          case ApiKeys.ALTER_PARTITION_REASSIGNMENTS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 0)
+            }
+
+          case ApiKeys.CREATE_PARTITIONS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 3)
+            }
+
+          case ApiKeys.CREATE_TOPICS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 6)
+            }
+
+          case ApiKeys.DELETE_TOPICS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 5)
+            }
+
+          case ApiKeys.UPDATE_FEATURES =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 0)
+            }
+
+          case ApiKeys.ALTER_USER_SCRAM_CREDENTIALS =>
+            if (ApiVersion.latestVersion >= KAFKA_2_8_IV0) {
+              verifyIBPVersionConstraint(apiKeys, 0)
+            }
+          case _ =>
+        }
+      }
+    )
+  }
+
+  private def verifyIBPVersionConstraint(apiKeys: ApiKeys, expectedVersion: Short): Unit = {
+    assertEquals(s"The latest version of RPC $apiKeys does not match " +
+      s"expected version $expectedVersion. If you recently " +
+      s"bumped this RPC version, you should also bump IBP and update this test correspondingly.",
+      expectedVersion, apiKeys.latestVersion())
+  }
 }
+


### PR DESCRIPTION
Per requirement from KIP-590, we need to add IBP as part of the ApiVersionResponse consideration. All redirected RPCs need to take IBP into consideration when getting a future bump. This PR ensures to remind the developer by doing a hard-coded ApiVersion test to check for any recent RPC version bump.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
