### PR TITLE
KAFKA-10426: Deadlock on session key update.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -699,46 +699,42 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                 if (started)
                     updateListener.onTaskConfigUpdate(updatedTasks);
             } else if (record.key().equals(SESSION_KEY_KEY)) {
-                SessionKey newSessionKey;
-                synchronized (lock) {
-                    if (value.value() == null) {
-                        log.error("Ignoring session key because it is unexpectedly null");
-                        return;
-                    }
-                    if (!(value.value() instanceof Map)) {
-                        log.error("Ignoring session key because the value is not a Map but is {}", value.value().getClass());
-                        return;
-                    }
-
-                    Map<String, Object> valueAsMap = (Map<String, Object>) value.value();
-
-                    Object sessionKey = valueAsMap.get("key");
-                    if (!(sessionKey instanceof String)) {
-                        log.error("Invalid data for session key 'key' field should be a String but is {}", sessionKey.getClass());
-                        return;
-                    }
-                    byte[] key = Base64.getDecoder().decode((String) sessionKey);
-
-                    Object keyAlgorithm = valueAsMap.get("algorithm");
-                    if (!(keyAlgorithm instanceof String)) {
-                        log.error("Invalid data for session key 'algorithm' field should be a String but it is {}", keyAlgorithm.getClass());
-                        return;
-                    }
-
-                    Object creationTimestamp = valueAsMap.get("creation-timestamp");
-                    if (!(creationTimestamp instanceof Long)) {
-                        log.error("Invalid data for session key 'creation-timestamp' field should be a long but it is {}", creationTimestamp.getClass());
-                        return;
-                    }
-                    KafkaConfigBackingStore.this.sessionKey = new SessionKey(
-                        new SecretKeySpec(key, (String) keyAlgorithm),
-                        (long) creationTimestamp
-                    );
-                    newSessionKey = KafkaConfigBackingStore.this.sessionKey;
+                if (value.value() == null) {
+                    log.error("Ignoring session key because it is unexpectedly null");
+                    return;
+                }
+                if (!(value.value() instanceof Map)) {
+                    log.error("Ignoring session key because the value is not a Map but is {}", value.value().getClass());
+                    return;
                 }
 
+                Map<String, Object> valueAsMap = (Map<String, Object>) value.value();
+
+                Object sessionKey = valueAsMap.get("key");
+                if (!(sessionKey instanceof String)) {
+                    log.error("Invalid data for session key 'key' field should be a String but is {}", sessionKey.getClass());
+                    return;
+                }
+                byte[] key = Base64.getDecoder().decode((String) sessionKey);
+
+                Object keyAlgorithm = valueAsMap.get("algorithm");
+                if (!(keyAlgorithm instanceof String)) {
+                    log.error("Invalid data for session key 'algorithm' field should be a String but it is {}", keyAlgorithm.getClass());
+                    return;
+                }
+
+                Object creationTimestamp = valueAsMap.get("creation-timestamp");
+                if (!(creationTimestamp instanceof Long)) {
+                    log.error("Invalid data for session key 'creation-timestamp' field should be a long but it is {}", creationTimestamp.getClass());
+                    return;
+                }
+                KafkaConfigBackingStore.this.sessionKey = new SessionKey(
+                        new SecretKeySpec(key, (String) keyAlgorithm),
+                        (long) creationTimestamp
+                );
+
                 if (started)
-                    updateListener.onSessionKeyUpdate(newSessionKey);
+                    updateListener.onSessionKeyUpdate(KafkaConfigBackingStore.this.sessionKey);
             } else {
                 log.error("Discarding config update record with invalid key: {}", record.key());
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -699,6 +699,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                 if (started)
                     updateListener.onTaskConfigUpdate(updatedTasks);
             } else if (record.key().equals(SESSION_KEY_KEY)) {
+                SessionKey newSessionKey;
                 synchronized (lock) {
                     if (value.value() == null) {
                         log.error("Ignoring session key because it is unexpectedly null");
@@ -733,10 +734,11 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                         new SecretKeySpec(key, (String) keyAlgorithm),
                         (long) creationTimestamp
                     );
-
-                    if (started)
-                        updateListener.onSessionKeyUpdate(KafkaConfigBackingStore.this.sessionKey);
+                    newSessionKey = KafkaConfigBackingStore.this.sessionKey;
                 }
+
+                if (started)
+                    updateListener.onSessionKeyUpdate(newSessionKey);
             } else {
                 log.error("Discarding config update record with invalid key: {}", record.key());
             }


### PR DESCRIPTION
DistributedHerder goes to updateConfigsWithIncrementalCooperative() synchronized method and called configBackingStore.snapshot() which take a lock on internal object in KafkaConfigBackingStore class.

Meanwhile KafkaConfigBackingStore in ConsumeCallback inside synchronized block on internal object gets SESSION_KEY record and calls updateListener.onSessionKeyUpdate() which take a lock on DistributedHerder.

So, we have a Deadlock.

To avoid this, updateListener with new session key should be called outside synchronized block as it's done, for example, for updateListener.onTaskConfigUpdate(updatedTasks).

This PR is a copy of: https://github.com/apache/kafka/pull/9211

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
