### PR TITLE
KAFKA-10615 Detail plain authentication failure log

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/internals/PlainSaslServer.java
@@ -93,7 +93,7 @@ public class PlainSaslServer implements SaslServer {
             throw new SaslAuthenticationException("Authentication failed: username not specified");
         }
         if (password.isEmpty()) {
-            throw new SaslAuthenticationException("Authentication failed: password not specified");
+            throw new SaslAuthenticationException(String.format("Authentication failed: password not specified for user %s", username));
         }
 
         NameCallback nameCallback = new NameCallback("username", username);
@@ -101,12 +101,12 @@ public class PlainSaslServer implements SaslServer {
         try {
             callbackHandler.handle(new Callback[]{nameCallback, authenticateCallback});
         } catch (Throwable e) {
-            throw new SaslAuthenticationException("Authentication failed: credentials for user could not be verified", e);
+            throw new SaslAuthenticationException(String.format("Authentication failed: credentials for user %s could not be verified", username), e);
         }
         if (!authenticateCallback.authenticated())
-            throw new SaslAuthenticationException("Authentication failed: Invalid username or password");
+            throw new SaslAuthenticationException(String.format("Authentication failed: Invalid username %s or password", username));
         if (!authorizationIdFromClient.isEmpty() && !authorizationIdFromClient.equals(username))
-            throw new SaslAuthenticationException("Authentication failed: Client requested an authorization id that is different from username");
+            throw new SaslAuthenticationException(String.format("Authentication failed: Client requested an authorization id that is different from username %s", username));
 
         this.authorizationId = username;
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
@@ -114,7 +114,7 @@ public class SaslAuthenticatorFailureDelayTest {
 
         server = createEchoServer(securityProtocol);
         createAndCheckClientAuthenticationFailure(securityProtocol, node, "PLAIN",
-                "Authentication failed: Invalid username or password");
+                "Authentication failed: Invalid username " + TestJaasConfig.USERNAME + " or password");
         server.verifyAuthenticationMetrics(0, 1);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -214,7 +214,7 @@ public class SaslAuthenticatorTest {
 
         server = createEchoServer(securityProtocol);
         createAndCheckClientAuthenticationFailure(securityProtocol, node, "PLAIN",
-                "Authentication failed: Invalid username or password");
+                "Authentication failed: Invalid username " + TestJaasConfig.USERNAME + " or password");
         server.verifyAuthenticationMetrics(0, 1);
         server.verifyReauthenticationMetrics(0, 0);
     }
@@ -231,7 +231,7 @@ public class SaslAuthenticatorTest {
 
         server = createEchoServer(securityProtocol);
         createAndCheckClientAuthenticationFailure(securityProtocol, node, "PLAIN",
-                "Authentication failed: Invalid username or password");
+                "Authentication failed: Invalid username invaliduser or password");
         server.verifyAuthenticationMetrics(0, 1);
         server.verifyReauthenticationMetrics(0, 0);
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -82,7 +82,7 @@ public class PlainSaslServerTest {
 
         e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("", "u", "")));
-        assertEquals("Authentication failed: password not specified", e.getMessage());
+        assertEquals("Authentication failed: password not specified for user u", e.getMessage());
 
         e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("a", "", "")));
@@ -94,7 +94,7 @@ public class PlainSaslServerTest {
 
         e = assertThrows(SaslAuthenticationException.class, () ->
             saslServer.evaluateResponse(saslMessage("a", "u", "")));
-        assertEquals("Authentication failed: password not specified", e.getMessage());
+        assertEquals("Authentication failed: password not specified for user u", e.getMessage());
 
         String nul = "\u0000";
 


### PR DESCRIPTION
Improve broker logs when a client authenticates using Plain mechanism and wrong password. 
This helps identifying wihich client is misconfigured.