### PR TITLE
MINOR: rename metrics "iotime-total" to "io-time-total" and "io-waitt…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -1272,7 +1272,7 @@ public class Selector implements Selectable, AutoCloseable {
                 String baseName, String action) {
             MetricName rateMetricName = metrics.metricName(baseName + "-ratio", groupName,
                     String.format("The fraction of time the I/O thread spent %s", action), metricTags);
-            MetricName totalMetricName = metrics.metricName(baseName + "time-total", groupName,
+            MetricName totalMetricName = metrics.metricName(baseName + "-time-total", groupName,
                     String.format("The total time the I/O thread spent %s", action), metricTags);
             return new Meter(TimeUnit.NANOSECONDS, rateMetricName, totalMetricName);
         }


### PR DESCRIPTION
I believe that is a kind of typo since it is not consistent to other related metrics name.

1. io-wait-time-ns-avg
1. io-time-ns-avg
1. io-wait-ratio
1. io-ratio

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
