### PR TITLE
MINOR: Check for active controller in UpdateFeatures request processing logic

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3132,6 +3132,8 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (!authorize(request.context, ALTER, CLUSTER, CLUSTER_NAME)) {
       sendResponseCallback(Left(new ApiError(Errors.CLUSTER_AUTHORIZATION_FAILED)))
+    } else if (!controller.isActive) {
+      sendResponseCallback(Left(new ApiError(Errors.NOT_CONTROLLER)))
     } else if (!config.isFeatureVersioningSupported) {
       sendResponseCallback(Left(new ApiError(Errors.INVALID_REQUEST, "Feature versioning system is disabled.")))
     } else {


### PR DESCRIPTION
Tuned the code a bit to check for active controller upfront in UpdateFeatures request processing logic, before the event is queued.

**Tests:**

Relying on existing test, particularly: `UpdateFeaturesTest.testShouldFailRequestIfNotController`.