### PR TITLE
MINOR: Fixed comment to refer to UpdateMetadataPartitionState 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/UpdateMetadataRequest.java
@@ -94,7 +94,7 @@ public class UpdateMetadataRequest extends AbstractControlRequest {
         private static Map<String, UpdateMetadataTopicState> groupByTopic(List<UpdateMetadataPartitionState> partitionStates) {
             Map<String, UpdateMetadataTopicState> topicStates = new HashMap<>();
             for (UpdateMetadataPartitionState partition : partitionStates) {
-                // We don't null out the topic name in UpdateMetadataTopicState since it's ignored by the generated
+                // We don't null out the topic name in UpdateMetadataPartitionState since it's ignored by the generated
                 // code if version >= 5
                 UpdateMetadataTopicState topicState = topicStates.computeIfAbsent(partition.topicName(),
                     t -> new UpdateMetadataTopicState().setTopicName(partition.topicName()));


### PR DESCRIPTION
This part of the code is a little confusing, so I thought I should fix this comment. 

When creating a builder for UpdateMetadataRequest, the topic name is set in UpdateMetadataPartitionState. For versions 5 and onward, the topic name is added to the UpdateMetadataTopicState, and this code does not null out the topic name in the  
UpdateMetadataPartitionState when it does this.