### PR TITLE
MINOR: move the test cases which don't need brokers from TopicCommand…

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -16,15 +16,23 @@
  */
 package kafka.admin
 
-import kafka.admin.TopicCommand.PartitionDescription
+import kafka.admin.TopicCommand.{PartitionDescription, TopicCommandOptions}
+import kafka.common.AdminCommandFailedException
+import kafka.utils.Exit
 import org.apache.kafka.clients.admin.PartitionReassignment
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.TopicPartitionInfo
 import org.junit.Assert._
 import org.junit.Test
+import org.scalatest.Assertions.intercept
+
 import scala.jdk.CollectionConverters._
 
 class TopicCommandTest {
+
+  private[this] val brokerList = "localhost:9092"
+  private[this] val topicName = "topicName"
+
   @Test
   def testIsNotUnderReplicatedWhenAdding(): Unit = {
     val replicaIds = List(1, 2)
@@ -41,7 +49,7 @@ class TopicCommandTest {
         List(new Node(1, "localhost", 9091)).asJava
       ),
       None,
-      false,
+      markedForDeletion = false,
       Some(
         new PartitionReassignment(
           replicaIds.map(id => id: java.lang.Integer).asJava,
@@ -52,5 +60,79 @@ class TopicCommandTest {
     )
 
     assertFalse(partitionDescription.isUnderReplicated)
+  }
+
+  @Test
+  def testAlterWithUnspecifiedPartitionCount(): Unit = {
+    assertCheckArgsExitCode(1, new TopicCommandOptions(
+      Array("--bootstrap-server", brokerList ,"--alter", "--topic", topicName)))
+  }
+
+  @Test
+  def testConfigOptWithBootstrapServers(): Unit = {
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", topicName, "--partitions", "3", "--config", "cleanup.policy=compact")))
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", topicName, "--partitions", "3", "--delete-config", "cleanup.policy")))
+    val opts =
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--create", "--topic", topicName, "--partitions", "3", "--replication-factor", "3", "--config", "cleanup.policy=compact"))
+    opts.checkArgs()
+    assertTrue(opts.hasCreateOption)
+    assertEquals(brokerList, opts.bootstrapServer.get)
+    assertEquals("cleanup.policy=compact", opts.topicConfig.get.get(0))
+  }
+
+  @Test
+  def testCreateWithAssignmentAndPartitionCount(): Unit = {
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(
+        Array("--bootstrap-server", brokerList,
+          "--create",
+          "--replica-assignment", "3:0,5:1",
+          "--partitions", "2",
+          "--topic", "testTopic")))
+  }
+
+  @Test
+  def testCreateWithAssignmentAndReplicationFactor(): Unit = {
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(
+        Array("--bootstrap-server", brokerList,
+          "--create",
+          "--replica-assignment", "3:0,5:1",
+          "--replication-factor", "2",
+          "--topic", "testTopic")))
+  }
+
+  @Test
+  def testParseAssignmentDuplicateEntries(): Unit = {
+    intercept[AdminCommandFailedException] {
+      TopicCommand.parseReplicaAssignment("5:5")
+    }
+  }
+
+  @Test
+  def testParseAssignmentPartitionsOfDifferentSize(): Unit = {
+    intercept[AdminOperationException] {
+      TopicCommand.parseReplicaAssignment("5:4:3,2:1")
+    }
+  }
+
+  @Test
+  def testParseAssignment(): Unit = {
+    val actualAssignment = TopicCommand.parseReplicaAssignment("5:4,3:2,1:0")
+    val expectedAssignment = Map(0 -> List(5, 4), 1 -> List(3, 2), 2 -> List(1, 0))
+    assertEquals(expectedAssignment, actualAssignment)
+  }
+
+  private[this] def assertCheckArgsExitCode(expected: Int, options: TopicCommandOptions): Unit = {
+    Exit.setExitProcedure {
+      (exitCode: Int, _: Option[String]) =>
+        assertEquals(expected, exitCode)
+        throw new RuntimeException
+    }
+    try intercept[RuntimeException] {
+      options.checkArgs()
+    } finally Exit.resetExitProcedure()
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -19,10 +19,9 @@ package kafka.admin
 import java.util.{Collections, Optional, Properties}
 
 import kafka.admin.TopicCommand.{AdminClientTopicService, TopicCommandOptions}
-import kafka.common.AdminCommandFailedException
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.{ConfigType, KafkaConfig}
-import kafka.utils.{Exit, Logging, TestUtils}
+import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin._
@@ -79,33 +78,14 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
   private var testTopicName: String = _
 
   private val _testName = new TestName
-  @Rule def testName = _testName
+  @Rule def testName: TestName = _testName
 
-  def assertExitCode(expected: Int, method: () => Unit): Unit = {
-    def mockExitProcedure(exitCode: Int, exitMessage: Option[String]): Nothing = {
-      assertEquals(expected, exitCode)
-      throw new RuntimeException
-    }
-    Exit.setExitProcedure(mockExitProcedure)
-    try {
-      intercept[RuntimeException] {
-        method()
-      }
-    } finally {
-      Exit.resetExitProcedure()
-    }
-  }
-
-  def assertCheckArgsExitCode(expected: Int, options: TopicCommandOptions): Unit = {
-    assertExitCode(expected, options.checkArgs _)
-  }
-
-  def createAndWaitTopic(opts: TopicCommandOptions): Unit = {
+  private[this] def createAndWaitTopic(opts: TopicCommandOptions): Unit = {
     topicService.createTopic(opts)
     waitForTopicCreated(opts.topic.get)
   }
 
-  def waitForTopicCreated(topicName: String, timeout: Int = 10000): Unit = {
+  private[this] def waitForTopicCreated(topicName: String, timeout: Int = 10000): Unit = {
     TestUtils.waitUntilMetadataIsPropagated(servers, topicName, partition = 0, timeout)
   }
 
@@ -124,42 +104,6 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
     // adminClient is closed by topicService
     if (topicService != null)
       topicService.close()
-  }
-
-  @Test
-  def testParseAssignment(): Unit = {
-    val actualAssignment = TopicCommand.parseReplicaAssignment("5:4,3:2,1:0")
-    val expectedAssignment = Map(0 -> List(5, 4), 1 -> List(3, 2), 2 -> List(1, 0))
-    assertEquals(expectedAssignment, actualAssignment)
-  }
-
-  @Test
-  def testParseAssignmentDuplicateEntries(): Unit = {
-    intercept[AdminCommandFailedException] {
-      TopicCommand.parseReplicaAssignment("5:5")
-    }
-  }
-
-  @Test
-  def testParseAssignmentPartitionsOfDifferentSize(): Unit = {
-    intercept[AdminOperationException] {
-      TopicCommand.parseReplicaAssignment("5:4:3,2:1")
-    }
-  }
-
-  @Test
-  def testConfigOptWithBootstrapServers(): Unit = {
-    assertCheckArgsExitCode(1,
-      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--partitions", "3", "--config", "cleanup.policy=compact")))
-    assertCheckArgsExitCode(1,
-      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--partitions", "3", "--delete-config", "cleanup.policy")))
-    val opts =
-      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--create", "--topic", testTopicName, "--partitions", "3", "--replication-factor", "3", "--config", "cleanup.policy=compact"))
-    opts.checkArgs()
-    assertTrue(opts.hasCreateOption)
-    assertEquals(brokerList, opts.bootstrapServer.get)
-    assertEquals("cleanup.policy=compact", opts.topicConfig.get.get(0))
-
   }
 
   @Test
@@ -283,28 +227,6 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
       topicService.createTopic(new TopicCommandOptions(
         Array("--partitions", "2", "--replication-factor", "-1", "--topic", testTopicName)))
     }
-  }
-
-  @Test
-  def testCreateWithAssignmentAndPartitionCount(): Unit = {
-    assertCheckArgsExitCode(1,
-      new TopicCommandOptions(
-        Array("--bootstrap-server", brokerList,
-          "--create",
-          "--replica-assignment", "3:0,5:1",
-          "--partitions", "2",
-          "--topic", "testTopic")))
-  }
-
-  @Test
-  def testCreateWithAssignmentAndReplicationFactor(): Unit = {
-    assertCheckArgsExitCode(1,
-      new TopicCommandOptions(
-        Array("--bootstrap-server", brokerList,
-          "--create",
-          "--replica-assignment", "3:0,5:1",
-          "--replication-factor", "2",
-          "--topic", "testTopic")))
   }
 
   @Test
@@ -434,12 +356,6 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
       topicService.alterTopic(new TopicCommandOptions(
         Array("--partitions", "-1", "--topic", testTopicName)))
     }
-  }
-
-  @Test
-  def testAlterWithUnspecifiedPartitionCount(): Unit = {
-    assertCheckArgsExitCode(1, new TopicCommandOptions(
-      Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName)))
   }
 
   @Test
@@ -614,9 +530,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
               val testPartitionMetadata = topicMetadatas.find(_.name.equals(testTopicName)).get.partitions.asScala.find(_.partitionIndex == partitionOnBroker0)
               testPartitionMetadata match {
                 case None => fail(s"Partition metadata is not found in metadata cache")
-                case Some(metadata) => {
-                  result && metadata.errorCode == Errors.LEADER_NOT_AVAILABLE.code
-                }
+                case Some(metadata) => result && metadata.errorCode == Errors.LEADER_NOT_AVAILABLE.code
               }
             }
           }
@@ -744,7 +658,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
         topicService.describeTopic(new TopicCommandOptions(Array("--at-min-isr-partitions"))))
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $testTopicName"))
-      assertEquals(1, rows.length);
+      assertEquals(1, rows.length)
     } finally {
       restartDeadBrokers()
     }
@@ -790,7 +704,7 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
       val rows = output.split("\n")
       assertTrue(rows(0).startsWith(s"\tTopic: $underMinIsrTopic"))
       assertTrue(rows(1).startsWith(s"\tTopic: $offlineTopic"))
-      assertEquals(2, rows.length);
+      assertEquals(2, rows.length)
     } finally {
       restartDeadBrokers()
     }


### PR DESCRIPTION
This patch can reduce the elapsed time of testing ```TopicCommandWithAdminClientTest``` (5m19s -> 4m18s on my local)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
