### PR TITLE
KAFKA-10645: Add null check to the array/Iterable values in RecordHeaders constructor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -38,6 +38,7 @@ public class RecordHeaders implements Headers {
     }
 
     public RecordHeaders(Header[] headers) {
+        checkNullHeader(headers);
         if (headers == null) {
             this.headers = new ArrayList<>();
         } else {
@@ -46,6 +47,7 @@ public class RecordHeaders implements Headers {
     }
 
     public RecordHeaders(Iterable<Header> headers) {
+        checkNullHeader(headers);
         //Use efficient copy constructor if possible, fallback to iteration otherwise
         if (headers == null) {
             this.headers = new ArrayList<>();
@@ -115,6 +117,23 @@ public class RecordHeaders implements Headers {
 
     public Header[] toArray() {
         return headers.isEmpty() ? Record.EMPTY_HEADERS : headers.toArray(new Header[headers.size()]);
+    }
+
+    private void checkNullHeader(Header[] headers) throws IllegalArgumentException {
+        if (headers != null) {
+            if (!Arrays.stream(headers).allMatch(Objects::nonNull)) {
+                throw new IllegalArgumentException("header value cannot be null.");
+            }
+        }
+    }
+
+    private void checkNullHeader(Iterable<Header> headers) throws IllegalArgumentException {
+        if (headers != null) {
+            headers.forEach(header -> {
+                if (header == null)
+                    throw new IllegalArgumentException("header value cannot be null.");
+            });
+        }
     }
 
     private void checkKey(String key) {

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -211,6 +211,16 @@ public class RecordHeadersTest {
         new RecordHeaders().add(null);
     }
 
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenPassingArrayWithNullValueInConstructor() {
+        new RecordHeaders(new Header[] {new RecordHeader("key", "value".getBytes()), null});
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenPassingIterableWithNullValueInConstructor() {
+        new RecordHeaders(Arrays.asList(new Header[] {new RecordHeader("key", "value".getBytes()), null}));
+    }
+
     private int getCount(Headers headers) {
         int count = 0;
         Iterator<Header> headerIterator = headers.iterator();


### PR DESCRIPTION
In https://github.com/apache/kafka/pull/6484, we add null check while adding headers with `add()` method, but we forgot to protect it while user passing the headers with null value in constructor. Add it and add tests. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
