### PR TITLE
MINOR: Change deprecated 'scala.collection.JavaConverters' to 'scala.jdk.CollectionConverters'

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -38,7 +38,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
-import scala.collection.JavaConverters;
+import scala.jdk.CollectionConverters;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -299,7 +299,7 @@ public class StreamsResetter {
             optionParser,
             options,
             option,
-            JavaConverters.asScalaSetConverter(invalidOptions).asScala());
+            CollectionConverters.SetHasAsScala(invalidOptions).asScala());
     }
 
     private int maybeResetInputAndSeekToEndIntermediateTopicOffsets(final Map<Object, Object> consumerConfig,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/acl/AclAuthorizerBenchmark.java
@@ -48,8 +48,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import scala.collection.JavaConverters;
 import scala.collection.immutable.TreeMap;
+import scala.jdk.CollectionConverters;
 
 import java.lang.reflect.Field;
 import java.net.InetAddress;
@@ -144,7 +144,7 @@ public class AclAuthorizerBenchmark {
         TreeMap<ResourcePattern, VersionedAcls> aclCache = new TreeMap<>(new AclAuthorizer.ResourceOrdering());
         for (Map.Entry<ResourcePattern, Set<AclEntry>> entry : aclEntries.entrySet()) {
             aclCache = aclCache.updated(entry.getKey(),
-                new VersionedAcls(JavaConverters.asScalaSetConverter(entry.getValue()).asScala().toSet(), 1));
+                new VersionedAcls(CollectionConverters.SetHasAsScala(entry.getValue()).asScala().toSet(), 1));
         }
 
         return aclCache;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -71,9 +71,9 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
 import scala.collection.Iterator;
-import scala.collection.JavaConverters;
 import scala.compat.java8.OptionConverters;
 import scala.collection.Map;
+import scala.jdk.CollectionConverters;
 
 import java.io.File;
 import java.io.IOException;
@@ -119,8 +119,8 @@ public class ReplicaFetcherThreadBenchmark {
         List<File> logDirs = Collections.singletonList(logDir);
         BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
         LogDirFailureChannel logDirFailureChannel = Mockito.mock(LogDirFailureChannel.class);
-        logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
-                JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
+        logManager = new LogManager(CollectionConverters.IteratorHasAsScala(logDirs.iterator()).asScala().toSeq(),
+                CollectionConverters.IteratorHasAsScala(new ArrayList<File>().iterator()).asScala().toSeq(),
                 new scala.collection.mutable.HashMap<>(),
                 logConfig,
                 new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -53,7 +53,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
-import scala.collection.JavaConverters;
+import scala.jdk.CollectionConverters;
 
 import java.io.File;
 import java.io.IOException;
@@ -96,8 +96,8 @@ public class PartitionMakeFollowerBenchmark {
         List<File> logDirs = Collections.singletonList(logDir);
         BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
         LogDirFailureChannel logDirFailureChannel = Mockito.mock(LogDirFailureChannel.class);
-        logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
-            JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
+        logManager = new LogManager(CollectionConverters.IteratorHasAsScala(logDirs.iterator()).asScala().toSeq(),
+            CollectionConverters.IteratorHasAsScala(new ArrayList<File>().iterator()).asScala().toSeq(),
             new scala.collection.mutable.HashMap<>(),
             logConfig,
             new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import scala.Option;
-import scala.collection.JavaConverters;
+import scala.jdk.CollectionConverters;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -81,8 +81,8 @@ public class UpdateFollowerFetchStateBenchmark {
         scheduler.startup();
         LogConfig logConfig = createLogConfig();
         List<File> logDirs = Collections.singletonList(logDir);
-        logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
-                JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
+        logManager = new LogManager(CollectionConverters.IteratorHasAsScala(logDirs.iterator()).asScala().toSeq(),
+                CollectionConverters.IteratorHasAsScala(new ArrayList<File>().iterator()).asScala().toSeq(),
                 new scala.collection.mutable.HashMap<>(),
                 logConfig,
                 new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import scala.collection.JavaConverters;
+import scala.jdk.CollectionConverters;
 import scala.Option;
 
 @Warmup(iterations = 5)
@@ -105,8 +105,8 @@ public class CheckpointBench {
         this.time = new MockTime();
         this.failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());
         final List<File> files =
-            JavaConverters.seqAsJavaList(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
-        this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
+            CollectionConverters.SeqHasAsJava(brokerProperties.logDirs()).asJava().stream().map(File::new).collect(Collectors.toList());
+        this.logManager = TestUtils.createLogManager(CollectionConverters.ListHasAsScala(files).asScala(),
                 LogConfig.apply(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
                         1024 * 1024, 32 * 1024 * 1024,
                         Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
@@ -167,7 +167,7 @@ public class CheckpointBench {
         this.metrics.close();
         this.scheduler.shutdown();
         this.quotaManagers.shutdown();
-        for (File dir : JavaConverters.asJavaCollection(logManager.liveLogDirs())) {
+        for (File dir : CollectionConverters.SeqHasAsJava(logManager.liveLogDirs()).asJava()) {
             Utils.delete(dir);
         }
     }


### PR DESCRIPTION
... with fixing typo, removing redundant method parameters, unused Throwables, and unused test methods.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
