### PR TITLE
MINOR: fix error in quota_test.py system tests

### DIFF
--- a/tests/kafkatest/tests/client/quota_test.py
+++ b/tests/kafkatest/tests/client/quota_test.py
@@ -79,7 +79,7 @@ class QuotaConfig(object):
     def configure_quota(self, kafka, producer_byte_rate, consumer_byte_rate, entity_args):
         force_use_zk_conection = not kafka.all_nodes_configs_command_uses_bootstrap_server()
         node = kafka.nodes[0]
-        cmd = "%s %s --alter --add-config producer_byte_rate=%d,consumer_byte_rate=%d" % \
+        cmd = "%s --alter --add-config producer_byte_rate=%d,consumer_byte_rate=%d" % \
               (kafka.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_conection), producer_byte_rate, consumer_byte_rate)
         cmd += " --entity-type " + entity_args[0] + self.entity_name_opt(entity_args[1])
         if len(entity_args) > 2:


### PR DESCRIPTION
quota_test.py tests are failing with below error.

```
23:24:42 [INFO:2020-10-24 17:54:42,366]: RunnerClient: kafkatest.tests.client.quota_test.QuotaTest.test_quota.quota_type=user.override_quota=False: FAIL: not enough arguments for format string
23:24:42 Traceback (most recent call last):
23:24:42   File "/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/venv/lib/python3.6/site-packages/ducktape-0.8.0-py3.6.egg/ducktape/tests/runner_client.py", line 134, in run
23:24:42     data = self.run_test()
23:24:42   File "/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/venv/lib/python3.6/site-packages/ducktape-0.8.0-py3.6.egg/ducktape/tests/runner_client.py", line 192, in run_test
23:24:42     return self.test_context.function(self.test)
23:24:42   File "/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/venv/lib/python3.6/site-packages/ducktape-0.8.0-py3.6.egg/ducktape/mark/_mark.py", line 429, in wrapper
23:24:42     return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
23:24:42   File "/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/tests/kafkatest/tests/client/quota_test.py", line 141, in test_quota
23:24:42     self.quota_config = QuotaConfig(quota_type, override_quota, self.kafka)
23:24:42   File "/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/tests/kafkatest/tests/client/quota_test.py", line 60, in __init__
23:24:42     self.configure_quota(kafka, self.producer_quota, self.consumer_quota, ['users', None])
23:24:42   File "/home/jenkins/workspace/system-test-kafka-branch-builder/kafka/tests/kafkatest/tests/client/quota_test.py", line 83, in configure_quota
23:24:42     (kafka.kafka_configs_cmd_with_optional_security_settings(node, force_use_zk_conection), producer_byte_rate, consumer_byte_rate)
23:24:42 TypeError: not enough arguments for format string
23:24:42 
```

ran thee tests locally.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
