### PR TITLE
MINOR: improve `null` checks for headers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.utils.AbstractIterator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -38,11 +37,7 @@ public class RecordHeaders implements Headers {
     }
 
     public RecordHeaders(Header[] headers) {
-        if (headers == null) {
-            this.headers = new ArrayList<>();
-        } else {
-            this.headers = new ArrayList<>(Arrays.asList(headers));
-        }
+        this(headers == null ? null : Arrays.asList(headers));
     }
 
     public RecordHeaders(Iterable<Header> headers) {
@@ -51,12 +46,12 @@ public class RecordHeaders implements Headers {
             this.headers = new ArrayList<>();
         } else if (headers instanceof RecordHeaders) {
             this.headers = new ArrayList<>(((RecordHeaders) headers).headers);
-        } else if (headers instanceof Collection) {
-            this.headers = new ArrayList<>((Collection<Header>) headers);
         } else {
             this.headers = new ArrayList<>();
-            for (Header header : headers)
+            for (Header header : headers) {
+                Objects.requireNonNull(header, "Header cannot be null.");
                 this.headers.add(header);
+            }
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -210,15 +210,12 @@ public class RecordHeadersTest {
     @Test
     public void shouldThrowNpeWhenAddingNullHeader() {
         final RecordHeaders recordHeaders = new RecordHeaders();
-
         assertThrows(NullPointerException.class, () -> recordHeaders.add(null));
     }
 
     @Test
     public void shouldThrowNpeWhenAddingCollectionWithNullHeader() {
-        final Header[] headers = new Header[1];
-
-        assertThrows(NullPointerException.class, () -> new RecordHeaders(headers));
+        assertThrows(NullPointerException.class, () -> new RecordHeaders(new Header[1]));
     }
 
     private int getCount(Headers headers) {

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -206,9 +207,18 @@ public class RecordHeadersTest {
         assertEquals(2, getCount(newHeaders));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNpeWhenAddingNullHeader() {
-        new RecordHeaders().add(null);
+        final RecordHeaders recordHeaders = new RecordHeaders();
+
+        assertThrows(NullPointerException.class, () -> recordHeaders.add(null));
+    }
+
+    @Test
+    public void shouldThrowNpeWhenAddingCollectionWithNullHeader() {
+        final Header[] headers = new Header[1];
+
+        assertThrows(NullPointerException.class, () -> new RecordHeaders(headers));
     }
 
     private int getCount(Headers headers) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -63,6 +63,7 @@ public class ConnectHeaders implements Headers {
         } else {
             headers = new LinkedList<>();
             for (Header header : original) {
+                Objects.requireNonNull(header, "Unable to add a null header.");
                 headers.add(header);
             }
         }
@@ -75,7 +76,7 @@ public class ConnectHeaders implements Headers {
 
     @Override
     public boolean isEmpty() {
-        return headers == null ? true : headers.isEmpty();
+        return headers == null || headers.isEmpty();
     }
 
     @Override

--- a/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -47,6 +48,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -496,6 +498,18 @@ public class ConnectHeadersTest {
     public void shouldDuplicateAndAlwaysReturnEquivalentButDifferentObject() {
         assertEquals(headers, headers.duplicate());
         assertNotSame(headers, headers.duplicate());
+    }
+
+    @Test
+    public void shouldNotAllowToAddNullHeader() {
+        final ConnectHeaders headers = new ConnectHeaders();
+        assertThrows(NullPointerException.class, () -> headers.add(null));
+    }
+
+    @Test
+    public void shouldThrowNpeWhenAddingCollectionWithNullHeader() {
+        final Iterable<Header> header = Arrays.asList(new ConnectHeader[1]);
+        assertThrows(NullPointerException.class, () -> new ConnectHeaders(header));
     }
 
     protected void assertSchemaMatches(Schema schema, Object value) {


### PR DESCRIPTION
Headers are not allowed to be `null`, and thus the code does not check for `null` headers. However, we don't have proper guards in place and had NPE in the past if a header was `null`. This PR adds additional `null` checks to avoid that users create corrupted headers.

Cf https://issues.apache.org/jira/browse/KAFKA-8142 and https://issues.apache.org/jira/browse/KAFKA-10645

Call for review @mimaison