### PR TITLE
MINOR: call super.close() when closing RocksDB options

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -1393,9 +1393,10 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
 
     @Override
     public void close() {
-        // ColumnFamilyOptions should be closed last
+        // ColumnFamilyOptions should be closed after DBOptions
         dbOptions.close();
         columnFamilyOptions.close();
+        // close super last since we initialized it first
         super.close();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter.java
@@ -1396,5 +1396,6 @@ public class RocksDBGenericOptionsToDbOptionsColumnFamilyOptionsAdapter extends 
         // ColumnFamilyOptions should be closed last
         dbOptions.close();
         columnFamilyOptions.close();
+        super.close();
     }
 }


### PR DESCRIPTION
Call super.close when closing rocksdb options. If we don't, then closing a state
store will leak the underlying rocksdb options object. This is actually somewhat
costly, since the default options object allocates it's own cache instance.