### PR TITLE
MINOR: Clean-up client javadoc warnings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/FeatureUpdate.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FeatureUpdate.java
@@ -27,7 +27,7 @@ public class FeatureUpdate {
 
     /**
      * @param maxVersionLevel   the new maximum version level for the finalized feature.
-     *                          a value < 1 is special and indicates that the update is intended to
+     *                          a value &lt; 1 is special and indicates that the update is intended to
      *                          delete the finalized feature, and should be accompanied by setting
      *                          the allowDowngrade flag to true.
      * @param allowDowngrade    - true, if this feature update was meant to downgrade the existing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
@@ -43,7 +43,7 @@ import java.util.Map;
  *
  * Since the introduction of static membership, we could leverage <code>group.instance.id</code> to make the assignment behavior more sticky.
  * For the above example, after one rolling bounce, group coordinator will attempt to assign new <code>member.id</code> towards consumers,
- * for example <code>C0</code> -> <code>C3</code> <code>C1</code> -> <code>C2</code>.
+ * for example <code>C0</code> -&gt; <code>C3</code> <code>C1</code> -&gt; <code>C2</code>.
  *
  * <p>The assignment could be completely shuffled to:
  * <ul>

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/SslEngineFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/SslEngineFactory.java
@@ -62,7 +62,7 @@ public interface SslEngineFactory extends Configurable, Closeable {
      * <p>
      * For example, if the implementation depends on file-based key material, it can check if the file was updated
      * compared to the previous/last-loaded timestamp and return true.
-     * </>
+     * </p>
      *
      * @param nextConfigs       The new configuration we want to use.
      * @return                  True only if the underlying <code>SSLEngine</code> object should be rebuilt.


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

To validate fix run `./gradlew javadoc`.  Note that this PR only addresses `client` javadoc warnings, there's #9461 for the streams warnings
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
