### PR TITLE
KAFKA-10616: Always call prepare-commit before suspending for active tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -779,7 +779,11 @@ public class TaskManager {
             // we call this function only to flush the case if necessary
             // before suspending and closing the topology
             task.prepareCommit();
+        } catch (final RuntimeException swallow) {
+            log.error("Error flushing caches of dirty task {} ", task.id(), swallow);
+        }
 
+        try {
             task.suspend();
         } catch (final RuntimeException swallow) {
             log.error("Error suspending dirty task {} ", task.id(), swallow);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -192,7 +192,11 @@ public class TaskManager {
                 // this call is only used for active tasks to flush the cache before suspending and
                 // closing the topology
                 task.prepareCommit();
+            } catch (final RuntimeException swallow) {
+                log.error("Error flushing cache for corrupted task {} ", task.id(), swallow);
+            }
 
+            try {
                 task.suspend();
                 // we need to enforce a checkpoint that removes the corrupted partitions
                 task.postCommit(true);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -188,6 +188,11 @@ public class TaskManager {
             task.markChangelogAsCorrupted(corruptedPartitions);
 
             try {
+                // we do not need to take the returned offsets since we are not going to commit anyways;
+                // this call is only used for active tasks to flush the cache before suspending and
+                // closing the topology
+                task.prepareCommit();
+
                 task.suspend();
                 // we need to enforce a checkpoint that removes the corrupted partitions
                 task.postCommit(true);
@@ -771,6 +776,10 @@ public class TaskManager {
 
     private void closeTaskDirty(final Task task) {
         try {
+            // we call this function only to flush the case if necessary
+            // before suspending and closing the topology
+            task.prepareCommit();
+
             task.suspend();
         } catch (final RuntimeException swallow) {
             log.error("Error suspending dirty task {} ", task.id(), swallow);


### PR DESCRIPTION
Today for active tasks we the following active task suspension:

1) closeAndRevive in handleTaskCorruption.
2) closeClean in assignor#onAssignment.
3) closeClean in shutdown.
4) closeDirty in assignor#onAssignment.
5) closeDirty in listener#onPartitionsLost.
6) closeDirty in shutdown.
7) suspend in listener#onPartitionsRevoked.

Among those, 1/4/5/6 do not call prepareCommit which would `stateManager#flushCache` and may cause illegal state manager. This PR would require a prepareCommit triggered before suspend.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
