### PR TITLE
MINOR: demote "Committing task offsets" log to DEBUG

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -692,6 +692,7 @@ public class StreamThread extends Thread {
                     break;
                 } else if (Math.max(now - lastPollMs, 0) > maxPollTimeMs / 2) {
                     numIterations = numIterations > 1 ? numIterations / 2 : numIterations;
+                    log.info("Pause processing to call poll before we hit the max.poll.interval.ms");
                     break;
                 } else if (punctuated > 0 || committed > 0) {
                     numIterations = numIterations > 1 ? numIterations / 2 : numIterations;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -630,6 +630,8 @@ public class StreamThread extends Thread {
         advanceNowAndComputeLatency();
 
         int totalProcessed = 0;
+        int totalPunctuated = 0;
+        int totalCommitted = 0;
         long totalCommitLatency = 0L;
         long totalProcessLatency = 0L;
         long totalPunctuateLatency = 0L;
@@ -667,6 +669,7 @@ public class StreamThread extends Thread {
                           numIterations);
 
                 final int punctuated = taskManager.punctuate();
+                totalPunctuated += punctuated;
                 final long punctuateLatency = advanceNowAndComputeLatency();
                 totalPunctuateLatency += punctuateLatency;
                 if (punctuated > 0) {
@@ -676,6 +679,7 @@ public class StreamThread extends Thread {
                 log.debug("{} punctuators ran.", punctuated);
 
                 final int committed = maybeCommit();
+                totalCommitted += committed;
                 final long commitLatency = advanceNowAndComputeLatency();
                 totalCommitLatency += commitLatency;
                 if (committed > 0) {
@@ -704,15 +708,9 @@ public class StreamThread extends Thread {
             // multiple iterations with reasonably large max.num.records and hence is less vulnerable to outliers
             taskManager.recordTaskProcessRatio(totalProcessLatency, now);
 
-            // Only log this at INFO when we actually processed some records to avoid flooding INFO-level logs when
-            // there are no records on the input topics
-            if (totalProcessed > 0) {
-                log.info("Processed {} records for tasks {}, polling for more records now",
-                         totalProcessed, taskManager.activeTaskIds());
-            } else {
-                log.debug("Processed {} records for tasks {}, polling for more records now",
-                          totalProcessed, taskManager.activeTaskIds());
-            }
+            log.info("Processed {} total records, ran {} punctuators, and committed {} total tasks " +
+                        "for active tasks {} and standby tasks {}",
+                     totalProcessed, totalPunctuated, totalCommitted, taskManager.activeTaskIds(), taskManager.standbyTaskIds());
         }
 
         now = time.milliseconds();
@@ -765,7 +763,7 @@ public class StreamThread extends Thread {
             // to unblock the restoration as soon as possible
             records = pollRequests(Duration.ZERO);
         } else if (state == State.PARTITIONS_REVOKED) {
-            // try to fetch som records with zero poll millis to unblock
+            // try to fetch some records with zero poll millis to unblock
             // other useful work while waiting for the join response
             records = pollRequests(Duration.ZERO);
         } else if (state == State.RUNNING || state == State.STARTING) {
@@ -784,13 +782,13 @@ public class StreamThread extends Thread {
 
         final long pollLatency = advanceNowAndComputeLatency();
 
-        if (log.isDebugEnabled()) {
-            log.debug("Main Consumer poll completed in {} ms and fetched {} records", pollLatency, records.count());
-        }
+        final int numRecords = records.count();
+        log.info("Main Consumer poll completed in {} ms and fetched {} records", pollLatency, numRecords);
+
         pollSensor.record(pollLatency, now);
 
         if (!records.isEmpty()) {
-            pollRecordsSensor.record(records.count(), now);
+            pollRecordsSensor.record(numRecords, now);
             taskManager.addRecordsToTasks(records);
         }
         return pollLatency;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -704,12 +704,14 @@ public class StreamThread extends Thread {
             // multiple iterations with reasonably large max.num.records and hence is less vulnerable to outliers
             taskManager.recordTaskProcessRatio(totalProcessLatency, now);
 
-            // Only log this when we actually processed some records to avoid flooding INFO-level logs when there are
-            // no records on the input topics
+            // Only log this at INFO when we actually processed some records to avoid flooding INFO-level logs when
+            // there are no records on the input topics
             if (totalProcessed > 0) {
-                log.info("Finished processing {} records, going to poll again", totalProcessed);
+                log.info("Processed {} records for tasks {}, polling for more records now",
+                         totalProcessed, taskManager.activeTaskIds());
             } else {
-                log.debug("Processed zero records, going to poll again");
+                log.debug("Processed {} records for tasks {}, polling for more records now",
+                          totalProcessed, taskManager.activeTaskIds());
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1070,7 +1070,7 @@ public class TaskManager {
     }
 
     private void commitOffsetsOrTransaction(final Map<TaskId, Map<TopicPartition, OffsetAndMetadata>> offsetsPerTask) {
-        log.info("Committing task offsets {}", offsetsPerTask);
+        log.debug("Committing task offsets {}", offsetsPerTask);
 
         if (!offsetsPerTask.isEmpty()) {
             if (processingMode == EXACTLY_ONCE_ALPHA) {


### PR DESCRIPTION
This message absolutely floods the logs, especially in an eos application where the commit interval is just 100ms. It's definitely a useful message but I don't think there's any justification for it being at the INFO level when it's logged 10 times a second. 