### PR TITLE
KAFKA-10641: ACL Command Exit properly always with error code

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -65,6 +65,7 @@ object AclCommand extends Logging {
       }
     }
 
+    var exitCode = 0
     try {
       if (opts.options.has(opts.addOpt))
         aclCommandService.addAcls()
@@ -76,7 +77,9 @@ object AclCommand extends Logging {
       case e: Throwable =>
         println(s"Error while executing ACL command: ${e.getMessage}")
         println(Utils.stackTrace(e))
-        Exit.exit(1)
+        exitCode = 1
+    } finally {
+      Exit.exit(exitCode)
     }
   }
 


### PR DESCRIPTION
When using ACL Command with SSL mode, the process is not terminating after successful ACL operation.