### PR TITLE
KAFKA-10606: Disable auto topic creation for fetch-all-topic-metadata request

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1249,7 +1249,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       val responsesForNonExistentTopics = nonExistentTopics.flatMap { topic =>
         if (isInternal(topic)) {
           val topicMetadata = createInternalTopic(topic)
-          List(
+          Some(
             if (topicMetadata.errorCode == Errors.COORDINATOR_NOT_AVAILABLE.code)
               metadataResponseTopic(Errors.INVALID_REPLICATION_FACTOR, topic, true, util.Collections.emptyList())
             else
@@ -1262,11 +1262,11 @@ class KafkaApis(val requestChannel: RequestChannel,
           //
           // However, in previous versions, UNKNOWN_TOPIC_OR_PARTITION won't happen on fetch all metadata,
           // so, for backward-compatibility, we need to skip these not founds during fetch all metadata here.
-          Nil
+          None
         } else if (allowAutoTopicCreation && config.autoCreateTopicsEnable) {
-          List(createTopic(topic, config.numPartitions, config.defaultReplicationFactor))
+          Some(createTopic(topic, config.numPartitions, config.defaultReplicationFactor))
         } else {
-          List(metadataResponseTopic(Errors.UNKNOWN_TOPIC_OR_PARTITION, topic, false, util.Collections.emptyList()))
+          Some(metadataResponseTopic(Errors.UNKNOWN_TOPIC_OR_PARTITION, topic, false, util.Collections.emptyList()))
         }
       }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1314,10 +1314,17 @@ class KafkaApis(val requestChannel: RequestChannel,
       if (authorizedTopics.isEmpty)
         Seq.empty[MetadataResponseTopic]
       else {
-        // If this request is to get metadata for all topics, auto topic creation should not be allowed
+        // KAFKA-10606: If this request is to get metadata for all topics, auto topic creation should not be allowed
+        // The special handling is necessary on broker side because allowAutoTopicCreation is hard coded to true
+        // for backward compatibility on client side.
         val allowAutoTopicCreation = (!metadataRequest.isAllTopics) && metadataRequest.allowAutoTopicCreation
-        getTopicMetadata(allowAutoTopicCreation, authorizedTopics, request.context.listenerName,
-          errorUnavailableEndpoints, errorUnavailableListeners)
+        getTopicMetadata(
+          allowAutoTopicCreation,
+          authorizedTopics,
+          request.context.listenerName,
+          errorUnavailableEndpoints,
+          errorUnavailableListeners
+        )
       }
 
     var clusterAuthorizedOperations = Int.MinValue

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1313,9 +1313,12 @@ class KafkaApis(val requestChannel: RequestChannel,
     val topicMetadata =
       if (authorizedTopics.isEmpty)
         Seq.empty[MetadataResponseTopic]
-      else
-        getTopicMetadata(metadataRequest.allowAutoTopicCreation, authorizedTopics, request.context.listenerName,
+      else {
+        // If this request is to get metadata for all topics, auto topic creation should not be allowed
+        val allowAutoTopicCreation = (!metadataRequest.isAllTopics) && metadataRequest.allowAutoTopicCreation
+        getTopicMetadata(allowAutoTopicCreation, authorizedTopics, request.context.listenerName,
           errorUnavailableEndpoints, errorUnavailableListeners)
+      }
 
     var clusterAuthorizedOperations = Int.MinValue
     if (request.header.apiVersion >= 8) {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1894,6 +1894,7 @@ class KafkaApisTest {
     val response = sendMetadataRequestWithInconsistentListeners(requestListener)
 
     assertFalse(createTopicIsCalled)
+    assertEquals(List("remaining-topic"), response.topicMetadata().asScala.map { metadata => metadata.topic() })
     assertTrue(response.topicsByError(Errors.UNKNOWN_TOPIC_OR_PARTITION).isEmpty)
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -70,7 +70,7 @@ import org.apache.kafka.server.authorizer.{Action, AuthorizationResult, Authoriz
 import org.easymock.EasyMock._
 import org.easymock.{Capture, EasyMock, IAnswer, IArgumentMatcher}
 import org.junit.Assert._
-import org.junit.{After, Before, Test}
+import org.junit.{After, Test}
 
 import scala.annotation.nowarn
 import scala.collection.{Map, Seq, mutable}
@@ -94,8 +94,8 @@ class KafkaApisTest {
   })
   private val zkClient: KafkaZkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
   private val metrics = new Metrics()
-  private val brokerId: Int = 1
-  private var metadataCache: MetadataCache = _
+  private val brokerId = 1
+  private var metadataCache: MetadataCache = new MetadataCache(brokerId)
   private val clientQuotaManager: ClientQuotaManager = EasyMock.createNiceMock(classOf[ClientQuotaManager])
   private val clientRequestQuotaManager: ClientRequestQuotaManager = EasyMock.createNiceMock(classOf[ClientRequestQuotaManager])
   private val clientControllerQuotaManager: ControllerMutationQuotaManager = EasyMock.createNiceMock(classOf[ControllerMutationQuotaManager])
@@ -107,11 +107,6 @@ class KafkaApisTest {
   private val clusterId = "clusterId"
   private val time = new MockTime
   private val clientId = ""
-
-  @Before
-  def setUp(): Unit = {
-    metadataCache = new MetadataCache(brokerId)
-  }
 
   @After
   def tearDown(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1840,7 +1840,12 @@ class KafkaApisTest {
 
 
   /**
-   * Test case for KAKFA-10606
+   * Metadata request to fetch all topics should not result in the followings:
+   * 1) Auto topic creation
+   * 2) UNKNOWN_TOPIC_OR_PARTITION
+   *
+   * This case is testing the case that a topic is being deleted from MetadataCache right after
+   * authorization but before checking in MetadataCache.
    */
   @Test
   def getAllTopicMetadataShouldNotCreateTopicOrReturnUnknownTopicPartition(): Unit = {

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -94,7 +94,7 @@ class KafkaApisTest {
   })
   private val zkClient: KafkaZkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
   private val metrics = new Metrics()
-  private val brokerId = 1
+  private val brokerId: Int = 1
   private var metadataCache: MetadataCache = _
   private val clientQuotaManager: ClientQuotaManager = EasyMock.createNiceMock(classOf[ClientQuotaManager])
   private val clientRequestQuotaManager: ClientRequestQuotaManager = EasyMock.createNiceMock(classOf[ClientRequestQuotaManager])
@@ -1849,7 +1849,7 @@ class KafkaApisTest {
     metadataCache =
       EasyMock.partialMockBuilder(classOf[MetadataCache])
         .withConstructor(classOf[Int])
-        .withArgs(brokerId)
+        .withArgs(Int.box(brokerId))  // Need to box it for <= Scala 2.12
         .addMockedMethod("getAllTopics")
         .addMockedMethod("getTopicMetadata")
         .createMock()
@@ -1859,7 +1859,10 @@ class KafkaApisTest {
     expect(metadataCache.getAllTopics()).andReturn(topicsReturnedFromMetadataCacheForAuthorization).once()
     // 1 topic is deleted from metadata right at the time between authorization and the next getTopicMetadata() call
     expect(metadataCache.getTopicMetadata(
-      EasyMock.eq(topicsReturnedFromMetadataCacheForAuthorization), anyObject, anyBoolean, anyBoolean
+      EasyMock.eq(topicsReturnedFromMetadataCacheForAuthorization),
+      anyObject[ListenerName],
+      anyBoolean,
+      anyBoolean
     )).andStubReturn(Seq(
       new MetadataResponseTopic()
         .setErrorCode(Errors.NONE.code)


### PR DESCRIPTION

There is a bug that causes fetch-all-topic-metadata requests triggering
auto topic creation. Details are described in KAFKA-10606. This is the
simplest way to fix this bug on the broker side.