### PR TITLE
Add recursive support to Connect Cast and ReplaceField transforms, and support for casting complex types to either a native or JSON string.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1784,6 +1784,8 @@ project(':connect:transforms') {
 
   dependencies {
     compile project(':connect:api')
+    compile project(':connect:json')
+    compile libs.jacksonDatabind
     compile libs.slf4jApi
 
     testCompile libs.easymock

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -23,6 +23,8 @@ import org.apache.kafka.common.cache.SynchronizedCache;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonDeserializer;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Field;
@@ -39,6 +41,9 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -52,18 +57,35 @@ import static org.apache.kafka.connect.transforms.util.Requirements.requireStruc
 public abstract class Cast<R extends ConnectRecord<R>> implements Transformation<R> {
     private static final Logger log = LoggerFactory.getLogger(Cast.class);
 
-    // TODO: Currently we only support top-level field casting. Ideally we could use a dotted notation in the spec to
-    // allow casting nested fields.
+    // TODO: Currently we only support field casting at the top level (recursive=false) or casting all nested children where the child field name matches the spec (recursive=true).
+    // Ideally we could use a dotted (parent.child) or a path-like notation (parent->child) in the spec to allow casting only specific nested fields.
     public static final String OVERVIEW_DOC =
             "Cast fields or the entire key or value to a specific type, e.g. to force an integer field to a smaller "
-                    + "width. Only simple primitive types are supported -- integers, floats, boolean, and string. "
+                    + "width. Simple primitive types are supported -- integers, floats, boolean, and string, plus "
+            		+ "support for string representation of complex types. Recursion through nested values is also "
+                    + "possible if setting <code>recursion</code> to <code>true</code>. "
                     + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
-                    + "or value (<code>" + Value.class.getName() + "</code>).";
+                    + "or value (<code>" + Value.class.getName() + "</code>). ";
 
+    /**
+     * <code>SPEC_CONFIG</code> is Deprecated, please use <code>ConfigName.SPEC</code> instead.
+     */
+    @Deprecated
     public static final String SPEC_CONFIG = "spec";
 
+    public static interface ConfigName {
+        String SPEC = "spec";
+        String RECURSIVE = "recursive";
+        String COMPLEX_STRING_AS_JSON = "complex.string.as.json";
+    }
+
+    public static interface ConfigDefault {
+    	boolean RECURSIVE = false;
+    	boolean COMPLEX_STRING_AS_JSON = false;
+    }
+
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(SPEC_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
+            .define(ConfigName.SPEC, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, new ConfigDef.Validator() {
                     @SuppressWarnings("unchecked")
                     @Override
                     public void ensureValid(String name, Object valueObject) {
@@ -82,20 +104,28 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             ConfigDef.Importance.HIGH,
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "
-                    + "int64, float32, float64, boolean, and string.");
+                    + "int64, float32, float64, boolean, string, and complex fields (array, map, and struct) to string.")
+    		.define(ConfigName.RECURSIVE, ConfigDef.Type.BOOLEAN, ConfigDefault.RECURSIVE, ConfigDef.Importance.MEDIUM, 
+    				"Boolean which indicates if the cast should recursively cast children fields of nested complex types, "
+    						+ "if any nested children fields exist with the same names as given in the <code>spec</code>.")
+    		.define(ConfigName.COMPLEX_STRING_AS_JSON, ConfigDef.Type.BOOLEAN, ConfigDefault.COMPLEX_STRING_AS_JSON, ConfigDef.Importance.MEDIUM, 
+    				"Boolean which indicates if a complex field (<code>Struct</code>, <code>Array</code>, or <code>Map</code>) "
+    						+ "is cast to a string, should it be represented as a JSON-like string instead of a string built "
+    						+ "from the native object itself.");
 
     private static final String PURPOSE = "cast types";
 
     private static final Set<Schema.Type> SUPPORTED_CAST_INPUT_TYPES = EnumSet.of(
             Schema.Type.INT8, Schema.Type.INT16, Schema.Type.INT32, Schema.Type.INT64,
                     Schema.Type.FLOAT32, Schema.Type.FLOAT64, Schema.Type.BOOLEAN,
-                            Schema.Type.STRING, Schema.Type.BYTES
+                    Schema.Type.STRING, Schema.Type.BYTES, Schema.Type.STRUCT, 
+                    Schema.Type.ARRAY, Schema.Type.MAP
     );
 
     private static final Set<Schema.Type> SUPPORTED_CAST_OUTPUT_TYPES = EnumSet.of(
             Schema.Type.INT8, Schema.Type.INT16, Schema.Type.INT32, Schema.Type.INT64,
                     Schema.Type.FLOAT32, Schema.Type.FLOAT64, Schema.Type.BOOLEAN,
-                            Schema.Type.STRING
+                    Schema.Type.STRING
     );
 
     // As a special case for casting the entire value (e.g. the incoming key is a int64 but you know it could be an
@@ -104,13 +134,21 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
 
     private Map<String, Schema.Type> casts;
     private Schema.Type wholeValueCastType;
+    private boolean isRecursive;
+    private boolean isComplexStringJson;
     private Cache<Schema, Schema> schemaUpdateCache;
+
+    // JSON objects to be used for casting complex types to JSON strings
+    private JsonConverter jsonConverter;
+    private JsonDeserializer jsonDeserializer;
 
     @Override
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-        casts = parseFieldTypes(config.getList(SPEC_CONFIG));
+        casts = parseFieldTypes(config.getList(ConfigName.SPEC));
         wholeValueCastType = casts.get(WHOLE_VALUE_CAST);
+        isRecursive = config.getBoolean(ConfigName.RECURSIVE);
+        isComplexStringJson = config.getBoolean(ConfigName.COMPLEX_STRING_AS_JSON);
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
     }
 
@@ -139,17 +177,62 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         }
 
         final Map<String, Object> value = requireMap(operatingValue(record), PURPOSE);
-        final HashMap<String, Object> updatedValue = new HashMap<>(value);
-        for (Map.Entry<String, Schema.Type> fieldSpec : casts.entrySet()) {
-            String field = fieldSpec.getKey();
-            updatedValue.put(field, castValueToType(null, value.get(field), fieldSpec.getValue()));
-        }
-        return newRecord(record, null, updatedValue);
+
+        log.debug("Generating new Schemaless Value based on Cast configuration.");
+		final Map<String, Object> updatedValue = buildUpdatedSchemalessValue(value);
+
+		return newRecord(record, null, updatedValue);
+    }
+
+    @SuppressWarnings("unchecked")
+	private Map<String, Object> buildUpdatedSchemalessValue(Map<String, Object> map) {
+		Map<String, Object> updatedMap = new HashMap<>(map.size());
+
+		for (Map.Entry<String, Object> field : map.entrySet()) {
+			String fieldName = field.getKey();
+			Object fieldValue = field.getValue();
+
+            if (casts.containsKey(fieldName)) {
+	            final Schema.Type targetType = casts.get(fieldName);
+	            final Object newFieldValue = castValueToType(null, fieldValue, targetType);
+	            log.debug("Cast field '{}' from '{}' to '{}'.", fieldName, fieldValue, newFieldValue);
+	            updatedMap.put(fieldName, newFieldValue);
+            }
+
+            else if (isRecursive && fieldValue instanceof Map<?,?>) {
+				updatedMap.put(fieldName, buildUpdatedSchemalessValue(requireMap(fieldValue, PURPOSE)));
+			}
+
+			else if (isRecursive && fieldValue instanceof List<?>) {
+				updatedMap.put(fieldName, buildUpdatedSchemalessArrayValue((List<Object>) fieldValue));
+			}
+
+			else
+				updatedMap.put(fieldName, fieldValue);
+		}
+
+		return updatedMap;
+    }
+
+    @SuppressWarnings("unchecked")
+	private List<Object> buildUpdatedSchemalessArrayValue(List<Object> array) {
+    	List<Object> updatedArray = new ArrayList<Object>(array.size());
+    	for (Object arrayElement : array) {
+    		if (isRecursive && arrayElement instanceof List<?>) {
+    			updatedArray.add(buildUpdatedSchemalessArrayValue((List<Object>) arrayElement));
+    		}
+    		else if (isRecursive && arrayElement instanceof Map<?,?>) {
+    			updatedArray.add(buildUpdatedSchemalessValue(requireMap(arrayElement, PURPOSE)));
+    		}
+    		else
+    			updatedArray.add(arrayElement);
+    	}
+    	return updatedArray;
     }
 
     private R applyWithSchema(R record) {
         Schema valueSchema = operatingSchema(record);
-        Schema updatedSchema = getOrBuildSchema(valueSchema);
+        Schema updatedSchema = getOrBuildUpdatedSchema(valueSchema);
 
         // Whole-record casting
         if (wholeValueCastType != null)
@@ -157,19 +240,12 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
 
         // Casting within a struct
         final Struct value = requireStruct(operatingValue(record), PURPOSE);
+        final Struct updatedValue = (Struct) buildUpdatedSchemaValue(value, updatedSchema);
 
-        final Struct updatedValue = new Struct(updatedSchema);
-        for (Field field : value.schema().fields()) {
-            final Object origFieldValue = value.get(field);
-            final Schema.Type targetType = casts.get(field.name());
-            final Object newFieldValue = targetType != null ? castValueToType(field.schema(), origFieldValue, targetType) : origFieldValue;
-            log.trace("Cast field '{}' from '{}' to '{}'", field.name(), origFieldValue, newFieldValue);
-            updatedValue.put(updatedSchema.field(field.name()), newFieldValue);
-        }
         return newRecord(record, updatedSchema, updatedValue);
     }
 
-    private Schema getOrBuildSchema(Schema valueSchema) {
+    private Schema getOrBuildUpdatedSchema(Schema valueSchema) {
         Schema updatedSchema = schemaUpdateCache.get(valueSchema);
         if (updatedSchema != null)
             return updatedSchema;
@@ -178,21 +254,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         if (wholeValueCastType != null) {
             builder = SchemaUtil.copySchemaBasics(valueSchema, convertFieldType(wholeValueCastType));
         } else {
-            builder = SchemaUtil.copySchemaBasics(valueSchema, SchemaBuilder.struct());
-            for (Field field : valueSchema.fields()) {
-                if (casts.containsKey(field.name())) {
-                    SchemaBuilder fieldBuilder = convertFieldType(casts.get(field.name()));
-                    if (field.schema().isOptional())
-                        fieldBuilder.optional();
-                    if (field.schema().defaultValue() != null) {
-                        Schema fieldSchema = field.schema();
-                        fieldBuilder.defaultValue(castValueToType(fieldSchema, fieldSchema.defaultValue(), fieldBuilder.type()));
-                    }
-                    builder.field(field.name(), fieldBuilder.build());
-                } else {
-                    builder.field(field.name(), field.schema());
-                }
-            }
+            builder = buildUpdatedSchema(valueSchema);
         }
 
         if (valueSchema.isOptional())
@@ -203,6 +265,182 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         updatedSchema = builder.build();
         schemaUpdateCache.put(valueSchema, updatedSchema);
         return updatedSchema;
+    }
+
+	/***
+	 * Method which recursively builds nested {@link SchemaBuilder}s based on the {@link Cast} configuration. 
+	 * Each child schema is also added to the <code>schemaUpdateCache</code> and can be fetched afterwards instead 
+	 * of being built again.
+	 * @param schema
+	 * @return {@link SchemaBuilder} which can be used to build the final {@link Schema}
+	 */
+    private SchemaBuilder buildUpdatedSchema(Schema schema) {
+
+    	// Perform different logic for different types of parent schemas.
+
+        if (schema.type() == Type.STRUCT) {
+        	SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+
+        	for (Field field : schema.fields()) {
+	        	if (!casts.containsKey(field.name()) && // If we shouldn't cast this parent,
+	        			isRecursive && // and the config says to recurse,
+	        			(field.schema().type() == Type.STRUCT // and the field is a complex type...
+	        			|| field.schema().type() == Type.ARRAY 
+	        			|| field.schema().type() == Type.MAP)
+	        			) { // ... then recurse one level deeper to get/build a child schema for the complex type.
+	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+	        		builder.field(field.name(), updatedChildSchema);
+	        	}
+            	else { // Otherwise this is where all non-parent Struct fields should be added: it is something we want to cast, and it is not recursive or we are at the bottom of a recursion
+    	            if (casts.containsKey(field.name())) {
+    	                SchemaBuilder fieldBuilder = convertFieldType(casts.get(field.name()));
+    	                if (field.schema().isOptional())
+    	                    fieldBuilder.optional();
+    	                if (field.schema().defaultValue() != null) {
+    	                    Schema fieldSchema = field.schema();
+    	                    fieldBuilder.defaultValue(castValueToType(fieldSchema, fieldSchema.defaultValue(), fieldBuilder.type()));
+    	                }
+    	                builder.field(field.name(), fieldBuilder.build());
+    	            }
+    	            else // Copy the existing field to the new schema if we do not want to cast
+    	                builder.field(field.name(), field.schema());
+            	}
+            }
+
+            return builder;
+        }
+
+        else if (isRecursive && schema.type() == Type.ARRAY) {
+
+        	// For complex types, just go one level lower to more detail and then return a new Array schema builder with the updated child value schema
+        	if (schema.valueSchema().type() == Type.STRUCT 
+					|| schema.valueSchema().type() == Type.ARRAY 
+					|| schema.valueSchema().type() == Type.MAP) {
+        		Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(updatedChildSchema));
+        	}
+
+        	else // Otherwise we will just assume to pass it along since the Array itself should be part of an upstream parent
+				return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(schema.valueSchema()));
+
+        }
+        else if (isRecursive && schema.type() == Type.MAP) {
+
+        	// For complex types, just go one level lower to more detail and then return a new Map schema builder with the updated child value schema
+        	if (schema.valueSchema().type() == Type.STRUCT 
+					|| schema.valueSchema().type() == Type.ARRAY 
+					|| schema.valueSchema().type() == Type.MAP) {
+        		Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), updatedChildSchema));
+        	}
+
+        	else // Otherwise we will just assume to pass it along since the Map itself should be part of an upstream parent
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), schema.valueSchema()));
+        }
+
+        else
+            throw new DataException(schema.type().toString() + " is not a supported parent Schema type for the Cast transformation.");
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object buildUpdatedSchemaValue(Object value, Schema updatedSchema) {
+
+    	if (value == null)
+    		return null;
+
+    	if (updatedSchema.type() == Type.STRUCT) {
+    		Struct struct = (Struct) value;
+        	Struct updatedStruct = new Struct(updatedSchema);
+
+            for (Field field : struct.schema().fields()) {
+	        	if (!casts.containsKey(field.name()) && // If we shouldn't cast this parent,
+	        			isRecursive && // and the config says to recurse,
+	        			(field.schema().type() == Type.STRUCT // and the field is a complex type...
+	        			|| field.schema().type() == Type.ARRAY 
+	        			|| field.schema().type() == Type.MAP)
+	        			) { // ... then recurse one level deeper to build the child values for the complex type.
+	        		Schema childSchema = getOrBuildUpdatedSchema(field.schema());
+	        		Object childObject = buildUpdatedSchemaValue(struct.get(field), childSchema);
+	        		updatedStruct.put(updatedSchema.field(field.name()), childObject);
+	        	}
+            	else { // Otherwise this is where all non-parent Struct fields should be added: it is something we want to cast, and it is not recursive or we are at the bottom of a recursion
+    	            if (casts.containsKey(field.name())) {
+    		    		final Object origFieldValue = struct.get(field);
+    		            final Schema.Type targetType = casts.get(field.name());
+    		            final Object newFieldValue = castValueToType(field.schema(), origFieldValue, targetType);
+    		            log.debug("Cast field '{}' from '{}' to '{}'.", field.name(), origFieldValue, newFieldValue);
+    		            updatedStruct.put(updatedSchema.field(field.name()), newFieldValue);
+    	            } 
+    	            else
+    	            	updatedStruct.put(updatedSchema.field(field.name()), struct.get(field));
+            	}
+            }
+            return updatedStruct;
+        }
+
+    	else if (isRecursive && updatedSchema.type() == Type.ARRAY) {
+            return buildUpdatedArrayValue((List<Object>) value);
+        }
+
+        else if (isRecursive && updatedSchema.type() == Type.MAP) {
+        	return buildUpdatedMapValue((Map<Object, Object>) value);
+    	}
+
+        else
+            throw new DataException(updatedSchema.type().toString() + " is not a supported schema type for the ReplaceField transformation.");
+    }
+
+    @SuppressWarnings("unchecked")
+	private List<Object> buildUpdatedArrayValue(List<Object> array) {
+    	List<Object> updatedArray = new ArrayList<Object>(array.size());
+    	for (Object arrayElement : array) {
+    		if (isRecursive && arrayElement instanceof Struct) {
+	    		Struct struct = (Struct) arrayElement;
+				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+				updatedArray.add(updatedStruct);
+    		}
+    		else if (isRecursive && arrayElement instanceof List<?>) {
+    			updatedArray.add(buildUpdatedArrayValue((List<Object>) arrayElement));
+    		}
+    		else if (isRecursive && arrayElement instanceof Map<?,?>) {
+    			updatedArray.add(buildUpdatedMapValue((Map<Object, Object>) arrayElement));
+    		}
+    		else
+    			updatedArray.add(arrayElement);
+    	}
+    	return updatedArray;
+    }
+
+    @SuppressWarnings("unchecked")
+	private Map<Object, Object> buildUpdatedMapValue(Map<Object, Object> map) {
+		Map<Object, Object> updatedMap = new HashMap<>(map.size());
+
+		for (Map.Entry<Object, Object> mapEntry : map.entrySet()) {
+			Object mapEntryKey = mapEntry.getKey();
+			Object mapEntryValue = mapEntry.getValue();
+
+			if (isRecursive && mapEntryValue instanceof Struct) {
+	    		Struct struct = (Struct) mapEntry.getValue();
+				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+				updatedMap.put(mapEntryKey, updatedStruct);
+			}
+
+			else if (isRecursive && mapEntryValue instanceof List<?>) {
+				updatedMap.put(mapEntryKey, buildUpdatedArrayValue((List<Object>) mapEntryValue));
+			}
+
+			else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
+				updatedMap.put(mapEntryKey, buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
+			}
+
+			else // Values for this map are not a complex type that we can drill down further. Send it through because we already know that this entry's parent map was allowed upstream.
+				updatedMap.put(mapEntryKey, mapEntryValue);
+			}
+
+		return updatedMap;
     }
 
     private SchemaBuilder convertFieldType(Schema.Type type) {
@@ -240,7 +478,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         return value;
     }
 
-    private static Object castValueToType(Schema schema, Object value, Schema.Type targetType) {
+    private Object castValueToType(Schema schema, Object value, Schema.Type targetType) {
         try {
             if (value == null) return null;
 
@@ -274,7 +512,10 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
                 case BOOLEAN:
                     return castToBoolean(value);
                 case STRING:
-                    return castToString(value);
+                	if (!inferredType.isPrimitive() && isComplexStringJson)
+                		return castToJsonString(value, schema);
+                	else
+                		return castToString(value);
                 default:
                     throw new DataException(targetType.toString() + " is not supported in the Cast transformation.");
             }
@@ -369,6 +610,33 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         }
     }
 
+    private String castToJsonString(Object value, Schema schema) {
+    	if (schema == null)
+            throw new DataException("Schema is required when casting a complex type as a JSON string.");
+
+		// initialise jsonConverter if it has not already been done 
+    	if (jsonConverter == null) {
+        	Map<String, Object> converterConfig = new HashMap<>();
+        	converterConfig.put("converter.type", "value");
+        	converterConfig.put("schemas.enable", false);
+
+    		jsonConverter = new JsonConverter();
+    		jsonConverter.configure(converterConfig);
+    	}
+    	// initialise jsonDeserializer if it has not already been done
+    	if (jsonDeserializer == null) {
+    		jsonDeserializer = new JsonDeserializer();
+    	}
+
+        if (value instanceof Struct || value instanceof List<?> || value instanceof Map<?,?>) {
+	    	byte[] serializedJson = jsonConverter.fromConnectData(null, schema, value);
+	    	JsonNode json = jsonDeserializer.deserialize(null, serializedJson);
+	    	return json.toString();
+        }
+        else
+            throw new DataException(schema.type().toString() + " is not a supported schema type to cast as a JSON string.");
+    }
+
     protected abstract Schema operatingSchema(R record);
 
     protected abstract Object operatingValue(R record);
@@ -381,7 +649,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         for (String mapping : mappings) {
             final String[] parts = mapping.split(":");
             if (parts.length > 2) {
-                throw new ConfigException(ReplaceField.ConfigName.RENAME, mappings, "Invalid rename mapping: " + mapping);
+                throw new ConfigException(ConfigName.SPEC, mappings, "Invalid cast mapping: " + mapping);
             }
             if (parts.length == 1) {
                 Schema.Type targetType = Schema.Type.valueOf(parts[0].trim().toUpperCase(Locale.ROOT));

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -257,7 +257,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
 
         if (valueSchema.isOptional())
             builder.optional();
-        if (valueSchema.defaultValue() != null)
+        if (valueSchema.defaultValue() != null && SUPPORTED_CAST_OUTPUT_TYPES.contains(builder.type()))
             builder.defaultValue(castValueToType(valueSchema, valueSchema.defaultValue(), builder.type()));
 
         updatedSchema = builder.build();

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
@@ -64,7 +64,7 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
     }
 
     public static interface ConfigDefault {
-    	boolean RECURSIVE = false;
+        boolean RECURSIVE = false;
     }
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -88,9 +88,10 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
                     return "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>";
                 }
             }, ConfigDef.Importance.MEDIUM, "Field rename mappings.")
-    		.define(ConfigName.RECURSIVE, ConfigDef.Type.BOOLEAN, ConfigDefault.RECURSIVE, ConfigDef.Importance.MEDIUM, 
-    				"Boolean which indicates if the ReplaceField should recursively replace child fields of nested complex types, "
-    						+ "if any nested children fields exist with the same names as given in the configuration.");
+            .define(ConfigName.RECURSIVE, ConfigDef.Type.BOOLEAN, ConfigDefault.RECURSIVE, ConfigDef.Importance.MEDIUM, 
+                    "Boolean which indicates if the ReplaceField should recursively replace child fields of nested complex types, "
+                    + "if any nested children fields exist with the same names as given in the configuration.");
+                            
 
     private static final String PURPOSE = "field replacement";
 
@@ -139,31 +140,31 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
     }
 
     boolean filter(String fieldName) {
-    	if (exclude.contains(fieldName)) {
-    		log.debug("Excluded field '{}' will be removed.", fieldName);
-    		return false;
-    	}
-    	else if (include.contains(fieldName)) {
-    		log.debug("Included field '{}' will be added.", fieldName);
-    		return true;
-    	}
-    	else if (include.isEmpty()) {
-    		return true;
-    	}
-    	else {
-    		log.debug("Field '{}' will be removed (missing from the include list or otherwise incompatible configuration).", fieldName);
-    		return false;
-    	}
+        if (exclude.contains(fieldName)) {
+            log.debug("Excluded field '{}' will be removed.", fieldName);
+            return false;
+        }
+        else if (include.contains(fieldName)) {
+            log.debug("Included field '{}' will be added.", fieldName);
+            return true;
+        }
+        else if (include.isEmpty()) {
+            return true;
+        }
+        else {
+            log.debug("Field '{}' will be removed (missing from the include list or otherwise incompatible configuration).", fieldName);
+            return false;
+        }
     }
 
     String renamed(String fieldName) {
         final String mapping = renames.get(fieldName);
         if (mapping == null) {
-        	return fieldName;
+            return fieldName;
         }
         else {
-        	log.debug("Renamed field '{}' to '{}'.", fieldName, mapping);
-        	return mapping;
+            log.debug("Renamed field '{}' to '{}'.", fieldName, mapping);
+            return mapping;
         }
     }
 
@@ -187,9 +188,9 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
         final Map<String, Object> value = requireMap(operatingValue(record), PURPOSE);
 
         Map<Object, Object> valueToConvert = new HashMap<>(value);
-		final Map<Object, Object> updatedValue = buildUpdatedMapValue(valueToConvert);
+        final Map<Object, Object> updatedValue = buildUpdatedMapValue(valueToConvert);
 
-		return newRecord(record, null, updatedValue);
+        return newRecord(record, null, updatedValue);
     }
 
     private R applyWithSchema(R record) {
@@ -219,33 +220,33 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
         return updatedSchema;
     }
 
-	/***
-	 * Method which recursively builds nested {@link SchemaBuilder}s based on the {@link ReplaceField} configuration. 
-	 * Each child schema is also added to the <code>schemaUpdateCache</code> and can be fetched afterwards instead 
-	 * of being built again.
-	 * @param schema
-	 * @return {@link SchemaBuilder} which can be used to build the final {@link Schema}
-	 */
+    /***
+     * Method which recursively builds nested {@link SchemaBuilder}s based on the {@link ReplaceField} configuration. 
+     * Each child schema is also added to the <code>schemaUpdateCache</code> and can be fetched afterwards instead 
+     * of being built again.
+     * @param schema
+     * @return {@link SchemaBuilder} which can be used to build the final {@link Schema}
+     */
     private SchemaBuilder buildUpdatedSchema(Schema schema) {
 
-    	// Perform different logic for different types of parent schemas.
+        // Perform different logic for different types of parent schemas.
 
         if (schema.type() == Schema.Type.STRUCT) {
-        	SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+            SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
 
-        	for (Field field : schema.fields()) {
-    	        if (filter(field.name())) {
-    	        	if (isRecursive && 
-    	        			(field.schema().type() == Schema.Type.STRUCT 
-    	        			|| field.schema().type() == Schema.Type.ARRAY 
-    	        			|| field.schema().type() == Schema.Type.MAP)
-    	        			) { 
-    	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
-    	        		builder.field(renamed(field.name()), updatedChildSchema);
-    	        	}
-    	        	else // This is where all non-parent Schema fields should be added (is not recursive, or we are at the bottom of a recursion) 
-    	        		builder.field(renamed(field.name()), field.schema());
-    	        }
+            for (Field field : schema.fields()) {
+                if (filter(field.name())) {
+                    if (isRecursive && 
+                            (field.schema().type() == Schema.Type.STRUCT 
+                            || field.schema().type() == Schema.Type.ARRAY 
+                            || field.schema().type() == Schema.Type.MAP)
+                            ) { 
+                        Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+                        builder.field(renamed(field.name()), updatedChildSchema);
+                    }
+                    else // This is where all non-parent Schema fields should be added (is not recursive, or we are at the bottom of a recursion) 
+                        builder.field(renamed(field.name()), field.schema());
+                }
             }
 
             return builder;
@@ -253,54 +254,54 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
 
         else if (isRecursive && schema.type() == Schema.Type.ARRAY) {
 
-        	// For complex types, just go one level lower to more detail and then return a new Array schema with the updated child value schema
-        	if (schema.valueSchema().type() == Schema.Type.STRUCT 
-					|| schema.valueSchema().type() == Schema.Type.ARRAY 
-					|| schema.valueSchema().type() == Schema.Type.MAP) {
-        		Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
-        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(updatedChildSchema));
-        	}
+            // For complex types, just go one level lower to more detail and then return a new Array schema with the updated child value schema
+            if (schema.valueSchema().type() == Schema.Type.STRUCT 
+                    || schema.valueSchema().type() == Schema.Type.ARRAY 
+                    || schema.valueSchema().type() == Schema.Type.MAP) {
+                Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
+                return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(updatedChildSchema));
+            }
 
-        	else // Otherwise we will just assume to pass it along since the Array itself was already allowed by an upstream filter()
-				return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(schema.valueSchema()));
+            else // Otherwise we will just assume to pass it along since the Array itself was already allowed by an upstream filter()
+                return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(schema.valueSchema()));
 
         }
         else if (isRecursive && schema.type() == Schema.Type.MAP) {
 
-        	// For complex type values, just go one level lower to more detail and then return a new Map schema with the updated child value schema
-        	if (schema.valueSchema().type() == Schema.Type.STRUCT 
-					|| schema.valueSchema().type() == Schema.Type.ARRAY 
-					|| schema.valueSchema().type() == Schema.Type.MAP) {
-        		Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
-        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), updatedChildSchema));
-        	}
+            // For complex type values, just go one level lower to more detail and then return a new Map schema with the updated child value schema
+            if (schema.valueSchema().type() == Schema.Type.STRUCT 
+                    || schema.valueSchema().type() == Schema.Type.ARRAY 
+                    || schema.valueSchema().type() == Schema.Type.MAP) {
+                Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
+                return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), updatedChildSchema));
+            }
 
-        	// Otherwise, if the Map key is a string, then we will also perform ReplaceField based on the key names within the Map fields
-        	else if (schema.keySchema().type() == Schema.Type.STRING) {
+            // Otherwise, if the Map key is a string, then we will also perform ReplaceField based on the key names within the Map fields
+            else if (schema.keySchema().type() == Schema.Type.STRING) {
 
-        		SchemaBuilder childBuilder = SchemaUtil.copySchemaBasics(schema.valueSchema());
+                SchemaBuilder childBuilder = SchemaUtil.copySchemaBasics(schema.valueSchema());
 
-            	for (Field field : schema.valueSchema().fields()) {
-            		String fieldName = field.name();
+                for (Field field : schema.valueSchema().fields()) {
+                    String fieldName = field.name();
 
-            		if (filter(fieldName)) {
+                    if (filter(fieldName)) {
 
-            			if (schema.valueSchema().type() == Schema.Type.STRUCT 
-            					|| schema.valueSchema().type() == Schema.Type.ARRAY 
-            					|| schema.valueSchema().type() == Schema.Type.MAP) {
-        	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
-        	        		childBuilder.field(renamed(field.name()), updatedChildSchema);
-            			}
+                        if (schema.valueSchema().type() == Schema.Type.STRUCT 
+                                || schema.valueSchema().type() == Schema.Type.ARRAY 
+                                || schema.valueSchema().type() == Schema.Type.MAP) {
+                            Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+                            childBuilder.field(renamed(field.name()), updatedChildSchema);
+                        }
 
-            			else
-		        			childBuilder.field(renamed(fieldName), field.schema());
-            		}
-            	}
+                        else
+                            childBuilder.field(renamed(fieldName), field.schema());
+                    }
+                }
 
-        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), childBuilder.build()));
-        	}
-        	else // And in the last-case scenario (not a complex value and not a String key type) then we will just assume to pass it along since the Map itself was already allowed by an upstream filter()
-        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), schema.valueSchema()));
+                return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), childBuilder.build()));
+            }
+            else // And in the last-case scenario (not a complex value and not a String key type) then we will just assume to pass it along since the Map itself was already allowed by an upstream filter()
+                return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), schema.valueSchema()));
         }
 
         else
@@ -309,128 +310,128 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
     }
 
     @SuppressWarnings("unchecked")
-	private Object buildUpdatedSchemaValue(Object value, Schema updatedSchema) {
+    private Object buildUpdatedSchemaValue(Object value, Schema updatedSchema) {
 
-    	if (value == null)
-    		return null;
+        if (value == null)
+            return null;
 
-    	if (updatedSchema.type() == Schema.Type.STRUCT) {
-    		Struct struct = (Struct) value;
-        	Struct updatedStruct = new Struct(updatedSchema);
+        if (updatedSchema.type() == Schema.Type.STRUCT) {
+            Struct struct = (Struct) value;
+            Struct updatedStruct = new Struct(updatedSchema);
 
             for (Field field : struct.schema().fields()) {
-    	        if (filter(field.name())) {
-    	        	if (isRecursive && 
-    	        			(field.schema().type() == Schema.Type.STRUCT 
-    	        			|| field.schema().type() == Schema.Type.ARRAY 
-    	        			|| field.schema().type() == Schema.Type.MAP)
-    	        			) {
-    	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
-    	        		Object updatedChildValue = buildUpdatedSchemaValue(struct.get(field), updatedChildSchema);
-    	        		updatedStruct.put(updatedSchema.field(renamed(field.name())), updatedChildValue);
-    	        	}
-    	        	else // This is where most non-parent Value fields should be added (Struct fields that match the filter(), and either we are not using recursion or we are at the bottom of any nested Struct)
-    	        		updatedStruct.put(updatedSchema.field(renamed(field.name())), struct.get(field));
-    	        }
+                if (filter(field.name())) {
+                    if (isRecursive && 
+                            (field.schema().type() == Schema.Type.STRUCT 
+                            || field.schema().type() == Schema.Type.ARRAY 
+                            || field.schema().type() == Schema.Type.MAP)
+                            ) {
+                        Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+                        Object updatedChildValue = buildUpdatedSchemaValue(struct.get(field), updatedChildSchema);
+                        updatedStruct.put(updatedSchema.field(renamed(field.name())), updatedChildValue);
+                    }
+                    else // This is where most non-parent Value fields should be added (Struct fields that match the filter(), and either we are not using recursion or we are at the bottom of any nested Struct)
+                        updatedStruct.put(updatedSchema.field(renamed(field.name())), struct.get(field));
+                }
             }
             return updatedStruct;
         }
 
-    	else if (isRecursive && updatedSchema.type() == Schema.Type.ARRAY) {
+        else if (isRecursive && updatedSchema.type() == Schema.Type.ARRAY) {
             return buildUpdatedArrayValue((List<Object>) value);
         }
 
         else if (isRecursive && updatedSchema.type() == Schema.Type.MAP) {
-        	return buildUpdatedMapValue((Map<Object, Object>) value);
-    	}
+            return buildUpdatedMapValue((Map<Object, Object>) value);
+        }
 
         else
             throw new DataException(updatedSchema.type().toString() + " is not a supported schema type for the ReplaceField transformation.");
     }
 
     @SuppressWarnings("unchecked")
-	private List<Object> buildUpdatedArrayValue(List<Object> array) {
-    	List<Object> updatedArray = new ArrayList<Object>(array.size());
-    	for (Object arrayElement : array) {
-    		if (isRecursive && arrayElement instanceof Struct) {
-	    		Struct struct = (Struct) arrayElement;
-				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
-				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
-				updatedArray.add(updatedStruct);
-    		}
-    		else if (isRecursive && arrayElement instanceof List<?>) {
-    			updatedArray.add(buildUpdatedArrayValue((List<Object>) arrayElement));
-    		}
-    		else if (isRecursive && arrayElement instanceof Map<?,?>) {
-    			updatedArray.add(buildUpdatedMapValue((Map<Object, Object>) arrayElement));
-    		}
-    		else
-    			updatedArray.add(arrayElement);
-    	}
-    	return updatedArray;
+    private List<Object> buildUpdatedArrayValue(List<Object> array) {
+        List<Object> updatedArray = new ArrayList<Object>(array.size());
+        for (Object arrayElement : array) {
+            if (isRecursive && arrayElement instanceof Struct) {
+                Struct struct = (Struct) arrayElement;
+                Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+                Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+                updatedArray.add(updatedStruct);
+            }
+            else if (isRecursive && arrayElement instanceof List<?>) {
+                updatedArray.add(buildUpdatedArrayValue((List<Object>) arrayElement));
+            }
+            else if (isRecursive && arrayElement instanceof Map<?,?>) {
+                updatedArray.add(buildUpdatedMapValue((Map<Object, Object>) arrayElement));
+            }
+            else
+                updatedArray.add(arrayElement);
+        }
+        return updatedArray;
     }
 
     @SuppressWarnings("unchecked")
-	private Map<Object, Object> buildUpdatedMapValue(Map<Object, Object> map) {
-    	Map<Object, Object> updatedMap = new HashMap<>(map.size());
+    private Map<Object, Object> buildUpdatedMapValue(Map<Object, Object> map) {
+        Map<Object, Object> updatedMap = new HashMap<>(map.size());
 
-    	for (Map.Entry<Object, Object> mapEntry : map.entrySet()) {
-    		Object mapEntryValue = mapEntry.getValue();
+        for (Map.Entry<Object, Object> mapEntry : map.entrySet()) {
+            Object mapEntryValue = mapEntry.getValue();
 
-        	// If the Map key is a string, then we will also perform ReplaceField based on the key names within the Map fields
-        	if (mapEntry.getKey() instanceof String) {
-        		String mapEntryKey = mapEntry.getKey().toString();
+            // If the Map key is a string, then we will also perform ReplaceField based on the key names within the Map fields
+            if (mapEntry.getKey() instanceof String) {
+                String mapEntryKey = mapEntry.getKey().toString();
 
-        		if (filter(mapEntryKey)) {
+                if (filter(mapEntryKey)) {
 
-        			if (isRecursive && mapEntryValue instanceof Struct) {
-        	    		Struct struct = (Struct) mapEntry.getValue();
-        				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
-        				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
-        				updatedMap.put(renamed(mapEntryKey), updatedStruct);
-        			}
+                    if (isRecursive && mapEntryValue instanceof Struct) {
+                        Struct struct = (Struct) mapEntry.getValue();
+                        Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+                        Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+                        updatedMap.put(renamed(mapEntryKey), updatedStruct);
+                    }
 
-        			else if (isRecursive && mapEntryValue instanceof List<?>) {
-        				updatedMap.put(renamed(mapEntryKey), buildUpdatedArrayValue((List<Object>) mapEntryValue));
-        			}
+                    else if (isRecursive && mapEntryValue instanceof List<?>) {
+                        updatedMap.put(renamed(mapEntryKey), buildUpdatedArrayValue((List<Object>) mapEntryValue));
+                    }
 
-        			else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
-        				updatedMap.put(renamed(mapEntryKey), buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
-        			}
+                    else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
+                        updatedMap.put(renamed(mapEntryKey), buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
+                    }
 
-        			else // This is not a complex type that we can drill down. Send it through because we already know that this entry's parent map was allowed from filter()
-        				updatedMap.put(renamed(mapEntryKey), mapEntry.getValue());
-        		}
+                    else // This is not a complex type that we can drill down. Send it through because we already know that this entry's parent map was allowed from filter()
+                        updatedMap.put(renamed(mapEntryKey), mapEntry.getValue());
+                }
 
-        	}
+            }
 
-        	// Otherwise the key is not a string, and we cannot do a filter() check on the Map keys. So go ahead with passing it through since 
-        	//  an upstream filter() allowed us to be here.
+            // Otherwise the key is not a string, and we cannot do a filter() check on the Map keys. So go ahead with passing it through since 
+            //  an upstream filter() allowed us to be here.
 
-        	// However, if the map value is another complex type, then we can go one level deeper into the value to continue performing ReplaceField 
-        	//  logic on the children.
+            // However, if the map value is another complex type, then we can go one level deeper into the value to continue performing ReplaceField 
+            //  logic on the children.
 
-        	// The logic is the same above, except we cannot check against the filter() or rename the keys
-        	else if (isRecursive && mapEntryValue instanceof Struct) {
-	    		Struct struct = (Struct) mapEntry.getValue();
-				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
-				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
-				updatedMap.put(mapEntry.getKey(), updatedStruct);
-			}
+            // The logic is the same above, except we cannot check against the filter() or rename the keys
+            else if (isRecursive && mapEntryValue instanceof Struct) {
+                Struct struct = (Struct) mapEntry.getValue();
+                Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+                Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+                updatedMap.put(mapEntry.getKey(), updatedStruct);
+            }
 
-			else if (isRecursive && mapEntryValue instanceof List<?>) {
-				updatedMap.put(mapEntry.getKey(), buildUpdatedArrayValue((List<Object>) mapEntryValue));
-			}
+            else if (isRecursive && mapEntryValue instanceof List<?>) {
+                updatedMap.put(mapEntry.getKey(), buildUpdatedArrayValue((List<Object>) mapEntryValue));
+            }
 
-			else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
-				updatedMap.put(mapEntry.getKey(), buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
-			}
+            else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
+                updatedMap.put(mapEntry.getKey(), buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
+            }
 
-			else // This is not a complex type that we can drill down. Send it through because we already know that this entry's parent map was allowed from filter()
-				updatedMap.put(mapEntry.getKey(), mapEntry.getValue());
-    	}
+            else // This is not a complex type that we can drill down. Send it through because we already know that this entry's parent map was allowed from filter()
+                updatedMap.put(mapEntry.getKey(), mapEntry.getValue());
+        }
 
-    	return updatedMap;
+        return updatedMap;
     }
 
     @Override

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/ReplaceField.java
@@ -28,9 +28,13 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.transforms.util.SchemaUtil;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -40,12 +44,13 @@ import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 
 public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transformation<R> {
+    private static final Logger log = LoggerFactory.getLogger(ReplaceField.class);
 
     public static final String OVERVIEW_DOC = "Filter or rename fields."
             + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
             + "or value (<code>" + Value.class.getName() + "</code>).";
 
-    interface ConfigName {
+    public static interface ConfigName {
         String EXCLUDE = "exclude";
         String INCLUDE = "include";
 
@@ -54,6 +59,12 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
         String EXCLUDE_ALIAS = "blacklist";
 
         String RENAME = "renames";
+        
+        String RECURSIVE = "recursive";
+    }
+
+    public static interface ConfigDefault {
+    	boolean RECURSIVE = false;
     }
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -76,7 +87,10 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
                 public String toString() {
                     return "list of colon-delimited pairs, e.g. <code>foo:bar,abc:xyz</code>";
                 }
-            }, ConfigDef.Importance.MEDIUM, "Field rename mappings.");
+            }, ConfigDef.Importance.MEDIUM, "Field rename mappings.")
+    		.define(ConfigName.RECURSIVE, ConfigDef.Type.BOOLEAN, ConfigDefault.RECURSIVE, ConfigDef.Importance.MEDIUM, 
+    				"Boolean which indicates if the ReplaceField should recursively replace child fields of nested complex types, "
+    						+ "if any nested children fields exist with the same names as given in the configuration.");
 
     private static final String PURPOSE = "field replacement";
 
@@ -84,6 +98,7 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
     private List<String> include;
     private Map<String, String> renames;
     private Map<String, String> reverseRenames;
+    private boolean isRecursive;
 
     private Cache<Schema, Schema> schemaUpdateCache;
 
@@ -98,6 +113,7 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
         include = config.getList(ConfigName.INCLUDE);
         renames = parseRenameMappings(config.getList(ConfigName.RENAME));
         reverseRenames = invert(renames);
+        isRecursive = config.getBoolean(ConfigName.RECURSIVE);
 
         schemaUpdateCache = new SynchronizedCache<>(new LRUCache<>(16));
     }
@@ -123,12 +139,32 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
     }
 
     boolean filter(String fieldName) {
-        return !exclude.contains(fieldName) && (include.isEmpty() || include.contains(fieldName));
+    	if (exclude.contains(fieldName)) {
+    		log.debug("Excluded field '{}' will be removed.", fieldName);
+    		return false;
+    	}
+    	else if (include.contains(fieldName)) {
+    		log.debug("Included field '{}' will be added.", fieldName);
+    		return true;
+    	}
+    	else if (include.isEmpty()) {
+    		return true;
+    	}
+    	else {
+    		log.debug("Field '{}' will be removed (missing from the include list or otherwise incompatible configuration).", fieldName);
+    		return false;
+    	}
     }
 
     String renamed(String fieldName) {
         final String mapping = renames.get(fieldName);
-        return mapping == null ? fieldName : mapping;
+        if (mapping == null) {
+        	return fieldName;
+        }
+        else {
+        	log.debug("Renamed field '{}' to '{}'.", fieldName, mapping);
+        	return mapping;
+        }
     }
 
     String reverseRenamed(String fieldName) {
@@ -150,46 +186,251 @@ public abstract class ReplaceField<R extends ConnectRecord<R>> implements Transf
     private R applySchemaless(R record) {
         final Map<String, Object> value = requireMap(operatingValue(record), PURPOSE);
 
-        final Map<String, Object> updatedValue = new HashMap<>(value.size());
+        Map<Object, Object> valueToConvert = new HashMap<>(value);
+		final Map<Object, Object> updatedValue = buildUpdatedMapValue(valueToConvert);
 
-        for (Map.Entry<String, Object> e : value.entrySet()) {
-            final String fieldName = e.getKey();
-            if (filter(fieldName)) {
-                final Object fieldValue = e.getValue();
-                updatedValue.put(renamed(fieldName), fieldValue);
-            }
-        }
-
-        return newRecord(record, null, updatedValue);
+		return newRecord(record, null, updatedValue);
     }
 
     private R applyWithSchema(R record) {
         final Struct value = requireStruct(operatingValue(record), PURPOSE);
 
-        Schema updatedSchema = schemaUpdateCache.get(value.schema());
-        if (updatedSchema == null) {
-            updatedSchema = makeUpdatedSchema(value.schema());
-            schemaUpdateCache.put(value.schema(), updatedSchema);
-        }
-
-        final Struct updatedValue = new Struct(updatedSchema);
-
-        for (Field field : updatedSchema.fields()) {
-            final Object fieldValue = value.get(reverseRenamed(field.name()));
-            updatedValue.put(field.name(), fieldValue);
-        }
+        Schema updatedSchema = getOrBuildUpdatedSchema(value.schema());
+        final Struct updatedValue = (Struct) buildUpdatedSchemaValue(value, updatedSchema);
 
         return newRecord(record, updatedSchema, updatedValue);
     }
 
-    private Schema makeUpdatedSchema(Schema schema) {
-        final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
-        for (Field field : schema.fields()) {
-            if (filter(field.name())) {
-                builder.field(renamed(field.name()), field.schema());
+    private Schema getOrBuildUpdatedSchema(Schema schema) {
+        Schema updatedSchema = schemaUpdateCache.get(schema);
+        if (updatedSchema != null)
+            return updatedSchema;
+
+        final SchemaBuilder builder;
+        builder = buildUpdatedSchema(schema);
+
+        if (schema.isOptional())
+            builder.optional();
+        if (schema.defaultValue() != null)
+            builder.defaultValue(schema.defaultValue());
+
+        updatedSchema = builder.build();
+        schemaUpdateCache.put(schema, updatedSchema);
+        return updatedSchema;
+    }
+
+	/***
+	 * Method which recursively builds nested {@link SchemaBuilder}s based on the {@link ReplaceField} configuration. 
+	 * Each child schema is also added to the <code>schemaUpdateCache</code> and can be fetched afterwards instead 
+	 * of being built again.
+	 * @param schema
+	 * @return {@link SchemaBuilder} which can be used to build the final {@link Schema}
+	 */
+    private SchemaBuilder buildUpdatedSchema(Schema schema) {
+
+    	// Perform different logic for different types of parent schemas.
+
+        if (schema.type() == Schema.Type.STRUCT) {
+        	SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema, SchemaBuilder.struct());
+
+        	for (Field field : schema.fields()) {
+    	        if (filter(field.name())) {
+    	        	if (isRecursive && 
+    	        			(field.schema().type() == Schema.Type.STRUCT 
+    	        			|| field.schema().type() == Schema.Type.ARRAY 
+    	        			|| field.schema().type() == Schema.Type.MAP)
+    	        			) { 
+    	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+    	        		builder.field(renamed(field.name()), updatedChildSchema);
+    	        	}
+    	        	else // This is where all non-parent Schema fields should be added (is not recursive, or we are at the bottom of a recursion) 
+    	        		builder.field(renamed(field.name()), field.schema());
+    	        }
             }
+
+            return builder;
         }
-        return builder.build();
+
+        else if (isRecursive && schema.type() == Schema.Type.ARRAY) {
+
+        	// For complex types, just go one level lower to more detail and then return a new Array schema with the updated child value schema
+        	if (schema.valueSchema().type() == Schema.Type.STRUCT 
+					|| schema.valueSchema().type() == Schema.Type.ARRAY 
+					|| schema.valueSchema().type() == Schema.Type.MAP) {
+        		Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(updatedChildSchema));
+        	}
+
+        	else // Otherwise we will just assume to pass it along since the Array itself was already allowed by an upstream filter()
+				return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.array(schema.valueSchema()));
+
+        }
+        else if (isRecursive && schema.type() == Schema.Type.MAP) {
+
+        	// For complex type values, just go one level lower to more detail and then return a new Map schema with the updated child value schema
+        	if (schema.valueSchema().type() == Schema.Type.STRUCT 
+					|| schema.valueSchema().type() == Schema.Type.ARRAY 
+					|| schema.valueSchema().type() == Schema.Type.MAP) {
+        		Schema updatedChildSchema = getOrBuildUpdatedSchema(schema.valueSchema());
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), updatedChildSchema));
+        	}
+
+        	// Otherwise, if the Map key is a string, then we will also perform ReplaceField based on the key names within the Map fields
+        	else if (schema.keySchema().type() == Schema.Type.STRING) {
+
+        		SchemaBuilder childBuilder = SchemaUtil.copySchemaBasics(schema.valueSchema());
+
+            	for (Field field : schema.valueSchema().fields()) {
+            		String fieldName = field.name();
+
+            		if (filter(fieldName)) {
+
+            			if (schema.valueSchema().type() == Schema.Type.STRUCT 
+            					|| schema.valueSchema().type() == Schema.Type.ARRAY 
+            					|| schema.valueSchema().type() == Schema.Type.MAP) {
+        	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+        	        		childBuilder.field(renamed(field.name()), updatedChildSchema);
+            			}
+
+            			else
+		        			childBuilder.field(renamed(fieldName), field.schema());
+            		}
+            	}
+
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), childBuilder.build()));
+        	}
+        	else // And in the last-case scenario (not a complex value and not a String key type) then we will just assume to pass it along since the Map itself was already allowed by an upstream filter()
+        		return SchemaUtil.copySchemaBasics(schema, SchemaBuilder.map(schema.keySchema(), schema.valueSchema()));
+        }
+
+        else
+            throw new DataException(schema.type().toString() + " is not a supported parent Schema type for the ReplaceField transformation.");
+
+    }
+
+    @SuppressWarnings("unchecked")
+	private Object buildUpdatedSchemaValue(Object value, Schema updatedSchema) {
+
+    	if (value == null)
+    		return null;
+
+    	if (updatedSchema.type() == Schema.Type.STRUCT) {
+    		Struct struct = (Struct) value;
+        	Struct updatedStruct = new Struct(updatedSchema);
+
+            for (Field field : struct.schema().fields()) {
+    	        if (filter(field.name())) {
+    	        	if (isRecursive && 
+    	        			(field.schema().type() == Schema.Type.STRUCT 
+    	        			|| field.schema().type() == Schema.Type.ARRAY 
+    	        			|| field.schema().type() == Schema.Type.MAP)
+    	        			) {
+    	        		Schema updatedChildSchema = getOrBuildUpdatedSchema(field.schema());
+    	        		Object updatedChildValue = buildUpdatedSchemaValue(struct.get(field), updatedChildSchema);
+    	        		updatedStruct.put(updatedSchema.field(renamed(field.name())), updatedChildValue);
+    	        	}
+    	        	else // This is where most non-parent Value fields should be added (Struct fields that match the filter(), and either we are not using recursion or we are at the bottom of any nested Struct)
+    	        		updatedStruct.put(updatedSchema.field(renamed(field.name())), struct.get(field));
+    	        }
+            }
+            return updatedStruct;
+        }
+
+    	else if (isRecursive && updatedSchema.type() == Schema.Type.ARRAY) {
+            return buildUpdatedArrayValue((List<Object>) value);
+        }
+
+        else if (isRecursive && updatedSchema.type() == Schema.Type.MAP) {
+        	return buildUpdatedMapValue((Map<Object, Object>) value);
+    	}
+
+        else
+            throw new DataException(updatedSchema.type().toString() + " is not a supported schema type for the ReplaceField transformation.");
+    }
+
+    @SuppressWarnings("unchecked")
+	private List<Object> buildUpdatedArrayValue(List<Object> array) {
+    	List<Object> updatedArray = new ArrayList<Object>(array.size());
+    	for (Object arrayElement : array) {
+    		if (isRecursive && arrayElement instanceof Struct) {
+	    		Struct struct = (Struct) arrayElement;
+				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+				updatedArray.add(updatedStruct);
+    		}
+    		else if (isRecursive && arrayElement instanceof List<?>) {
+    			updatedArray.add(buildUpdatedArrayValue((List<Object>) arrayElement));
+    		}
+    		else if (isRecursive && arrayElement instanceof Map<?,?>) {
+    			updatedArray.add(buildUpdatedMapValue((Map<Object, Object>) arrayElement));
+    		}
+    		else
+    			updatedArray.add(arrayElement);
+    	}
+    	return updatedArray;
+    }
+
+    @SuppressWarnings("unchecked")
+	private Map<Object, Object> buildUpdatedMapValue(Map<Object, Object> map) {
+    	Map<Object, Object> updatedMap = new HashMap<>(map.size());
+
+    	for (Map.Entry<Object, Object> mapEntry : map.entrySet()) {
+    		Object mapEntryValue = mapEntry.getValue();
+
+        	// If the Map key is a string, then we will also perform ReplaceField based on the key names within the Map fields
+        	if (mapEntry.getKey() instanceof String) {
+        		String mapEntryKey = mapEntry.getKey().toString();
+
+        		if (filter(mapEntryKey)) {
+
+        			if (isRecursive && mapEntryValue instanceof Struct) {
+        	    		Struct struct = (Struct) mapEntry.getValue();
+        				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+        				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+        				updatedMap.put(renamed(mapEntryKey), updatedStruct);
+        			}
+
+        			else if (isRecursive && mapEntryValue instanceof List<?>) {
+        				updatedMap.put(renamed(mapEntryKey), buildUpdatedArrayValue((List<Object>) mapEntryValue));
+        			}
+
+        			else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
+        				updatedMap.put(renamed(mapEntryKey), buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
+        			}
+
+        			else // This is not a complex type that we can drill down. Send it through because we already know that this entry's parent map was allowed from filter()
+        				updatedMap.put(renamed(mapEntryKey), mapEntry.getValue());
+        		}
+
+        	}
+
+        	// Otherwise the key is not a string, and we cannot do a filter() check on the Map keys. So go ahead with passing it through since 
+        	//  an upstream filter() allowed us to be here.
+
+        	// However, if the map value is another complex type, then we can go one level deeper into the value to continue performing ReplaceField 
+        	//  logic on the children.
+
+        	// The logic is the same above, except we cannot check against the filter() or rename the keys
+        	else if (isRecursive && mapEntryValue instanceof Struct) {
+	    		Struct struct = (Struct) mapEntry.getValue();
+				Schema updatedSchema = getOrBuildUpdatedSchema(struct.schema()); 
+				Object updatedStruct = buildUpdatedSchemaValue(struct, updatedSchema);
+				updatedMap.put(mapEntry.getKey(), updatedStruct);
+			}
+
+			else if (isRecursive && mapEntryValue instanceof List<?>) {
+				updatedMap.put(mapEntry.getKey(), buildUpdatedArrayValue((List<Object>) mapEntryValue));
+			}
+
+			else if (isRecursive && mapEntryValue instanceof Map<?,?>) {
+				updatedMap.put(mapEntry.getKey(), buildUpdatedMapValue((Map<Object, Object>) mapEntryValue));
+			}
+
+			else // This is not a complex type that we can drill down. Send it through because we already know that this entry's parent map was allowed from filter()
+				updatedMap.put(mapEntry.getKey(), mapEntry.getValue());
+    	}
+
+    	return updatedMap;
     }
 
     @Override

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -427,8 +427,8 @@ public class CastTest {
 
         Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA).build();
         Schema supportedTypesSchema = SchemaBuilder.struct()
-        		.field("array", arraySchema)
-        		.build();
+                .field("array", arraySchema)
+                .build();
 
         List<Byte> array = Arrays.asList((byte) 1, (byte) 2);
 
@@ -486,7 +486,7 @@ public class CastTest {
 
         //Compare simple string against result after removing any spaces (just in case of variations in deepToString)
         assertEquals("[" + arrayMember1.toString().replaceAll("\\s+","") + "," + arrayMember2.toString().replaceAll("\\s+","") + "]",
-        		((Struct) transformed.value()).get("array").toString().replaceAll("\\s+",""));
+                ((Struct) transformed.value()).get("array").toString().replaceAll("\\s+",""));
 
         Schema transformedSchema = ((Struct) transformed.value()).schema();
         assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("array").schema().type());
@@ -534,7 +534,7 @@ public class CastTest {
 
         //Compare simple string against result after removing any spaces (just in case of variations in deepToString)
         assertEquals("[{\"name\":\"Member 1\",\"value\":15,\"boolean\":true},{\"name\":\"Member 2\",\"value\":800,\"boolean\":false}]",
-        		((Struct) transformed.value()).get("array").toString());
+                ((Struct) transformed.value()).get("array").toString());
 
         Schema transformedSchema = ((Struct) transformed.value()).schema();
         assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("array").schema().type());
@@ -547,8 +547,8 @@ public class CastTest {
 
         Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
         Schema supportedTypesSchema = SchemaBuilder.struct()
-        		.field("map", mapSchema)
-        		.build();
+                .field("map", mapSchema)
+                .build();
 
         Map<String, Object> map = new LinkedHashMap<String, Object>();
         map.put("key1", 1);
@@ -655,7 +655,7 @@ public class CastTest {
 
         //Compare JSON string of map with result
         assertEquals("{\"key1\":{\"name\":\"Member 1\",\"value\":15,\"boolean\":true},\"key2\":{\"name\":\"Member 2\",\"value\":800,\"boolean\":false}}", 
-        		((Struct) transformed.value()).get("map").toString());
+                ((Struct) transformed.value()).get("map").toString());
 
         Schema transformedSchema = ((Struct) transformed.value()).schema();
         assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("map").schema().type());
@@ -760,65 +760,65 @@ public class CastTest {
     }
 
     @SuppressWarnings("unchecked")
-	@Test
-	public void castFieldsWithSchemaRecursive() {
-	    Map<String, Object> config = new HashMap<>();
-	    config.put(Cast.ConfigName.SPEC, "int8:int16,int32:int64,float64:boolean,boolean:int8,string:int32,bigdecimal:string,optional:int32,arraystring:string,mapstring:string,structstring:string");
-	    config.put(Cast.ConfigName.RECURSIVE, true);
-	    xformValue.configure(config);
+    @Test
+    public void castFieldsWithSchemaRecursive() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(Cast.ConfigName.SPEC, "int8:int16,int32:int64,float64:boolean,boolean:int8,string:int32,bigdecimal:string,optional:int32,arraystring:string,mapstring:string,structstring:string");
+        config.put(Cast.ConfigName.RECURSIVE, true);
+        xformValue.configure(config);
 
-	    // Schema
+        // Schema
 
-	    final Schema schema = SchemaBuilder.struct()
-	    	    .field("int8", Schema.INT8_SCHEMA)
-	    	    .field("int32", SchemaBuilder.int32().defaultValue(2).build())
-	    	    // Default value here ensures we correctly convert default values
-	    	    .field("float64", SchemaBuilder.float64().defaultValue(-1.125).build())
-	    	    .field("boolean", Schema.BOOLEAN_SCHEMA)
-	    	    .field("string", Schema.STRING_SCHEMA)
-	    	    .field("bigdecimal", Decimal.schema(new BigDecimal(42).scale()))
-	    	    .field("optional", Schema.OPTIONAL_FLOAT32_SCHEMA)
-	            .build();
+        final Schema schema = SchemaBuilder.struct()
+                .field("int8", Schema.INT8_SCHEMA)
+                .field("int32", SchemaBuilder.int32().defaultValue(2).build())
+                // Default value here ensures we correctly convert default values
+                .field("float64", SchemaBuilder.float64().defaultValue(-1.125).build())
+                .field("boolean", Schema.BOOLEAN_SCHEMA)
+                .field("string", Schema.STRING_SCHEMA)
+                .field("bigdecimal", Decimal.schema(new BigDecimal(42).scale()))
+                .field("optional", Schema.OPTIONAL_FLOAT32_SCHEMA)
+                .build();
 
-	    final Schema arraySchema = SchemaBuilder.array(schema);
+        final Schema arraySchema = SchemaBuilder.array(schema);
 
-	    final Schema parentASchema = SchemaBuilder.struct()
-	    	    .field("string", Schema.STRING_SCHEMA)
-	            .field("array", arraySchema)
-	            .field("arraystring", arraySchema)
-	    	    .field("struct", schema)
-	    	    .field("structstring", schema)
-	            .build();
+        final Schema parentASchema = SchemaBuilder.struct()
+                .field("string", Schema.STRING_SCHEMA)
+                .field("array", arraySchema)
+                .field("arraystring", arraySchema)
+                .field("struct", schema)
+                .field("structstring", schema)
+                .build();
 
-	    final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, parentASchema);
+        final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, parentASchema);
 
-	    final Schema parentBSchema = SchemaBuilder.struct()
-	            .field("array", arraySchema)
-	            .field("arraystring", arraySchema)
-	    	    .field("struct", parentASchema)
-	    	    .field("structstring", parentASchema)
-	    	    .field("map", mapSchema)
-	    	    .field("mapstring", mapSchema)
-	            .build();
+        final Schema parentBSchema = SchemaBuilder.struct()
+                .field("array", arraySchema)
+                .field("arraystring", arraySchema)
+                .field("struct", parentASchema)
+                .field("structstring", parentASchema)
+                .field("map", mapSchema)
+                .field("mapstring", mapSchema)
+                .build();
 
-	    // Value
+        // Value
 
-	    final Struct struct1 = new Struct(schema)
-	    	    .put("int8", (byte) 8)
-	    	    .put("int32", 32)
-	    	    .put("float64", -64.)
-	    	    .put("boolean", true)
-	    	    .put("string", "42")
-	    	    .put("bigdecimal", new BigDecimal(42));
+        final Struct struct1 = new Struct(schema)
+                .put("int8", (byte) 8)
+                .put("int32", 32)
+                .put("float64", -64.)
+                .put("boolean", true)
+                .put("string", "42")
+                .put("bigdecimal", new BigDecimal(42));
         // optional field intentionally omitted
 
-	    final Struct struct2 = new Struct(schema)
-	    	    .put("int8", (byte) 8)
-	    	    .put("int32", 32)
-	    	    .put("float64", -64.)
-	    	    .put("boolean", true)
-	    	    .put("string", "42")
-	    	    .put("bigdecimal", new BigDecimal(42));
+        final Struct struct2 = new Struct(schema)
+                .put("int8", (byte) 8)
+                .put("int32", 32)
+                .put("float64", -64.)
+                .put("boolean", true)
+                .put("string", "42")
+                .put("bigdecimal", new BigDecimal(42));
         // optional field intentionally omitted
 
         final List<Object> array = new ArrayList<Object>();
@@ -826,30 +826,30 @@ public class CastTest {
         array.add(struct2);
 
         final Struct parentAValue = new Struct(parentASchema)
-	    	    .put("string", "42")
-	    	    .put("array", array)
-	    	    .put("arraystring", array)
-			    .put("struct", struct1)
-			    .put("structstring", struct2);
+                .put("string", "42")
+                .put("array", array)
+                .put("arraystring", array)
+                .put("struct", struct1)
+                .put("structstring", struct2);
 
         final Map<String, Object> map = new HashMap<>();
-		map.put("key1", parentAValue);
-		map.put("key2", parentAValue);
+        map.put("key1", parentAValue);
+        map.put("key2", parentAValue);
 
         final Struct parentBValue = new Struct(parentBSchema)
-	    	    .put("array", array)
-	    	    .put("arraystring", array)
-			    .put("struct", parentAValue)
-			    .put("structstring", parentAValue)
-			    .put("map", map)
-			    .put("mapstring", map);
+                .put("array", array)
+                .put("arraystring", array)
+                .put("struct", parentAValue)
+                .put("structstring", parentAValue)
+                .put("map", map)
+                .put("mapstring", map);
 
         // Create and transform record
 
-	    SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
-	    		parentBSchema, parentBValue));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
+                parentBSchema, parentBValue));
 
-	    // Assert results
+        // Assert results
 
         final Struct updatedB = (Struct) transformed.value();
         assertEquals(6, updatedB.schema().fields().size());
@@ -858,75 +858,75 @@ public class CastTest {
         assertEquals(2, updatedB_array.size());
 
         final Struct updatedB_array_0 = (Struct) updatedB_array.get(0);
-	    assertEquals((short) 8, updatedB_array_0.get("int8"));
-	    assertEquals((long) 32, updatedB_array_0.get("int32"));
-	    assertEquals(2L, updatedB_array_0.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_array_0.get("float64"));
-	    assertEquals(true, updatedB_array_0.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_array_0.get("boolean"));
-	    assertEquals(42, updatedB_array_0.get("string"));
-	    assertEquals("42", updatedB_array_0.get("bigdecimal"));
-	    assertNull(updatedB_array_0.get("optional"));
+        assertEquals((short) 8, updatedB_array_0.get("int8"));
+        assertEquals((long) 32, updatedB_array_0.get("int32"));
+        assertEquals(2L, updatedB_array_0.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_array_0.get("float64"));
+        assertEquals(true, updatedB_array_0.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_array_0.get("boolean"));
+        assertEquals(42, updatedB_array_0.get("string"));
+        assertEquals("42", updatedB_array_0.get("bigdecimal"));
+        assertNull(updatedB_array_0.get("optional"));
 
         final Struct updatedB_array_1 = (Struct) updatedB_array.get(1);
-	    assertEquals((short) 8, updatedB_array_1.get("int8"));
-	    assertEquals((long) 32, updatedB_array_1.get("int32"));
-	    assertEquals(2L, updatedB_array_1.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_array_1.get("float64"));
-	    assertEquals(true, updatedB_array_1.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_array_1.get("boolean"));
-	    assertEquals(42, updatedB_array_1.get("string"));
-	    assertEquals("42", updatedB_array_1.get("bigdecimal"));
-	    assertNull(updatedB_array_1.get("optional"));
+        assertEquals((short) 8, updatedB_array_1.get("int8"));
+        assertEquals((long) 32, updatedB_array_1.get("int32"));
+        assertEquals(2L, updatedB_array_1.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_array_1.get("float64"));
+        assertEquals(true, updatedB_array_1.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_array_1.get("boolean"));
+        assertEquals(42, updatedB_array_1.get("string"));
+        assertEquals("42", updatedB_array_1.get("bigdecimal"));
+        assertNull(updatedB_array_1.get("optional"));
 
-	    // arraystring should match toString() of array
+        // arraystring should match toString() of array
         assertEquals(array.toString(), updatedB.get("arraystring"));
 
         // B->struct should be of type A and have child fields converted as configured
         // B->A should have string, array, arraystring, struct, structstring
         final Struct updatedB_updatedA = (Struct) updatedB.get("struct");
-	    assertEquals(42, updatedB_updatedA.get("string"));
+        assertEquals(42, updatedB_updatedA.get("string"));
 
-	    // B->A->array should have 2 items converted from struct1 and struct2
+        // B->A->array should have 2 items converted from struct1 and struct2
         final List<Object> updatedB_updatedA_array = (List<Object>) updatedB_updatedA.get("array");
         assertEquals(2, updatedB_updatedA_array.size());
 
         final Struct updatedB_updatedA_array_0 = (Struct) updatedB_updatedA_array.get(0);
-	    assertEquals((short) 8, updatedB_updatedA_array_0.get("int8"));
-	    assertEquals((long) 32, updatedB_updatedA_array_0.get("int32"));
-	    assertEquals(2L, updatedB_updatedA_array_0.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_updatedA_array_0.get("float64"));
-	    assertEquals(true, updatedB_updatedA_array_0.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_updatedA_array_0.get("boolean"));
-	    assertEquals(42, updatedB_updatedA_array_0.get("string"));
-	    assertEquals("42", updatedB_updatedA_array_0.get("bigdecimal"));
-	    assertNull(updatedB_updatedA_array_0.get("optional"));
+        assertEquals((short) 8, updatedB_updatedA_array_0.get("int8"));
+        assertEquals((long) 32, updatedB_updatedA_array_0.get("int32"));
+        assertEquals(2L, updatedB_updatedA_array_0.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_updatedA_array_0.get("float64"));
+        assertEquals(true, updatedB_updatedA_array_0.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_updatedA_array_0.get("boolean"));
+        assertEquals(42, updatedB_updatedA_array_0.get("string"));
+        assertEquals("42", updatedB_updatedA_array_0.get("bigdecimal"));
+        assertNull(updatedB_updatedA_array_0.get("optional"));
 
         final Struct updatedB_updatedA_array_1 = (Struct) updatedB_updatedA_array.get(1);
-	    assertEquals((short) 8, updatedB_updatedA_array_1.get("int8"));
-	    assertEquals((long) 32, updatedB_updatedA_array_1.get("int32"));
-	    assertEquals(2L, updatedB_updatedA_array_1.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_updatedA_array_1.get("float64"));
-	    assertEquals(true, updatedB_updatedA_array_1.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_updatedA_array_1.get("boolean"));
-	    assertEquals(42, updatedB_updatedA_array_1.get("string"));
-	    assertEquals("42", updatedB_updatedA_array_1.get("bigdecimal"));
-	    assertNull(updatedB_updatedA_array_1.get("optional"));
+        assertEquals((short) 8, updatedB_updatedA_array_1.get("int8"));
+        assertEquals((long) 32, updatedB_updatedA_array_1.get("int32"));
+        assertEquals(2L, updatedB_updatedA_array_1.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_updatedA_array_1.get("float64"));
+        assertEquals(true, updatedB_updatedA_array_1.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_updatedA_array_1.get("boolean"));
+        assertEquals(42, updatedB_updatedA_array_1.get("string"));
+        assertEquals("42", updatedB_updatedA_array_1.get("bigdecimal"));
+        assertNull(updatedB_updatedA_array_1.get("optional"));
 
-	    // B->A->arraystring should match toString() of array
+        // B->A->arraystring should match toString() of array
         assertEquals(array.toString(), updatedB_updatedA.get("arraystring"));
 
-	    // B->A->struct should be a converted version of struct1
-	    final Struct updatedB_updatedA_struct = (Struct) updatedB_updatedA.get("struct");
-	    assertEquals((short) 8, updatedB_updatedA_struct.get("int8"));
-	    assertEquals((long) 32, updatedB_updatedA_struct.get("int32"));
-	    assertEquals(2L, updatedB_updatedA_struct.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_updatedA_struct.get("float64"));
-	    assertEquals(true, updatedB_updatedA_struct.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_updatedA_struct.get("boolean"));
-	    assertEquals(42, updatedB_updatedA_struct.get("string"));
-	    assertEquals("42", updatedB_updatedA_struct.get("bigdecimal"));
-	    assertNull(updatedB_updatedA_struct.get("optional"));
+        // B->A->struct should be a converted version of struct1
+        final Struct updatedB_updatedA_struct = (Struct) updatedB_updatedA.get("struct");
+        assertEquals((short) 8, updatedB_updatedA_struct.get("int8"));
+        assertEquals((long) 32, updatedB_updatedA_struct.get("int32"));
+        assertEquals(2L, updatedB_updatedA_struct.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_updatedA_struct.get("float64"));
+        assertEquals(true, updatedB_updatedA_struct.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_updatedA_struct.get("boolean"));
+        assertEquals(42, updatedB_updatedA_struct.get("string"));
+        assertEquals("42", updatedB_updatedA_struct.get("bigdecimal"));
+        assertNull(updatedB_updatedA_struct.get("optional"));
 
         // B->A->structstring should match toString() of struct1
         assertEquals(struct2.toString(), updatedB_updatedA.get("structstring"));
@@ -940,147 +940,147 @@ public class CastTest {
 
         // Assert the entire structure and values of key1
         final Struct updatedB_map_key1 = (Struct) updatedB_map.get("key1");
-	    assertEquals(42, updatedB_map_key1.get("string"));
+        assertEquals(42, updatedB_map_key1.get("string"));
 
-	    // key1 array should have 2 items converted from struct1 and struct2
+        // key1 array should have 2 items converted from struct1 and struct2
         final List<Object> updatedB_map_key1_array = (List<Object>) updatedB_map_key1.get("array");
         assertEquals(2, updatedB_map_key1_array.size());
 
         final Struct updatedB_map_key1_array_0 = (Struct) updatedB_map_key1_array.get(0);
-	    assertEquals((short) 8, updatedB_map_key1_array_0.get("int8"));
-	    assertEquals((long) 32, updatedB_map_key1_array_0.get("int32"));
-	    assertEquals(2L, updatedB_map_key1_array_0.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_map_key1_array_0.get("float64"));
-	    assertEquals(true, updatedB_map_key1_array_0.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_map_key1_array_0.get("boolean"));
-	    assertEquals(42, updatedB_map_key1_array_0.get("string"));
-	    assertEquals("42", updatedB_map_key1_array_0.get("bigdecimal"));
-	    assertNull(updatedB_map_key1_array_0.get("optional"));
+        assertEquals((short) 8, updatedB_map_key1_array_0.get("int8"));
+        assertEquals((long) 32, updatedB_map_key1_array_0.get("int32"));
+        assertEquals(2L, updatedB_map_key1_array_0.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_map_key1_array_0.get("float64"));
+        assertEquals(true, updatedB_map_key1_array_0.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_map_key1_array_0.get("boolean"));
+        assertEquals(42, updatedB_map_key1_array_0.get("string"));
+        assertEquals("42", updatedB_map_key1_array_0.get("bigdecimal"));
+        assertNull(updatedB_map_key1_array_0.get("optional"));
 
         final Struct updatedB_map_key1_array_1 = (Struct) updatedB_map_key1_array.get(1);
-	    assertEquals((short) 8, updatedB_map_key1_array_1.get("int8"));
-	    assertEquals((long) 32, updatedB_map_key1_array_1.get("int32"));
-	    assertEquals(2L, updatedB_map_key1_array_1.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_map_key1_array_1.get("float64"));
-	    assertEquals(true, updatedB_map_key1_array_1.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_map_key1_array_1.get("boolean"));
-	    assertEquals(42, updatedB_map_key1_array_1.get("string"));
-	    assertEquals("42", updatedB_map_key1_array_1.get("bigdecimal"));
-	    assertNull(updatedB_map_key1_array_1.get("optional"));
+        assertEquals((short) 8, updatedB_map_key1_array_1.get("int8"));
+        assertEquals((long) 32, updatedB_map_key1_array_1.get("int32"));
+        assertEquals(2L, updatedB_map_key1_array_1.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_map_key1_array_1.get("float64"));
+        assertEquals(true, updatedB_map_key1_array_1.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_map_key1_array_1.get("boolean"));
+        assertEquals(42, updatedB_map_key1_array_1.get("string"));
+        assertEquals("42", updatedB_map_key1_array_1.get("bigdecimal"));
+        assertNull(updatedB_map_key1_array_1.get("optional"));
 
-	    // key1 arraystring should match toString() of array
+        // key1 arraystring should match toString() of array
         assertEquals(array.toString(), updatedB_map_key1.get("arraystring"));
 
-	    // key1 struct should be a converted version of struct1
-	    final Struct updatedB_map_key1_struct = (Struct) updatedB_map_key1.get("struct");
-	    assertEquals((short) 8, updatedB_map_key1_struct.get("int8"));
-	    assertEquals((long) 32, updatedB_map_key1_struct.get("int32"));
-	    assertEquals(2L, updatedB_map_key1_struct.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_map_key1_struct.get("float64"));
-	    assertEquals(true, updatedB_map_key1_struct.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_map_key1_struct.get("boolean"));
-	    assertEquals(42, updatedB_map_key1_struct.get("string"));
-	    assertEquals("42", updatedB_map_key1_struct.get("bigdecimal"));
-	    assertNull(updatedB_map_key1_struct.get("optional"));
+        // key1 struct should be a converted version of struct1
+        final Struct updatedB_map_key1_struct = (Struct) updatedB_map_key1.get("struct");
+        assertEquals((short) 8, updatedB_map_key1_struct.get("int8"));
+        assertEquals((long) 32, updatedB_map_key1_struct.get("int32"));
+        assertEquals(2L, updatedB_map_key1_struct.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_map_key1_struct.get("float64"));
+        assertEquals(true, updatedB_map_key1_struct.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_map_key1_struct.get("boolean"));
+        assertEquals(42, updatedB_map_key1_struct.get("string"));
+        assertEquals("42", updatedB_map_key1_struct.get("bigdecimal"));
+        assertNull(updatedB_map_key1_struct.get("optional"));
 
         // key1 structstring should match toString() of struct1
         assertEquals(struct2.toString(), updatedB_map_key1.get("structstring"));
 
         // And then repeat all of the above for key1, but now for key2
         final Struct updatedB_map_key2 = (Struct) updatedB_map.get("key2");
-	    assertEquals(42, updatedB_map_key2.get("string"));
+        assertEquals(42, updatedB_map_key2.get("string"));
 
-	    // key2 array should have 2 items converted from struct1 and struct2
+        // key2 array should have 2 items converted from struct1 and struct2
         final List<Object> updatedB_map_key2_array = (List<Object>) updatedB_map_key2.get("array");
         assertEquals(2, updatedB_map_key2_array.size());
 
         final Struct updatedB_map_key2_array_0 = (Struct) updatedB_map_key2_array.get(0);
-	    assertEquals((short) 8, updatedB_map_key2_array_0.get("int8"));
-	    assertEquals((long) 32, updatedB_map_key2_array_0.get("int32"));
-	    assertEquals(2L, updatedB_map_key2_array_0.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_map_key2_array_0.get("float64"));
-	    assertEquals(true, updatedB_map_key2_array_0.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_map_key2_array_0.get("boolean"));
-	    assertEquals(42, updatedB_map_key2_array_0.get("string"));
-	    assertEquals("42", updatedB_map_key2_array_0.get("bigdecimal"));
-	    assertNull(updatedB_map_key2_array_0.get("optional"));
+        assertEquals((short) 8, updatedB_map_key2_array_0.get("int8"));
+        assertEquals((long) 32, updatedB_map_key2_array_0.get("int32"));
+        assertEquals(2L, updatedB_map_key2_array_0.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_map_key2_array_0.get("float64"));
+        assertEquals(true, updatedB_map_key2_array_0.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_map_key2_array_0.get("boolean"));
+        assertEquals(42, updatedB_map_key2_array_0.get("string"));
+        assertEquals("42", updatedB_map_key2_array_0.get("bigdecimal"));
+        assertNull(updatedB_map_key2_array_0.get("optional"));
 
         final Struct updatedB_map_key2_array_1 = (Struct) updatedB_map_key2_array.get(1);
-	    assertEquals((short) 8, updatedB_map_key2_array_1.get("int8"));
-	    assertEquals((long) 32, updatedB_map_key2_array_1.get("int32"));
-	    assertEquals(2L, updatedB_map_key2_array_1.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_map_key2_array_1.get("float64"));
-	    assertEquals(true, updatedB_map_key2_array_1.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_map_key2_array_1.get("boolean"));
-	    assertEquals(42, updatedB_map_key2_array_1.get("string"));
-	    assertEquals("42", updatedB_map_key2_array_1.get("bigdecimal"));
-	    assertNull(updatedB_map_key2_array_1.get("optional"));
+        assertEquals((short) 8, updatedB_map_key2_array_1.get("int8"));
+        assertEquals((long) 32, updatedB_map_key2_array_1.get("int32"));
+        assertEquals(2L, updatedB_map_key2_array_1.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_map_key2_array_1.get("float64"));
+        assertEquals(true, updatedB_map_key2_array_1.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_map_key2_array_1.get("boolean"));
+        assertEquals(42, updatedB_map_key2_array_1.get("string"));
+        assertEquals("42", updatedB_map_key2_array_1.get("bigdecimal"));
+        assertNull(updatedB_map_key2_array_1.get("optional"));
 
-	    // key2 arraystring should match toString() of array
+        // key2 arraystring should match toString() of array
         assertEquals(array.toString(), updatedB_map_key2.get("arraystring"));
 
-	    // key2 struct should be a converted version of struct1
-	    final Struct updatedB_map_key2_struct = (Struct) updatedB_map_key2.get("struct");
-	    assertEquals((short) 8, updatedB_map_key2_struct.get("int8"));
-	    assertEquals((long) 32, updatedB_map_key2_struct.get("int32"));
-	    assertEquals(2L, updatedB_map_key2_struct.schema().field("int32").schema().defaultValue());
-	    assertEquals(true, updatedB_map_key2_struct.get("float64"));
-	    assertEquals(true, updatedB_map_key2_struct.schema().field("float64").schema().defaultValue());
-	    assertEquals((byte) 1, updatedB_map_key2_struct.get("boolean"));
-	    assertEquals(42, updatedB_map_key2_struct.get("string"));
-	    assertEquals("42", updatedB_map_key2_struct.get("bigdecimal"));
-	    assertNull(updatedB_map_key2_struct.get("optional"));
+        // key2 struct should be a converted version of struct1
+        final Struct updatedB_map_key2_struct = (Struct) updatedB_map_key2.get("struct");
+        assertEquals((short) 8, updatedB_map_key2_struct.get("int8"));
+        assertEquals((long) 32, updatedB_map_key2_struct.get("int32"));
+        assertEquals(2L, updatedB_map_key2_struct.schema().field("int32").schema().defaultValue());
+        assertEquals(true, updatedB_map_key2_struct.get("float64"));
+        assertEquals(true, updatedB_map_key2_struct.schema().field("float64").schema().defaultValue());
+        assertEquals((byte) 1, updatedB_map_key2_struct.get("boolean"));
+        assertEquals(42, updatedB_map_key2_struct.get("string"));
+        assertEquals("42", updatedB_map_key2_struct.get("bigdecimal"));
+        assertNull(updatedB_map_key2_struct.get("optional"));
 
         // key2 structstring should match toString() of struct1
         assertEquals(struct2.toString(), updatedB_map_key2.get("structstring"));
 
         // B->mapstring should match toString() of map
         assertEquals(map.toString(), updatedB.get("mapstring"));
-	}
+    }
 
     @SuppressWarnings("unchecked")
-	@Test
-	public void castFieldsSchemalessRecursive() {
+    @Test
+    public void castFieldsSchemalessRecursive() {
         Map<String, Object> config = new HashMap<>();
-	    config.put(Cast.ConfigName.SPEC, "boolean:int8,int32:string,string:int32,childstring:string,parentstring:string,arraystring:string");
-	    config.put(Cast.ConfigName.RECURSIVE, true);
-	    xformValue.configure(config);
+        config.put(Cast.ConfigName.SPEC, "boolean:int8,int32:string,string:int32,childstring:string,parentstring:string,arraystring:string");
+        config.put(Cast.ConfigName.RECURSIVE, true);
+        xformValue.configure(config);
 
 
-	    // Build and fill child
-	    Map<String, Object> child = new HashMap<String, Object>();
-	    child.put("boolean", true);
-	    child.put("int32", 42);
-	    child.put("string", "42");
+        // Build and fill child
+        Map<String, Object> child = new HashMap<String, Object>();
+        child.put("boolean", true);
+        child.put("int32", 42);
+        child.put("string", "42");
 
-	    List<Object> array = new ArrayList<Object>();
-	    array.add(child);
+        List<Object> array = new ArrayList<Object>();
+        array.add(child);
 
-	    // Build and fill parentA
-	    Map<String, Object> parentA = new HashMap<String, Object>();
-	    parentA.put("boolean", true);
-	    parentA.put("int32", 42);
-	    parentA.put("string", "42");
-	    parentA.put("child", child);
-	    parentA.put("childstring", child);
-	    parentA.put("array", array);
-	    parentA.put("arraystring", array);
+        // Build and fill parentA
+        Map<String, Object> parentA = new HashMap<String, Object>();
+        parentA.put("boolean", true);
+        parentA.put("int32", 42);
+        parentA.put("string", "42");
+        parentA.put("child", child);
+        parentA.put("childstring", child);
+        parentA.put("array", array);
+        parentA.put("arraystring", array);
 
-	    // Build and fill parentB
-	    Map<String, Object> parentB = new HashMap<String, Object>();
-	    parentB.put("boolean", true);
-	    parentB.put("int32", 42);
-	    parentB.put("string", "42");
-	    parentB.put("parent", parentA);
-	    parentB.put("parentstring", parentA);
-
-
-	    // Transform the record
-	    SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
-	    		null, parentB));
+        // Build and fill parentB
+        Map<String, Object> parentB = new HashMap<String, Object>();
+        parentB.put("boolean", true);
+        parentB.put("int32", 42);
+        parentB.put("string", "42");
+        parentB.put("parent", parentA);
+        parentB.put("parentstring", parentA);
 
 
-	    // Assert the results
+        // Transform the record
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
+                null, parentB));
+
+
+        // Assert the results
         assertNull(transformed.valueSchema());
 
         Map<String, Object> updatedB = (Map<String, Object>) transformed.value();
@@ -1116,6 +1116,6 @@ public class CastTest {
         assertEquals(array.toString(), updatedA.get("arraystring"));
 
         assertEquals(parentA.toString(), updatedB.get("parentstring"));
-	}
+    }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.connect.transforms;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -38,6 +39,7 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -58,37 +60,37 @@ public class CastTest {
 
     @Test(expected = ConfigException.class)
     public void testConfigEmpty() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, ""));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidSchemaType() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "foo:faketype"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidTargetType() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "foo:array"));
     }
 
     @Test(expected = ConfigException.class)
     public void testUnsupportedTargetType() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:bytes"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "foo:bytes"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidMap() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "foo:int8:extra"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigMixWholeAndFieldTransformation() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "foo:int8,int32"));
     }
 
     @Test
     public void castWholeRecordKeyWithSchema() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8"));
         SourceRecord transformed = xformKey.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42, Schema.STRING_SCHEMA, "bogus"));
 
@@ -98,7 +100,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaInt8() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -108,7 +110,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaInt16() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int16"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int16"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -118,7 +120,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaInt32() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int32"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -128,7 +130,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaInt64() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int64"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int64"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -138,7 +140,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaFloat32() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "float32"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -148,7 +150,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaFloat64() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float64"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "float64"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -158,7 +160,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaBooleanTrue() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "boolean"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -168,7 +170,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaBooleanFalse() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "boolean"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 0));
 
@@ -178,7 +180,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueWithSchemaString() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "string"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
@@ -189,7 +191,7 @@ public class CastTest {
     @Test
     public void castWholeBigDecimalRecordValueWithSchemaString() {
         BigDecimal bigDecimal = new BigDecimal(42);
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "string"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Decimal.schema(bigDecimal.scale()), bigDecimal));
 
@@ -200,7 +202,7 @@ public class CastTest {
     @Test
     public void castWholeDateRecordValueWithSchemaString() {
         Date timestamp = new Date(MILLIS_PER_DAY + 1); // day + 1msec to get a timestamp formatting.
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "string"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Timestamp.SCHEMA, timestamp));
 
@@ -211,7 +213,7 @@ public class CastTest {
     @Test
     public void castWholeRecordDefaultValue() {
         // Validate default value in schema is correctly converted
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int32"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 SchemaBuilder.float32().defaultValue(-42.125f).build(), 42.125f));
 
@@ -222,7 +224,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordKeySchemaless() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        xformKey.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8"));
         SourceRecord transformed = xformKey.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42, Schema.STRING_SCHEMA, "bogus"));
 
@@ -232,7 +234,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessInt8() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -242,7 +244,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessInt16() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int16"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int16"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -252,7 +254,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessInt32() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int32"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -262,7 +264,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessInt64() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int64"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int64"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -272,7 +274,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessFloat32() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "float32"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -282,7 +284,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessFloat64() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float64"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "float64"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -292,7 +294,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessBooleanTrue() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "boolean"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -302,7 +304,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessBooleanFalse() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "boolean"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 0));
 
@@ -312,7 +314,7 @@ public class CastTest {
 
     @Test
     public void castWholeRecordValueSchemalessString() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "string"));
         SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
@@ -322,7 +324,7 @@ public class CastTest {
 
     @Test(expected = DataException.class)
     public void castWholeRecordValueSchemalessUnsupportedType() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8"));
         xformValue.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
     }
 
@@ -338,7 +340,7 @@ public class CastTest {
         );
 
         Date day = new Date(MILLIS_PER_DAY);
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG,
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC,
             String.join(",", specParts)));
 
         SchemaBuilder builder = SchemaBuilder.struct();
@@ -385,7 +387,7 @@ public class CastTest {
         Date time = new Date(MILLIS_PER_HOUR);
         Date timestamp = new Date();
 
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG,
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC,
             "date:string,decimal:string,time:string,timestamp:string"));
 
         SchemaBuilder builder = SchemaBuilder.struct();
@@ -419,9 +421,250 @@ public class CastTest {
     }
 
     @Test
+    public void castArrayToString() {
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC,
+            "array:string"));
+
+        Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA).build();
+        Schema supportedTypesSchema = SchemaBuilder.struct()
+        		.field("array", arraySchema)
+        		.build();
+
+        List<Byte> array = Arrays.asList((byte) 1, (byte) 2);
+
+        Struct recordValue = new Struct(supportedTypesSchema);
+        recordValue.put("array", array);
+
+        SourceRecord transformed = xformValue.apply(
+                new SourceRecord(null, null, "topic", 0,
+                        supportedTypesSchema, recordValue));
+
+        //Compare simple string "[1,2]" against result after removing any spaces (just in case of variations in deepToString)
+        assertEquals("[1,2]", ((Struct) transformed.value()).get("array").toString().replaceAll("\\s+",""));
+
+        Schema transformedSchema = ((Struct) transformed.value()).schema();
+        assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("array").schema().type());
+    }
+
+    @Test
+    public void castComplexArrayToString() {
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC,
+            "array:string"));
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("name", Schema.STRING_SCHEMA);
+        builder.field("value", Schema.INT32_SCHEMA);
+        builder.field("boolean", Schema.BOOLEAN_SCHEMA);
+        Schema arrayMemberSchema = builder.build();
+
+        Schema arraySchema = SchemaBuilder.array(arrayMemberSchema).build();
+
+        builder = SchemaBuilder.struct();
+        builder.field("array", arraySchema);
+        Schema supportedTypesSchema = builder.build();
+
+        Struct arrayMember1 = new Struct(arrayMemberSchema);
+        arrayMember1.put("name", "Member 1");
+        arrayMember1.put("value", 15);
+        arrayMember1.put("boolean", true);
+
+        Struct arrayMember2 = new Struct(arrayMemberSchema);
+        arrayMember2.put("name", "Member 2");
+        arrayMember2.put("value", 800);
+        arrayMember2.put("boolean", false);
+
+        List<Struct> array = new ArrayList<Struct>();
+        array.add(arrayMember1);
+        array.add(arrayMember2);
+
+        Struct recordValue = new Struct(supportedTypesSchema);
+        recordValue.put("array", array);
+
+        SourceRecord transformed = xformValue.apply(
+                new SourceRecord(null, null, "topic", 0,
+                        supportedTypesSchema, recordValue));
+
+        //Compare simple string against result after removing any spaces (just in case of variations in deepToString)
+        assertEquals("[" + arrayMember1.toString().replaceAll("\\s+","") + "," + arrayMember2.toString().replaceAll("\\s+","") + "]",
+        		((Struct) transformed.value()).get("array").toString().replaceAll("\\s+",""));
+
+        Schema transformedSchema = ((Struct) transformed.value()).schema();
+        assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("array").schema().type());
+    }
+
+    @Test
+    public void castComplexArrayToJsonString() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(Cast.ConfigName.SPEC, "array:string");
+        config.put(Cast.ConfigName.COMPLEX_STRING_AS_JSON, true);
+        xformValue.configure(config);
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("name", Schema.STRING_SCHEMA);
+        builder.field("value", Schema.INT32_SCHEMA);
+        builder.field("boolean", Schema.BOOLEAN_SCHEMA);
+        Schema arrayMemberSchema = builder.build();
+
+        Schema arraySchema = SchemaBuilder.array(arrayMemberSchema).build();
+
+        builder = SchemaBuilder.struct();
+        builder.field("array", arraySchema);
+        Schema supportedTypesSchema = builder.build();
+
+        Struct arrayMember1 = new Struct(arrayMemberSchema);
+        arrayMember1.put("name", "Member 1");
+        arrayMember1.put("value", 15);
+        arrayMember1.put("boolean", true);
+
+        Struct arrayMember2 = new Struct(arrayMemberSchema);
+        arrayMember2.put("name", "Member 2");
+        arrayMember2.put("value", 800);
+        arrayMember2.put("boolean", false);
+
+        List<Struct> array = new ArrayList<Struct>();
+        array.add(arrayMember1);
+        array.add(arrayMember2);
+
+        Struct recordValue = new Struct(supportedTypesSchema);
+        recordValue.put("array", array);
+
+        SourceRecord transformed = xformValue.apply(
+                new SourceRecord(null, null, "topic", 0,
+                        supportedTypesSchema, recordValue));
+
+        //Compare simple string against result after removing any spaces (just in case of variations in deepToString)
+        assertEquals("[{\"name\":\"Member 1\",\"value\":15,\"boolean\":true},{\"name\":\"Member 2\",\"value\":800,\"boolean\":false}]",
+        		((Struct) transformed.value()).get("array").toString());
+
+        Schema transformedSchema = ((Struct) transformed.value()).schema();
+        assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("array").schema().type());
+    }
+
+    @Test
+    public void castMapToString() {
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC,
+            "map:string"));
+
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build();
+        Schema supportedTypesSchema = SchemaBuilder.struct()
+        		.field("map", mapSchema)
+        		.build();
+
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        map.put("key1", 1);
+        map.put("key2", 2);
+
+        Struct recordValue = new Struct(supportedTypesSchema);
+        recordValue.put("map", map);
+
+        SourceRecord transformed = xformValue.apply(
+                new SourceRecord(null, null, "topic", 0,
+                        supportedTypesSchema, recordValue));
+
+        //Compare map.toString() with result
+        assertEquals(map.toString(), ((Struct) transformed.value()).get("map").toString());
+
+        Schema transformedSchema = ((Struct) transformed.value()).schema();
+        assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("map").schema().type());
+    }
+
+    @Test
+    public void castComplexMapToString() {
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC,
+            "map:string"));
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("name", Schema.STRING_SCHEMA);
+        builder.field("value", Schema.INT32_SCHEMA);
+        builder.field("boolean", Schema.BOOLEAN_SCHEMA);
+        Schema mapEntrySchema = builder.build();
+
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, mapEntrySchema).build();
+
+        builder = SchemaBuilder.struct();
+        builder.field("map", mapSchema);
+        Schema supportedTypesSchema = builder.build();
+
+        Struct mapEntry1 = new Struct(mapEntrySchema);
+        mapEntry1.put("name", "Member 1");
+        mapEntry1.put("value", 15);
+        mapEntry1.put("boolean", true);
+
+        Struct mapEntry2 = new Struct(mapEntrySchema);
+        mapEntry2.put("name", "Member 2");
+        mapEntry2.put("value", 800);
+        mapEntry2.put("boolean", false);
+
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        map.put("key1", mapEntry1);
+        map.put("key2", mapEntry2);
+
+        Struct recordValue = new Struct(supportedTypesSchema);
+        recordValue.put("map", map);
+
+        SourceRecord transformed = xformValue.apply(
+                new SourceRecord(null, null, "topic", 0,
+                        supportedTypesSchema, recordValue));
+
+        //Compare map.toString() with result
+        assertEquals(map.toString(), ((Struct) transformed.value()).get("map").toString());
+
+        Schema transformedSchema = ((Struct) transformed.value()).schema();
+        assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("map").schema().type());
+    }
+
+    @Test
+    public void castComplexMapToJsonString() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(Cast.ConfigName.SPEC, "map:string");
+        config.put(Cast.ConfigName.COMPLEX_STRING_AS_JSON, true);
+        xformValue.configure(config);
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("name", Schema.STRING_SCHEMA);
+        builder.field("value", Schema.INT32_SCHEMA);
+        builder.field("boolean", Schema.BOOLEAN_SCHEMA);
+        Schema mapEntrySchema = builder.build();
+
+        Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, mapEntrySchema).build();
+
+        builder = SchemaBuilder.struct();
+        builder.field("map", mapSchema);
+        Schema supportedTypesSchema = builder.build();
+
+        Struct mapEntry1 = new Struct(mapEntrySchema);
+        mapEntry1.put("name", "Member 1");
+        mapEntry1.put("value", 15);
+        mapEntry1.put("boolean", true);
+
+        Struct mapEntry2 = new Struct(mapEntrySchema);
+        mapEntry2.put("name", "Member 2");
+        mapEntry2.put("value", 800);
+        mapEntry2.put("boolean", false);
+
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
+        map.put("key1", mapEntry1);
+        map.put("key2", mapEntry2);
+
+        Struct recordValue = new Struct(supportedTypesSchema);
+        recordValue.put("map", map);
+
+        SourceRecord transformed = xformValue.apply(
+                new SourceRecord(null, null, "topic", 0,
+                        supportedTypesSchema, recordValue));
+
+        //Compare JSON string of map with result
+        assertEquals("{\"key1\":{\"name\":\"Member 1\",\"value\":15,\"boolean\":true},\"key2\":{\"name\":\"Member 2\",\"value\":800,\"boolean\":false}}", 
+        		((Struct) transformed.value()).get("map").toString());
+
+        Schema transformedSchema = ((Struct) transformed.value()).schema();
+        assertEquals(Schema.STRING_SCHEMA.type(), transformedSchema.field("map").schema().type());
+    }
+
+    @Test
     public void castFieldsWithSchema() {
         Date day = new Date(MILLIS_PER_DAY);
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32,bigdecimal:string,date:string,optional:int32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32,bigdecimal:string,date:string,optional:int32"));
 
         // Include an optional fields and fields with defaults to validate their values are passed through properly
         SchemaBuilder builder = SchemaBuilder.struct();
@@ -492,7 +735,7 @@ public class CastTest {
     @SuppressWarnings("unchecked")
     @Test
     public void castFieldsSchemaless() {
-        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32"));
+        xformValue.configure(Collections.singletonMap(Cast.ConfigName.SPEC, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32"));
         Map<String, Object> recordValue = new HashMap<>();
         recordValue.put("int8", (byte) 8);
         recordValue.put("int16", (short) 16);
@@ -515,5 +758,364 @@ public class CastTest {
         assertEquals((byte) 1, ((Map<String, Object>) transformed.value()).get("boolean"));
         assertEquals(42, ((Map<String, Object>) transformed.value()).get("string"));
     }
+
+    @SuppressWarnings("unchecked")
+	@Test
+	public void castFieldsWithSchemaRecursive() {
+	    Map<String, Object> config = new HashMap<>();
+	    config.put(Cast.ConfigName.SPEC, "int8:int16,int32:int64,float64:boolean,boolean:int8,string:int32,bigdecimal:string,optional:int32,arraystring:string,mapstring:string,structstring:string");
+	    config.put(Cast.ConfigName.RECURSIVE, true);
+	    xformValue.configure(config);
+
+	    // Schema
+
+	    final Schema schema = SchemaBuilder.struct()
+	    	    .field("int8", Schema.INT8_SCHEMA)
+	    	    .field("int32", SchemaBuilder.int32().defaultValue(2).build())
+	    	    // Default value here ensures we correctly convert default values
+	    	    .field("float64", SchemaBuilder.float64().defaultValue(-1.125).build())
+	    	    .field("boolean", Schema.BOOLEAN_SCHEMA)
+	    	    .field("string", Schema.STRING_SCHEMA)
+	    	    .field("bigdecimal", Decimal.schema(new BigDecimal(42).scale()))
+	    	    .field("optional", Schema.OPTIONAL_FLOAT32_SCHEMA)
+	            .build();
+
+	    final Schema arraySchema = SchemaBuilder.array(schema);
+
+	    final Schema parentASchema = SchemaBuilder.struct()
+	    	    .field("string", Schema.STRING_SCHEMA)
+	            .field("array", arraySchema)
+	            .field("arraystring", arraySchema)
+	    	    .field("struct", schema)
+	    	    .field("structstring", schema)
+	            .build();
+
+	    final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, parentASchema);
+
+	    final Schema parentBSchema = SchemaBuilder.struct()
+	            .field("array", arraySchema)
+	            .field("arraystring", arraySchema)
+	    	    .field("struct", parentASchema)
+	    	    .field("structstring", parentASchema)
+	    	    .field("map", mapSchema)
+	    	    .field("mapstring", mapSchema)
+	            .build();
+
+	    // Value
+
+	    final Struct struct1 = new Struct(schema)
+	    	    .put("int8", (byte) 8)
+	    	    .put("int32", 32)
+	    	    .put("float64", -64.)
+	    	    .put("boolean", true)
+	    	    .put("string", "42")
+	    	    .put("bigdecimal", new BigDecimal(42));
+        // optional field intentionally omitted
+
+	    final Struct struct2 = new Struct(schema)
+	    	    .put("int8", (byte) 8)
+	    	    .put("int32", 32)
+	    	    .put("float64", -64.)
+	    	    .put("boolean", true)
+	    	    .put("string", "42")
+	    	    .put("bigdecimal", new BigDecimal(42));
+        // optional field intentionally omitted
+
+        final List<Object> array = new ArrayList<Object>();
+        array.add(struct1);
+        array.add(struct2);
+
+        final Struct parentAValue = new Struct(parentASchema)
+	    	    .put("string", "42")
+	    	    .put("array", array)
+	    	    .put("arraystring", array)
+			    .put("struct", struct1)
+			    .put("structstring", struct2);
+
+        final Map<String, Object> map = new HashMap<>();
+		map.put("key1", parentAValue);
+		map.put("key2", parentAValue);
+
+        final Struct parentBValue = new Struct(parentBSchema)
+	    	    .put("array", array)
+	    	    .put("arraystring", array)
+			    .put("struct", parentAValue)
+			    .put("structstring", parentAValue)
+			    .put("map", map)
+			    .put("mapstring", map);
+
+        // Create and transform record
+
+	    SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
+	    		parentBSchema, parentBValue));
+
+	    // Assert results
+
+        final Struct updatedB = (Struct) transformed.value();
+        assertEquals(6, updatedB.schema().fields().size());
+
+        final List<Object> updatedB_array = (List<Object>) updatedB.get("array");
+        assertEquals(2, updatedB_array.size());
+
+        final Struct updatedB_array_0 = (Struct) updatedB_array.get(0);
+	    assertEquals((short) 8, updatedB_array_0.get("int8"));
+	    assertEquals((long) 32, updatedB_array_0.get("int32"));
+	    assertEquals(2L, updatedB_array_0.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_array_0.get("float64"));
+	    assertEquals(true, updatedB_array_0.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_array_0.get("boolean"));
+	    assertEquals(42, updatedB_array_0.get("string"));
+	    assertEquals("42", updatedB_array_0.get("bigdecimal"));
+	    assertNull(updatedB_array_0.get("optional"));
+
+        final Struct updatedB_array_1 = (Struct) updatedB_array.get(1);
+	    assertEquals((short) 8, updatedB_array_1.get("int8"));
+	    assertEquals((long) 32, updatedB_array_1.get("int32"));
+	    assertEquals(2L, updatedB_array_1.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_array_1.get("float64"));
+	    assertEquals(true, updatedB_array_1.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_array_1.get("boolean"));
+	    assertEquals(42, updatedB_array_1.get("string"));
+	    assertEquals("42", updatedB_array_1.get("bigdecimal"));
+	    assertNull(updatedB_array_1.get("optional"));
+
+	    // arraystring should match toString() of array
+        assertEquals(array.toString(), updatedB.get("arraystring"));
+
+        // B->struct should be of type A and have child fields converted as configured
+        // B->A should have string, array, arraystring, struct, structstring
+        final Struct updatedB_updatedA = (Struct) updatedB.get("struct");
+	    assertEquals(42, updatedB_updatedA.get("string"));
+
+	    // B->A->array should have 2 items converted from struct1 and struct2
+        final List<Object> updatedB_updatedA_array = (List<Object>) updatedB_updatedA.get("array");
+        assertEquals(2, updatedB_updatedA_array.size());
+
+        final Struct updatedB_updatedA_array_0 = (Struct) updatedB_updatedA_array.get(0);
+	    assertEquals((short) 8, updatedB_updatedA_array_0.get("int8"));
+	    assertEquals((long) 32, updatedB_updatedA_array_0.get("int32"));
+	    assertEquals(2L, updatedB_updatedA_array_0.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_updatedA_array_0.get("float64"));
+	    assertEquals(true, updatedB_updatedA_array_0.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_updatedA_array_0.get("boolean"));
+	    assertEquals(42, updatedB_updatedA_array_0.get("string"));
+	    assertEquals("42", updatedB_updatedA_array_0.get("bigdecimal"));
+	    assertNull(updatedB_updatedA_array_0.get("optional"));
+
+        final Struct updatedB_updatedA_array_1 = (Struct) updatedB_updatedA_array.get(1);
+	    assertEquals((short) 8, updatedB_updatedA_array_1.get("int8"));
+	    assertEquals((long) 32, updatedB_updatedA_array_1.get("int32"));
+	    assertEquals(2L, updatedB_updatedA_array_1.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_updatedA_array_1.get("float64"));
+	    assertEquals(true, updatedB_updatedA_array_1.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_updatedA_array_1.get("boolean"));
+	    assertEquals(42, updatedB_updatedA_array_1.get("string"));
+	    assertEquals("42", updatedB_updatedA_array_1.get("bigdecimal"));
+	    assertNull(updatedB_updatedA_array_1.get("optional"));
+
+	    // B->A->arraystring should match toString() of array
+        assertEquals(array.toString(), updatedB_updatedA.get("arraystring"));
+
+	    // B->A->struct should be a converted version of struct1
+	    final Struct updatedB_updatedA_struct = (Struct) updatedB_updatedA.get("struct");
+	    assertEquals((short) 8, updatedB_updatedA_struct.get("int8"));
+	    assertEquals((long) 32, updatedB_updatedA_struct.get("int32"));
+	    assertEquals(2L, updatedB_updatedA_struct.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_updatedA_struct.get("float64"));
+	    assertEquals(true, updatedB_updatedA_struct.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_updatedA_struct.get("boolean"));
+	    assertEquals(42, updatedB_updatedA_struct.get("string"));
+	    assertEquals("42", updatedB_updatedA_struct.get("bigdecimal"));
+	    assertNull(updatedB_updatedA_struct.get("optional"));
+
+        // B->A->structstring should match toString() of struct1
+        assertEquals(struct2.toString(), updatedB_updatedA.get("structstring"));
+
+        // B->structstring should match toString() of parentAValue
+        assertEquals(parentAValue.toString(), updatedB.get("structstring"));
+
+        // B->map should have two entries, both of which are converted structs of type A
+        final Map<String, Object> updatedB_map = (Map<String, Object>) updatedB.get("map");
+        assertEquals(2, updatedB_map.size());
+
+        // Assert the entire structure and values of key1
+        final Struct updatedB_map_key1 = (Struct) updatedB_map.get("key1");
+	    assertEquals(42, updatedB_map_key1.get("string"));
+
+	    // key1 array should have 2 items converted from struct1 and struct2
+        final List<Object> updatedB_map_key1_array = (List<Object>) updatedB_map_key1.get("array");
+        assertEquals(2, updatedB_map_key1_array.size());
+
+        final Struct updatedB_map_key1_array_0 = (Struct) updatedB_map_key1_array.get(0);
+	    assertEquals((short) 8, updatedB_map_key1_array_0.get("int8"));
+	    assertEquals((long) 32, updatedB_map_key1_array_0.get("int32"));
+	    assertEquals(2L, updatedB_map_key1_array_0.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_map_key1_array_0.get("float64"));
+	    assertEquals(true, updatedB_map_key1_array_0.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_map_key1_array_0.get("boolean"));
+	    assertEquals(42, updatedB_map_key1_array_0.get("string"));
+	    assertEquals("42", updatedB_map_key1_array_0.get("bigdecimal"));
+	    assertNull(updatedB_map_key1_array_0.get("optional"));
+
+        final Struct updatedB_map_key1_array_1 = (Struct) updatedB_map_key1_array.get(1);
+	    assertEquals((short) 8, updatedB_map_key1_array_1.get("int8"));
+	    assertEquals((long) 32, updatedB_map_key1_array_1.get("int32"));
+	    assertEquals(2L, updatedB_map_key1_array_1.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_map_key1_array_1.get("float64"));
+	    assertEquals(true, updatedB_map_key1_array_1.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_map_key1_array_1.get("boolean"));
+	    assertEquals(42, updatedB_map_key1_array_1.get("string"));
+	    assertEquals("42", updatedB_map_key1_array_1.get("bigdecimal"));
+	    assertNull(updatedB_map_key1_array_1.get("optional"));
+
+	    // key1 arraystring should match toString() of array
+        assertEquals(array.toString(), updatedB_map_key1.get("arraystring"));
+
+	    // key1 struct should be a converted version of struct1
+	    final Struct updatedB_map_key1_struct = (Struct) updatedB_map_key1.get("struct");
+	    assertEquals((short) 8, updatedB_map_key1_struct.get("int8"));
+	    assertEquals((long) 32, updatedB_map_key1_struct.get("int32"));
+	    assertEquals(2L, updatedB_map_key1_struct.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_map_key1_struct.get("float64"));
+	    assertEquals(true, updatedB_map_key1_struct.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_map_key1_struct.get("boolean"));
+	    assertEquals(42, updatedB_map_key1_struct.get("string"));
+	    assertEquals("42", updatedB_map_key1_struct.get("bigdecimal"));
+	    assertNull(updatedB_map_key1_struct.get("optional"));
+
+        // key1 structstring should match toString() of struct1
+        assertEquals(struct2.toString(), updatedB_map_key1.get("structstring"));
+
+        // And then repeat all of the above for key1, but now for key2
+        final Struct updatedB_map_key2 = (Struct) updatedB_map.get("key2");
+	    assertEquals(42, updatedB_map_key2.get("string"));
+
+	    // key2 array should have 2 items converted from struct1 and struct2
+        final List<Object> updatedB_map_key2_array = (List<Object>) updatedB_map_key2.get("array");
+        assertEquals(2, updatedB_map_key2_array.size());
+
+        final Struct updatedB_map_key2_array_0 = (Struct) updatedB_map_key2_array.get(0);
+	    assertEquals((short) 8, updatedB_map_key2_array_0.get("int8"));
+	    assertEquals((long) 32, updatedB_map_key2_array_0.get("int32"));
+	    assertEquals(2L, updatedB_map_key2_array_0.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_map_key2_array_0.get("float64"));
+	    assertEquals(true, updatedB_map_key2_array_0.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_map_key2_array_0.get("boolean"));
+	    assertEquals(42, updatedB_map_key2_array_0.get("string"));
+	    assertEquals("42", updatedB_map_key2_array_0.get("bigdecimal"));
+	    assertNull(updatedB_map_key2_array_0.get("optional"));
+
+        final Struct updatedB_map_key2_array_1 = (Struct) updatedB_map_key2_array.get(1);
+	    assertEquals((short) 8, updatedB_map_key2_array_1.get("int8"));
+	    assertEquals((long) 32, updatedB_map_key2_array_1.get("int32"));
+	    assertEquals(2L, updatedB_map_key2_array_1.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_map_key2_array_1.get("float64"));
+	    assertEquals(true, updatedB_map_key2_array_1.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_map_key2_array_1.get("boolean"));
+	    assertEquals(42, updatedB_map_key2_array_1.get("string"));
+	    assertEquals("42", updatedB_map_key2_array_1.get("bigdecimal"));
+	    assertNull(updatedB_map_key2_array_1.get("optional"));
+
+	    // key2 arraystring should match toString() of array
+        assertEquals(array.toString(), updatedB_map_key2.get("arraystring"));
+
+	    // key2 struct should be a converted version of struct1
+	    final Struct updatedB_map_key2_struct = (Struct) updatedB_map_key2.get("struct");
+	    assertEquals((short) 8, updatedB_map_key2_struct.get("int8"));
+	    assertEquals((long) 32, updatedB_map_key2_struct.get("int32"));
+	    assertEquals(2L, updatedB_map_key2_struct.schema().field("int32").schema().defaultValue());
+	    assertEquals(true, updatedB_map_key2_struct.get("float64"));
+	    assertEquals(true, updatedB_map_key2_struct.schema().field("float64").schema().defaultValue());
+	    assertEquals((byte) 1, updatedB_map_key2_struct.get("boolean"));
+	    assertEquals(42, updatedB_map_key2_struct.get("string"));
+	    assertEquals("42", updatedB_map_key2_struct.get("bigdecimal"));
+	    assertNull(updatedB_map_key2_struct.get("optional"));
+
+        // key2 structstring should match toString() of struct1
+        assertEquals(struct2.toString(), updatedB_map_key2.get("structstring"));
+
+        // B->mapstring should match toString() of map
+        assertEquals(map.toString(), updatedB.get("mapstring"));
+	}
+
+    @SuppressWarnings("unchecked")
+	@Test
+	public void castFieldsSchemalessRecursive() {
+        Map<String, Object> config = new HashMap<>();
+	    config.put(Cast.ConfigName.SPEC, "boolean:int8,int32:string,string:int32,childstring:string,parentstring:string,arraystring:string");
+	    config.put(Cast.ConfigName.RECURSIVE, true);
+	    xformValue.configure(config);
+
+
+	    // Build and fill child
+	    Map<String, Object> child = new HashMap<String, Object>();
+	    child.put("boolean", true);
+	    child.put("int32", 42);
+	    child.put("string", "42");
+
+	    List<Object> array = new ArrayList<Object>();
+	    array.add(child);
+
+	    // Build and fill parentA
+	    Map<String, Object> parentA = new HashMap<String, Object>();
+	    parentA.put("boolean", true);
+	    parentA.put("int32", 42);
+	    parentA.put("string", "42");
+	    parentA.put("child", child);
+	    parentA.put("childstring", child);
+	    parentA.put("array", array);
+	    parentA.put("arraystring", array);
+
+	    // Build and fill parentB
+	    Map<String, Object> parentB = new HashMap<String, Object>();
+	    parentB.put("boolean", true);
+	    parentB.put("int32", 42);
+	    parentB.put("string", "42");
+	    parentB.put("parent", parentA);
+	    parentB.put("parentstring", parentA);
+
+
+	    // Transform the record
+	    SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
+	    		null, parentB));
+
+
+	    // Assert the results
+        assertNull(transformed.valueSchema());
+
+        Map<String, Object> updatedB = (Map<String, Object>) transformed.value();
+
+        assertEquals(5, updatedB.size());
+        assertEquals((byte) 1, updatedB.get("boolean"));
+        assertEquals("42", updatedB.get("int32"));
+        assertEquals(42, updatedB.get("string"));
+
+        Map<String, Object> updatedA = (Map<String, Object>) updatedB.get("parent");
+        assertEquals(7, updatedA.size());
+        assertEquals((byte) 1, updatedA.get("boolean"));
+        assertEquals("42", updatedA.get("int32"));
+        assertEquals(42, updatedA.get("string"));
+
+        Map<String, Object> updatedChild = (Map<String, Object>) updatedA.get("child");
+        assertEquals(3, updatedChild.size());
+        assertEquals((byte) 1, updatedChild.get("boolean"));
+        assertEquals("42", updatedChild.get("int32"));
+        assertEquals(42, updatedChild.get("string"));
+
+        assertEquals(child.toString(), updatedA.get("childstring"));
+
+        List<Object> updatedArray = (List<Object>) updatedA.get("array");
+        assertEquals(1, updatedArray.size());
+
+        Map<String, Object> updatedArray_child = (Map<String, Object>) updatedArray.get(0);
+        assertEquals(3, updatedArray_child.size());
+        assertEquals((byte) 1, updatedArray_child.get("boolean"));
+        assertEquals("42", updatedArray_child.get("int32"));
+        assertEquals(42, updatedArray_child.get("string"));
+
+        assertEquals(array.toString(), updatedA.get("arraystring"));
+
+        assertEquals(parentA.toString(), updatedB.get("parentstring"));
+	}
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
@@ -171,7 +171,7 @@ public class ReplaceFieldTest {
     }
 
     @SuppressWarnings("unchecked")
-	@Test
+    @Test
     public void schemalessRecursive() {
         final Map<String, Object> props = new HashMap<>();
         props.put(ReplaceField.ConfigName.EXCLUDE, "dont");
@@ -237,80 +237,80 @@ public class ReplaceFieldTest {
         assertEquals("etc", updatedParentA_array_1.get("etc"));
     }
 
-	@SuppressWarnings("unchecked")
-	@Test
-	public void withSchemaRecursive() {
-	    final Map<String, Object> props = new HashMap<>();
-	    props.put(ReplaceField.ConfigName.INCLUDE, "abc,foo,do,array,map");
-	    props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
+    @SuppressWarnings("unchecked")
+    @Test
+    public void withSchemaRecursive() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put(ReplaceField.ConfigName.INCLUDE, "abc,foo,do,array,map");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
         props.put(ReplaceField.ConfigName.RECURSIVE, true);
 
-	    xform.configure(props);
+        xform.configure(props);
 
-	    // Schema
+        // Schema
 
-	    final Schema schema = SchemaBuilder.struct()
-	            .field("dont", Schema.STRING_SCHEMA)
-	            .field("abc", Schema.INT32_SCHEMA)
-	            .field("foo", Schema.BOOLEAN_SCHEMA)
-	            .field("etc", Schema.STRING_SCHEMA)
-	            .build();
+        final Schema schema = SchemaBuilder.struct()
+                .field("dont", Schema.STRING_SCHEMA)
+                .field("abc", Schema.INT32_SCHEMA)
+                .field("foo", Schema.BOOLEAN_SCHEMA)
+                .field("etc", Schema.STRING_SCHEMA)
+                .build();
 
-	    final Schema arraySchema = SchemaBuilder.array(schema);
+        final Schema arraySchema = SchemaBuilder.array(schema);
 
-	    final Schema parentASchema = SchemaBuilder.struct()
-	            .field("abc", Schema.INT32_SCHEMA)
-	            .field("foo", Schema.BOOLEAN_SCHEMA)
-	            .field("etc", Schema.STRING_SCHEMA)
-	            .field("dont", schema)
-	            .field("do", schema)
-	            .field("array", arraySchema)
-	            .build();
+        final Schema parentASchema = SchemaBuilder.struct()
+                .field("abc", Schema.INT32_SCHEMA)
+                .field("foo", Schema.BOOLEAN_SCHEMA)
+                .field("etc", Schema.STRING_SCHEMA)
+                .field("dont", schema)
+                .field("do", schema)
+                .field("array", arraySchema)
+                .build();
 
-	    final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, parentASchema);
+        final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, parentASchema);
 
-	    final Schema parentBSchema = SchemaBuilder.struct()
-	            .field("dont", parentASchema)
-	            .field("do", parentASchema)
-	            .field("array", arraySchema)
-	            .field("map", mapSchema)
-	            .build();
+        final Schema parentBSchema = SchemaBuilder.struct()
+                .field("dont", parentASchema)
+                .field("do", parentASchema)
+                .field("array", arraySchema)
+                .field("map", mapSchema)
+                .build();
 
-	    // Value
+        // Value
 
-	    final Struct value1 = new Struct(schema)
-			    .put("dont", "whatever")
-			    .put("abc", 42)
-			    .put("foo", true)
-			    .put("etc", "etc");
+        final Struct value1 = new Struct(schema)
+                .put("dont", "whatever")
+                .put("abc", 42)
+                .put("foo", true)
+                .put("etc", "etc");
 
-	    final Struct value2 = new Struct(schema)
-			    .put("dont", "whatever")
-			    .put("abc", 42)
-			    .put("foo", true)
-			    .put("etc", "etc");
+        final Struct value2 = new Struct(schema)
+                .put("dont", "whatever")
+                .put("abc", 42)
+                .put("foo", true)
+                .put("etc", "etc");
 
         final List<Object> array = new ArrayList<Object>();
         array.add(value1);
         array.add(value2);
 
         final Struct parentAValue = new Struct(parentASchema)
-			    .put("abc", 42)
-			    .put("foo", true)
-			    .put("etc", "etc")
-			    .put("dont", value1)
-			    .put("do", value2)
-			    .put("array", array);
+                .put("abc", 42)
+                .put("foo", true)
+                .put("etc", "etc")
+                .put("dont", value1)
+                .put("do", value2)
+                .put("array", array);
 
         final Map<String, Object> map = new HashMap<>();
         map.put("dont", parentAValue);
         map.put("do", parentAValue);
 
         final Struct parentBValue = new Struct(parentBSchema)
-			    .put("dont", parentAValue)
-			    .put("do", parentAValue)
-			    .put("array", array)
-			    .put("map", map);
+                .put("dont", parentAValue)
+                .put("do", parentAValue)
+                .put("array", array)
+                .put("map", map);
 
         // Create and transform record
 
@@ -373,6 +373,6 @@ public class ReplaceFieldTest {
         assertEquals(2, updatedMap_do_array_1.schema().fields().size());
         assertEquals(42, updatedMap_do_array_1.get("xyz"));
         assertEquals(true, updatedMap_do_array_1.get("bar"));
-	}
+    }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
@@ -23,7 +23,9 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -39,9 +41,9 @@ public class ReplaceFieldTest {
 
     @Test
     public void tombstoneSchemaless() {
-        final Map<String, String> props = new HashMap<>();
-        props.put("include", "abc,foo");
-        props.put("renames", "abc:xyz,foo:bar");
+        final Map<String, Object> props = new HashMap<>();
+        props.put(ReplaceField.ConfigName.INCLUDE, "abc,foo");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
 
         xform.configure(props);
 
@@ -54,9 +56,9 @@ public class ReplaceFieldTest {
 
     @Test
     public void tombstoneWithSchema() {
-        final Map<String, String> props = new HashMap<>();
-        props.put("include", "abc,foo");
-        props.put("renames", "abc:xyz,foo:bar");
+        final Map<String, Object> props = new HashMap<>();
+        props.put(ReplaceField.ConfigName.INCLUDE, "abc,foo");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
 
         xform.configure(props);
 
@@ -76,9 +78,9 @@ public class ReplaceFieldTest {
 
     @Test
     public void schemaless() {
-        final Map<String, String> props = new HashMap<>();
-        props.put("exclude", "dont");
-        props.put("renames", "abc:xyz,foo:bar");
+        final Map<String, Object> props = new HashMap<>();
+        props.put(ReplaceField.ConfigName.EXCLUDE, "dont");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
 
         xform.configure(props);
 
@@ -100,9 +102,9 @@ public class ReplaceFieldTest {
 
     @Test
     public void withSchema() {
-        final Map<String, String> props = new HashMap<>();
-        props.put("include", "abc,foo");
-        props.put("renames", "abc:xyz,foo:bar");
+        final Map<String, Object> props = new HashMap<>();
+        props.put(ReplaceField.ConfigName.INCLUDE, "abc,foo");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
 
         xform.configure(props);
 
@@ -131,9 +133,9 @@ public class ReplaceFieldTest {
 
     @Test
     public void testIncludeBackwardsCompatibility() {
-        final Map<String, String> props = new HashMap<>();
+        final Map<String, Object> props = new HashMap<>();
         props.put("whitelist", "abc,foo");
-        props.put("renames", "abc:xyz,foo:bar");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
 
         xform.configure(props);
 
@@ -144,12 +146,11 @@ public class ReplaceFieldTest {
         assertNull(transformedRecord.valueSchema());
     }
 
-
     @Test
     public void testExcludeBackwardsCompatibility() {
-        final Map<String, String> props = new HashMap<>();
+        final Map<String, Object> props = new HashMap<>();
         props.put("blacklist", "dont");
-        props.put("renames", "abc:xyz,foo:bar");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
 
         xform.configure(props);
 
@@ -168,4 +169,210 @@ public class ReplaceFieldTest {
         assertEquals(true, updatedValue.get("bar"));
         assertEquals("etc", updatedValue.get("etc"));
     }
+
+    @SuppressWarnings("unchecked")
+	@Test
+    public void schemalessRecursive() {
+        final Map<String, Object> props = new HashMap<>();
+        props.put(ReplaceField.ConfigName.EXCLUDE, "dont");
+        props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
+        props.put(ReplaceField.ConfigName.RECURSIVE, true);
+
+        xform.configure(props);
+
+        final Map<String, Object> value = new HashMap<>();
+        value.put("dont", "whatever");
+        value.put("abc", 42);
+        value.put("foo", true);
+        value.put("etc", "etc");
+
+        final List<Object> array = new ArrayList<Object>();
+        array.add(value);
+        array.add(new HashMap<String, Object>(value)); //shallow copy to force new identity
+
+        final Map<String, Object> parentValueA = new HashMap<>();
+        parentValueA.put("abc", 42);
+        parentValueA.put("foo", true);
+        parentValueA.put("etc", "etc");
+        parentValueA.put("dont", value);
+        parentValueA.put("do", value);
+        parentValueA.put("array", array);
+
+        final Map<String, Object> parentValueB = new HashMap<>();
+        parentValueB.put("dont", parentValueA);
+        parentValueB.put("do", parentValueA);
+        parentValueB.put("array", array);
+
+        final SinkRecord record = new SinkRecord("test", 0, null, null, null, parentValueB, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        final Map<String, Object> updatedParentB = (Map<String, Object>) transformedRecord.value();
+        assertEquals(2, updatedParentB.size());
+
+        final Map<String, Object> updatedParentA_do = (Map<String, Object>) updatedParentB.get("do");
+        assertEquals(5, updatedParentA_do.size());
+        assertEquals(42, updatedParentA_do.get("xyz"));
+        assertEquals(true, updatedParentA_do.get("bar"));
+        assertEquals("etc", updatedParentA_do.get("etc"));
+
+        final Map<String, Object> updatedParentA_do_do = (Map<String, Object>) updatedParentA_do.get("do");
+        assertEquals(3, updatedParentA_do_do.size());
+        assertEquals(42, updatedParentA_do_do.get("xyz"));
+        assertEquals(true, updatedParentA_do_do.get("bar"));
+        assertEquals("etc", updatedParentA_do_do.get("etc"));
+
+        final List<Object> updatedParentA_array = (ArrayList<Object>) updatedParentB.get("array");
+        assertEquals(2, updatedParentA_array.size());
+
+        final Map<String, Object> updatedParentA_array_0 = (Map<String, Object>) updatedParentA_array.get(0);
+        assertEquals(3, updatedParentA_array_0.size());
+        assertEquals(42, updatedParentA_array_0.get("xyz"));
+        assertEquals(true, updatedParentA_array_0.get("bar"));
+        assertEquals("etc", updatedParentA_array_0.get("etc"));
+
+        final Map<String, Object> updatedParentA_array_1 = (Map<String, Object>) updatedParentA_array.get(1);
+        assertEquals(3, updatedParentA_array_1.size());
+        assertEquals(42, updatedParentA_array_1.get("xyz"));
+        assertEquals(true, updatedParentA_array_1.get("bar"));
+        assertEquals("etc", updatedParentA_array_1.get("etc"));
+    }
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void withSchemaRecursive() {
+	    final Map<String, Object> props = new HashMap<>();
+	    props.put(ReplaceField.ConfigName.INCLUDE, "abc,foo,do,array,map");
+	    props.put(ReplaceField.ConfigName.RENAME, "abc:xyz,foo:bar");
+        props.put(ReplaceField.ConfigName.RECURSIVE, true);
+
+	    xform.configure(props);
+
+	    // Schema
+
+	    final Schema schema = SchemaBuilder.struct()
+	            .field("dont", Schema.STRING_SCHEMA)
+	            .field("abc", Schema.INT32_SCHEMA)
+	            .field("foo", Schema.BOOLEAN_SCHEMA)
+	            .field("etc", Schema.STRING_SCHEMA)
+	            .build();
+
+	    final Schema arraySchema = SchemaBuilder.array(schema);
+
+	    final Schema parentASchema = SchemaBuilder.struct()
+	            .field("abc", Schema.INT32_SCHEMA)
+	            .field("foo", Schema.BOOLEAN_SCHEMA)
+	            .field("etc", Schema.STRING_SCHEMA)
+	            .field("dont", schema)
+	            .field("do", schema)
+	            .field("array", arraySchema)
+	            .build();
+
+	    final Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, parentASchema);
+
+	    final Schema parentBSchema = SchemaBuilder.struct()
+	            .field("dont", parentASchema)
+	            .field("do", parentASchema)
+	            .field("array", arraySchema)
+	            .field("map", mapSchema)
+	            .build();
+
+	    // Value
+
+	    final Struct value1 = new Struct(schema)
+			    .put("dont", "whatever")
+			    .put("abc", 42)
+			    .put("foo", true)
+			    .put("etc", "etc");
+
+	    final Struct value2 = new Struct(schema)
+			    .put("dont", "whatever")
+			    .put("abc", 42)
+			    .put("foo", true)
+			    .put("etc", "etc");
+
+        final List<Object> array = new ArrayList<Object>();
+        array.add(value1);
+        array.add(value2);
+
+        final Struct parentAValue = new Struct(parentASchema)
+			    .put("abc", 42)
+			    .put("foo", true)
+			    .put("etc", "etc")
+			    .put("dont", value1)
+			    .put("do", value2)
+			    .put("array", array);
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("dont", parentAValue);
+        map.put("do", parentAValue);
+
+        final Struct parentBValue = new Struct(parentBSchema)
+			    .put("dont", parentAValue)
+			    .put("do", parentAValue)
+			    .put("array", array)
+			    .put("map", map);
+
+        // Create and transform record
+
+        final SinkRecord record = new SinkRecord("test", 0, null, null, parentBSchema, parentBValue, 0);
+        final SinkRecord transformedRecord = xform.apply(record);
+
+        // Assert results
+
+        final Struct updatedParentB = (Struct) transformedRecord.value();
+        assertEquals(3, updatedParentB.schema().fields().size());
+
+        final Struct updatedDo = (Struct) updatedParentB.get("do");
+        assertEquals(4, updatedDo.schema().fields().size());
+        assertEquals(42, updatedDo.get("xyz"));
+        assertEquals(true, updatedDo.get("bar"));
+        
+        final List<Object> updatedDo_array = (List<Object>) updatedDo.get("array");
+        assertEquals(2, updatedDo_array.size());
+
+        final Struct updatedDo_array_0 = (Struct) updatedDo_array.get(0);
+        assertEquals(2, updatedDo_array_0.schema().fields().size());
+        assertEquals(42, updatedDo_array_0.get("xyz"));
+        assertEquals(true, updatedDo_array_0.get("bar"));
+
+        final Struct updatedDo_array_1 = (Struct) updatedDo_array.get(1);
+        assertEquals(2, updatedDo_array_1.schema().fields().size());
+        assertEquals(42, updatedDo_array_1.get("xyz"));
+        assertEquals(true, updatedDo_array_1.get("bar"));
+
+        final List<Object> updatedArray = (List<Object>) updatedParentB.get("array");
+        assertEquals(2, updatedArray.size());
+
+        final Struct updatedArray_0 = (Struct) updatedArray.get(0);
+        assertEquals(2, updatedArray_0.schema().fields().size());
+        assertEquals(42, updatedArray_0.get("xyz"));
+        assertEquals(true, updatedArray_0.get("bar"));
+
+        final Struct updatedArray_1 = (Struct) updatedArray.get(1);
+        assertEquals(2, updatedArray_1.schema().fields().size());
+        assertEquals(42, updatedArray_1.get("xyz"));
+        assertEquals(true, updatedArray_1.get("bar"));
+
+        final Map<String, Object> updatedMap = (Map<String, Object>) updatedParentB.get("map");
+        assertEquals(1, updatedMap.size());
+
+        final Struct updatedMap_do = (Struct) updatedMap.get("do");
+        assertEquals(4, updatedMap_do.schema().fields().size());
+        assertEquals(42, updatedMap_do.get("xyz"));
+        assertEquals(true, updatedMap_do.get("bar"));
+
+        final List<Object> updatedMap_do_array = (List<Object>) updatedMap_do.get("array");
+        assertEquals(2, updatedMap_do_array.size());
+
+        final Struct updatedMap_do_array_0 = (Struct) updatedMap_do_array.get(0);
+        assertEquals(2, updatedMap_do_array_0.schema().fields().size());
+        assertEquals(42, updatedMap_do_array_0.get("xyz"));
+        assertEquals(true, updatedMap_do_array_0.get("bar"));
+
+        final Struct updatedMap_do_array_1 = (Struct) updatedMap_do_array.get(1);
+        assertEquals(2, updatedMap_do_array_1.schema().fields().size());
+        assertEquals(42, updatedMap_do_array_1.get("xyz"));
+        assertEquals(true, updatedMap_do_array_1.get("bar"));
+	}
+
 }


### PR DESCRIPTION
I have added support for the `Cast` and `ReplaceField` transformations to recursively traverse the structure of messages (both with and without a schema) and perform the Cast or Replace operations on matching child primitive fields if they are found at any level nested within the structure.  Nested parents of all currently-supported Connect complex types should be supported (Map, Array, or Struct) but most of the primitive field handling is still similar to before (the lowest level within the nesting would normally be a Struct when using Schema or Map when schemaless).

This behavior can be controlled by a new configuration parameter called `recursive` for both transformations.  The default setting is **false** so any existing connectors would not be impacted -- you must set the parameter to **true** in order for the child complex types to be traversed.  Otherwise, the default behavior should be the same as before.

I have also cleaned up the Config names a bit to match some of the other transformations (namely, using a class interface called `ConfigName` which can be accessed statically), it is a bit nicer to work with and brings a little more consistency across the different built-in transforms.

Since this is more than just a trivial change, I have created a few new unit tests, some of them quite complex, to try and make sure that everything is working ok compared to before.  I have also been running both of these as custom SMTs against data in our production kafka cluster and used some learnings there to iron out a few issues.  I have had tens of millions of events actually using this updated code so I think/hope the changes are pretty well-tested but welcome if there is some kind of feedback or concern with them!

Here is a full list of everything that I have changed:

### Cast

#### Added new Config Parameters:
- `recursive` optional boolean, default = `false`
- `complex.string.as.json` optional boolean, default = `false`

#### Changes:

- Created new public static interface `ConfigName` and marked the old public static string `SPEC_CONFIG` as deprecated (so it can still be used for a while until it is removed later).
- Added new `ConfigName` for `SPEC`, `RECURSIVE`, and `COMPLEX_STRING_AS_JSON`
- Created new interface `ConfigDefault` to provide an easy way to set and consume default values for these two new optional configuration parameters.
- And then of course defined and set up the config parameters for usage within the rest of the class.
- Added ARRAY, MAP, and STRUCT as valid types to convert FROM (but the only thing they can convert TO is STRING, otherwise if your `SPEC` tries to convert them to something else it will throw a `DataException`).  Before you would receive a `DataException` if you tried to include a complex type in the `SPEC` but now at least you are given the option to Cast them to a string!
- Refactored the `apply...` methods so that they will call a child method that recursively builds the structure of the schema or value depending if the user sets the `recursive` config parameter to true (otherwise it should basically work the same as before -- look at everything that is at the top level of the structure and then return).  There are new methods for recursively handling different type of structures but in the end the same basic flow happens at each child level as what was happening before (`for each field in fields...`). 
   - However, one change in the design is that when building the new Value, instead of looping through each field from the new schema and performing an `oldstruct.get(oldfield)`, it instead will loop again through each field in the old schema.  This is so that nested primitive conversions happen correctly and what happens in the Value should be exactly the same thing that happened in the Schema.
- When a child schema is created as part of the recursion, it is also added to the `schemaUpdateCache`, and the recursive methods call `getOrBuildUpdatedSchema` so they should fetch it from the cast in case it has already been converted.  This is the same when child values are converted -- they should fetch their new child schemas from the cache instead of building them again.
- Added usage of an instance of `JsonConverter` and `JsonDeserializer` if you wish to have the complex types toString come out in a JSON text format instead of the Java object's toString() implementation.  This is helpful for scenarios for example like using a JdbcSinkConnector where you have an array of structs as one field in your source, you can put these values into a database table as a blob of JSON text, then parse these values as JSON (for example PostgreSQL has loads of really good JSON parsing).  This behavior is controlled by the new configuration parameter `complex.string.as.json` but again by default it is set to false (so you have to set to true in order to use this).
- I also changed `castValueToType` from `private static` to `private`.  This was so that we can allow a check in this method on the instance value of our new `complex.string.as.json` configuration parameter and decide to call `castToJsonString` instead of the old `castToString` method.
  - I realize this one can maybe be a bit controversial, and there were several options I considered.  First, however, I tried to examine any public static method or property of any kind and see if anything ever makes use of `castValueToType` and could not see any (please mention if you see something I missed).  So a change from private static to private in this case seems very minor and should not impact any functionality -- nothing else can see or use it anyway outside of this class itself.
  - Another option is possibly a bit more like the `TimestampConverter` transform, where they have created a private instance of a `Config` subclass and then pass the entire instance to some of the static methods.  But I think that change would have to "touch"  a lot more places, and given the point above (I did not see where it was actually used anywhere from anything public static ) this seemed like a bit too much of a rebuild.
  - Also usage of this `castToJsonString` with using the `JsonConverter` and `JsonDeserializer` could be done a few other ways... but this was the one that I felt tried to use existing functionalities within Connect and was the "cleanest" looking that I could initially come up with from a code perspective.  And the reason to use a single private instance of the classes was to try and save a bit on resources -- it is possible that you will have multiple Json string conversions even within one record so I thought it was better to only have one instance we can re-use over and over.
- Changed the log level for the Cast log message from Trace to Debug (this seems like something you definitely want to see in Debug and not just Trace!).
- Added new test cases for casting Arrays and Maps to string, to JSON Strings, as well as for working with different types of recursive records (both with and without schema).  In these tests, I found that a lot of the weird issues only happen once you go a few levels deep so I have made the tests a little more complicated to ensure that everything was working properly even with multiple nested levels.

#### Example Usage

```
curl -X PUT -H "Content-Type: application/json" --data '{
  "connector.class": "FileStreamSink",
  "topics": "test",
  "file": "/tmp/cast.txt",
  "transforms": "cast",
  "transforms.cast.type": "org.apache.kafka.connect.transforms.Cast$Value",
  "transforms.cast.spec": "child_int:string,child_array_of_structs:string",
  "transforms.cast.recursive": "true",
  "transforms.cast.complex.string.as.json": "true"
}' http://localhost:8083/connectors/filestreamsink_cast_test/config
```


### ReplaceField

#### Added new Config Parameters:
- `recursive` optional boolean, default = `false`

#### Changes:

- A lot of the changes here are very similar to what was done in `Cast`.  In fact, even before my changes, the flow of these two transforms was actually almost identical, so it worked quite well to do them both like this at the same time and they are easily used together in transform chains within Connect.
- Namely, there is a new `recursive` configuration parameter and the `apply...` methods have been updated to recursively call methods to build the new target schema and values.  A lot of the code is exactly the same so you should even find direct copy-paste from `Cast` to here and using a lot of the same private object names, methods, etc.
   - Note also that the pattern follows the same as with `Cast` -- looping through the old schema and converted child values based on the old structure instead of first creating a new schema and then getting the old field.  This new flow also means that the `reverseRenamed` method and its `reverseRenames` map are no longer needed either (but I left them in for now).
- Added a logger instance and added Debug-level logging for a few different events, such as when a field is excluded or included, or when it is renamed.  So some of the methods were refactored a bit in order to provide this logging (for example the `filter` and `renamed` methods).
- I also added support when using `renames` for a "contains exactly one of" kind of scenario.  What I mean by this is that in your schema, you have several fields which you know by design that only one of them will have a value, and when that one has a value, all of the rest within that group will be null.  The change to this transform now allows you to specify a target name more than one time, but when the value transform is occurring, if more than one of them have a value then it will throw a `DataException`.  Before, the transform would throw a `DataException` when building the new schema based on the `renames` config (trying to add a duplicate field to the schema) but instead now this check happens when building the updated value instead.
- Also added a few unit tests to handle new scenarios and recursive operation (both with and without schemas).

#### Example Usage

```
curl -X PUT -H "Content-Type: application/json" --data '{
  "connector.class": "FileStreamSink",
  "topics": "test",
  "file": "/tmp/replace.txt",
  "transforms": "replace",
  "transforms.replace.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
  "transforms.replace.renames": "child_value_one:child_value,child_value_two:child_value",
  "transforms.replace.recursive": "true",
}' http://localhost:8083/connectors/filestreamsink_replace_test/config
```

I hope this covers everything but if you have any questions or concerns then please feel free to ask!



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
