### PR TITLE
KAFKA-10284: Disable static membership test in 2.4

### DIFF
--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -49,6 +49,9 @@ class StreamsStaticMembershipTest(Test):
                                            throughput=1000,
                                            acks=1)
 
+    # This test fails due to a bug that is fixed in 2.5+ (KAFKA-10284). We opted not to backport
+    # the fix to 2.4 and instead marked this test as ignored. If desired, the fix can be backported,
+    # but it is non-trivial to do so.
     @ignore
     def test_rolling_bounces_will_not_trigger_rebalance_under_static_membership(self):
         self.zookeeper.start()

--- a/tests/kafkatest/tests/streams/streams_static_membership_test.py
+++ b/tests/kafkatest/tests/streams/streams_static_membership_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ducktape.mark import ignore
 from ducktape.tests.test import Test
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StaticMemberTestService
@@ -48,6 +49,7 @@ class StreamsStaticMembershipTest(Test):
                                            throughput=1000,
                                            acks=1)
 
+    @ignore
     def test_rolling_bounces_will_not_trigger_rebalance_under_static_membership(self):
         self.zookeeper.start()
         self.kafka.start()


### PR DESCRIPTION
This test was fixed in https://github.com/apache/kafka/pull/9270
for 2.5+, but the code in 2.4 is too different to have a clean backport.
Rather than risk introducing a worse bug in 2.4, and also because the
probability of a new bugfix release for 2.4 seems low, I'm proposing
just to disable this test in the 2.4 branch.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
