### PR TITLE
MINOR: Remove unused TopicCommand.askToProceed() method

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -45,7 +45,6 @@ import scala.jdk.CollectionConverters._
 import scala.collection._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionException
-import scala.io.StdIn
 
 object TopicCommand extends Logging {
 
@@ -776,14 +775,5 @@ object TopicCommand extends Logging {
       CommandLineUtils.checkInvalidArgs(parser, options, excludeInternalTopicOpt, allTopicLevelOpts -- Set(listOpt, describeOpt))
     }
   }
-
-  def askToProceed(): Unit = {
-    println("Are you sure you want to continue? [y/n]")
-    if (!StdIn.readLine().equalsIgnoreCase("y")) {
-      println("Ending your session")
-      Exit.exit(0)
-    }
-  }
-
 }
 


### PR DESCRIPTION
The method `TopicCommand.askToProceed()` is unused. So I've removed it in this PR.
I'm relying on existing tests to report any regressions, but I code searched for the method in GitHub and it was not used at other places.