### PR TITLE
KAFKA-10623: Refactor code to avoid discovery conflicts for admin.VersionRange

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/FeatureMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FeatureMetadata.java
@@ -29,15 +29,15 @@ import java.util.Optional;
  */
 public class FeatureMetadata {
 
-    private final Map<String, FinalizedVersionRange> finalizedFeatures;
+    private final Map<String, FinalizedVersions> finalizedFeatures;
 
     private final Optional<Long> finalizedFeaturesEpoch;
 
-    private final Map<String, SupportedVersionRange> supportedFeatures;
+    private final Map<String, SupportedVersions> supportedFeatures;
 
-    FeatureMetadata(final Map<String, FinalizedVersionRange> finalizedFeatures,
+    FeatureMetadata(final Map<String, FinalizedVersions> finalizedFeatures,
                            final Optional<Long> finalizedFeaturesEpoch,
-                           final Map<String, SupportedVersionRange> supportedFeatures) {
+                           final Map<String, SupportedVersions> supportedFeatures) {
         this.finalizedFeatures = new HashMap<>(finalizedFeatures);
         this.finalizedFeaturesEpoch = finalizedFeaturesEpoch;
         this.supportedFeatures = new HashMap<>(supportedFeatures);
@@ -48,7 +48,7 @@ public class FeatureMetadata {
      * feature name and the value being a range of version levels supported by every broker in the
      * cluster.
      */
-    public Map<String, FinalizedVersionRange> finalizedFeatures() {
+    public Map<String, FinalizedVersions> finalizedFeatures() {
         return new HashMap<>(finalizedFeatures);
     }
 
@@ -65,7 +65,7 @@ public class FeatureMetadata {
      * feature name and the value being a range of versions supported by a particular broker in the
      * cluster.
      */
-    public Map<String, SupportedVersionRange> supportedFeatures() {
+    public Map<String, SupportedVersions> supportedFeatures() {
         return new HashMap<>(supportedFeatures);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/FinalizedVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/FinalizedVersions.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 /**
  * Represents a range of version levels supported by every broker in a cluster for some feature.
  */
-public class FinalizedVersionRange {
+public class FinalizedVersions {
     private final short minVersionLevel;
 
     private final short maxVersionLevel;
@@ -35,7 +35,7 @@ public class FinalizedVersionRange {
      *
      * @throws IllegalArgumentException   Raised when the condition described above is not met.
      */
-    FinalizedVersionRange(final short minVersionLevel, final short maxVersionLevel) {
+    FinalizedVersions(final short minVersionLevel, final short maxVersionLevel) {
         if (minVersionLevel < 1 || maxVersionLevel < 1 || maxVersionLevel < minVersionLevel) {
             throw new IllegalArgumentException(
                 String.format(
@@ -60,11 +60,11 @@ public class FinalizedVersionRange {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof FinalizedVersionRange)) {
+        if (!(other instanceof FinalizedVersions)) {
             return false;
         }
 
-        final FinalizedVersionRange that = (FinalizedVersionRange) other;
+        final FinalizedVersions that = (FinalizedVersions) other;
         return this.minVersionLevel == that.minVersionLevel &&
             this.maxVersionLevel == that.maxVersionLevel;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4347,9 +4347,9 @@ public class KafkaAdminClient extends AdminClient {
             "describeFeatures", calcDeadlineMs(now, options.timeoutMs()), provider) {
 
             private FeatureMetadata createFeatureMetadata(final ApiVersionsResponse response) {
-                final Map<String, FinalizedVersionRange> finalizedFeatures = new HashMap<>();
+                final Map<String, FinalizedVersions> finalizedFeatures = new HashMap<>();
                 for (final FinalizedFeatureKey key : response.data().finalizedFeatures().valuesSet()) {
-                    finalizedFeatures.put(key.name(), new FinalizedVersionRange(key.minVersionLevel(), key.maxVersionLevel()));
+                    finalizedFeatures.put(key.name(), new FinalizedVersions(key.minVersionLevel(), key.maxVersionLevel()));
                 }
 
                 Optional<Long> finalizedFeaturesEpoch;
@@ -4359,9 +4359,9 @@ public class KafkaAdminClient extends AdminClient {
                     finalizedFeaturesEpoch = Optional.empty();
                 }
 
-                final Map<String, SupportedVersionRange> supportedFeatures = new HashMap<>();
+                final Map<String, SupportedVersions> supportedFeatures = new HashMap<>();
                 for (final SupportedFeatureKey key : response.data().supportedFeatures().valuesSet()) {
-                    supportedFeatures.put(key.name(), new SupportedVersionRange(key.minVersion(), key.maxVersion()));
+                    supportedFeatures.put(key.name(), new SupportedVersions(key.minVersion(), key.maxVersion()));
                 }
 
                 return new FeatureMetadata(finalizedFeatures, finalizedFeaturesEpoch, supportedFeatures);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/SupportedVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/SupportedVersions.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 /**
  * Represents a range of versions that a particular broker supports for some feature.
  */
-public class SupportedVersionRange {
+public class SupportedVersions {
     private final short minVersion;
 
     private final short maxVersion;
@@ -35,7 +35,7 @@ public class SupportedVersionRange {
      *
      * @throws IllegalArgumentException   Raised when the condition described above is not met.
      */
-    SupportedVersionRange(final short minVersion, final short maxVersion) {
+    SupportedVersions(final short minVersion, final short maxVersion) {
         if (minVersion < 1 || maxVersion < 1 || maxVersion < minVersion) {
             throw new IllegalArgumentException(
                 String.format(
@@ -65,7 +65,7 @@ public class SupportedVersionRange {
             return false;
         }
 
-        final SupportedVersionRange that = (SupportedVersionRange) other;
+        final SupportedVersions that = (SupportedVersions) other;
         return this.minVersion == that.minVersion && this.maxVersion == that.maxVersion;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -486,15 +486,15 @@ public class KafkaAdminClientTest {
 
     private static FeatureMetadata defaultFeatureMetadata() {
         return new FeatureMetadata(
-            Utils.mkMap(Utils.mkEntry("test_feature_1", new FinalizedVersionRange((short) 2, (short) 3))),
+            Utils.mkMap(Utils.mkEntry("test_feature_1", new FinalizedVersions((short) 2, (short) 3))),
             Optional.of(1L),
-            Utils.mkMap(Utils.mkEntry("test_feature_1", new SupportedVersionRange((short) 1, (short) 5))));
+            Utils.mkMap(Utils.mkEntry("test_feature_1", new SupportedVersions((short) 1, (short) 5))));
     }
 
-    private static Features<org.apache.kafka.common.feature.SupportedVersionRange> convertSupportedFeaturesMap(Map<String, SupportedVersionRange> features) {
+    private static Features<org.apache.kafka.common.feature.SupportedVersionRange> convertSupportedFeaturesMap(Map<String, SupportedVersions> features) {
         final Map<String, org.apache.kafka.common.feature.SupportedVersionRange> featuresMap = new HashMap<>();
-        for (final Map.Entry<String, SupportedVersionRange> entry : features.entrySet()) {
-            final SupportedVersionRange versionRange = entry.getValue();
+        for (final Map.Entry<String, SupportedVersions> entry : features.entrySet()) {
+            final SupportedVersions versionRange = entry.getValue();
             featuresMap.put(
                 entry.getKey(),
                 new org.apache.kafka.common.feature.SupportedVersionRange(versionRange.minVersion(),
@@ -504,10 +504,10 @@ public class KafkaAdminClientTest {
         return Features.supportedFeatures(featuresMap);
     }
 
-    private static Features<org.apache.kafka.common.feature.FinalizedVersionRange> convertFinalizedFeaturesMap(Map<String, FinalizedVersionRange> features) {
+    private static Features<org.apache.kafka.common.feature.FinalizedVersionRange> convertFinalizedFeaturesMap(Map<String, FinalizedVersions> features) {
         final Map<String, org.apache.kafka.common.feature.FinalizedVersionRange> featuresMap = new HashMap<>();
-        for (final Map.Entry<String, FinalizedVersionRange> entry : features.entrySet()) {
-            final FinalizedVersionRange versionRange = entry.getValue();
+        for (final Map.Entry<String, FinalizedVersions> entry : features.entrySet()) {
+            final FinalizedVersions versionRange = entry.getValue();
             featuresMap.put(
                 entry.getKey(),
                 new org.apache.kafka.common.feature.FinalizedVersionRange(

--- a/clients/src/test/java/org/apache/kafka/common/feature/FinalizedVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/FinalizedVersionsTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
  * Most of the unit tests required for BaseVersionRange are part of the SupportedVersionRangeTest
  * suite. This suite only tests behavior very specific to FinalizedVersionRange.
  */
-public class FinalizedVersionRangeTest {
+public class FinalizedVersionsTest {
 
     @Test
     public void testFromToMap() {

--- a/clients/src/test/java/org/apache/kafka/common/feature/SupportedVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/SupportedVersionsTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertTrue;
  * Unit tests for the SupportedVersionRange class.
  * Along the way, this suite also includes extensive tests for the base class BaseVersionRange.
  */
-public class SupportedVersionRangeTest {
+public class SupportedVersionsTest {
     @Test
     public void testFailDueToInvalidParams() {
         // min and max can't be < 1.

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -24,7 +24,7 @@ import kafka.api.KAFKA_2_7_IV0
 import kafka.utils.TestUtils
 import kafka.zk.{FeatureZNode, FeatureZNodeStatus, ZkVersion}
 import kafka.utils.TestUtils.waitUntilTrue
-import org.apache.kafka.clients.admin.{Admin, DescribeFeaturesOptions, FeatureUpdate, UpdateFeaturesOptions, UpdateFeaturesResult}
+import org.apache.kafka.clients.admin.{Admin, DescribeFeaturesOptions, FeatureUpdate, FinalizedVersions, SupportedVersions, UpdateFeaturesOptions, UpdateFeaturesResult}
 import org.apache.kafka.common.errors.InvalidRequestException
 import org.apache.kafka.common.feature.FinalizedVersionRange
 import org.apache.kafka.common.feature.{Features, SupportedVersionRange}
@@ -101,14 +101,14 @@ class UpdateFeaturesTest extends BaseRequestTest {
     FeatureZNode.decode(mayBeFeatureZNodeBytes.get)
   }
 
-  private def finalizedFeatures(features: java.util.Map[String, org.apache.kafka.clients.admin.FinalizedVersionRange]): Features[FinalizedVersionRange] = {
+  private def finalizedFeatures(features: java.util.Map[String, FinalizedVersions]): Features[FinalizedVersionRange] = {
     Features.finalizedFeatures(features.asScala.map {
       case(name, versionRange) =>
         (name, new FinalizedVersionRange(versionRange.minVersionLevel(), versionRange.maxVersionLevel()))
     }.asJava)
   }
 
-  private def supportedFeatures(features: java.util.Map[String, org.apache.kafka.clients.admin.SupportedVersionRange]): Features[SupportedVersionRange] = {
+  private def supportedFeatures(features: java.util.Map[String, SupportedVersions]): Features[SupportedVersionRange] = {
     Features.supportedFeatures(features.asScala.map {
       case(name, versionRange) =>
         (name, new SupportedVersionRange(versionRange.minVersion(), versionRange.maxVersion()))


### PR DESCRIPTION
Rename admin.VersionRange into admin.Versions to avoid discovery conflicts

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
