### PR TITLE
MINOR; DescribeUserScramCredentialsRequest API should handle request with users equals to `null`

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -3066,7 +3066,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     if (authorize(request.context, DESCRIBE, CLUSTER, CLUSTER_NAME)) {
       val result = adminManager.describeUserScramCredentials(
-        Option(describeUserScramCredentialsRequest.data.users.asScala.map(_.name).toList))
+        Option(describeUserScramCredentialsRequest.data.users).map(_.asScala.map(_.name).toList))
       sendResponseMaybeThrottle(request, requestThrottleMs =>
         new DescribeUserScramCredentialsResponse(result.setThrottleTimeMs(requestThrottleMs)))
     } else {

--- a/core/src/test/scala/unit/kafka/server/DescribeUserScramCredentialsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeUserScramCredentialsRequestTest.scala
@@ -67,6 +67,19 @@ class DescribeUserScramCredentialsRequestTest extends BaseRequestTest {
   }
 
   @Test
+  def testDescribeWithNull(): Unit = {
+    val request = new DescribeUserScramCredentialsRequest.Builder(
+      new DescribeUserScramCredentialsRequestData().setUsers(null)).build()
+    val response = sendDescribeUserScramCredentialsRequest(request)
+
+    val error = response.data.errorCode
+    assertEquals("Expected no error when describing everything and there are no credentials",
+      Errors.NONE.code, error)
+    assertEquals("Expected no credentials when describing everything and there are no credentials",
+      0, response.data.results.size)
+  }
+
+  @Test
   def testDescribeNotController(): Unit = {
     val request = new DescribeUserScramCredentialsRequest.Builder(
       new DescribeUserScramCredentialsRequestData()).build()


### PR DESCRIPTION
DescribeUserScramCredentialsRequest states that all users are described when `Users` is empty or `null`. `null` is not handled at the moment and throws an NPE. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
