### PR TITLE
KAFKA-10650: Use Murmur3 instead of MD5 in SkimpyOffsetMap

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Murmur3.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Murmur3.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.state.internals;
+package org.apache.kafka.common.utils;
 
 /**
  * This class was taken from Hive org.apache.hive.common.util;
@@ -145,9 +145,9 @@ public class Murmur3 {
         for (int i = 0; i < nblocks; i++) {
             int i_4 = i << 2;
             int k = (data[offset + i_4] & 0xff)
-                    | ((data[offset + i_4 + 1] & 0xff) << 8)
-                    | ((data[offset + i_4 + 2] & 0xff) << 16)
-                    | ((data[offset + i_4 + 3] & 0xff) << 24);
+                | ((data[offset + i_4 + 1] & 0xff) << 8)
+                | ((data[offset + i_4 + 2] & 0xff) << 16)
+                | ((data[offset + i_4 + 3] & 0xff) << 24);
 
             hash = mix32(k, hash);
         }
@@ -268,13 +268,13 @@ public class Murmur3 {
         for (int i = 0; i < nblocks; i++) {
             final int i8 = i << 3;
             long k = ((long) data[offset + i8] & 0xff)
-                    | (((long) data[offset + i8 + 1] & 0xff) << 8)
-                    | (((long) data[offset + i8 + 2] & 0xff) << 16)
-                    | (((long) data[offset + i8 + 3] & 0xff) << 24)
-                    | (((long) data[offset + i8 + 4] & 0xff) << 32)
-                    | (((long) data[offset + i8 + 5] & 0xff) << 40)
-                    | (((long) data[offset + i8 + 6] & 0xff) << 48)
-                    | (((long) data[offset + i8 + 7] & 0xff) << 56);
+                | (((long) data[offset + i8 + 1] & 0xff) << 8)
+                | (((long) data[offset + i8 + 2] & 0xff) << 16)
+                | (((long) data[offset + i8 + 3] & 0xff) << 24)
+                | (((long) data[offset + i8 + 4] & 0xff) << 32)
+                | (((long) data[offset + i8 + 5] & 0xff) << 40)
+                | (((long) data[offset + i8 + 6] & 0xff) << 48)
+                | (((long) data[offset + i8 + 7] & 0xff) << 56);
 
             // mix functions
             k *= C1;
@@ -343,22 +343,22 @@ public class Murmur3 {
         for (int i = 0; i < nblocks; i++) {
             final int i16 = i << 4;
             long k1 = ((long) data[offset + i16] & 0xff)
-                    | (((long) data[offset + i16 + 1] & 0xff) << 8)
-                    | (((long) data[offset + i16 + 2] & 0xff) << 16)
-                    | (((long) data[offset + i16 + 3] & 0xff) << 24)
-                    | (((long) data[offset + i16 + 4] & 0xff) << 32)
-                    | (((long) data[offset + i16 + 5] & 0xff) << 40)
-                    | (((long) data[offset + i16 + 6] & 0xff) << 48)
-                    | (((long) data[offset + i16 + 7] & 0xff) << 56);
+                | (((long) data[offset + i16 + 1] & 0xff) << 8)
+                | (((long) data[offset + i16 + 2] & 0xff) << 16)
+                | (((long) data[offset + i16 + 3] & 0xff) << 24)
+                | (((long) data[offset + i16 + 4] & 0xff) << 32)
+                | (((long) data[offset + i16 + 5] & 0xff) << 40)
+                | (((long) data[offset + i16 + 6] & 0xff) << 48)
+                | (((long) data[offset + i16 + 7] & 0xff) << 56);
 
             long k2 = ((long) data[offset + i16 + 8] & 0xff)
-                    | (((long) data[offset + i16 + 9] & 0xff) << 8)
-                    | (((long) data[offset + i16 + 10] & 0xff) << 16)
-                    | (((long) data[offset + i16 + 11] & 0xff) << 24)
-                    | (((long) data[offset + i16 + 12] & 0xff) << 32)
-                    | (((long) data[offset + i16 + 13] & 0xff) << 40)
-                    | (((long) data[offset + i16 + 14] & 0xff) << 48)
-                    | (((long) data[offset + i16 + 15] & 0xff) << 56);
+                | (((long) data[offset + i16 + 9] & 0xff) << 8)
+                | (((long) data[offset + i16 + 10] & 0xff) << 16)
+                | (((long) data[offset + i16 + 11] & 0xff) << 24)
+                | (((long) data[offset + i16 + 12] & 0xff) << 32)
+                | (((long) data[offset + i16 + 13] & 0xff) << 40)
+                | (((long) data[offset + i16 + 14] & 0xff) << 48)
+                | (((long) data[offset + i16 + 15] & 0xff) << 56);
 
             // mix functions for k1
             k1 *= C1;

--- a/clients/src/test/java/org/apache/kafka/common/utils/Murmur3Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/Murmur3Test.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.state.internals;
+package org.apache.kafka.common.utils;
 
 import static org.junit.Assert.*;
 

--- a/core/src/main/scala/kafka/log/CleanerConfig.scala
+++ b/core/src/main/scala/kafka/log/CleanerConfig.scala
@@ -27,7 +27,6 @@ package kafka.log
  * @param maxIoBytesPerSecond The maximum read and write I/O that all cleaner threads are allowed to do
  * @param backOffMs The amount of time to wait before rechecking if no logs are eligible for cleaning
  * @param enableCleaner Allows completely disabling the log cleaner
- * @param hashAlgorithm The hash algorithm to use in key comparison.
  */
 case class CleanerConfig(numThreads: Int = 1,
                          dedupeBufferSize: Long = 4*1024*1024L,
@@ -36,6 +35,5 @@ case class CleanerConfig(numThreads: Int = 1,
                          maxMessageSize: Int = 32*1024*1024,
                          maxIoBytesPerSecond: Double = Double.MaxValue,
                          backOffMs: Long = 15 * 1000,
-                         enableCleaner: Boolean = true,
-                         hashAlgorithm: String = "MD5") {
+                         enableCleaner: Boolean = true) {
 }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -296,8 +296,7 @@ class LogCleaner(initialConfig: CleanerConfig,
       warn("Cannot use more than 2G of cleaner buffer space per cleaner thread, ignoring excess buffer space...")
 
     val cleaner = new Cleaner(id = threadId,
-                              offsetMap = new SkimpyOffsetMap(memory = math.min(config.dedupeBufferSize / config.numThreads, Int.MaxValue).toInt,
-                                                              hashAlgorithm = config.hashAlgorithm),
+                              offsetMap = new SkimpyOffsetMap(math.min(config.dedupeBufferSize / config.numThreads, Int.MaxValue).toInt),
                               ioBufferSize = config.ioBufferSize / config.numThreads / 2,
                               maxIoBufferSize = config.maxMessageSize,
                               dupBufferLoadFactor = config.dedupeBufferLoadFactor,

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -4600,6 +4600,15 @@ object LogTest {
       yield TestUtils.readString(record.key).toLong
   }
 
+  def keysValuesInLog(log: Log): Map[String, String] = {
+    {
+      for (logSegment <- log.logSegments;
+           batch <- logSegment.log.batches.asScala if !batch.isControlBatch;
+           record <- batch.asScala if record.hasValue && record.hasKey)
+        yield TestUtils.readString(record.key) -> TestUtils.readString(record.value)
+    }.toMap
+  }
+
   def recoverAndCheck(logDir: File,
                       config: LogConfig,
                       expectedKeys: Iterable[Long],

--- a/core/src/test/scala/unit/kafka/log/LogUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogUtils.scala
@@ -19,8 +19,11 @@ package kafka.log
 
 import java.io.File
 
-import org.apache.kafka.common.record.FileRecords
+import kafka.server.{BrokerTopicStats, LogDirFailureChannel}
+import kafka.utils.{Scheduler, TestUtils, Throttler}
+import org.apache.kafka.common.record.{CompressionType, FileRecords, MemoryRecords, RecordBatch, SimpleRecord}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.TopicPartition
 
 object LogUtils {
   /**
@@ -37,4 +40,33 @@ object LogUtils {
 
     new LogSegment(ms, idx, timeIdx, txnIndex, offset, indexIntervalBytes, 0, time)
   }
+
+  def createLog(dir: File, config: LogConfig, time: Time, scheduler: Scheduler, recoveryPoint: Long = 0L) =
+    Log(dir = dir, config = config, logStartOffset = 0L, recoveryPoint = recoveryPoint, scheduler = scheduler,
+      time = time, brokerTopicStats = new BrokerTopicStats, maxProducerIdExpirationMs = 60 * 60 * 1000,
+      producerIdExpirationCheckIntervalMs = LogManager.ProducerIdExpirationCheckIntervalMs,
+      logDirFailureChannel = new LogDirFailureChannel(10))
+
+  def record(key: Int, value: Int,
+             producerId: Long = RecordBatch.NO_PRODUCER_ID,
+             producerEpoch: Short = RecordBatch.NO_PRODUCER_EPOCH,
+             sequence: Int = RecordBatch.NO_SEQUENCE,
+             partitionLeaderEpoch: Int = RecordBatch.NO_PARTITION_LEADER_EPOCH): MemoryRecords = {
+    MemoryRecords.withIdempotentRecords(RecordBatch.CURRENT_MAGIC_VALUE, 0L, CompressionType.NONE, producerId, producerEpoch, sequence,
+      partitionLeaderEpoch, new SimpleRecord(key.toString.getBytes, value.toString.getBytes))
+  }
+
+  def record(key: Int, value: Array[Byte]): MemoryRecords =
+    TestUtils.singletonRecords(key = key.toString.getBytes, value = value)
+
+  def createCleaner(capacity: Int,time: Time , throttler: Throttler,
+                  checkDone: TopicPartition => Unit = _ => (), maxMessageSize: Int = 64*1024) =
+    new Cleaner(id = 0,
+      offsetMap = new FakeOffsetMap(capacity),
+      ioBufferSize = maxMessageSize,
+      maxIoBufferSize = maxMessageSize,
+      dupBufferLoadFactor = 0.75,
+      throttler = throttler,
+      time = time,
+      checkDone = checkDone)
 }

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -314,7 +314,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
 
     <Match>
         <!-- Suppress a warning about intentional missing default cases and fallthroughs. -->
-        <Class name="org.apache.kafka.streams.state.internals.Murmur3"/>
+        <Class name="org.apache.kafka.common.utils.Murmur3"/>
         <Or>
             <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
             <Bug pattern="SF_SWITCH_FALLTHROUGH"/>
@@ -324,7 +324,7 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
 
     <Match>
         <!-- Suppress a warning about intentional missing default cases and fallthroughs. -->
-        <Class name="org.apache.kafka.streams.state.internals.Murmur3$IncrementalHash32"/>
+        <Class name="org.apache.kafka.common.utils.Murmur3$IncrementalHash32"/>
         <Or>
             <Bug pattern="SF_SWITCH_NO_DEFAULT"/>
             <Bug pattern="SF_SWITCH_FALLTHROUGH"/>

--- a/jmh-benchmarks/jmh.sh
+++ b/jmh-benchmarks/jmh.sh
@@ -37,6 +37,6 @@ echo "gradle build done"
 
 echo "running JMH with args [$@]"
 
-java -jar ${libDir}/kafka-jmh-benchmarks-all.jar "$@"
+java -Xms256M -Xmx8G -jar ${libDir}/kafka-jmh-benchmarks-all.jar "$@"
 
 echo "JMH benchmarks done"

--- a/jmh-benchmarks/jmh.sh
+++ b/jmh-benchmarks/jmh.sh
@@ -37,6 +37,6 @@ echo "gradle build done"
 
 echo "running JMH with args [$@]"
 
-java -Xms256M -Xmx8G -jar ${libDir}/kafka-jmh-benchmarks-all.jar "$@"
+java -jar ${libDir}/kafka-jmh-benchmarks-all.jar "$@"
 
 echo "JMH benchmarks done"

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -123,7 +123,7 @@ public class ReplicaFetcherThreadBenchmark {
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
                 new scala.collection.mutable.HashMap<>(),
                 logConfig,
-                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
+                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false),
                 1,
                 1000L,
                 10000L,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -100,7 +100,7 @@ public class PartitionMakeFollowerBenchmark {
             JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
             new scala.collection.mutable.HashMap<>(),
             logConfig,
-            new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
+            new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false),
             1,
             1000L,
             10000L,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -85,7 +85,7 @@ public class UpdateFollowerFetchStateBenchmark {
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
                 new scala.collection.mutable.HashMap<>(),
                 logConfig,
-                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
+                new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false),
                 1,
                 1000L,
                 10000L,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -109,7 +109,7 @@ public class CheckpointBench {
         this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
                 LogConfig.apply(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
                         1024 * 1024, 32 * 1024 * 1024,
-                        Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
+                        Double.MAX_VALUE, 15 * 1000, true), time);
         scheduler.startup();
         final BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
         final MetadataCache metadataCache =

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/LogCleanerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/LogCleanerBenchmark.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.server;
+
+import kafka.api.ApiVersion;
+import kafka.log.AppendOrigin;
+import kafka.log.CleanedTransactionMetadata;
+import kafka.log.Cleaner;
+import kafka.log.CleanerStats;
+import kafka.log.Log;
+import kafka.log.LogConfig;
+import kafka.log.LogUtils;
+import kafka.log.SkimpyOffsetMap;
+import kafka.utils.MockScheduler;
+import kafka.utils.MockTime;
+import kafka.utils.Scheduler;
+import kafka.utils.TestUtils;
+import kafka.utils.Throttler;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.Time;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import scala.collection.immutable.Set$;
+import scala.runtime.BoxedUnit;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(value = Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+public class LogCleanerBenchmark {
+
+    @Param({"10485760"})
+    public int memory;
+
+    @Param({"10485760", "104857600", "524288000", "1073741824"})
+    public int segmentSize;
+
+    @Param({"10", "100", "1000", "2000", "4000"})
+    public int numKeys;
+
+    @Param({"10"})
+    public int keyLength;
+
+    private Random random = new Random();
+
+    private SkimpyOffsetMap skimpyOffsetMap;
+    private Cleaner cleaner;
+    private CleanerStats cleanerStats;
+    private Log log;
+
+    @Setup(Level.Invocation)
+    public void setupTrial() {
+        Time time = new MockTime();
+        Scheduler scheduler = new MockScheduler(time);
+        skimpyOffsetMap = new SkimpyOffsetMap(memory);
+        Throttler throttler = new Throttler(Double.MAX_VALUE, Long.MAX_VALUE,
+            true, "throttler", "entries", time);
+        int maxMessageSize = 65536;
+        cleaner = new Cleaner(0, skimpyOffsetMap, maxMessageSize, maxMessageSize,
+            0.75, throttler, time, tp -> BoxedUnit.UNIT);
+        cleanerStats = new CleanerStats(time);
+        Properties logProps = new Properties();
+        logProps.put(LogConfig.SegmentBytesProp(), segmentSize);
+        logProps.put(LogConfig.CleanupPolicyProp(), LogConfig.Compact());
+        logProps.put(LogConfig.MessageTimestampDifferenceMaxMsProp(), Long.toString(Long.MAX_VALUE));
+        LogConfig config = new LogConfig(logProps, Set$.MODULE$.empty());
+
+        File dir = TestUtils.randomPartitionLogDir(TestUtils.tempDir());
+
+        log = LogUtils.createLog(dir, config, time, scheduler, 0);
+
+        Set<String> keysSet = new HashSet<>(numKeys);
+        for (int i = 0; i < numKeys; ++i) {
+            String nextRandom;
+            do {
+                nextRandom = nextRandomString(keyLength);
+            } while (keysSet.contains(nextRandom));
+            keysSet.add(nextRandom);
+        }
+        String[] keys = new ArrayList<>(keysSet).toArray(new String[]{});
+
+        long value = 0;
+        while (log.numberOfSegments() < 4) {
+            log.appendAsLeader(
+                TestUtils.singletonRecords(
+                    String.valueOf(value).getBytes(Charset.defaultCharset()),
+                    keys[random.nextInt(numKeys)].getBytes(Charset.defaultCharset()),
+                    CompressionType.NONE,
+                    RecordBatch.NO_TIMESTAMP,
+                    RecordBatch.CURRENT_MAGIC_VALUE
+                    ), 0, AppendOrigin.Client$.MODULE$, ApiVersion.latestVersion());
+            value++;
+        }
+    }
+
+    private String nextRandomString(int length) {
+        int leftLimit = 97; // letter 'a'
+        int rightLimit = 122; // letter 'z'
+        return random.ints(leftLimit, rightLimit + 1)
+            .limit(length)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void benchmarkLogCleanerBenchmark() {
+        cleaner.buildOffsetMap(log, log.logStartOffset(), log.logEndOffset(), skimpyOffsetMap, cleanerStats);
+        cleaner.cleanSegments(log, log.logSegments().toSeq(), skimpyOffsetMap, 0L, cleanerStats, new CleanedTransactionMetadata());
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/OffsetMapBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/OffsetMapBenchmark.java
@@ -92,9 +92,8 @@ public class OffsetMapBenchmark {
     private String nextRandomString(int length) {
         int leftLimit = 97; // letter 'a'
         int rightLimit = 122; // letter 'z'
-        int targetStringLength = 10;
         return random.ints(leftLimit, rightLimit + 1)
-            .limit(targetStringLength)
+            .limit(length)
             .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
             .toString();
     }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/OffsetMapBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/OffsetMapBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.server;
+
+import kafka.log.SkimpyOffsetMap;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(value = Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+public class OffsetMapBenchmark {
+
+    @Param({"10000000"})
+    public int logLength;
+
+    @Param({"100"})
+    public int numKeys;
+
+    @Param({"10"})
+    public int keyLength;
+
+    @Param({"1048576"})
+    public int memory;
+
+    private Random random = new Random();
+
+    private SkimpyOffsetMap skimpyOffsetMap;
+    private ByteBuffer[] keys;
+    private Map<Long, ByteBuffer> offsetToKeyMap;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        skimpyOffsetMap = new SkimpyOffsetMap(memory);
+        Set<String> keysSet = new HashSet<>(numKeys);
+        for (int i = 0; i < numKeys; ++i) {
+            String nextRandom;
+            do {
+                nextRandom = nextRandomString(keyLength);
+            } while (keysSet.contains(nextRandom));
+            keysSet.add(nextRandom);
+        }
+        keys = keysSet
+            .stream()
+            .map(k -> ByteBuffer.wrap(k.getBytes(Charset.defaultCharset())))
+            .collect(Collectors.toList()).toArray(new ByteBuffer[]{});
+        offsetToKeyMap = new HashMap<>(logLength);
+        for (long i = 0; i < logLength; ++i) {
+            offsetToKeyMap.put(i, ByteBuffer.wrap(keys[random.nextInt(numKeys)].array()));
+        }
+    }
+
+    private String nextRandomString(int length) {
+        int leftLimit = 97; // letter 'a'
+        int rightLimit = 122; // letter 'z'
+        int targetStringLength = 10;
+        return random.ints(leftLimit, rightLimit + 1)
+            .limit(targetStringLength)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void benchmarkSkimpyOffsetMapHashingSpeed() {
+        skimpyOffsetMap.put(keys[random.nextInt(numKeys)], random.nextLong());
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionSendProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionSendProcessorSupplier.java
@@ -20,6 +20,7 @@ package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Murmur3;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
@@ -27,7 +28,6 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
-import org.apache.kafka.streams.state.internals.Murmur3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResolverJoinProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResolverJoinProcessorSupplier.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Murmur3;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.internals.KTableValueGetter;
 import org.apache.kafka.streams.kstream.internals.KTableValueGetterSupplier;
@@ -27,7 +28,6 @@ import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.apache.kafka.streams.state.internals.Murmur3;
 
 import java.util.function.Supplier;
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResolverJoinProcessorSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResolverJoinProcessorSupplierTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Murmur3;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.internals.KTableValueGetter;
@@ -27,7 +28,6 @@ import org.apache.kafka.streams.processor.MockProcessorContext;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.apache.kafka.streams.state.internals.Murmur3;
 import org.junit.Test;
 
 import java.util.HashMap;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapperSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapperSerdeTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.state.internals.Murmur3;
+import org.apache.kafka.common.utils.Murmur3;
 import org.junit.Test;
 
 import java.util.Map;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.kstream.internals.foreignkeyjoin;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.state.internals.Murmur3;
+import org.apache.kafka.common.utils.Murmur3;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;


### PR DESCRIPTION
Introduces a new offset map in the log cleaner which uses Murmur hashing
algorithm instead of the current MD5.
This commit:
- Moves Murmur3 from Streams into Clients
- Changes SkimpyOffsetMap to use Murmur3 hashing
- Removes the option to change hashing algorithm in SkimpyOffsetMap
- Adds benchmark tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
