### PR TITLE
Pin ducktape to version 0.7.10

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -35,7 +35,7 @@ LABEL ducker.creator=$ducker_creator
 # we have to install git since it is included in openjdk:8 but not openjdk:11
 RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
 RUN python3 -m pip install -U pip==20.2.2;
-RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip3 install --upgrade ducktape==0.8.0
+RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip3 install --upgrade ducktape==0.7.10
 
 # Set up ssh
 COPY ./ssh-config /root/.ssh/config

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -51,7 +51,7 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.7.9", "requests==2.22.0"],
+      install_requires=["ducktape==0.7.10", "requests==2.22.0"],
       tests_require=["pytest", "mock"],
       cmdclass={'test': PyTest},
       )


### PR DESCRIPTION
Ducktape version 0.7.10 pinned paramiko to version 2.3.2 to deal with random `SSHException`s confluent had been seeing since ducktape was updated to a later version of paramiko.
This PR pins both the version in `setup.py` and in `ducker-ak`'s `Dockerfile` to the same version. Previously ducker version was pinned to 0.8.0. 
I'll send a separate PR that pins both versions to 0.8.0 (unless someone is already working on that separately) - the idea is that we can backport ducktape 0.7.10 change as far back as possible, while keep the ducktape 0.8.0 change in trunk only (unless we plan to backport python3 changes).

Tested:
http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2020-10-23--001.1603440055--stan-confluent--ducktape-710--3c51234d0/report.html

There are 10 failing tests, 9 of which have been failing before this change, and 1 (streams_upgrade_test) I've seen failing on different branches recently as well, though it was passing on trunk as of couple of days ago. Since ducktape version only changed the paramiko dependencies, I don't think it could've affected it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
