### PR TITLE
MINOR: fix a bug in removing elements from an ImplicitLinkedHashColle…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollection.java
@@ -208,8 +208,7 @@ public class ImplicitLinkedHashCollection<E extends ImplicitLinkedHashCollection
                 throw new IllegalStateException();
             }
             Element nextElement = indexToElement(head, elements, lastReturned.next());
-            removeFromList(head, elements, nextElement.prev());
-            size--;
+            ImplicitLinkedHashCollection.this.removeElementAtSlot(nextElement.prev());
             if (lastReturned == cur) {
                 // If the element we are removing was cur, set cur to cur->next.
                 cur = nextElement;

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -604,7 +603,7 @@ public class ImplicitLinkedHashCollectionTest {
         ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>();
         List<TestElement> elements  = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
-            TestElement element  = new TestElement(i, i); //random.nextInt(0x7fff) << 16 | i, i);
+            TestElement element  = new TestElement(i, i);
             elements.add(element);
             coll.add(element);
         }
@@ -616,7 +615,7 @@ public class ImplicitLinkedHashCollectionTest {
         }
         assertEquals(50, coll.size());
         for (int i = 50; i < 100; i++) {
-            assertNotNull(coll.find(elements.get(i)));
+            assertEquals(new TestElement(i, i), coll.find(elements.get(i)));
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -103,7 +104,8 @@ public class ImplicitLinkedHashCollectionTest {
 
         @Override
         public int hashCode() {
-            return key;
+            long hashCode = 2654435761L * key;
+            return (int) (hashCode >> 32);
         }
     }
 
@@ -595,5 +597,26 @@ public class ImplicitLinkedHashCollectionTest {
         expectTraversal(coll.iterator(), 2, 3, 1);
         Assert.assertThrows(RuntimeException.class, () ->
             coll.moveToEnd(new TestElement(4, 4)));
+    }
+
+    @Test
+    public void testRemovals() {
+        ImplicitLinkedHashCollection<TestElement> coll = new ImplicitLinkedHashCollection<>();
+        List<TestElement> elements  = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            TestElement element  = new TestElement(i, i); //random.nextInt(0x7fff) << 16 | i, i);
+            elements.add(element);
+            coll.add(element);
+        }
+        assertEquals(100, coll.size());
+        Iterator<TestElement> iter = coll.iterator();
+        for (int i = 0; i < 50; i++) {
+            iter.next();
+            iter.remove();
+        }
+        assertEquals(50, coll.size());
+        for (int i = 50; i < 100; i++) {
+            assertNotNull(coll.find(elements.get(i)));
+        }
     }
 }


### PR DESCRIPTION
Fix a bug that was introduced by change 86013dc9f8cf02813418f41c3c49c745f9ee6ea5 that resulted in incorrect behavior when deleting through an iterator.

The bug is that the hash table relies on a denseness invariant... if you remove something, you might have to move some other things.  Calling removeElementAtSlot will do this.  Calling removeFromList is not enough.