### PR TITLE
KAFKA-10604: The StreamsConfig.STATE_DIR_CONFIG's default value does not reflect the JVM parameter or OS-specific settings

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -119,7 +119,7 @@ public class StreamsResetter {
             + "* This tool will not clean up the local state on the stream application instances (the persisted "
             + "stores used to cache aggregation results).\n"
             + "You need to call KafkaStreams#cleanUp() in your application or manually delete them from the "
-            + "directory specified by \"state.dir\" configuration (/tmp/kafka-streams/<application.id> by default).\n"
+            + "directory specified by \"state.dir\" configuration (${java.io.tmpdir}/kafka-streams/<application.id> by default).\n"
             + "* When long session timeout has been configured, active members could take longer to get expired on the "
             + "broker thus blocking the reset job to complete. Use the \"--force\" option could remove those left-over "
             + "members immediately. Make sure to stop all stream applications when this option is specified "

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -45,6 +45,7 @@ import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -604,7 +605,7 @@ public class StreamsConfig extends AbstractConfig {
                     REPLICATION_FACTOR_DOC)
             .define(STATE_DIR_CONFIG,
                     Type.STRING,
-                    "/tmp/kafka-streams",
+                    System.getProperty("java.io.tmpdir") + File.separator + "kafka-streams",
                     Importance.HIGH,
                     STATE_DIR_DOC)
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -447,7 +447,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
             checkpointFile.write(filteredOffsets);
         } catch (final IOException e) {
             log.warn("Failed to write offset checkpoint file to {} for global stores: {}." +
-                " This may occur if OS cleaned the state.dir in case when it is located in the (default) /tmp/kafka-streams directory." +
+                " This may occur if OS cleaned the state.dir in case when it is located in the (default) ${java.io.tmpdir}/kafka-streams directory." +
                 " Changing the location of state.dir may resolve the problem", checkpointFile, e);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -604,7 +604,7 @@ public class ProcessorStateManager implements StateManager {
             checkpointFile.write(checkpointingOffsets);
         } catch (final IOException e) {
             log.warn("Failed to write offset checkpoint file to [{}]." +
-                " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
+                " This may occur if OS cleaned the state.dir in case when it located in ${java.io.tmpdir} directory." +
                 " This may also occur due to running multiple instances on the same machine using the same state dir." +
                 " Changing the location of state.dir may resolve the problem.",
                 checkpointFile, e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -104,9 +104,10 @@ public class StateDirectory {
                 throw new ProcessorStateException(
                     String.format("state directory [%s] doesn't exist and couldn't be created", stateDir.getPath()));
             }
-            if (stateDirName.startsWith("/tmp")) {
-                log.warn("Using /tmp directory in the state.dir property can cause failures with writing the checkpoint file" +
-                    " due to the fact that this directory can be cleared by the OS");
+            if (stateDirName.startsWith(System.getProperty("java.io.tmpdir"))) {
+                log.warn("Using an OS temp directory in the state.dir property can cause failures with writing" +
+                    " the checkpoint file due to the fact that this directory can be cleared by the OS." +
+                    " Resolved state.dir: ["+stateDirName+"]");
             }
             // change the dir permission to "rwxr-x---" to avoid world readable
             configurePermissions(baseDir);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -107,7 +107,7 @@ public class StateDirectory {
             if (stateDirName.startsWith(System.getProperty("java.io.tmpdir"))) {
                 log.warn("Using an OS temp directory in the state.dir property can cause failures with writing" +
                     " the checkpoint file due to the fact that this directory can be cleared by the OS." +
-                    " Resolved state.dir: ["+stateDirName+"]");
+                    " Resolved state.dir: [" + stateDirName + "]");
             }
             // change the dir permission to "rwxr-x---" to avoid world readable
             configurePermissions(baseDir);

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -47,6 +48,7 @@ import static org.apache.kafka.common.IsolationLevel.READ_COMMITTED;
 import static org.apache.kafka.common.IsolationLevel.READ_UNCOMMITTED;
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_BETA;
+import static org.apache.kafka.streams.StreamsConfig.STATE_DIR_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.adminClientPrefix;
 import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
@@ -873,6 +875,13 @@ public class StreamsConfigTest {
                 e.getMessage()
             );
         }
+    }
+
+    @Test
+    public void shouldStateDirStartsWithJavaIOTmpDir() {
+        final String expectedPrefix = System.getProperty("java.io.tmpdir") + File.separator;
+        final String actual = streamsConfig.getString(STATE_DIR_CONFIG);
+        assertTrue(actual.startsWith(expectedPrefix));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -771,13 +771,12 @@ public class ProcessorStateManagerTest {
             stateMgr.updateChangelogOffsets(singletonMap(persistentStorePartition, 10L));
             stateMgr.checkpoint();
 
-
             boolean foundExpectedLogMessage = false;
             for (final LogCaptureAppender.Event event : appender.getEvents()) {
                 if ("WARN".equals(event.getLevel())
                     && event.getMessage().startsWith("process-state-manager-test Failed to write offset checkpoint file to [")
                     && event.getMessage().endsWith(".checkpoint]." +
-                        " This may occur if OS cleaned the state.dir in case when it located in /tmp directory." +
+                        " This may occur if OS cleaned the state.dir in case when it located in ${java.io.tmpdir} directory." +
                         " This may also occur due to running multiple instances on the same machine using the same state dir." +
                         " Changing the location of state.dir may resolve the problem.")
                     && event.getThrowableInfo().get().startsWith("java.io.FileNotFoundException: ")) {


### PR DESCRIPTION
Make the default state store directory location to follow OS-specific temporary directory settings or `java.io.tmpdir` JVM parameter, with `Utils#getTempDir`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
