### PR TITLE
KAFKA-10647; Only serialize owned partitions when consumer protocol version >= 1

### DIFF
--- a/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
+++ b/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
@@ -26,7 +26,7 @@
     { "name": "Topics", "type": "[]string", "versions": "0+" },
     { "name": "UserData", "type": "bytes", "versions": "0+", "nullableVersions": "0+",
       "default": "null", "zeroCopy": true },
-    { "name": "OwnedPartitions", "type": "[]TopicPartition", "versions": "1+",
+    { "name": "OwnedPartitions", "type": "[]TopicPartition", "versions": "1+", "ignorable": true,
       "fields": [
         { "name": "Topic", "type": "string", "versions": "1+" },
         { "name": "Partitions", "type": "[]int32", "versions": "1+"}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
@@ -47,6 +47,30 @@ public class ConsumerProtocolTest {
     private final Optional<String> groupInstanceId = Optional.of("instance.id");
 
     @Test
+    public void serializeDeserializeSubscriptionAllVersions() {
+        List<TopicPartition> ownedPartitions = Arrays.asList(
+            new TopicPartition("foo", 0),
+            new TopicPartition("bar", 0));
+        Subscription subscription = new Subscription(Arrays.asList("foo", "bar"),
+            ByteBuffer.wrap("hello".getBytes()), ownedPartitions);
+
+        for (short version = ConsumerProtocolSubscription.LOWEST_SUPPORTED_VERSION; version <= ConsumerProtocolSubscription.HIGHEST_SUPPORTED_VERSION; version++) {
+            ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription, version);
+            Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer);
+
+            assertEquals(subscription.topics(), parsedSubscription.topics());
+            assertEquals(subscription.userData(), parsedSubscription.userData());
+            assertFalse(parsedSubscription.groupInstanceId().isPresent());
+
+            if (version >= 1) {
+                assertEquals(toSet(subscription.ownedPartitions()), toSet(parsedSubscription.ownedPartitions()));
+            } else {
+                assertTrue(parsedSubscription.ownedPartitions().isEmpty());
+            }
+        }
+    }
+
+    @Test
     public void serializeDeserializeMetadata() {
         Subscription subscription = new Subscription(Arrays.asList("foo", "bar"), ByteBuffer.wrap(new byte[0]));
         ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription);
@@ -135,6 +159,19 @@ public class ConsumerProtocolTest {
         assertEquals(Collections.singletonList("topic"), subscription.topics());
         assertEquals(Collections.singletonList(tp2), subscription.ownedPartitions());
         assertEquals(groupInstanceId, subscription.groupInstanceId());
+    }
+
+    @Test
+    public void serializeDeserializeAssignmentAllVersions() {
+        List<TopicPartition> partitions = Arrays.asList(tp1, tp2);
+        Assignment assignment = new Assignment(partitions, ByteBuffer.wrap("hello".getBytes()));
+
+        for (short version = ConsumerProtocolAssignment.LOWEST_SUPPORTED_VERSION; version <= ConsumerProtocolAssignment.HIGHEST_SUPPORTED_VERSION; version++) {
+            ByteBuffer buffer = ConsumerProtocol.serializeAssignment(assignment, version);
+            Assignment parsedAssignment = ConsumerProtocol.deserializeAssignment(buffer);
+            assertEquals(toSet(partitions), toSet(parsedAssignment.partitions()));
+            assertEquals(parsedAssignment.userData(), parsedAssignment.userData());
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
@@ -65,7 +65,7 @@ public class ConsumerProtocolTest {
             if (version >= 1) {
                 assertEquals(toSet(subscription.ownedPartitions()), toSet(parsedSubscription.ownedPartitions()));
             } else {
-                assertTrue(parsedSubscription.ownedPartitions().isEmpty());
+                assertEquals(Collections.emptyList(), parsedSubscription.ownedPartitions());
             }
         }
     }
@@ -170,7 +170,7 @@ public class ConsumerProtocolTest {
             ByteBuffer buffer = ConsumerProtocol.serializeAssignment(assignment, version);
             Assignment parsedAssignment = ConsumerProtocol.deserializeAssignment(buffer);
             assertEquals(toSet(partitions), toSet(parsedAssignment.partitions()));
-            assertEquals(parsedAssignment.userData(), parsedAssignment.userData());
+            assertEquals(assignment.userData(), parsedAssignment.userData());
         }
     }
 


### PR DESCRIPTION
A regression got introduced by https://github.com/apache/kafka/pull/8897. The owned partition field must be ignored for version < 1 otherwise the serialization fails with an unsupported version exception.

This must be merged in 2.7.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
