### PR TITLE
MINOR: Remove unnecessary code in the ConnectHeader class

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeader.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeader.java
@@ -36,7 +36,6 @@ class ConnectHeader implements Header {
         Objects.requireNonNull(key, "Null header keys are not permitted");
         this.key = key;
         this.schemaAndValue = schemaAndValue != null ? schemaAndValue : NULL_SCHEMA_AND_VALUE;
-        assert this.schemaAndValue != null;
     }
 
     @Override


### PR DESCRIPTION
```this.schemaAndValue``` is always not null. So ```assert this.schemaAndValue != null;``` is unnecessary code. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
