### PR TITLE
KAFKA-10642: Expose the real stack trace if any exception occurred during SSL Client Trust Verification in extension

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -95,6 +95,7 @@ public class SslFactory implements Reconfigurable, Closeable {
             try {
                 SslEngineValidator.validate(builder, builder);
             } catch (Exception e) {
+                log.error("SSLFactory configure failed during validate", e);
                 throw new ConfigException("A client SSLEngine created with the provided settings " +
                         "can't connect to a server SSLEngine created with those settings.", e);
             }


### PR DESCRIPTION
If there is any exception occurred in the custom implementation of client trust verification (i.e. using security.provider), the inner exception is suppressed or hidden and not logged to the log file...

@junrao @mjsax @guozhangwang