### PR TITLE
MirrorMaker2 Exactly-once Semantics

### DIFF
--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/DefaultReplicationPolicy.java
@@ -51,6 +51,11 @@ public class DefaultReplicationPolicy implements ReplicationPolicy, Configurable
     }
 
     @Override
+    public String restoreSourceTopic(String sourceClusterAlias, String topic) {
+        return topic.substring(sourceClusterAlias.length() + separator.length());
+    }
+    
+    @Override
     public String topicSource(String topic) {
         String[] parts = separatorPattern.split(topic);
         if (parts.length < 2) {

--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/ReplicationPolicy.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/ReplicationPolicy.java
@@ -26,6 +26,9 @@ public interface ReplicationPolicy {
     /** How to rename remote topics; generally should be like us-west.topic1. */
     String formatRemoteTopic(String sourceClusterAlias, String topic);
 
+    /** How to restore source topics from remote topics; generally should be like us-west.topic1 -> topic1 */
+    String restoreSourceTopic(String sourceClusterAlias, String topic);
+    
     /** Source cluster alias of given remote topic, e.g. "us-west" for "us-west.topic1".
      *  Returns null if not a remote topic.
      */

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -93,7 +93,7 @@ public class MirrorMaker {
             new AllConnectorClientConfigOverridePolicy();
 
     private static final List<Class<?>> CONNECTOR_CLASSES = Arrays.asList(
-        MirrorSourceConnector.class,
+        MirrorSinkConnector.class,
         MirrorHeartbeatConnector.class,
         MirrorCheckpointConnector.class);
  

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSinkConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSinkConnector.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AccessControlEntryFilter;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.resource.ResourceType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourcePatternFilter;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidPartitionsException;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
+
+import java.util.Map;
+import java.util.List;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Replicate data, configuration, and ACLs between clusters.
+ *
+ *  @see MirrorConnectorConfig for supported config properties.
+ */
+public class MirrorSinkConnector extends SinkConnector {
+
+    private static final Logger log = LoggerFactory.getLogger(MirrorSinkConnector.class);
+    private static final ResourcePatternFilter ANY_TOPIC = new ResourcePatternFilter(ResourceType.TOPIC,
+        null, PatternType.ANY);
+    private static final AclBindingFilter ANY_TOPIC_ACL = new AclBindingFilter(ANY_TOPIC, AccessControlEntryFilter.ANY);
+
+    private Scheduler scheduler;
+    private MirrorConnectorConfig config;
+    private SourceAndTarget sourceAndTarget;
+    private String connectorName;
+    private TopicFilter topicFilter;
+    private ConfigPropertyFilter configPropertyFilter;
+    private List<TopicPartition> knownSourceTopicPartitions = Collections.emptyList();
+    private List<TopicPartition> knownTargetTopicPartitions = Collections.emptyList();
+    private ReplicationPolicy replicationPolicy;
+    private int replicationFactor;
+    private AdminClient sourceAdminClient;
+    private AdminClient targetAdminClient;
+    private String connectConsumerGroup;
+
+    public MirrorSinkConnector() {
+        // nop
+    }
+
+    // visible for testing
+    MirrorSinkConnector(List<TopicPartition> knownSourceTopicPartitions, MirrorConnectorConfig config) {
+        this.knownSourceTopicPartitions = knownSourceTopicPartitions;
+        this.config = config;
+    }
+
+    // visible for testing
+    MirrorSinkConnector(SourceAndTarget sourceAndTarget, ReplicationPolicy replicationPolicy,
+            TopicFilter topicFilter, ConfigPropertyFilter configPropertyFilter) {
+        this.sourceAndTarget = sourceAndTarget;
+        this.replicationPolicy = replicationPolicy;
+        this.topicFilter = topicFilter;
+        this.configPropertyFilter = configPropertyFilter;
+    } 
+
+    @Override
+    public void start(Map<String, String> props) {
+        long start = System.currentTimeMillis();
+        config = new MirrorConnectorConfig(props);
+        if (!config.enabled()) {
+            return;
+        }
+        connectorName = config.connectorName();
+        sourceAndTarget = new SourceAndTarget(config.sourceClusterAlias(), config.targetClusterAlias());
+        topicFilter = config.topicFilter();
+        configPropertyFilter = config.configPropertyFilter();
+        replicationPolicy = config.replicationPolicy();
+        replicationFactor = config.replicationFactor();
+        sourceAdminClient = AdminClient.create(config.sourceAdminConfig());
+        targetAdminClient = AdminClient.create(config.targetAdminConfig());
+        connectConsumerGroup = config.connectorConsumerGroup();
+        scheduler = new Scheduler(MirrorSinkConnector.class, config.adminTimeout());
+        scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
+        scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
+        scheduler.execute(this::computeAndCreateTopicPartitions, "creating downstream topic-partitions");
+        scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
+        scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");
+        scheduler.scheduleRepeating(this::syncTopicConfigs, config.syncTopicConfigsInterval(),
+            "syncing topic configs");
+        scheduler.scheduleRepeatingDelayed(this::refreshTopicPartitions, config.refreshTopicsInterval(),
+            "refreshing topics");
+        
+        if (config.transactionalProducer()) {
+            scheduler.execute(this::createConnectorConsumerGroupsOnTarget, "create consumer group of MirrorSinkConnector on target");
+        }
+        
+        log.info("Started {} with {} topic-partitions.", connectorName, knownSourceTopicPartitions.size());
+        log.info("Starting {} took {} ms.", connectorName, System.currentTimeMillis() - start);
+    }
+    
+    /* the MirrorSinkConnector's consumer group is automatically created (if not exist) on source cluster.
+     * However in transaction mode, the group offsets with the same ConsumerGroup Id are involved in kafka
+     * transaction. So we need to intentionally create MirrorSinkConnector's consumer group on target cluster, if not exist
+     */
+    private void createConnectorConsumerGroupsOnTarget() throws InterruptedException, ExecutionException {
+        Map<TopicPartition, OffsetAndMetadata> offsetsOnTarget = MirrorUtils.listConsumerGroupOffset(targetAdminClient, connectConsumerGroup);
+        if (offsetsOnTarget == null || offsetsOnTarget.size() == 0) {
+            log.info("consumer group {} does not exist on target cluster, creating it", connectConsumerGroup);
+            Map<String, Object> consumerProps = new HashMap<>();
+            consumerProps.put(BOOTSTRAP_SERVERS_CONFIG, config.targetProducerConfig().get(BOOTSTRAP_SERVERS_CONFIG));
+            consumerProps.put(GROUP_ID_CONFIG, connectConsumerGroup);
+            // create a consumer just for writing initial group offsets on target
+            Consumer<byte[], byte[]> consumer = MirrorUtils.newConsumer(consumerProps);
+            String sourceClusterAlias = config.sourceClusterAlias();
+            Set<String> mirroredTopic = new HashSet<>();
+            
+            for (String topic : topicsBeingReplicated()) {
+                mirroredTopic.add(sourceClusterAlias + "." + topic); 
+            }
+            consumer.subscribe(mirroredTopic);
+            consumer.poll(Duration.ofMillis(500));
+            consumer.commitSync();
+            consumer.close();
+        }
+    }
+    
+    @Override
+    public void stop() {
+        long start = System.currentTimeMillis();
+        if (!config.enabled()) {
+            return;
+        }
+        Utils.closeQuietly(scheduler, "scheduler");
+        Utils.closeQuietly(topicFilter, "topic filter");
+        Utils.closeQuietly(configPropertyFilter, "config property filter");
+        Utils.closeQuietly(sourceAdminClient, "source admin client");
+        Utils.closeQuietly(targetAdminClient, "target admin client");
+        log.info("Stopping {} took {} ms.", connectorName, System.currentTimeMillis() - start);
+    }
+
+    @Override
+    public Class<? extends Task> taskClass() {
+        return MirrorSinkTask.class;
+    }
+
+    // divide topic-partitions among tasks
+    // since each mirrored topic has different traffic and number of partitions, to balance the load
+    // across all mirrormaker instances (workers), 'roundrobin' helps to evenly assign all
+    // topic-partition to the tasks, then the tasks are further distributed to workers.
+    // For example, 3 tasks to mirror 3 topics with 8, 2 and 2 partitions respectively.
+    // 't1' denotes 'task 1', 't0p5' denotes 'topic 0, partition 5'
+    // t1 -> [t0p0, t0p3, t0p6, t1p1]
+    // t2 -> [t0p1, t0p4, t0p7, t2p0]
+    // t3 -> [t0p2, t0p5, t1p0, t2p1]
+    @Override
+    public List<Map<String, String>> taskConfigs(int maxTasks) {
+        if (!config.enabled() || knownSourceTopicPartitions.isEmpty()) {
+            return Collections.emptyList();
+        }
+        int numTasks = Math.min(maxTasks, knownSourceTopicPartitions.size());
+        List<List<TopicPartition>> roundRobinByTask = new ArrayList<>(numTasks);
+        for (int i = 0; i < numTasks; i++) {
+            roundRobinByTask.add(new ArrayList<>());
+        }
+        int count = 0;
+        for (TopicPartition partition : knownSourceTopicPartitions) {
+            int index = count % numTasks;
+            roundRobinByTask.get(index).add(partition);
+            count++;
+        }
+
+        return roundRobinByTask.stream().map(config::taskConfigForTopicPartitions)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public ConfigDef config() {
+        return MirrorConnectorConfig.CONNECTOR_CONFIG_DEF;
+    }
+
+    @Override
+    public String version() {
+        return "1";
+    }
+
+    // visible for testing
+    List<TopicPartition> findSourceTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        Set<String> topics = listTopics(sourceAdminClient).stream()
+            .filter(this::shouldReplicateTopic)
+            .collect(Collectors.toSet());
+        return describeTopics(sourceAdminClient, topics).stream()
+            .flatMap(MirrorSinkConnector::expandTopicDescription)
+            .collect(Collectors.toList());
+    }
+
+    // visible for testing
+    List<TopicPartition> findTargetTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        Set<String> topics = listTopics(targetAdminClient).stream()
+            .filter(t -> sourceAndTarget.source().equals(replicationPolicy.topicSource(t)))
+            .collect(Collectors.toSet());
+        return describeTopics(targetAdminClient, topics).stream()
+                .flatMap(MirrorSinkConnector::expandTopicDescription)
+                .collect(Collectors.toList());
+    }
+
+    // visible for testing
+    void refreshTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findTargetTopicPartitions();
+        List<TopicPartition> upstreamTargetTopicPartitions = knownTargetTopicPartitions.stream()
+                .map(x -> new TopicPartition(replicationPolicy.upstreamTopic(x.topic()), x.partition()))
+                .collect(Collectors.toList());
+
+        Set<TopicPartition> newTopicPartitions = new HashSet<>(knownSourceTopicPartitions);
+        newTopicPartitions.removeAll(upstreamTargetTopicPartitions);
+        Set<TopicPartition> deadTopicPartitions = new HashSet<>(upstreamTargetTopicPartitions);
+        deadTopicPartitions.removeAll(knownSourceTopicPartitions);
+        if (!newTopicPartitions.isEmpty() || !deadTopicPartitions.isEmpty()) {
+            log.info("Found {} topic-partitions on {}. {} are new. {} were removed. Previously had {}.",
+                    knownSourceTopicPartitions.size(), sourceAndTarget.source(), newTopicPartitions.size(),
+                    deadTopicPartitions.size(), knownSourceTopicPartitions.size());
+            log.trace("Found new topic-partitions: {}", newTopicPartitions);
+            computeAndCreateTopicPartitions();
+            context.requestTaskReconfiguration();
+        }
+    }
+
+    private void loadTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        knownSourceTopicPartitions = findSourceTopicPartitions();
+        knownTargetTopicPartitions = findTargetTopicPartitions();
+    }
+
+    private void refreshKnownTargetTopics()
+            throws InterruptedException, ExecutionException {
+        knownTargetTopicPartitions = findTargetTopicPartitions();
+    }
+
+    private Set<String> topicsBeingReplicated() {
+        Set<String> knownTargetTopics = toTopics(knownTargetTopicPartitions);
+        return knownSourceTopicPartitions.stream()
+            .map(x -> x.topic())
+            .distinct()
+            .filter(x -> knownTargetTopics.contains(formatRemoteTopic(x)))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<String> toTopics(Collection<TopicPartition> tps) {
+        return tps.stream()
+                .map(x -> x.topic())
+                .collect(Collectors.toSet());
+    }
+
+    private void syncTopicAcls()
+            throws InterruptedException, ExecutionException {
+        List<AclBinding> bindings = listTopicAclBindings().stream()
+            .filter(x -> x.pattern().resourceType() == ResourceType.TOPIC)
+            .filter(x -> x.pattern().patternType() == PatternType.LITERAL)
+            .filter(this::shouldReplicateAcl)
+            .filter(x -> shouldReplicateTopic(x.pattern().name()))
+            .map(this::targetAclBinding)
+            .collect(Collectors.toList());
+        updateTopicAcls(bindings);
+    }
+
+    private void syncTopicConfigs()
+            throws InterruptedException, ExecutionException {
+        Map<String, Config> sourceConfigs = describeTopicConfigs(topicsBeingReplicated());
+        Map<String, Config> targetConfigs = sourceConfigs.entrySet().stream()
+            .collect(Collectors.toMap(x -> formatRemoteTopic(x.getKey()), x -> targetConfig(x.getValue())));
+        updateTopicConfigs(targetConfigs);
+    }
+
+    private void createOffsetSyncsTopic() {
+        MirrorUtils.createSinglePartitionCompactedTopic(config.offsetSyncsTopic(), config.offsetSyncsTopicReplicationFactor(), config.sourceAdminConfig());
+    }
+
+    // visible for testing
+    void computeAndCreateTopicPartitions()
+            throws InterruptedException, ExecutionException {
+        Map<String, Long> partitionCounts = knownSourceTopicPartitions.stream()
+            .collect(Collectors.groupingBy(x -> x.topic(), Collectors.counting())).entrySet().stream()
+            .collect(Collectors.toMap(x -> formatRemoteTopic(x.getKey()), x -> x.getValue()));
+        Set<String> knownTargetTopics = toTopics(knownTargetTopicPartitions);
+        List<NewTopic> newTopics = partitionCounts.entrySet().stream()
+            .filter(x -> !knownTargetTopics.contains(x.getKey()))
+            .map(x -> new NewTopic(x.getKey(), x.getValue().intValue(), (short) replicationFactor))
+            .collect(Collectors.toList());
+        Map<String, NewPartitions> newPartitions = partitionCounts.entrySet().stream()
+            .filter(x -> knownTargetTopics.contains(x.getKey()))
+            .collect(Collectors.toMap(x -> x.getKey(), x -> NewPartitions.increaseTo(x.getValue().intValue())));
+        createTopicPartitions(partitionCounts, newTopics, newPartitions);
+    }
+
+    // visible for testing
+    void createTopicPartitions(Map<String, Long> partitionCounts, List<NewTopic> newTopics,
+            Map<String, NewPartitions> newPartitions) {
+        targetAdminClient.createTopics(newTopics, new CreateTopicsOptions()).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e != null) {
+                log.warn("Could not create topic {}.", k, e);
+            } else {
+                log.info("Created remote topic {} with {} partitions.", k, partitionCounts.get(k));
+            }
+        }));
+        targetAdminClient.createPartitions(newPartitions).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e instanceof InvalidPartitionsException) {
+                // swallow, this is normal
+            } else if (e != null) {
+                log.warn("Could not create topic-partitions for {}.", k, e);
+            } else {
+                log.info("Increased size of {} to {} partitions.", k, partitionCounts.get(k));
+            }
+        }));
+    }
+
+    private Set<String> listTopics(AdminClient adminClient)
+            throws InterruptedException, ExecutionException {
+        return adminClient.listTopics().names().get();
+    }
+
+    private Collection<AclBinding> listTopicAclBindings()
+            throws InterruptedException, ExecutionException {
+        return sourceAdminClient.describeAcls(ANY_TOPIC_ACL).values().get();
+    }
+
+    private static Collection<TopicDescription> describeTopics(AdminClient adminClient, Collection<String> topics)
+            throws InterruptedException, ExecutionException {
+        return adminClient.describeTopics(topics).all().get().values();
+    }
+
+    @SuppressWarnings("deprecation")
+    // use deprecated alterConfigs API for broker compatibility back to 0.11.0
+    private void updateTopicConfigs(Map<String, Config> topicConfigs)
+            throws InterruptedException, ExecutionException {
+        Map<ConfigResource, Config> configs = topicConfigs.entrySet().stream()
+            .collect(Collectors.toMap(x ->
+                new ConfigResource(ConfigResource.Type.TOPIC, x.getKey()), x -> x.getValue()));
+        log.trace("Syncing configs for {} topics.", configs.size());
+        targetAdminClient.alterConfigs(configs).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e != null) {
+                log.warn("Could not alter configuration of topic {}.", k.name(), e);
+            }
+        }));
+    }
+
+    private void updateTopicAcls(List<AclBinding> bindings)
+            throws InterruptedException, ExecutionException {
+        log.trace("Syncing {} topic ACL bindings.", bindings.size());
+        targetAdminClient.createAcls(bindings).values().forEach((k, v) -> v.whenComplete((x, e) -> {
+            if (e != null) {
+                log.warn("Could not sync ACL of topic {}.", k.pattern().name(), e);
+            }
+        }));
+    }
+
+    private static Stream<TopicPartition> expandTopicDescription(TopicDescription description) {
+        String topic = description.name();
+        return description.partitions().stream()
+            .map(x -> new TopicPartition(topic, x.partition()));
+    }
+
+    private Map<String, Config> describeTopicConfigs(Set<String> topics)
+            throws InterruptedException, ExecutionException {
+        Set<ConfigResource> resources = topics.stream()
+            .map(x -> new ConfigResource(ConfigResource.Type.TOPIC, x))
+            .collect(Collectors.toSet());
+        return sourceAdminClient.describeConfigs(resources).all().get().entrySet().stream()
+            .collect(Collectors.toMap(x -> x.getKey().name(), x -> x.getValue()));
+    }
+
+    Config targetConfig(Config sourceConfig) {
+        List<ConfigEntry> entries = sourceConfig.entries().stream()
+            .filter(x -> !x.isDefault() && !x.isReadOnly() && !x.isSensitive())
+            .filter(x -> x.source() != ConfigEntry.ConfigSource.STATIC_BROKER_CONFIG)
+            .filter(x -> shouldReplicateTopicConfigurationProperty(x.name()))
+            .collect(Collectors.toList());
+        return new Config(entries);
+    }
+
+    private static AccessControlEntry downgradeAllowAllACL(AccessControlEntry entry) {
+        return new AccessControlEntry(entry.principal(), entry.host(), AclOperation.READ, entry.permissionType());
+    }
+
+    AclBinding targetAclBinding(AclBinding sourceAclBinding) {
+        String targetTopic = formatRemoteTopic(sourceAclBinding.pattern().name());
+        final AccessControlEntry entry;
+        if (sourceAclBinding.entry().permissionType() == AclPermissionType.ALLOW
+                && sourceAclBinding.entry().operation() == AclOperation.ALL) {
+            entry = downgradeAllowAllACL(sourceAclBinding.entry());
+        } else {
+            entry = sourceAclBinding.entry();
+        }
+        return new AclBinding(new ResourcePattern(ResourceType.TOPIC, targetTopic, PatternType.LITERAL), entry);
+    }
+
+    boolean shouldReplicateTopic(String topic) {
+        return (topicFilter.shouldReplicateTopic(topic) || isHeartbeatTopic(topic))
+            && !replicationPolicy.isInternalTopic(topic) && !isCycle(topic);
+    }
+
+    boolean shouldReplicateAcl(AclBinding aclBinding) {
+        return !(aclBinding.entry().permissionType() == AclPermissionType.ALLOW
+            && aclBinding.entry().operation() == AclOperation.WRITE);
+    }
+
+    boolean shouldReplicateTopicConfigurationProperty(String property) {
+        return configPropertyFilter.shouldReplicateConfigProperty(property);
+    }
+
+    // Recurse upstream to detect cycles, i.e. whether this topic is already on the target cluster
+    boolean isCycle(String topic) {
+        String source = replicationPolicy.topicSource(topic);
+        if (source == null) {
+            return false;
+        } else if (source.equals(sourceAndTarget.target())) {
+            return true;
+        } else {
+            return isCycle(replicationPolicy.upstreamTopic(topic));
+        }
+    }
+
+    // e.g. heartbeats, us-west.heartbeats
+    boolean isHeartbeatTopic(String topic) {
+        return MirrorClientConfig.HEARTBEATS_TOPIC.equals(replicationPolicy.originalTopic(topic));
+    }
+
+    String formatRemoteTopic(String topic) {
+        return replicationPolicy.formatRemoteTopic(sourceAndTarget.source(), topic);
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSinkTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSinkTask.java
@@ -1,0 +1,458 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.mirror;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.CommitFailedException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.LinkedList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/** Replicates a set of topic-partitions. */
+public class MirrorSinkTask extends SinkTask {
+    private static final Logger log = LoggerFactory.getLogger(MirrorSinkTask.class);
+    private static final int DEFAULT_ABORT_RETRY_BACKOFF_MS = 300;
+    private static final int MAX_OUTSTANDING_OFFSET_SYNCS = 10;
+    
+    private KafkaProducer<byte[], byte[]> producer;
+    private KafkaProducer<byte[], byte[]> offsetProducer;
+    private String sourceClusterAlias;
+    private MirrorMetrics metrics;
+    // use kafka transaction or not
+    private boolean isTransactional;
+    // a transaction currently open or not
+    private boolean transactionOpen = false;
+    private int maxRetries = 10; // TODO: make configuragble
+
+    private Converter converter;
+    private MirrorTaskConfig config;
+    private String connectConsumerGroup;
+    protected long abortRetryBackoffMs = DEFAULT_ABORT_RETRY_BACKOFF_MS; // TODO: make configuragble
+    private Admin targetAdminClient;
+    private Admin sourceAdminClient;
+    private Set<TopicPartition> taskTopicPartitions;
+    private ReplicationPolicy replicationPolicy;
+    private Scheduler scheduler;
+    private Map<TopicPartition, Long> currentOffsets = new HashMap<>();
+    
+    public MirrorSinkTask() {}
+
+    @Override
+    public String version() {
+        return getClass().getPackage().getImplementationVersion();
+    }
+    
+    @Override
+    public void start(Map<String, String> props) {
+        config = new MirrorTaskConfig(props);
+        sourceClusterAlias = config.sourceClusterAlias();
+        metrics = config.metrics();
+        taskTopicPartitions = config.taskTopicPartitions();
+        isTransactional = config.transactionalProducer();
+        replicationPolicy = config.replicationPolicy();
+        connectConsumerGroup = config.connectorConsumerGroup();
+        producer = initProducer();       
+        initTransactions(producer);
+        offsetProducer = MirrorUtils.newProducer(config.sourceProducerConfig());
+        converter = new ByteArrayConverter();
+        converter.configure(Collections.emptyMap(), false);
+
+        if (isTransactional) {
+            loadContextOffsets();
+        }
+    }
+    
+    @Override
+    public void open(Collection<TopicPartition> partitions) {
+        if (isTransactional) {
+            loadContextOffsets();
+        }
+    }
+    
+    /*
+     * load SinkTaskContext with self-managed offsets only for the partitions assigned to this task
+     */
+    private void loadContextOffsets() {
+        log.info("trying to load offsets from target cluster");
+        targetAdminClient = AdminClient.create(config.targetAdminConfig());
+
+        scheduler = new Scheduler(MirrorSinkTask.class, config.adminTimeout());
+        scheduler.execute(this::loadInitialOffsets, "load initial consumer offsets on target cluster");
+        
+        Set<TopicPartition> assignments = context.assignment();
+        log.info("assignments:");
+        
+        assignments.forEach(x -> log.info("{}", x.toString()));
+        // only keep the offsets of the partitions assigned to this task
+        Map<TopicPartition, Long> contextOffsets = assignments.stream()
+                                                              .filter(x -> currentOffsets.containsKey(x))
+                                                              .collect(Collectors.toMap(
+                                                                  x -> x, x -> currentOffsets.get(x)));
+
+        log.info("loaded consumer offsets:");
+        contextOffsets.entrySet().forEach(x -> log.info("{}, {}", x.getKey(), x.getValue()));
+        context.offset(contextOffsets);
+    }
+
+    /*
+     * read SinkConnector's group offsets from target cluster
+     */
+    private void loadInitialOffsets() throws InterruptedException, ExecutionException {
+        Map<TopicPartition, OffsetAndMetadata> wrappedOffsets = 
+               MirrorUtils.listConsumerGroupOffset(targetAdminClient, connectConsumerGroup);
+        for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : wrappedOffsets.entrySet()) {
+            TopicPartition targetTopicPartition = entry.getKey();
+            //  restore the remote topic name on target cluster to the source topic name
+            String sourceTopic = restoreSourceTopic(targetTopicPartition.topic());
+            TopicPartition sourceTopicPartition = new TopicPartition(sourceTopic, targetTopicPartition.partition());
+            // To rewind consumer to correct offset per <topic, partition> assigned to this task, there are more than one case:
+            // (1) offset exists on target cluster, use (target offset + 1) as the starting point of consumption
+            // (2) offset DOES NOT exist on target cluster, e.g. a new topic, set offset to 0
+            if (entry.getValue().offset() == 0)
+                currentOffsets.put(sourceTopicPartition, 0L);
+            else
+                currentOffsets.put(sourceTopicPartition, entry.getValue().offset() + 1);
+ 
+        }
+    }
+
+    /*
+     * create trannsaction or non-transaciton Kafka producer 
+     */
+    private KafkaProducer<byte[], byte[]> initProducer() {
+        Map<String, Object> producerConfig = config.targetProducerConfig(); 
+        String uniqueId = getHostName() + context.toString(); 
+        if (isTransactional) {
+            log.info("use transactional producer with tran Id: {} ", uniqueId);
+            producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
+            producerConfig.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+            producerConfig.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, uniqueId);
+        }
+        producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, uniqueId);
+        return MirrorUtils.newProducer(producerConfig);
+    }
+
+    /*
+     * Receive records from consumer in WorkerSinkTask and call sendBatchWithRetries() to forward
+     * them to producer
+     * 
+     * @see org.apache.kafka.connect.sink.SinkTask#put(java.util.Collection)
+     */
+    @Override
+    public void put(Collection<SinkRecord> records) {
+
+        if (records.size() == 0) {
+            return;
+        }
+        log.info("receive {} messages from consumner", records.size());
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsMap = new HashMap<>();
+        for (SinkRecord record : records) {
+            // use binary converter to translate from SinkRecord to byte[]
+            byte[] value = converter.fromConnectData(record.topic(), record.valueSchema(), record.value());
+            byte[] key = converter.fromConnectData(record.topic(), record.keySchema(), record.key());
+            addConsumerRecordToRecordsMap(new ConsumerRecord<byte[], byte[]>(
+                formatRemoteTopic(record.topic()), // prefix the topic with source cluster alias
+                record.kafkaPartition(), record.kafkaOffset(), key, value), recordsMap);
+        }
+ 
+        ConsumerRecords<byte[], byte[]> consumerRecords = new ConsumerRecords<byte[], byte[]>(recordsMap);
+
+        try {
+            sendBatchWithRetries(consumerRecords);
+        } catch (RebalanceException e) {
+            // when a rebalance occurs, do not abort the consumer as this will cause rebalance again.
+            log.warn("Rebalance may occurred during transaction.");
+            producer.close();
+            producer = initProducer();  
+        } catch (Throwable e) {
+            log.error(getHostName() + " terminating on exception: {}", e);
+        }
+    }
+
+    /*
+     * Call sendBatch() with retries.
+     *
+     * If an abortable Exception occurs, this method will abort the transaction and
+     * retry up to maxRetries times, with an increasing backoff between attempts.
+     */
+    protected void sendBatchWithRetries(ConsumerRecords<byte[], byte[]> records) throws Throwable {
+        for (int retries = 0; retries < maxRetries; retries++) {
+            try {
+                sendBatch(records);
+            } catch (RemainingRecordsException remainingRecordsException) {
+                log.info("Caught remainingRecordsException with num " + remainingRecordsException.getRemainingRecords().count() + " of " + records.count());
+                Throwable cause = remainingRecordsException.getCause();
+
+                // remainingRecordsException returns a set of records that have not yet been sent
+                // if NOT transactional, only retry the remaining records, not all
+                records = remainingRecordsException.getRemainingRecords();
+                if (cause instanceof ProducerFencedException ||
+                        cause instanceof OutOfOrderSequenceException ||
+                        cause instanceof AuthorizationException ||
+                        cause instanceof UnsupportedVersionException) {
+
+                    // from Kafka Producer doc, due to above exceptions can not be recovered, 
+                    // the only option is to throw and close the producer
+                    log.error(getHostName() + " non-abortable transaction exception: {}", cause.getMessage());
+                    throw cause;
+                }
+
+                // for any other KafkaException, abort the transaction and retry
+                abortTransaction(producer, "on exception: " + cause.getMessage());
+
+                if (retries < maxRetries - 1) {
+                    long backOffMillis = abortRetryBackoffMs * retries;
+                    log.info("Sleep " + backOffMillis + " before retry " + retries);
+                    Thread.sleep(backOffMillis);
+                    continue;
+                }
+                throw new TransactionRetriesExceededException("Produce exceeded retries after " + retries + " attempts.", cause);
+            } catch (CommitFailedException e) {
+                // CommitFailedException may thrown when rebalance is in progress
+                // abort the transaction and throw RebalanceException
+                abortTransaction(producer, "on rebalance");
+                throw new RebalanceException();
+            } catch (RuntimeException e) {
+                // not much to do for RuntimeException
+                throw e;
+            }
+            // if reach here, do not need to retry further
+            return;
+        }
+    }
+    
+    private LinkedList<ConsumerRecord<byte[], byte[]>> populateOffsetMap(ConsumerRecords<byte[], byte[]> records, 
+            Map<TopicPartition, OffsetAndMetadata> offsetsMap) {
+        List<ConsumerRecord<byte[], byte[]>> outRecords;
+        outRecords = records.partitions().stream().map(records::records)
+                .flatMap(Collection::stream)
+                .peek(consumerRecord -> {
+                    offsetsMap.compute(new TopicPartition(consumerRecord.topic(), consumerRecord.partition()),
+                        (tp, curOffsetMeta) ->
+                                   (curOffsetMeta == null || consumerRecord.offset() > curOffsetMeta.offset())
+                                            ?
+                                            new OffsetAndMetadata(consumerRecord.offset())
+                                            : curOffsetMeta);
+                })
+                .collect(Collectors.toList());
+
+        return new LinkedList<>(outRecords);
+    }
+    /*
+     * if transaction enabled, use transactional producer which also commits the consumer offsets as a part of the transaction, 
+     */
+    protected void sendBatch(ConsumerRecords<byte[], byte[]> records) throws RemainingRecordsException, Throwable {
+        // map of the largest offset for each partition in the current batch
+        Map<TopicPartition, OffsetAndMetadata> offsetsMap = new HashMap<>();
+        // map of the remaining records for each partition
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> remainingRecordsMap = new HashMap<>();
+        // populate offset map from consumer records and flatten them into linkedlist
+        LinkedList<ConsumerRecord<byte[], byte[]>> outList = populateOffsetMap(records, offsetsMap);
+        // track the Future from Producer::send
+        List<Future<RecordMetadata>> futures = new ArrayList<>();
+        Map<Future<RecordMetadata>, ConsumerRecord<byte[], byte[]>> futureMap = new HashMap<>();
+        Throwable lastException = null;
+        KafkaException lastKafkaException = null;
+        log.info("preparing to produce {} messages", outList.size());
+        try {
+            // if transaction enabled, begin a new transaction 
+            beginTransaction(producer);
+
+            ConsumerRecord<byte[], byte[]> consumerRecord;
+            while ((consumerRecord = outList.peek()) != null) {
+                // Construct a producer record and send
+                ProducerRecord<byte[], byte[]> producerRecord = convertToProducerRecord(consumerRecord);
+                Future<RecordMetadata> future = producer.send(producerRecord);
+                futures.add(future);
+                futureMap.put(future, consumerRecord);
+                // pop current record off from the list of remaining records.
+                outList.poll();
+            }
+        } catch (KafkaException e) {
+            // exception may be thrown when sending messages
+            // any unsent messages are added to the remaining list
+            for (ConsumerRecord<byte[], byte[]> record = outList.poll(); record != null; record = outList.poll()) {
+                addConsumerRecordToRecordsMap(record, remainingRecordsMap);
+            }
+            lastKafkaException = e;
+        } finally {
+            // some or all messages are sent to kafka, then resolve the futures
+            // any futures which have failed are added to the remainingRecordsMap
+            for (Future<RecordMetadata> future : futures) {
+                try {
+                    RecordMetadata metadata = future.get();
+                    // TODO: retrieve the offset from metadata and invoke the same logic as 
+                    // CommitRecord() in MirrorSourceTask about sending OffsetSync
+                } catch (Exception e) {
+                    ConsumerRecord<byte[], byte[]> failedRecords = futureMap.get(future);
+                    // when record failed to send, add it to the list of remaining records
+                    addConsumerRecordToRecordsMap(failedRecords, remainingRecordsMap);
+                    lastException = e.getCause();
+                    if (KafkaException.class.isAssignableFrom(e.getCause().getClass())) {
+                        lastKafkaException = (KafkaException) e.getCause();
+                    }
+                }
+            }
+            
+            if (isTransactional && remainingRecordsMap.size() == 0) {
+                producer.sendOffsetsToTransaction(offsetsMap, connectConsumerGroup);
+                commitTransaction(producer);
+            } else {
+                // If a kafka exception is thrown and there are records that did not successfully produce
+                // then throw a RemainingRecordsException and so the caller can retry the failed records.
+                if ((remainingRecordsMap.size() > 0) && (lastKafkaException != null)) {
+                    ConsumerRecords<byte[], byte[]> recordsToThrow;
+                    if (isTransactional) {
+                        // for transaction, all records are put into remainingRecords since the whole transaction should redo
+                        recordsToThrow = records;
+                    } else {
+                        // non-transaction: only retry failed records, others already were finished and sent.
+                        recordsToThrow = new ConsumerRecords<>(remainingRecordsMap);
+                    }
+                    throw new RemainingRecordsException(recordsToThrow, lastKafkaException);
+                }
+                if (lastException != null) {
+                    throw lastException;
+                }
+            }
+            
+        }
+    }
+    
+    @Override
+    public void stop() {
+        long start = System.currentTimeMillis();
+
+        Utils.closeQuietly(producer, "sink producer");
+        Utils.closeQuietly(offsetProducer, "offset producer");
+        Utils.closeQuietly(metrics, "metrics");
+        log.info("Stopping {} took {} ms.", getHostName(), System.currentTimeMillis() - start);
+    }
+    
+    /**
+     * convert a ProducerRecord to a ConsumerRecord with topic name prefix /w sourceClusterAlias 
+     */
+    protected ProducerRecord<byte[], byte[]> convertToProducerRecord(ConsumerRecord<byte[], byte[]> record) {
+        return new ProducerRecord<>(record.topic(), record.key(), record.value());
+    }
+    
+    private String restoreSourceTopic(String topic) {
+        return replicationPolicy.restoreSourceTopic(sourceClusterAlias, topic);
+    }
+    
+    private String formatRemoteTopic(String topic) {
+        return replicationPolicy.formatRemoteTopic(sourceClusterAlias, topic);
+    }
+    
+    private void beginTransaction(KafkaProducer<byte[], byte[]> producer) {
+        if (isTransactional) {
+            producer.beginTransaction();
+            transactionOpen = true;
+        }
+    }
+
+    private void initTransactions(KafkaProducer<byte[], byte[]> producer) {
+        if (isTransactional) {
+            producer.initTransactions();
+        }
+    }
+    
+    private void commitTransaction(KafkaProducer<byte[], byte[]> producer) {
+        if (isTransactional) {
+            producer.commitTransaction();
+            transactionOpen = false;
+        }
+    }
+    
+    private void abortTransaction(KafkaProducer<byte[], byte[]> producer, String reason) {
+        if (isTransactional && transactionOpen) {
+            log.warn(getHostName() + " aborting transaction: " + reason);
+            producer.abortTransaction();
+            transactionOpen = false;
+        }
+    }
+    
+    /**
+     * given a ConsumerRecord, add to to a list in the recordsMap keyed on the topic/partition
+     */
+    private void addConsumerRecordToRecordsMap(ConsumerRecord<byte[], byte[]> record,
+                                             Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> recordsMap) {
+        TopicPartition tp = new TopicPartition(record.topic(), record.partition());
+        List<ConsumerRecord<byte[], byte[]>> tpRecList = recordsMap.getOrDefault(tp, new ArrayList<>());
+        tpRecList.add(record);
+        recordsMap.put(tp, tpRecList);
+    }
+     
+    protected String getHostName() {
+        return System.getenv("HOSTNAME") == null ? "" : System.getenv("HOSTNAME");
+    }
+    
+    private static class RebalanceException extends Exception {
+    }
+    
+    private static class TransactionRetriesExceededException extends Exception {
+        public TransactionRetriesExceededException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+    
+    public static class RemainingRecordsException extends Exception {
+        private final ConsumerRecords<byte[], byte[]> remainingRecords;
+
+        public RemainingRecordsException(ConsumerRecords<byte[], byte[]> remainingRecords,
+                                         KafkaException cause) {
+            super(cause);
+            this.remainingRecords = remainingRecords;
+        }
+
+        public ConsumerRecords<byte[], byte[]> getRemainingRecords() {
+            return remainingRecords;
+        }
+    }
+}

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorUtils.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.connect.mirror;
 
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.TopicPartition;
@@ -26,6 +28,7 @@ import org.apache.kafka.connect.util.TopicAdmin;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Collections;
@@ -112,5 +115,10 @@ final class MirrorUtils {
 
     static void createSinglePartitionCompactedTopic(String topicName, short replicationFactor, Map<String, Object> adminProps) {
         createCompactedTopic(topicName, (short) 1, replicationFactor, adminProps);
+    }
+    
+    static Map<TopicPartition, OffsetAndMetadata> listConsumerGroupOffset(Admin adminClient, String group)
+            throws InterruptedException, ExecutionException {
+        return adminClient.listConsumerGroupOffsets(group).partitionsToOffsetAndMetadata().get();
     }
 }


### PR DESCRIPTION
KIP: https://cwiki.apache.org/confluence/display/KAFKA/KIP-656%3A+MirrorMaker2+Exactly-once+Semantics

config to enable exactly-once (aka. transaction producer)
```
primary->backup.transaction.producer.enabled: true
primary->backup.topics: foo,bar,heartbeats
topics: foo,bar,heartbeats
primary.consumer.isolation.level: read_committed
```
validation tool on k8s: https://github.com/ning2008wisc/kafka-producer-consumer-test

TODO: (1) add unit test, (2) switch between `MirrorSinkConnector` and `MirrorSourceConnector` by config