### PR TITLE
MINOR: replace test "expected" parameter by assertThrows

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -20,11 +20,13 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
@@ -62,19 +64,20 @@ public class ClientUtilsTest {
         validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidConfig() {
-        ClientUtils.parseAndValidateAddresses(Arrays.asList("localhost:10000"), "random.value");
+        assertThrows(IllegalArgumentException.class,
+            () -> ClientUtils.parseAndValidateAddresses(Collections.singletonList("localhost:10000"), "random.value"));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testNoPort() {
-        checkWithoutLookup("127.0.0.1");
+        assertThrows(ConfigException.class, () -> checkWithoutLookup("127.0.0.1"));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testOnlyBadHostname() {
-        checkWithoutLookup("some.invalid.hostname.foo.bar.local:9999");
+        assertThrows(ConfigException.class, () -> checkWithoutLookup("some.invalid.hostname.foo.bar.local:9999"));
     }
 
     @Test
@@ -95,9 +98,10 @@ public class ClientUtilsTest {
         assertEquals(1, result.size());
     }
 
-    @Test(expected = UnknownHostException.class)
-    public void testResolveUnknownHostException() throws UnknownHostException {
-        ClientUtils.resolve("some.invalid.hostname.foo.bar.local", ClientDnsLookup.USE_ALL_DNS_IPS);
+    @Test
+    public void testResolveUnknownHostException() {
+        assertThrows(UnknownHostException.class,
+            () -> ClientUtils.resolve("some.invalid.hostname.foo.bar.local", ClientDnsLookup.USE_ALL_DNS_IPS));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -99,7 +99,7 @@ public class ClientUtilsTest {
     }
 
     @Test
-    public void testResolveUnknownHostException() throws UnknownHostException {
+    public void testResolveUnknownHostException() {
         assertThrows(UnknownHostException.class,
             () -> ClientUtils.resolve("some.invalid.hostname.foo.bar.local", ClientDnsLookup.USE_ALL_DNS_IPS));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -99,7 +99,7 @@ public class ClientUtilsTest {
     }
 
     @Test
-    public void testResolveUnknownHostException() {
+    public void testResolveUnknownHostException() throws UnknownHostException {
         assertThrows(UnknownHostException.class,
             () -> ClientUtils.resolve("some.invalid.hostname.foo.bar.local", ClientDnsLookup.USE_ALL_DNS_IPS));
     }

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class InFlightRequestsTest {
 
@@ -99,14 +100,14 @@ public class InFlightRequestsTest {
         assertEquals(0, inFlightRequests.count());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCompleteNextThrowsIfNoInflights() {
-        inFlightRequests.completeNext(dest);
+        assertThrows(IllegalStateException.class, () -> inFlightRequests.completeNext(dest));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCompleteLastSentThrowsIfNoInFlights() {
-        inFlightRequests.completeLastSent(dest);
+        assertThrows(IllegalStateException.class, () -> inFlightRequests.completeLastSent(dest));
     }
 
     private int addRequest(String destination) {

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -76,10 +76,10 @@ public class MetadataTest {
                 Collections.emptyList());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMetadataUpdateAfterClose() {
         metadata.close();
-        metadata.updateWithCurrentRequestVersion(emptyMetadataResponse(), false, 1000);
+        assertThrows(IllegalStateException.class, () -> metadata.updateWithCurrentRequestVersion(emptyMetadataResponse(), false, 1000));
     }
 
     private static void checkTimeToNextUpdate(long refreshBackoffMs, long metadataExpireMs) {

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class NetworkClientTest {
@@ -119,13 +120,12 @@ public class NetworkClientTest {
         selector.reset();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSendToUnreadyNode() {
         MetadataRequest.Builder builder = new MetadataRequest.Builder(Collections.singletonList("test"), true);
         long now = time.milliseconds();
         ClientRequest request = client.newClientRequest("5", builder, now, false);
-        client.send(request, now);
-        client.poll(1, time.milliseconds());
+        assertThrows(IllegalStateException.class, () -> client.send(request, now));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class NodeApiVersionsTest {
@@ -103,28 +104,32 @@ public class NodeApiVersionsTest {
         assertEquals(3, apiVersions.latestUsableVersion(ApiKeys.PRODUCE, (short) 3, (short) 4));
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testLatestUsableVersionOutOfRangeLow() {
         NodeApiVersions apiVersions = NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 1, (short) 2);
-        apiVersions.latestUsableVersion(ApiKeys.PRODUCE, (short) 3, (short) 4);
+        assertThrows(UnsupportedVersionException.class,
+            () -> apiVersions.latestUsableVersion(ApiKeys.PRODUCE, (short) 3, (short) 4));
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testLatestUsableVersionOutOfRangeHigh() {
         NodeApiVersions apiVersions = NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 2, (short) 3);
-        apiVersions.latestUsableVersion(ApiKeys.PRODUCE, (short) 0, (short) 1);
+        assertThrows(UnsupportedVersionException.class,
+            () -> apiVersions.latestUsableVersion(ApiKeys.PRODUCE, (short) 0, (short) 1));
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testUsableVersionCalculationNoKnownVersions() {
         NodeApiVersions versions = new NodeApiVersions(new ApiVersionsResponseKeyCollection());
-        versions.latestUsableVersion(ApiKeys.FETCH);
+        assertThrows(UnsupportedVersionException.class,
+            () -> versions.latestUsableVersion(ApiKeys.FETCH));
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testLatestUsableVersionOutOfRange() {
         NodeApiVersions apiVersions = NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 300, (short) 300);
-        apiVersions.latestUsableVersion(ApiKeys.PRODUCE);
+        assertThrows(UnsupportedVersionException.class,
+            () -> apiVersions.latestUsableVersion(ApiKeys.PRODUCE));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -221,20 +221,22 @@ public class KafkaConsumerTest {
         consumer.close();
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testInvalidSocketSendBufferSize() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ConsumerConfig.SEND_BUFFER_CONFIG, -2);
-        new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        assertThrows(KafkaException.class,
+            () -> new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()));
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testInvalidSocketReceiveBufferSize() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ConsumerConfig.RECEIVE_BUFFER_CONFIG, -2);
-        new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        assertThrows(KafkaException.class,
+            () -> new KafkaConsumer<>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()));
     }
 
     @Test
@@ -270,65 +272,69 @@ public class KafkaConsumerTest {
         consumer.close();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscriptionOnNullTopicCollection() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
-            consumer.subscribe((List<String>) null);
+            assertThrows(IllegalArgumentException.class, () -> consumer.subscribe((List<String>) null));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscriptionOnNullTopic() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
-            consumer.subscribe(singletonList(null));
+            assertThrows(IllegalArgumentException.class, () -> consumer.subscribe(singletonList(null)));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscriptionOnEmptyTopic() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
             String emptyTopic = "  ";
-            consumer.subscribe(singletonList(emptyTopic));
+            assertThrows(IllegalArgumentException.class, () -> consumer.subscribe(singletonList(emptyTopic)));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscriptionOnNullPattern() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
-            consumer.subscribe((Pattern) null);
+            assertThrows(IllegalArgumentException.class,
+                () -> consumer.subscribe((Pattern) null));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSubscriptionOnEmptyPattern() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
-            consumer.subscribe(Pattern.compile(""));
+            assertThrows(IllegalArgumentException.class,
+                () -> consumer.subscribe(Pattern.compile("")));
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testSubscriptionWithEmptyPartitionAssignment() {
         Properties props = new Properties();
         props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         props.setProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, "");
         props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(props)) {
-            consumer.subscribe(singletonList(topic));
+            assertThrows(IllegalStateException.class,
+                () -> consumer.subscribe(singletonList(topic)));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSeekNegative() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer((String) null)) {
             consumer.assign(singleton(new TopicPartition("nonExistTopic", 0)));
-            consumer.seek(new TopicPartition("nonExistTopic", 0), -1);
+            assertThrows(IllegalArgumentException.class,
+                () -> consumer.seek(new TopicPartition("nonExistTopic", 0), -1));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAssignOnNullTopicPartition() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer((String) null)) {
-            consumer.assign(null);
+            assertThrows(IllegalArgumentException.class, () -> consumer.assign(null));
         }
     }
 
@@ -341,17 +347,17 @@ public class KafkaConsumerTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAssignOnNullTopicInPartition() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer((String) null)) {
-            consumer.assign(singleton(new TopicPartition(null, 0)));
+            assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition(null, 0))));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAssignOnEmptyTopicInPartition() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer((String) null)) {
-            consumer.assign(singleton(new TopicPartition("  ", 0)));
+            assertThrows(IllegalArgumentException.class, () -> consumer.assign(singleton(new TopicPartition("  ", 0))));
         }
     }
 
@@ -635,7 +641,7 @@ public class KafkaConsumerTest {
         mockClient.updateMetadata(initialMetadata);
     }
 
-    @Test(expected = NoOffsetForPartitionException.class)
+    @Test
     public void testMissingOffsetNoResetPolicy() {
         Time time = new MockTime();
         SubscriptionState subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.NONE);
@@ -656,7 +662,7 @@ public class KafkaConsumerTest {
 
         // lookup committed offset and find nothing
         client.prepareResponseFrom(offsetResponse(Collections.singletonMap(tp0, -1L), Errors.NONE), coordinator);
-        consumer.poll(Duration.ZERO);
+        assertThrows(NoOffsetForPartitionException.class, () -> consumer.poll(Duration.ZERO));
     }
 
     @Test
@@ -1456,26 +1462,26 @@ public class KafkaConsumerTest {
         consumer.close();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testPollWithNoSubscription() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer((String) null)) {
-            consumer.poll(Duration.ZERO);
+            assertThrows(IllegalStateException.class, () -> consumer.poll(Duration.ZERO));
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testPollWithEmptySubscription() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
             consumer.subscribe(Collections.emptyList());
-            consumer.poll(Duration.ZERO);
+            assertThrows(IllegalStateException.class, () -> consumer.poll(Duration.ZERO));
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testPollWithEmptyUserAssignment() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer(groupId)) {
             consumer.assign(Collections.emptySet());
-            consumer.poll(Duration.ZERO);
+            assertThrows(IllegalStateException.class, () -> consumer.poll(Duration.ZERO));
         }
     }
 
@@ -1756,49 +1762,49 @@ public class KafkaConsumerTest {
         }
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testPartitionsForAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
-        consumer.partitionsFor("some other topic");
+        assertThrows(AuthenticationException.class, () -> consumer.partitionsFor("some other topic"));
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testBeginningOffsetsAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
-        consumer.beginningOffsets(Collections.singleton(tp0));
+        assertThrows(AuthenticationException.class, () -> consumer.beginningOffsets(Collections.singleton(tp0)));
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testEndOffsetsAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
-        consumer.endOffsets(Collections.singleton(tp0));
+        assertThrows(AuthenticationException.class, () -> consumer.endOffsets(Collections.singleton(tp0)));
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testPollAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
         consumer.subscribe(singleton(topic));
-        consumer.poll(Duration.ZERO);
+        assertThrows(AuthenticationException.class, () -> consumer.poll(Duration.ZERO));
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testOffsetsForTimesAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
-        consumer.offsetsForTimes(singletonMap(tp0, 0L));
+        assertThrows(AuthenticationException.class, () -> consumer.offsetsForTimes(singletonMap(tp0, 0L)));
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testCommitSyncAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
         Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         offsets.put(tp0, new OffsetAndMetadata(10L));
-        consumer.commitSync(offsets);
+        assertThrows(AuthenticationException.class, () -> consumer.commitSync(offsets));
     }
 
-    @Test(expected = AuthenticationException.class)
+    @Test
     public void testCommittedAuthenticationFailure() {
         final KafkaConsumer<String, String> consumer = consumerWithPendingAuthenticationError();
-        consumer.committed(Collections.singleton(tp0)).get(tp0);
+        assertThrows(AuthenticationException.class, () -> consumer.committed(Collections.singleton(tp0)).get(tp0));
     }
 
     @Test
@@ -2392,7 +2398,7 @@ public class KafkaConsumerTest {
         verify(consumer).close(Duration.ofSeconds(1));
     }
 
-    @Test(expected = InvalidTopicException.class)
+    @Test
     public void testSubscriptionOnInvalidTopic() {
         Time time = new MockTime();
         SubscriptionState subscription = new SubscriptionState(new LogContext(), OffsetResetStrategy.EARLIEST);
@@ -2418,7 +2424,7 @@ public class KafkaConsumerTest {
         KafkaConsumer<String, String> consumer = newConsumer(time, client, subscription, metadata, assignor, true, groupInstanceId);
         consumer.subscribe(singleton(invalidTopicName), getConsumerRebalanceListener(consumer));
 
-        consumer.poll(Duration.ZERO);
+        assertThrows(InvalidTopicException.class, () -> consumer.poll(Duration.ZERO));
     }
 
     @Test
@@ -2539,11 +2545,11 @@ public class KafkaConsumerTest {
         assertFalse(consumerMetricPresent(consumer, "time-between-poll-max"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testEnforceRebalanceWithManualAssignment() {
         try (KafkaConsumer<byte[], byte[]> consumer = newConsumer((String) null)) {
             consumer.assign(singleton(new TopicPartition("topic", 0)));
-            consumer.enforceRebalance();
+            assertThrows(IllegalStateException.class, consumer::enforceRebalance);
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/OffsetAndMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/OffsetAndMetadataTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 /**
  * This test case ensures OffsetAndMetadata class is serializable and is serialization compatible.
@@ -31,9 +32,9 @@ import static org.junit.Assert.assertEquals;
  */
 public class OffsetAndMetadataTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidNegativeOffset() {
-        new OffsetAndMetadata(-239L, Optional.of(15), "");
+        assertThrows(IllegalArgumentException.class, () -> new OffsetAndMetadata(-239L, Optional.of(15), ""));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -246,20 +247,20 @@ public class ConsumerNetworkClientTest {
         }
     }
 
-    @Test(expected = InvalidTopicException.class)
+    @Test
     public void testInvalidTopicExceptionPropagatedFromMetadata() {
         MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith("clusterId", 1,
                 Collections.singletonMap("topic", Errors.INVALID_TOPIC_EXCEPTION), Collections.emptyMap());
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, time.milliseconds());
-        consumerClient.poll(time.timer(Duration.ZERO));
+        assertThrows(InvalidTopicException.class, () -> consumerClient.poll(time.timer(Duration.ZERO)));
     }
 
-    @Test(expected = TopicAuthorizationException.class)
+    @Test
     public void testTopicAuthorizationExceptionPropagatedFromMetadata() {
         MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith("clusterId", 1,
                 Collections.singletonMap("topic", Errors.TOPIC_AUTHORIZATION_FAILED), Collections.emptyMap());
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, time.milliseconds());
-        consumerClient.poll(time.timer(Duration.ZERO));
+        assertThrows(TopicAuthorizationException.class, () -> consumerClient.poll(time.timer(Duration.ZERO)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1948,12 +1948,12 @@ public class FetcherTest {
         assertEquals(initialUpdateResponse.topicMetadata().size(), allTopics.size());
     }
 
-    @Test(expected = TimeoutException.class)
+    @Test
     public void testGetAllTopicsTimeout() {
         // since no response is prepared, the request should timeout
         buildFetcher();
         assignFromUser(singleton(tp0));
-        fetcher.getAllTopicMetadata(time.timer(50L));
+        assertThrows(TimeoutException.class, () -> fetcher.getAllTopicMetadata(time.timer(50L)));
     }
 
     @Test
@@ -1969,13 +1969,13 @@ public class FetcherTest {
         }
     }
 
-    @Test(expected = InvalidTopicException.class)
+    @Test
     public void testGetTopicMetadataInvalidTopic() {
         buildFetcher();
         assignFromUser(singleton(tp0));
         client.prepareResponse(newMetadataResponse(topicName, Errors.INVALID_TOPIC_EXCEPTION));
-        fetcher.getTopicMetadata(
-                new MetadataRequest.Builder(Collections.singletonList(topicName), true), time.timer(5000L));
+        assertThrows(InvalidTopicException.class, () -> fetcher.getTopicMetadata(
+                new MetadataRequest.Builder(Collections.singletonList(topicName), true), time.timer(5000L)));
     }
 
     @Test
@@ -2728,7 +2728,7 @@ public class FetcherTest {
         Assert.assertNotNull(metadata.fetch().partitionCountForTopic(anotherTopic));
     }
 
-    @Test(expected = TimeoutException.class)
+    @Test
     public void testBatchedListOffsetsMetadataErrors() {
         buildFetcher();
 
@@ -2753,7 +2753,7 @@ public class FetcherTest {
         offsetsToSearch.put(tp0, ListOffsetsRequest.EARLIEST_TIMESTAMP);
         offsetsToSearch.put(tp1, ListOffsetsRequest.EARLIEST_TIMESTAMP);
 
-        fetcher.offsetsForTimes(offsetsToSearch, time.timer(0));
+        assertThrows(TimeoutException.class, () -> fetcher.offsetsForTimes(offsetsToSearch, time.timer(0)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestFutureTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class RequestFutureTest {
@@ -52,52 +53,52 @@ public class RequestFutureTest {
         assertNull(future.value());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRuntimeExceptionInComplete() {
         RequestFuture<Exception> future = new RequestFuture<>();
-        future.complete(new RuntimeException());
+        assertThrows(IllegalArgumentException.class, () -> future.complete(new RuntimeException()));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invokeCompleteAfterAlreadyComplete() {
         RequestFuture<Void> future = new RequestFuture<>();
         future.complete(null);
-        future.complete(null);
+        assertThrows(IllegalStateException.class, () -> future.complete(null));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invokeCompleteAfterAlreadyFailed() {
         RequestFuture<Void> future = new RequestFuture<>();
         future.raise(new RuntimeException());
-        future.complete(null);
+        assertThrows(IllegalStateException.class, () -> future.complete(null));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invokeRaiseAfterAlreadyFailed() {
         RequestFuture<Void> future = new RequestFuture<>();
         future.raise(new RuntimeException());
-        future.raise(new RuntimeException());
+        assertThrows(IllegalStateException.class, () -> future.raise(new RuntimeException()));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invokeRaiseAfterAlreadyCompleted() {
         RequestFuture<Void> future = new RequestFuture<>();
         future.complete(null);
-        future.raise(new RuntimeException());
+        assertThrows(IllegalStateException.class, () -> future.raise(new RuntimeException()));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invokeExceptionAfterSuccess() {
         RequestFuture<Void> future = new RequestFuture<>();
         future.complete(null);
-        future.exception();
+        assertThrows(IllegalStateException.class, future::exception);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invokeValueAfterFailure() {
         RequestFuture<Void> future = new RequestFuture<>();
         future.raise(new RuntimeException());
-        future.value();
+        assertThrows(IllegalStateException.class, future::value);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -46,6 +46,7 @@ import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UND
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class SubscriptionStateTest {
@@ -254,13 +255,14 @@ public class SubscriptionStateTest {
         assertTrue(state.isFetchable(tp0));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void invalidPositionUpdate() {
         state.subscribe(singleton(topic), rebalanceListener);
         assertTrue(state.checkAssignmentMatchedSubscription(singleton(tp0)));
         state.assignFromSubscribed(singleton(tp0));
 
-        state.position(tp0, new SubscriptionState.FetchPosition(0, Optional.empty(), leaderAndEpoch));
+        assertThrows(IllegalStateException.class, () -> state.position(tp0,
+            new SubscriptionState.FetchPosition(0, Optional.empty(), leaderAndEpoch)));
     }
 
     @Test
@@ -276,33 +278,34 @@ public class SubscriptionStateTest {
         assertFalse(state.checkAssignmentMatchedSubscription(Collections.singletonList(t1p0)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantChangePositionForNonAssignedPartition() {
-        state.position(tp0, new SubscriptionState.FetchPosition(1, Optional.empty(), leaderAndEpoch));
+        assertThrows(IllegalStateException.class, () -> state.position(tp0,
+            new SubscriptionState.FetchPosition(1, Optional.empty(), leaderAndEpoch)));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantSubscribeTopicAndPattern() {
         state.subscribe(singleton(topic), rebalanceListener);
-        state.subscribe(Pattern.compile(".*"), rebalanceListener);
+        assertThrows(IllegalStateException.class, () -> state.subscribe(Pattern.compile(".*"), rebalanceListener));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantSubscribePartitionAndPattern() {
         state.assignFromUser(singleton(tp0));
-        state.subscribe(Pattern.compile(".*"), rebalanceListener);
+        assertThrows(IllegalStateException.class, () -> state.subscribe(Pattern.compile(".*"), rebalanceListener));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantSubscribePatternAndTopic() {
         state.subscribe(Pattern.compile(".*"), rebalanceListener);
-        state.subscribe(singleton(topic), rebalanceListener);
+        assertThrows(IllegalStateException.class, () -> state.subscribe(singleton(topic), rebalanceListener));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void cantSubscribePatternAndPartition() {
         state.subscribe(Pattern.compile(".*"), rebalanceListener);
-        state.assignFromUser(singleton(tp0));
+        assertThrows(IllegalStateException.class, () -> state.assignFromUser(singleton(tp0)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -196,7 +196,6 @@ public class KafkaProducerTest {
     public void testNoSerializerProvided() {
         Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
-
         assertThrows(ConfigException.class, () -> new KafkaProducer(producerProps));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -192,11 +192,12 @@ public class KafkaProducerTest {
         new KafkaProducer<>(producerProps, new ByteArraySerializer(), new ByteArraySerializer()).close();
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testNoSerializerProvided() {
         Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
-        new KafkaProducer(producerProps);
+
+        assertThrows(ConfigException.class, () -> new KafkaProducer(producerProps));
     }
 
     @Test
@@ -357,20 +358,20 @@ public class KafkaProducerTest {
         new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer()).close();
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testInvalidSocketSendBufferSize() {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ProducerConfig.SEND_BUFFER_CONFIG, -2);
-        new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer());
+        assertThrows(KafkaException.class, () -> new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer()));
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testInvalidSocketReceiveBufferSize() {
         Map<String, Object> config = new HashMap<>();
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ProducerConfig.RECEIVE_BUFFER_CONFIG, -2);
-        new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer());
+        assertThrows(KafkaException.class, () -> new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer()));
     }
 
     private static KafkaProducer<String, String> producerWithOverrideNewSender(Map<String, Object> configs,

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -623,7 +623,13 @@ public class MockProducerTest {
         producer.beginTransaction();
 
         String group2 = "g2";
-        producer.sendOffsetsToTransaction(groupCommit, new ConsumerGroupMetadata(group2));
+        Map<TopicPartition, OffsetAndMetadata> groupCommit2 = new HashMap<TopicPartition, OffsetAndMetadata>() {
+            {
+                put(new TopicPartition(topic, 2), new OffsetAndMetadata(53L, null));
+                put(new TopicPartition(topic, 3), new OffsetAndMetadata(84L, null));
+            }
+        };
+        producer.sendOffsetsToTransaction(groupCommit2, new ConsumerGroupMetadata(group2));
         producer.abortTransaction();
 
         Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -352,7 +352,7 @@ public class MockProducerTest {
     }
 
     @Test
-    public void shouldThrowOnAbortForNonAutoCompleteIfTransactionsAreEnabled() throws Exception {
+    public void shouldThrowOnAbortForNonAutoCompleteIfTransactionsAreEnabled() {
         buildMockProducer(false);
         producer.initTransactions();
         producer.beginTransaction();
@@ -700,11 +700,11 @@ public class MockProducerTest {
         producer.close();
         assertThrows(IllegalStateException.class, producer::flush);
     }
-
+    
     @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowClassCastException() {
-        try (MockProducer<Integer, String> customProducer = new MockProducer<>(true, new IntegerSerializer(), new StringSerializer());) {
+        try (MockProducer<Integer, String> customProducer = new MockProducer<>(true, new IntegerSerializer(), new StringSerializer())) {
             assertThrows(ClassCastException.class, () -> customProducer.send(new ProducerRecord(topic, "key1", "value1")));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -352,7 +352,7 @@ public class MockProducerTest {
     }
 
     @Test
-    public void shouldThrowOnAbortForNonAutoCompleteIfTransactionsAreEnabled() {
+    public void shouldThrowOnAbortForNonAutoCompleteIfTransactionsAreEnabled() throws Exception {
         buildMockProducer(false);
         producer.initTransactions();
         producer.beginTransaction();
@@ -700,11 +700,11 @@ public class MockProducerTest {
         producer.close();
         assertThrows(IllegalStateException.class, producer::flush);
     }
-    
+
     @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowClassCastException() {
-        try (MockProducer<Integer, String> customProducer = new MockProducer<>(true, new IntegerSerializer(), new StringSerializer())) {
+        try (MockProducer<Integer, String> customProducer = new MockProducer<>(true, new IntegerSerializer(), new StringSerializer());) {
             assertThrows(ClassCastException.class, () -> customProducer.send(new ProducerRecord(topic, "key1", "value1")));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -132,16 +132,13 @@ public class MockProducerTest {
     public void shouldThrowOnInitTransactionIfProducerAlreadyInitializedForTransactions() {
         buildMockProducer(true);
         producer.initTransactions();
-        try {
-            producer.initTransactions();
-            fail("Should have thrown as producer is already initialized");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::initTransactions);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowOnBeginTransactionIfTransactionsNotInitialized() {
         buildMockProducer(true);
-        producer.beginTransaction();
+        assertThrows(IllegalStateException.class, producer::beginTransaction);
     }
 
     @Test
@@ -152,44 +149,38 @@ public class MockProducerTest {
         assertTrue(producer.transactionInFlight());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowOnBeginTransactionsIfTransactionInflight() {
         buildMockProducer(true);
         producer.initTransactions();
         producer.beginTransaction();
-        producer.beginTransaction();
+        assertThrows(IllegalStateException.class, () -> producer.beginTransaction());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowOnSendOffsetsToTransactionIfTransactionsNotInitialized() {
         buildMockProducer(true);
-        producer.sendOffsetsToTransaction(null, groupId);
+        assertThrows(IllegalStateException.class, () -> producer.sendOffsetsToTransaction(null, groupId));
     }
 
     @Test
     public void shouldThrowOnSendOffsetsToTransactionTransactionIfNoTransactionGotStarted() {
         buildMockProducer(true);
         producer.initTransactions();
-        try {
-            producer.sendOffsetsToTransaction(null, groupId);
-            fail("Should have thrown as producer has no open transaction");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, () -> producer.sendOffsetsToTransaction(null, groupId));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowOnCommitIfTransactionsNotInitialized() {
         buildMockProducer(true);
-        producer.commitTransaction();
+        assertThrows(IllegalStateException.class, producer::commitTransaction);
     }
 
     @Test
     public void shouldThrowOnCommitTransactionIfNoTransactionGotStarted() {
         buildMockProducer(true);
         producer.initTransactions();
-        try {
-            producer.commitTransaction();
-            fail("Should have thrown as producer has no open transaction");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::commitTransaction);
     }
 
     @Test
@@ -227,20 +218,17 @@ public class MockProducerTest {
         assertThat(producer.commitCount(), equalTo(1L));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowOnAbortIfTransactionsNotInitialized() {
         buildMockProducer(true);
-        producer.abortTransaction();
+        assertThrows(IllegalStateException.class, () -> producer.abortTransaction());
     }
 
     @Test
     public void shouldThrowOnAbortTransactionIfNoTransactionGotStarted() {
         buildMockProducer(true);
         producer.initTransactions();
-        try {
-            producer.abortTransaction();
-            fail("Should have thrown as producer has no open transaction");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::abortTransaction);
     }
 
     @Test
@@ -254,10 +242,10 @@ public class MockProducerTest {
         assertFalse(producer.transactionCommitted());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowFenceProducerIfTransactionsNotInitialized() {
         buildMockProducer(true);
-        producer.fenceProducer();
+        assertThrows(IllegalStateException.class, () -> producer.fenceProducer());
     }
 
     @Test
@@ -265,10 +253,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.fenceProducer();
-        try {
-            producer.beginTransaction();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        assertThrows(ProducerFencedException.class, producer::beginTransaction);
     }
 
     @Test
@@ -276,12 +261,8 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.fenceProducer();
-        try {
-            producer.send(null);
-            fail("Should have thrown as producer is fenced off");
-        } catch (KafkaException e) {
-            assertTrue("The root cause of the exception should be ProducerFenced", e.getCause() instanceof ProducerFencedException);
-        }
+        Throwable e = assertThrows(KafkaException.class, () -> producer.send(null));
+        assertTrue("The root cause of the exception should be ProducerFenced", e.getCause() instanceof ProducerFencedException);
     }
 
     @Test
@@ -289,10 +270,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.fenceProducer();
-        try {
-            producer.sendOffsetsToTransaction(null, groupId);
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        assertThrows(ProducerFencedException.class, () -> producer.sendOffsetsToTransaction(null, groupId));
     }
 
     @Test
@@ -300,10 +278,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.fenceProducer();
-        try {
-            producer.sendOffsetsToTransaction(null, new ConsumerGroupMetadata(groupId));
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        assertThrows(ProducerFencedException.class, () -> producer.sendOffsetsToTransaction(null, new ConsumerGroupMetadata(groupId)));
     }
 
     @Test
@@ -311,10 +286,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.fenceProducer();
-        try {
-            producer.commitTransaction();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        assertThrows(ProducerFencedException.class, producer::commitTransaction);
     }
 
     @Test
@@ -322,10 +294,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.fenceProducer();
-        try {
-            producer.abortTransaction();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        assertThrows(ProducerFencedException.class, producer::abortTransaction);
     }
 
     @Test
@@ -383,7 +352,7 @@ public class MockProducerTest {
     }
 
     @Test
-    public void shouldThrowOnAbortForNonAutoCompleteIfTransactionsAreEnabled() throws Exception {
+    public void shouldThrowOnAbortForNonAutoCompleteIfTransactionsAreEnabled() {
         buildMockProducer(false);
         producer.initTransactions();
         producer.beginTransaction();
@@ -453,12 +422,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.beginTransaction();
-
-        try {
-            String consumerGroupId = null;
-            producer.sendOffsetsToTransaction(Collections.emptyMap(), consumerGroupId);
-            fail("Should have thrown NullPointerException");
-        } catch (NullPointerException e) { }
+        assertThrows(NullPointerException.class, () -> producer.sendOffsetsToTransaction(Collections.emptyMap(), (String) null));
     }
 
     @Test
@@ -466,11 +430,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.beginTransaction();
-
-        try {
-            producer.sendOffsetsToTransaction(Collections.emptyMap(), new ConsumerGroupMetadata(null));
-            fail("Should have thrown NullPointerException");
-        } catch (NullPointerException e) { }
+        assertThrows(NullPointerException.class, () -> producer.sendOffsetsToTransaction(Collections.emptyMap(), new ConsumerGroupMetadata(null)));
     }
 
     @Test
@@ -478,7 +438,7 @@ public class MockProducerTest {
         buildMockProducer(true);
         producer.initTransactions();
         producer.beginTransaction();
-        producer.sendOffsetsToTransaction(Collections.<TopicPartition, OffsetAndMetadata>emptyMap(), "groupId");
+        producer.sendOffsetsToTransaction(Collections.emptyMap(), "groupId");
         assertFalse(producer.sentOffsets());
     }
 
@@ -663,12 +623,6 @@ public class MockProducerTest {
         producer.beginTransaction();
 
         String group2 = "g2";
-        Map<TopicPartition, OffsetAndMetadata> groupCommit2 = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 2), new OffsetAndMetadata(53L, null));
-                put(new TopicPartition(topic, 3), new OffsetAndMetadata(84L, null));
-            }
-        };
         producer.sendOffsetsToTransaction(groupCommit, new ConsumerGroupMetadata(group2));
         producer.abortTransaction();
 
@@ -682,96 +636,69 @@ public class MockProducerTest {
     public void shouldThrowOnInitTransactionIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.initTransactions();
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::initTransactions);
     }
 
     @Test
     public void shouldThrowOnSendIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.send(null);
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, () -> producer.send(null));
     }
 
     @Test
     public void shouldThrowOnBeginTransactionIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.beginTransaction();
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::beginTransaction);
     }
 
     @Test
     public void shouldThrowSendOffsetsToTransactionByGroupIdIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.sendOffsetsToTransaction(null, groupId);
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, () -> producer.sendOffsetsToTransaction(null, groupId));
     }
 
     @Test
     public void shouldThrowSendOffsetsToTransactionByGroupMetadataIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.sendOffsetsToTransaction(null, new ConsumerGroupMetadata(groupId));
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, () -> producer.sendOffsetsToTransaction(null, new ConsumerGroupMetadata(groupId)));
     }
 
     @Test
     public void shouldThrowOnCommitTransactionIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.commitTransaction();
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::commitTransaction);
     }
 
     @Test
     public void shouldThrowOnAbortTransactionIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.abortTransaction();
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::abortTransaction);
     }
 
     @Test
     public void shouldThrowOnFenceProducerIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.fenceProducer();
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::fenceProducer);
     }
 
     @Test
     public void shouldThrowOnFlushProducerIfProducerIsClosed() {
         buildMockProducer(true);
         producer.close();
-        try {
-            producer.flush();
-            fail("Should have thrown as producer is already closed");
-        } catch (IllegalStateException e) { }
+        assertThrows(IllegalStateException.class, producer::flush);
     }
     
     @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowClassCastException() {
-        try (MockProducer<Integer, String> customProducer = new MockProducer<>(true, new IntegerSerializer(), new StringSerializer());) {
+        try (MockProducer<Integer, String> customProducer = new MockProducer<>(true, new IntegerSerializer(), new StringSerializer())) {
             assertThrows(ClassCastException.class, () -> customProducer.send(new ProducerRecord(topic, "key1", "value1")));
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.clients.producer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -64,11 +65,11 @@ public class RecordSendTest {
     /**
      * Test that an asynchronous request will eventually throw the right exception
      */
-    @Test(expected = ExecutionException.class)
+    @Test
     public void testError() throws Exception {
         FutureRecordMetadata future = new FutureRecordMetadata(asyncRequest(baseOffset, new CorruptRecordException(), 50L),
                 relOffset, RecordBatch.NO_TIMESTAMP, 0L, 0, 0, Time.SYSTEM);
-        future.get();
+        assertThrows(ExecutionException.class, future::get);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -91,13 +91,13 @@ public class BufferPoolTest {
     /**
      * Test that we cannot try to allocate more memory then we have in the whole pool
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCantAllocateMoreMemoryThanWeHave() throws Exception {
         BufferPool pool = new BufferPool(1024, 512, metrics, time, metricGroup);
         ByteBuffer buffer = pool.allocate(1024, maxBlockTimeMs);
         assertEquals(1024, buffer.limit());
         pool.deallocate(buffer);
-        pool.allocate(1025, maxBlockTimeMs);
+        assertThrows(IllegalArgumentException.class, () -> pool.allocate(1025, maxBlockTimeMs));
     }
 
     /**
@@ -155,11 +155,11 @@ public class BufferPoolTest {
      * Test if BufferExhausted exception is thrown when there is not enough memory to allocate and the elapsed
      * time is greater than the max specified block time.
      */
-    @Test(expected = BufferExhaustedException.class)
+    @Test
     public void testBufferExhaustedExceptionIsThrown() throws Exception {
         BufferPool pool = new BufferPool(2, 1, metrics, time, metricGroup);
         pool.allocate(1, maxBlockTimeMs);
-        pool.allocate(2, maxBlockTimeMs);
+        assertThrows(BufferExhaustedException.class, () -> pool.allocate(2, maxBlockTimeMs));
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -63,6 +63,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -693,7 +694,7 @@ public class RecordAccumulatorTest {
         assertTrue("The batch should have been drained.", drained.get(node1.id()).size() > 0);
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testIdempotenceWithOldMagic() throws InterruptedException {
         // Simulate talking to an older broker, ie. one which supports a lower magic.
         ApiVersions apiVersions = new ApiVersions();
@@ -709,7 +710,8 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(logContext, batchSize + DefaultRecordBatch.RECORD_BATCH_OVERHEAD,
             CompressionType.NONE, lingerMs, retryBackoffMs, deliveryTimeoutMs, metrics, metricGrpName, time, apiVersions, transactionManager,
             new BufferPool(totalSize, batchSize, metrics, time, metricGrpName));
-        accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0, false, time.milliseconds());
+        assertThrows(UnsupportedVersionException.class,
+            () -> accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0, false, time.milliseconds()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -445,18 +445,18 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testMaybeAddPartitionToTransactionBeforeInitTransactions() {
+    public void testNotReadyForSendBeforeInitTransactions() {
         assertThrows(IllegalStateException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
     @Test
-    public void testMaybeAddPartitionToTransactionBeforeBeginTransaction() {
+    public void testNotReadyForSendBeforeBeginTransaction() {
         doInitTransactions();
         assertThrows(IllegalStateException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
     @Test
-    public void testMaybeAddPartitionToTransactionAfterAbortableError() {
+    public void testNotReadyForSendAfterAbortableError() {
         doInitTransactions();
         transactionManager.beginTransaction();
         transactionManager.transitionToAbortableError(new KafkaException());
@@ -464,7 +464,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testMaybeAddPartitionToTransactionAfterFatalError() {
+    public void testNotReadyForSendAfterFatalError() {
         doInitTransactions();
         transactionManager.transitionToFatalError(new KafkaException());
         assertThrows(KafkaException.class, () -> transactionManager.failIfNotReadyForSend());

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -3143,7 +3143,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testRetryAbortTransactionAfterCommitTimeout() {
+    public void testRetryAbortTransactionAfterCommitTimeout() throws InterruptedException {
         assertThrows(KafkaException.class, () -> verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.ABORT));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -213,9 +213,9 @@ public class TransactionManagerTest {
         assertTrue(transactionManager.nextRequest(false).isEndTxn());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testFailIfNotReadyForSendNoProducerId() {
-        transactionManager.failIfNotReadyForSend();
+        assertThrows(IllegalStateException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
     @Test
@@ -224,32 +224,32 @@ public class TransactionManagerTest {
         transactionManager.failIfNotReadyForSend();
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testFailIfNotReadyForSendIdempotentProducerFatalError() {
         initializeTransactionManager(Optional.empty(), false);
         transactionManager.transitionToFatalError(new KafkaException());
-        transactionManager.failIfNotReadyForSend();
+        assertThrows(KafkaException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testFailIfNotReadyForSendNoOngoingTransaction() {
         doInitTransactions();
-        transactionManager.failIfNotReadyForSend();
+        assertThrows(IllegalStateException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testFailIfNotReadyForSendAfterAbortableError() {
         doInitTransactions();
         transactionManager.beginTransaction();
         transactionManager.transitionToAbortableError(new KafkaException());
-        transactionManager.failIfNotReadyForSend();
+        assertThrows(KafkaException.class, transactionManager::failIfNotReadyForSend);
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testFailIfNotReadyForSendAfterFatalError() {
         doInitTransactions();
         transactionManager.transitionToFatalError(new KafkaException());
-        transactionManager.failIfNotReadyForSend();
+        assertThrows(KafkaException.class, transactionManager::failIfNotReadyForSend);
     }
 
     @Test
@@ -444,34 +444,30 @@ public class TransactionManagerTest {
         assertEquals(DEFAULT_RETRY_BACKOFF_MS, handler.retryBackoffMs());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMaybeAddPartitionToTransactionBeforeInitTransactions() {
-        transactionManager.failIfNotReadyForSend();
-        transactionManager.maybeAddPartitionToTransaction(new TopicPartition("foo", 0));
+        assertThrows(IllegalStateException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testMaybeAddPartitionToTransactionBeforeBeginTransaction() {
         doInitTransactions();
-        transactionManager.failIfNotReadyForSend();
-        transactionManager.maybeAddPartitionToTransaction(new TopicPartition("foo", 0));
+        assertThrows(IllegalStateException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testMaybeAddPartitionToTransactionAfterAbortableError() {
         doInitTransactions();
         transactionManager.beginTransaction();
         transactionManager.transitionToAbortableError(new KafkaException());
-        transactionManager.failIfNotReadyForSend();
-        transactionManager.maybeAddPartitionToTransaction(new TopicPartition("foo", 0));
+        assertThrows(KafkaException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testMaybeAddPartitionToTransactionAfterFatalError() {
         doInitTransactions();
         transactionManager.transitionToFatalError(new KafkaException());
-        transactionManager.failIfNotReadyForSend();
-        transactionManager.maybeAddPartitionToTransaction(new TopicPartition("foo", 0));
+        assertThrows(KafkaException.class, () -> transactionManager.failIfNotReadyForSend());
     }
 
     @Test
@@ -3146,14 +3142,14 @@ public class TransactionManagerTest {
         verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.COMMIT);
     }
 
-    @Test(expected = KafkaException.class)
-    public void testRetryAbortTransactionAfterCommitTimeout() throws InterruptedException {
-        verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.ABORT);
+    @Test
+    public void testRetryAbortTransactionAfterCommitTimeout() {
+        assertThrows(KafkaException.class, () -> verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.ABORT));
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testRetryCommitTransactionAfterAbortTimeout() throws InterruptedException {
-        verifyCommitOrAbortTransactionRetriable(TransactionResult.ABORT, TransactionResult.COMMIT);
+        assertThrows(KafkaException.class, () -> verifyCommitOrAbortTransactionRetriable(TransactionResult.ABORT, TransactionResult.COMMIT));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -3143,7 +3143,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testRetryAbortTransactionAfterCommitTimeout() throws InterruptedException {
+    public void testRetryAbortTransactionAfterCommitTimeout() {
         assertThrows(KafkaException.class, () -> verifyCommitOrAbortTransactionRetriable(TransactionResult.COMMIT, TransactionResult.ABORT));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -196,10 +197,10 @@ public class KafkaFutureTest {
         allFuture.get();
     }
 
-    @Test(expected = TimeoutException.class)
-    public void testFutureTimeoutWithZeroWait() throws Exception {
+    @Test
+    public void testFutureTimeoutWithZeroWait() {
         final KafkaFutureImpl<String> future = new KafkaFutureImpl<>();
-        future.get(0, TimeUnit.MILLISECONDS);
+        assertThrows(TimeoutException.class, () -> future.get(0, TimeUnit.MILLISECONDS));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -198,7 +198,7 @@ public class KafkaFutureTest {
     }
 
     @Test
-    public void testFutureTimeoutWithZeroWait() throws Exception {
+    public void testFutureTimeoutWithZeroWait() {
         final KafkaFutureImpl<String> future = new KafkaFutureImpl<>();
         assertThrows(TimeoutException.class, () -> future.get(0, TimeUnit.MILLISECONDS));
     }

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -198,7 +198,7 @@ public class KafkaFutureTest {
     }
 
     @Test
-    public void testFutureTimeoutWithZeroWait() {
+    public void testFutureTimeoutWithZeroWait() throws Exception {
         final KafkaFutureImpl<String> future = new KafkaFutureImpl<>();
         assertThrows(TimeoutException.class, () -> future.get(0, TimeUnit.MILLISECONDS));
     }

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclBindingTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclBindingTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class AclBindingTest {
@@ -124,18 +125,21 @@ public class AclBindingTest {
         new AclBinding(new ResourcePattern(ResourceType.UNKNOWN, "foo", PatternType.LITERAL), ACL1.entry());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowOnMatchPatternType() {
-        new AclBinding(new ResourcePattern(ResourceType.TOPIC, "foo", PatternType.MATCH), ACL1.entry());
+        assertThrows(IllegalArgumentException.class,
+            () -> new AclBinding(new ResourcePattern(ResourceType.TOPIC, "foo", PatternType.MATCH), ACL1.entry()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowOnAnyPatternType() {
-        new AclBinding(new ResourcePattern(ResourceType.TOPIC, "foo", PatternType.ANY), ACL1.entry());
+        assertThrows(IllegalArgumentException.class,
+            () -> new AclBinding(new ResourcePattern(ResourceType.TOPIC, "foo", PatternType.ANY), ACL1.entry()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowOnAnyResourceType() {
-        new AclBinding(new ResourcePattern(ResourceType.ANY, "foo", PatternType.LITERAL), ACL1.entry());
+        assertThrows(IllegalArgumentException.class,
+            () -> new AclBinding(new ResourcePattern(ResourceType.ANY, "foo", PatternType.LITERAL), ACL1.entry()));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/acl/ResourcePatternTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/ResourcePatternTest.java
@@ -22,24 +22,28 @@ import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public class ResourcePatternTest {
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test
     public void shouldThrowIfResourceTypeIsAny() {
-        new ResourcePattern(ResourceType.ANY, "name", PatternType.LITERAL);
+        assertThrows(IllegalArgumentException.class,
+            () -> new ResourcePattern(ResourceType.ANY, "name", PatternType.LITERAL));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfPatternTypeIsMatch() {
-        new ResourcePattern(ResourceType.TOPIC, "name", PatternType.MATCH);
+        assertThrows(IllegalArgumentException.class, () -> new ResourcePattern(ResourceType.TOPIC, "name", PatternType.MATCH));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfPatternTypeIsAny() {
-        new ResourcePattern(ResourceType.TOPIC, "name", PatternType.ANY);
+        assertThrows(IllegalArgumentException.class, () -> new ResourcePattern(ResourceType.TOPIC, "name", PatternType.ANY));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfResourceNameIsNull() {
-        new ResourcePattern(ResourceType.TOPIC, null, PatternType.ANY);
+        assertThrows(NullPointerException.class, () -> new ResourcePattern(ResourceType.TOPIC, null, PatternType.ANY));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -41,6 +41,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -84,9 +85,9 @@ public class ConfigDefTest {
         assertEquals(Password.HIDDEN, vals.get("j").toString());
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testInvalidDefault() {
-        new ConfigDef().define("a", Type.INT, "hello", Importance.HIGH, "docs");
+        assertThrows(ConfigException.class, () -> new ConfigDef().define("a", Type.INT, "hello", Importance.HIGH, "docs"));
     }
 
     @Test
@@ -97,9 +98,9 @@ public class ConfigDefTest {
         assertEquals(null, vals.get("a"));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testMissingRequired() {
-        new ConfigDef().define("a", Type.INT, Importance.HIGH, "docs").parse(new HashMap<String, Object>());
+        assertThrows(ConfigException.class, () -> new ConfigDef().define("a", Type.INT, Importance.HIGH, "docs").parse(new HashMap<String, Object>()));
     }
 
     @Test
@@ -108,9 +109,10 @@ public class ConfigDefTest {
                 .parse(new HashMap<String, Object>());
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testDefinedTwice() {
-        new ConfigDef().define("a", Type.STRING, Importance.HIGH, "docs").define("a", Type.INT, Importance.HIGH, "docs");
+        assertThrows(ConfigException.class, () -> new ConfigDef().define("a", Type.STRING,
+            Importance.HIGH, "docs").define("a", Type.INT, Importance.HIGH, "docs"));
     }
 
     @Test
@@ -138,14 +140,16 @@ public class ConfigDefTest {
         }
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testInvalidDefaultRange() {
-        new ConfigDef().define("name", Type.INT, -1, Range.between(0, 10), Importance.HIGH, "docs");
+        assertThrows(ConfigException.class, () -> new ConfigDef().define("name", Type.INT, -1,
+            Range.between(0, 10), Importance.HIGH, "docs"));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testInvalidDefaultString() {
-        new ConfigDef().define("name", Type.STRING, "bad", ValidString.in("valid", "values"), Importance.HIGH, "docs");
+        assertThrows(ConfigException.class, () -> new ConfigDef().define("name", Type.STRING, "bad",
+            ValidString.in("valid", "values"), Importance.HIGH, "docs"));
     }
 
     @Test
@@ -414,12 +418,12 @@ public class ConfigDefTest {
         }
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testMissingDependentConfigs() {
         // Should not be possible to parse a config if a dependent config has not been defined
         final ConfigDef configDef = new ConfigDef()
                 .define("parent", Type.STRING, Importance.HIGH, "parent docs", "group", 1, Width.LONG, "Parent", Collections.singletonList("child"));
-        configDef.parse(Collections.emptyMap());
+        assertThrows(ConfigException.class, () -> configDef.parse(Collections.emptyMap()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/config/SaslConfigsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/SaslConfigsTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,59 +67,59 @@ public class SaslConfigsTest {
         assertEquals(Short.valueOf("3600"), vals.get(SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshWindowFactorMinValueIsReallyMinimum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR, "0.499999");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshWindowFactorMaxValueIsReallyMaximum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_FACTOR, "1.0001");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshWindowJitterMinValueIsReallyMinimum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER, "-0.000001");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshWindowJitterMaxValueIsReallyMaximum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_WINDOW_JITTER, "0.251");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshMinPeriodSecondsMinValueIsReallyMinimum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS, "-1");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshMinPeriodSecondsMaxValueIsReallyMaximum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_MIN_PERIOD_SECONDS, "901");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshBufferSecondsMinValueIsReallyMinimum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS, "-1");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testSaslLoginRefreshBufferSecondsMaxValueIsReallyMaximum() {
         Map<Object, Object> props = new HashMap<>();
         props.put(SaslConfigs.SASL_LOGIN_REFRESH_BUFFER_SECONDS, "3601");
-        new ConfigDef().withClientSaslSupport().parse(props);
+        assertThrows(ConfigException.class, () -> new ConfigDef().withClientSaslSupport().parse(props));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
@@ -20,81 +20,103 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.utils.Utils;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
 
+
 public class GarbageCollectedMemoryPoolTest {
 
-    @Test
-    public void testZeroSize() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(0, 7, true, null));
+    private GarbageCollectedMemoryPool pool;
+
+    @After
+    public void releasePool() {
+        if (pool != null) pool.close();
     }
 
     @Test
-    public void testNegativeSize() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(-1, 7, false, null));
+    public void testZeroSize() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(0, 7, true, null));
     }
 
     @Test
-    public void testZeroMaxAllocation() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(100, 0, true, null));
+    public void testNegativeSize() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(-1, 7, false, null));
     }
 
     @Test
-    public void testNegativeMaxAllocation() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(100, -1, false, null));
+    public void testZeroMaxAllocation() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(100, 0, true, null));
     }
 
     @Test
-    public void testMaxAllocationLargerThanSize() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(100, 101, true, null));
+    public void testNegativeMaxAllocation() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(100, -1, false, null));
     }
 
     @Test
-    public void testAllocationOverMaxAllocation() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+    public void testMaxAllocationLargerThanSize() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(100, 101, true, null));
+    }
+
+    @Test
+    public void testAllocationOverMaxAllocation() {
+        pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(11));
     }
 
     @Test
-    public void testAllocationZero() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+    public void testAllocationZero() {
+        pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(0));
     }
 
     @Test
-    public void testAllocationNegative() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+    public void testAllocationNegative() {
+        pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(-1));
     }
 
     @Test
-    public void testReleaseNull() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+    public void testReleaseNull() {
+        pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         assertThrows(IllegalArgumentException.class, () -> pool.release(null));
     }
 
     @Test
-    public void testReleaseForeignBuffer() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+    public void testReleaseForeignBuffer() {
+        pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         ByteBuffer fellOffATruck = ByteBuffer.allocate(1);
         assertThrows(IllegalArgumentException.class, () -> pool.release(fellOffATruck));
     }
 
     @Test
-    public void testDoubleFree() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+    public void testDoubleFree() {
+        pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         ByteBuffer buffer = pool.tryAllocate(5);
         Assert.assertNotNull(buffer);
         pool.release(buffer); //so far so good
-        assertThrows(IllegalArgumentException.class, () -> pool.release(buffer));
+        try {
+            pool.release(buffer);
+            Assert.fail("2nd release() should have failed");
+        } catch (IllegalArgumentException e) {
+            //as expected
+        } catch (Throwable t) {
+            Assert.fail("expected an IllegalArgumentException. instead got " + t);
+        }
     }
 
     @Test
-    public void testAllocationBound() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(21, 10, false, null);
+    public void testAllocationBound() {
+        pool = new GarbageCollectedMemoryPool(21, 10, false, null);
         ByteBuffer buf1 = pool.tryAllocate(10);
         Assert.assertNotNull(buf1);
         Assert.assertEquals(10, buf1.capacity());
@@ -123,7 +145,7 @@ public class GarbageCollectedMemoryPoolTest {
         long maxPool = maxHeap / 2;
         long maxSingleAllocation = maxPool / 10;
         Assert.assertTrue(maxSingleAllocation < Integer.MAX_VALUE / 2); //test JVM running with too much memory for this test logic (?)
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null);
+        pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null);
 
         //we will allocate 30 buffers from this pool, which is sized such that at-most
         //11 should coexist and 30 do not fit in the JVM memory, proving that:

--- a/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
@@ -23,68 +23,74 @@ import org.apache.kafka.common.utils.Utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 
 public class GarbageCollectedMemoryPoolTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testZeroSize() throws Exception {
-        new GarbageCollectedMemoryPool(0, 7, true, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNegativeSize() throws Exception {
-        new GarbageCollectedMemoryPool(-1, 7, false, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testZeroMaxAllocation() throws Exception {
-        new GarbageCollectedMemoryPool(100, 0, true, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNegativeMaxAllocation() throws Exception {
-        new GarbageCollectedMemoryPool(100, -1, false, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testMaxAllocationLargerThanSize() throws Exception {
-        new GarbageCollectedMemoryPool(100, 101, true, null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAllocationOverMaxAllocation() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
-        pool.tryAllocate(11);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAllocationZero() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
-        pool.tryAllocate(0);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAllocationNegative() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
-        pool.tryAllocate(-1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testReleaseNull() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
-        pool.release(null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testReleaseForeignBuffer() throws Exception {
-        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
-        ByteBuffer fellOffATruck = ByteBuffer.allocate(1);
-        pool.release(fellOffATruck);
-        pool.close();
+    @Test
+    public void testZeroSize() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(0, 7, true, null));
     }
 
     @Test
-    public void testDoubleFree() throws Exception {
+    public void testNegativeSize() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(-1, 7, false, null));
+    }
+
+    @Test
+    public void testZeroMaxAllocation() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(100, 0, true, null));
+    }
+
+    @Test
+    public void testNegativeMaxAllocation() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(100, -1, false, null));
+    }
+
+    @Test
+    public void testMaxAllocationLargerThanSize() {
+        assertThrows(IllegalArgumentException.class,
+            () -> new GarbageCollectedMemoryPool(100, 101, true, null));
+    }
+
+    @Test
+    public void testAllocationOverMaxAllocation() {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+        assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(11));
+    }
+
+    @Test
+    public void testAllocationZero() {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+        assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(0));
+    }
+
+    @Test
+    public void testAllocationNegative() {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+        assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(-1));
+    }
+
+    @Test
+    public void testReleaseNull() {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+        assertThrows(IllegalArgumentException.class, () -> pool.release(null));
+    }
+
+    @Test
+    public void testReleaseForeignBuffer() {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+        ByteBuffer fellOffATruck = ByteBuffer.allocate(1);
+        assertThrows(IllegalArgumentException.class, () -> pool.release(fellOffATruck));
+    }
+
+    @Test
+    public void testDoubleFree() {
         GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         ByteBuffer buffer = pool.tryAllocate(5);
         Assert.assertNotNull(buffer);

--- a/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/memory/GarbageCollectedMemoryPoolTest.java
@@ -20,103 +20,81 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.utils.Utils;
-
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThrows;
 
-
 public class GarbageCollectedMemoryPoolTest {
 
-    private GarbageCollectedMemoryPool pool;
-
-    @After
-    public void releasePool() {
-        if (pool != null) pool.close();
+    @Test
+    public void testZeroSize() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(0, 7, true, null));
     }
 
     @Test
-    public void testZeroSize() {
-        assertThrows(IllegalArgumentException.class,
-            () -> new GarbageCollectedMemoryPool(0, 7, true, null));
+    public void testNegativeSize() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(-1, 7, false, null));
     }
 
     @Test
-    public void testNegativeSize() {
-        assertThrows(IllegalArgumentException.class,
-            () -> new GarbageCollectedMemoryPool(-1, 7, false, null));
+    public void testZeroMaxAllocation() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(100, 0, true, null));
     }
 
     @Test
-    public void testZeroMaxAllocation() {
-        assertThrows(IllegalArgumentException.class,
-            () -> new GarbageCollectedMemoryPool(100, 0, true, null));
+    public void testNegativeMaxAllocation() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(100, -1, false, null));
     }
 
     @Test
-    public void testNegativeMaxAllocation() {
-        assertThrows(IllegalArgumentException.class,
-            () -> new GarbageCollectedMemoryPool(100, -1, false, null));
+    public void testMaxAllocationLargerThanSize() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> new GarbageCollectedMemoryPool(100, 101, true, null));
     }
 
     @Test
-    public void testMaxAllocationLargerThanSize() {
-        assertThrows(IllegalArgumentException.class,
-            () -> new GarbageCollectedMemoryPool(100, 101, true, null));
-    }
-
-    @Test
-    public void testAllocationOverMaxAllocation() {
-        pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+    public void testAllocationOverMaxAllocation() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(11));
     }
 
     @Test
-    public void testAllocationZero() {
-        pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+    public void testAllocationZero() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(0));
     }
 
     @Test
-    public void testAllocationNegative() {
-        pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+    public void testAllocationNegative() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         assertThrows(IllegalArgumentException.class, () -> pool.tryAllocate(-1));
     }
 
     @Test
-    public void testReleaseNull() {
-        pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+    public void testReleaseNull() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         assertThrows(IllegalArgumentException.class, () -> pool.release(null));
     }
 
     @Test
-    public void testReleaseForeignBuffer() {
-        pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
+    public void testReleaseForeignBuffer() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, true, null);
         ByteBuffer fellOffATruck = ByteBuffer.allocate(1);
         assertThrows(IllegalArgumentException.class, () -> pool.release(fellOffATruck));
     }
 
     @Test
-    public void testDoubleFree() {
-        pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
+    public void testDoubleFree() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(1000, 10, false, null);
         ByteBuffer buffer = pool.tryAllocate(5);
         Assert.assertNotNull(buffer);
         pool.release(buffer); //so far so good
-        try {
-            pool.release(buffer);
-            Assert.fail("2nd release() should have failed");
-        } catch (IllegalArgumentException e) {
-            //as expected
-        } catch (Throwable t) {
-            Assert.fail("expected an IllegalArgumentException. instead got " + t);
-        }
+        assertThrows(IllegalArgumentException.class, () -> pool.release(buffer));
     }
 
     @Test
-    public void testAllocationBound() {
-        pool = new GarbageCollectedMemoryPool(21, 10, false, null);
+    public void testAllocationBound() throws Exception {
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(21, 10, false, null);
         ByteBuffer buf1 = pool.tryAllocate(10);
         Assert.assertNotNull(buf1);
         Assert.assertEquals(10, buf1.capacity());
@@ -145,7 +123,7 @@ public class GarbageCollectedMemoryPoolTest {
         long maxPool = maxHeap / 2;
         long maxSingleAllocation = maxPool / 10;
         Assert.assertTrue(maxSingleAllocation < Integer.MAX_VALUE / 2); //test JVM running with too much memory for this test logic (?)
-        pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null);
+        GarbageCollectedMemoryPool pool = new GarbageCollectedMemoryPool(maxPool, (int) maxSingleAllocation, false, null);
 
         //we will allocate 30 buffers from this pool, which is sized such that at-most
         //11 should coexist and 30 do not fit in the JVM memory, proving that:

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -294,12 +294,13 @@ public class SimpleExampleMessageTest {
             message -> assertEquals(myStruct, message.myStruct()), (short) 2);
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testMyStructUnsupportedVersion() {
         SimpleExampleMessageData.MyStruct myStruct =
                 new SimpleExampleMessageData.MyStruct().setStructId(10);
         // Check serialization throws exception for unsupported version
-        testRoundTrip(new SimpleExampleMessageData().setMyStruct(myStruct), (short) 1);
+        assertThrows(UnsupportedVersionException.class,
+            () -> testRoundTrip(new SimpleExampleMessageData().setMyStruct(myStruct), (short) 1));
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -196,12 +197,12 @@ public class MetricsTest {
         assertNull(metrics.childrenSensors().get(grandchild));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBadSensorHierarchy() {
         Sensor p = metrics.sensor("parent");
         Sensor c1 = metrics.sensor("child1", p);
         Sensor c2 = metrics.sensor("child2", p);
-        metrics.sensor("gc", c1, c2); // should fail
+        assertThrows(IllegalArgumentException.class, () -> metrics.sensor("gc", c1, c2)); // should fail
     }
 
     @Test
@@ -412,10 +413,11 @@ public class MetricsTest {
         assertEquals(0.0, sampledTotal.measure(config, time.milliseconds()), EPS);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDuplicateMetricName() {
         metrics.sensor("test").add(metrics.metricName("test", "grp1"), new Avg());
-        metrics.sensor("test2").add(metrics.metricName("test", "grp1"), new CumulativeSum());
+        assertThrows(IllegalArgumentException.class, () ->
+                metrics.sensor("test2").add(metrics.metricName("test", "grp1"), new CumulativeSum()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -202,7 +202,7 @@ public class MetricsTest {
         Sensor p = metrics.sensor("parent");
         Sensor c1 = metrics.sensor("child1", p);
         Sensor c2 = metrics.sensor("child2", p);
-        assertThrows(IllegalArgumentException.class, () -> metrics.sensor("gc", c1, c2)); // should fail
+        assertThrows(IllegalArgumentException.class, () -> metrics.sensor("gc", c1, c2));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class FrequenciesTest {
 
@@ -53,22 +54,22 @@ public class FrequenciesTest {
         metrics.close();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFrequencyCenterValueAboveMax() {
-        new Frequencies(4, 1.0, 4.0,
-                        freq("1", 1.0), freq("2", 20.0));
+        assertThrows(IllegalArgumentException.class,
+            () -> new Frequencies(4, 1.0, 4.0, freq("1", 1.0), freq("2", 20.0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFrequencyCenterValueBelowMin() {
-        new Frequencies(4, 1.0, 4.0,
-                        freq("1", 1.0), freq("2", -20.0));
+        assertThrows(IllegalArgumentException.class,
+            () -> new Frequencies(4, 1.0, 4.0, freq("1", 1.0), freq("2", -20.0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMoreFrequencyParametersThanBuckets() {
-        new Frequencies(1, 1.0, 4.0,
-                        freq("1", 1.0), freq("2", -20.0));
+        assertThrows(IllegalArgumentException.class,
+            () -> new Frequencies(1, 1.0, 4.0, freq("1", 1.0), freq("2", -20.0)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -177,18 +177,18 @@ public class SelectorTest {
     /**
      * Sending a request to a node without an existing connection should result in an exception
      */
-    @Test(expected = IllegalStateException.class)
-    public void testCantSendWithoutConnecting() throws Exception {
-        selector.send(createSend("0", "test"));
-        selector.poll(1000L);
+    @Test
+    public void testSendWithoutConnecting() {
+        assertThrows(IllegalStateException.class, () -> selector.send(createSend("0", "test")));
     }
 
     /**
      * Sending a request to a node with a bad hostname should result in an exception during connect
      */
-    @Test(expected = IOException.class)
-    public void testNoRouteToHost() throws Exception {
-        selector.connect("0", new InetSocketAddress("some.invalid.hostname.foo.bar.local", server.port), BUFFER_SIZE, BUFFER_SIZE);
+    @Test
+    public void testNoRouteToHost() {
+        assertThrows(IOException.class,
+            () -> selector.connect("0", new InetSocketAddress("some.invalid.hostname.foo.bar.local", server.port), BUFFER_SIZE, BUFFER_SIZE));
     }
 
     /**
@@ -375,10 +375,10 @@ public class SelectorTest {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testExistingConnectionId() throws IOException {
         blockingConnect("0");
-        blockingConnect("0");
+        assertThrows(IllegalStateException.class, () -> blockingConnect("0"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -178,7 +178,7 @@ public class SelectorTest {
      * Sending a request to a node without an existing connection should result in an exception
      */
     @Test
-    public void testSendWithoutConnecting() throws Exception {
+    public void testSendWithoutConnecting() {
         assertThrows(IllegalStateException.class, () -> selector.send(createSend("0", "test")));
     }
 
@@ -186,7 +186,7 @@ public class SelectorTest {
      * Sending a request to a node with a bad hostname should result in an exception during connect
      */
     @Test
-    public void testNoRouteToHost() throws Exception {
+    public void testNoRouteToHost() {
         assertThrows(IOException.class,
             () -> selector.connect("0", new InetSocketAddress("some.invalid.hostname.foo.bar.local", server.port), BUFFER_SIZE, BUFFER_SIZE));
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -178,7 +178,7 @@ public class SelectorTest {
      * Sending a request to a node without an existing connection should result in an exception
      */
     @Test
-    public void testSendWithoutConnecting() {
+    public void testSendWithoutConnecting() throws Exception {
         assertThrows(IllegalStateException.class, () -> selector.send(createSend("0", "test")));
     }
 
@@ -186,7 +186,7 @@ public class SelectorTest {
      * Sending a request to a node with a bad hostname should result in an exception during connect
      */
     @Test
-    public void testNoRouteToHost() {
+    public void testNoRouteToHost() throws Exception {
         assertThrows(IOException.class,
             () -> selector.connect("0", new InetSocketAddress("some.invalid.hostname.foo.bar.local", server.port), BUFFER_SIZE, BUFFER_SIZE));
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -987,14 +987,14 @@ public class SslTransportLayerTest {
      * Verifies that inter-broker listener with validation of truststore against keystore
      * fails if certs from keystore are not trusted.
      */
-    @Test(expected = KafkaException.class)
+    @Test
     public void testInterBrokerSslConfigValidationFailure() {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
         sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
         TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
         ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
-        ChannelBuilders.serverChannelBuilder(listenerName, true, securityProtocol, config,
-                null, null, time, new LogContext());
+        assertThrows(KafkaException.class, () -> ChannelBuilders.serverChannelBuilder(listenerName, true, securityProtocol, config,
+                null, null, time, new LogContext()));
     }
 
     /**
@@ -1205,10 +1205,10 @@ public class SslTransportLayerTest {
     /**
      * Tests invalid ssl.engine.factory plugin class
      */
-    @Test(expected = KafkaException.class)
+    @Test
     public void testInvalidSslEngineFactory() {
         sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, String.class);
-        createSelector(sslClientConfigs);
+        assertThrows(KafkaException.class, () -> createSelector(sslClientConfigs));
     }
 
     private void verifyInvalidReconfigure(ListenerReconfigurable reconfigurable,

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -25,18 +25,19 @@ import java.util.Set;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApiKeysTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testForIdWithInvalidIdLow() {
-        ApiKeys.forId(-1);
+        assertThrows(IllegalArgumentException.class, () -> ApiKeys.forId(-1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testForIdWithInvalidIdHigh() {
-        ApiKeys.forId(10000);
+        assertThrows(IllegalArgumentException.class, () -> ApiKeys.forId(10000));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/AbstractLegacyRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/AbstractLegacyRecordBatchTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -85,7 +86,7 @@ public class AbstractLegacyRecordBatchTest {
         }
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidWrapperOffsetV1() {
         SimpleRecord[] simpleRecords = new SimpleRecord[] {
             new SimpleRecord(1L, "a".getBytes(), "1".getBytes()),
@@ -99,10 +100,10 @@ public class AbstractLegacyRecordBatchTest {
         ByteBufferLegacyRecordBatch batch = new ByteBufferLegacyRecordBatch(records.buffer());
         batch.setLastOffset(1L);
 
-        batch.iterator();
+        assertThrows(InvalidRecordException.class, batch::iterator);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetNoTimestampTypeNotAllowed() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V1, 0L,
                 CompressionType.GZIP, TimestampType.CREATE_TIME,
@@ -110,10 +111,10 @@ public class AbstractLegacyRecordBatchTest {
                 new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
         ByteBufferLegacyRecordBatch batch = new ByteBufferLegacyRecordBatch(records.buffer());
-        batch.setMaxTimestamp(TimestampType.NO_TIMESTAMP_TYPE, RecordBatch.NO_TIMESTAMP);
+        assertThrows(IllegalArgumentException.class, () -> batch.setMaxTimestamp(TimestampType.NO_TIMESTAMP_TYPE, RecordBatch.NO_TIMESTAMP));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetLogAppendTimeNotAllowedV0() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V0, 0L,
                 CompressionType.GZIP, TimestampType.CREATE_TIME,
@@ -122,10 +123,10 @@ public class AbstractLegacyRecordBatchTest {
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
         long logAppendTime = 15L;
         ByteBufferLegacyRecordBatch batch = new ByteBufferLegacyRecordBatch(records.buffer());
-        batch.setMaxTimestamp(TimestampType.LOG_APPEND_TIME, logAppendTime);
+        assertThrows(UnsupportedOperationException.class, () -> batch.setMaxTimestamp(TimestampType.LOG_APPEND_TIME, logAppendTime));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetCreateTimeNotAllowedV0() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V0, 0L,
                 CompressionType.GZIP, TimestampType.CREATE_TIME,
@@ -134,10 +135,10 @@ public class AbstractLegacyRecordBatchTest {
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
         long createTime = 15L;
         ByteBufferLegacyRecordBatch batch = new ByteBufferLegacyRecordBatch(records.buffer());
-        batch.setMaxTimestamp(TimestampType.CREATE_TIME, createTime);
+        assertThrows(UnsupportedOperationException.class, () -> batch.setMaxTimestamp(TimestampType.CREATE_TIME, createTime));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetPartitionLeaderEpochNotAllowedV0() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V0, 0L,
                 CompressionType.GZIP, TimestampType.CREATE_TIME,
@@ -145,10 +146,10 @@ public class AbstractLegacyRecordBatchTest {
                 new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
         ByteBufferLegacyRecordBatch batch = new ByteBufferLegacyRecordBatch(records.buffer());
-        batch.setPartitionLeaderEpoch(15);
+        assertThrows(UnsupportedOperationException.class, () -> batch.setPartitionLeaderEpoch(15));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testSetPartitionLeaderEpochNotAllowedV1() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V1, 0L,
                 CompressionType.GZIP, TimestampType.CREATE_TIME,
@@ -156,7 +157,7 @@ public class AbstractLegacyRecordBatchTest {
                 new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
         ByteBufferLegacyRecordBatch batch = new ByteBufferLegacyRecordBatch(records.buffer());
-        batch.setPartitionLeaderEpoch(15);
+        assertThrows(UnsupportedOperationException.class, () -> batch.setPartitionLeaderEpoch(15));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -106,17 +106,16 @@ public class ByteBufferLogInputStreamTest {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
         builder.append(15L, "a".getBytes(), "1".getBytes());
-        builder.append(20L, "b".getBytes(), "2".getBytes());
         builder.close();
 
         builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 2L);
         builder.append(30L, "c".getBytes(), "3".getBytes());
         builder.append(40L, "d".getBytes(), "4".getBytes());
         builder.close();
-
         buffer.flip();
 
-        ByteBufferLogInputStream logInputStream = new ByteBufferLogInputStream(buffer, 25);
+        ByteBufferLogInputStream logInputStream = new ByteBufferLogInputStream(buffer, 60);
+        assertNotNull(logInputStream.nextBatch());
         assertThrows(CorruptRecordException.class, logInputStream::nextBatch);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ByteBufferLogInputStreamTest {
@@ -54,7 +55,7 @@ public class ByteBufferLogInputStreamTest {
         assertFalse(iterator.hasNext());
     }
 
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void iteratorRaisesOnTooSmallRecords() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
@@ -74,10 +75,10 @@ public class ByteBufferLogInputStreamTest {
 
         ByteBufferLogInputStream logInputStream = new ByteBufferLogInputStream(buffer, Integer.MAX_VALUE);
         assertNotNull(logInputStream.nextBatch());
-        logInputStream.nextBatch();
+        assertThrows(CorruptRecordException.class, logInputStream::nextBatch);
     }
 
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void iteratorRaisesOnInvalidMagic() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
@@ -97,10 +98,10 @@ public class ByteBufferLogInputStreamTest {
 
         ByteBufferLogInputStream logInputStream = new ByteBufferLogInputStream(buffer, Integer.MAX_VALUE);
         assertNotNull(logInputStream.nextBatch());
-        logInputStream.nextBatch();
+        assertThrows(CorruptRecordException.class, logInputStream::nextBatch);
     }
 
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void iteratorRaisesOnTooLargeRecords() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
@@ -116,8 +117,7 @@ public class ByteBufferLogInputStreamTest {
         buffer.flip();
 
         ByteBufferLogInputStream logInputStream = new ByteBufferLogInputStream(buffer, 25);
-        assertNotNull(logInputStream.nextBatch());
-        logInputStream.nextBatch();
+        assertThrows(CorruptRecordException.class, logInputStream::nextBatch);
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
@@ -18,17 +18,20 @@ package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
+import static org.junit.Assert.assertThrows;
+
 public class ControlRecordUtilsTest {
 
     @Test
     public void testInvalidControlRecordType() {
-        IllegalArgumentException thrown = Assert.assertThrows(
+        IllegalArgumentException thrown = assertThrows(
             IllegalArgumentException.class, () -> testDeserializeRecord(ControlRecordType.COMMIT));
         Assert.assertEquals("Expected LEADER_CHANGE control record type(3), but found COMMIT", thrown.getMessage());
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
@@ -18,20 +18,17 @@ package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
-
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
-import static org.junit.Assert.assertThrows;
-
 public class ControlRecordUtilsTest {
 
     @Test
     public void testInvalidControlRecordType() {
-        IllegalArgumentException thrown = assertThrows(
+        IllegalArgumentException thrown = Assert.assertThrows(
             IllegalArgumentException.class, () -> testDeserializeRecord(ControlRecordType.COMMIT));
         Assert.assertEquals("Expected LEADER_CHANGE control record type(3), but found COMMIT", thrown.getMessage());
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static org.apache.kafka.common.record.DefaultRecordBatch.RECORDS_COUNT_OFFSET;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultRecordBatchTest {
@@ -175,7 +176,7 @@ public class DefaultRecordBatchTest {
         assertEquals(actualSize, DefaultRecordBatch.sizeInBytes(Arrays.asList(records)));
     }
 
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void testInvalidRecordSize() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
                 CompressionType.NONE, TimestampType.CREATE_TIME,
@@ -188,54 +189,46 @@ public class DefaultRecordBatchTest {
 
         DefaultRecordBatch batch = new DefaultRecordBatch(buffer);
         assertFalse(batch.isValid());
-        batch.ensureValid();
+        assertThrows(CorruptRecordException.class, batch::ensureValid);
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidRecordCountTooManyNonCompressedV2() {
         long now = System.currentTimeMillis();
         DefaultRecordBatch batch = recordsWithInvalidRecordCount(RecordBatch.MAGIC_VALUE_V2, now, CompressionType.NONE, 5);
         // force iteration through the batch to execute validation
         // batch validation is a part of normal workflow for LogValidator.validateMessagesAndAssignOffsets
-        for (Record record: batch) {
-            record.isValid();
-        }
+        assertThrows(InvalidRecordException.class, () -> batch.forEach(Record::isValid));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidRecordCountTooLittleNonCompressedV2() {
         long now = System.currentTimeMillis();
         DefaultRecordBatch batch = recordsWithInvalidRecordCount(RecordBatch.MAGIC_VALUE_V2, now, CompressionType.NONE, 2);
         // force iteration through the batch to execute validation
         // batch validation is a part of normal workflow for LogValidator.validateMessagesAndAssignOffsets
-        for (Record record: batch) {
-            record.isValid();
-        }
+        assertThrows(InvalidRecordException.class, () -> batch.forEach(Record::isValid));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidRecordCountTooManyCompressedV2() {
         long now = System.currentTimeMillis();
         DefaultRecordBatch batch = recordsWithInvalidRecordCount(RecordBatch.MAGIC_VALUE_V2, now, CompressionType.GZIP, 5);
         // force iteration through the batch to execute validation
         // batch validation is a part of normal workflow for LogValidator.validateMessagesAndAssignOffsets
-        for (Record record: batch) {
-            record.isValid();
-        }
+        assertThrows(InvalidRecordException.class, () -> batch.forEach(Record::isValid));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidRecordCountTooLittleCompressedV2() {
         long now = System.currentTimeMillis();
         DefaultRecordBatch batch = recordsWithInvalidRecordCount(RecordBatch.MAGIC_VALUE_V2, now, CompressionType.GZIP, 2);
         // force iteration through the batch to execute validation
         // batch validation is a part of normal workflow for LogValidator.validateMessagesAndAssignOffsets
-        for (Record record: batch) {
-            record.isValid();
-        }
+        assertThrows(InvalidRecordException.class, () -> batch.forEach(Record::isValid));
     }
 
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void testInvalidCrc() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
                 CompressionType.NONE, TimestampType.CREATE_TIME,
@@ -248,7 +241,7 @@ public class DefaultRecordBatchTest {
 
         DefaultRecordBatch batch = new DefaultRecordBatch(buffer);
         assertFalse(batch.isValid());
-        batch.ensureValid();
+        assertThrows(CorruptRecordException.class, batch::ensureValid);
     }
 
     @Test
@@ -324,7 +317,7 @@ public class DefaultRecordBatchTest {
             assertEquals(logAppendTime, record.timestamp());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetNoTimestampTypeNotAllowed() {
         MemoryRecords records = MemoryRecords.withRecords(RecordBatch.MAGIC_VALUE_V2, 0L,
                 CompressionType.NONE, TimestampType.CREATE_TIME,
@@ -332,7 +325,7 @@ public class DefaultRecordBatchTest {
                 new SimpleRecord(2L, "b".getBytes(), "2".getBytes()),
                 new SimpleRecord(3L, "c".getBytes(), "3".getBytes()));
         DefaultRecordBatch batch = new DefaultRecordBatch(records.buffer());
-        batch.setMaxTimestamp(TimestampType.NO_TIMESTAMP_TYPE, RecordBatch.NO_TIMESTAMP);
+        assertThrows(IllegalArgumentException.class, () -> batch.setMaxTimestamp(TimestampType.NO_TIMESTAMP_TYPE, RecordBatch.NO_TIMESTAMP));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 public class DefaultRecordTest {
 
@@ -85,11 +86,11 @@ public class DefaultRecordTest {
         }
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testBasicSerdeInvalidHeaderCountTooHigh() throws IOException {
         Header[] headers = new Header[] {
             new RecordHeader("foo", "value".getBytes()),
-            new RecordHeader("bar", (byte[]) null),
+            new RecordHeader("bar", null),
             new RecordHeader("\"A\\u00ea\\u00f1\\u00fcC\"", "value".getBytes())
         };
 
@@ -107,18 +108,15 @@ public class DefaultRecordTest {
         ByteBuffer buffer = out.buffer();
         buffer.flip();
         buffer.put(14, (byte) 8);
-
-        DefaultRecord logRecord = DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, null);
-        // force iteration through the record to validate the number of headers
-        assertEquals(DefaultRecord.sizeInBytes(offsetDelta, timestampDelta, record.key(), record.value(),
-                record.headers()), logRecord.sizeInBytes());
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testBasicSerdeInvalidHeaderCountTooLow() throws IOException {
         Header[] headers = new Header[] {
             new RecordHeader("foo", "value".getBytes()),
-            new RecordHeader("bar", (byte[]) null),
+            new RecordHeader("bar", null),
             new RecordHeader("\"A\\u00ea\\u00f1\\u00fcC\"", "value".getBytes())
         };
 
@@ -137,13 +135,11 @@ public class DefaultRecordTest {
         buffer.flip();
         buffer.put(14, (byte) 4);
 
-        DefaultRecord logRecord = DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, null);
-        // force iteration through the record to validate the number of headers
-        assertEquals(DefaultRecord.sizeInBytes(offsetDelta, timestampDelta, record.key(), record.value(),
-                record.headers()), logRecord.sizeInBytes());
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidKeySize() {
         byte attributes = 0;
         long timestampDelta = 2;
@@ -160,11 +156,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testInvalidKeySizePartial() throws IOException {
+    @Test
+    public void testInvalidKeySizePartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -181,11 +178,12 @@ public class DefaultRecordTest {
 
         buf.flip();
         DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testInvalidValueSize() throws IOException {
+    @Test
+    public void testInvalidValueSize() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -202,10 +200,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidValueSizePartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
@@ -224,11 +223,12 @@ public class DefaultRecordTest {
 
         buf.flip();
         DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testInvalidNumHeaders() throws IOException {
+    @Test
+    public void testInvalidNumHeaders() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -245,11 +245,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testInvalidNumHeadersPartial() throws IOException {
+    @Test
+    public void testInvalidNumHeadersPartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -267,10 +268,11 @@ public class DefaultRecordTest {
 
         buf.flip();
         DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidHeaderKey() {
         byte attributes = 0;
         long timestampDelta = 2;
@@ -289,11 +291,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () ->  DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testInvalidHeaderKeyPartial() throws IOException {
+    @Test
+    public void testInvalidHeaderKeyPartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -312,10 +315,11 @@ public class DefaultRecordTest {
 
         buf.flip();
         DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testNullHeaderKey() {
         byte attributes = 0;
         long timestampDelta = 2;
@@ -334,11 +338,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testNullHeaderKeyPartial() throws IOException {
+    @Test
+    public void testNullHeaderKeyPartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -357,10 +362,11 @@ public class DefaultRecordTest {
 
         buf.flip();
         DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidHeaderValue() {
         byte attributes = 0;
         long timestampDelta = 2;
@@ -381,11 +387,12 @@ public class DefaultRecordTest {
         buf.position(buf.limit());
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
-    public void testInvalidHeaderValuePartial() throws IOException {
+    @Test
+    public void testInvalidHeaderValuePartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -406,10 +413,11 @@ public class DefaultRecordTest {
 
         buf.flip();
         DataInputStream inputStream = new DataInputStream(new ByteBufferInputStream(buf));
-        DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readPartiallyFrom(inputStream, skipArray, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testUnderflowReadingTimestamp() {
         byte attributes = 0;
         int sizeOfBodyInBytes = 1;
@@ -418,10 +426,11 @@ public class DefaultRecordTest {
         buf.put(attributes);
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testUnderflowReadingVarlong() {
         byte attributes = 0;
         int sizeOfBodyInBytes = 2; // one byte for attributes, one byte for partial timestamp
@@ -432,10 +441,11 @@ public class DefaultRecordTest {
         buf.position(buf.limit() - 1);
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testInvalidVarlong() {
         byte attributes = 0;
         int sizeOfBodyInBytes = 11; // one byte for attributes, 10 bytes for max timestamp
@@ -448,7 +458,8 @@ public class DefaultRecordTest {
         buf.put(recordStartPosition + 10, Byte.MIN_VALUE); // use an invalid final byte
 
         buf.flip();
-        DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null);
+        assertThrows(InvalidRecordException.class,
+            () -> DefaultRecord.readFrom(buf, 0L, 0L, RecordBatch.NO_SEQUENCE, null));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
@@ -90,7 +90,7 @@ public class DefaultRecordTest {
     public void testBasicSerdeInvalidHeaderCountTooHigh() throws IOException {
         Header[] headers = new Header[] {
             new RecordHeader("foo", "value".getBytes()),
-            new RecordHeader("bar", (byte[]) null),
+            new RecordHeader("bar", null),
             new RecordHeader("\"A\\u00ea\\u00f1\\u00fcC\"", "value".getBytes())
         };
 
@@ -161,7 +161,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidKeySizePartial() throws IOException {
+    public void testInvalidKeySizePartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -183,7 +183,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidValueSize() throws IOException {
+    public void testInvalidValueSize() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -228,7 +228,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidNumHeaders() throws IOException {
+    public void testInvalidNumHeaders() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -250,7 +250,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidNumHeadersPartial() throws IOException {
+    public void testInvalidNumHeadersPartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -296,7 +296,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidHeaderKeyPartial() throws IOException {
+    public void testInvalidHeaderKeyPartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -343,7 +343,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testNullHeaderKeyPartial() throws IOException {
+    public void testNullHeaderKeyPartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -392,7 +392,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidHeaderValuePartial() throws IOException {
+    public void testInvalidHeaderValuePartial() {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
@@ -90,7 +90,7 @@ public class DefaultRecordTest {
     public void testBasicSerdeInvalidHeaderCountTooHigh() throws IOException {
         Header[] headers = new Header[] {
             new RecordHeader("foo", "value".getBytes()),
-            new RecordHeader("bar", null),
+            new RecordHeader("bar", (byte[]) null),
             new RecordHeader("\"A\\u00ea\\u00f1\\u00fcC\"", "value".getBytes())
         };
 
@@ -161,7 +161,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidKeySizePartial() {
+    public void testInvalidKeySizePartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -183,7 +183,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidValueSize() {
+    public void testInvalidValueSize() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -228,7 +228,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidNumHeaders() {
+    public void testInvalidNumHeaders() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -250,7 +250,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidNumHeadersPartial() {
+    public void testInvalidNumHeadersPartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -296,7 +296,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidHeaderKeyPartial() {
+    public void testInvalidHeaderKeyPartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -343,7 +343,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testNullHeaderKeyPartial() {
+    public void testNullHeaderKeyPartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;
@@ -392,7 +392,7 @@ public class DefaultRecordTest {
     }
 
     @Test
-    public void testInvalidHeaderValuePartial() {
+    public void testInvalidHeaderValuePartial() throws IOException {
         byte attributes = 0;
         long timestampDelta = 2;
         int offsetDelta = 1;

--- a/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class EndTransactionMarkerTest {
 
@@ -35,12 +36,12 @@ public class EndTransactionMarkerTest {
         EndTransactionMarker.deserializeValue(ControlRecordType.UNKNOWN, ByteBuffer.wrap(new byte[0]));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testIllegalNegativeVersion() {
         ByteBuffer buffer = ByteBuffer.allocate(2);
         buffer.putShort((short) -1);
         buffer.flip();
-        EndTransactionMarker.deserializeValue(ControlRecordType.ABORT, buffer);
+        assertThrows(InvalidRecordException.class, () -> EndTransactionMarker.deserializeValue(ControlRecordType.ABORT, buffer));
     }
 
     @Test(expected = InvalidRecordException.class)

--- a/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
@@ -26,14 +26,16 @@ import static org.junit.Assert.assertThrows;
 
 public class EndTransactionMarkerTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUnknownControlTypeNotAllowed() {
-        new EndTransactionMarker(ControlRecordType.UNKNOWN, 24);
+        assertThrows(IllegalArgumentException.class,
+            () -> new EndTransactionMarker(ControlRecordType.UNKNOWN, 24));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCannotDeserializeUnknownControlType() {
-        EndTransactionMarker.deserializeValue(ControlRecordType.UNKNOWN, ByteBuffer.wrap(new byte[0]));
+        assertThrows(IllegalArgumentException.class,
+            () -> EndTransactionMarker.deserializeValue(ControlRecordType.UNKNOWN, ByteBuffer.wrap(new byte[0])));
     }
 
     @Test
@@ -44,9 +46,10 @@ public class EndTransactionMarkerTest {
         assertThrows(InvalidRecordException.class, () -> EndTransactionMarker.deserializeValue(ControlRecordType.ABORT, buffer));
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testNotEnoughBytes() {
-        EndTransactionMarker.deserializeValue(ControlRecordType.COMMIT, ByteBuffer.wrap(new byte[0]));
+        assertThrows(InvalidRecordException.class,
+            () -> EndTransactionMarker.deserializeValue(ControlRecordType.COMMIT, ByteBuffer.wrap(new byte[0])));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -73,28 +74,29 @@ public class FileRecordsTest {
         this.time = new MockTime();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAppendProtectsFromOverflow() throws Exception {
         File fileMock = mock(File.class);
         FileChannel fileChannelMock = mock(FileChannel.class);
         when(fileChannelMock.size()).thenReturn((long) Integer.MAX_VALUE);
 
         FileRecords records = new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE, false);
-        append(records, values);
+        assertThrows(IllegalArgumentException.class, () -> append(records, values));
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testOpenOversizeFile() throws Exception {
         File fileMock = mock(File.class);
         FileChannel fileChannelMock = mock(FileChannel.class);
         when(fileChannelMock.size()).thenReturn(Integer.MAX_VALUE + 5L);
 
-        new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE, false);
+        assertThrows(KafkaException.class, () -> new FileRecords(fileMock, fileChannelMock, 0, Integer.MAX_VALUE, false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testOutOfRangeSlice() throws Exception {
-        this.fileRecords.slice(fileRecords.sizeInBytes() + 1, 15).sizeInBytes();
+    @Test
+    public void testOutOfRangeSlice() {
+        assertThrows(IllegalArgumentException.class,
+            () -> this.fileRecords.slice(fileRecords.sizeInBytes() + 1, 15).sizeInBytes());
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -94,7 +94,7 @@ public class FileRecordsTest {
     }
 
     @Test
-    public void testOutOfRangeSlice() {
+    public void testOutOfRangeSlice() throws Exception {
         assertThrows(IllegalArgumentException.class,
             () -> this.fileRecords.slice(fileRecords.sizeInBytes() + 1, 15).sizeInBytes());
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -94,7 +94,7 @@ public class FileRecordsTest {
     }
 
     @Test
-    public void testOutOfRangeSlice() throws Exception {
+    public void testOutOfRangeSlice() {
         assertThrows(IllegalArgumentException.class,
             () -> this.fileRecords.slice(fileRecords.sizeInBytes() + 1, 15).sizeInBytes());
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -101,7 +101,7 @@ public class MemoryRecordsBuilderTest {
         assertTrue(batches.get(0).isTransactional());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteTransactionalNotAllowedMagicV0() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -110,11 +110,12 @@ public class MemoryRecordsBuilderTest {
         short epoch = 15;
         int sequence = 2342;
 
-        new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V0, compressionType, TimestampType.CREATE_TIME,
-                0L, 0L, pid, epoch, sequence, true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
+        assertThrows(IllegalArgumentException.class, () -> new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V0,
+            compressionType, TimestampType.CREATE_TIME, 0L, 0L, pid, epoch, sequence,
+                true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteTransactionalNotAllowedMagicV1() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -123,11 +124,12 @@ public class MemoryRecordsBuilderTest {
         short epoch = 15;
         int sequence = 2342;
 
-        new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V1, compressionType, TimestampType.CREATE_TIME,
-                0L, 0L, pid, epoch, sequence, true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
+        assertThrows(IllegalArgumentException.class, () -> new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V1,
+            compressionType, TimestampType.CREATE_TIME, 0L, 0L, pid, epoch, sequence,
+            true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteControlBatchNotAllowedMagicV0() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -136,11 +138,12 @@ public class MemoryRecordsBuilderTest {
         short epoch = 15;
         int sequence = 2342;
 
-        new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V0, compressionType, TimestampType.CREATE_TIME,
-                0L, 0L, pid, epoch, sequence, false, true, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
+        assertThrows(IllegalArgumentException.class, () -> new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V0,
+            compressionType, TimestampType.CREATE_TIME, 0L, 0L, pid, epoch, sequence,
+                false, true, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteControlBatchNotAllowedMagicV1() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -149,11 +152,12 @@ public class MemoryRecordsBuilderTest {
         short epoch = 15;
         int sequence = 2342;
 
-        new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V1, compressionType, TimestampType.CREATE_TIME,
-                0L, 0L, pid, epoch, sequence, false, true, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
+        assertThrows(IllegalArgumentException.class, () -> new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V1,
+            compressionType, TimestampType.CREATE_TIME, 0L, 0L, pid, epoch, sequence,
+            false, true, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteTransactionalWithInvalidPID() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -164,10 +168,10 @@ public class MemoryRecordsBuilderTest {
 
         MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
                 0L, 0L, pid, epoch, sequence, true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
-        builder.close();
+        assertThrows(IllegalArgumentException.class, builder::close);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteIdempotentWithInvalidEpoch() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -178,10 +182,10 @@ public class MemoryRecordsBuilderTest {
 
         MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
                 0L, 0L, pid, epoch, sequence, true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
-        builder.close();
+        assertThrows(IllegalArgumentException.class, builder::close);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteIdempotentWithInvalidBaseSequence() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -192,10 +196,10 @@ public class MemoryRecordsBuilderTest {
 
         MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
                 0L, 0L, pid, epoch, sequence, true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
-        builder.close();
+        assertThrows(IllegalArgumentException.class, builder::close);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteEndTxnMarkerNonTransactionalBatch() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -206,10 +210,11 @@ public class MemoryRecordsBuilderTest {
 
         MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
                 0L, 0L, pid, epoch, sequence, false, true, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
-        builder.appendEndTxnMarker(RecordBatch.NO_TIMESTAMP, new EndTransactionMarker(ControlRecordType.ABORT, 0));
+        assertThrows(IllegalArgumentException.class, () -> builder.appendEndTxnMarker(RecordBatch.NO_TIMESTAMP,
+            new EndTransactionMarker(ControlRecordType.ABORT, 0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteEndTxnMarkerNonControlBatch() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -220,10 +225,11 @@ public class MemoryRecordsBuilderTest {
 
         MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
                 0L, 0L, pid, epoch, sequence, true, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
-        builder.appendEndTxnMarker(RecordBatch.NO_TIMESTAMP, new EndTransactionMarker(ControlRecordType.ABORT, 0));
+        assertThrows(IllegalArgumentException.class, () -> builder.appendEndTxnMarker(RecordBatch.NO_TIMESTAMP,
+                new EndTransactionMarker(ControlRecordType.ABORT, 0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteLeaderChangeControlBatchWithoutLeaderEpoch() {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         buffer.position(bufferOffset);
@@ -233,10 +239,10 @@ public class MemoryRecordsBuilderTest {
             0L, 0L,
             RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
             false, true, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
-        builder.appendLeaderChangeMessage(RecordBatch.NO_TIMESTAMP,
+        assertThrows(IllegalArgumentException.class, () -> builder.appendLeaderChangeMessage(RecordBatch.NO_TIMESTAMP,
             new LeaderChangeMessage()
                 .setLeaderId(leaderId)
-                .setVoters(Collections.emptyList()));
+                .setVoters(Collections.emptyList())));
     }
 
     @Test
@@ -504,20 +510,21 @@ public class MemoryRecordsBuilderTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAppendAtInvalidOffset() {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         buffer.position(bufferOffset);
 
         long logAppendTime = System.currentTimeMillis();
-        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V1, compressionType,
+        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.MAGIC_VALUE_V2, compressionType,
                 TimestampType.CREATE_TIME, 0L, logAppendTime, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
                 false, false, RecordBatch.NO_PARTITION_LEADER_EPOCH, buffer.capacity());
 
         builder.appendWithOffset(0L, System.currentTimeMillis(), "a".getBytes(), null);
 
         // offsets must increase monotonically
-        builder.appendWithOffset(0L, System.currentTimeMillis(), "b".getBytes(), null);
+        assertThrows(IllegalArgumentException.class, () -> builder.appendWithOffset(0L, System.currentTimeMillis(),
+            "b".getBytes(), null));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/SimpleLegacyRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/SimpleLegacyRecordTest.java
@@ -27,11 +27,11 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class SimpleLegacyRecordTest {
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testCompressedIterationWithNullValue() throws Exception {
         ByteBuffer buffer = ByteBuffer.allocate(128);
         DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer));
@@ -40,13 +40,11 @@ public class SimpleLegacyRecordTest {
                 CompressionType.GZIP, TimestampType.CREATE_TIME);
 
         buffer.flip();
-
         MemoryRecords records = MemoryRecords.readableRecords(buffer);
-        if (records.records().iterator().hasNext())
-            fail("Iteration should have caused invalid record error");
+        assertThrows(InvalidRecordException.class, () -> records.records().iterator().hasNext());
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testCompressedIterationWithEmptyRecords() throws Exception {
         ByteBuffer emptyCompressedValue = ByteBuffer.allocate(64);
         OutputStream gzipOutput = CompressionType.GZIP.wrapForOutput(new ByteBufferOutputStream(emptyCompressedValue),
@@ -63,27 +61,27 @@ public class SimpleLegacyRecordTest {
         buffer.flip();
 
         MemoryRecords records = MemoryRecords.readableRecords(buffer);
-        if (records.records().iterator().hasNext())
-            fail("Iteration should have caused invalid record error");
+        assertThrows(InvalidRecordException.class, () -> records.records().iterator().hasNext());
     }
 
     /* This scenario can happen if the record size field is corrupt and we end up allocating a buffer that is too small */
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void testIsValidWithTooSmallBuffer() {
         ByteBuffer buffer = ByteBuffer.allocate(2);
         LegacyRecord record = new LegacyRecord(buffer);
         assertFalse(record.isValid());
-        record.ensureValid();
+        assertThrows(CorruptRecordException.class, record::ensureValid);
+
     }
 
-    @Test(expected = CorruptRecordException.class)
+    @Test
     public void testIsValidWithChecksumMismatch() {
         ByteBuffer buffer = ByteBuffer.allocate(4);
         // set checksum
         buffer.putInt(2);
         LegacyRecord record = new LegacyRecord(buffer);
         assertFalse(record.isValid());
-        record.ensureValid();
+        assertThrows(CorruptRecordException.class, record::ensureValid);
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/CreateAclsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/CreateAclsRequestTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class CreateAclsRequestTest {
     private static final short V0 = 0;
@@ -51,14 +52,14 @@ public class CreateAclsRequestTest {
     private static final AclBinding UNKNOWN_ACL1 = new AclBinding(new ResourcePattern(ResourceType.UNKNOWN, "unknown", PatternType.LITERAL),
         new AccessControlEntry("User:*", "127.0.0.1", AclOperation.CREATE, AclPermissionType.ALLOW));
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void shouldThrowOnV0IfNotLiteral() {
-        new CreateAclsRequest(data(PREFIXED_ACL1), V0);
+        assertThrows(UnsupportedVersionException.class, () -> new CreateAclsRequest(data(PREFIXED_ACL1), V0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowOnIfUnknown() {
-        new CreateAclsRequest(data(UNKNOWN_ACL1), V0);
+        assertThrows(IllegalArgumentException.class, () -> new CreateAclsRequest(data(UNKNOWN_ACL1), V0));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsResponseTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class DeleteGroupsResponseTest {
 
@@ -67,9 +68,9 @@ public class DeleteGroupsResponseTest {
         assertEquals(expectedErrorCounts, deleteGroupsResponse.errorCounts());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetErrorWithInvalidGroupId() {
-        deleteGroupsResponse.get("invalid-group-id");
+        assertThrows(IllegalArgumentException.class, () -> deleteGroupsResponse.get("invalid-group-id"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsResponseTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class DescribeAclsResponseTest {
     private static final short V0 = 0;
@@ -80,14 +81,16 @@ public class DescribeAclsResponseTest {
             PatternType.LITERAL,
             Collections.singletonList(DENY_READ_ACL));
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void shouldThrowOnV0IfNotLiteral() {
-        buildResponse(10, Errors.NONE, Collections.singletonList(PREFIXED_ACL1)).serialize(V0);
+        assertThrows(UnsupportedVersionException.class,
+            () -> buildResponse(10, Errors.NONE, Collections.singletonList(PREFIXED_ACL1)).serialize(V0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfUnknown() {
-        buildResponse(10, Errors.NONE, Collections.singletonList(UNKNOWN_ACL)).serialize(V0);
+        assertThrows(IllegalArgumentException.class,
+            () -> buildResponse(10, Errors.NONE, Collections.singletonList(UNKNOWN_ACL)).serialize(V0));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/HeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/HeartbeatRequestTest.java
@@ -20,15 +20,17 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.HeartbeatRequestData;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public class HeartbeatRequestTest {
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testRequestVersionCompatibilityFailBuild() {
-        new HeartbeatRequest.Builder(
-                new HeartbeatRequestData()
-                        .setGroupId("groupId")
-                        .setMemberId("consumerId")
-                        .setGroupInstanceId("groupInstanceId")
-        ).build((short) 2);
+        assertThrows(UnsupportedVersionException.class, () -> new HeartbeatRequest.Builder(
+            new HeartbeatRequestData()
+                .setGroupId("groupId")
+                .setMemberId("consumerId")
+                .setGroupInstanceId("groupInstanceId")
+        ).build((short) 2));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class JoinGroupRequestTest {
@@ -68,15 +69,15 @@ public class JoinGroupRequestTest {
         }
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testRequestVersionCompatibilityFailBuild() {
-        new JoinGroupRequest.Builder(
-                new JoinGroupRequestData()
-                        .setGroupId("groupId")
-                        .setMemberId("consumerId")
-                        .setGroupInstanceId("groupInstanceId")
-                        .setProtocolType("consumer")
-        ).build((short) 4);
+        assertThrows(UnsupportedVersionException.class, () -> new JoinGroupRequest.Builder(
+            new JoinGroupRequestData()
+                .setGroupId("groupId")
+                .setMemberId("consumerId")
+                .setGroupInstanceId("groupInstanceId")
+                .setProtocolType("consumer")
+        ).build((short) 4));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupRequestTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -121,8 +122,9 @@ public class LeaveGroupRequestTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuildEmptyMembers() {
-        new LeaveGroupRequest.Builder(groupId, Collections.emptyList());
+        assertThrows(IllegalArgumentException.class,
+            () -> new LeaveGroupRequest.Builder(groupId, Collections.emptyList()));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -617,13 +617,13 @@ public class RequestResponseTest {
         }
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void cannotUseFindCoordinatorV0ToFindTransactionCoordinator() {
         FindCoordinatorRequest.Builder builder = new FindCoordinatorRequest.Builder(
                 new FindCoordinatorRequestData()
                     .setKeyType(CoordinatorType.TRANSACTION.id)
                     .setKey("foobar"));
-        builder.build((short) 0);
+        assertThrows(UnsupportedVersionException.class, () -> builder.build((short) 0));
     }
 
     @Test
@@ -782,9 +782,10 @@ public class RequestResponseTest {
         assertEquals(response.data().remainingPartitions(), deserialized.data().remainingPartitions());
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testCreateTopicRequestV0FailsIfValidateOnly() {
-        createCreateTopicRequest(0, true);
+        assertThrows(UnsupportedVersionException.class,
+            () -> createCreateTopicRequest(0, true));
     }
 
     @Test
@@ -908,11 +909,11 @@ public class RequestResponseTest {
         assertTrue(request.isValid());
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testListGroupRequestV3FailsWithStates() {
         ListGroupsRequestData data = new ListGroupsRequestData()
                 .setStatesFilter(asList(ConsumerGroupState.STABLE.name()));
-        new ListGroupsRequest.Builder(data).build((short) 3);
+        assertThrows(UnsupportedVersionException.class, () -> new ListGroupsRequest.Builder(data).build((short) 3));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/SyncGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/SyncGroupRequestTest.java
@@ -20,15 +20,17 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
+
 public class SyncGroupRequestTest {
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     public void testRequestVersionCompatibilityFailBuild() {
-        new SyncGroupRequest.Builder(
-                new SyncGroupRequestData()
-                        .setGroupId("groupId")
-                        .setMemberId("consumerId")
-                        .setGroupInstanceId("groupInstanceId")
-        ).build((short) 2);
+        assertThrows(UnsupportedVersionException.class, () -> new SyncGroupRequest.Builder(
+            new SyncGroupRequestData()
+                .setGroupId("groupId")
+                .setMemberId("consumerId")
+                .setGroupInstanceId("groupInstanceId")
+        ).build((short) 2));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -32,6 +32,7 @@ import javax.security.auth.login.Configuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import org.apache.kafka.common.config.SaslConfigs;
@@ -217,11 +218,11 @@ public class JaasContextTest {
             Collections.emptyMap());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLoadForServerWithWrongListenerName() throws IOException {
         writeConfiguration("Server", "test.LoginModule required;");
-        JaasContext.loadServerContext(new ListenerName("plaintext"), "SOME-MECHANISM",
-            Collections.emptyMap());
+        assertThrows(IllegalArgumentException.class, () -> JaasContext.loadServerContext(new ListenerName("plaintext"),
+                "SOME-MECHANISM", Collections.emptyMap()));
     }
 
     private AppConfigurationEntry configurationEntry(JaasContext.Type contextType, String jaasConfigProp) {

--- a/clients/src/test/java/org/apache/kafka/common/security/SaslExtensionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/SaslExtensionsTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class SaslExtensionsTest {
     Map<String, String> map;
@@ -35,10 +36,10 @@ public class SaslExtensionsTest {
         this.map.put("who", "me");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testReturnedMapIsImmutable() {
         SaslExtensions extensions = new SaslExtensions(this.map);
-        extensions.map().put("hello", "test");
+        assertThrows(UnsupportedOperationException.class, () -> extensions.map().put("hello", "test"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -125,7 +125,6 @@ import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandl
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -1606,9 +1605,9 @@ public class SaslAuthenticatorTest {
         ListOffsetsResponse response = new ListOffsetsResponse(data);
         ByteBuffer buffer = RequestTestUtils.serializeResponseWithHeader(response, LIST_OFFSETS.latestVersion(), 0);
         final RequestHeader header0 = new RequestHeader(LIST_OFFSETS, LIST_OFFSETS.latestVersion(), "id", SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID);
-        Assert.assertThrows(SchemaException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header0));
+        assertThrows(SchemaException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header0));
         final RequestHeader header1 = new RequestHeader(LIST_OFFSETS, LIST_OFFSETS.latestVersion(), "id", 1);
-        Assert.assertThrows(IllegalStateException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header1));
+        assertThrows(IllegalStateException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header1));
     }
     
     /**

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -125,6 +125,7 @@ import org.apache.kafka.common.security.plain.internals.PlainServerCallbackHandl
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -1605,9 +1606,9 @@ public class SaslAuthenticatorTest {
         ListOffsetsResponse response = new ListOffsetsResponse(data);
         ByteBuffer buffer = RequestTestUtils.serializeResponseWithHeader(response, LIST_OFFSETS.latestVersion(), 0);
         final RequestHeader header0 = new RequestHeader(LIST_OFFSETS, LIST_OFFSETS.latestVersion(), "id", SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID);
-        assertThrows(SchemaException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header0));
+        Assert.assertThrows(SchemaException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header0));
         final RequestHeader header1 = new RequestHeader(LIST_OFFSETS, LIST_OFFSETS.latestVersion(), "id", 1);
-        assertThrows(IllegalStateException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header1));
+        Assert.assertThrows(IllegalStateException.class, () -> NetworkClient.parseResponse(buffer.duplicate(), header1));
     }
     
     /**

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -69,6 +69,7 @@ public class SaslServerAuthenticatorTest {
             return 4;
         });
         assertThrows(InvalidReceiveException.class, authenticator::authenticate);
+        verify(transportLayer).read(any(ByteBuffer.class));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -46,6 +46,7 @@ import org.mockito.Answers;
 
 import static org.apache.kafka.common.security.scram.internals.ScramMechanism.SCRAM_SHA_256;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -55,7 +56,7 @@ import static org.mockito.Mockito.when;
 
 public class SaslServerAuthenticatorTest {
 
-    @Test(expected = InvalidReceiveException.class)
+    @Test
     public void testOversizeRequest() throws IOException {
         TransportLayer transportLayer = mock(TransportLayer.class);
         Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
@@ -67,8 +68,7 @@ public class SaslServerAuthenticatorTest {
             invocation.<ByteBuffer>getArgument(0).putInt(SaslServerAuthenticator.MAX_RECEIVE_SIZE + 1);
             return 4;
         });
-        authenticator.authenticate();
-        verify(transportLayer).read(any(ByteBuffer.class));
+        assertThrows(InvalidReceiveException.class, authenticator::authenticate);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerExtensionsValidatorCallbackTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerExtensionsValidatorCallbackTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class OAuthBearerExtensionsValidatorCallbackTest {
@@ -78,13 +79,13 @@ public class OAuthBearerExtensionsValidatorCallbackTest {
         assertEquals("nothing", callback.ignoredExtensions().get("nothing"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCannotValidateExtensionWhichWasNotGiven() {
         Map<String, String> extensions = new HashMap<>();
         extensions.put("hello", "bye");
 
         OAuthBearerExtensionsValidatorCallback callback = new OAuthBearerExtensionsValidatorCallback(TOKEN, new SaslExtensions(extensions));
 
-        callback.valid("???");
+        assertThrows(IllegalArgumentException.class, () -> callback.valid("???"));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.security.oauthbearer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -61,18 +62,17 @@ public class OAuthBearerSaslClienCallbackHandlerTest {
         };
     }
 
-    @Test(expected = IOException.class)
-    public void testWithZeroTokens() throws Throwable {
+    @Test
+    public void testWithZeroTokens() {
         OAuthBearerSaslClientCallbackHandler handler = createCallbackHandler();
-        try {
-            Subject.doAs(new Subject(), (PrivilegedExceptionAction<Void>) () -> {
+        PrivilegedActionException e = assertThrows(PrivilegedActionException.class, () -> Subject.doAs(new Subject(),
+            (PrivilegedExceptionAction<Void>) () -> {
                 OAuthBearerTokenCallback callback = new OAuthBearerTokenCallback();
                 handler.handle(new Callback[] {callback});
                 return null;
-            });
-        } catch (PrivilegedActionException e) {
-            throw e.getCause();
-        }
+            }
+        ));
+        assertEquals(IOException.class, e.getCause().getClass());
     }
 
     @Test()

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
@@ -63,7 +63,7 @@ public class OAuthBearerSaslClienCallbackHandlerTest {
     }
 
     @Test
-    public void testWithZeroTokens() throws Throwable {
+    public void testWithZeroTokens() {
         OAuthBearerSaslClientCallbackHandler handler = createCallbackHandler();
         PrivilegedActionException e = assertThrows(PrivilegedActionException.class, () -> Subject.doAs(new Subject(),
             (PrivilegedExceptionAction<Void>) () -> {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
@@ -63,7 +63,7 @@ public class OAuthBearerSaslClienCallbackHandlerTest {
     }
 
     @Test
-    public void testWithZeroTokens() {
+    public void testWithZeroTokens() throws Throwable {
         OAuthBearerSaslClientCallbackHandler handler = createCallbackHandler();
         PrivilegedActionException e = assertThrows(PrivilegedActionException.class, () -> Subject.doAs(new Subject(),
             (PrivilegedExceptionAction<Void>) () -> {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.security.oauthbearer.internals;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.kafka.common.security.auth.SaslExtensions;
@@ -55,11 +56,11 @@ public class OAuthBearerClientInitialResponseTest {
         assertEquals(serverMessage, message);
     }
 
-    @Test(expected = SaslException.class)
+    @Test
     public void testThrowsSaslExceptionOnInvalidExtensionKey() throws Exception {
         Map<String, String> extensions = new HashMap<>();
         extensions.put("19", "42"); // keys can only be a-z
-        new OAuthBearerClientInitialResponse("123.345.567", new SaslExtensions(extensions));
+        assertThrows(SaslException.class, () -> new OAuthBearerClientInitialResponse("123.345.567", new SaslExtensions(extensions)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.security.oauthbearer.internals;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
 
@@ -154,8 +155,8 @@ public class OAuthBearerSaslServerTest {
      * If the callback handler handles the `OAuthBearerExtensionsValidatorCallback`
      *  and finds an invalid extension, SaslServer should throw an authentication exception
      */
-    @Test(expected = SaslAuthenticationException.class)
-    public void throwsAuthenticationExceptionOnInvalidExtensions() throws Exception {
+    @Test
+    public void throwsAuthenticationExceptionOnInvalidExtensions() {
         OAuthBearerUnsecuredValidatorCallbackHandler invalidHandler = new OAuthBearerUnsecuredValidatorCallbackHandler() {
             @Override
             public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
@@ -177,7 +178,8 @@ public class OAuthBearerSaslServerTest {
         customExtensions.put("firstKey", "value");
         customExtensions.put("secondKey", "value");
 
-        saslServer.evaluateResponse(clientInitialResponse(null, false, customExtensions));
+        assertThrows(SaslAuthenticationException.class,
+            () -> saslServer.evaluateResponse(clientInitialResponse(null, false, customExtensions)));
     }
 
     @Test
@@ -187,9 +189,10 @@ public class OAuthBearerSaslServerTest {
         assertTrue("Next challenge is not empty", nextChallenge.length == 0);
     }
 
-    @Test(expected = SaslAuthenticationException.class)
-    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
-        saslServer.evaluateResponse(clientInitialResponse(USER + "x"));
+    @Test
+    public void authorizatonIdNotEqualsAuthenticationId() {
+        assertThrows(SaslAuthenticationException.class,
+            () -> saslServer.evaluateResponse(clientInitialResponse(USER + "x")));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
@@ -190,7 +190,7 @@ public class OAuthBearerSaslServerTest {
     }
 
     @Test
-    public void authorizatonIdNotEqualsAuthenticationId() {
+    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
         assertThrows(SaslAuthenticationException.class,
             () -> saslServer.evaluateResponse(clientInitialResponse(USER + "x")));
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
@@ -190,7 +190,7 @@ public class OAuthBearerSaslServerTest {
     }
 
     @Test
-    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
+    public void authorizatonIdNotEqualsAuthenticationId() {
         assertThrows(SaslAuthenticationException.class,
             () -> saslServer.evaluateResponse(clientInitialResponse(USER + "x")));
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJwsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJwsTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -81,24 +82,26 @@ public class OAuthBearerUnsecuredJwsTest {
         assertEquals("", jws.splits().get(2));
     }
 
-    @Test(expected = OAuthBearerIllegalTokenException.class)
+    @Test
     public void missingPrincipal() {
         String subject = null;
         long issuedAt = 100;
         Long expirationTime = null;
         List<String> scope = Arrays.asList("scopeValue1", "scopeValue2");
         String validCompactSerialization = compactSerialization(subject, issuedAt, expirationTime, scope);
-        new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope");
+        assertThrows(OAuthBearerIllegalTokenException.class,
+            () -> new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope"));
     }
 
-    @Test(expected = OAuthBearerIllegalTokenException.class)
+    @Test
     public void blankPrincipalName() {
         String subject = "   ";
         long issuedAt = 100;
         long expirationTime = issuedAt + 60 * 60;
         List<String> scope = Arrays.asList("scopeValue1", "scopeValue2");
         String validCompactSerialization = compactSerialization(subject, issuedAt, expirationTime, scope);
-        new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope");
+        assertThrows(OAuthBearerIllegalTokenException.class,
+            () -> new OAuthBearerUnsecuredJws(validCompactSerialization, "sub", "scope"));
     }
 
     private static String compactSerialization(String subject, Long issuedAt, Long expirationTime, List<String> scope) {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -51,24 +52,24 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
         assertEquals("1", callback.extensions().map().get("testId"));
     }
 
-    @Test(expected = IOException.class)
-    public void throwsErrorOnInvalidExtensionName() throws IOException, UnsupportedCallbackException {
+    @Test
+    public void throwsErrorOnInvalidExtensionName() {
         Map<String, String> options = new HashMap<>();
         options.put("unsecuredLoginExtension_test.Id", "1");
         OAuthBearerUnsecuredLoginCallbackHandler callbackHandler = createCallbackHandler(options, new MockTime());
         SaslExtensionsCallback callback = new SaslExtensionsCallback();
 
-        callbackHandler.handle(new Callback[] {callback});
+        assertThrows(IOException.class, () -> callbackHandler.handle(new Callback[] {callback}));
     }
 
-    @Test(expected = IOException.class)
-    public void throwsErrorOnInvalidExtensionValue() throws IOException, UnsupportedCallbackException {
+    @Test
+    public void throwsErrorOnInvalidExtensionValue() {
         Map<String, String> options = new HashMap<>();
         options.put("unsecuredLoginExtension_testId", "Çalifornia");
         OAuthBearerUnsecuredLoginCallbackHandler callbackHandler = createCallbackHandler(options, new MockTime());
         SaslExtensionsCallback callback = new SaslExtensionsCallback();
 
-        callbackHandler.handle(new Callback[] {callback});
+        assertThrows(IOException.class, () -> callbackHandler.handle(new Callback[] {callback}));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
@@ -53,7 +53,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
     }
 
     @Test
-    public void throwsErrorOnInvalidExtensionName() {
+    public void throwsErrorOnInvalidExtensionName() throws IOException, UnsupportedCallbackException {
         Map<String, String> options = new HashMap<>();
         options.put("unsecuredLoginExtension_test.Id", "1");
         OAuthBearerUnsecuredLoginCallbackHandler callbackHandler = createCallbackHandler(options, new MockTime());
@@ -63,7 +63,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
     }
 
     @Test
-    public void throwsErrorOnInvalidExtensionValue() {
+    public void throwsErrorOnInvalidExtensionValue() throws IOException, UnsupportedCallbackException {
         Map<String, String> options = new HashMap<>();
         options.put("unsecuredLoginExtension_testId", "Çalifornia");
         OAuthBearerUnsecuredLoginCallbackHandler callbackHandler = createCallbackHandler(options, new MockTime());

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
@@ -53,7 +53,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
     }
 
     @Test
-    public void throwsErrorOnInvalidExtensionName() throws IOException, UnsupportedCallbackException {
+    public void throwsErrorOnInvalidExtensionName() {
         Map<String, String> options = new HashMap<>();
         options.put("unsecuredLoginExtension_test.Id", "1");
         OAuthBearerUnsecuredLoginCallbackHandler callbackHandler = createCallbackHandler(options, new MockTime());
@@ -63,7 +63,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
     }
 
     @Test
-    public void throwsErrorOnInvalidExtensionValue() throws IOException, UnsupportedCallbackException {
+    public void throwsErrorOnInvalidExtensionValue() {
         Map<String, String> options = new HashMap<>();
         options.put("unsecuredLoginExtension_testId", "Çalifornia");
         OAuthBearerUnsecuredLoginCallbackHandler callbackHandler = createCallbackHandler(options, new MockTime());

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -65,9 +65,9 @@ public class PlainSaslServerTest {
         assertEquals(0, nextChallenge.length);
     }
 
-    @Test(expected = SaslAuthenticationException.class)
-    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
-        saslServer.evaluateResponse(saslMessage(USER_B, USER_A, PASSWORD_A));
+    @Test
+    public void authorizatonIdNotEqualsAuthenticationId() {
+        assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(saslMessage(USER_B, USER_A, PASSWORD_A)));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -66,7 +66,7 @@ public class PlainSaslServerTest {
     }
 
     @Test
-    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
+    public void authorizatonIdNotEqualsAuthenticationId() {
         assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(saslMessage(USER_B, USER_A, PASSWORD_A)));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -66,7 +66,7 @@ public class PlainSaslServerTest {
     }
 
     @Test
-    public void authorizatonIdNotEqualsAuthenticationId() {
+    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
         assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(saslMessage(USER_B, USER_A, PASSWORD_A)));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
@@ -63,9 +63,9 @@ public class ScramCredentialUtilsTest {
         assertNotEquals(ScramCredentialUtils.credentialToString(credential1), ScramCredentialUtils.credentialToString(credential2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void invalidCredential() {
-        ScramCredentialUtils.credentialFromString("abc");
+        assertThrows(IllegalArgumentException.class, () -> ScramCredentialUtils.credentialFromString("abc"));
     }
 
     @Test
@@ -74,10 +74,10 @@ public class ScramCredentialUtilsTest {
         assertThrows(IllegalArgumentException.class, () -> ScramCredentialUtils.credentialFromString(cred.substring(cred.indexOf(','))));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void extraneousFields() {
         String cred = ScramCredentialUtils.credentialToString(formatter.generateCredential("password", 2048));
-        ScramCredentialUtils.credentialFromString(cred + ",a=test");
+        assertThrows(IllegalArgumentException.class, () -> ScramCredentialUtils.credentialFromString(cred + ",a=test"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 
@@ -67,10 +68,10 @@ public class ScramCredentialUtilsTest {
         ScramCredentialUtils.credentialFromString("abc");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void missingFields() {
         String cred = ScramCredentialUtils.credentialToString(formatter.generateCredential("password", 2048));
-        ScramCredentialUtils.credentialFromString(cred.substring(cred.indexOf(',')));
+        assertThrows(IllegalArgumentException.class, () -> ScramCredentialUtils.credentialFromString(cred.substring(cred.indexOf(','))));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
@@ -27,6 +27,8 @@ import org.apache.kafka.common.security.token.delegation.internals.DelegationTok
 
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ScramSaslServerTest {
@@ -61,9 +63,9 @@ public class ScramSaslServerTest {
         assertTrue("Next challenge is empty", nextChallenge.length > 0);
     }
 
-    @Test(expected = SaslAuthenticationException.class)
-    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
-        saslServer.evaluateResponse(clientFirstMessage(USER_A, USER_B));
+    @Test
+    public void authorizatonIdNotEqualsAuthenticationId() {
+        assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(clientFirstMessage(USER_A, USER_B)));
     }
 
     private byte[] clientFirstMessage(String userName, String authorizationId) {

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
@@ -64,7 +64,7 @@ public class ScramSaslServerTest {
     }
 
     @Test
-    public void authorizatonIdNotEqualsAuthenticationId() {
+    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
         assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(clientFirstMessage(USER_A, USER_B)));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
@@ -64,7 +64,7 @@ public class ScramSaslServerTest {
     }
 
     @Test
-    public void authorizatonIdNotEqualsAuthenticationId() throws Exception {
+    public void authorizatonIdNotEqualsAuthenticationId() {
         assertThrows(SaslAuthenticationException.class, () -> saslServer.evaluateResponse(clientFirstMessage(USER_A, USER_B)));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -57,6 +57,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.security.Security;
@@ -111,7 +112,7 @@ public class SslFactoryTest {
         Security.removeProvider(testProviderCreator.getProvider().getName());
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testSslFactoryWithoutProviderClassConfiguration() {
         // An exception is thrown as the algorithm is not registered through a provider
         Map<String, Object> serverSslConfig = TestSslUtils.createSslConfig(
@@ -120,10 +121,10 @@ public class SslFactoryTest {
                 tlsProtocol
         );
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
-        sslFactory.configure(serverSslConfig);
+        assertThrows(KafkaException.class, () -> sslFactory.configure(serverSslConfig));
     }
 
-    @Test(expected = KafkaException.class)
+    @Test
     public void testSslFactoryWithIncorrectProviderClassConfiguration() {
         // An exception is thrown as the algorithm is not registered through a provider
         Map<String, Object> serverSslConfig = TestSslUtils.createSslConfig(
@@ -134,7 +135,7 @@ public class SslFactoryTest {
         serverSslConfig.put(SecurityConfig.SECURITY_PROVIDERS_CONFIG,
                 "com.fake.ProviderClass1,com.fake.ProviderClass2");
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
-        sslFactory.configure(serverSslConfig);
+        assertThrows(KafkaException.class, () -> sslFactory.configure(serverSslConfig));
     }
 
     @Test
@@ -518,7 +519,7 @@ public class SslFactoryTest {
     /**
      * Tests invalid ssl.engine.factory configuration
      */
-    @Test(expected = ClassCastException.class)
+    @Test
     public void testInvalidSslEngineFactory() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
         Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
@@ -527,7 +528,7 @@ public class SslFactoryTest {
                 .build();
         clientSslConfig.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, String.class);
         SslFactory sslFactory = new SslFactory(Mode.CLIENT);
-        sslFactory.configure(clientSslConfig);
+        assertThrows(ClassCastException.class, () -> sslFactory.configure(clientSslConfig));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class SerializationTest {
 
@@ -79,15 +80,15 @@ public class SerializationTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSerdeFromUnknown() {
-        Serdes.serdeFrom(DummyClass.class);
+        assertThrows(IllegalArgumentException.class, () -> Serdes.serdeFrom(DummyClass.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSerdeFromNotNull() {
         try (Serde<Long> serde = Serdes.Long()) {
-            Serdes.serdeFrom(null, serde.deserializer());
+            assertThrows(IllegalArgumentException.class, () -> Serdes.serdeFrom(null, serde.deserializer()));
         }
     }
 
@@ -107,25 +108,25 @@ public class SerializationTest {
         }
     }
 
-    @Test(expected = SerializationException.class)
+    @Test
     public void floatDeserializerShouldThrowSerializationExceptionOnZeroBytes() {
         try (Serde<Float> serde = Serdes.Float()) {
-            serde.deserializer().deserialize(topic, new byte[0]);
+            assertThrows(SerializationException.class, () -> serde.deserializer().deserialize(topic, new byte[0]));
         }
     }
 
-    @Test(expected = SerializationException.class)
+    @Test
     public void floatDeserializerShouldThrowSerializationExceptionOnTooFewBytes() {
         try (Serde<Float> serde = Serdes.Float()) {
-            serde.deserializer().deserialize(topic, new byte[3]);
+            assertThrows(SerializationException.class, () -> serde.deserializer().deserialize(topic, new byte[3]));
         }
     }
 
 
-    @Test(expected = SerializationException.class)
+    @Test
     public void floatDeserializerShouldThrowSerializationExceptionOnTooManyBytes() {
         try (Serde<Float> serde = Serdes.Float()) {
-            serde.deserializer().deserialize(topic, new byte[5]);
+            assertThrows(SerializationException.class, () -> serde.deserializer().deserialize(topic, new byte[5]));
         }
     }
 
@@ -161,10 +162,10 @@ public class SerializationTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void voidDeserializerShouldThrowOnNotNullValues() {
         try (Serde<Void> serde = Serdes.Void()) {
-            serde.deserializer().deserialize(topic, new byte[5]);
+            assertThrows(IllegalArgumentException.class, () -> serde.deserializer().deserialize(topic, new byte[5]));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/AbstractIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/AbstractIteratorTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -46,10 +47,10 @@ public class AbstractIteratorTest {
         assertFalse(iter.hasNext());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testEmptyIterator() {
-        Iterator<Object> iter = new ListIterator<Object>(Collections.emptyList());
-        iter.next();
+        Iterator<Object> iter = new ListIterator<>(Collections.emptyList());
+        assertThrows(NoSuchElementException.class, iter::next);
     }
 
     static class ListIterator<T> extends AbstractIterator<T> {

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ByteUtilsTest {
     private final byte x00 = 0x00;
@@ -207,18 +208,18 @@ public class ByteUtilsTest {
         assertVarlongSerde(Long.MIN_VALUE, new byte[] {xFF, xFF, xFF, xFF, xFF, xFF, xFF, xFF, xFF, x01});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidVarint() {
         // varint encoding has one overflow byte
         ByteBuffer buf = ByteBuffer.wrap(new byte[] {xFF, xFF, xFF, xFF, xFF, x01});
-        ByteUtils.readVarint(buf);
+        assertThrows(IllegalArgumentException.class, () -> ByteUtils.readVarint(buf));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidVarlong() {
         // varlong encoding has one overflow byte
         ByteBuffer buf = ByteBuffer.wrap(new byte[] {xFF, xFF, xFF, xFF, xFF, xFF, xFF, xFF, xFF, xFF, x01});
-        ByteUtils.readVarlong(buf);
+        assertThrows(IllegalArgumentException.class, () -> ByteUtils.readVarlong(buf));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 /**
  * A unit test for ImplicitLinkedHashCollection.
@@ -594,8 +595,7 @@ public class ImplicitLinkedHashCollectionTest {
         assertTrue(coll.add(e3));
         coll.moveToEnd(e1);
         expectTraversal(coll.iterator(), 2, 3, 1);
-        Assert.assertThrows(RuntimeException.class, () ->
-            coll.moveToEnd(new TestElement(4, 4)));
+        assertThrows(RuntimeException.class, () -> coll.moveToEnd(new TestElement(4, 4)));
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/connector/ConnectorReconfigurationTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/connector/ConnectorReconfigurationTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.connector;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.errors.ConnectException;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ConnectorReconfigurationTest {
 
@@ -36,10 +38,10 @@ public class ConnectorReconfigurationTest {
         assertEquals(conn.configureOrder, 1);
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testReconfigureStopException() {
         TestConnector conn = new TestConnector(true);
-        conn.reconfigure(Collections.<String, String>emptyMap());
+        assertThrows(ConnectException.class, () -> conn.reconfigure(Collections.emptyMap()));
     }
 
     private static class TestConnector extends Connector {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class ConnectSchemaTest {
     private static final Schema MAP_INT_STRING_SCHEMA = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.STRING_SCHEMA).build();
@@ -66,9 +67,10 @@ public class ConnectSchemaTest {
     }
 
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFieldsOnlyValidForStructs() {
-        Schema.INT8_SCHEMA.fields();
+        assertThrows(DataException.class,
+            () -> Schema.INT8_SCHEMA.fields());
     }
 
     @Test
@@ -109,128 +111,140 @@ public class ConnectSchemaTest {
     // To avoid requiring excessive numbers of tests, these checks for invalid types use a similar type where possible
     // to only include a single test for each type
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchInt8() {
-        ConnectSchema.validateValue(Schema.INT8_SCHEMA, 1);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.INT8_SCHEMA, 1));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchInt16() {
-        ConnectSchema.validateValue(Schema.INT16_SCHEMA, 1);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.INT16_SCHEMA, 1));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchInt32() {
-        ConnectSchema.validateValue(Schema.INT32_SCHEMA, (long) 1);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.INT32_SCHEMA, (long) 1));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchInt64() {
-        ConnectSchema.validateValue(Schema.INT64_SCHEMA, 1);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.INT64_SCHEMA, 1));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchFloat() {
-        ConnectSchema.validateValue(Schema.FLOAT32_SCHEMA, 1.0);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.FLOAT32_SCHEMA, 1.0));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchDouble() {
-        ConnectSchema.validateValue(Schema.FLOAT64_SCHEMA, 1.f);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.FLOAT64_SCHEMA, 1.f));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchBoolean() {
-        ConnectSchema.validateValue(Schema.BOOLEAN_SCHEMA, 1.f);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.BOOLEAN_SCHEMA, 1.f));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchString() {
         // CharSequence is a similar type (supertype of String), but we restrict to String.
         CharBuffer cbuf = CharBuffer.wrap("abc");
-        ConnectSchema.validateValue(Schema.STRING_SCHEMA, cbuf);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.STRING_SCHEMA, cbuf));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchBytes() {
-        ConnectSchema.validateValue(Schema.BYTES_SCHEMA, new Object[]{1, "foo"});
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(Schema.BYTES_SCHEMA, new Object[]{1, "foo"}));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchArray() {
-        ConnectSchema.validateValue(SchemaBuilder.array(Schema.INT32_SCHEMA).build(), Arrays.asList("a", "b", "c"));
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(SchemaBuilder.array(Schema.INT32_SCHEMA).build(), Arrays.asList("a", "b", "c")));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchArraySomeMatch() {
         // Even if some match the right type, this should fail if any mismatch. In this case, type erasure loses
         // the fact that the list is actually List<Object>, but we couldn't tell if only checking the first element
-        ConnectSchema.validateValue(SchemaBuilder.array(Schema.INT32_SCHEMA).build(), Arrays.asList(1, 2, "c"));
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(SchemaBuilder.array(Schema.INT32_SCHEMA).build(), Arrays.asList(1, 2, "c")));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchMapKey() {
-        ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, Collections.singletonMap("wrong key type", "value"));
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, Collections.singletonMap("wrong key type", "value")));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchMapValue() {
-        ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, Collections.singletonMap(1, 2));
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, Collections.singletonMap(1, 2)));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchMapSomeKeys() {
         Map<Object, String> data = new HashMap<>();
         data.put(1, "abc");
         data.put("wrong", "it's as easy as one two three");
-        ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, data);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, data));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchMapSomeValues() {
         Map<Integer, Object> data = new HashMap<>();
         data.put(1, "abc");
         data.put(2, "wrong".getBytes());
-        ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, data);
+        assertThrows(DataException.class,
+            () -> ConnectSchema.validateValue(MAP_INT_STRING_SCHEMA, data));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchStructWrongSchema() {
         // Completely mismatching schemas
-        ConnectSchema.validateValue(
-                FLAT_STRUCT_SCHEMA,
-                new Struct(SchemaBuilder.struct().field("x", Schema.INT32_SCHEMA).build()).put("x", 1)
-        );
+        assertThrows(DataException.class, () -> ConnectSchema.validateValue(FLAT_STRUCT_SCHEMA,
+            new Struct(SchemaBuilder.struct().field("x", Schema.INT32_SCHEMA).build()).put("x", 1)));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchStructWrongNestedSchema() {
         // Top-level schema  matches, but nested does not.
-        ConnectSchema.validateValue(
-                PARENT_STRUCT_SCHEMA,
-                new Struct(PARENT_STRUCT_SCHEMA)
-                        .put("nested", new Struct(SchemaBuilder.struct().field("x", Schema.INT32_SCHEMA).build()).put("x", 1))
-        );
+        assertThrows(DataException.class, () -> ConnectSchema.validateValue(PARENT_STRUCT_SCHEMA,
+            new Struct(PARENT_STRUCT_SCHEMA)
+                .put("nested", new Struct(SchemaBuilder.struct()
+                    .field("x", Schema.INT32_SCHEMA).build()).put("x", 1))));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchDecimal() {
-        ConnectSchema.validateValue(Decimal.schema(2), new BigInteger("156"));
+        assertThrows(DataException.class, () -> ConnectSchema.validateValue(Decimal.schema(2), new BigInteger("156")));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchDate() {
-        ConnectSchema.validateValue(Date.SCHEMA, 1000L);
+        assertThrows(DataException.class, () -> ConnectSchema.validateValue(Date.SCHEMA, 1000L));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchTime() {
-        ConnectSchema.validateValue(Time.SCHEMA, 1000L);
+        assertThrows(DataException.class, () -> ConnectSchema.validateValue(Time.SCHEMA, 1000L));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testValidateValueMismatchTimestamp() {
-        ConnectSchema.validateValue(Timestamp.SCHEMA, 1000L);
+        assertThrows(DataException.class, () -> ConnectSchema.validateValue(Timestamp.SCHEMA, 1000L));
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DateTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DateTest.java
@@ -24,6 +24,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class DateTest {
     private static final GregorianCalendar EPOCH;
@@ -54,14 +55,16 @@ public class DateTest {
         assertEquals(10000, Date.fromLogical(Date.SCHEMA, EPOCH_PLUS_TEN_THOUSAND_DAYS.getTime()));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromLogicalInvalidSchema() {
-        Date.fromLogical(Date.builder().name("invalid").build(), EPOCH.getTime());
+        assertThrows(DataException.class,
+            () -> Date.fromLogical(Date.builder().name("invalid").build(), EPOCH.getTime()));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromLogicalInvalidHasTimeComponents() {
-        Date.fromLogical(Date.SCHEMA, EPOCH_PLUS_TIME_COMPONENT.getTime());
+        assertThrows(DataException.class,
+            () -> Date.fromLogical(Date.SCHEMA, EPOCH_PLUS_TIME_COMPONENT.getTime()));
     }
 
     @Test
@@ -70,8 +73,9 @@ public class DateTest {
         assertEquals(EPOCH_PLUS_TEN_THOUSAND_DAYS.getTime(), Date.toLogical(Date.SCHEMA, 10000));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testToLogicalInvalidSchema() {
-        Date.toLogical(Date.builder().name("invalid").build(), 0);
+        assertThrows(DataException.class,
+            () -> Date.toLogical(Date.builder().name("invalid").build(), 0));
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaBuilderTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class SchemaBuilderTest {
     private static final String NAME = "name";
@@ -47,9 +48,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testInt8BuilderInvalidDefault() {
-        SchemaBuilder.int8().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.int8().defaultValue("invalid"));
     }
 
     @Test
@@ -64,9 +65,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testInt16BuilderInvalidDefault() {
-        SchemaBuilder.int16().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.int16().defaultValue("invalid"));
     }
 
     @Test
@@ -81,9 +82,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testInt32BuilderInvalidDefault() {
-        SchemaBuilder.int32().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.int32().defaultValue("invalid"));
     }
 
     @Test
@@ -98,9 +99,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testInt64BuilderInvalidDefault() {
-        SchemaBuilder.int64().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.int64().defaultValue("invalid"));
     }
 
     @Test
@@ -115,9 +116,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testFloatBuilderInvalidDefault() {
-        SchemaBuilder.float32().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.float32().defaultValue("invalid"));
     }
 
     @Test
@@ -132,9 +133,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testDoubleBuilderInvalidDefault() {
-        SchemaBuilder.float64().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.float64().defaultValue("invalid"));
     }
 
     @Test
@@ -149,9 +150,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testBooleanBuilderInvalidDefault() {
-        SchemaBuilder.bool().defaultValue("invalid");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.bool().defaultValue("invalid"));
     }
 
     @Test
@@ -166,9 +167,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testStringBuilderInvalidDefault() {
-        SchemaBuilder.string().defaultValue(true);
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.string().defaultValue(true));
     }
 
     @Test
@@ -183,9 +184,9 @@ public class SchemaBuilderTest {
         assertMetadata(schema, NAME, VERSION, DOC, NO_PARAMS);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testBytesBuilderInvalidDefault() {
-        SchemaBuilder.bytes().defaultValue("a string, not bytes");
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.bytes().defaultValue("a string, not bytes"));
     }
 
 
@@ -222,9 +223,9 @@ public class SchemaBuilderTest {
         assertNoMetadata(schema);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testNonStructCantHaveFields() {
-        SchemaBuilder.int8().field("field", SchemaBuilder.int8().build());
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.int8().field("field", SchemaBuilder.int8().build()));
     }
 
 
@@ -243,10 +244,11 @@ public class SchemaBuilderTest {
         assertNoMetadata(schema);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testArrayBuilderInvalidDefault() {
         // Array, but wrong embedded type
-        SchemaBuilder.array(Schema.INT8_SCHEMA).defaultValue(Arrays.asList("string")).build();
+        assertThrows(SchemaBuilderException.class,
+            () -> SchemaBuilder.array(Schema.INT8_SCHEMA).defaultValue(Collections.singletonList("string")).build());
     }
 
     @Test
@@ -274,12 +276,12 @@ public class SchemaBuilderTest {
         assertNoMetadata(schema);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testMapBuilderInvalidDefault() {
         // Map, but wrong embedded type
         Map<Byte, String> defMap = Collections.singletonMap((byte) 5, "foo");
-        SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA)
-                .defaultValue(defMap).build();
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA)
+                .defaultValue(defMap).build());
     }
 
     @Test
@@ -293,16 +295,13 @@ public class SchemaBuilderTest {
         new Struct(emptyStructSchema);
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testDuplicateFields() {
-        final Schema schema = SchemaBuilder.struct()
-                .name("testing")
-                .field("id", SchemaBuilder.string().doc("").build())
-                .field("id", SchemaBuilder.string().doc("").build())
-                .build();
-        final Struct struct = new Struct(schema)
-                .put("id", "testing");
-        struct.validate();
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.struct()
+            .name("testing")
+            .field("id", SchemaBuilder.string().doc("").build())
+            .field("id", SchemaBuilder.string().doc("").build())
+            .build());
     }
 
     @Test
@@ -315,49 +314,44 @@ public class SchemaBuilderTest {
         assertEquals("testing", schemaBuilder.name());
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testDefaultFieldsDifferentValueOverwriting() {
         final SchemaBuilder schemaBuilder = SchemaBuilder.string().name("testing").version(123);
 
         schemaBuilder.name("testing");
-        schemaBuilder.version(456);
+        assertThrows(SchemaBuilderException.class, () -> schemaBuilder.version(456));
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testFieldNameNull() {
-        Schema schema = SchemaBuilder.struct()
-            .field(null, Schema.STRING_SCHEMA)
-            .build();
+        assertThrows(SchemaBuilderException.class,
+            () -> SchemaBuilder.struct().field(null, Schema.STRING_SCHEMA).build());
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testFieldSchemaNull() {
-        Schema schema = SchemaBuilder.struct()
-            .field("fieldName", null)
-            .build();
+        assertThrows(SchemaBuilderException.class,
+            () -> SchemaBuilder.struct().field("fieldName", null).build());
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testArraySchemaNull() {
-        Schema schema = SchemaBuilder.array(null)
-            .build();
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.array(null).build());
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testMapKeySchemaNull() {
-        Schema schema = SchemaBuilder.map(null, Schema.STRING_SCHEMA)
-            .build();
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.map(null, Schema.STRING_SCHEMA).build());
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testMapValueSchemaNull() {
-        Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, null)
-            .build();
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.map(Schema.STRING_SCHEMA, null).build());
     }
 
-    @Test(expected = SchemaBuilderException.class)
+    @Test
     public void testTypeNotNull() {
-        SchemaBuilder.type(null);
+        assertThrows(SchemaBuilderException.class, () -> SchemaBuilder.type(null));
     }
 
     private void assertTypeAndDefault(Schema schema, Schema.Type type, boolean optional, Object defaultValue) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class SchemaProjectorTest {
@@ -495,11 +496,11 @@ public class SchemaProjectorTest {
         assertEquals(null, ((Struct) SchemaProjector.project(source, new Struct(source), target)).getInt64("id"));
     }
 
-    @Test(expected = SchemaProjectorException.class)
+    @Test
     public void testProjectMissingRequiredField() {
         final Schema source = SchemaBuilder.struct().build();
         final Schema target = SchemaBuilder.struct().field("id", SchemaBuilder.INT64_SCHEMA).build();
-        SchemaProjector.project(source, new Struct(source), target);
+        assertThrows(SchemaProjectorException.class, () -> SchemaProjector.project(source, new Struct(source), target));
     }
 
     private void verifyOptionalProjection(Schema source, Type targetType, Object value, Object defaultValue, Object expectedProjected, boolean optional) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.data;
 
 import org.apache.kafka.connect.errors.DataException;
+
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -114,38 +115,43 @@ public class StructTest {
     // tests in SchemaTest. These are meant to ensure that we are invoking the same code path and that we do deeper
     // inspection than just checking the class of the object
 
-    @Test(expected = DataException.class)
+    @Test
     public void testInvalidFieldType() {
-        new Struct(FLAT_STRUCT_SCHEMA).put("int8", "should fail because this is a string, not int8");
+        assertThrows(DataException.class,
+            () -> new Struct(FLAT_STRUCT_SCHEMA).put("int8", "should fail because this is a string, not int8"));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testInvalidArrayFieldElements() {
-        new Struct(NESTED_SCHEMA).put("array", Arrays.asList("should fail since elements should be int8s"));
+        assertThrows(DataException.class,
+            () -> new Struct(NESTED_SCHEMA).put("array", Collections.singletonList("should fail since elements should be int8s")));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testInvalidMapKeyElements() {
-        new Struct(NESTED_SCHEMA).put("map", Collections.singletonMap("should fail because keys should be int8s", (byte) 12));
+        assertThrows(DataException.class,
+            () -> new Struct(NESTED_SCHEMA).put("map", Collections.singletonMap("should fail because keys should be int8s", (byte) 12)));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testInvalidStructFieldSchema() {
-        new Struct(NESTED_SCHEMA).put("nested", new Struct(MAP_SCHEMA));
+        assertThrows(DataException.class,
+            () -> new Struct(NESTED_SCHEMA).put("nested", new Struct(MAP_SCHEMA)));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testInvalidStructFieldValue() {
-        new Struct(NESTED_SCHEMA).put("nested", new Struct(NESTED_CHILD_SCHEMA));
+        assertThrows(DataException.class,
+            () -> new Struct(NESTED_SCHEMA).put("nested", new Struct(NESTED_CHILD_SCHEMA)));
     }
 
 
-    @Test(expected = DataException.class)
+    @Test
     public void testMissingFieldValidation() {
         // Required int8 field
         Schema schema = SchemaBuilder.struct().field("field", REQUIRED_FIELD_SCHEMA).build();
         Struct struct = new Struct(schema);
-        struct.validate();
+        assertThrows(DataException.class, struct::validate);
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.data;
 
 import org.apache.kafka.connect.errors.DataException;
+
 import org.junit.Test;
 
 import java.nio.ByteBuffer;

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.data;
 
 import org.apache.kafka.connect.errors.DataException;
-
 import org.junit.Test;
 
 import java.nio.ByteBuffer;

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimeTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimeTest.java
@@ -24,6 +24,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TimeTest {
     private static final GregorianCalendar EPOCH;
@@ -56,14 +57,16 @@ public class TimeTest {
         assertEquals(10000, Time.fromLogical(Time.SCHEMA, EPOCH_PLUS_TEN_THOUSAND_MILLIS.getTime()));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromLogicalInvalidSchema() {
-        Time.fromLogical(Time.builder().name("invalid").build(), EPOCH.getTime());
+        assertThrows(DataException.class,
+            () -> Time.fromLogical(Time.builder().name("invalid").build(), EPOCH.getTime()));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromLogicalInvalidHasDateComponents() {
-        Time.fromLogical(Time.SCHEMA, EPOCH_PLUS_DATE_COMPONENT.getTime());
+        assertThrows(DataException.class,
+            () -> Time.fromLogical(Time.SCHEMA, EPOCH_PLUS_DATE_COMPONENT.getTime()));
     }
 
     @Test
@@ -72,8 +75,9 @@ public class TimeTest {
         assertEquals(EPOCH_PLUS_TEN_THOUSAND_MILLIS.getTime(), Time.toLogical(Time.SCHEMA, 10000));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testToLogicalInvalidSchema() {
-        Time.toLogical(Time.builder().name("invalid").build(), 0);
+        assertThrows(DataException.class,
+            () -> Time.toLogical(Time.builder().name("invalid").build(), 0));
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampTest.java
@@ -24,6 +24,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TimestampTest {
     private static final GregorianCalendar EPOCH;
@@ -56,9 +57,10 @@ public class TimestampTest {
         assertEquals(TOTAL_MILLIS, Timestamp.fromLogical(Timestamp.SCHEMA, EPOCH_PLUS_MILLIS.getTime()));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromLogicalInvalidSchema() {
-        Timestamp.fromLogical(Timestamp.builder().name("invalid").build(), EPOCH.getTime());
+        assertThrows(DataException.class,
+            () -> Timestamp.fromLogical(Timestamp.builder().name("invalid").build(), EPOCH.getTime()));
     }
 
     @Test
@@ -67,8 +69,9 @@ public class TimestampTest {
         assertEquals(EPOCH_PLUS_MILLIS.getTime(), Timestamp.toLogical(Timestamp.SCHEMA, TOTAL_MILLIS));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testToLogicalInvalidSchema() {
-        Date.toLogical(Date.builder().name("invalid").build(), 0);
+        assertThrows(DataException.class,
+            () -> Date.toLogical(Date.builder().name("invalid").build(), 0));
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -257,9 +258,9 @@ public class ValuesTest {
         assertEquals(Boolean.TRUE, resultTrue.value());
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToParseInvalidBooleanValueString() {
-        Values.convertToBoolean(Schema.STRING_SCHEMA, "\"green\"");
+        assertThrows(DataException.class, () -> Values.convertToBoolean(Schema.STRING_SCHEMA, "\"green\""));
     }
 
     @Test
@@ -542,50 +543,53 @@ public class ValuesTest {
     /**
      * This is technically invalid JSON, and we don't want to simply ignore the blank elements.
      */
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToConvertToListFromStringWithExtraDelimiters() {
-        Values.convertToList(Schema.STRING_SCHEMA, "[1, 2, 3,,,]");
+        assertThrows(DataException.class, () -> Values.convertToList(Schema.STRING_SCHEMA, "[1, 2, 3,,,]"));
     }
 
     /**
      * Schema of type ARRAY requires a schema for the values, but Connect has no union or "any" schema type.
      * Therefore, we can't represent this.
      */
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToConvertToListFromStringWithNonCommonElementTypeAndBlankElement() {
-        Values.convertToList(Schema.STRING_SCHEMA, "[1, 2, 3, \"four\",,,]");
+        assertThrows(DataException.class, () -> Values.convertToList(Schema.STRING_SCHEMA, "[1, 2, 3, \"four\",,,]"));
     }
 
     /**
      * This is technically invalid JSON, and we don't want to simply ignore the blank entry.
      */
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToParseStringOfMapWithIntValuesWithBlankEntry() {
-        Values.convertToMap(Schema.STRING_SCHEMA, " { \"foo\" :  1234567890 ,, \"bar\" : 0,  \"baz\" : -987654321 }  ");
+        assertThrows(DataException.class,
+            () -> Values.convertToMap(Schema.STRING_SCHEMA, " { \"foo\" :  1234567890 ,, \"bar\" : 0,  \"baz\" : -987654321 }  "));
     }
 
     /**
      * This is technically invalid JSON, and we don't want to simply ignore the malformed entry.
      */
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToParseStringOfMalformedMap() {
-        Values.convertToMap(Schema.STRING_SCHEMA, " { \"foo\" :  1234567890 , \"a\", \"bar\" : 0,  \"baz\" : -987654321 }  ");
+        assertThrows(DataException.class,
+            () -> Values.convertToMap(Schema.STRING_SCHEMA, " { \"foo\" :  1234567890 , \"a\", \"bar\" : 0,  \"baz\" : -987654321 }  "));
     }
 
     /**
      * This is technically invalid JSON, and we don't want to simply ignore the blank entries.
      */
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToParseStringOfMapWithIntValuesWithOnlyBlankEntries() {
-        Values.convertToMap(Schema.STRING_SCHEMA, " { ,,  , , }  ");
+        assertThrows(DataException.class, () -> Values.convertToMap(Schema.STRING_SCHEMA, " { ,,  , , }  "));
     }
 
     /**
      * This is technically invalid JSON, and we don't want to simply ignore the blank entry.
      */
-    @Test(expected = DataException.class)
+    @Test
     public void shouldFailToParseStringOfMapWithIntValuesWithBlankEntries() {
-        Values.convertToMap(Schema.STRING_SCHEMA, " { \"foo\" :  \"1234567890\" ,, \"bar\" : \"0\",  \"baz\" : \"boz\" }  ");
+        assertThrows(DataException.class,
+            () -> Values.convertToMap(Schema.STRING_SCHEMA, " { \"foo\" :  \"1234567890\" ,, \"bar\" : \"0\",  \"baz\" : \"boz\" }  "));
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/header/ConnectHeadersTest.java
@@ -79,9 +79,10 @@ public class ConnectHeadersTest {
         other = "other key";
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullKey() {
-        headers.add(null, "value", Schema.STRING_SCHEMA);
+        assertThrows(NullPointerException.class,
+            () -> headers.add(null, "value", Schema.STRING_SCHEMA));
     }
 
     protected void populate(Headers headers) {

--- a/connect/api/src/test/java/org/apache/kafka/connect/util/ConnectorUtilsTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/util/ConnectorUtilsTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class ConnectorUtilsTest {
 
@@ -59,8 +60,9 @@ public class ConnectorUtilsTest {
                 Collections.emptyList()), grouped);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGroupPartitionsInvalidCount() {
-        ConnectorUtils.groupPartitions(FIVE_ELEMENTS, 0);
+        assertThrows(IllegalArgumentException.class,
+            () -> ConnectorUtils.groupPartitions(FIVE_ELEMENTS, 0));
     }
 }

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
@@ -22,6 +22,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.ChoiceCallback;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.UriInfo;
+
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
@@ -46,6 +47,7 @@ import javax.security.auth.login.Configuration;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 
+import static org.junit.Assert.assertThrows;
 import static org.powermock.api.easymock.PowerMock.replayAll;
 
 @RunWith(PowerMockRunner.class)
@@ -173,8 +175,8 @@ public class JaasBasicAuthFilterTest {
         EasyMock.verify(requestContext);
     }
 
-    @Test(expected = ConnectException.class)
-    public void testUnsupportedCallback() throws Exception {
+    @Test
+    public void testUnsupportedCallback() {
         String authHeader = authHeader("basic", "user", "pwd");
         CallbackHandler callbackHandler = new JaasBasicAuthFilter.BasicAuthCallBackHandler(authHeader);
         Callback unsupportedCallback = new ChoiceCallback(
@@ -184,7 +186,7 @@ public class JaasBasicAuthFilterTest {
             1,
             true
         );
-        callbackHandler.handle(new Callback[] {unsupportedCallback});
+        assertThrows(ConnectException.class, () -> callbackHandler.handle(new Callback[] {unsupportedCallback}));
     }
 
     private String authHeader(String authorization, String username, String password) {

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
@@ -22,7 +22,6 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.ChoiceCallback;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.UriInfo;
-
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
@@ -176,7 +175,7 @@ public class JaasBasicAuthFilterTest {
     }
 
     @Test
-    public void testUnsupportedCallback() {
+    public void testUnsupportedCallback() throws Exception {
         String authHeader = authHeader("basic", "user", "pwd");
         CallbackHandler callbackHandler = new JaasBasicAuthFilter.BasicAuthCallBackHandler(authHeader);
         Callback unsupportedCallback = new ChoiceCallback(

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
@@ -22,6 +22,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.ChoiceCallback;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.UriInfo;
+
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
@@ -175,7 +176,7 @@ public class JaasBasicAuthFilterTest {
     }
 
     @Test
-    public void testUnsupportedCallback() throws Exception {
+    public void testUnsupportedCallback() {
         String authHeader = authHeader("basic", "user", "pwd");
         CallbackHandler callbackHandler = new JaasBasicAuthFilter.BasicAuthCallBackHandler(authHeader);
         Callback unsupportedCallback = new ChoiceCallback(

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class FileStreamSourceConnectorTest extends EasyMockSupport {
 
@@ -98,10 +99,10 @@ public class FileStreamSourceConnectorTest extends EasyMockSupport {
         EasyMock.verify(ctx);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testMultipleSourcesInvalid() {
         sourceProperties.put(FileStreamSourceConnector.TOPIC_CONFIG, MULTIPLE_TOPICS);
-        connector.start(sourceProperties);
+        assertThrows(ConfigException.class, () -> connector.start(sourceProperties));
     }
 
     @Test
@@ -114,22 +115,22 @@ public class FileStreamSourceConnectorTest extends EasyMockSupport {
         EasyMock.verify(ctx);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testMissingTopic() {
         sourceProperties.remove(FileStreamSourceConnector.TOPIC_CONFIG);
-        connector.start(sourceProperties);
+        assertThrows(ConfigException.class, () -> connector.start(sourceProperties));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testBlankTopic() {
         // Because of trimming this tests is same as testing for empty string.
         sourceProperties.put(FileStreamSourceConnector.TOPIC_CONFIG, "     ");
-        connector.start(sourceProperties);
+        assertThrows(ConfigException.class, () -> connector.start(sourceProperties));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testInvalidBatchSize() {
         sourceProperties.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG, "abcd");
-        connector.start(sourceProperties);
+        assertThrows(ConfigException.class, () -> connector.start(sourceProperties));
     }
 }

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -823,10 +823,11 @@ public class JsonConverterTest {
         assertNull(converted);
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void mismatchSchemaJson() {
         // If we have mismatching schema info, we should properly convert to a DataException
-        converter.fromConnectData(TOPIC, Schema.FLOAT64_SCHEMA, true);
+        assertThrows(DataException.class,
+            () -> converter.fromConnectData(TOPIC, Schema.FLOAT64_SCHEMA, true));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/converters/ByteArrayConverterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/converters/ByteArrayConverterTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ByteArrayConverterTest {
@@ -59,14 +60,16 @@ public class ByteArrayConverterTest {
         );
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromConnectBadSchema() {
-        converter.fromConnectData(TOPIC, Schema.INT32_SCHEMA, SAMPLE_BYTES);
+        assertThrows(DataException.class,
+            () -> converter.fromConnectData(TOPIC, Schema.INT32_SCHEMA, SAMPLE_BYTES));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testFromConnectInvalidValue() {
-        converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, 12);
+        assertThrows(DataException.class,
+            () -> converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, 12));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/converters/NumberConverterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/converters/NumberConverterTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public abstract class NumberConverterTest<T extends Number> {
     private static final String TOPIC = "topic";
@@ -71,24 +72,25 @@ public abstract class NumberConverterTest<T extends Number> {
         }
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testDeserializingDataWithTooManyBytes() {
-        converter.toConnectData(TOPIC, new byte[10]);
+        assertThrows(DataException.class, () -> converter.toConnectData(TOPIC, new byte[10]));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testDeserializingHeaderWithTooManyBytes() {
-        converter.toConnectHeader(TOPIC, HEADER_NAME, new byte[10]);
+        assertThrows(DataException.class, () -> converter.toConnectHeader(TOPIC, HEADER_NAME, new byte[10]));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testSerializingIncorrectType() {
-        converter.fromConnectData(TOPIC, schema, "not a valid number");
+        assertThrows(DataException.class, () -> converter.fromConnectData(TOPIC, schema, "not a valid number"));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testSerializingIncorrectHeader() {
-        converter.fromConnectHeader(TOPIC, HEADER_NAME, schema, "not a valid number");
+        assertThrows(DataException.class,
+            () -> converter.fromConnectHeader(TOPIC, HEADER_NAME, schema, "not a valid number"));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -275,7 +275,7 @@ public class AbstractHerderTest {
 
 
     @Test
-    public void testConfigValidationEmptyConfig() {
+    public void testConfigValidationEmptyConfig() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy, 0);
         replayAll();
 
@@ -314,7 +314,7 @@ public class AbstractHerderTest {
     }
 
     @Test
-    public void testConfigValidationInvalidTopics() {
+    public void testConfigValidationInvalidTopics() throws Throwable {
         AbstractHerder herder = createConfigValidationHerder(TestSinkConnector.class, noneConnectorClientConfigOverridePolicy);
         replayAll();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -275,7 +275,7 @@ public class AbstractHerderTest {
 
 
     @Test
-    public void testConfigValidationEmptyConfig() throws Throwable {
+    public void testConfigValidationEmptyConfig() {
         AbstractHerder herder = createConfigValidationHerder(TestSourceConnector.class, noneConnectorClientConfigOverridePolicy, 0);
         replayAll();
 
@@ -314,7 +314,7 @@ public class AbstractHerderTest {
     }
 
     @Test
-    public void testConfigValidationInvalidTopics() throws Throwable {
+    public void testConfigValidationInvalidTopics() {
         AbstractHerder herder = createConfigValidationHerder(TestSinkConnector.class, noneConnectorClientConfigOverridePolicy);
         replayAll();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("deprecation")
 public class ConnectMetricsTest {
@@ -67,9 +68,10 @@ public class ConnectMetricsTest {
         assertNotNull(metrics.metrics());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGettingGroupWithOddNumberOfTags() {
-        metrics.group("name", "k1", "v1", "k2", "v2", "extra");
+        assertThrows(IllegalArgumentException.class,
+            () -> metrics.group("name", "k1", "v1", "k2", "v2", "extra"));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectorConfigTest.java
@@ -153,7 +153,7 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         assertEquals(42, xform.magicNumber);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void multipleTransformsOneDangling() {
         Map<String, String> props = new HashMap<>();
         props.put("name", "test");
@@ -161,7 +161,7 @@ public class ConnectorConfigTest<R extends ConnectRecord<R>> {
         props.put("transforms", "a, b");
         props.put("transforms.a.type", SimpleTransformation.class.getName());
         props.put("transforms.a.magic.number", "42");
-        new ConnectorConfig(MOCK_PLUGINS, props);
+        assertThrows(ConfigException.class, () -> new ConnectorConfig(MOCK_PLUGINS, props));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTest.java
@@ -75,18 +75,18 @@ public class WorkerConfigTest {
         new WorkerConfig(WorkerConfig.baseConfigDef(), props);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testAdminListenersNotAllowingEmptyStrings() {
         Map<String, String> props = baseProps();
         props.put(WorkerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999,");
-        new WorkerConfig(WorkerConfig.baseConfigDef(), props);
+        assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testAdminListenersNotAllowingBlankStrings() {
         Map<String, String> props = baseProps();
         props.put(WorkerConfig.ADMIN_LISTENERS_CONFIG, "http://a.b:9999, ,https://a.b:9999");
-        new WorkerConfig(WorkerConfig.baseConfigDef(), props);
+        assertThrows(ConfigException.class, () -> new WorkerConfig(WorkerConfig.baseConfigDef(), props));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -91,6 +91,7 @@ import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_CREATION_ENABL
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @PowerMockIgnore({"javax.management.*",
@@ -541,7 +542,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testSendRecordsCorruptTimestamp() throws Exception {
         final Long timestamp = -3L;
         createWorkerTask();
@@ -555,8 +556,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", records);
-        Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(null, sent.getValue().timestamp());
+        assertThrows(InvalidRecordException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
+        assertFalse(sent.hasCaptured());
 
         PowerMock.verifyAll();
     }
@@ -619,7 +620,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testSendRecordsProducerCallbackFail() throws Exception {
         createWorkerTask();
 
@@ -633,7 +634,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
-        Whitebox.invokeMethod(workerTask, "sendRecords");
+        assertThrows(ConnectException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskWithTopicCreationTest.java
@@ -102,8 +102,8 @@ import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_F
 import static org.apache.kafka.connect.runtime.WorkerConfig.TOPIC_CREATION_ENABLE_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @PowerMockIgnore({"javax.management.*",
@@ -566,7 +566,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = InvalidRecordException.class)
+    @Test
     public void testSendRecordsCorruptTimestamp() throws Exception {
         final Long timestamp = -3L;
         createWorkerTask();
@@ -580,8 +580,8 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", records);
-        Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertEquals(null, sent.getValue().timestamp());
+        assertThrows(InvalidRecordException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
+        assertFalse(sent.hasCaptured());
 
         PowerMock.verifyAll();
     }
@@ -644,7 +644,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testSendRecordsProducerCallbackFail() throws Exception {
         createWorkerTask();
 
@@ -658,11 +658,11 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
-        Whitebox.invokeMethod(workerTask, "sendRecords");
+        assertThrows(ConnectException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
     }
 
-    @Test(expected = ConnectException.class)
-    public void testSendRecordsProducerSendFailsImmediately() throws Exception {
+    @Test
+    public void testSendRecordsProducerSendFailsImmediately() {
         createWorkerTask();
 
         SourceRecord record1 = new SourceRecord(PARTITION, OFFSET, TOPIC, 1, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);
@@ -677,7 +677,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
-        Whitebox.invokeMethod(workerTask, "sendRecords");
+        assertThrows(ConnectException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
     }
 
     @Test
@@ -1057,8 +1057,8 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = ConnectException.class)
-    public void testTopicDescribeFails() throws Exception {
+    @Test
+    public void testTopicDescribeFails() {
         createWorkerTask();
 
         SourceRecord record1 = new SourceRecord(PARTITION, OFFSET, TOPIC, 1, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);
@@ -1071,10 +1071,10 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
-        Whitebox.invokeMethod(workerTask, "sendRecords");
+        assertThrows(ConnectException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testTopicCreateFails() throws Exception {
         createWorkerTask();
 
@@ -1091,11 +1091,11 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
-        Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertNotNull(newTopicCapture.getValue());
+        assertThrows(ConnectException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
+        assertTrue(newTopicCapture.hasCaptured());
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testTopicCreateFailsWithExceptionWhenCreateReturnsFalse() throws Exception {
         createWorkerTask();
 
@@ -1111,8 +1111,8 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
         PowerMock.replayAll();
 
         Whitebox.setInternalState(workerTask, "toSend", Arrays.asList(record1, record2));
-        Whitebox.invokeMethod(workerTask, "sendRecords");
-        assertNotNull(newTopicCapture.getValue());
+        assertThrows(ConnectException.class, () -> Whitebox.invokeMethod(workerTask, "sendRecords"));
+        assertTrue(newTopicCapture.hasCaptured());
     }
 
     private void expectPreliminaryCalls() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskWithTopicCreationTest.java
@@ -662,7 +662,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testSendRecordsProducerSendFailsImmediately() throws Exception {
+    public void testSendRecordsProducerSendFailsImmediately() {
         createWorkerTask();
 
         SourceRecord record1 = new SourceRecord(PARTITION, OFFSET, TOPIC, 1, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);
@@ -1058,7 +1058,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testTopicDescribeFails() throws Exception {
+    public void testTopicDescribeFails() {
         createWorkerTask();
 
         SourceRecord record1 = new SourceRecord(PARTITION, OFFSET, TOPIC, 1, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskWithTopicCreationTest.java
@@ -662,7 +662,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testSendRecordsProducerSendFailsImmediately() {
+    public void testSendRecordsProducerSendFailsImmediately() throws Exception {
         createWorkerTask();
 
         SourceRecord record1 = new SourceRecord(PARTITION, OFFSET, TOPIC, 1, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);
@@ -1058,7 +1058,7 @@ public class WorkerSourceTaskWithTopicCreationTest extends ThreadedTest {
     }
 
     @Test
-    public void testTopicDescribeFails() {
+    public void testTopicDescribeFails() throws Exception {
         createWorkerTask();
 
         SourceRecord record1 = new SourceRecord(PARTITION, OFFSET, TOPIC, 1, KEY_SCHEMA, KEY, RECORD_SCHEMA, RECORD);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -108,6 +108,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
@@ -1186,7 +1187,7 @@ public class WorkerTest extends ThreadedTest {
             null, allConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testConsumerConfigsClientOverridesWithNonePolicy() {
         Map<String, String> props = new HashMap<>(workerProps);
         props.put("consumer.auto.offset.reset", "latest");
@@ -1199,8 +1200,8 @@ public class WorkerTest extends ThreadedTest {
         EasyMock.expect(connectorConfig.originalsWithPrefix(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX))
             .andReturn(connConfig);
         PowerMock.replayAll();
-        Worker.consumerConfigs(new ConnectorTaskId("test", 1), configWithOverrides, connectorConfig,
-            null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID);
+        assertThrows(ConnectException.class, () -> Worker.consumerConfigs(new ConnectorTaskId("test", 1),
+            configWithOverrides, connectorConfig, null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
     @Test
@@ -1230,7 +1231,7 @@ public class WorkerTest extends ThreadedTest {
                                                              null, allConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testAdminConfigsClientOverridesWithNonePolicy() {
         Map<String, String> props = new HashMap<>(workerProps);
         props.put("admin.client.id", "testid");
@@ -1243,8 +1244,8 @@ public class WorkerTest extends ThreadedTest {
         EasyMock.expect(connectorConfig.originalsWithPrefix(ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX))
             .andReturn(connConfig);
         PowerMock.replayAll();
-        Worker.adminConfigs(new ConnectorTaskId("test", 1), "", configWithOverrides, connectorConfig,
-                null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID);
+        assertThrows(ConnectException.class, () -> Worker.adminConfigs(new ConnectorTaskId("test", 1),
+            "", configWithOverrides, connectorConfig, null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID));
 
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerWithTopicCreationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerWithTopicCreationTest.java
@@ -102,6 +102,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
@@ -1169,21 +1170,21 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
                                                              null, allConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testConsumerConfigsClientOverridesWithNonePolicy() {
         Map<String, String> props = new HashMap<>(workerProps);
         props.put("consumer.auto.offset.reset", "latest");
         props.put("consumer.max.poll.records", "5000");
         WorkerConfig configWithOverrides = new StandaloneConfig(props);
 
-        Map<String, Object> connConfig = new HashMap<String, Object>();
+        Map<String, Object> connConfig = new HashMap<>();
         connConfig.put("max.poll.records", "5000");
         connConfig.put("max.poll.interval.ms", "1000");
         EasyMock.expect(connectorConfig.originalsWithPrefix(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX))
             .andReturn(connConfig);
         PowerMock.replayAll();
-        Worker.consumerConfigs(new ConnectorTaskId("test", 1), configWithOverrides, connectorConfig,
-                               null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID);
+        assertThrows(ConnectException.class, () -> Worker.consumerConfigs(new ConnectorTaskId("test", 1),
+            configWithOverrides, connectorConfig, null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
     @Test
@@ -1212,7 +1213,7 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
                                                              null, allConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testAdminConfigsClientOverridesWithNonePolicy() {
         Map<String, String> props = new HashMap<>(workerProps);
         props.put("admin.client.id", "testid");
@@ -1225,8 +1226,8 @@ public class WorkerWithTopicCreationTest extends ThreadedTest {
         EasyMock.expect(connectorConfig.originalsWithPrefix(ConnectorConfig.CONNECTOR_CLIENT_ADMIN_OVERRIDES_PREFIX))
             .andReturn(connConfig);
         PowerMock.replayAll();
-        Worker.adminConfigs(new ConnectorTaskId("test", 1), "", configWithOverrides, connectorConfig,
-                                                          null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID);
+        assertThrows(ConnectException.class, () -> Worker.adminConfigs(new ConnectorTaskId("test", 1),
+            "", configWithOverrides, connectorConfig, null, noneConnectorClientConfigOverridePolicy, CLUSTER_ID));
     }
 
     private void assertStatusMetrics(long expected, String metricName) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedConfigTest.java
@@ -66,33 +66,33 @@ public class DistributedConfigTest {
         assertEquals(512 / 8, keyGenerator.generateKey().getEncoded().length);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldFailWithEmptyListOfVerificationAlgorithms() {
         Map<String, String> configs = configs();
         configs.put(DistributedConfig.INTER_WORKER_VERIFICATION_ALGORITHMS_CONFIG, "");
-        new DistributedConfig(configs);
+        assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldFailIfKeyAlgorithmNotInVerificationAlgorithmsList() {
         Map<String, String> configs = configs();
         configs.put(DistributedConfig.INTER_WORKER_KEY_GENERATION_ALGORITHM_CONFIG, "HmacSHA1");
         configs.put(DistributedConfig.INTER_WORKER_VERIFICATION_ALGORITHMS_CONFIG, "HmacSHA256");
-        new DistributedConfig(configs);
+        assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldFailWithInvalidKeyAlgorithm() {
         Map<String, String> configs = configs();
         configs.put(DistributedConfig.INTER_WORKER_KEY_GENERATION_ALGORITHM_CONFIG, "not-actually-a-key-algorithm");
-        new DistributedConfig(configs);
+        assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldFailWithInvalidKeySize() {
         Map<String, String> configs = configs();
         configs.put(DistributedConfig.INTER_WORKER_KEY_SIZE_CONFIG, "0");
-        new DistributedConfig(configs);
+        assertThrows(ConfigException.class, () -> new DistributedConfig(configs));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
@@ -61,6 +61,7 @@ import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ER
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
@@ -96,9 +97,9 @@ public class ErrorReporterTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void initializeDLQWithNullMetrics() {
-        new DeadLetterQueueReporter(producer, config(emptyMap()), TASK_ID, null);
+        assertThrows(NullPointerException.class, () -> new DeadLetterQueueReporter(producer, config(emptyMap()), TASK_ID, null));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/RetryWithToleranceOperatorTest.java
@@ -68,6 +68,7 @@ import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
@@ -116,14 +117,14 @@ public class RetryWithToleranceOperatorTest {
             SinkTask.class, consumerRecord, new Throwable());
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testExecuteFailedNoTolerance() {
         RetryWithToleranceOperator retryWithToleranceOperator = new RetryWithToleranceOperator(0,
             ERRORS_RETRY_MAX_DELAY_DEFAULT, NONE, SYSTEM);
         retryWithToleranceOperator.metrics(errorHandlingMetrics);
 
-        retryWithToleranceOperator.executeFailed(Stage.TASK_PUT,
-            SinkTask.class, consumerRecord, new Throwable());
+        assertThrows(ConnectException.class, () -> retryWithToleranceOperator.executeFailed(Stage.TASK_PUT,
+            SinkTask.class, consumerRecord, new Throwable()));
     }
 
     @Test
@@ -156,24 +157,24 @@ public class RetryWithToleranceOperatorTest {
         testHandleExceptionInStage(Stage.TASK_POLL, new org.apache.kafka.connect.errors.RetriableException("Test"));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testThrowExceptionInTaskPut() {
-        testHandleExceptionInStage(Stage.TASK_PUT, new Exception());
+        assertThrows(ConnectException.class, () -> testHandleExceptionInStage(Stage.TASK_PUT, new Exception()));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testThrowExceptionInTaskPoll() {
-        testHandleExceptionInStage(Stage.TASK_POLL, new Exception());
+        assertThrows(ConnectException.class, () -> testHandleExceptionInStage(Stage.TASK_POLL, new Exception()));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testThrowExceptionInKafkaConsume() {
-        testHandleExceptionInStage(Stage.KAFKA_CONSUME, new Exception());
+        assertThrows(ConnectException.class, () -> testHandleExceptionInStage(Stage.KAFKA_CONSUME, new Exception()));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testThrowExceptionInKafkaProduce() {
-        testHandleExceptionInStage(Stage.KAFKA_PRODUCE, new Exception());
+        assertThrows(ConnectException.class, () -> testHandleExceptionInStage(Stage.KAFKA_PRODUCE, new Exception()));
     }
 
     private void testHandleExceptionInStage(Stage type, Exception ex) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class DelegatingClassLoaderTest {
@@ -50,13 +51,13 @@ public class DelegatingClassLoaderTest {
         assertFalse(DelegatingClassLoader.serviceLoaderManifestForPlugin("resource/version.properties"));
     }
 
-    @Test(expected = ClassNotFoundException.class)
+    @Test
     public void testLoadingUnloadedPluginClass() throws ClassNotFoundException {
         TestPlugins.assertAvailable();
         DelegatingClassLoader classLoader = new DelegatingClassLoader(Collections.emptyList());
         classLoader.initLoaders();
         for (String pluginClassName : TestPlugins.pluginClasses()) {
-            classLoader.loadClass(pluginClassName);
+            assertThrows(ClassNotFoundException.class, () -> classLoader.loadClass(pluginClassName));
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class PluginsTest {
@@ -184,15 +185,15 @@ public class PluginsTest {
         assertTrue(headerConverter instanceof SimpleHeaderConverter);
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void shouldThrowIfPluginThrows() {
         TestPlugins.assertAvailable();
 
-        plugins.newPlugin(
+        assertThrows(ConnectException.class, () -> plugins.newPlugin(
             TestPlugins.ALWAYS_THROW_EXCEPTION,
             new AbstractConfig(new ConfigDef(), Collections.emptyMap()),
             Converter.class
-        );
+        ));
     }
 
     @Test
@@ -251,11 +252,11 @@ public class PluginsTest {
         assertPluginClassLoaderAlwaysActive(samples);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldFailToFindConverterInCurrentClassloader() {
         TestPlugins.assertAvailable();
         props.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, TestPlugins.SAMPLING_CONVERTER);
-        createConfig();
+        assertThrows(ConfigException.class, this::createConfig);
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/InternalRequestSignatureTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/InternalRequestSignatureTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -71,14 +72,16 @@ public class InternalRequestSignatureTest {
         assertNull(InternalRequestSignature.fromHeaders(REQUEST_BODY, internalRequestHeaders(ENCODED_SIGNATURE, null)));
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void fromHeadersShouldThrowExceptionOnInvalidSignatureAlgorithm() {
-        InternalRequestSignature.fromHeaders(REQUEST_BODY, internalRequestHeaders(ENCODED_SIGNATURE, "doesn'texist"));
+        assertThrows(BadRequestException.class, () -> InternalRequestSignature.fromHeaders(REQUEST_BODY,
+            internalRequestHeaders(ENCODED_SIGNATURE, "doesn'texist")));
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void fromHeadersShouldThrowExceptionOnInvalidBase64Signature() {
-        InternalRequestSignature.fromHeaders(REQUEST_BODY, internalRequestHeaders("not valid base 64", SIGNATURE_ALGORITHM));
+        assertThrows(BadRequestException.class, () -> InternalRequestSignature.fromHeaders(REQUEST_BODY,
+            internalRequestHeaders("not valid base 64", SIGNATURE_ALGORITHM)));
     }
 
     @Test
@@ -89,10 +92,10 @@ public class InternalRequestSignatureTest {
         assertNotNull(signature.keyAlgorithm());
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void addToRequestShouldThrowExceptionOnInvalidSignatureAlgorithm() {
         Request request = mock(Request.class);
-        InternalRequestSignature.addToRequest(KEY, REQUEST_BODY, "doesn'texist", request);
+        assertThrows(ConnectException.class, () -> InternalRequestSignature.addToRequest(KEY, REQUEST_BODY, "doesn'texist", request));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -79,6 +79,7 @@ import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
@@ -334,79 +335,18 @@ public class ConnectorPluginsResourceTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = BadRequestException.class)
-    public void testValidateConfigWithNonExistentName() throws Throwable {
-        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
-        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
-            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
-
-            Connector connector = new ConnectorPluginsResourceTestConnector();
-            Config config = connector.validate(props);
-            ConfigDef configDef = connector.config();
-            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-            List<ConfigValue> configValues = config.configValues();
-
-            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-            resultConfigKeys.putAll(connectorConfigDef.configKeys());
-            configValues.addAll(connectorConfigValues);
-
-            ConfigInfos configInfos = AbstractHerder.generateResult(
-                    ConnectorPluginsResourceTestConnector.class.getName(),
-                    resultConfigKeys,
-                    configValues,
-                    Collections.singletonList("Test")
-            );
-            configInfosCallback.getValue().onCompletion(null, configInfos);
-            return null;
-        });
-
-        PowerMock.replayAll();
-
+    @Test
+    public void testValidateConfigWithNonExistentName() {
         // make a request to connector-plugins resource using a non-loaded connector with the same
         // simple name but different package.
         String customClassname = "com.custom.package."
             + ConnectorPluginsResourceTestConnector.class.getSimpleName();
-        connectorPluginsResource.validateConfigs(customClassname, props);
-
-        PowerMock.verifyAll();
+        assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs(customClassname, props));
     }
 
-    @Test(expected = BadRequestException.class)
-    public void testValidateConfigWithNonExistentAlias() throws Throwable {
-        Capture<Callback<ConfigInfos>> configInfosCallback = EasyMock.newCapture();
-        herder.validateConnectorConfig(EasyMock.eq(props), EasyMock.capture(configInfosCallback), EasyMock.anyBoolean());
-
-        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
-            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
-
-            Connector connector = new ConnectorPluginsResourceTestConnector();
-            Config config = connector.validate(props);
-            ConfigDef configDef = connector.config();
-            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-            List<ConfigValue> configValues = config.configValues();
-
-            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-            resultConfigKeys.putAll(connectorConfigDef.configKeys());
-            configValues.addAll(connectorConfigValues);
-
-            ConfigInfos configInfos = AbstractHerder.generateResult(
-                    ConnectorPluginsResourceTestConnector.class.getName(),
-                    resultConfigKeys,
-                    configValues,
-                    Collections.singletonList("Test")
-            );
-            configInfosCallback.getValue().onCompletion(null, configInfos);
-            return null;
-        });
-
-        PowerMock.replayAll();
-
-        connectorPluginsResource.validateConfigs("ConnectorPluginsTest", props);
-
-        PowerMock.verifyAll();
+    @Test
+    public void testValidateConfigWithNonExistentAlias() {
+        assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs("ConnectorPluginsTest", props));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -336,7 +336,7 @@ public class ConnectorPluginsResourceTest {
     }
 
     @Test
-    public void testValidateConfigWithNonExistentName() throws Throwable {
+    public void testValidateConfigWithNonExistentName() {
         // make a request to connector-plugins resource using a non-loaded connector with the same
         // simple name but different package.
         String customClassname = "com.custom.package."
@@ -345,7 +345,7 @@ public class ConnectorPluginsResourceTest {
     }
 
     @Test
-    public void testValidateConfigWithNonExistentAlias() throws Throwable {
+    public void testValidateConfigWithNonExistentAlias() {
         assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs("ConnectorPluginsTest", props));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -336,7 +336,7 @@ public class ConnectorPluginsResourceTest {
     }
 
     @Test
-    public void testValidateConfigWithNonExistentName() {
+    public void testValidateConfigWithNonExistentName() throws Throwable {
         // make a request to connector-plugins resource using a non-loaded connector with the same
         // simple name but different package.
         String customClassname = "com.custom.package."
@@ -345,7 +345,7 @@ public class ConnectorPluginsResourceTest {
     }
 
     @Test
-    public void testValidateConfigWithNonExistentAlias() {
+    public void testValidateConfigWithNonExistentAlias() throws Throwable {
         assertThrows(BadRequestException.class, () -> connectorPluginsResource.validateConfigs("ConnectorPluginsTest", props));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -361,8 +361,8 @@ public class ConnectorsResourceTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = AlreadyExistsException.class)
-    public void testCreateConnectorExists() throws Throwable {
+    @Test
+    public void testCreateConnectorExists() {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
 
         final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
@@ -371,7 +371,7 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.createConnector(FORWARD, NULL_HEADERS, body);
+        assertThrows(AlreadyExistsException.class, () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, body));
 
         PowerMock.verifyAll();
     }
@@ -463,7 +463,7 @@ public class ConnectorsResourceTest {
     }
 
     // Not found exceptions should pass through to caller so they can be processed for 404s
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testDeleteConnectorNotFound() throws Throwable {
         final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
         herder.deleteConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
@@ -471,7 +471,7 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        assertThrows(NotFoundException.class, () -> connectorsResource.destroyConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
 
         PowerMock.verifyAll();
     }
@@ -506,15 +506,15 @@ public class ConnectorsResourceTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = NotFoundException.class)
-    public void testGetConnectorConfigConnectorNotFound() throws Throwable {
+    @Test
+    public void testGetConnectorConfigConnectorNotFound() {
         final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
         herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));
 
         PowerMock.replayAll();
 
-        connectorsResource.getConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        assertThrows(NotFoundException.class, () -> connectorsResource.getConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
 
         PowerMock.verifyAll();
     }
@@ -603,19 +603,20 @@ public class ConnectorsResourceTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = BadRequestException.class)
-    public void testPutConnectorConfigNameMismatch() throws Throwable {
+    @Test
+    public void testPutConnectorConfigNameMismatch() {
         Map<String, String> connConfig = new HashMap<>(CONNECTOR_CONFIG);
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
-        connectorsResource.putConnectorConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD, connConfig);
+        assertThrows(BadRequestException.class, () -> connectorsResource.putConnectorConfig(CONNECTOR_NAME,
+            NULL_HEADERS, FORWARD, connConfig));
     }
 
-    @Test(expected = BadRequestException.class)
-    public void testCreateConnectorConfigNameMismatch() throws Throwable {
+    @Test
+    public void testCreateConnectorConfigNameMismatch() {
         Map<String, String> connConfig = new HashMap<>();
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         CreateConnectorRequest request = new CreateConnectorRequest(CONNECTOR_NAME, connConfig);
-        connectorsResource.createConnector(FORWARD, NULL_HEADERS, request);
+        assertThrows(BadRequestException.class, () -> connectorsResource.createConnector(FORWARD, NULL_HEADERS, request));
     }
 
     @Test
@@ -632,7 +633,7 @@ public class ConnectorsResourceTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testGetConnectorTaskConfigsConnectorNotFound() throws Throwable {
         final Capture<Callback<List<TaskInfo>>> cb = Capture.newInstance();
         herder.taskConfigs(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
@@ -640,7 +641,7 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.getTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        assertThrows(NotFoundException.class, () -> connectorsResource.getTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
 
         PowerMock.verifyAll();
     }
@@ -702,7 +703,7 @@ public class ConnectorsResourceTest {
         );
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testPutConnectorTaskConfigsConnectorNotFound() throws Throwable {
         final Capture<Callback<Void>> cb = Capture.newInstance();
         herder.putTaskConfigs(
@@ -715,20 +716,21 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS, FORWARD, serializeAsBytes(TASK_CONFIGS));
+        assertThrows(NotFoundException.class, () -> connectorsResource.putTaskConfigs(CONNECTOR_NAME, NULL_HEADERS,
+            FORWARD, serializeAsBytes(TASK_CONFIGS)));
 
         PowerMock.verifyAll();
     }
 
-    @Test(expected = NotFoundException.class)
-    public void testRestartConnectorNotFound() throws Throwable {
+    @Test
+    public void testRestartConnectorNotFound() {
         final Capture<Callback<Void>> cb = Capture.newInstance();
         herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));
 
         PowerMock.replayAll();
 
-        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        assertThrows(NotFoundException.class, () -> connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
 
         PowerMock.verifyAll();
     }
@@ -768,7 +770,7 @@ public class ConnectorsResourceTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testRestartTaskNotFound() throws Throwable {
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
         final Capture<Callback<Void>> cb = Capture.newInstance();
@@ -777,7 +779,7 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, FORWARD);
+        assertThrows(NotFoundException.class, () -> connectorsResource.restartTask(CONNECTOR_NAME, 0, NULL_HEADERS, FORWARD));
 
         PowerMock.verifyAll();
     }
@@ -936,12 +938,9 @@ public class ConnectorsResourceTest {
     }
 
     private  <T> void expectAndCallbackException(final Capture<Callback<T>> cb, final Throwable t) {
-        PowerMock.expectLastCall().andAnswer(new IAnswer<Void>() {
-            @Override
-            public Void answer() throws Throwable {
-                cb.getValue().onCompletion(t, null);
-                return null;
-            }
+        PowerMock.expectLastCall().andAnswer((IAnswer<Void>) () -> {
+            cb.getValue().onCompletion(t, null);
+            return null;
         });
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -362,7 +362,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testCreateConnectorExists() {
+    public void testCreateConnectorExists() throws Throwable {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
 
         final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
@@ -507,7 +507,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testGetConnectorConfigConnectorNotFound() {
+    public void testGetConnectorConfigConnectorNotFound() throws Throwable {
         final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
         herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));
@@ -604,7 +604,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testPutConnectorConfigNameMismatch() {
+    public void testPutConnectorConfigNameMismatch() throws Throwable {
         Map<String, String> connConfig = new HashMap<>(CONNECTOR_CONFIG);
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         assertThrows(BadRequestException.class, () -> connectorsResource.putConnectorConfig(CONNECTOR_NAME,
@@ -612,7 +612,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testCreateConnectorConfigNameMismatch() {
+    public void testCreateConnectorConfigNameMismatch() throws Throwable {
         Map<String, String> connConfig = new HashMap<>();
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         CreateConnectorRequest request = new CreateConnectorRequest(CONNECTOR_NAME, connConfig);
@@ -723,7 +723,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testRestartConnectorNotFound() {
+    public void testRestartConnectorNotFound() throws Throwable {
         final Capture<Callback<Void>> cb = Capture.newInstance();
         herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -362,7 +362,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testCreateConnectorExists() throws Throwable {
+    public void testCreateConnectorExists() {
         CreateConnectorRequest body = new CreateConnectorRequest(CONNECTOR_NAME, Collections.singletonMap(ConnectorConfig.NAME_CONFIG, CONNECTOR_NAME));
 
         final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
@@ -507,7 +507,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testGetConnectorConfigConnectorNotFound() throws Throwable {
+    public void testGetConnectorConfigConnectorNotFound() {
         final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
         herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));
@@ -604,7 +604,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testPutConnectorConfigNameMismatch() throws Throwable {
+    public void testPutConnectorConfigNameMismatch() {
         Map<String, String> connConfig = new HashMap<>(CONNECTOR_CONFIG);
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         assertThrows(BadRequestException.class, () -> connectorsResource.putConnectorConfig(CONNECTOR_NAME,
@@ -612,7 +612,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testCreateConnectorConfigNameMismatch() throws Throwable {
+    public void testCreateConnectorConfigNameMismatch() {
         Map<String, String> connConfig = new HashMap<>();
         connConfig.put(ConnectorConfig.NAME_CONFIG, "mismatched-name");
         CreateConnectorRequest request = new CreateConnectorRequest(CONNECTOR_NAME, connConfig);
@@ -723,7 +723,7 @@ public class ConnectorsResourceTest {
     }
 
     @Test
-    public void testRestartConnectorNotFound() throws Throwable {
+    public void testRestartConnectorNotFound() {
         final Capture<Callback<Void>> cb = Capture.newInstance();
         herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/LoggingResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/LoggingResourceTest.java
@@ -32,6 +32,7 @@ import java.util.Vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -77,7 +78,7 @@ public class LoggingResourceTest {
         assertEquals("ERROR", level.get("level"));
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void getUnknownLoggerTest() {
         LoggingResource loggingResource = mock(LoggingResource.class);
         Logger root = new Logger("root") {
@@ -91,7 +92,7 @@ public class LoggingResourceTest {
         when(loggingResource.currentLoggers()).thenReturn(loggers(a, b));
         when(loggingResource.rootLogger()).thenReturn(root);
         when(loggingResource.getLogger(any())).thenCallRealMethod();
-        loggingResource.getLogger("c");
+        assertThrows(NotFoundException.class, () -> loggingResource.getLogger("c"));
     }
 
     @Test
@@ -154,7 +155,7 @@ public class LoggingResourceTest {
         assertEquals(z.getLevel(), Level.DEBUG);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void setLevelWithEmptyArgTest() {
         LoggingResource loggingResource = mock(LoggingResource.class);
         Logger root = new Logger("root") {
@@ -168,10 +169,10 @@ public class LoggingResourceTest {
         when(loggingResource.currentLoggers()).thenReturn(loggers(a, b));
         when(loggingResource.rootLogger()).thenReturn(root);
         when(loggingResource.setLevel(any(), any())).thenCallRealMethod();
-        loggingResource.setLevel("@root", Collections.emptyMap());
+        assertThrows(BadRequestException.class, () -> loggingResource.setLevel("@root", Collections.emptyMap()));
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void setLevelWithInvalidArgTest() {
         LoggingResource loggingResource = mock(LoggingResource.class);
         Logger root = new Logger("root") {
@@ -185,7 +186,7 @@ public class LoggingResourceTest {
         when(loggingResource.currentLoggers()).thenReturn(loggers(a, b));
         when(loggingResource.rootLogger()).thenReturn(root);
         when(loggingResource.setLevel(any(), any())).thenCallRealMethod();
-        loggingResource.setLevel("@root", Collections.singletonMap("level", "HIGH"));
+        assertThrows(NotFoundException.class, () -> loggingResource.setLevel("@root", Collections.singletonMap("level", "HIGH")));
     }
 
     private Enumeration<Logger> loggers(Logger... loggers) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Callable;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
@@ -164,7 +165,7 @@ public class OffsetStorageWriterTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testAlreadyFlushing() {
         @SuppressWarnings("unchecked")
         final Callback<Void> callback = PowerMock.createMock(Callback.class);
@@ -177,7 +178,7 @@ public class OffsetStorageWriterTest {
         writer.offset(OFFSET_KEY, OFFSET_VALUE);
         assertTrue(writer.beginFlush());
         writer.doFlush(callback);
-        assertTrue(writer.beginFlush()); // should throw
+        assertThrows(ConnectException.class, writer::beginFlush);
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class ConnectUtilsTest {
 
@@ -55,7 +56,7 @@ public class ConnectUtilsTest {
         assertNull(ConnectUtils.lookupKafkaClusterId(adminClient));
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testLookupKafkaClusterIdTimeout() {
         final Node broker1 = new Node(0, "dummyHost-1", 1234);
         final Node broker2 = new Node(1, "dummyHost-2", 1234);
@@ -64,7 +65,7 @@ public class ConnectUtilsTest {
             brokers(cluster).build();
         adminClient.timeoutNextRequest(1);
 
-        ConnectUtils.lookupKafkaClusterId(adminClient);
+        assertThrows(ConnectException.class, () -> ConnectUtils.lookupKafkaClusterId(adminClient));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -95,11 +96,11 @@ public class ConvertingFutureCallbackTest {
         }
     }
   
-    @Test(expected = CancellationException.class)
-    public void shouldCancelBeforeGetIfMayCancelWhileRunning() throws Exception {
+    @Test
+    public void shouldCancelBeforeGetIfMayCancelWhileRunning() {
         TestConvertingFutureCallback testCallback = new TestConvertingFutureCallback();
         assertTrue(testCallback.cancel(true));
-        testCallback.get();
+        assertThrows(CancellationException.class, testCallback::get);
     }
 
     @Test
@@ -151,8 +152,8 @@ public class ConvertingFutureCallbackTest {
         }
     }
 
-    @Test(expected = CancellationException.class)
-    public void shouldBlockUntilCancellation() throws Exception {
+    @Test
+    public void shouldBlockUntilCancellation() {
         AtomicReference<Exception> testThreadException = new AtomicReference<>();
         TestConvertingFutureCallback testCallback = new TestConvertingFutureCallback();
         executor.submit(() -> {
@@ -164,10 +165,7 @@ public class ConvertingFutureCallbackTest {
             }
         });
         assertFalse(testCallback.isDone());
-        testCallback.get();
-        if (testThreadException.get() != null) {
-            throw testThreadException.get();
-        }
+        assertThrows(CancellationException.class, testCallback::get);
     }
 
     @Test
@@ -190,9 +188,7 @@ public class ConvertingFutureCallbackTest {
         assertTrue(testCallback.isDone());
         assertEquals(expectedConversion, testCallback.get());
         assertEquals(1, testCallback.numberOfConversions());
-        if (testThreadException.get() != null) {
-            throw testThreadException.get();
-        }
+        if (testThreadException.get() != null) assertThrows(CancellationException.class, testThreadException::get);
     }
   
     protected static class TestConvertingFutureCallback extends ConvertingFutureCallback<Object, Object> {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
@@ -97,7 +97,7 @@ public class ConvertingFutureCallbackTest {
     }
   
     @Test
-    public void shouldCancelBeforeGetIfMayCancelWhileRunning() {
+    public void shouldCancelBeforeGetIfMayCancelWhileRunning() throws Exception {
         TestConvertingFutureCallback testCallback = new TestConvertingFutureCallback();
         assertTrue(testCallback.cancel(true));
         assertThrows(CancellationException.class, testCallback::get);
@@ -153,7 +153,7 @@ public class ConvertingFutureCallbackTest {
     }
 
     @Test
-    public void shouldBlockUntilCancellation() {
+    public void shouldBlockUntilCancellation() throws Exception {
         AtomicReference<Exception> testThreadException = new AtomicReference<>();
         TestConvertingFutureCallback testCallback = new TestConvertingFutureCallback();
         executor.submit(() -> {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConvertingFutureCallbackTest.java
@@ -97,7 +97,7 @@ public class ConvertingFutureCallbackTest {
     }
   
     @Test
-    public void shouldCancelBeforeGetIfMayCancelWhileRunning() throws Exception {
+    public void shouldCancelBeforeGetIfMayCancelWhileRunning() {
         TestConvertingFutureCallback testCallback = new TestConvertingFutureCallback();
         assertTrue(testCallback.cancel(true));
         assertThrows(CancellationException.class, testCallback::get);
@@ -153,7 +153,7 @@ public class ConvertingFutureCallbackTest {
     }
 
     @Test
-    public void shouldBlockUntilCancellation() throws Exception {
+    public void shouldBlockUntilCancellation() {
         AtomicReference<Exception> testThreadException = new AtomicReference<>();
         TestConvertingFutureCallback testCallback = new TestConvertingFutureCallback();
         executor.submit(() -> {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class LoggingContextTest {
@@ -63,19 +64,19 @@ public class LoggingContextTest {
         MDC.setContextMap(mdc);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullConnectorNameForConnectorContext() {
-        LoggingContext.forConnector(null);
+        assertThrows(NullPointerException.class, () -> LoggingContext.forConnector(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTaskIdForTaskContext() {
-        LoggingContext.forTask(null);
+        assertThrows(NullPointerException.class, () -> LoggingContext.forTask(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTaskIdForOffsetContext() {
-        LoggingContext.forOffsets(null);
+        assertThrows(NullPointerException.class, () -> LoggingContext.forOffsets(null));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.connect.transforms;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -42,6 +43,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class CastTest {
@@ -56,34 +58,34 @@ public class CastTest {
         xformValue.close();
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigEmpty() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigInvalidSchemaType() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigInvalidTargetType() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testUnsupportedTargetType() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:bytes"));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:bytes")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigInvalidMap() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigMixWholeAndFieldTransformation() {
-        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
+        assertThrows(ConfigException.class, () -> xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32")));
     }
 
     @Test
@@ -320,10 +322,12 @@ public class CastTest {
         assertEquals("42", transformed.value());
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void castWholeRecordValueSchemalessUnsupportedType() {
         xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-        xformValue.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
+        assertThrows(DataException.class,
+            () -> xformValue.apply(new SourceRecord(null, null, "topic", 0,
+                    null, Collections.singletonList("foo"))));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class FlattenTest {
@@ -46,16 +47,18 @@ public class FlattenTest {
         xformValue.close();
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void topLevelStructRequired() {
         xformValue.configure(Collections.<String, String>emptyMap());
-        xformValue.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
+        assertThrows(DataException.class, () -> xformValue.apply(new SourceRecord(null, null,
+                "topic", 0, Schema.INT32_SCHEMA, 42)));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void topLevelMapRequired() {
         xformValue.configure(Collections.<String, String>emptyMap());
-        xformValue.apply(new SourceRecord(null, null, "topic", 0, null, 42));
+        assertThrows(DataException.class, () -> xformValue.apply(new SourceRecord(null, null,
+                "topic", 0, null, 42)));
     }
 
     @Test
@@ -258,11 +261,12 @@ public class FlattenTest {
         assertEquals(12, transformedMap.get("A.B"));
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void testUnsupportedTypeInMap() {
         xformValue.configure(Collections.<String, String>emptyMap());
         Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
-        xformValue.apply(new SourceRecord(null, null, "topic", 0, null, value));
+        assertThrows(DataException.class, () -> xformValue.apply(new SourceRecord(null, null,
+                "topic", 0, null, value)));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class InsertFieldTest {
     private InsertField<SourceRecord> xformKey = new InsertField.Key<>();
@@ -42,10 +43,11 @@ public class InsertFieldTest {
         xformValue.close();
     }
 
-    @Test(expected = DataException.class)
+    @Test
     public void topLevelStructRequired() {
         xformValue.configure(Collections.singletonMap("topic.field", "topic_field"));
-        xformValue.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42));
+        assertThrows(DataException.class,
+            () -> xformValue.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42)));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -38,6 +38,7 @@ import java.util.TimeZone;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class TimestampConverterTest {
     private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
@@ -98,12 +99,12 @@ public class TimestampConverterTest {
         xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigInvalidFormat() {
         Map<String, String> config = new HashMap<>();
         config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
         config.put(TimestampConverter.FORMAT_CONFIG, "bad-format");
-        xformValue.configure(config);
+        assertThrows(ConfigException.class, () -> xformValue.configure(config));
     }
 
     // Conversions without schemas (most flexible Timestamp -> other types)

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -84,19 +84,21 @@ public class TimestampConverterTest {
         xformValue.close();
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigNoTargetType() {
-        xformValue.configure(Collections.<String, String>emptyMap());
+        assertThrows(ConfigException.class, () -> xformValue.configure(Collections.<String, String>emptyMap()));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigInvalidTargetType() {
-        xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "invalid"));
+        assertThrows(ConfigException.class,
+            () -> xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "invalid")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testConfigMissingFormat() {
-        xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
+        assertThrows(ConfigException.class,
+            () -> xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string")));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/util/NonEmptyListValidatorTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/util/NonEmptyListValidatorTest.java
@@ -17,20 +17,24 @@
 package org.apache.kafka.connect.transforms.util;
 
 import org.apache.kafka.common.config.ConfigException;
+
 import org.junit.Test;
 
 import java.util.Collections;
 
+import static org.junit.Assert.assertThrows;
+
 public class NonEmptyListValidatorTest {
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testNullList() {
-        new NonEmptyListValidator().ensureValid("foo", null);
+        assertThrows(ConfigException.class, () -> new NonEmptyListValidator().ensureValid("foo", null));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testEmptyList() {
-        new NonEmptyListValidator().ensureValid("foo", Collections.emptyList());
+        assertThrows(ConfigException.class,
+            () -> new NonEmptyListValidator().ensureValid("foo", Collections.emptyList()));
     }
 
     @Test

--- a/core/src/test/scala/integration/kafka/api/AdminClientWithPoliciesIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientWithPoliciesIntegrationTest.scala
@@ -26,10 +26,9 @@ import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.errors.{InvalidRequestException, PolicyViolationException}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.server.policy.AlterConfigPolicy
-import org.junit.Assert.{assertEquals, assertNull, assertTrue}
+import org.junit.Assert.{assertEquals, assertNull, assertTrue, assertThrows}
 import org.junit.{After, Before, Rule, Test}
 import org.junit.rules.Timeout
-import org.scalatest.Assertions.intercept
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
@@ -132,10 +131,10 @@ class AdminClientWithPoliciesIntegrationTest extends KafkaServerTestHarness with
     ).asJava)
 
     assertEquals(Set(topicResource1, topicResource2, topicResource3, brokerResource).asJava, alterResult.values.keySet)
-    assertTrue(intercept[ExecutionException](alterResult.values.get(topicResource1).get).getCause.isInstanceOf[PolicyViolationException])
+    assertTrue(assertThrows(classOf[ExecutionException], () => alterResult.values.get(topicResource1).get).getCause.isInstanceOf[PolicyViolationException])
     alterResult.values.get(topicResource2).get
-    assertTrue(intercept[ExecutionException](alterResult.values.get(topicResource3).get).getCause.isInstanceOf[InvalidRequestException])
-    assertTrue(intercept[ExecutionException](alterResult.values.get(brokerResource).get).getCause.isInstanceOf[InvalidRequestException])
+    assertTrue(assertThrows(classOf[ExecutionException], () => alterResult.values.get(topicResource3).get).getCause.isInstanceOf[InvalidRequestException])
+    assertTrue(assertThrows(classOf[ExecutionException], () => alterResult.values.get(brokerResource).get).getCause.isInstanceOf[InvalidRequestException])
 
     // Verify that the second resource was updated and the others were not
     var describeResult = client.describeConfigs(Seq(topicResource1, topicResource2, topicResource3, brokerResource).asJava)
@@ -162,10 +161,10 @@ class AdminClientWithPoliciesIntegrationTest extends KafkaServerTestHarness with
     ).asJava, new AlterConfigsOptions().validateOnly(true))
 
     assertEquals(Set(topicResource1, topicResource2, topicResource3, brokerResource).asJava, alterResult.values.keySet)
-    assertTrue(intercept[ExecutionException](alterResult.values.get(topicResource1).get).getCause.isInstanceOf[PolicyViolationException])
+    assertTrue(assertThrows(classOf[ExecutionException], () => alterResult.values.get(topicResource1).get).getCause.isInstanceOf[PolicyViolationException])
     alterResult.values.get(topicResource2).get
-    assertTrue(intercept[ExecutionException](alterResult.values.get(topicResource3).get).getCause.isInstanceOf[InvalidRequestException])
-    assertTrue(intercept[ExecutionException](alterResult.values.get(brokerResource).get).getCause.isInstanceOf[InvalidRequestException])
+    assertTrue(assertThrows(classOf[ExecutionException], () => alterResult.values.get(topicResource3).get).getCause.isInstanceOf[InvalidRequestException])
+    assertTrue(assertThrows(classOf[ExecutionException], () => alterResult.values.get(brokerResource).get).getCause.isInstanceOf[InvalidRequestException])
 
     // Verify that no resources are updated since validate_only = true
     describeResult = client.describeConfigs(Seq(topicResource1, topicResource2, topicResource3, brokerResource).asJava)

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -1195,44 +1195,44 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     }
   }
 
-  @Test(expected = classOf[GroupAuthorizationException])
+  @Test
   def testCommitWithNoAccess(): Unit = {
     val consumer = createConsumer()
-    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    assertThrows(classOf[GroupAuthorizationException], () => consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava))
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testCommitWithNoTopicAccess(): Unit = {
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResource)
     val consumer = createConsumer()
-    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava))
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testCommitWithTopicWrite(): Unit = {
     createTopic(topic)
 
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResource)
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, WRITE, ALLOW)), topicResource)
     val consumer = createConsumer()
-    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava))
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testCommitWithTopicDescribe(): Unit = {
     createTopic(topic)
 
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResource)
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), topicResource)
     val consumer = createConsumer()
-    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava))
   }
 
-  @Test(expected = classOf[GroupAuthorizationException])
+  @Test
   def testCommitWithNoGroupAccess(): Unit = {
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), topicResource)
     val consumer = createConsumer()
-    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    assertThrows(classOf[GroupAuthorizationException], () => consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava))
   }
 
   @Test
@@ -1244,28 +1244,28 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testOffsetFetchWithNoAccess(): Unit = {
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    consumer.position(tp)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.position(tp))
   }
 
-  @Test(expected = classOf[GroupAuthorizationException])
+  @Test
   def testOffsetFetchWithNoGroupAccess(): Unit = {
     createTopic(topic)
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), topicResource)
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    consumer.position(tp)
+    assertThrows(classOf[GroupAuthorizationException], () => consumer.position(tp))
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testOffsetFetchWithNoTopicAccess(): Unit = {
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, READ, ALLOW)), groupResource)
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    consumer.position(tp)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.position(tp))
   }
 
   @Test
@@ -1319,10 +1319,10 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     consumer.position(tp)
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testMetadataWithNoTopicAccess(): Unit = {
     val consumer = createConsumer()
-    consumer.partitionsFor(topic)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.partitionsFor(topic))
   }
 
   @Test
@@ -1333,10 +1333,10 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     consumer.partitionsFor(topic)
   }
 
-  @Test(expected = classOf[TopicAuthorizationException])
+  @Test
   def testListOffsetsWithNoTopicAccess(): Unit = {
     val consumer = createConsumer()
-    consumer.endOffsets(Set(tp).asJava)
+    assertThrows(classOf[TopicAuthorizationException], () => consumer.endOffsets(Set(tp).asJava))
   }
 
   @Test
@@ -1571,17 +1571,17 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     assertEquals(Errors.NONE.code(), createPartitionsResponse.data.results.asScala.head.errorCode())
   }
 
-  @Test(expected = classOf[TransactionalIdAuthorizationException])
+  @Test
   def testTransactionalProducerInitTransactionsNoWriteTransactionalIdAcl(): Unit = {
     addAndVerifyAcls(Set(new AccessControlEntry(clientPrincipalString, WildcardHost, DESCRIBE, ALLOW)), transactionalIdResource)
     val producer = buildTransactionalProducer()
-    producer.initTransactions()
+    assertThrows(classOf[TransactionalIdAuthorizationException], () => producer.initTransactions())
   }
 
-  @Test(expected = classOf[TransactionalIdAuthorizationException])
+  @Test
   def testTransactionalProducerInitTransactionsNoDescribeTransactionalIdAcl(): Unit = {
     val producer = buildTransactionalProducer()
-    producer.initTransactions()
+    assertThrows(classOf[TransactionalIdAuthorizationException], () => producer.initTransactions())
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
@@ -127,7 +126,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
           assertNotEquals(metadata.checksum(), 0)
           offset += 1
         } else {
-          fail("Send callback returns the following exception", exception)
+          fail(s"Send callback returns the following exception: $exception")
         }
       }
     }
@@ -239,7 +238,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
           offset += 1
           timestampDiff += 1
         } else {
-          fail("Send callback returns the following exception", exception)
+          fail(s"Send callback returns the following exception: $exception")
         }
       }
     }

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -35,7 +35,6 @@ import org.apache.kafka.common.quota.ClientQuotaEntity
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.Assert._
 import org.junit.{Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.collection.Map
 import scala.jdk.CollectionConverters._
@@ -301,7 +300,7 @@ abstract class QuotaTestClients(topic: String,
       metric match {
         case m: Meter => m.count.toDouble
         case m: Histogram => m.max
-        case m => fail(s"Unexpected broker metric of class ${m.getClass}")
+        case m => throw new AssertionError(s"Unexpected broker metric of class ${m.getClass}")
       }
     }
 

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -18,10 +18,10 @@
 package kafka.api
 
 import com.yammer.metrics.core.Gauge
+
 import java.io.File
 import java.util.Collections
 import java.util.concurrent.ExecutionException
-
 import kafka.admin.AclCommand
 import kafka.metrics.KafkaYammerMetrics
 import kafka.security.authorizer.AclAuthorizer
@@ -42,7 +42,6 @@ import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.{assertThrows, fail, intercept}
 
 import scala.jdk.CollectionConverters._
 
@@ -244,10 +243,9 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
 
   private def getGauge(metricName: String) = {
     KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
-           .filter { case (k, _) => k.getName == metricName }
-           .headOption
-           .getOrElse { fail( "Unable to find metric " + metricName ) }
-           ._2.asInstanceOf[Gauge[Double]]
+      .find { case (k, _) => k.getName == metricName }
+      .getOrElse(throw new RuntimeException( "Unable to find metric " + metricName))
+      ._2.asInstanceOf[Gauge[Double]]
   }
 
   @Test
@@ -343,12 +341,12 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
 
     // Verify produce/consume/describe throw TopicAuthorizationException
     val producer = createProducer()
-    assertThrows[TopicAuthorizationException] { sendRecords(producer, numRecords, tp) }
+    assertThrows(classOf[TopicAuthorizationException], () => sendRecords(producer, numRecords, tp))
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    assertThrows[TopicAuthorizationException] { consumeRecords(consumer, numRecords, topic = tp.topic) }
+    assertThrows(classOf[TopicAuthorizationException], () => consumeRecords(consumer, numRecords, topic = tp.topic))
     val adminClient = createAdminClient()
-    val e1 = intercept[ExecutionException] { adminClient.describeTopics(Set(topic).asJava).all().get() }
+    val e1 = assertThrows(classOf[ExecutionException], () => adminClient.describeTopics(Set(topic).asJava).all().get())
     assertTrue("Unexpected exception " + e1.getCause, e1.getCause.isInstanceOf[TopicAuthorizationException])
 
     // Verify successful produce/consume/describe on another topic using the same producer, consumer and adminClient
@@ -360,7 +358,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     consumeRecords(consumer, numRecords, topic = topic2)
     val describeResults = adminClient.describeTopics(Set(topic, topic2).asJava).values
     assertEquals(1, describeResults.get(topic2).get().partitions().size())
-    val e2 = intercept[ExecutionException] { adminClient.describeTopics(Set(topic).asJava).all().get() }
+    val e2 = assertThrows(classOf[ExecutionException], () => adminClient.describeTopics(Set(topic).asJava).all().get())
     assertTrue("Unexpected exception " + e2.getCause, e2.getCause.isInstanceOf[TopicAuthorizationException])
 
     // Verify that consumer manually assigning both authorized and unauthorized topic doesn't consume
@@ -374,9 +372,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
       topic2RecordConsumed = true
       false
     }
-    assertThrows[TopicAuthorizationException] {
-      TestUtils.pollRecordsUntilTrue(consumer, verifyNoRecords, "Consumer didn't fail with authorization exception within timeout")
-    }
+    assertThrows(classOf[TopicAuthorizationException],
+      () => TestUtils.pollRecordsUntilTrue(consumer, verifyNoRecords, "Consumer didn't fail with authorization exception within timeout"))
 
     // Add ACLs and verify successful produce/consume/describe on first topic
     setReadAndWriteAcls(tp)
@@ -417,7 +414,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
     // the exception is expected when the consumer attempts to lookup offsets
-    assertThrows[KafkaException](consumeRecords(consumer))
+    assertThrows(classOf[KafkaException], () => consumeRecords(consumer))
+    confirmReauthenticationMetrics()
   }
 
   @Test
@@ -426,12 +424,12 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
     // this should timeout since the consumer will not be able to fetch any metadata for the topic
-    assertThrows[TopicAuthorizationException] { consumeRecords(consumer, timeout = 3000) }
+    assertThrows(classOf[TopicAuthorizationException], () => consumeRecords(consumer, timeout = 3000))
 
     // Verify that no records are consumed even if one of the requested topics is authorized
     setReadAndWriteAcls(tp)
     consumer.subscribe(List(topic, "topic2").asJava)
-    assertThrows[TopicAuthorizationException] { consumeRecords(consumer, timeout = 3000) }
+    assertThrows(classOf[TopicAuthorizationException], () => consumeRecords(consumer, timeout = 3000))
 
     // Verify that records are consumed if all topics are authorized
     consumer.subscribe(List(topic).asJava)

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -411,14 +411,13 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     * Tests that a consumer fails to consume messages without the appropriate
     * ACL set.
     */
-  @Test(expected = classOf[KafkaException])
+  @Test
   def testNoConsumeWithoutDescribeAclViaAssign(): Unit = {
     noConsumeWithoutDescribeAclSetup()
     val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
     // the exception is expected when the consumer attempts to lookup offsets
-    consumeRecords(consumer)
-    confirmReauthenticationMetrics()
+    assertThrows[KafkaException](consumeRecords(consumer))
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -29,7 +29,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.security.authenticator.TestJaasConfig
 import org.junit.{After, Before, Test}
 import org.junit.Assert._
-import org.scalatest.Assertions.fail
 
 import scala.jdk.CollectionConverters._
 
@@ -289,7 +288,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
       .getOrElse(fail(s"Unable to find broker metric $name: allMetrics: ${allMetrics.keySet.map(_.getMBeanName)}"))
     metric match {
       case m: Histogram => m
-      case m => fail(s"Unexpected broker metric of class ${m.getClass}")
+      case m => throw new AssertionError(s"Unexpected broker metric of class ${m.getClass}")
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.test.{MockConsumerInterceptor, MockProducerInterceptor}
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.Buffer
@@ -628,9 +627,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertNull(consumer.committed(Set(topicPartition).asJava).get(topicPartition))
 
     // position() on a partition that we aren't subscribed to throws an exception
-    intercept[IllegalStateException] {
-      consumer.position(topicPartition)
-    }
+    assertThrows(classOf[IllegalStateException], () => consumer.position(topicPartition))
 
     consumer.assign(List(tp).asJava)
 
@@ -680,16 +677,12 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // poll should fail because there is no offset reset strategy set.
     // we fail only when resetting positions after coordinator is known, so using a long timeout.
-    intercept[NoOffsetForPartitionException] {
-      consumer.poll(Duration.ofMillis(15000))
-    }
+    assertThrows(classOf[NoOffsetForPartitionException], () => consumer.poll(Duration.ofMillis(15000)))
 
     // seek to out of range position
     val outOfRangePos = totalRecords + 1
     consumer.seek(tp, outOfRangePos)
-    val e = intercept[OffsetOutOfRangeException] {
-      consumer.poll(Duration.ofMillis(20000))
-    }
+    val e = assertThrows(classOf[OffsetOutOfRangeException], () => consumer.poll(Duration.ofMillis(20000)))
     val outOfRangePartitions = e.offsetOutOfRangePartitions()
     assertNotNull(outOfRangePartitions)
     assertEquals(1, outOfRangePartitions.size)
@@ -1201,8 +1194,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val consumer = createConsumer()
 
     // Test negative target time
-    intercept[IllegalArgumentException](
-      consumer.offsetsForTimes(Collections.singletonMap(new TopicPartition(topic1, 0), -1)))
+    assertThrows(classOf[IllegalArgumentException],
+      () => consumer.offsetsForTimes(Collections.singletonMap(new TopicPartition(topic1, 0), -1)))
 
     val producer = createProducer()
     val timestampsToSearch = new util.HashMap[TopicPartition, java.lang.Long]()

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -557,10 +557,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertFalse(partitions.isEmpty)
   }
 
-  @Test(expected = classOf[InvalidTopicException])
+  @Test
   def testPartitionsForInvalidTopic(): Unit = {
     val consumer = createConsumer()
-    consumer.partitionsFor(";3# ads,{234")
+    assertThrows(classOf[InvalidTopicException], () => consumer.partitionsFor(";3# ads,{234"))
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/PlaintextEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextEndToEndAuthorizationTest.scala
@@ -22,7 +22,6 @@ import org.apache.kafka.common.security.auth._
 import org.junit.{Before, Test}
 import org.junit.Assert._
 import org.apache.kafka.common.errors.TopicAuthorizationException
-import org.scalatest.Assertions.intercept
 
 // This test case uses a separate listener for client and inter-broker communication, from
 // which we derive corresponding principals
@@ -80,7 +79,7 @@ class PlaintextEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   def testListenerName(): Unit = {
     // To check the client listener name, establish a session on the server by sending any request eg sendRecords
     val producer = createProducer()
-    intercept[TopicAuthorizationException](sendRecords(producer, numRecords = 1, tp))
+    assertThrows(classOf[TopicAuthorizationException], () => sendRecords(producer, numRecords = 1, tp))
 
     assertEquals(Some("CLIENT"), PlaintextEndToEndAuthorizationTest.clientListenerName)
     assertEquals(Some("SERVER"), PlaintextEndToEndAuthorizationTest.serverListenerName)

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -29,7 +29,6 @@ import org.apache.kafka.common.record.{DefaultRecord, DefaultRecordBatch, Record
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 
 class PlaintextProducerSendTest extends BaseProducerSendTest {
@@ -98,9 +97,8 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
 
     val producer = createProducer(brokerList = brokerList)
     try {
-      val e = intercept[ExecutionException] {
-        producer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()
-      }.getCause
+      val e = assertThrows(classOf[ExecutionException],
+        () => producer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()).getCause
       assertTrue(e.isInstanceOf[InvalidTimestampException])
       assertEquals("One or more records have been rejected due to invalid timestamp", e.getMessage)
     } finally {
@@ -110,9 +108,8 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
     // Test compressed messages.
     val compressedProducer = createProducer(brokerList = brokerList, compressionType = "gzip")
     try {
-      val e = intercept[ExecutionException] {
-        compressedProducer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()
-      }.getCause
+      val e = assertThrows(classOf[ExecutionException],
+        () => compressedProducer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()).getCause
       assertTrue(e.isInstanceOf[InvalidTimestampException])
       assertEquals("One or more records have been rejected due to invalid timestamp", e.getMessage)
     } finally {
@@ -154,12 +151,12 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
 
     def verifyMetadataNotAvailable(future: Future[RecordMetadata]): Unit = {
       assertTrue(future.isDone)  // verify future was completed immediately
-      assertEquals(classOf[TimeoutException], intercept[ExecutionException](future.get).getCause.getClass)
+      assertEquals(classOf[TimeoutException], assertThrows(classOf[ExecutionException], () => future.get).getCause.getClass)
     }
 
     def verifyBufferExhausted(future: Future[RecordMetadata]): Unit = {
       assertTrue(future.isDone)  // verify future was completed immediately
-      assertEquals(classOf[BufferExhaustedException], intercept[ExecutionException](future.get).getCause.getClass)
+      assertEquals(classOf[BufferExhaustedException], assertThrows(classOf[ExecutionException], () => future.get).getCause.getClass)
     }
 
     // Topic metadata not available, send should fail without blocking
@@ -195,7 +192,7 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
     assertEquals(record0.value.length, producer.send(record0).get.serializedValueSize)
 
     val record1 = new ProducerRecord(topic, new Array[Byte](0), new Array[Byte](valueSize + 1))
-    assertEquals(classOf[RecordTooLargeException], intercept[ExecutionException](producer.send(record1).get).getCause.getClass)
+    assertEquals(classOf[RecordTooLargeException], assertThrows(classOf[ExecutionException], () => producer.send(record1).get).getCause.getClass)
   }
 
 }

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -34,7 +34,7 @@ import org.scalatest.Assertions.intercept
 
 class PlaintextProducerSendTest extends BaseProducerSendTest {
 
-  @Test(expected = classOf[SerializationException])
+  @Test
   def testWrongSerializer(): Unit = {
     val producerProps = new Properties()
     producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
@@ -42,7 +42,7 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
     val producer = registerProducer(new KafkaProducer(producerProps))
     val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, 0, "key".getBytes, "value".getBytes)
-    producer.send(record)
+    assertThrows(classOf[SerializationException], () => producer.send(record))
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -20,8 +20,7 @@ import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.errors.{GroupAuthorizationException, TopicAuthorizationException}
 import org.junit.{Before, Test}
-import org.junit.Assert.{assertEquals, assertTrue}
-import org.scalatest.Assertions.fail
+import org.junit.Assert.{assertEquals, assertTrue, fail}
 
 import scala.collection.immutable.List
 import scala.jdk.CollectionConverters._

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -33,7 +33,6 @@ import org.apache.kafka.common.errors.{InvalidProducerEpochException, ProducerFe
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
@@ -332,7 +331,7 @@ class TransactionsTest extends KafkaServerTestHarness {
       case _: ProducerFencedException =>
         // good!
       case e: Exception =>
-        fail("Got an unexpected exception from a fenced producer.", e)
+        throw new AssertionError("Got an unexpected exception from a fenced producer.", e)
     }
 
     producer2.commitTransaction()  // ok
@@ -371,7 +370,7 @@ class TransactionsTest extends KafkaServerTestHarness {
       case _: ProducerFencedException =>
         // good!
       case e: Exception =>
-        fail("Got an unexpected exception from a fenced producer.", e)
+        throw new AssertionError("Got an unexpected exception from a fenced producer.", e)
     }
 
     producer2.commitTransaction()  // ok
@@ -482,7 +481,7 @@ class TransactionsTest extends KafkaServerTestHarness {
       case e: ExecutionException =>
         assertTrue(e.getCause.isInstanceOf[InvalidProducerEpochException])
       case e: Exception =>
-        fail("Got an unexpected exception from a fenced producer.", e)
+        throw new AssertionError("Got an unexpected exception from a fenced producer.", e)
     }
 
     producer2.commitTransaction() // ok
@@ -528,7 +527,7 @@ class TransactionsTest extends KafkaServerTestHarness {
       case e: ExecutionException =>
         assertTrue(e.getCause.isInstanceOf[ProducerFencedException])
       case e: Exception =>
-        fail("Got an unexpected exception from a fenced producer.", e)
+        throw new AssertionError("Got an unexpected exception from a fenced producer.", e)
     }
 
     producer2.commitTransaction()  // ok
@@ -714,7 +713,7 @@ class TransactionsTest extends KafkaServerTestHarness {
       case _: TimeoutException =>
         // good!
       case e: Exception =>
-        fail("Got an unexpected exception from initTransactions", e)
+        throw new AssertionError("Got an unexpected exception from initTransactions", e)
     } finally {
       producer2.close()
     }
@@ -728,7 +727,7 @@ class TransactionsTest extends KafkaServerTestHarness {
       case _: ProducerFencedException =>
         // good!
       case e: Exception =>
-        fail("Got an unexpected exception from commitTransaction", e)
+        throw new AssertionError("Got an unexpected exception from commitTransaction", e)
     } finally {
       producer1.close()
     }

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -406,46 +406,40 @@ class TransactionsTest extends KafkaServerTestHarness {
     TestUtils.waitUntilTrue(() => offsetAndMetadata.equals(consumer.committed(Set(tp).asJava).get(tp)), "cannot read committed offset")
   }
 
-  @Test(expected = classOf[TimeoutException])
+  @Test
   def testInitTransactionsTimeout(): Unit = {
     testTimeout(false, producer => producer.initTransactions())
   }
 
-  @Test(expected = classOf[TimeoutException])
+  @Test
   def testSendOffsetsToTransactionTimeout(): Unit = {
     testTimeout(true, producer => producer.sendOffsetsToTransaction(
       Map(new TopicPartition(topic1, 0) -> new OffsetAndMetadata(0)).asJava, "test-group"))
   }
 
-  @Test(expected = classOf[TimeoutException])
+  @Test
   def testCommitTransactionTimeout(): Unit = {
     testTimeout(true, producer => producer.commitTransaction())
   }
 
-  @Test(expected = classOf[TimeoutException])
+  @Test
   def testAbortTransactionTimeout(): Unit = {
     testTimeout(true, producer => producer.abortTransaction())
   }
 
-  def testTimeout(needInitAndSendMsg: Boolean,
+  private def testTimeout(needInitAndSendMsg: Boolean,
                   timeoutProcess: KafkaProducer[Array[Byte], Array[Byte]] => Unit): Unit = {
-    val producer = createTransactionalProducer("transactionProducer", maxBlockMs =  1000)
-
+    val producer = createTransactionalProducer("transactionProducer", maxBlockMs = 3000)
     if (needInitAndSendMsg) {
       producer.initTransactions()
       producer.beginTransaction()
       producer.send(new ProducerRecord[Array[Byte], Array[Byte]](topic1, "foo".getBytes, "bar".getBytes))
     }
 
-    for  (i <- servers.indices)
-      killBroker(i)
+    for  (i <- servers.indices) killBroker(i)
 
-    try {
-      timeoutProcess(producer)
-      fail("Should raise a TimeoutException")
-    } finally {
-      producer.close(Duration.ZERO)
-    }
+    assertThrows(classOf[TimeoutException], () => timeoutProcess(producer))
+    producer.close(Duration.ZERO)
   }
 
   @Test
@@ -619,13 +613,12 @@ class TransactionsTest extends KafkaServerTestHarness {
     }
   }
 
-  @Test(expected = classOf[KafkaException])
+  @Test
   def testConsecutivelyRunInitTransactions(): Unit = {
     val producer = createTransactionalProducer(transactionalId = "normalProducer")
 
     producer.initTransactions()
-    producer.initTransactions()
-    fail("Should have raised a KafkaException")
+    assertThrows(classOf[KafkaException], () => producer.initTransactions())
   }
 
   @Test

--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -36,7 +36,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.{KafkaException, requests}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
@@ -165,7 +164,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     plaintextConns ++= (0 until 2).map(_ => connect("PLAINTEXT"))
     TestUtils.waitUntilTrue(() => connectionCount <= 10, "Internal connections not closed")
     plaintextConns.foreach(verifyConnection)
-    intercept[IOException](internalConns.foreach { socket =>
+    assertThrows(classOf[IOException], () => internalConns.foreach { socket =>
       sendAndReceive[ProduceResponse](produceRequest, socket)
     })
     plaintextConns.foreach(_.close())
@@ -359,7 +358,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
     conns = conns :+ connect("PLAINTEXT")
 
     // now try one more (should fail)
-    intercept[IOException](connectWithFailure.apply())
+    assertThrows(classOf[IOException], () => connectWithFailure.apply())
 
     //close one connection
     conns.head.close()

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -62,7 +62,6 @@ import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializ
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.junit.Assert._
 import org.junit.{After, Before, Ignore, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.annotation.nowarn
 import scala.collection._
@@ -982,10 +981,10 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
       .bootstrapServers(bootstrap)
       .build()
 
-    assertTrue(intercept[ExecutionException] {
+    assertTrue(assertThrows(classOf[ExecutionException], () => {
       val future = producer1.send(new ProducerRecord(topic, "key", "value"))
       future.get(2, TimeUnit.SECONDS)
-    }.getCause.isInstanceOf[org.apache.kafka.common.errors.TimeoutException])
+    }).getCause.isInstanceOf[org.apache.kafka.common.errors.TimeoutException])
 
     alterAdvertisedListener(adminClient, externalAdminClient, invalidHost, "localhost")
     servers.foreach(validateEndpointsInZooKeeper(_, endpoints => !endpoints.contains(invalidHost)))
@@ -1428,7 +1427,7 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
       else
         Seq(new ConfigResource(ConfigResource.Type.BROKER, ""))
       brokerResources.foreach { brokerResource =>
-        val exception = intercept[ExecutionException](alterResult.values.get(brokerResource).get)
+        val exception = assertThrows(classOf[ExecutionException], () => alterResult.values.get(brokerResource).get)
         assertTrue(exception.getCause.isInstanceOf[InvalidRequestException])
       }
       servers.foreach { server =>

--- a/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
@@ -58,7 +58,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     }
   }
 
-  @Test(expected = classOf[TimeoutException])
+  @Test
   def testCommitOffsetsThrowTimeoutException(): Unit = {
     val consumerProps = new Properties
     consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group")
@@ -68,7 +68,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     val consumer = new KafkaConsumer(consumerProps, new ByteArrayDeserializer, new ByteArrayDeserializer)
     val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, whitelistOpt = Some("any"))
     mirrorMakerConsumer.offsets.put(new TopicPartition("test", 0), 0L)
-    mirrorMakerConsumer.commit()
+    assertThrows(classOf[TimeoutException], () => mirrorMakerConsumer.commit())
   }
 
   @Test

--- a/core/src/test/scala/kafka/security/auth/ResourceTest.scala
+++ b/core/src/test/scala/kafka/security/auth/ResourceTest.scala
@@ -24,14 +24,14 @@ import org.junit.Assert._
 
 @deprecated("Use org.apache.kafka.common.resource.ResourcePattern", "Since 2.5")
 class ResourceTest {
-  @Test(expected = classOf[KafkaException])
+  @Test
   def shouldThrowOnTwoPartStringWithUnknownResourceType(): Unit = {
-    Resource.fromString("Unknown:fred")
+    assertThrows(classOf[KafkaException], () => Resource.fromString("Unknown:fred"))
   }
 
-  @Test(expected = classOf[KafkaException])
+  @Test
   def shouldThrowOnBadResourceTypeSeparator(): Unit = {
-    Resource.fromString("Topic-fred")
+    assertThrows(classOf[KafkaException], () => Resource.fromString("Topic-fred"))
   }
 
   @Test

--- a/core/src/test/scala/kafka/utils/ExitTest.scala
+++ b/core/src/test/scala/kafka/utils/ExitTest.scala
@@ -19,9 +19,8 @@ package kafka.utils
 
 import java.io.IOException
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 class ExitTest {
   @Test
@@ -36,11 +35,11 @@ class ExitTest {
     val statusCode = 0
     val message = Some("message")
     try {
-      intercept[IOException] {Exit.halt(statusCode)}
+      assertThrows(classOf[IOException], () => Exit.halt(statusCode))
       assertEquals(statusCode, array(0))
       assertEquals(None, array(1))
 
-      intercept[IOException] {Exit.halt(statusCode, message)}
+      assertThrows(classOf[IOException], () => Exit.halt(statusCode, message))
       assertEquals(statusCode, array(0))
       assertEquals(message, array(1))
     } finally {
@@ -60,11 +59,11 @@ class ExitTest {
     val statusCode = 0
     val message = Some("message")
     try {
-      intercept[IOException] {Exit.exit(statusCode)}
+      assertThrows(classOf[IOException], () => Exit.exit(statusCode))
       assertEquals(statusCode, array(0))
       assertEquals(None, array(1))
 
-      intercept[IOException] {Exit.exit(statusCode, message)}
+      assertThrows(classOf[IOException], () => Exit.exit(statusCode, message))
       assertEquals(statusCode, array(0))
       assertEquals(message, array(1))
     } finally {

--- a/core/src/test/scala/kafka/zk/ExtendedAclStoreTest.scala
+++ b/core/src/test/scala/kafka/zk/ExtendedAclStoreTest.scala
@@ -20,7 +20,7 @@ package kafka.zk
 import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.resource.ResourceType.TOPIC
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
 
 class ExtendedAclStoreTest {
@@ -40,14 +40,14 @@ class ExtendedAclStoreTest {
     assertEquals(PREFIXED, store.patternType)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldThrowIfConstructedWithLiteral(): Unit = {
-    new ExtendedAclStore(LITERAL)
+    assertThrows(classOf[IllegalArgumentException], () => new ExtendedAclStore(LITERAL))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldThrowFromEncodeOnLiteral(): Unit = {
-    store.changeStore.createChangeNode(literalResource)
+    assertThrows(classOf[IllegalArgumentException], () => store.changeStore.createChangeNode(literalResource))
   }
 
   @Test

--- a/core/src/test/scala/kafka/zk/LiteralAclStoreTest.scala
+++ b/core/src/test/scala/kafka/zk/LiteralAclStoreTest.scala
@@ -18,12 +18,11 @@
 package kafka.zk
 
 import java.nio.charset.StandardCharsets.UTF_8
-
 import kafka.security.authorizer.AclEntry
 import org.apache.kafka.common.resource.PatternType.{LITERAL, PREFIXED}
 import org.apache.kafka.common.resource.ResourcePattern
 import org.apache.kafka.common.resource.ResourceType.{GROUP, TOPIC}
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
 
 class LiteralAclStoreTest {
@@ -43,9 +42,9 @@ class LiteralAclStoreTest {
     assertEquals(LITERAL, store.patternType)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldThrowFromEncodeOnNoneLiteral(): Unit = {
-    store.changeStore.createChangeNode(prefixedResource)
+    assertThrows(classOf[IllegalArgumentException], () => store.changeStore.createChangeNode(prefixedResource))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/KafkaConfigTest.scala
@@ -61,22 +61,22 @@ class KafkaTest {
     assertEquals(util.Arrays.asList("compact","delete"), config4.logCleanupPolicy)
   }
 
-  @Test(expected = classOf[FatalExitError])
+  @Test
   def testGetKafkaConfigFromArgsNonArgsAtTheEnd(): Unit = {
     val propertiesFile = prepareDefaultConfig()
-    KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "broker.id=1", "broker.id=2")))
+    assertThrows(classOf[FatalExitError], () => KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "--override", "broker.id=1", "broker.id=2"))))
   }
 
-  @Test(expected = classOf[FatalExitError])
+  @Test
   def testGetKafkaConfigFromArgsNonArgsOnly(): Unit = {
     val propertiesFile = prepareDefaultConfig()
-    KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "broker.id=1", "broker.id=2")))
+    assertThrows(classOf[FatalExitError], () => KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "broker.id=1", "broker.id=2"))))
   }
 
-  @Test(expected = classOf[FatalExitError])
+  @Test
   def testGetKafkaConfigFromArgsNonArgsAtTheBegging(): Unit = {
     val propertiesFile = prepareDefaultConfig()
-    KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "broker.id=1", "--override", "broker.id=2")))
+    assertThrows(classOf[FatalExitError], () => KafkaConfig.fromProps(Kafka.getPropsFromArgs(Array(propertiesFile, "broker.id=1", "--override", "broker.id=2"))))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -263,12 +263,12 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
     }
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testInvalidAuthorizerProperty(): Unit = {
     val args = Array("--authorizer-properties", "zookeeper.connect " + zkConnect)
     val aclCommandService = new AclCommand.AuthorizerService(classOf[AclAuthorizer].getName,
       new AclCommandOptions(args))
-    aclCommandService.listAcls()
+    assertThrows(classOf[IllegalArgumentException], () => aclCommandService.listAcls())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -36,9 +36,8 @@ import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.utils.{AppInfoParser, SecurityUtils}
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.log4j.Level
-import org.junit.Assert.assertFalse
+import org.junit.Assert.{assertFalse, assertThrows}
 import org.junit.{After, Assert, Before, Test}
-import org.scalatest.Assertions.intercept
 
 class AclCommandTest extends ZooKeeperTestHarness with Logging {
 
@@ -284,7 +283,7 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
       if (isValid)
         callMain(cmd)
       else
-        intercept[RuntimeException](callMain(cmd))
+        assertThrows(classOf[RuntimeException], () => callMain(cmd))
     }
     try {
       PatternType.values.foreach { patternType =>

--- a/core/src/test/scala/unit/kafka/admin/AdminRackAwareTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AdminRackAwareTest.scala
@@ -20,7 +20,6 @@ import kafka.utils.Logging
 import org.apache.kafka.common.errors.InvalidReplicationFactorException
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions._
 
 import scala.collection.Map
 
@@ -200,14 +199,12 @@ class AdminRackAwareTest extends RackAwareTest with Logging {
     val brokerMetadatas = (0 to 4).map(new BrokerMetadata(_, None))
 
     // test 0 replication factor
-    intercept[InvalidReplicationFactorException] {
-      AdminUtils.assignReplicasToBrokers(brokerMetadatas, 10, 0)
-    }
+    assertThrows(classOf[InvalidReplicationFactorException],
+      () => AdminUtils.assignReplicasToBrokers(brokerMetadatas, 10, 0))
 
     // test wrong replication factor
-    intercept[InvalidReplicationFactorException] {
-      AdminUtils.assignReplicasToBrokers(brokerMetadatas, 10, 6)
-    }
+    assertThrows(classOf[InvalidReplicationFactorException],
+      () => AdminUtils.assignReplicasToBrokers(brokerMetadatas, 10, 6))
 
     // correct assignment
     val expectedAssignment = Map(

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -249,7 +249,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     assertTrue(addedProps2.getProperty("f").isEmpty)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfAddAndAddFile(): Unit = {
     // Should not parse correctly
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
@@ -259,7 +259,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--add-config", "a=b,c=d",
       "--add-config-file", "/tmp/new.properties"
     ))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
   @Test
@@ -335,88 +335,88 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     doTestOptionEntityTypeNames(zkConfig = false)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfUnrecognisedEntityTypeUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "client", "--entity-type", "not-recognised", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+    assertThrows(classOf[IllegalArgumentException], () => ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient)))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfUnrecognisedEntityType(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "client", "--entity-type", "not-recognised", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
+    assertThrows(classOf[IllegalArgumentException], () => ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfBrokerEntityTypeIsNotAnIntegerUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "A", "--entity-type", "brokers", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+    assertThrows(classOf[IllegalArgumentException], () => ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient)))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfBrokerEntityTypeIsNotAnInteger(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "A", "--entity-type", "brokers", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
+    assertThrows(classOf[IllegalArgumentException], () => ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfShortBrokerEntityTypeIsNotAnIntegerUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--broker", "A", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient))
+    assertThrows(classOf[IllegalArgumentException], () => ConfigCommand.alterConfigWithZk(null, createOpts, new DummyAdminZkClient(zkClient)))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfShortBrokerEntityTypeIsNotAnInteger(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--broker", "A", "--alter", "--add-config", "a=b,c=d"))
-    ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts)
+    assertThrows(classOf[IllegalArgumentException], () => ConfigCommand.alterConfig(new DummyAdminClient(new Node(1, "localhost", 9092)), createOpts))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfMixedEntityTypeFlagsUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "A", "--entity-type", "users", "--client", "B", "--describe"))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfMixedEntityTypeFlags(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "A", "--entity-type", "users", "--client", "B", "--describe"))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfInvalidHost(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "A,B", "--entity-type", "ips", "--describe"))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfInvalidHostUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "A,B", "--entity-type", "ips", "--describe"))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfUnresolvableHost(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--bootstrap-server", "localhost:9092",
       "--entity-name", "admin", "--entity-type", "ips", "--describe"))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailIfUnresolvableHostUsingZookeeper(): Unit = {
     val createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
       "--entity-name", "admin", "--entity-type", "ips", "--describe"))
-    createOpts.checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => createOpts.checkArgs())
   }
 
   @Test
@@ -913,7 +913,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     new ConfigCommandOptions(optsList.toArray).checkArgs()
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testDescribeAllBrokerConfigBootstrapServerRequired(): Unit = {
     val optsList = List("--zookeeper", zkConnect,
       "--entity-type", ConfigType.Broker,
@@ -921,10 +921,10 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--describe",
       "--all")
 
-    new ConfigCommandOptions(optsList.toArray).checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => new ConfigCommandOptions(optsList.toArray).checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testEntityDefaultOptionWithDescribeBrokerLoggerIsNotAllowed(): Unit = {
     val optsList = List("--bootstrap-server", "localhost:9092",
       "--entity-type", ConfigCommand.BrokerLoggerConfigType,
@@ -932,10 +932,10 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--describe"
     )
 
-    new ConfigCommandOptions(optsList.toArray).checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => new ConfigCommandOptions(optsList.toArray).checkArgs())
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testEntityDefaultOptionWithAlterBrokerLoggerIsNotAllowed(): Unit = {
     val optsList = List("--bootstrap-server", "localhost:9092",
       "--entity-type", ConfigCommand.BrokerLoggerConfigType,
@@ -944,17 +944,17 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
       "--add-config", "kafka.log.LogCleaner=DEBUG"
     )
 
-    new ConfigCommandOptions(optsList.toArray).checkArgs()
+    assertThrows(classOf[IllegalArgumentException], () => new ConfigCommandOptions(optsList.toArray).checkArgs())
   }
 
-  @Test(expected = classOf[InvalidConfigurationException])
+  @Test
   def shouldRaiseInvalidConfigurationExceptionWhenAddingInvalidBrokerLoggerConfig(): Unit = {
     val node = new Node(1, "localhost", 9092)
     // verifyAlterBrokerLoggerConfig tries to alter kafka.log.LogCleaner, kafka.server.ReplicaManager and kafka.server.KafkaApi
     // yet, we make it so DescribeConfigs returns only one logger, implying that kafka.server.ReplicaManager and kafka.log.LogCleaner are invalid
-    verifyAlterBrokerLoggerConfig(node, "1", "1", List(
+    assertThrows(classOf[InvalidConfigurationException], () => verifyAlterBrokerLoggerConfig(node, "1", "1", List(
       new ConfigEntry("kafka.server.KafkaApi", "INFO")
-    ))
+    )))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/DelegationTokenCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DelegationTokenCommandTest.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionException
@@ -104,7 +103,7 @@ class DelegationTokenCommandTest extends BaseRequestTest with SaslSetup {
     assertTrue(tokens.size == 0)
 
     //create token with invalid renewer principal type
-    intercept[ExecutionException](DelegationTokenCommand.createToken(adminClient, getCreateOpts(List("Group:Renewer3"))))
+    assertThrows(classOf[ExecutionException], () => DelegationTokenCommand.createToken(adminClient, getCreateOpts(List("Group:Renewer3"))))
 
     // try describing tokens for unknown owner
     assertTrue(DelegationTokenCommand.describeToken(adminClient, getDescribeOpts(List("User:Unknown"))).isEmpty)

--- a/core/src/test/scala/unit/kafka/admin/DeleteConsumerGroupsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteConsumerGroupsTest.scala
@@ -25,11 +25,11 @@ import org.junit.Test
 
 class DeleteConsumerGroupsTest extends ConsumerGroupCommandTest {
 
-  @Test(expected = classOf[OptionException])
+  @Test
   def testDeleteWithTopicOption(): Unit = {
     TestUtils.createOffsetsTopic(zkClient, servers)
     val cgcArgs = Array("--bootstrap-server", brokerList, "--delete", "--group", group, "--topic")
-    getConsumerGroupService(cgcArgs)
+    assertThrows(classOf[OptionException], () => getConsumerGroupService(cgcArgs))
   }
 
   @Test
@@ -240,9 +240,9 @@ class DeleteConsumerGroupsTest extends ConsumerGroupCommandTest {
   }
 
 
-  @Test(expected = classOf[OptionException])
+  @Test
   def testDeleteWithUnrecognizedNewConsumerOption(): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", brokerList, "--delete", "--group", group)
-    getConsumerGroupService(cgcArgs)
+    assertThrows(classOf[OptionException], () => getConsumerGroupService(cgcArgs))
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -32,7 +32,6 @@ import kafka.controller.{OfflineReplica, PartitionAndReplica, ReplicaAssignment,
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, NewPartitionReassignment, NewPartitions}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
-import org.scalatest.Assertions.fail
 import scala.jdk.CollectionConverters._
 
 class DeleteTopicTest extends ZooKeeperTestHarness {
@@ -171,7 +170,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
   }
 
   private def getController() : (KafkaServer, Int) = {
-    val controllerId = zkClient.getControllerId.getOrElse(fail("Controller doesn't exist"))
+    val controllerId = zkClient.getControllerId.getOrElse(throw new AssertionError("Controller doesn't exist"))
     val controller = servers.find(s => s.config.brokerId == controllerId).get
     (controller, controllerId)
   }

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -686,11 +686,10 @@ class DescribeConsumerGroupTest extends ConsumerGroupCommandTest {
     }
   }
 
-  @Test(expected = classOf[joptsimple.OptionException])
+  @Test
   def testDescribeWithUnrecognizedNewConsumerOption(): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", brokerList, "--describe", "--group", group)
-    getConsumerGroupService(cgcArgs)
-    fail("Expected an error due to presence of unrecognized --new-consumer option")
+    assertThrows(classOf[joptsimple.OptionException], () => getConsumerGroupService(cgcArgs))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
@@ -26,9 +26,8 @@ import org.apache.kafka.common.utils.Utils
 
 import java.util.Properties
 
-import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Assert.{assertEquals, assertTrue, assertThrows}
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 class FeatureCommandTest extends BaseRequestTest {
   override def brokerCount: Int = 3
@@ -219,9 +218,7 @@ class FeatureCommandTest extends BaseRequestTest {
                       Utils.mkEntry("feature_3", new SupportedVersionRange(1, 3))))
       featureApis.setSupportedFeatures(targetFeaturesWithIncompatibilities)
       val output = TestUtils.grabConsoleOutput({
-        val exception = intercept[UpdateFeaturesException] {
-          featureApis.upgradeAllFeatures()
-        }
+        val exception = assertThrows(classOf[UpdateFeaturesException], () => featureApis.upgradeAllFeatures())
         assertEquals("2 feature updates failed!", exception.getMessage)
       })
       val expected =

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -23,7 +23,6 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.ConsumerGroupState
 import org.apache.kafka.clients.admin.ConsumerGroupListing
 import java.util.Optional
-import org.scalatest.Assertions.assertThrows
 
 class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
@@ -90,21 +89,13 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     result = ConsumerGroupCommand.consumerGroupStatesFromString("Dead,CompletingRebalance,")
     assertEquals(Set(ConsumerGroupState.DEAD, ConsumerGroupState.COMPLETING_REBALANCE), result)
 
-    assertThrows[IllegalArgumentException] {
-      ConsumerGroupCommand.consumerGroupStatesFromString("bad, wrong")
-    }
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupStatesFromString("bad, wrong"))
 
-    assertThrows[IllegalArgumentException] {
-      ConsumerGroupCommand.consumerGroupStatesFromString("stable")
-    }
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupStatesFromString("stable"))
 
-    assertThrows[IllegalArgumentException] {
-      ConsumerGroupCommand.consumerGroupStatesFromString("  bad, Stable")
-    }
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupStatesFromString("  bad, Stable"))
 
-    assertThrows[IllegalArgumentException] {
-      ConsumerGroupCommand.consumerGroupStatesFromString("   ,   ,")
-    }
+    assertThrows(classOf[IllegalArgumentException], () => ConsumerGroupCommand.consumerGroupStatesFromString("   ,   ,"))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -43,10 +43,10 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     }, s"Expected --list to show groups $expectedGroups, but found $foundGroups.")
   }
 
-  @Test(expected = classOf[OptionException])
+  @Test
   def testListWithUnrecognizedNewConsumerOption(): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", brokerList, "--list")
-    getConsumerGroupService(cgcArgs)
+    assertThrows(classOf[OptionException], () => getConsumerGroupService(cgcArgs))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -413,11 +413,11 @@ class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
     adminZkClient.deleteTopic(topic)
   }
 
-  @Test(expected = classOf[OptionException])
+  @Test
   def testResetWithUnrecognizedNewConsumerOption(): Unit = {
     val cgcArgs = Array("--new-consumer", "--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics",
       "--to-offset", "2", "--export")
-    getConsumerGroupService(cgcArgs)
+    assertThrows(classOf[OptionException], () => getConsumerGroupService(cgcArgs))
   }
 
   private def produceMessages(topic: String, numMessages: Int): Unit = {

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -24,7 +24,6 @@ import org.apache.kafka.common.Node
 import org.apache.kafka.common.TopicPartitionInfo
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 
@@ -106,16 +105,12 @@ class TopicCommandTest {
 
   @Test
   def testParseAssignmentDuplicateEntries(): Unit = {
-    intercept[AdminCommandFailedException] {
-      TopicCommand.parseReplicaAssignment("5:5")
-    }
+    assertThrows(classOf[AdminCommandFailedException], () => TopicCommand.parseReplicaAssignment("5:5"))
   }
 
   @Test
   def testParseAssignmentPartitionsOfDifferentSize(): Unit = {
-    intercept[AdminOperationException] {
-      TopicCommand.parseReplicaAssignment("5:4:3,2:1")
-    }
+    assertThrows(classOf[AdminOperationException], () => TopicCommand.parseReplicaAssignment("5:4:3,2:1"))
   }
 
   @Test
@@ -131,8 +126,6 @@ class TopicCommandTest {
         assertEquals(expected, exitCode)
         throw new RuntimeException
     }
-    try intercept[RuntimeException] {
-      options.checkArgs()
-    } finally Exit.resetExitProcedure()
+    try assertThrows(classOf[RuntimeException], () => options.checkArgs()) finally Exit.resetExitProcedure()
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -16,8 +16,6 @@
   */
 package kafka.admin
 
-import java.util.{Collections, Optional, Properties}
-
 import kafka.admin.TopicCommand.{AdminClientTopicService, TopicCommandOptions}
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.{ConfigType, KafkaConfig}
@@ -25,28 +23,24 @@ import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin._
-import org.apache.kafka.common.Node
-import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.TopicPartitionInfo
+import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionInfo}
 import org.apache.kafka.common.config.{ConfigException, ConfigResource, TopicConfig}
-import org.apache.kafka.common.errors.ClusterAuthorizationException
-import org.apache.kafka.common.errors.ThrottlingQuotaExceededException
-import org.apache.kafka.common.errors.TopicExistsException
+import org.apache.kafka.common.errors.{ClusterAuthorizationException, ThrottlingQuotaExceededException, TopicExistsException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.junit.Assert.assertThrows
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.Assert._
 import org.junit.rules.TestName
 import org.junit.{After, Before, Rule, Test}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.{eq => eqThat, _}
 import org.mockito.Mockito._
 
-import scala.jdk.CollectionConverters._
+import java.util.{Collections, Optional, Properties}
 import scala.collection.Seq
 import scala.concurrent.ExecutionException
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Logging with RackAwareTest {

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -16,6 +16,8 @@
   */
 package kafka.admin
 
+import java.util.{Collections, Optional, Properties}
+
 import kafka.admin.TopicCommand.{AdminClientTopicService, TopicCommandOptions}
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.{ConfigType, KafkaConfig}
@@ -23,24 +25,28 @@ import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode}
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin._
-import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionInfo}
+import org.apache.kafka.common.Node
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.TopicPartitionInfo
 import org.apache.kafka.common.config.{ConfigException, ConfigResource, TopicConfig}
-import org.apache.kafka.common.errors.{ClusterAuthorizationException, ThrottlingQuotaExceededException, TopicExistsException}
+import org.apache.kafka.common.errors.ClusterAuthorizationException
+import org.apache.kafka.common.errors.ThrottlingQuotaExceededException
+import org.apache.kafka.common.errors.TopicExistsException
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.junit.Assert._
+import org.junit.Assert.assertThrows
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.rules.TestName
 import org.junit.{After, Before, Rule, Test}
 import org.mockito.ArgumentMatcher
 import org.mockito.ArgumentMatchers.{eq => eqThat, _}
 import org.mockito.Mockito._
 
-import java.util.{Collections, Optional, Properties}
+import scala.jdk.CollectionConverters._
 import scala.collection.Seq
 import scala.concurrent.ExecutionException
-import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Logging with RackAwareTest {

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithZKClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithZKClientTest.scala
@@ -27,7 +27,6 @@ import org.apache.kafka.common.internals.Topic
 import org.junit.Assert._
 import org.junit.rules.TestName
 import org.junit.{After, Before, Rule, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.util.Random
 
@@ -89,9 +88,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     topicService.createTopic(createOpts)
 
     // try to re-create the topic without --if-not-exists
-    intercept[TopicExistsException] {
-      topicService.createTopic(createOpts)
-    }
+    assertThrows(classOf[TopicExistsException], () => topicService.createTopic(createOpts))
 
     // try to re-create the topic with --if-not-exists
     val createNotExistsOpts = new TopicCommandOptions(
@@ -119,10 +116,9 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     val brokers = List(0)
     TestUtils.createBrokersInZk(zkClient, brokers)
 
-    intercept[InvalidReplicationFactorException] {
-      topicService.createTopic(new TopicCommandOptions(
-        Array("--partitions", "2", "--replication-factor", (Short.MaxValue+1).toString, "--topic", testTopicName)))
-    }
+    assertThrows(classOf[InvalidReplicationFactorException],
+      () => topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "2", "--replication-factor", (Short.MaxValue+1).toString, "--topic", testTopicName))))
   }
 
   @Test
@@ -130,10 +126,9 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     val brokers = List(0)
     TestUtils.createBrokersInZk(zkClient, brokers)
 
-    intercept[InvalidReplicationFactorException] {
-      topicService.createTopic(new TopicCommandOptions(
-        Array("--partitions", "2", "--replication-factor", "-1", "--topic", testTopicName)))
-    }
+    assertThrows(classOf[InvalidReplicationFactorException],
+      () => topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "2", "--replication-factor", "-1", "--topic", testTopicName))))
   }
 
   @Test
@@ -141,10 +136,9 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     val brokers = List(0)
     TestUtils.createBrokersInZk(zkClient, brokers)
 
-    intercept[InvalidPartitionsException] {
-      topicService.createTopic(new TopicCommandOptions(
-        Array("--partitions", "-1", "--replication-factor", "1", "--topic", testTopicName)))
-    }
+    assertThrows(classOf[InvalidPartitionsException],
+      () => topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "-1", "--replication-factor", "1", "--topic", testTopicName))))
   }
 
   @Test
@@ -155,17 +149,13 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     val createOpts = new TopicCommandOptions(
       Array("--partitions", "1", "--replication-factor", "1", "--topic", testTopicName,
         "--config", "message.timestamp.type=boom"))
-    intercept[ConfigException] {
-      topicService.createTopic(createOpts)
-    }
+    assertThrows(classOf[ConfigException], () => topicService.createTopic(createOpts))
 
     // try to create the topic with another invalid config
     val createOpts2 = new TopicCommandOptions(
       Array("--partitions", "1", "--replication-factor", "1", "--topic", testTopicName,
         "--config", "message.format.version=boom"))
-    intercept[ConfigException] {
-      topicService.createTopic(createOpts2)
-    }
+    assertThrows(classOf[ConfigException], () => topicService.createTopic(createOpts2))
   }
 
   @Test
@@ -253,10 +243,9 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     topicService.createTopic(new TopicCommandOptions(
       Array("--partitions", "1", "--replication-factor", "1", "--topic", testTopicName)))
 
-    intercept[InvalidPartitionsException] {
-      topicService.alterTopic(new TopicCommandOptions(
-        Array("--partitions", "-1", "--topic", testTopicName)))
-    }
+    assertThrows(classOf[InvalidPartitionsException],
+      () => topicService.alterTopic(new TopicCommandOptions(
+        Array("--partitions", "-1", "--topic", testTopicName))))
   }
 
   @Test
@@ -267,9 +256,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
 
     // alter a topic that does not exist without --if-exists
     val alterOpts = new TopicCommandOptions(Array("--topic", testTopicName, "--partitions", "1"))
-    intercept[IllegalArgumentException] {
-      topicService.alterTopic(alterOpts)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => topicService.alterTopic(alterOpts))
 
     // alter a topic that does not exist with --if-exists
     val alterExistsOpts = new TopicCommandOptions(Array("--topic", testTopicName, "--partitions", "1", "--if-exists"))
@@ -362,9 +349,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
     val deleteOffsetTopicPath = DeleteTopicsTopicZNode.path(Topic.GROUP_METADATA_TOPIC_NAME)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deleteOffsetTopicPath))
-    intercept[AdminOperationException] {
-      topicService.deleteTopic(deleteOffsetTopicOpts)
-    }
+    assertThrows(classOf[AdminOperationException], () => topicService.deleteTopic(deleteOffsetTopicOpts))
     assertFalse("Delete path for topic shouldn't exist after deletion.", zkClient.pathExists(deleteOffsetTopicPath))
   }
 
@@ -376,9 +361,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
 
     // delete a topic that does not exist without --if-exists
     val deleteOpts = new TopicCommandOptions(Array("--topic", testTopicName))
-    intercept[IllegalArgumentException] {
-      topicService.deleteTopic(deleteOpts)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => topicService.deleteTopic(deleteOpts))
 
     // delete a topic that does not exist with --if-exists
     val deleteExistsOpts = new TopicCommandOptions(Array("--topic", testTopicName, "--if-exists"))
@@ -399,9 +382,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
     val deleteOffsetTopicPath = DeleteTopicsTopicZNode.path(Topic.GROUP_METADATA_TOPIC_NAME)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deleteOffsetTopicPath))
-    intercept[AdminOperationException] {
-      topicService.deleteTopic(deleteOffsetTopicOpts)
-    }
+    assertThrows(classOf[AdminOperationException], () => topicService.deleteTopic(deleteOffsetTopicOpts))
   }
 
   @Test
@@ -412,9 +393,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
 
     // describe topic that does not exist
     val describeOpts = new TopicCommandOptions(Array("--topic", testTopicName))
-    intercept[IllegalArgumentException] {
-      topicService.describeTopic(describeOpts)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => topicService.describeTopic(describeOpts))
 
     // describe all topics
     val describeOptsAllTopics = new TopicCommandOptions(Array())
@@ -612,9 +591,7 @@ class TopicCommandWithZKClientTest extends ZooKeeperTestHarness with Logging wit
     }
     Exit.setExitProcedure(mockExitProcedure)
     try {
-      intercept[RuntimeException] {
-        method()
-      }
+      assertThrows(classOf[RuntimeException], () => method())
     } finally {
       Exit.resetExitProcedure()
     }

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -16,6 +16,9 @@
  */
 package kafka.cluster
 
+import java.nio.ByteBuffer
+import java.util.Optional
+import java.util.concurrent.{CountDownLatch, Semaphore}
 import com.yammer.metrics.core.Metric
 import kafka.api.{ApiVersion, KAFKA_2_6_IV0}
 import kafka.common.UnexpectedAppendOffsetException
@@ -42,9 +45,6 @@ import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
-import java.nio.ByteBuffer
-import java.util.Optional
-import java.util.concurrent.{CountDownLatch, Semaphore}
 import scala.jdk.CollectionConverters._
 
 class PartitionTest extends AbstractPartitionTest {

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -16,9 +16,6 @@
  */
 package kafka.cluster
 
-import java.nio.ByteBuffer
-import java.util.Optional
-import java.util.concurrent.{CountDownLatch, Semaphore}
 import com.yammer.metrics.core.Metric
 import kafka.api.{ApiVersion, KAFKA_2_6_IV0}
 import kafka.common.UnexpectedAppendOffsetException
@@ -45,6 +42,9 @@ import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 
+import java.nio.ByteBuffer
+import java.util.Optional
+import java.util.concurrent.{CountDownLatch, Semaphore}
 import scala.jdk.CollectionConverters._
 
 class PartitionTest extends AbstractPartitionTest {

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -114,7 +114,7 @@ class ReplicaTest {
     assertEquals(0, log.activeSegment.size)
   }
 
-  @Test(expected = classOf[OffsetOutOfRangeException])
+  @Test
   def testCannotIncrementLogStartOffsetPastHighWatermark(): Unit = {
     for (i <- 0 until 100) {
       val records = TestUtils.singletonRecords(value = s"test$i".getBytes)
@@ -122,6 +122,6 @@ class ReplicaTest {
     }
 
     log.updateHighWatermark(25L)
-    log.maybeIncrementLogStartOffset(26L, ClientRecordDeletion)
+    assertThrows(classOf[OffsetOutOfRangeException], () => log.maybeIncrementLogStartOffset(26L, ClientRecordDeletion))
   }
 }

--- a/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerChannelManagerTest.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrTopi
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -552,7 +551,7 @@ class ControllerChannelManagerTest {
     // We should only receive events for the topic being deleted
     val includedPartitions = batch.sentEvents.flatMap {
       case event: TopicDeletionStopReplicaResponseReceived => event.partitionErrors.keySet
-      case otherEvent => Assertions.fail(s"Unexpected sent event: $otherEvent")
+      case otherEvent => throw new AssertionError(s"Unexpected sent event: $otherEvent")
     }.toSet
     assertEquals(partitions.keys.filter(_.topic == "foo"), includedPartitions)
   }

--- a/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
@@ -29,7 +29,6 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.log4j.Logger
 import org.junit.{After, Test}
 import org.junit.Assert._
-import org.scalatest.Assertions.fail
 
 class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   val log = Logger.getLogger(classOf[ControllerFailoverTest])
@@ -57,7 +56,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   @Test
   def testHandleIllegalStateException(): Unit = {
     val initialController = servers.find(_.kafkaController.isActive).map(_.kafkaController).getOrElse {
-      fail("Could not find controller")
+      throw new AssertionError("Could not find controller")
     }
     val initialEpoch = initialController.epoch
     // Create topic with one partition

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -42,7 +42,6 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
 import org.junit.Assert._
 import org.junit.{After, Assert, Before, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Seq, mutable}
@@ -1323,9 +1322,8 @@ class GroupCoordinatorTest {
     EasyMock.reset(replicaManager)
 
     // Illegal state exception shall trigger since follower id resides in pending member bucket.
-    val expectedException = intercept[IllegalStateException] {
-      staticJoinGroup(groupId, rebalanceResult.followerId, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1)
-    }
+    val expectedException = assertThrows(classOf[IllegalStateException],
+      () => staticJoinGroup(groupId, rebalanceResult.followerId, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1))
 
     val message = expectedException.getMessage
     assertTrue(message.contains(rebalanceResult.followerId))
@@ -1341,9 +1339,8 @@ class GroupCoordinatorTest {
     EasyMock.reset(replicaManager)
 
     // Illegal state exception shall trigger since follower id resides in pending member bucket.
-    val expectedException = intercept[IllegalStateException] {
-      singleLeaveGroup(groupId, rebalanceResult.followerId, followerInstanceId)
-    }
+    val expectedException = assertThrows(classOf[IllegalStateException],
+      () => singleLeaveGroup(groupId, rebalanceResult.followerId, followerInstanceId))
 
     val message = expectedException.getMessage
     assertTrue(message.contains(rebalanceResult.followerId))
@@ -1360,9 +1357,8 @@ class GroupCoordinatorTest {
     EasyMock.reset(replicaManager)
 
     // Illegal state exception shall trigger since follower id resides in pending member bucket.
-    val expectedException = intercept[IllegalStateException] {
-      staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1)
-    }
+    val expectedException = assertThrows(classOf[IllegalStateException],
+      () => staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1))
 
     val message = expectedException.getMessage
     assertTrue(message.contains(group.groupId))
@@ -1378,9 +1374,8 @@ class GroupCoordinatorTest {
     EasyMock.reset(replicaManager)
 
     // Illegal state exception shall trigger since follower corresponding id is not defined in member list.
-    val expectedException = intercept[IllegalArgumentException] {
-      staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1)
-    }
+    val expectedException = assertThrows(classOf[IllegalArgumentException],
+      () => staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1))
 
     val message = expectedException.getMessage
     assertTrue(message.contains(invalidMemberId))
@@ -3251,10 +3246,9 @@ class GroupCoordinatorTest {
     val instanceId = "instanceId"
     val pendingMemberId = pendingMember.memberId
     getGroup(groupId).addStaticMember(Option(instanceId), pendingMemberId)
-    val expectedException = intercept[IllegalStateException] {
-      batchLeaveGroup(groupId, List(new MemberIdentity().setGroupInstanceId("unknown-instance"),
-        new MemberIdentity().setGroupInstanceId(instanceId).setMemberId(pendingMemberId)))
-    }
+    val expectedException = assertThrows(classOf[IllegalStateException],
+      () => batchLeaveGroup(groupId, List(new MemberIdentity().setGroupInstanceId("unknown-instance"),
+        new MemberIdentity().setGroupInstanceId(instanceId).setMemberId(pendingMemberId))))
 
     val message = expectedException.getMessage
     assertTrue(message.contains(instanceId))

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -46,7 +46,6 @@ import org.apache.kafka.common.utils.Utils
 import org.easymock.{Capture, EasyMock, IAnswer}
 import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue, assertThrows}
 import org.junit.{Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.jdk.CollectionConverters._
 import scala.collection._
@@ -142,7 +141,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(committedOffsets.size, group.allOffsets.size)
@@ -174,7 +173,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(generation, group.generationId)
@@ -211,7 +210,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(committedOffsets.size, group.allOffsets.size)
@@ -278,7 +277,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
     // The group should be loaded with pending offsets.
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     // Ensure that no offsets are materialized, but that we have offsets pending.
@@ -324,7 +323,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     // Ensure that only the committed offsets are materialized, and that there are no pending commits for the producer.
@@ -379,7 +378,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
 
@@ -442,7 +441,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
 
@@ -489,7 +488,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
     // The group should be loaded with pending offsets.
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(1, group.allOffsets.size)
@@ -531,7 +530,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
     // The group should be loaded with pending offsets.
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(1, group.allOffsets.size)
@@ -614,7 +613,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(committedOffsets.size - 1, group.allOffsets.size)
@@ -651,7 +650,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Stable, group.currentState)
     assertEquals(memberId, group.leaderOrNull)
@@ -712,7 +711,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     committedOffsets.foreach { case (topicPartition, offset) =>
       assertEquals(Some(offset), group.offset(topicPartition).map(_.offset))
     }
@@ -772,7 +771,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(committedOffsets.size, group.allOffsets.size)
@@ -815,7 +814,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Stable, group.currentState)
 
@@ -2001,7 +2000,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Stable, group.currentState)
     assertEquals(memberId, group.leaderOrNull)
@@ -2041,7 +2040,7 @@ class GroupMetadataManagerTest {
 
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Stable, group.currentState)
     assertEquals(memberId, group.leaderOrNull)
@@ -2193,7 +2192,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.loadGroupsAndOffsets(groupMetadataTopicPartition, _ => (), 0L)
 
     // Empty control batch should not have caused the load to fail
-    val group = groupMetadataManager.getGroup(groupId).getOrElse(fail("Group was not loaded into the cache"))
+    val group = groupMetadataManager.getGroup(groupId).getOrElse(throw new AssertionError("Group was not loaded into the cache"))
     assertEquals(groupId, group.groupId)
     assertEquals(Empty, group.currentState)
     assertEquals(generation, group.generationId)

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -127,9 +127,9 @@ class GroupMetadataTest {
     assertState(group, Stable)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testEmptyToStableIllegalTransition(): Unit = {
-    group.transitionTo(Stable)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(Stable))
   }
 
   @Test
@@ -145,28 +145,28 @@ class GroupMetadataTest {
     }
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testEmptyToAwaitingRebalanceIllegalTransition(): Unit = {
-    group.transitionTo(CompletingRebalance)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(CompletingRebalance))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testPreparingRebalanceToPreparingRebalanceIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
-    group.transitionTo(PreparingRebalance)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(PreparingRebalance))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testPreparingRebalanceToStableIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
-    group.transitionTo(Stable)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(Stable))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testAwaitingRebalanceToAwaitingRebalanceIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
     group.transitionTo(CompletingRebalance)
-    group.transitionTo(CompletingRebalance)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(CompletingRebalance))
   }
 
   def testDeadToDeadIllegalTransition(): Unit = {
@@ -176,25 +176,25 @@ class GroupMetadataTest {
     assertState(group, Dead)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testDeadToStableIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
     group.transitionTo(Dead)
-    group.transitionTo(Stable)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(Stable))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testDeadToPreparingRebalanceIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
     group.transitionTo(Dead)
-    group.transitionTo(PreparingRebalance)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(PreparingRebalance))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testDeadToAwaitingRebalanceIllegalTransition(): Unit = {
     group.transitionTo(PreparingRebalance)
     group.transitionTo(Dead)
-    group.transitionTo(CompletingRebalance)
+    assertThrows(classOf[IllegalStateException], () => group.transitionTo(CompletingRebalance))
   }
 
   @Test
@@ -223,10 +223,9 @@ class GroupMetadataTest {
     assertEquals("roundrobin", group.selectProtocol)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testSelectProtocolRaisesIfNoMembers(): Unit = {
-    group.selectProtocol
-    fail()
+    assertThrows(classOf[IllegalStateException], () => group.selectProtocol)
   }
 
   @Test
@@ -519,7 +518,7 @@ class GroupMetadataTest {
     assertFalse(group.hasPendingOffsetCommitsFromProducer(producerId))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testReplaceGroupInstanceWithEmptyGroupInstanceId(): Unit = {
     group.add(member)
     group.addStaticMember(groupInstanceId, memberId)
@@ -527,13 +526,13 @@ class GroupMetadataTest {
     assertEquals(memberId, group.getStaticMemberId(groupInstanceId))
 
     val newMemberId = "newMemberId"
-    group.replaceGroupInstance(memberId, newMemberId, Option.empty)
+    assertThrows(classOf[IllegalArgumentException], () => group.replaceGroupInstance(memberId, newMemberId, Option.empty))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testReplaceGroupInstanceWithNonExistingMember(): Unit = {
     val newMemberId = "newMemberId"
-    group.replaceGroupInstance(memberId, newMemberId, groupInstanceId)
+    assertThrows(classOf[IllegalArgumentException], () => group.replaceGroupInstance(memberId, newMemberId, groupInstanceId))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/group/MemberMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/MemberMetadataTest.scala
@@ -64,24 +64,22 @@ class MemberMetadataTest {
     assertTrue(Arrays.equals(Array[Byte](1), member.metadata("roundrobin")))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testMetadataRaisesOnUnsupportedProtocol(): Unit = {
     val protocols = List(("range", Array.empty[Byte]), ("roundrobin", Array.empty[Byte]))
 
     val member = new MemberMetadata(memberId, groupId, groupInstanceId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs,
       protocolType, protocols)
-    member.metadata("blah")
-    fail()
+    assertThrows(classOf[IllegalArgumentException], () => member.metadata("blah"))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testVoteRaisesOnNoSupportedProtocols(): Unit = {
     val protocols = List(("range", Array.empty[Byte]), ("roundrobin", Array.empty[Byte]))
 
     val member = new MemberMetadata(memberId, groupId, groupInstanceId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs,
       protocolType, protocols)
-    member.vote(Set("blah"))
-    fail()
+    assertThrows(classOf[IllegalArgumentException], () => member.vote(Set("blah")))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/ProducerIdManagerTest.scala
@@ -72,7 +72,7 @@ class ProducerIdManagerTest {
     assertEquals(pid2 + ProducerIdManager.PidBlockSize * 2, manager2.generateProducerId())
   }
 
-  @Test(expected = classOf[KafkaException])
+  @Test
   def testExceedProducerIdLimit(): Unit = {
     EasyMock.expect(zkClient.getDataAndVersion(EasyMock.anyString)).andAnswer(() => {
       val json = ProducerIdManager.generateProducerIdBlockJson(
@@ -80,7 +80,7 @@ class ProducerIdManagerTest {
       (Some(json), 0)
     }).anyTimes()
     EasyMock.replay(zkClient)
-    new ProducerIdManager(0, zkClient)
+    assertThrows(classOf[KafkaException], () => new ProducerIdManager(0, zkClient))
   }
 }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionLogTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionLogTest.scala
@@ -20,9 +20,8 @@ package kafka.coordinator.transaction
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 
@@ -45,9 +44,7 @@ class TransactionLogTest {
     val txnMetadata = TransactionMetadata(transactionalId, producerId, producerEpoch, transactionTimeoutMs, 0)
     txnMetadata.addPartitions(topicPartitions)
 
-    intercept[IllegalStateException] {
-      TransactionLog.valueToBytes(txnMetadata.prepareNoTransit())
-    }
+    assertThrows(classOf[IllegalStateException], () => TransactionLog.valueToBytes(txnMetadata.prepareNoTransit()))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
@@ -22,7 +22,6 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.record.RecordBatch
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions
 
 import scala.collection.mutable
 
@@ -482,7 +481,7 @@ class TransactionMetadataTest {
                                                       now: Option[Long] = None): TxnTransitMetadata = {
     val result = txnMetadata.prepareIncrementProducerEpoch(30000, expectedProducerEpoch,
       now.getOrElse(time.milliseconds()))
-    result.getOrElse(Assertions.fail(s"prepareIncrementProducerEpoch failed with $result"))
+    result.getOrElse(throw new AssertionError(s"prepareIncrementProducerEpoch failed with $result"))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
@@ -75,7 +75,7 @@ class TransactionMetadataTest {
     assertEquals(RecordBatch.NO_PRODUCER_EPOCH, txnMetadata.lastProducerEpoch)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testBumpEpochNotAllowedIfEpochsExhausted(): Unit = {
     val producerEpoch = (Short.MaxValue - 1).toShort
 
@@ -91,7 +91,8 @@ class TransactionMetadataTest {
       txnLastUpdateTimestamp = time.milliseconds())
     assertTrue(txnMetadata.isProducerEpochExhausted)
 
-    txnMetadata.prepareIncrementProducerEpoch(30000, None, time.milliseconds())
+    assertThrows(classOf[IllegalStateException], () => txnMetadata.prepareIncrementProducerEpoch(30000,
+      None, time.milliseconds()))
   }
 
   @Test
@@ -314,7 +315,7 @@ class TransactionMetadataTest {
     assertEquals(producerId, transitMetadata.producerId)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testFenceProducerNotAllowedIfItWouldOverflow(): Unit = {
     val producerEpoch = Short.MaxValue
 
@@ -329,7 +330,7 @@ class TransactionMetadataTest {
       topicPartitions = mutable.Set.empty,
       txnLastUpdateTimestamp = time.milliseconds())
     assertTrue(txnMetadata.isProducerEpochExhausted)
-    txnMetadata.prepareFenceProducerEpoch()
+    assertThrows(classOf[IllegalStateException], () => txnMetadata.prepareFenceProducerEpoch())
   }
 
   @Test
@@ -356,19 +357,19 @@ class TransactionMetadataTest {
     assertEquals(producerEpoch, txnMetadata.lastProducerEpoch)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testRotateProducerIdInOngoingState(): Unit = {
-    testRotateProducerIdInOngoingState(Ongoing)
+    assertThrows(classOf[IllegalStateException], () => testRotateProducerIdInOngoingState(Ongoing))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testRotateProducerIdInPrepareAbortState(): Unit = {
-    testRotateProducerIdInOngoingState(PrepareAbort)
+    assertThrows(classOf[IllegalStateException], () => testRotateProducerIdInOngoingState(PrepareAbort))
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testRotateProducerIdInPrepareCommitState(): Unit = {
-    testRotateProducerIdInOngoingState(PrepareCommit)
+    assertThrows(classOf[IllegalStateException], () => testRotateProducerIdInOngoingState(PrepareCommit))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -35,9 +35,8 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.MockTime
 import org.easymock.{Capture, EasyMock, IAnswer}
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, mutable}
@@ -278,12 +277,12 @@ class TransactionStateManagerTest {
     )
 
     val cachedPidMetadata1 = transactionManager.getTransactionState(transactionalId1).fold(
-      err => fail(transactionalId1 + "'s transaction state access returns error " + err),
-      entry => entry.getOrElse(fail(transactionalId1 + "'s transaction state was not loaded into the cache"))
+      err => throw new AssertionError(transactionalId1 + "'s transaction state access returns error " + err),
+      entry => entry.getOrElse(throw new AssertionError(transactionalId1 + "'s transaction state was not loaded into the cache"))
     )
     val cachedPidMetadata2 = transactionManager.getTransactionState(transactionalId2).fold(
-      err => fail(transactionalId2 + "'s transaction state access returns error " + err),
-      entry => entry.getOrElse(fail(transactionalId2 + "'s transaction state was not loaded into the cache"))
+      err => throw new AssertionError(transactionalId2 + "'s transaction state access returns error " + err),
+      entry => entry.getOrElse(throw new AssertionError(transactionalId2 + "'s transaction state was not loaded into the cache"))
     )
 
     // they should be equal to the latest status of the transaction

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -20,7 +20,6 @@ import java.lang.management.ManagementFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.locks.ReentrantLock
-
 import javax.management.ObjectName
 import kafka.log.{AppendOrigin, Log}
 import kafka.server.{FetchDataInfo, FetchLogEnd, LogOffsetMetadata, ReplicaManager}
@@ -35,7 +34,7 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.MockTime
 import org.easymock.{Capture, EasyMock, IAnswer}
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
+import org.junit.Assert.{assertEquals, assertFalse, assertThrows, assertTrue, fail}
 import org.junit.{After, Before, Test}
 
 import scala.jdk.CollectionConverters._
@@ -455,7 +454,7 @@ class TransactionStateManagerTest {
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, newMetadata, assertCallback)
   }
 
-  @Test(expected = classOf[IllegalStateException])
+  @Test
   def testAppendTransactionToLogWhilePendingStateChanged(): Unit = {
     // first insert the initial transaction metadata
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
@@ -471,7 +470,8 @@ class TransactionStateManagerTest {
     txnMetadata1.pendingState = None
 
     // append the new metadata into log
-    transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, newMetadata, assertCallback)
+    assertThrows(classOf[IllegalStateException], () => transactionManager.appendTransactionToLog(transactionalId1,
+      coordinatorEpoch = 10, newMetadata, assertCallback))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/MetricsDuringTopicCreationDeletionTest.scala
@@ -23,7 +23,6 @@ import kafka.server.KafkaConfig
 import kafka.utils.{Logging, TestUtils}
 
 import scala.jdk.CollectionConverters._
-import org.scalatest.Assertions.fail
 import org.junit.{Before, Test}
 import com.yammer.metrics.core.Gauge
 import kafka.metrics.KafkaYammerMetrics
@@ -124,10 +123,9 @@ class MetricsDuringTopicCreationDeletionTest extends KafkaServerTestHarness with
 
   private def getGauge(metricName: String) = {
     KafkaYammerMetrics.defaultRegistry.allMetrics.asScala
-                      .filter { case (k, _) => k.getName.endsWith(metricName) }
-                      .headOption
-                      .getOrElse { fail( "Unable to find metric " + metricName ) }
-                      ._2.asInstanceOf[Gauge[Int]]
+      .find { case (k, _) => k.getName.endsWith(metricName) }
+      .getOrElse(throw new AssertionError( "Unable to find metric " + metricName))
+      ._2.asInstanceOf[Gauge[Int]]
   }
 
   private def createDeleteTopics(): Unit = {

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -38,7 +38,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigsResult, Config, ConfigEntry}
 import org.junit.Assert._
-import org.scalatest.Assertions.intercept
 
 import scala.annotation.nowarn
 
@@ -164,9 +163,8 @@ class UncleanLeaderElectionTest extends ZooKeeperTestHarness {
     val topicProps = new Properties()
     topicProps.put("unclean.leader.election.enable", "invalid")
 
-    intercept[ConfigException] {
-      TestUtils.createTopic(zkClient, topic, Map(partitionId -> Seq(brokerId1)), servers, topicProps)
-    }
+    assertThrows(classOf[ConfigException],
+      () => TestUtils.createTopic(zkClient, topic, Map(partitionId -> Seq(brokerId1)), servers, topicProps))
   }
 
   def verifyUncleanLeaderElectionEnabled(): Unit = {

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -27,7 +27,6 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.Utils
 import org.junit.Assert._
 import org.junit.{After, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.collection.mutable
 
@@ -118,9 +117,7 @@ class LogCleanerManagerTest extends Logging {
     val cleanerManager = createCleanerManagerMock(logsPool)
     cleanerCheckpoints.put(tp, 1)
 
-    val thrownException = intercept[LogCleaningException] {
-      cleanerManager.grabFilthiestCompactedLog(time).get
-    }
+    val thrownException = assertThrows(classOf[LogCleaningException], () => cleanerManager.grabFilthiestCompactedLog(time).get)
     assertEquals(log, thrownException.log)
     assertTrue(thrownException.getCause.isInstanceOf[IllegalStateException])
   }
@@ -657,10 +654,10 @@ class LogCleanerManagerTest extends Logging {
 
     val cleanerManager: LogCleanerManager = createCleanerManager(log)
 
-    intercept[IllegalStateException](cleanerManager.doneCleaning(topicPartition, log.dir, 1))
+    assertThrows(classOf[IllegalStateException], () => cleanerManager.doneCleaning(topicPartition, log.dir, 1))
 
     cleanerManager.setCleaningState(topicPartition, LogCleaningPaused(1))
-    intercept[IllegalStateException](cleanerManager.doneCleaning(topicPartition, log.dir, 1))
+    assertThrows(classOf[IllegalStateException], () => cleanerManager.doneCleaning(topicPartition, log.dir, 1))
 
     cleanerManager.setCleaningState(topicPartition, LogCleaningInProgress)
     cleanerManager.doneCleaning(topicPartition, log.dir, 1)
@@ -680,10 +677,10 @@ class LogCleanerManagerTest extends Logging {
     val cleanerManager: LogCleanerManager = createCleanerManager(log)
     val tp = new TopicPartition("log", 0)
 
-    intercept[IllegalStateException](cleanerManager.doneDeleting(Seq(tp)))
+    assertThrows(classOf[IllegalStateException], () => cleanerManager.doneDeleting(Seq(tp)))
 
     cleanerManager.setCleaningState(tp, LogCleaningPaused(1))
-    intercept[IllegalStateException](cleanerManager.doneDeleting(Seq(tp)))
+    assertThrows(classOf[IllegalStateException], () => cleanerManager.doneDeleting(Seq(tp)))
 
     cleanerManager.setCleaningState(tp, LogCleaningInProgress)
     cleanerManager.doneDeleting(Seq(tp))

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.config.{ConfigException, TopicConfig}
 import org.junit.Assert._
 import org.junit.{Assert, Test}
 
-import java.util.Properties
+import java.util.{Collections, Properties}
 
 class LogConfigTest {
 
@@ -125,7 +125,7 @@ class LogConfigTest {
   /* Sanity check that toHtml produces one of the expected configs */
   @Test
   def testToHtml(): Unit = {
-    val html = LogConfig.configDefCopy.toHtml(4, (key: String) => "prefix_" + key)
+    val html = LogConfig.configDefCopy.toHtml(4, (key: String) => "prefix_" + key, Collections.emptyMap())
     val expectedConfig = "<h4><a id=\"file.delete.delay.ms\"></a><a id=\"prefix_file.delete.delay.ms\" href=\"#prefix_file.delete.delay.ms\">file.delete.delay.ms</a></h4>"
     assertTrue(s"Could not find `$expectedConfig` in:\n $html", html.contains(expectedConfig))
   }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -17,15 +17,15 @@
 
 package kafka.log
 
+import java.util.{Collections, Properties}
+
 import kafka.server.{KafkaConfig, KafkaServer, ThrottledReplicaListValidator}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM
 import org.apache.kafka.common.config.ConfigDef.Type.INT
 import org.apache.kafka.common.config.{ConfigException, TopicConfig}
-import org.junit.Assert._
 import org.junit.{Assert, Test}
-
-import java.util.{Collections, Properties}
+import org.junit.Assert._
 
 class LogConfigTest {
 

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -17,16 +17,15 @@
 
 package kafka.log
 
-import java.util.{Collections, Properties}
-
 import kafka.server.{KafkaConfig, KafkaServer, ThrottledReplicaListValidator}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM
 import org.apache.kafka.common.config.ConfigDef.Type.INT
 import org.apache.kafka.common.config.{ConfigException, TopicConfig}
-import org.junit.{Assert, Test}
 import org.junit.Assert._
-import org.scalatest.Assertions._
+import org.junit.{Assert, Test}
+
+import java.util.Properties
 
 class LogConfigTest {
 
@@ -88,9 +87,7 @@ class LogConfigTest {
     val props = new Properties
     props.setProperty(LogConfig.MaxCompactionLagMsProp, "100")
     props.setProperty(LogConfig.MinCompactionLagMsProp, "200")
-    intercept[Exception] {
-      LogConfig.validate(props)
-    }
+    assertThrows(classOf[Exception], () => LogConfig.validate(props))
   }
 
   @Test
@@ -128,7 +125,7 @@ class LogConfigTest {
   /* Sanity check that toHtml produces one of the expected configs */
   @Test
   def testToHtml(): Unit = {
-    val html = LogConfig.configDefCopy.toHtml(4, (key: String) => "prefix_" + key, Collections.emptyMap())
+    val html = LogConfig.configDefCopy.toHtml(4, (key: String) => "prefix_" + key)
     val expectedConfig = "<h4><a id=\"file.delete.delay.ms\"></a><a id=\"prefix_file.delete.delay.ms\" href=\"#prefix_file.delete.delay.ms\">file.delete.delay.ms</a></h4>"
     assertTrue(s"Could not find `$expectedConfig` in:\n $html", html.contains(expectedConfig))
   }
@@ -178,9 +175,7 @@ class LogConfigTest {
     values.foreach((value) => {
       val props = new Properties
       props.setProperty(name, value.toString)
-      intercept[Exception] {
-        LogConfig(props)
-      }
+      assertThrows(classOf[Exception], () => LogConfig(props))
     })
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -17,15 +17,15 @@
 
 package kafka.log
 
-import java.util.{Collections, Properties}
-
 import kafka.server.{KafkaConfig, KafkaServer, ThrottledReplicaListValidator}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigDef.Importance.MEDIUM
 import org.apache.kafka.common.config.ConfigDef.Type.INT
 import org.apache.kafka.common.config.{ConfigException, TopicConfig}
-import org.junit.{Assert, Test}
 import org.junit.Assert._
+import org.junit.{Assert, Test}
+
+import java.util.{Collections, Properties}
 
 class LogConfigTest {
 

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -2891,11 +2891,9 @@ class LogTest {
     // Kind of a hack, but renaming the index to a directory ensures that the append
     // to the index will fail.
     log.activeSegment.txnIndex.renameTo(log.dir)
-    assertThrows[KafkaStorageException] {
-      appendEndTxnMarkerAsLeader(log, pid, epoch, ControlRecordType.ABORT, coordinatorEpoch = 1)
-    }
-    assertThrows[KafkaStorageException](log.appendAsLeader(TestUtils.singletonRecords(value = null), leaderEpoch = 0))
-    assertThrows[KafkaStorageException](readLog(log, 0, 4096).records.records.iterator.next().offset)
+    assertThrows(classOf[KafkaStorageException], () => appendEndTxnMarkerAsLeader(log, pid, epoch, ControlRecordType.ABORT, coordinatorEpoch = 1))
+    assertThrows(classOf[KafkaStorageException], () => log.appendAsLeader(TestUtils.singletonRecords(value = null), leaderEpoch = 0))
+    assertThrows(classOf[KafkaStorageException], () => readLog(log, 0, 4096).records.records.iterator.next().offset)
   }
 
   @Test
@@ -4518,9 +4516,7 @@ class LogTest {
     // Try the append a second time. The appended offset in the log should not increase
     // because the log dir is marked as failed.  Nor will there be a write to the transaction
     // index.
-    assertThrows[KafkaStorageException] {
-      appendEndTxnMarkerAsLeader(log, pid, epoch, ControlRecordType.ABORT, coordinatorEpoch = 1)
-    }
+    assertThrows(classOf[KafkaStorageException], () => appendEndTxnMarkerAsLeader(log, pid, epoch, ControlRecordType.ABORT, coordinatorEpoch = 1))
     assertEquals(11L, log.logEndOffset)
     assertEquals(0L, log.lastStableOffset)
 
@@ -4528,10 +4524,7 @@ class LogTest {
     log.updateHighWatermark(12L)
     assertEquals(0L, log.lastStableOffset)
 
-    assertThrows[KafkaStorageException] {
-      log.close()
-    }
-
+    assertThrows(classOf[KafkaStorageException], () => log.close())
     val reopenedLog = createLog(logDir, logConfig, lastShutdownClean = false)
     assertEquals(11L, reopenedLog.logEndOffset)
     assertEquals(1, reopenedLog.activeSegment.txnIndex.allAbortedTxns.size)

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -604,12 +604,12 @@ class LogValidatorTest {
     checkCompressed(RecordBatch.MAGIC_VALUE_V2)
   }
 
-  @Test(expected = classOf[RecordValidationException])
+  @Test
   def testInvalidCreateTimeNonCompressedV1(): Unit = {
     val now = System.currentTimeMillis()
     val records = createRecords(magicValue = RecordBatch.MAGIC_VALUE_V1, timestamp = now - 1001L,
       codec = CompressionType.NONE)
-    LogValidator.validateMessagesAndAssignOffsets(
+    assertThrows[RecordValidationException](LogValidator.validateMessagesAndAssignOffsets(
       records,
       topicPartition,
       offsetCounter = new LongRef(0),
@@ -624,15 +624,15 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = ApiVersion.latestVersion,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
-  @Test(expected = classOf[RecordValidationException])
+  @Test
   def testInvalidCreateTimeNonCompressedV2(): Unit = {
     val now = System.currentTimeMillis()
     val records = createRecords(magicValue = RecordBatch.MAGIC_VALUE_V2, timestamp = now - 1001L,
       codec = CompressionType.NONE)
-    LogValidator.validateMessagesAndAssignOffsets(
+    assertThrows[RecordValidationException](LogValidator.validateMessagesAndAssignOffsets(
       records,
       topicPartition,
       offsetCounter = new LongRef(0),
@@ -647,15 +647,15 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = ApiVersion.latestVersion,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
-  @Test(expected = classOf[RecordValidationException])
+  @Test
   def testInvalidCreateTimeCompressedV1(): Unit = {
     val now = System.currentTimeMillis()
     val records = createRecords(magicValue = RecordBatch.MAGIC_VALUE_V1, timestamp = now - 1001L,
       codec = CompressionType.GZIP)
-    LogValidator.validateMessagesAndAssignOffsets(
+    assertThrows[RecordValidationException](LogValidator.validateMessagesAndAssignOffsets(
       records,
       topicPartition,
       offsetCounter = new LongRef(0),
@@ -670,15 +670,15 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = ApiVersion.latestVersion,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
-  @Test(expected = classOf[RecordValidationException])
+  @Test
   def testInvalidCreateTimeCompressedV2(): Unit = {
     val now = System.currentTimeMillis()
     val records = createRecords(magicValue = RecordBatch.MAGIC_VALUE_V2, timestamp = now - 1001L,
       codec = CompressionType.GZIP)
-    LogValidator.validateMessagesAndAssignOffsets(
+    assertThrows[RecordValidationException](LogValidator.validateMessagesAndAssignOffsets(
       records,
       topicPartition,
       offsetCounter = new LongRef(0),
@@ -693,7 +693,7 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = ApiVersion.latestVersion,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
   @Test
@@ -938,12 +938,12 @@ class LogValidatorTest {
       compressed = true)
   }
 
-  @Test(expected = classOf[InvalidRecordException])
+  @Test
   def testControlRecordsNotAllowedFromClients(): Unit = {
     val offset = 1234567
     val endTxnMarker = new EndTransactionMarker(ControlRecordType.COMMIT, 0)
     val records = MemoryRecords.withEndTransactionMarker(23423L, 5, endTxnMarker)
-    LogValidator.validateMessagesAndAssignOffsets(records,
+    assertThrows[InvalidRecordException](LogValidator.validateMessagesAndAssignOffsets(records,
       topicPartition,
       offsetCounter = new LongRef(offset),
       time = time,
@@ -957,7 +957,7 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = ApiVersion.latestVersion,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
   @Test
@@ -1122,7 +1122,7 @@ class LogValidatorTest {
       brokerTopicStats = brokerTopicStats).validatedRecords, offset)
   }
 
-  @Test(expected = classOf[UnsupportedForMessageFormatException])
+  @Test
   def testDownConversionOfTransactionalRecordsNotPermitted(): Unit = {
     val offset = 1234567
     val producerId = 1344L
@@ -1130,7 +1130,7 @@ class LogValidatorTest {
     val sequence = 0
     val records = MemoryRecords.withTransactionalRecords(CompressionType.NONE, producerId, producerEpoch, sequence,
       new SimpleRecord("hello".getBytes), new SimpleRecord("there".getBytes), new SimpleRecord("beautiful".getBytes))
-    checkOffsets(LogValidator.validateMessagesAndAssignOffsets(records,
+    assertThrows[UnsupportedForMessageFormatException](LogValidator.validateMessagesAndAssignOffsets(records,
       topicPartition,
       offsetCounter = new LongRef(offset),
       time = time,
@@ -1147,7 +1147,7 @@ class LogValidatorTest {
       brokerTopicStats = brokerTopicStats).validatedRecords, offset)
   }
 
-  @Test(expected = classOf[UnsupportedForMessageFormatException])
+  @Test
   def testDownConversionOfIdempotentRecordsNotPermitted(): Unit = {
     val offset = 1234567
     val producerId = 1344L
@@ -1155,7 +1155,7 @@ class LogValidatorTest {
     val sequence = 0
     val records = MemoryRecords.withIdempotentRecords(CompressionType.NONE, producerId, producerEpoch, sequence,
       new SimpleRecord("hello".getBytes), new SimpleRecord("there".getBytes), new SimpleRecord("beautiful".getBytes))
-    checkOffsets(LogValidator.validateMessagesAndAssignOffsets(records,
+    assertThrows[UnsupportedForMessageFormatException](LogValidator.validateMessagesAndAssignOffsets(records,
       topicPartition,
       offsetCounter = new LongRef(offset),
       time = time,
@@ -1248,12 +1248,12 @@ class LogValidatorTest {
     testBatchWithoutRecordsNotAllowed(DefaultCompressionCodec, DefaultCompressionCodec)
   }
 
-  @Test(expected = classOf[UnsupportedCompressionTypeException])
+  @Test
   def testZStdCompressedWithUnavailableIBPVersion(): Unit = {
     val now = System.currentTimeMillis()
     // The timestamps should be overwritten
     val records = createRecords(magicValue = RecordBatch.MAGIC_VALUE_V2, timestamp = 1234L, codec = CompressionType.NONE)
-    LogValidator.validateMessagesAndAssignOffsets(records,
+    assertThrows[UnsupportedCompressionTypeException](LogValidator.validateMessagesAndAssignOffsets(records,
       topicPartition,
       offsetCounter = new LongRef(0),
       time= time,
@@ -1267,7 +1267,7 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = KAFKA_2_0_IV1,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
   @Test(expected = classOf[InvalidRecordException])

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -1240,7 +1240,7 @@ class LogValidatorTest {
     assertTrue(meterCount(s"${BrokerTopicStats.InvalidOffsetOrSequenceRecordsPerSec}") > 0)
   }
 
-  @Test(expected = classOf[InvalidRecordException])
+  @Test
   def testCompressedBatchWithoutRecordsNotAllowed(): Unit = {
     testBatchWithoutRecordsNotAllowed(DefaultCompressionCodec, DefaultCompressionCodec)
   }
@@ -1267,12 +1267,12 @@ class LogValidatorTest {
       brokerTopicStats = brokerTopicStats))
   }
 
-  @Test(expected = classOf[InvalidRecordException])
+  @Test
   def testUncompressedBatchWithoutRecordsNotAllowed(): Unit = {
     testBatchWithoutRecordsNotAllowed(NoCompressionCodec, NoCompressionCodec)
   }
 
-  @Test(expected = classOf[InvalidRecordException])
+  @Test
   def testRecompressedBatchWithoutRecordsNotAllowed(): Unit = {
     testBatchWithoutRecordsNotAllowed(NoCompressionCodec, DefaultCompressionCodec)
   }
@@ -1362,7 +1362,7 @@ class LogValidatorTest {
       isTransactional, false)
     buffer.flip()
     val records = MemoryRecords.readableRecords(buffer)
-    LogValidator.validateMessagesAndAssignOffsets(records,
+    assertThrows(classOf[InvalidRecordException], () => LogValidator.validateMessagesAndAssignOffsets(records,
       topicPartition,
       offsetCounter = new LongRef(offset),
       time = time,
@@ -1376,7 +1376,7 @@ class LogValidatorTest {
       partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
       origin = AppendOrigin.Client,
       interBrokerProtocolVersion = ApiVersion.latestVersion,
-      brokerTopicStats = brokerTopicStats)
+      brokerTopicStats = brokerTopicStats))
   }
 
   private def createRecords(magicValue: Byte,

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -24,7 +24,6 @@ import org.junit.Assert._
 import java.util.{Arrays, Collections}
 
 import org.junit._
-import org.scalatest.Assertions.intercept
 
 import scala.collection._
 import scala.util.Random
@@ -192,7 +191,7 @@ class OffsetIndexTest {
     val idx = new OffsetIndex(nonExistentTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
     idx.forceUnmap()
     // mmap should be null after unmap causing lookup to throw a NPE
-    intercept[NullPointerException](idx.lookup(1))
+    assertThrows(classOf[NullPointerException], () => idx.lookup(1))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -96,9 +96,9 @@ class OffsetIndexTest {
       assertEquals(OffsetPosition(idx.baseOffset + i + 1, i), idx.entry(i))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testEntryOverflow(): Unit = {
-    idx.entry(0)
+    assertThrows(classOf[IllegalArgumentException], () => idx.entry(0))
   }
   
   @Test
@@ -110,10 +110,10 @@ class OffsetIndexTest {
     assertWriteFails("Append should fail on a full index", idx, idx.maxEntries + 1, classOf[IllegalArgumentException])
   }
   
-  @Test(expected = classOf[InvalidOffsetException])
+  @Test
   def appendOutOfOrder(): Unit = {
     idx.append(51, 0)
-    idx.append(50, 1)
+    assertThrows(classOf[InvalidOffsetException], () => idx.append(50, 1))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/TimeIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/TimeIndexTest.scala
@@ -22,8 +22,7 @@ import java.io.File
 import kafka.utils.TestUtils
 import org.apache.kafka.common.errors.InvalidOffsetException
 import org.junit.{After, Before, Test}
-import org.junit.Assert.assertEquals
-import org.scalatest.Assertions.intercept
+import org.junit.Assert.{assertEquals, assertThrows}
 
 /**
  * Unit test for time index.
@@ -88,12 +87,8 @@ class TimeIndexTest {
   @Test
   def testAppend(): Unit = {
     appendEntries(maxEntries - 1)
-    intercept[IllegalArgumentException] {
-      idx.maybeAppend(10000L, 1000L)
-    }
-    intercept[InvalidOffsetException] {
-      idx.maybeAppend(10000L, (maxEntries - 2) * 10, true)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => idx.maybeAppend(10000L, 1000L))
+    assertThrows(classOf[InvalidOffsetException], () => idx.maybeAppend(10000L, (maxEntries - 2) * 10, true))
     idx.maybeAppend(10000L, 1000L, true)
   }
 
@@ -133,15 +128,15 @@ class TimeIndexTest {
     }
 
     shouldCorruptOffset = true
-    intercept[CorruptIndexException](idx.sanityCheck())
+    assertThrows(classOf[CorruptIndexException], () => idx.sanityCheck())
     shouldCorruptOffset = false
 
     shouldCorruptTimestamp = true
-    intercept[CorruptIndexException](idx.sanityCheck())
+    assertThrows(classOf[CorruptIndexException], () => idx.sanityCheck())
     shouldCorruptTimestamp = false
 
     shouldCorruptLength = true
-    intercept[CorruptIndexException](idx.sanityCheck())
+    assertThrows(classOf[CorruptIndexException], () => idx.sanityCheck())
     shouldCorruptLength = false
 
     idx.sanityCheck()

--- a/core/src/test/scala/unit/kafka/log/TimeIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/TimeIndexTest.scala
@@ -68,9 +68,9 @@ class TimeIndexTest {
     assertEquals(TimestampOffset(40L, 85L), idx.entry(3))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testEntryOverflow(): Unit = {
-    idx.entry(0)
+    assertThrows(classOf[IllegalArgumentException], () => idx.entry(0))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/TransactionIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/TransactionIndexTest.scala
@@ -16,12 +16,12 @@
  */
 package kafka.log
 
+import java.io.File
+
 import kafka.utils.TestUtils
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-
-import java.io.File
 
 class TransactionIndexTest {
   var file: File = _

--- a/core/src/test/scala/unit/kafka/log/TransactionIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/TransactionIndexTest.scala
@@ -16,12 +16,12 @@
  */
 package kafka.log
 
-import java.io.File
-
 import kafka.utils.TestUtils
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
+
+import java.io.File
 
 class TransactionIndexTest {
   var file: File = _

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -49,7 +49,6 @@ import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
 import org.apache.log4j.Level
 import org.junit.Assert._
 import org.junit._
-import org.scalatest.Assertions.fail
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -128,8 +127,8 @@ class SocketServerTest {
   private def receiveRequest(channel: RequestChannel, timeout: Long = 2000L): RequestChannel.Request = {
     channel.receiveRequest(timeout) match {
       case request: RequestChannel.Request => request
-      case RequestChannel.ShutdownRequest => fail("Unexpected shutdown received")
-      case null => fail("receiveRequest timed out")
+      case RequestChannel.ShutdownRequest => throw new AssertionError("Unexpected shutdown received")
+      case null => throw new AssertionError("receiveRequest timed out")
     }
   }
 

--- a/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
@@ -18,9 +18,8 @@ package kafka.security.auth
 
 import kafka.common.KafkaException
 import org.apache.kafka.common.acl.AclPermissionType
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
-import org.scalatest.Assertions.fail
 
 @deprecated("Scala Authorizer API classes gave been deprecated", "Since 2.5")
 class PermissionTypeTest {

--- a/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
@@ -17,9 +17,8 @@
 package kafka.security.auth
 
 import kafka.common.KafkaException
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, fail}
 import org.junit.Test
-import org.scalatest.Assertions.fail
 import org.apache.kafka.common.resource.{ResourceType => JResourceType}
 
 @deprecated("Scala Authorizer API classes gave been deprecated", "Since 2.5")

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
@@ -87,9 +87,9 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
     super.tearDown()
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testAuthorizeThrowsOnNonLiteralResource(): Unit = {
-    simpleAclAuthorizer.authorize(session, Read, Resource(Topic, "something", PREFIXED))
+    assertThrows(classOf[IllegalArgumentException], () => simpleAclAuthorizer.authorize(session, Read, Resource(Topic, "something", PREFIXED)))
   }
 
   @Test
@@ -100,9 +100,9 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
   }
 
   // Authorizing the empty resource is not supported because we create a znode with the resource name.
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testEmptyAclThrowsException(): Unit = {
-    simpleAclAuthorizer.addAcls(Set[Acl](allowReadAcl), Resource(Group, "", LITERAL))
+    assertThrows(classOf[IllegalArgumentException], () => simpleAclAuthorizer.addAcls(Set[Acl](allowReadAcl), Resource(Group, "", LITERAL)))
   }
 
   @Test
@@ -629,10 +629,10 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
       0, simpleAclAuthorizer.getAcls(principal).size)
   }
 
-  @Test(expected = classOf[UnsupportedVersionException])
+  @Test
   def testThrowsOnAddPrefixedAclIfInterBrokerProtocolVersionTooLow(): Unit = {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV0))
-    simpleAclAuthorizer.addAcls(Set[Acl](denyReadAcl), Resource(Topic, "z_other", PREFIXED))
+    assertThrows(classOf[UnsupportedVersionException], () => simpleAclAuthorizer.addAcls(Set[Acl](denyReadAcl), Resource(Topic, "z_other", PREFIXED)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
@@ -45,7 +45,6 @@ import org.apache.kafka.server.authorizer._
 import org.apache.kafka.common.utils.{Time, SecurityUtils => JSecurityUtils}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -113,9 +112,8 @@ class AclAuthorizerTest extends ZooKeeperTestHarness with BaseAuthorizerTest {
   // Authorizing the empty resource is not supported because we create a znode with the resource name.
   @Test
   def testEmptyAclThrowsException(): Unit = {
-    val e = intercept[ApiException] {
-      addAcls(aclAuthorizer, Set(allowReadAcl), new ResourcePattern(GROUP, "", LITERAL))
-    }
+    val e = assertThrows(classOf[ApiException],
+      () => addAcls(aclAuthorizer, Set(allowReadAcl), new ResourcePattern(GROUP, "", LITERAL)))
     assertTrue(s"Unexpected exception $e", e.getCause.isInstanceOf[IllegalArgumentException])
   }
 
@@ -718,9 +716,8 @@ class AclAuthorizerTest extends ZooKeeperTestHarness with BaseAuthorizerTest {
   @Test
   def testThrowsOnAddPrefixedAclIfInterBrokerProtocolVersionTooLow(): Unit = {
     givenAuthorizerWithProtocolVersion(Option(KAFKA_2_0_IV0))
-    val e = intercept[ApiException] {
-      addAcls(aclAuthorizer, Set(denyReadAcl), new ResourcePattern(TOPIC, "z_other", PREFIXED))
-    }
+    val e = assertThrows(classOf[ApiException],
+      () => addAcls(aclAuthorizer, Set(denyReadAcl), new ResourcePattern(TOPIC, "z_other", PREFIXED)))
     assertTrue(s"Unexpected exception $e", e.getCause.isInstanceOf[UnsupportedVersionException])
   }
 

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerTest.scala
@@ -97,9 +97,10 @@ class AclAuthorizerTest extends ZooKeeperTestHarness with BaseAuthorizerTest {
     super.tearDown()
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testAuthorizeThrowsOnNonLiteralResource(): Unit = {
-    authorize(aclAuthorizer, requestContext, READ, new ResourcePattern(TOPIC, "something", PREFIXED))
+    assertThrows(classOf[IllegalArgumentException], () => authorize(aclAuthorizer, requestContext, READ,
+      new ResourcePattern(TOPIC, "something", PREFIXED)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -45,7 +45,6 @@ import org.junit.{Before, Test}
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Set, mutable}
 import scala.util.Random
-import org.scalatest.Assertions.assertThrows
 
 import scala.collection.mutable.ArrayBuffer
 import scala.compat.java8.OptionConverters._
@@ -747,9 +746,7 @@ class AbstractFetcherThreadTest {
     fetcher.setLeaderState(partition, MockFetcherThread.PartitionState(leaderEpoch = 0))
 
     // first round of truncation should throw an exception
-    assertThrows[IllegalStateException] {
-      fetcher.doWork()
-    }
+    assertThrows(classOf[IllegalStateException], () => fetcher.doWork())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -270,7 +270,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
 
   @Test
   def testAlterClientQuotasEmptyEntity(): Unit = {
-    val entity = new ClientQuotaEntity(util.Collections.emptyMap())
+    val entity = new ClientQuotaEntity(Map.empty.asJava)
     assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map(ProducerByteRateProp -> Some(10000.5)), validateOnly = true))
   }
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -250,40 +250,40 @@ class ClientQuotasRequestTest extends BaseRequestTest {
     verifyIpQuotas(allIpEntityFilter, Map.empty)
   }
 
-  @Test(expected = classOf[InvalidRequestException])
+  @Test
   def testAlterClientQuotasBadUser(): Unit = {
     val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.USER -> "")).asJava)
-    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
+    assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map(RequestPercentageProp -> Some(12.34)), validateOnly = true))
   }
 
-  @Test(expected = classOf[InvalidRequestException])
+  @Test
   def testAlterClientQuotasBadClientId(): Unit = {
     val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.CLIENT_ID -> "")).asJava)
-    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
+    assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map(RequestPercentageProp -> Some(12.34)), validateOnly = true))
   }
 
-  @Test(expected = classOf[InvalidRequestException])
+  @Test
   def testAlterClientQuotasBadEntityType(): Unit = {
     val entity = new ClientQuotaEntity(Map(("" -> "name")).asJava)
-    alterEntityQuotas(entity, Map((RequestPercentageProp -> Some(12.34))), validateOnly = true)
+    assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map(RequestPercentageProp -> Some(12.34)), validateOnly = true))
   }
 
-  @Test(expected = classOf[InvalidRequestException])
+  @Test
   def testAlterClientQuotasEmptyEntity(): Unit = {
-    val entity = new ClientQuotaEntity(Map.empty.asJava)
-    alterEntityQuotas(entity, Map((ProducerByteRateProp -> Some(10000.5))), validateOnly = true)
+    val entity = new ClientQuotaEntity(util.Collections.emptyMap())
+    assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map(ProducerByteRateProp -> Some(10000.5)), validateOnly = true))
   }
 
-  @Test(expected = classOf[InvalidRequestException])
+  @Test
   def testAlterClientQuotasBadConfigKey(): Unit = {
-    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.USER -> "user")).asJava)
-    alterEntityQuotas(entity, Map(("bad" -> Some(1.0))), validateOnly = true)
+    val entity = new ClientQuotaEntity(Map(ClientQuotaEntity.USER -> "user").asJava)
+    assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map("bad" -> Some(1.0)), validateOnly = true))
   }
 
-  @Test(expected = classOf[InvalidRequestException])
+  @Test
   def testAlterClientQuotasBadConfigValue(): Unit = {
-    val entity = new ClientQuotaEntity(Map((ClientQuotaEntity.USER -> "user")).asJava)
-    alterEntityQuotas(entity, Map((ProducerByteRateProp -> Some(10000.5))), validateOnly = true)
+    val entity = new ClientQuotaEntity(Map(ClientQuotaEntity.USER -> "user").asJava)
+    assertThrows(classOf[InvalidRequestException], () => alterEntityQuotas(entity, Map(ProducerByteRateProp -> Some(10000.5)), validateOnly = true))
   }
 
   private def expectInvalidRequestWithMessage(runnable: => Unit, expectedMessage: String): Unit = {

--- a/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
@@ -27,7 +27,6 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.utils.Time
 import org.junit.{After, Before, Test}
 import org.junit.Assert._
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 
@@ -175,7 +174,7 @@ class DelayedOperationTest {
     assertTrue(s"Time for expiration $elapsed should at least $expirationMs", elapsed >= expirationMs)
     assertEquals(40, futures4.head.get)
     assertEquals(classOf[org.apache.kafka.common.errors.TimeoutException],
-      intercept[ExecutionException](futures4(1).get).getCause.getClass)
+      assertThrows(classOf[ExecutionException], () => futures4(1).get).getCause.getClass)
     assertEquals(40, result.get())
   }
 

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
@@ -22,7 +22,7 @@ import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.errors.UnsupportedByAuthenticationException
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.intercept
+import org.junit.Assert.assertThrows
 
 import scala.concurrent.ExecutionException
 
@@ -50,16 +50,16 @@ class DelegationTokenRequestsOnPlainTextTest extends BaseRequestTest {
     adminClient = Admin.create(createAdminConfig)
 
     val createResult = adminClient.createDelegationToken()
-    intercept[ExecutionException](createResult.delegationToken().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
+    assertThrows(classOf[ExecutionException], () => createResult.delegationToken().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
 
     val describeResult = adminClient.describeDelegationToken()
-    intercept[ExecutionException](describeResult.delegationTokens().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
+    assertThrows(classOf[ExecutionException], () => describeResult.delegationTokens().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
 
     val renewResult = adminClient.renewDelegationToken("".getBytes())
-    intercept[ExecutionException](renewResult.expiryTimestamp().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
+    assertThrows(classOf[ExecutionException], () => renewResult.expiryTimestamp().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
 
     val expireResult = adminClient.expireDelegationToken("".getBytes())
-    intercept[ExecutionException](expireResult.expiryTimestamp().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
+    assertThrows(classOf[ExecutionException], () => expireResult.expiryTimestamp().get()).getCause.isInstanceOf[UnsupportedByAuthenticationException]
   }
 
 

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -16,8 +16,6 @@
   */
 package kafka.server
 
-import java.util
-
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateDelegationTokenOptions, DescribeDelegationTokenOptions}
@@ -26,10 +24,10 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.SecurityUtils
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.intercept
 
-import scala.jdk.CollectionConverters._
+import java.util
 import scala.concurrent.ExecutionException
+import scala.jdk.CollectionConverters._
 
 class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
@@ -117,7 +115,7 @@ class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
     //create token with invalid principal type
     val renewer3 = List(SecurityUtils.parseKafkaPrincipal("Group:Renewer3")).asJava
     val createResult3 = adminClient.createDelegationToken(new CreateDelegationTokenOptions().renewers(renewer3))
-    intercept[ExecutionException](createResult3.delegationToken().get()).getCause.isInstanceOf[InvalidPrincipalTypeException]
+    assertThrows(classOf[ExecutionException], () => createResult3.delegationToken().get()).getCause.isInstanceOf[InvalidPrincipalTypeException]
 
     // try describing tokens for unknown owner
     val unknownOwner = List(SecurityUtils.parseKafkaPrincipal("User:Unknown")).asJava

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -16,6 +16,8 @@
   */
 package kafka.server
 
+import java.util
+
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateDelegationTokenOptions, DescribeDelegationTokenOptions}
@@ -25,9 +27,8 @@ import org.apache.kafka.common.utils.SecurityUtils
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 
-import java.util
-import scala.concurrent.ExecutionException
 import scala.jdk.CollectionConverters._
+import scala.concurrent.ExecutionException
 
 class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsTest.scala
@@ -16,8 +16,6 @@
   */
 package kafka.server
 
-import java.util
-
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, CreateDelegationTokenOptions, DescribeDelegationTokenOptions}
@@ -27,8 +25,9 @@ import org.apache.kafka.common.utils.SecurityUtils
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 
-import scala.jdk.CollectionConverters._
+import java.util
 import scala.concurrent.ExecutionException
+import scala.jdk.CollectionConverters._
 
 class DelegationTokenRequestsTest extends BaseRequestTest with SaslSetup {
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
@@ -16,16 +16,15 @@
   */
 package kafka.server
 
-import java.util
-
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.errors.DelegationTokenDisabledException
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.junit.Assert.assertThrows
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.intercept
 
+import java.util
 import scala.concurrent.ExecutionException
 
 class DelegationTokenRequestsWithDisableTokenFeatureTest extends BaseRequestTest with SaslSetup {
@@ -58,16 +57,19 @@ class DelegationTokenRequestsWithDisableTokenFeatureTest extends BaseRequestTest
     adminClient = Admin.create(createAdminConfig)
 
     val createResult = adminClient.createDelegationToken()
-    intercept[ExecutionException](createResult.delegationToken().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
+    assertThrows(classOf[ExecutionException], () => createResult.delegationToken().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
 
     val describeResult = adminClient.describeDelegationToken()
-    intercept[ExecutionException](describeResult.delegationTokens().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
+    assertThrows(classOf[ExecutionException],
+      () => describeResult.delegationTokens().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
 
     val renewResult = adminClient.renewDelegationToken("".getBytes())
-    intercept[ExecutionException](renewResult.expiryTimestamp().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
+    assertThrows(classOf[ExecutionException],
+      () => renewResult.expiryTimestamp().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
 
     val expireResult = adminClient.expireDelegationToken("".getBytes())
-    intercept[ExecutionException](expireResult.expiryTimestamp().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
+    assertThrows(classOf[ExecutionException],
+      () => expireResult.expiryTimestamp().get()).getCause.isInstanceOf[DelegationTokenDisabledException]
   }
 
   @After

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
@@ -16,6 +16,8 @@
   */
 package kafka.server
 
+import java.util
+
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
@@ -24,7 +26,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert.assertThrows
 import org.junit.{After, Before, Test}
 
-import java.util
 import scala.concurrent.ExecutionException
 
 class DelegationTokenRequestsWithDisableTokenFeatureTest extends BaseRequestTest with SaslSetup {

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
@@ -16,8 +16,6 @@
   */
 package kafka.server
 
-import java.util
-
 import kafka.api.{KafkaSasl, SaslSetup}
 import kafka.utils.{JaasTestUtils, TestUtils}
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
@@ -26,6 +24,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert.assertThrows
 import org.junit.{After, Before, Test}
 
+import java.util
 import scala.concurrent.ExecutionException
 
 class DelegationTokenRequestsWithDisableTokenFeatureTest extends BaseRequestTest with SaslSetup {

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.server.authorizer._
 import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Set
@@ -144,9 +143,8 @@ class DynamicBrokerConfigTest {
       override def validateReconfiguration(configs: util.Map[String, _]): Unit = {}
       override def reconfigure(configs: util.Map[String, _]): Unit = {}
     }
-    intercept[IllegalArgumentException] {
-      config.dynamicConfig.addReconfigurable(createReconfigurable(invalidReconfigurableProps))
-    }
+    assertThrows(classOf[IllegalArgumentException],
+      () => config.dynamicConfig.addReconfigurable(createReconfigurable(invalidReconfigurableProps)))
     config.dynamicConfig.addReconfigurable(createReconfigurable(validReconfigurableProps))
 
     def createBrokerReconfigurable(configs: Set[String]) = new BrokerReconfigurable {
@@ -154,9 +152,8 @@ class DynamicBrokerConfigTest {
       override def validateReconfiguration(newConfig: KafkaConfig): Unit = {}
       override def reconfigure(oldConfig: KafkaConfig, newConfig: KafkaConfig): Unit = {}
     }
-    intercept[IllegalArgumentException] {
-      config.dynamicConfig.addBrokerReconfigurable(createBrokerReconfigurable(invalidReconfigurableProps))
-    }
+    assertThrows(classOf[IllegalArgumentException],
+      () => config.dynamicConfig.addBrokerReconfigurable(createBrokerReconfigurable(invalidReconfigurableProps)))
     config.dynamicConfig.addBrokerReconfigurable(createBrokerReconfigurable(validReconfigurableProps))
   }
 
@@ -343,7 +340,7 @@ class DynamicBrokerConfigTest {
 
     class TestAuthorizer extends Authorizer with Reconfigurable {
       @volatile var superUsers = ""
-      override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, _ <: CompletionStage[Void]] = Map.empty.asJava
+      override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, _ <: CompletionStage[Void]] = util.Collections.emptyMap()
       override def authorize(requestContext: AuthorizableRequestContext, actions: util.List[Action]): util.List[AuthorizationResult] = null
       override def createAcls(requestContext: AuthorizableRequestContext, aclBindings: util.List[AclBinding]): util.List[_ <: CompletionStage[AclCreateResult]] = null
       override def deleteAcls(requestContext: AuthorizableRequestContext, aclBindingFilters: util.List[AclBindingFilter]): util.List[_ <: CompletionStage[AclDeleteResult]] = null

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -340,7 +340,7 @@ class DynamicBrokerConfigTest {
 
     class TestAuthorizer extends Authorizer with Reconfigurable {
       @volatile var superUsers = ""
-      override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, _ <: CompletionStage[Void]] = util.Collections.emptyMap()
+      override def start(serverInfo: AuthorizerServerInfo): util.Map[Endpoint, _ <: CompletionStage[Void]] = Map.empty.asJava
       override def authorize(requestContext: AuthorizableRequestContext, actions: util.List[Action]): util.List[AuthorizationResult] = null
       override def createAcls(requestContext: AuthorizableRequestContext, aclBindings: util.List[AclBinding]): util.List[_ <: CompletionStage[AclCreateResult]] = null
       override def deleteAcls(requestContext: AuthorizableRequestContext, aclBindingFilters: util.List[AclBindingFilter]): util.List[_ <: CompletionStage[AclDeleteResult]] = null

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -35,7 +35,6 @@ import org.apache.kafka.common.metrics.Quota
 import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.assertThrows
 
 import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
@@ -201,9 +200,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val props: Properties = new Properties()
     props.put(DynamicConfig.Ip.IpConnectionRateOverrideProp, "1")
 
-    assertThrows[IllegalArgumentException]{
-      configHandler.processConfigChanges("illegal-hostname", props)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => configHandler.processConfigChanges("illegal-hostname", props))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -20,46 +20,52 @@ import kafka.admin.AdminOperationException
 import kafka.utils.CoreUtils._
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.common.config._
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class DynamicConfigTest extends ZooKeeperTestHarness {
   private final val nonExistentConfig: String = "some.config.that.does.not.exist"
   private final val someValue: String = "some interesting value"
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailWhenChangingClientIdUnknownConfig(): Unit = {
-    adminZkClient.changeClientIdConfig("ClientId", propsWith(nonExistentConfig, someValue))
+    assertThrows(classOf[IllegalArgumentException], () => adminZkClient.changeClientIdConfig("ClientId",
+      propsWith(nonExistentConfig, someValue)))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldFailWhenChangingUserUnknownConfig(): Unit = {
-    adminZkClient.changeUserOrUserClientIdConfig("UserId", propsWith(nonExistentConfig, someValue))
+    assertThrows(classOf[IllegalArgumentException], () => adminZkClient.changeUserOrUserClientIdConfig("UserId",
+      propsWith(nonExistentConfig, someValue)))
   }
 
-  @Test(expected = classOf[ConfigException])
+  @Test
   def shouldFailLeaderConfigsWithInvalidValues(): Unit = {
-    adminZkClient.changeBrokerConfig(Seq(0),
-      propsWith(DynamicConfig.Broker.LeaderReplicationThrottledRateProp, "-100"))
+    assertThrows(classOf[ConfigException], () => adminZkClient.changeBrokerConfig(Seq(0),
+      propsWith(DynamicConfig.Broker.LeaderReplicationThrottledRateProp, "-100")))
   }
 
-  @Test(expected = classOf[ConfigException])
+  @Test
   def shouldFailFollowerConfigsWithInvalidValues(): Unit = {
-    adminZkClient.changeBrokerConfig(Seq(0),
-      propsWith(DynamicConfig.Broker.FollowerReplicationThrottledRateProp, "-100"))
+    assertThrows(classOf[ConfigException], () => adminZkClient.changeBrokerConfig(Seq(0),
+      propsWith(DynamicConfig.Broker.FollowerReplicationThrottledRateProp, "-100")))
   }
 
-  @Test(expected = classOf[ConfigException])
+  @Test
   def shouldFailIpConfigsWithInvalidValues(): Unit = {
-    adminZkClient.changeIpConfig("1.2.3.4", propsWith(DynamicConfig.Ip.IpConnectionRateOverrideProp, "-1"))
+    assertThrows(classOf[ConfigException], () => adminZkClient.changeIpConfig("1.2.3.4",
+      propsWith(DynamicConfig.Ip.IpConnectionRateOverrideProp, "-1")))
   }
 
-  @Test(expected = classOf[AdminOperationException])
+  @Test
   def shouldFailIpConfigsWithInvalidIpv4Entity(): Unit = {
-    adminZkClient.changeIpConfig("1,1.1.1", propsWith(DynamicConfig.Ip.IpConnectionRateOverrideProp, "2"));
+    assertThrows(classOf[AdminOperationException], () => adminZkClient.changeIpConfig("1,1.1.1",
+      propsWith(DynamicConfig.Ip.IpConnectionRateOverrideProp, "2")))
   }
 
-  @Test(expected = classOf[AdminOperationException])
+  @Test
   def shouldFailIpConfigsWithBadHost(): Unit = {
-    adminZkClient.changeIpConfig("ip", propsWith(DynamicConfig.Ip.IpConnectionRateOverrideProp, "2"));
+    assertThrows(classOf[AdminOperationException], () => adminZkClient.changeIpConfig("ip",
+      propsWith(DynamicConfig.Ip.IpConnectionRateOverrideProp, "2")))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1340,29 +1340,29 @@ class KafkaApisTest {
     checkInvalidPartition(1) // topic has only one partition
   }
 
-  @Test(expected = classOf[UnsupportedVersionException])
+  @Test
   def shouldThrowUnsupportedVersionExceptionOnHandleAddOffsetToTxnRequestWhenInterBrokerProtocolNotSupported(): Unit = {
-    createKafkaApis(KAFKA_0_10_2_IV0).handleAddOffsetsToTxnRequest(null)
+    assertThrows(classOf[UnsupportedVersionException], () => createKafkaApis(KAFKA_0_10_2_IV0).handleAddOffsetsToTxnRequest(null))
   }
 
-  @Test(expected = classOf[UnsupportedVersionException])
+  @Test
   def shouldThrowUnsupportedVersionExceptionOnHandleAddPartitionsToTxnRequestWhenInterBrokerProtocolNotSupported(): Unit = {
-    createKafkaApis(KAFKA_0_10_2_IV0).handleAddPartitionToTxnRequest(null)
+    assertThrows(classOf[UnsupportedVersionException], () => createKafkaApis(KAFKA_0_10_2_IV0).handleAddPartitionToTxnRequest(null))
   }
 
-  @Test(expected = classOf[UnsupportedVersionException])
+  @Test
   def shouldThrowUnsupportedVersionExceptionOnHandleTxnOffsetCommitRequestWhenInterBrokerProtocolNotSupported(): Unit = {
-    createKafkaApis(KAFKA_0_10_2_IV0).handleAddPartitionToTxnRequest(null)
+    assertThrows(classOf[UnsupportedVersionException], () => createKafkaApis(KAFKA_0_10_2_IV0).handleAddPartitionToTxnRequest(null))
   }
 
-  @Test(expected = classOf[UnsupportedVersionException])
+  @Test
   def shouldThrowUnsupportedVersionExceptionOnHandleEndTxnRequestWhenInterBrokerProtocolNotSupported(): Unit = {
-    createKafkaApis(KAFKA_0_10_2_IV0).handleEndTxnRequest(null)
+    assertThrows(classOf[UnsupportedVersionException], () => createKafkaApis(KAFKA_0_10_2_IV0).handleEndTxnRequest(null))
   }
 
-  @Test(expected = classOf[UnsupportedVersionException])
+  @Test
   def shouldThrowUnsupportedVersionExceptionOnHandleWriteTxnMarkersRequestWhenInterBrokerProtocolNotSupported(): Unit = {
-    createKafkaApis(KAFKA_0_10_2_IV0).handleWriteTxnMarkersRequest(null)
+    assertThrows(classOf[UnsupportedVersionException], () => createKafkaApis(KAFKA_0_10_2_IV0).handleWriteTxnMarkersRequest(null))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 class KafkaConfigTest {
 
@@ -117,9 +116,7 @@ class KafkaConfigTest {
 
     props5.put("log.retention.ms", "0")
 
-    intercept[IllegalArgumentException] {
-      KafkaConfig.fromProps(props5)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props5))
   }
 
   @Test
@@ -132,15 +129,9 @@ class KafkaConfigTest {
     props2.put("log.retention.minutes", "0")
     props3.put("log.retention.hours", "0")
 
-    intercept[IllegalArgumentException] {
-      KafkaConfig.fromProps(props1)
-    }
-    intercept[IllegalArgumentException] {
-      KafkaConfig.fromProps(props2)
-    }
-    intercept[IllegalArgumentException] {
-      KafkaConfig.fromProps(props3)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props1))
+    assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props2))
+    assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props3))
 
   }
 
@@ -219,12 +210,12 @@ class KafkaConfigTest {
 
     // listeners with duplicate port
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://localhost:9091,SSL://localhost:9091")
-    var caught = intercept[IllegalArgumentException] { KafkaConfig.fromProps(props) }
+    var caught = assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
     assertTrue(caught.getMessage.contains("Each listener must have a different port"))
 
     // listeners with duplicate name
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://localhost:9091,PLAINTEXT://localhost:9092")
-    caught = intercept[IllegalArgumentException] { KafkaConfig.fromProps(props) }
+    caught = assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
     assertTrue(caught.getMessage.contains("Each listener must have a different name"))
 
     // advertised listeners can have duplicate ports
@@ -236,7 +227,7 @@ class KafkaConfigTest {
 
     // but not duplicate names
     props.put(KafkaConfig.AdvertisedListenersProp, "HOST://localhost:9091,HOST://localhost:9091")
-    caught = intercept[IllegalArgumentException] { KafkaConfig.fromProps(props) }
+    caught = assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
     assertTrue(caught.getMessage.contains("Each listener must have a different name"))
   }
 
@@ -473,9 +464,7 @@ class KafkaConfigTest {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     props.put(KafkaConfig.UncleanLeaderElectionEnableProp, "invalid")
 
-    intercept[ConfigException] {
-      KafkaConfig.fromProps(props)
-    }
+    assertThrows(classOf[ConfigException], () => KafkaConfig.fromProps(props))
   }
 
   @Test
@@ -526,9 +515,7 @@ class KafkaConfigTest {
   def testInvalidCompressionType(): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     props.put(KafkaConfig.CompressionTypeProp, "abc")
-    intercept[IllegalArgumentException] {
-      KafkaConfig.fromProps(props)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
   }
 
   @Test
@@ -536,9 +523,7 @@ class KafkaConfigTest {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     props.put(KafkaConfig.ListenersProp, "SSL://localhost:0")
     props.put(KafkaConfig.InterBrokerSecurityProtocolProp, SecurityProtocol.PLAINTEXT.toString)
-    intercept[IllegalArgumentException] {
-      KafkaConfig.fromProps(props)
-    }
+    assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
   }
 
   @Test
@@ -554,11 +539,11 @@ class KafkaConfigTest {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 8181)
     props.put(KafkaConfig.ListenersProp, "TRACE://localhost:9091,SSL://localhost:9093")
     props.put(KafkaConfig.AdvertisedListenersProp, "PLAINTEXT://localhost:9092")
-    var caught = intercept[IllegalArgumentException] { KafkaConfig.fromProps(props) }
+    var caught = assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
     assertTrue(caught.getMessage.contains("No security protocol defined for listener TRACE"))
 
     props.put(KafkaConfig.ListenerSecurityProtocolMapProp, "PLAINTEXT:PLAINTEXT,TRACE:PLAINTEXT,SSL:SSL")
-    caught = intercept[IllegalArgumentException] { KafkaConfig.fromProps(props) }
+    caught = assertThrows(classOf[IllegalArgumentException], () => KafkaConfig.fromProps(props))
     assertTrue(caught.getMessage.contains("advertised.listeners listener names must be equal to or a subset of the ones defined in listeners"))
   }
 
@@ -578,9 +563,7 @@ class KafkaConfigTest {
           assertEquals(messageFormatVersion, config.logMessageFormatVersion)
           assertEquals(interBrokerVersion, config.interBrokerProtocolVersion)
         } else {
-          intercept[IllegalArgumentException] {
-            buildConfig(interBrokerVersion, messageFormatVersion)
-          }
+          assertThrows(classOf[IllegalArgumentException], () => buildConfig(interBrokerVersion, messageFormatVersion))
         }
       }
     }
@@ -954,9 +937,7 @@ class KafkaConfigTest {
     values.foreach((value) => {
       val props = validRequiredProps
       props.setProperty(name, value.toString)
-      intercept[Exception] {
-        KafkaConfig.fromProps(props)
-      }
+      assertThrows(classOf[Exception], () => KafkaConfig.fromProps(props))
     })
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -18,14 +18,13 @@
 package kafka.server
 
 import kafka.api.ApiVersion
-
-import java.util.Properties
 import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.zookeeper.client.ZKClientConfig
+import org.junit.Assert.{assertEquals, assertThrows, fail}
 import org.junit.Test
-import org.junit.Assert.{assertEquals, fail}
-import org.scalatest.Assertions.intercept
+
+import java.util.Properties
 
 class KafkaServerTest extends ZooKeeperTestHarness {
 
@@ -35,9 +34,8 @@ class KafkaServerTest extends ZooKeeperTestHarness {
     val server1 = createServer(1, "myhost", TestUtils.RandomPort)
 
     //start a server with same advertised listener
-    intercept[IllegalArgumentException] {
-      createServer(2, "myhost", TestUtils.boundPort(server1))
-    }
+    assertThrows(classOf[IllegalArgumentException],
+      () => createServer(2, "myhost", TestUtils.boundPort(server1)))
 
     //start a server with same host but with different port
     val server2 = createServer(2, "myhost", TestUtils.RandomPort)

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -18,13 +18,13 @@
 package kafka.server
 
 import kafka.api.ApiVersion
+
+import java.util.Properties
 import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.zookeeper.client.ZKClientConfig
-import org.junit.Assert.{assertEquals, assertThrows, fail}
 import org.junit.Test
-
-import java.util.Properties
+import org.junit.Assert.{assertEquals, assertThrows, fail}
 
 class KafkaServerTest extends ZooKeeperTestHarness {
 

--- a/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaServerTest.scala
@@ -18,13 +18,13 @@
 package kafka.server
 
 import kafka.api.ApiVersion
-
-import java.util.Properties
 import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.zookeeper.client.ZKClientConfig
-import org.junit.Test
 import org.junit.Assert.{assertEquals, assertThrows, fail}
+import org.junit.Test
+
+import java.util.Properties
 
 class KafkaServerTest extends ZooKeeperTestHarness {
 

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -29,9 +29,8 @@ import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.{KafkaStorageException, NotLeaderOrFollowerException}
 import org.apache.kafka.common.utils.Utils
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.{Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.jdk.CollectionConverters._
 

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -29,7 +29,6 @@ import org.apache.kafka.common.requests.UpdateMetadataRequest
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Test
 import org.junit.Assert._
-import org.scalatest.Assertions
 
 import scala.jdk.CollectionConverters._
 
@@ -136,7 +135,7 @@ class MetadataCacheTest {
           assertEquals(Errors.NONE.code, partitionMetadata.errorCode)
           assertEquals(partitionId, partitionMetadata.partitionIndex)
           val partitionState = topicPartitionStates.find(_.partitionIndex == partitionId).getOrElse(
-            Assertions.fail(s"Unable to find partition state for partition $partitionId"))
+            throw new AssertionError(s"Unable to find partition state for partition $partitionId"))
           assertEquals(partitionState.leader, partitionMetadata.leaderId)
           assertEquals(partitionState.leaderEpoch, partitionMetadata.leaderEpoch)
           assertEquals(partitionState.isr, partitionMetadata.isrNodes)

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -30,7 +30,6 @@ import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
 import org.apache.kafka.test.TestUtils.isValidClusterId
 import org.junit.Assert._
 import org.junit.{Before, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
@@ -152,9 +151,8 @@ class MetadataRequestTest extends BaseRequestTest {
     checkAutoCreatedTopic(topic3, response2)
 
     // V3 doesn't support a configurable allowAutoTopicCreation, so disabling auto-creation is not supported
-    intercept[UnsupportedVersionException] {
-      sendMetadataRequest(new MetadataRequest(requestData(List(topic4), false), 3.toShort))
-    }
+    assertThrows(classOf[UnsupportedVersionException],
+      () => sendMetadataRequest(new MetadataRequest(requestData(List(topic4), false), 3.toShort)))
 
     // V4 and higher support a configurable allowAutoTopicCreation
     val response3 = sendMetadataRequest(new MetadataRequest.Builder(Seq(topic4, topic5).asJava, false, 4.toShort).build)

--- a/core/src/test/scala/unit/kafka/server/ProduceRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ProduceRequestTest.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.{ProduceRequest, ProduceResponse}
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.fail
 
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
@@ -162,7 +161,7 @@ class ProduceRequestTest extends BaseRequestTest {
     val partitionToLeader = TestUtils.createTopic(zkClient, topic, 3, 2, servers)
     partitionToLeader.collectFirst {
       case (partition, leader) if leader != -1 => (partition, leader)
-    }.getOrElse(fail(s"No leader elected for topic $topic"))
+    }.getOrElse(throw new AssertionError(s"No leader elected for topic $topic"))
   }
 
   @nowarn("cat=deprecation")

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -1055,7 +1055,7 @@ class ReplicaManagerTest {
     assertEquals(fetchOffset, followerResult.assertFired.highWatermark)
   }
 
-  @Test(expected = classOf[ClassNotFoundException])
+  @Test
   def testUnknownReplicaSelector(): Unit = {
     val topicPartition = 0
     val followerBrokerId = 0
@@ -1066,9 +1066,9 @@ class ReplicaManagerTest {
 
     val props = new Properties()
     props.put(KafkaConfig.ReplicaSelectorClassProp, "non-a-class")
-    prepareReplicaManagerAndLogManager(new MockTimer(time),
+    assertThrows(classOf[ClassNotFoundException], () => prepareReplicaManagerAndLogManager(new MockTimer(time),
       topicPartition, leaderEpoch + leaderEpochIncrement, followerBrokerId,
-      leaderBrokerId, countDownLatch, expectTruncation = true, extraProps = props)
+      leaderBrokerId, countDownLatch, expectTruncation = true, extraProps = props))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
@@ -25,7 +25,6 @@ import kafka.utils.TestUtils
 import org.junit.{After, Before, Test}
 import org.junit.Assert._
 import java.io.File
-import org.scalatest.Assertions.intercept
 
 import org.apache.zookeeper.KeeperException.NodeExistsException
 
@@ -154,9 +153,7 @@ class ServerGenerateBrokerIdTest extends ZooKeeperTestHarness {
     val propsB = TestUtils.createBrokerConfig(1, zkConnect)
     val configB = KafkaConfig.fromProps(propsB)
     val serverB = new KafkaServer(configB, threadNamePrefix = Option(this.getClass.getName))
-    intercept[NodeExistsException] {
-      serverB.startup()
-    }
+    assertThrows(classOf[NodeExistsException], () => serverB.startup())
     servers = Seq(serverA)
 
     // verify no broker metadata was written

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
@@ -30,7 +30,6 @@ import kafka.zk.ZooKeeperTestHarness
 
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.assertThrows
 import org.apache.kafka.test.TestUtils.isValidClusterId
 
 
@@ -175,9 +174,7 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
     val server = new KafkaServer(config1, threadNamePrefix = Option(this.getClass.getName))
 
     // Startup fails
-    assertThrows[InconsistentClusterIdException] {
-      server.startup()
-    }
+    assertThrows(classOf[InconsistentClusterIdException], () => server.startup())
 
     server.shutdown()
 
@@ -201,9 +198,7 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
     val server = new KafkaServer(config, threadNamePrefix = Option(this.getClass.getName))
 
     // Startup fails
-    assertThrows[InconsistentBrokerMetadataException] {
-      server.startup()
-    }
+    assertThrows(classOf[InconsistentBrokerMetadataException], () => server.startup())
 
     server.shutdown()
 

--- a/core/src/test/scala/unit/kafka/server/ServerMetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerMetricsTest.scala
@@ -21,7 +21,6 @@ import kafka.utils.TestUtils
 import org.apache.kafka.common.metrics.Sensor
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.intercept
 
 class ServerMetricsTest {
 
@@ -39,11 +38,11 @@ class ServerMetricsTest {
     }
 
     for (illegalName <- illegalNames) {
-      intercept[IllegalArgumentException] {
+      assertThrows(classOf[IllegalArgumentException], () => {
         props.put(KafkaConfig.MetricRecordingLevelProp, illegalName)
         val config = KafkaConfig.fromProps(props)
         KafkaServer.metricConfig(config)
-      }
+      })
     }
 
   }

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -34,8 +34,7 @@ import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{UpdateFeaturesRequest, UpdateFeaturesResponse}
 import org.apache.kafka.common.utils.Utils
 import org.junit.Test
-import org.junit.Assert.{assertEquals, assertFalse, assertNotEquals, assertNotNull, assertTrue}
-import org.scalatest.Assertions.intercept
+import org.junit.Assert.{assertEquals, assertFalse, assertNotEquals, assertNotNull, assertTrue, assertThrows}
 
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -132,9 +131,7 @@ class UpdateFeaturesTest extends BaseRequestTest {
                                                         (implicit tag: ClassTag[ExceptionType]): Unit = {
     featureExceptionMsgPatterns.foreach {
       case (feature, exceptionMsgPattern) =>
-        val exception = intercept[ExecutionException] {
-          result.values().get(feature).get()
-        }
+        val exception = assertThrows(classOf[ExecutionException], () => result.values().get(feature).get())
         val cause = exception.getCause
         assertNotNull(cause)
         assertEquals(cause.getClass, tag.runtimeClass)

--- a/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileTest.scala
@@ -23,7 +23,6 @@ import org.apache.kafka.common.errors.KafkaStorageException
 import org.junit.Assert._
 import org.junit.Test
 import org.mockito.Mockito
-import org.scalatest.Assertions.assertThrows
 
 import scala.collection.Map
 
@@ -129,9 +128,8 @@ class OffsetCheckpointFileTest extends Logging {
     val logDir = "/tmp/kafka-logs"
     val mockCheckpointFile = Mockito.mock(classOf[OffsetCheckpointFile])
     val lazyCheckpoints = new LazyOffsetCheckpoints(Map(logDir -> mockCheckpointFile))
-    assertThrows[IllegalArgumentException] {
-      lazyCheckpoints.fetch("/invalid/kafka-logs", new TopicPartition("foo", 0))
-    }
+    assertThrows(classOf[IllegalArgumentException],
+      () => lazyCheckpoints.fetch("/invalid/kafka-logs", new TopicPartition("foo", 0)))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/OffsetCheckpointFileTest.scala
@@ -89,14 +89,14 @@ class OffsetCheckpointFileTest extends Logging {
     assertEquals(Map(), checkpoint.read())
   }
 
-  @Test(expected = classOf[KafkaStorageException])
+  @Test
   def shouldThrowIfVersionIsNotRecognised(): Unit = {
     val file = TestUtils.tempFile()
     val logDirFailureChannel = new LogDirFailureChannel(10)
     val checkpointFile = new CheckpointFile(file, OffsetCheckpointFile.CurrentVersion + 1,
       OffsetCheckpointFile.Formatter, logDirFailureChannel, file.getParent)
     checkpointFile.write(Seq(new TopicPartition("foo", 5) -> 10L))
-    new OffsetCheckpointFile(checkpointFile.file, logDirFailureChannel).read()
+    assertThrows(classOf[KafkaStorageException], () => new OffsetCheckpointFile(checkpointFile.file, logDirFailureChannel).read())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -151,7 +151,7 @@ class ConsoleConsumerTest {
 
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldExitOnUnrecognizedNewConsumerOption(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
 
@@ -162,12 +162,8 @@ class ConsoleConsumerTest {
       "--topic", "test",
       "--from-beginning")
 
-    //When
-    try {
-      new ConsoleConsumer.ConsumerConfig(args)
-    } finally {
-      Exit.resetExitProcedure()
-    }
+    try assertThrows(classOf[IllegalArgumentException], () => new ConsoleConsumer.ConsumerConfig(args))
+    finally Exit.resetExitProcedure()
   }
 
   @Test
@@ -268,7 +264,7 @@ class ConsoleConsumerTest {
     assertEquals("latest", consumerProperties.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldExitOnInvalidConfigWithAutoOffsetResetAndConflictingFromBeginning(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
 
@@ -278,13 +274,11 @@ class ConsoleConsumerTest {
       "--topic", "test",
       "--consumer-property", "auto.offset.reset=latest",
       "--from-beginning")
-
     try {
       val config = new ConsoleConsumer.ConsumerConfig(args)
-      ConsoleConsumer.consumerProps(config)
-    } finally {
-      Exit.resetExitProcedure()
+      assertThrows(classOf[IllegalArgumentException], () => ConsoleConsumer.consumerProps(config))
     }
+    finally Exit.resetExitProcedure()
   }
 
   @Test
@@ -462,7 +456,7 @@ class ConsoleConsumerTest {
     assertEquals(false, config.fromBeginning)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldExitOnGroupIdAndPartitionGivenTogether(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
     //Given
@@ -472,15 +466,11 @@ class ConsoleConsumerTest {
       "--group", "test-group",
       "--partition", "0")
 
-    //When
-    try {
-      new ConsoleConsumer.ConsumerConfig(args)
-    } finally {
-      Exit.resetExitProcedure()
-    }
+    try assertThrows(classOf[IllegalArgumentException], () => new ConsoleConsumer.ConsumerConfig(args))
+    finally Exit.resetExitProcedure()
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def shouldExitOnOffsetWithoutPartition(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
     //Given
@@ -489,12 +479,8 @@ class ConsoleConsumerTest {
       "--topic", "test",
       "--offset", "10")
 
-    //When
-    try {
-      new ConsoleConsumer.ConsumerConfig(args)
-    } finally {
-      Exit.resetExitProcedure()
-    }
+    try assertThrows(classOf[IllegalArgumentException], () => new ConsoleConsumer.ConsumerConfig(args))
+    finally Exit.resetExitProcedure()
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -17,13 +17,13 @@
 
 package kafka.tools
 
-import java.util
-
-import ConsoleProducer.LineMessageReader
-import org.apache.kafka.clients.producer.ProducerConfig
-import org.junit.Test
-import org.junit.Assert.{assertEquals, assertThrows}
+import kafka.tools.ConsoleProducer.LineMessageReader
 import kafka.utils.Exit
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.junit.Assert.{assertEquals, assertThrows}
+import org.junit.Test
+
+import java.util
 
 class ConsoleProducerTest {
 

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import org.junit.{Assert, Test}
 import Assert.assertEquals
 import kafka.utils.Exit
+import org.scalatest.Assertions.assertThrows
 
 class ConsoleProducerTest {
 
@@ -84,14 +85,11 @@ class ConsoleProducerTest {
       producerConfig.getList(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG))
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testInvalidConfigs(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
-    try {
-      new ConsoleProducer.ProducerConfig(invalidArgs)
-    } finally {
-      Exit.resetExitProcedure()
-    }
+    try assertThrows[IllegalArgumentException](new ConsoleProducer.ProducerConfig(invalidArgs))
+    finally Exit.resetExitProcedure()
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -17,13 +17,13 @@
 
 package kafka.tools
 
-import kafka.tools.ConsoleProducer.LineMessageReader
-import kafka.utils.Exit
-import org.apache.kafka.clients.producer.ProducerConfig
-import org.junit.Assert.{assertEquals, assertThrows}
-import org.junit.Test
-
 import java.util
+
+import ConsoleProducer.LineMessageReader
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.junit.Test
+import org.junit.Assert.{assertEquals, assertThrows}
+import kafka.utils.Exit
 
 class ConsoleProducerTest {
 

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -17,14 +17,13 @@
 
 package kafka.tools
 
-import java.util
-
-import ConsoleProducer.LineMessageReader
-import org.apache.kafka.clients.producer.ProducerConfig
-import org.junit.{Assert, Test}
-import Assert.assertEquals
+import kafka.tools.ConsoleProducer.LineMessageReader
 import kafka.utils.Exit
-import org.scalatest.Assertions.assertThrows
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.junit.Assert.{assertEquals, assertThrows}
+import org.junit.Test
+
+import java.util
 
 class ConsoleProducerTest {
 
@@ -88,7 +87,7 @@ class ConsoleProducerTest {
   @Test
   def testInvalidConfigs(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
-    try assertThrows[IllegalArgumentException](new ConsoleProducer.ProducerConfig(invalidArgs))
+    try assertThrows(classOf[IllegalArgumentException], () => new ConsoleProducer.ProducerConfig(invalidArgs))
     finally Exit.resetExitProcedure()
   }
 

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat
 import kafka.utils.Exit
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.scalatest.Assertions.assertThrows
 
 class ConsumerPerformanceTest {
 
@@ -97,7 +98,7 @@ class ConsumerPerformanceTest {
     assertEquals(10, config.numMessages)
   }
 
-  @Test(expected = classOf[IllegalArgumentException])
+  @Test
   def testConfigWithUnrecognizedOption(): Unit = {
     Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
     //Given
@@ -107,12 +108,8 @@ class ConsumerPerformanceTest {
       "--messages", "10",
       "--new-consumer"
     )
-    try {
-      //When
-      new ConsumerPerformance.ConsumerPerfConfig(args)
-    } finally {
-      Exit.resetExitProcedure()
-    }
+    try assertThrows[IllegalArgumentException](new ConsumerPerformance.ConsumerPerfConfig(args))
+    finally Exit.resetExitProcedure()
   }
 
   private def testHeaderMatchContent(detailed: Boolean, expectedOutputLineCount: Int, fun: () => Unit): Unit = {

--- a/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsumerPerformanceTest.scala
@@ -21,9 +21,8 @@ import java.io.ByteArrayOutputStream
 import java.text.SimpleDateFormat
 
 import kafka.utils.Exit
-import org.junit.Assert.assertEquals
+import org.junit.Assert.{assertEquals, assertThrows}
 import org.junit.Test
-import org.scalatest.Assertions.assertThrows
 
 class ConsumerPerformanceTest {
 
@@ -108,7 +107,7 @@ class ConsumerPerformanceTest {
       "--messages", "10",
       "--new-consumer"
     )
-    try assertThrows[IllegalArgumentException](new ConsumerPerformance.ConsumerPerfConfig(args))
+    try assertThrows(classOf[IllegalArgumentException], () => new ConsumerPerformance.ConsumerPerfConfig(args))
     finally Exit.resetExitProcedure()
   }
 

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -28,7 +28,6 @@ import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRec
 import org.apache.kafka.common.utils.Utils
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.fail
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -99,7 +98,7 @@ class DumpLogSegmentsTest {
             i += 1
           }
         }
-        fail(s"No match for index $index")
+        throw new AssertionError(s"No match for index $index")
       }
 
       val output = runDumpLogSegments(args)

--- a/core/src/test/scala/unit/kafka/utils/CommandLineUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CommandLineUtilsTest.scala
@@ -26,18 +26,18 @@ import org.junit.Test
 class CommandLineUtilsTest {
 
 
-  @Test(expected = classOf[java.lang.IllegalArgumentException])
+  @Test
   def testParseEmptyArg(): Unit = {
     val argArray = Array("my.empty.property=")
 
-    CommandLineUtils.parseKeyValueArgs(argArray, acceptMissingValue = false)
+    assertThrows(classOf[java.lang.IllegalArgumentException], () => CommandLineUtils.parseKeyValueArgs(argArray, acceptMissingValue = false))
   }
 
-  @Test(expected = classOf[java.lang.IllegalArgumentException])
+  @Test
   def testParseEmptyArgWithNoDelimiter(): Unit = {
     val argArray = Array("my.empty.property")
 
-    CommandLineUtils.parseKeyValueArgs(argArray, acceptMissingValue = false)
+    assertThrows(classOf[java.lang.IllegalArgumentException], () => CommandLineUtils.parseKeyValueArgs(argArray, acceptMissingValue = false))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
@@ -17,16 +17,13 @@
 
 package kafka.utils
 
-import java.util.concurrent.TimeUnit
-
 import org.apache.kafka.common.MetricName
-import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Quota, QuotaViolationException}
 import org.apache.kafka.common.metrics.stats.{Rate, Value}
-
-import scala.jdk.CollectionConverters._
+import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Quota, QuotaViolationException}
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.assertThrows
+
+import java.util.concurrent.TimeUnit
 
 class QuotaUtilsTest {
 
@@ -34,7 +31,7 @@ class QuotaUtilsTest {
   private val numSamples = 10
   private val sampleWindowSec = 1
   private val maxThrottleTimeMs = 500
-  private val metricName = new MetricName("test-metric", "groupA", "testA", Map.empty.asJava)
+  private val metricName = new MetricName("test-metric", "groupA", "testA", java.util.Collections.emptyMap())
 
   @Test
   def testThrottleTimeObservedRateEqualsQuota(): Unit = {
@@ -102,18 +99,16 @@ class QuotaUtilsTest {
   def testThrottleTimeThrowsExceptionIfProvidedNonRateMetric(): Unit = {
     val testMetric = new KafkaMetric(new Object(), metricName, new Value(), new MetricConfig, time);
 
-    assertThrows[IllegalArgumentException] {
-      QuotaUtils.throttleTime(new QuotaViolationException(testMetric, 10.0, 20.0), time.milliseconds)
-    }
+    assertThrows(classOf[IllegalArgumentException],
+      () => QuotaUtils.throttleTime(new QuotaViolationException(testMetric, 10.0, 20.0), time.milliseconds))
   }
 
   @Test
   def testBoundedThrottleTimeThrowsExceptionIfProvidedNonRateMetric(): Unit = {
     val testMetric = new KafkaMetric(new Object(), metricName, new Value(), new MetricConfig, time);
 
-    assertThrows[IllegalArgumentException] {
-      QuotaUtils.boundedThrottleTime(new QuotaViolationException(testMetric, 10.0, 20.0), maxThrottleTimeMs, time.milliseconds)
-    }
+    assertThrows(classOf[IllegalArgumentException],
+      () => QuotaUtils.boundedThrottleTime(new QuotaViolationException(testMetric, 10.0, 20.0), maxThrottleTimeMs, time.milliseconds))
   }
 
   // the `metric` passed into the returned QuotaViolationException will return windowSize = 'numSamples' - 1

--- a/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.metrics.stats.{Rate, Value}
 import scala.jdk.CollectionConverters._
 import org.junit.Assert._
 import org.junit.Test
+import org.scalatest.Assertions.assertThrows
 
 class QuotaUtilsTest {
 

--- a/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.common.metrics.stats.{Rate, Value}
 import scala.jdk.CollectionConverters._
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions.assertThrows
 
 class QuotaUtilsTest {
 

--- a/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/QuotaUtilsTest.scala
@@ -17,13 +17,16 @@
 
 package kafka.utils
 
+import java.util.concurrent.TimeUnit
+
 import org.apache.kafka.common.MetricName
-import org.apache.kafka.common.metrics.stats.{Rate, Value}
 import org.apache.kafka.common.metrics.{KafkaMetric, MetricConfig, Quota, QuotaViolationException}
+import org.apache.kafka.common.metrics.stats.{Rate, Value}
+
+import scala.jdk.CollectionConverters._
 import org.junit.Assert._
 import org.junit.Test
-
-import java.util.concurrent.TimeUnit
+import org.scalatest.Assertions.assertThrows
 
 class QuotaUtilsTest {
 
@@ -31,7 +34,7 @@ class QuotaUtilsTest {
   private val numSamples = 10
   private val sampleWindowSec = 1
   private val maxThrottleTimeMs = 500
-  private val metricName = new MetricName("test-metric", "groupA", "testA", java.util.Collections.emptyMap())
+  private val metricName = new MetricName("test-metric", "groupA", "testA", Map.empty.asJava)
 
   @Test
   def testThrottleTimeObservedRateEqualsQuota(): Unit = {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -64,7 +64,6 @@ import org.apache.zookeeper.KeeperException.SessionExpiredException
 import org.apache.zookeeper.ZooDefs._
 import org.apache.zookeeper.data.ACL
 import org.junit.Assert._
-import org.scalatest.Assertions.fail
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
@@ -753,7 +752,7 @@ object TestUtils extends Logging {
         case _ =>
           s"Timing out after $timeoutMs ms since a leader was not elected for partition $topicPartition"
       }
-      fail(errorMessage)
+      throw new AssertionError(errorMessage)
     }
   }
 
@@ -884,7 +883,7 @@ object TestUtils extends Logging {
                       servers: Iterable[KafkaServer]): Int = {
     val leaderServer = servers.find(_.config.brokerId == brokerId)
     val leaderPartition = leaderServer.flatMap(_.replicaManager.nonOfflinePartition(topicPartition))
-      .getOrElse(fail(s"Failed to find expected replica on broker $brokerId"))
+      .getOrElse(throw new AssertionError(s"Failed to find expected replica on broker $brokerId"))
     leaderPartition.getLeaderEpoch
   }
 
@@ -898,7 +897,7 @@ object TestUtils extends Logging {
     }
     followerOpt
       .map(_.config.brokerId)
-      .getOrElse(fail(s"Unable to locate follower for $topicPartition"))
+      .getOrElse(throw new AssertionError(s"Unable to locate follower for $topicPartition"))
   }
 
   /**
@@ -945,7 +944,7 @@ object TestUtils extends Logging {
 
   def waitUntilControllerElected(zkClient: KafkaZkClient, timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
     val (controllerId, _) = TestUtils.computeUntilTrue(zkClient.getControllerId, waitTime = timeout)(_.isDefined)
-    controllerId.getOrElse(fail(s"Controller not elected after $timeout ms"))
+    controllerId.getOrElse(throw new AssertionError(s"Controller not elected after $timeout ms"))
   }
 
   def awaitLeaderChange(servers: Seq[KafkaServer],

--- a/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
@@ -36,7 +36,6 @@ import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.{After, Test}
-import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, immutable}
@@ -59,29 +58,24 @@ class AdminZkClientTest extends ZooKeeperTestHarness with Logging with RackAware
     val topicConfig = new Properties()
 
     // duplicate brokers
-    intercept[InvalidReplicaAssignmentException] {
-      adminZkClient.createTopicWithAssignment("test", topicConfig, Map(0->Seq(0,0)))
-    }
+    assertThrows(classOf[InvalidReplicaAssignmentException],
+      () => adminZkClient.createTopicWithAssignment("test", topicConfig, Map(0->Seq(0,0))))
 
     // inconsistent replication factor
-    intercept[InvalidReplicaAssignmentException] {
-      adminZkClient.createTopicWithAssignment("test", topicConfig, Map(0->Seq(0,1), 1->Seq(0)))
-    }
+    assertThrows(classOf[InvalidReplicaAssignmentException],
+      () => adminZkClient.createTopicWithAssignment("test", topicConfig, Map(0->Seq(0,1), 1->Seq(0))))
 
     // partitions should be 0-based
-    intercept[InvalidReplicaAssignmentException] {
-      adminZkClient.createTopicWithAssignment("test", topicConfig, Map(1->Seq(1,2), 2->Seq(1,2)))
-    }
+    assertThrows(classOf[InvalidReplicaAssignmentException],
+      () => adminZkClient.createTopicWithAssignment("test", topicConfig, Map(1->Seq(1,2), 2->Seq(1,2))))
 
     // partitions should be 0-based and consecutive
-    intercept[InvalidReplicaAssignmentException] {
-      adminZkClient.createTopicWithAssignment("test", topicConfig, Map(0->Seq(1,2), 0->Seq(1,2), 3->Seq(1,2)))
-    }
+    assertThrows(classOf[InvalidReplicaAssignmentException],
+      () => adminZkClient.createTopicWithAssignment("test", topicConfig, Map(0->Seq(1,2), 0->Seq(1,2), 3->Seq(1,2))))
 
     // partitions should be 0-based and consecutive
-    intercept[InvalidReplicaAssignmentException] {
-      adminZkClient.createTopicWithAssignment("test", topicConfig, Map(-1->Seq(1,2), 1->Seq(1,2), 2->Seq(1,2), 4->Seq(1,2)))
-    }
+    assertThrows(classOf[InvalidReplicaAssignmentException],
+      () => adminZkClient.createTopicWithAssignment("test", topicConfig, Map(-1->Seq(1,2), 1->Seq(1,2), 2->Seq(1,2), 4->Seq(1,2))))
 
     // good assignment
     val assignment = Map(0 -> List(0, 1, 2),
@@ -133,10 +127,9 @@ class AdminZkClientTest extends ZooKeeperTestHarness with Logging with RackAware
     for(i <- 0 until actualReplicaMap.size)
       assertEquals(expectedReplicaAssignment.get(i).get, actualReplicaMap(i))
 
-    intercept[TopicExistsException] {
+    assertThrows(classOf[TopicExistsException],
       // shouldn't be able to create a topic that already exists
-      adminZkClient.createTopicWithAssignment(topic, topicConfig, expectedReplicaAssignment)
-    }
+      () => adminZkClient.createTopicWithAssignment(topic, topicConfig, expectedReplicaAssignment))
   }
 
   @Test
@@ -147,10 +140,9 @@ class AdminZkClientTest extends ZooKeeperTestHarness with Logging with RackAware
     // create the topic
     adminZkClient.createTopic(topic, 3, 1)
 
-    intercept[InvalidTopicException] {
+    assertThrows(classOf[InvalidTopicException],
       // shouldn't be able to create a topic that collides
-      adminZkClient.createTopic(collidingTopic, 3, 1)
-    }
+      () => adminZkClient.createTopic(collidingTopic, 3, 1))
   }
 
   @Test
@@ -164,9 +156,8 @@ class AdminZkClientTest extends ZooKeeperTestHarness with Logging with RackAware
     EasyMock.replay(zkMock)
     val adminZkClient = new AdminZkClient(zkMock)
 
-    intercept[TopicExistsException] {
-      adminZkClient.validateTopicCreate(topic, Map.empty, new Properties)
-    }
+    assertThrows(classOf[TopicExistsException],
+      () => adminZkClient.validateTopicCreate(topic, Map.empty, new Properties))
   }
 
   @Test
@@ -351,9 +342,8 @@ class AdminZkClientTest extends ZooKeeperTestHarness with Logging with RackAware
     assertEquals(brokerList, processedMetadatas2.map(_.id))
     assertEquals(List.fill(brokerList.size)(None), processedMetadatas2.map(_.rack))
 
-    intercept[AdminOperationException] {
-      adminZkClient.getBrokerMetadatas(RackAwareMode.Enforced)
-    }
+    assertThrows(classOf[AdminOperationException],
+      () => adminZkClient.getBrokerMetadatas(RackAwareMode.Enforced))
 
     val partialList = List(0, 1, 2, 3, 5)
     val processedMetadatas3 = adminZkClient.getBrokerMetadatas(RackAwareMode.Enforced, Some(partialList))

--- a/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import org.apache.kafka.common.TopicPartition
 import org.junit.Assert._
 import org.junit.Test
-import org.scalatest.Assertions
 
 class ReassignPartitionsZNodeTest {
 
@@ -43,7 +42,7 @@ class ReassignPartitionsZNodeTest {
   @Test
   def testDecodeInvalidJson(): Unit = {
     val result = ReassignPartitionsZNode.decode("invalid json".getBytes)
-    val exception = result.left.getOrElse(Assertions.fail(s"decode should have failed, result $result"))
+    val exception = result.left.getOrElse(throw new AssertionError(s"decode should have failed, result $result"))
     assertTrue(exception.isInstanceOf[JsonProcessingException])
   }
 

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -35,7 +35,7 @@ import org.apache.zookeeper.client.ZKClientConfig
 import org.apache.zookeeper.{CreateMode, WatchedEvent, ZooDefs}
 import org.junit.Assert.{assertArrayEquals, assertEquals, assertFalse, assertTrue}
 import org.junit.{After, Before, Test}
-import org.scalatest.Assertions.{fail, intercept}
+import org.scalatest.Assertions.{assertThrows, fail, intercept}
 
 import scala.jdk.CollectionConverters._
 
@@ -79,11 +79,11 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
     .map(_.getName)
     .filter(t => t.contains("SendThread()"))
 
-  @Test(expected = classOf[ZooKeeperClientTimeoutException])
+  @Test
   def testConnectionTimeout(): Unit = {
     zookeeper.shutdown()
-    new ZooKeeperClient(zkConnect, zkSessionTimeout, connectionTimeoutMs = 10, Int.MaxValue, time, "testMetricGroup",
-      "testMetricType").close()
+    assertThrows[ZooKeeperClientTimeoutException](new ZooKeeperClient(zkConnect, zkSessionTimeout,
+      connectionTimeoutMs = 10, Int.MaxValue, time, "testMetricGroup", "testMetricType").close())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -711,7 +711,7 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
 
   private def cleanMetricsRegistry(): Unit = {
     val metrics = KafkaYammerMetrics.defaultRegistry
-    metrics.allMetrics.keySet.forEach(m => metrics.removeMetric(m))
+    metrics.allMetrics.keySet.forEach(metrics.removeMetric)
   }
 
   private def bytes = UUID.randomUUID().toString.getBytes(StandardCharsets.UTF_8)

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -721,22 +721,22 @@ public class KafkaStreamsTest {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotGetAllTasksWhenNotRunning() {
         final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time);
-        streams.allMetadata();
+        assertThrows(IllegalStateException.class, streams::allMetadata);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotGetAllTasksWithStoreWhenNotRunning() {
         final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time);
-        streams.allMetadataForStore("store");
+        assertThrows(IllegalStateException.class, () -> streams.allMetadataForStore("store"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotGetQueryMetadataWithSerializerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time);
-        streams.queryMetadataForKey("store", "key", Serdes.String().serializer());
+        assertThrows(IllegalStateException.class, () -> streams.queryMetadataForKey("store", "key", Serdes.String().serializer()));
     }
 
     @Test
@@ -746,10 +746,10 @@ public class KafkaStreamsTest {
         assertEquals(KeyQueryMetadata.NOT_AVAILABLE, streams.queryMetadataForKey("store", "key", Serdes.String().serializer()));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldNotGetQueryMetadataWithPartitionerWhenNotRunningOrRebalancing() {
         final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time);
-        streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0);
+        assertThrows(IllegalStateException.class, () -> streams.queryMetadataForKey("store", "key", (topic, key, value, numPartitions) -> 0));
     }
 
     @Test
@@ -781,10 +781,10 @@ public class KafkaStreamsTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowOnNegativeTimeoutForClose() {
         try (final KafkaStreams streams = new KafkaStreams(getBuilderWithSource().build(), props, supplier, time)) {
-            streams.close(Duration.ofMillis(-1L));
+            assertThrows(IllegalArgumentException.class, () -> streams.close(Duration.ofMillis(-1L)));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -513,16 +513,16 @@ public class StreamsBuilderTest {
             equalTo(Collections.singleton("appId-store-changelog")));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldThrowExceptionWhenNoTopicPresent() {
         builder.stream(Collections.emptyList());
-        builder.build();
+        assertThrows(TopologyException.class, builder::build);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowExceptionWhenTopicNamesAreNull() {
         builder.stream(Arrays.asList(null, null));
-        builder.build();
+        assertThrows(NullPointerException.class, builder::build);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -84,10 +84,10 @@ public class StreamsConfigTest {
         streamsConfig = new StreamsConfig(props);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testIllegalMetricsRecordingLevel() {
         props.put(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, "illegalConfig");
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
     @Test
@@ -97,28 +97,28 @@ public class StreamsConfigTest {
         new StreamsConfig(props);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testInvalidSocketSendBufferSize() {
         props.put(StreamsConfig.SEND_BUFFER_CONFIG, -2);
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testInvalidSocketReceiveBufferSize() {
         props.put(StreamsConfig.RECEIVE_BUFFER_CONFIG, -2);
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldThrowExceptionIfApplicationIdIsNotSet() {
         props.remove(StreamsConfig.APPLICATION_ID_CONFIG);
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldThrowExceptionIfBootstrapServersIsNotSet() {
         props.remove(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
     @Test
@@ -360,18 +360,18 @@ public class StreamsConfigTest {
         assertEquals(10, configs.get(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowStreamsExceptionIfKeySerdeConfigFails() {
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, MisconfiguredSerde.class);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        streamsConfig.defaultKeySerde();
+        assertThrows(StreamsException.class, streamsConfig::defaultKeySerde);
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowStreamsExceptionIfValueSerdeConfigFails() {
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, MisconfiguredSerde.class);
         final StreamsConfig streamsConfig = new StreamsConfig(props);
-        streamsConfig.defaultValueSerde();
+        assertThrows(StreamsException.class, streamsConfig::defaultValueSerde);
     }
 
     @Test
@@ -547,10 +547,10 @@ public class StreamsConfigTest {
         new StreamsConfig(props);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldThrowExceptionIfNotAtLeastOnceOrExactlyOnce() {
         props.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, "bad_value");
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
     @Test
@@ -891,10 +891,10 @@ public class StreamsConfigTest {
         assertEquals("Optimization should be \"all\"", expectedOptimizeConfig, actualOptimizedConifig);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void shouldThrowConfigExceptionWhenOptimizationConfigNotValueInRange() {
         props.put(TOPOLOGY_OPTIMIZATION_CONFIG, "maybe");
-        new StreamsConfig(props);
+        assertThrows(ConfigException.class, () -> new StreamsConfig(props));
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -51,6 +51,7 @@ import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class TopologyTest {
@@ -254,11 +255,11 @@ public class TopologyTest {
         } catch (final TopologyException expected) { }
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowToAddStateStoreToNonExistingProcessor() {
         mockStoreBuilder();
         EasyMock.replay(storeBuilder);
-        topology.addStateStore(storeBuilder, "no-such-processor");
+        assertThrows(TopologyException.class, () -> topology.addStateStore(storeBuilder, "no-such-processor"));
     }
 
     @Test
@@ -377,18 +378,18 @@ public class TopologyTest {
     }
 
     @Deprecated // testing old PAPI
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowToAddGlobalStoreWithSourceNameEqualsProcessorName() {
         EasyMock.expect(globalStoreBuilder.name()).andReturn("anyName").anyTimes();
         EasyMock.replay(globalStoreBuilder);
-        topology.addGlobalStore(
+        assertThrows(TopologyException.class, () -> topology.addGlobalStore(
             globalStoreBuilder,
             "sameName",
             null,
             null,
             "anyTopicName",
             "sameName",
-            new MockProcessorSupplier<>());
+            new MockProcessorSupplier<>()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -61,74 +61,75 @@ public class TopologyTest {
     private final Topology topology = new Topology();
     private final InternalTopologyBuilder.TopologyDescription expectedDescription = new InternalTopologyBuilder.TopologyDescription();
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingSourceWithTopic() {
-        topology.addSource((String) null, "topic");
+        assertThrows(NullPointerException.class, () -> topology.addSource((String) null, "topic"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingSourceWithPattern() {
-        topology.addSource(null, Pattern.compile(".*"));
+        assertThrows(NullPointerException.class, () -> topology.addSource(null, Pattern.compile(".*")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTopicsWhenAddingSoureWithTopic() {
-        topology.addSource("source", (String[]) null);
+        assertThrows(NullPointerException.class, () -> topology.addSource("source", (String[]) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTopicsWhenAddingSourceWithPattern() {
-        topology.addSource("source", (Pattern) null);
+        assertThrows(NullPointerException.class, () -> topology.addSource("source", (Pattern) null));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowZeroTopicsWhenAddingSource() {
-        topology.addSource("source");
+        assertThrows(TopologyException.class, () -> topology.addSource("source"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingProcessor() {
-        topology.addProcessor(null, () -> new MockApiProcessorSupplier<>().get());
+        assertThrows(NullPointerException.class, () -> topology.addProcessor(null, () -> new MockApiProcessorSupplier<>().get()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProcessorSupplierWhenAddingProcessor() {
-        topology.addProcessor("name", (ProcessorSupplier<Object, Object, Object, Object>) null);
+        assertThrows(NullPointerException.class, () -> topology.addProcessor("name",
+            (ProcessorSupplier<Object, Object, Object, Object>) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingSink() {
-        topology.addSink(null, "topic");
+        assertThrows(NullPointerException.class, () -> topology.addSink(null, "topic"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTopicWhenAddingSink() {
-        topology.addSink("name", (String) null);
+        assertThrows(NullPointerException.class, () -> topology.addSink("name", (String) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTopicChooserWhenAddingSink() {
-        topology.addSink("name", (TopicNameExtractor<Object, Object>) null);
+        assertThrows(NullPointerException.class, () -> topology.addSink("name", (TopicNameExtractor<Object, Object>) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProcessorNameWhenConnectingProcessorAndStateStores() {
-        topology.connectProcessorAndStateStores(null, "store");
+        assertThrows(NullPointerException.class, () -> topology.connectProcessorAndStateStores(null, "store"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullStoreNameWhenConnectingProcessorAndStateStores() {
-        topology.connectProcessorAndStateStores("processor", (String[]) null);
+        assertThrows(NullPointerException.class, () -> topology.connectProcessorAndStateStores("processor", (String[]) null));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowZeroStoreNameWhenConnectingProcessorAndStateStores() {
-        topology.connectProcessorAndStateStores("processor");
+        assertThrows(TopologyException.class, () -> topology.connectProcessorAndStateStores("processor"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAddNullStateStoreSupplier() {
-        topology.addStateStore(null);
+        assertThrows(NullPointerException.class, () -> topology.addStateStore(null));
     }
 
     @Test
@@ -195,14 +196,14 @@ public class TopologyTest {
         } catch (final NullPointerException expected) { }
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldFailOnUnknownSource() {
-        topology.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
+        assertThrows(TopologyException.class, () -> topology.addProcessor("processor", new MockApiProcessorSupplier<>(), "source"));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldFailIfNodeIsItsOwnParent() {
-        topology.addProcessor("processor", new MockApiProcessorSupplier<>(), "processor");
+        assertThrows(TopologyException.class, () -> topology.addProcessor("processor", new MockApiProcessorSupplier<>(), "processor"));
     }
 
     @Test
@@ -235,14 +236,14 @@ public class TopologyTest {
         } catch (final NullPointerException expected) { }
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldFailWithUnknownParent() {
-        topology.addSink("sink", "topic-2", "source");
+        assertThrows(TopologyException.class, () -> topology.addSink("sink", "topic-2", "source"));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldFailIfSinkIsItsOwnParent() {
-        topology.addSink("sink", "topic-2", "sink");
+        assertThrows(TopologyException.class, () -> topology.addSink("sink", "topic-2", "sink"));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -22,6 +22,7 @@ import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
@@ -45,9 +46,9 @@ public class JoinWindowsTest {
                    .after(ofMillis(-ANY_OTHER_SIZE));              // [ -anyOtherSize ; -anyOtherSize ]
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void timeDifferenceMustNotBeNegative() {
-        JoinWindows.of(ofMillis(-1));
+        assertThrows(IllegalArgumentException.class, () -> JoinWindows.of(ofMillis(-1)));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/NamedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/NamedTest.java
@@ -21,13 +21,14 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class NamedTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowExceptionGivenNullName() {
-        Named.as(null);
+        assertThrows(NullPointerException.class, () -> Named.as(null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/PrintedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/PrintedTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Files;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class PrintedTest {
 
@@ -107,28 +108,28 @@ public class PrintedTest {
         assertThat(sysOut.toString(StandardCharsets.UTF_8.name()), equalTo("[processor]: hello -> 1\n"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionIfFilePathIsNull() {
-        Printed.toFile(null);
+        assertThrows(NullPointerException.class, () -> Printed.toFile(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionIfMapperIsNull() {
-        sysOutPrinter.withKeyValueMapper(null);
+        assertThrows(NullPointerException.class, () -> sysOutPrinter.withKeyValueMapper(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionIfLabelIsNull() {
-        sysOutPrinter.withLabel(null);
+        assertThrows(NullPointerException.class, () -> sysOutPrinter.withLabel(null));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldThrowTopologyExceptionIfFilePathIsEmpty() {
-        Printed.toFile("");
+        assertThrows(TopologyException.class, () -> Printed.toFile(""));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldThrowTopologyExceptionIfFilePathDoesntExist() {
-        Printed.toFile("/this/should/not/exist");
+        assertThrows(TopologyException.class, () -> Printed.toFile("/this/should/not/exist"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -26,6 +26,7 @@ import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("deprecation")
@@ -57,14 +58,14 @@ public class TimeWindowsTest {
         assertEquals(windowSize, TimeWindows.of(ofMillis(windowSize)).maintainMs());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void windowSizeMustNotBeZero() {
-        TimeWindows.of(ofMillis(0));
+        assertThrows(IllegalArgumentException.class, () -> TimeWindows.of(ofMillis(0)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void windowSizeMustNotBeNegative() {
-        TimeWindows.of(ofMillis(-1));
+        assertThrows(IllegalArgumentException.class, () -> TimeWindows.of(ofMillis(-1)));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
@@ -25,6 +25,7 @@ import static java.time.Instant.ofEpochMilli;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -37,9 +38,9 @@ public class UnlimitedWindowsTest {
         assertEquals(anyStartTime, UnlimitedWindows.of().startOn(ofEpochMilli(anyStartTime)).startMs);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void startTimeMustNotBeNegative() {
-        UnlimitedWindows.of().startOn(ofEpochMilli(-1));
+        assertThrows(IllegalArgumentException.class, () -> UnlimitedWindows.of().startOn(ofEpochMilli(-1)));
     }
 
     @SuppressWarnings("deprecation")

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 public class WindowTest {
 
@@ -47,14 +48,14 @@ public class WindowTest {
 
     private final TestWindow window = new TestWindow(5, 10);
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfStartIsNegative() {
-        new TestWindow(-1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new TestWindow(-1, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowIfEndIsSmallerThanStart() {
-        new TestWindow(1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new TestWindow(1, 0));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class WindowsTest {
 
@@ -48,15 +49,15 @@ public class WindowsTest {
     }
 
     @SuppressWarnings("deprecation") // specifically testing deprecated APIs
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void numberOfSegmentsMustBeAtLeastTwo() {
-        new TestWindows().segments(1);
+        assertThrows(IllegalArgumentException.class, () -> new TestWindows().segments(1));
     }
 
     @SuppressWarnings("deprecation") // specifically testing deprecated APIs
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void retentionTimeMustNotBeNegative() {
-        new TestWindows().until(-1);
+        assertThrows(IllegalArgumentException.class, () -> new TestWindows().until(-1));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImplTest.java
@@ -49,6 +49,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class KGroupedTableImplTest {
 
@@ -65,64 +66,64 @@ public class KGroupedTableImplTest {
             .groupBy(MockMapper.selectValueKeyValueMapper());
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowInvalidStoreNameOnAggregate() {
-        groupedTable.aggregate(
+        assertThrows(TopologyException.class, () -> groupedTable.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
             MockAggregator.TOSTRING_REMOVER,
-            Materialized.as(INVALID_STORE_NAME));
+            Materialized.as(INVALID_STORE_NAME)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullInitializerOnAggregate() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             null,
             MockAggregator.TOSTRING_ADDER,
             MockAggregator.TOSTRING_REMOVER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullAdderOnAggregate() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             MockInitializer.STRING_INIT,
             null,
             MockAggregator.TOSTRING_REMOVER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullSubtractorOnAggregate() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullAdderOnReduce() {
-        groupedTable.reduce(
+        assertThrows(NullPointerException.class, () -> groupedTable.reduce(
             null,
             MockReducer.STRING_REMOVER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullSubtractorOnReduce() {
-        groupedTable.reduce(
+        assertThrows(NullPointerException.class, () -> groupedTable.reduce(
             MockReducer.STRING_ADDER,
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowInvalidStoreNameOnReduce() {
-        groupedTable.reduce(
+        assertThrows(TopologyException.class, () -> groupedTable.reduce(
             MockReducer.STRING_ADDER,
             MockReducer.STRING_REMOVER,
-            Materialized.as(INVALID_STORE_NAME));
+            Materialized.as(INVALID_STORE_NAME)));
     }
 
     private MockProcessorSupplier<String, Integer> getReducedResults(final KTable<String, Integer> inputKTable) {
@@ -300,71 +301,70 @@ public class KGroupedTableImplTest {
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointOnCountWhenMaterializedIsNull() {
-        groupedTable.count((Materialized) null);
+        assertThrows(NullPointerException.class, () -> groupedTable.count((Materialized) null));
     }
 
-    @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnReduceWhenMaterializedIsNull() {
-        groupedTable.reduce(
+        assertThrows(NullPointerException.class, () -> groupedTable.reduce(
             MockReducer.STRING_ADDER,
             MockReducer.STRING_REMOVER,
-            (Materialized) null);
+            null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnReduceWhenAdderIsNull() {
-        groupedTable.reduce(
+        assertThrows(NullPointerException.class, () -> groupedTable.reduce(
             null,
             MockReducer.STRING_REMOVER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnReduceWhenSubtractorIsNull() {
-        groupedTable.reduce(
+        assertThrows(NullPointerException.class, () -> groupedTable.reduce(
             MockReducer.STRING_ADDER,
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateWhenInitializerIsNull() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             null,
             MockAggregator.TOSTRING_ADDER,
             MockAggregator.TOSTRING_REMOVER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateWhenAdderIsNull() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             MockInitializer.STRING_INIT,
             null,
             MockAggregator.TOSTRING_REMOVER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateWhenSubtractorIsNull() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateWhenMaterializedIsNull() {
-        groupedTable.aggregate(
+        assertThrows(NullPointerException.class, () -> groupedTable.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
             MockAggregator.TOSTRING_REMOVER,
-            (Materialized) null);
+            (Materialized) null));
     }
 
     private void processData(final String topic,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("unchecked")
 public class KTableImplTest {
@@ -469,39 +470,39 @@ public class KTableImplTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullSelectorOnToStream() {
-        table.toStream((KeyValueMapper) null);
+        assertThrows(NullPointerException.class, () -> table.toStream((KeyValueMapper) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullPredicateOnFilter() {
-        table.filter(null);
+        assertThrows(NullPointerException.class, () -> table.filter(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullPredicateOnFilterNot() {
-        table.filterNot(null);
+        assertThrows(NullPointerException.class, () -> table.filterNot(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullMapperOnMapValues() {
-        table.mapValues((ValueMapper) null);
+        assertThrows(NullPointerException.class, () -> table.mapValues((ValueMapper) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullMapperOnMapValueWithKey() {
-        table.mapValues((ValueMapperWithKey) null);
+        assertThrows(NullPointerException.class, () -> table.mapValues((ValueMapperWithKey) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullSelectorOnGroupBy() {
-        table.groupBy(null);
+        assertThrows(NullPointerException.class, () -> table.groupBy(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullOtherTableOnJoin() {
-        table.join(null, MockValueJoiner.TOSTRING_JOINER);
+        assertThrows(NullPointerException.class, () -> table.join(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
     @Test
@@ -509,74 +510,74 @@ public class KTableImplTest {
         table.join(table, MockValueJoiner.TOSTRING_JOINER);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullJoinerJoin() {
-        table.join(table, null);
+        assertThrows(NullPointerException.class, () -> table.join(table, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullOtherTableOnOuterJoin() {
-        table.outerJoin(null, MockValueJoiner.TOSTRING_JOINER);
+        assertThrows(NullPointerException.class, () -> table.outerJoin(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullJoinerOnOuterJoin() {
-        table.outerJoin(table, null);
+        assertThrows(NullPointerException.class, () -> table.outerJoin(table, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullJoinerOnLeftJoin() {
-        table.leftJoin(table, null);
+        assertThrows(NullPointerException.class, () -> table.leftJoin(table, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullOtherTableOnLeftJoin() {
-        table.leftJoin(null, MockValueJoiner.TOSTRING_JOINER);
+        assertThrows(NullPointerException.class, () -> table.leftJoin(null, MockValueJoiner.TOSTRING_JOINER));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFilterWhenMaterializedIsNull() {
-        table.filter((key, value) -> false, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> table.filter((key, value) -> false, (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFilterNotWhenMaterializedIsNull() {
-        table.filterNot((key, value) -> false, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> table.filterNot((key, value) -> false, (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnJoinWhenMaterializedIsNull() {
-        table.join(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> table.join(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnLeftJoinWhenMaterializedIsNull() {
-        table.leftJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> table.leftJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnOuterJoinWhenMaterializedIsNull() {
-        table.outerJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> table.outerJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnTransformValuesWithKeyWhenTransformerSupplierIsNull() {
-        table.transformValues((ValueTransformerWithKeySupplier) null);
+        assertThrows(NullPointerException.class, () -> table.transformValues(null));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnTransformValuesWithKeyWhenMaterializedIsNull() {
         final ValueTransformerWithKeySupplier<String, String, ?> valueTransformerSupplier =
             mock(ValueTransformerWithKeySupplier.class);
-        table.transformValues(valueTransformerSupplier, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> table.transformValues(valueTransformerSupplier, (Materialized) null));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnTransformValuesWithKeyWhenStoreNamesNull() {
         final ValueTransformerWithKeySupplier<String, String, ?> valueTransformerSupplier =
             mock(ValueTransformerWithKeySupplier.class);
-        table.transformValues(valueTransformerSupplier, (String[]) null);
+        assertThrows(NullPointerException.class, () -> table.transformValues(valueTransformerSupplier, (String[]) null));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class SessionWindowTest {
@@ -115,8 +116,8 @@ public class SessionWindowTest {
         assertFalse(window.overlap(new SessionWindow(125, 150)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cannotCompareSessionWindowWithDifferentWindowType() {
-        window.overlap(timeWindow);
+        assertThrows(IllegalArgumentException.class, () -> window.overlap(timeWindow));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImplTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.streams.kstream.internals;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
@@ -80,54 +81,61 @@ public class SessionWindowedCogroupedKStreamImplTest {
         windowedCogroupedStream = cogroupedStream.windowedBy(SessionWindows.with(ofMillis(100)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullInitializerOnAggregate() {
-        windowedCogroupedStream.aggregate(null, sessionMerger);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, sessionMerger));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullSessionMergerOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullMaterializedOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, sessionMerger, (Named) null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
+            sessionMerger, (Named) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullSessionMerger2OnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
+            null, Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullInitializer2OnAggregate() {
-        windowedCogroupedStream.aggregate(null, sessionMerger, Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, sessionMerger,
+            Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullMaterialized2OnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, sessionMerger, Named.as("name"), null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
+            sessionMerger, Named.as("name"), null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullSessionMerger3OnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, Named.as("name"), Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
+            null, Named.as("name"), Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullNamedOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, sessionMerger, null, Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
+            sessionMerger, null, Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullInitializer3OnAggregate() {
-        windowedCogroupedStream.aggregate(null, sessionMerger, Named.as("name"), Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, sessionMerger,
+            Named.as("name"), Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullNamed2OnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, sessionMerger, (Named) null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, sessionMerger, (Named) null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
@@ -52,6 +52,7 @@ import java.util.Properties;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class SessionWindowedKStreamImplTest {
     private static final String TOPIC = "input";
@@ -213,83 +214,83 @@ public class SessionWindowedKStreamImplTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateIfInitializerIsNull() {
-        stream.aggregate(null, MockAggregator.TOSTRING_ADDER, sessionMerger);
+        assertThrows(NullPointerException.class, () -> stream.aggregate(null, MockAggregator.TOSTRING_ADDER, sessionMerger));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateIfAggregatorIsNull() {
-        stream.aggregate(MockInitializer.STRING_INIT, null, sessionMerger);
+        assertThrows(NullPointerException.class, () -> stream.aggregate(MockInitializer.STRING_INIT, null, sessionMerger));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateIfMergerIsNull() {
-        stream.aggregate(MockInitializer.STRING_INIT, MockAggregator.TOSTRING_ADDER, null);
+        assertThrows(NullPointerException.class, () -> stream.aggregate(MockInitializer.STRING_INIT, MockAggregator.TOSTRING_ADDER, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnReduceIfReducerIsNull() {
-        stream.reduce(null);
+        assertThrows(NullPointerException.class, () -> stream.reduce(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull() {
-        stream.aggregate(
+        assertThrows(NullPointerException.class, () -> stream.aggregate(
             null,
             MockAggregator.TOSTRING_ADDER,
             sessionMerger,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull() {
-        stream.aggregate(
+        assertThrows(NullPointerException.class, () -> stream.aggregate(
             MockInitializer.STRING_INIT,
             null,
             sessionMerger,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfMergerIsNull() {
-        stream.aggregate(
+        assertThrows(NullPointerException.class, () -> stream.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfMaterializedIsNull() {
-        stream.aggregate(
+        assertThrows(NullPointerException.class, () -> stream.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
             sessionMerger,
-            (Materialized) null);
+            (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull() {
-        stream.reduce(null, Materialized.as("store"));
+        assertThrows(NullPointerException.class, () -> stream.reduce(null, Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowNullPointerOnMaterializedReduceIfMaterializedIsNull() {
-        stream.reduce(MockReducer.STRING_ADDER, (Materialized) null);
+        assertThrows(NullPointerException.class, () -> stream.reduce(MockReducer.STRING_ADDER, (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowNullPointerOnMaterializedReduceIfNamedIsNull() {
-        stream.reduce(MockReducer.STRING_ADDER, (Named) null);
+        assertThrows(NullPointerException.class, () -> stream.reduce(MockReducer.STRING_ADDER, (Named) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnCountIfMaterializedIsNull() {
-        stream.count((Materialized<String, Long, SessionStore<Bytes, byte[]>>) null);
+        assertThrows(NullPointerException.class, () -> stream.count((Materialized<String, Long, SessionStore<Bytes, byte[]>>) null));
     }
 
     private void processData(final TopologyTestDriver driver) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static java.time.Duration.ofMillis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class TimeWindowTest {
@@ -33,9 +34,9 @@ public class TimeWindowTest {
     private final TimeWindow window = new TimeWindow(start, end);
     private final SessionWindow sessionWindow = new SessionWindow(start, end);
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void endMustBeLargerThanStart() {
-        new TimeWindow(start, start);
+        assertThrows(IllegalArgumentException.class, () -> new TimeWindow(start, start));
     }
 
     @Test
@@ -118,9 +119,9 @@ public class TimeWindowTest {
         assertFalse(window.overlap(new TimeWindow(125, 150)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cannotCompareTimeWindowWithDifferentWindowType() {
-        window.overlap(sessionWindow);
+        assertThrows(IllegalArgumentException.class, () -> window.overlap(sessionWindow));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImplTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.streams.kstream.internals;
 import static java.time.Duration.ofMillis;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Properties;
 import org.apache.kafka.common.serialization.Serdes;
@@ -79,42 +80,45 @@ public class TimeWindowedCogroupedKStreamImplTest {
         windowedCogroupedStream = cogroupedStream.windowedBy(TimeWindows.of(ofMillis(500L)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullInitializerOnAggregate() {
-        windowedCogroupedStream.aggregate(null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullMaterializedOnTwoOptionAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Materialized<String, String, WindowStore<Bytes, byte[]>>) null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT,
+            (Materialized<String, String, WindowStore<Bytes, byte[]>>) null));
     }
-    @Test(expected = NullPointerException.class)
+
+    @Test
     public void shouldNotHaveNullNamedTwoOptionOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Named) null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, (Named) null));
     }
-    @Test(expected = NullPointerException.class)
+
+    @Test
     public void shouldNotHaveNullInitializerTwoOptionNamedOnAggregate() {
-        windowedCogroupedStream.aggregate(null, Named.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, Named.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullInitializerTwoOptionMaterializedOnAggregate() {
-        windowedCogroupedStream.aggregate(null, Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullInitializerThreeOptionOnAggregate() {
-        windowedCogroupedStream.aggregate(null, Named.as("test"), Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(null, Named.as("test"), Materialized.as("test")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullMaterializedOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, Named.as("Test"), null);
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, Named.as("Test"), null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotHaveNullNamedOnAggregate() {
-        windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, Materialized.as("test"));
+        assertThrows(NullPointerException.class, () -> windowedCogroupedStream.aggregate(MockInitializer.STRING_INIT, null, Materialized.as("test")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
@@ -50,6 +50,7 @@ import static java.time.Duration.ofMillis;
 import static java.time.Instant.ofEpochMilli;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class TimeWindowedKStreamImplTest {
     private static final String TOPIC = "input";
@@ -243,72 +244,72 @@ public class TimeWindowedKStreamImplTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateIfInitializerIsNull() {
-        windowedStream.aggregate(null, MockAggregator.TOSTRING_ADDER);
+        assertThrows(NullPointerException.class, () -> windowedStream.aggregate(null, MockAggregator.TOSTRING_ADDER));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnAggregateIfAggregatorIsNull() {
-        windowedStream.aggregate(MockInitializer.STRING_INIT, null);
+        assertThrows(NullPointerException.class, () -> windowedStream.aggregate(MockInitializer.STRING_INIT, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnReduceIfReducerIsNull() {
-        windowedStream.reduce(null);
+        assertThrows(NullPointerException.class, () -> windowedStream.reduce(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull() {
-        windowedStream.aggregate(
+        assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             null,
             MockAggregator.TOSTRING_ADDER,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull() {
-        windowedStream.aggregate(
+        assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedAggregateIfMaterializedIsNull() {
-        windowedStream.aggregate(
+        assertThrows(NullPointerException.class, () -> windowedStream.aggregate(
             MockInitializer.STRING_INIT,
             MockAggregator.TOSTRING_ADDER,
-            (Materialized) null);
+            (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull() {
-        windowedStream.reduce(
+        assertThrows(NullPointerException.class, () -> windowedStream.reduce(
             null,
-            Materialized.as("store"));
+            Materialized.as("store")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowNullPointerOnMaterializedReduceIfMaterializedIsNull() {
-        windowedStream.reduce(
+        assertThrows(NullPointerException.class, () -> windowedStream.reduce(
             MockReducer.STRING_ADDER,
-            (Materialized) null);
+            (Materialized) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowNullPointerOnMaterializedReduceIfNamedIsNull() {
-        windowedStream.reduce(
+        assertThrows(NullPointerException.class, () -> windowedStream.reduce(
             MockReducer.STRING_ADDER,
-            (Named) null);
+            (Named) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnCountIfMaterializedIsNull() {
-        windowedStream.count((Materialized<String, Long, WindowStore<Bytes, byte[]>>) null);
+        assertThrows(NullPointerException.class, () -> windowedStream.count((Materialized<String, Long, WindowStore<Bytes, byte[]>>) null));
     }
 
     private void processData(final TopologyTestDriver driver) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/UnlimitedWindowTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/UnlimitedWindowTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class UnlimitedWindowTest {
@@ -33,8 +34,8 @@ public class UnlimitedWindowTest {
         assertTrue(window.overlap(new UnlimitedWindow(start + 1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void cannotCompareUnlimitedWindowWithDifferentWindowType() {
-        window.overlap(sessionWindow);
+        assertThrows(IllegalArgumentException.class, () -> window.overlap(sessionWindow));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchemaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/CombinedKeySchemaTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class CombinedKeySchemaTest {
 
@@ -40,22 +41,22 @@ public class CombinedKeySchemaTest {
         assertEquals(primary, deserializedKey.getPrimaryKey());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullPrimaryKeySerdeTest() {
         final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>(
             () -> "fkTopic", Serdes.String(),
             () -> "pkTopic", Serdes.Integer()
         );
-        cks.toBytes("foreignKey", null);
+        assertThrows(NullPointerException.class, () -> cks.toBytes("foreignKey", null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullForeignKeySerdeTest() {
         final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>(
             () -> "fkTopic", Serdes.String(),
             () -> "pkTopic", Serdes.Integer()
         );
-        cks.toBytes(null, 10);
+        assertThrows(NullPointerException.class, () -> cks.toBytes(null, 10));
     }
 
     @Test
@@ -77,13 +78,13 @@ public class CombinedKeySchemaTest {
         assertEquals(expectedPrefixBytes, prefix);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullPrefixKeySerdeTest() {
         final CombinedKeySchema<String, Integer> cks = new CombinedKeySchema<>(
             () -> "fkTopic", Serdes.String(),
             () -> "pkTopic", Serdes.Integer()
         );
         final String foreignKey = null;
-        cks.prefixBytes(foreignKey);
+        assertThrows(NullPointerException.class, () -> cks.prefixBytes(foreignKey));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapperSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionResponseWrapperSerdeTest.java
@@ -30,6 +30,7 @@ import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class SubscriptionResponseWrapperSerdeTest {
     private static final class NonNullableSerde<T> implements Serde<T>, Serializer<T>, Deserializer<T> {
@@ -125,10 +126,11 @@ public class SubscriptionResponseWrapperSerdeTest {
         assertEquals(foreignValue, result.getForeignValue());
     }
 
-    @Test(expected = UnsupportedVersionException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowExceptionWithBadVersionTest() {
         final long[] hashedValue = null;
-        new SubscriptionResponseWrapper<>(hashedValue, "foreignValue", (byte) 0xFF);
+        assertThrows(UnsupportedVersionException.class,
+            () -> new SubscriptionResponseWrapper<>(hashedValue, "foreignValue", (byte) 0xFF));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionWrapperSerdeTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class SubscriptionWrapperSerdeTest {
@@ -57,24 +58,21 @@ public class SubscriptionWrapperSerdeTest {
         assertEquals(originalKey, deserialized.getPrimaryKey());
     }
 
-    @Test (expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowExceptionOnNullKeyTest() {
         final String originalKey = null;
-        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
-        final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(hashedValue, SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE, originalKey);
-        swSerde.serializer().serialize(null, wrapper);
+        assertThrows(NullPointerException.class, () -> new SubscriptionWrapper<>(hashedValue,
+            SubscriptionWrapper.Instruction.PROPAGATE_ONLY_IF_FK_VAL_AVAILABLE, originalKey));
     }
 
-    @Test (expected = NullPointerException.class)
+    @Test
     @SuppressWarnings("unchecked")
     public void shouldThrowExceptionOnNullInstructionTest() {
         final String originalKey = "originalKey";
-        final SubscriptionWrapperSerde swSerde = new SubscriptionWrapperSerde<>(() -> "pkTopic", Serdes.String());
         final long[] hashedValue = Murmur3.hash128(new byte[] {(byte) 0xFF, (byte) 0xAA, (byte) 0x00, (byte) 0x19});
-        final SubscriptionWrapper wrapper = new SubscriptionWrapper<>(hashedValue, null, originalKey);
-        swSerde.serializer().serialize(null, wrapper);
+        assertThrows(NullPointerException.class, () -> new SubscriptionWrapper<>(hashedValue, null, originalKey));
     }
 
     @Test (expected = UnsupportedVersionException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/DefaultPartitionGrouperTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/DefaultPartitionGrouperTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("deprecation")
 public class DefaultPartitionGrouperTest {
@@ -92,7 +93,7 @@ public class DefaultPartitionGrouperTest {
         assertEquals(expectedPartitionsForTask, grouper.partitionGroups(topicGroups, metadata));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldNotCreateAnyTasksBecauseOneTopicHasUnknownPartitions() {
         final PartitionGrouper grouper = new DefaultPartitionGrouper();
         final Map<Integer, Set<String>> topicGroups = new HashMap<>();
@@ -100,6 +101,6 @@ public class DefaultPartitionGrouperTest {
         final int topicGroupId = 0;
     
         topicGroups.put(topicGroupId, mkSet("topic1", "unknownTopic", "topic2"));
-        grouper.partitionGroups(topicGroups, metadata);
+        assertThrows(RuntimeException.class, () -> grouper.partitionGroups(topicGroups, metadata));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/FailOnInvalidTimestampTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/FailOnInvalidTimestampTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.errors.StreamsException;
+import static org.junit.Assert.assertThrows;
 import org.junit.Test;
 
 public class FailOnInvalidTimestampTest extends TimestampExtractorTest {
@@ -27,10 +28,11 @@ public class FailOnInvalidTimestampTest extends TimestampExtractorTest {
         testExtractMetadataTimestamp(new FailOnInvalidTimestamp());
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void failOnInvalidTimestamp() {
         final TimestampExtractor extractor = new FailOnInvalidTimestamp();
-        extractor.extract(new ConsumerRecord<>("anyTopic", 0, 0, null, null), 42);
+        assertThrows(StreamsException.class, () -> extractor.extract(new ConsumerRecord<>("anyTopic",
+                0, 0, null, null), 42));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class AbstractProcessorContextTest {
@@ -78,9 +79,9 @@ public class AbstractProcessorContextTest {
         context.register(stateStore, null);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnRegisterIfStateStoreIsNull() {
-        context.register(null, null);
+        assertThrows(NullPointerException.class, () -> context.register(null, null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/CopartitionedTopicsEnforcerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/CopartitionedTopicsEnforcerTest.java
@@ -58,19 +58,18 @@ public class CopartitionedTopicsEnforcerTest {
             new PartitionInfo("second", 1, null, null, null));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowTopologyBuilderExceptionIfNoPartitionsFoundForCoPartitionedTopic() {
-        validator.enforce(Collections.singleton("topic"),
-                          Collections.emptyMap(),
-                          cluster);
+        assertThrows(IllegalStateException.class, () -> validator.enforce(Collections.singleton("topic"),
+            Collections.emptyMap(), cluster));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldThrowTopologyBuilderExceptionIfPartitionCountsForCoPartitionedTopicsDontMatch() {
         partitions.remove(new TopicPartition("second", 0));
-        validator.enforce(Utils.mkSet("first", "second"),
+        assertThrows(TopologyException.class, () -> validator.enforce(Utils.mkSet("first", "second"),
                           Collections.emptyMap(),
-                          cluster.withPartitions(partitions));
+                          cluster.withPartitions(partitions)));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContextTest.java
@@ -26,6 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertThrows;
+
 @RunWith(EasyMockRunner.class)
 public class ForwardingDisabledProcessorContextTest {
     @Mock(MockType.NICE)
@@ -37,25 +39,25 @@ public class ForwardingDisabledProcessorContextTest {
         context = new ForwardingDisabledProcessorContext(delegate);
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowOnForward() {
-        context.forward("key", "value");
+        assertThrows(StreamsException.class, () -> context.forward("key", "value"));
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowOnForwardWithTo() {
-        context.forward("key", "value", To.all());
+        assertThrows(StreamsException.class, () -> context.forward("key", "value", To.all()));
     }
 
     @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowOnForwardWithChildIndex() {
-        context.forward("key", "value", 1);
+        assertThrows(StreamsException.class, () -> context.forward("key", "value", 1));
     }
 
     @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowOnForwardWithChildName() {
-        context.forward("key", "value", "child1");
+        assertThrows(StreamsException.class, () -> context.forward("key", "value", "child1"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -40,6 +40,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class GlobalProcessorContextImplTest {
@@ -110,21 +111,21 @@ public class GlobalProcessorContextImplTest {
         verify(child, recordContext);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldFailToForwardUsingToParameter() {
-        globalContext.forward(null, null, To.all());
+        assertThrows(IllegalStateException.class, () -> globalContext.forward(null, null, To.all()));
     }
 
     @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotSupportForwardingViaChildIndex() {
-        globalContext.forward(null, null, 0);
+        assertThrows(UnsupportedOperationException.class, () -> globalContext.forward(null, null, 0));
     }
 
     @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotSupportForwardingViaChildName() {
-        globalContext.forward(null, null, "processorName");
+        assertThrows(UnsupportedOperationException.class, () -> globalContext.forward(null, null, "processorName"));
     }
 
     @Test
@@ -133,14 +134,14 @@ public class GlobalProcessorContextImplTest {
     }
 
     @SuppressWarnings("deprecation")
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToSchedulePunctuationsUsingDeprecatedApi() {
-        globalContext.schedule(0L, null, null);
+        assertThrows(UnsupportedOperationException.class, () -> globalContext.schedule(0L, null, null));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldNotAllowToSchedulePunctuations() {
-        globalContext.schedule(null, null, null);
+        assertThrows(UnsupportedOperationException.class, () -> globalContext.schedule(null, null, null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -163,12 +163,12 @@ public class GlobalStateManagerImplTest {
         assertTrue(new File(stateDirectory.globalStateDir(), ".lock").exists());
     }
 
-    @Test(expected = LockException.class)
+    @Test
     public void shouldThrowLockExceptionIfCantGetLock() throws IOException {
         final StateDirectory stateDir = new StateDirectory(streamsConfig, time, true);
         try {
             stateDir.lockGlobalState();
-            stateManager.initialize();
+            assertThrows(LockException.class, stateManager::initialize);
         } finally {
             stateDir.unlockGlobalState();
         }
@@ -232,10 +232,10 @@ public class GlobalStateManagerImplTest {
         assertTrue(checkpointFile.exists());
     }
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowStreamsExceptionIfFailedToReadCheckpointedOffsets() throws IOException {
         writeCorruptCheckpoint();
-        stateManager.initialize();
+        assertThrows(StreamsException.class, stateManager::initialize);
     }
 
     @Test
@@ -398,7 +398,7 @@ public class GlobalStateManagerImplTest {
         assertTrue(store2.flushed);
     }
 
-    @Test(expected = ProcessorStateException.class)
+    @Test
     public void shouldThrowProcessorStateStoreExceptionIfStoreFlushFailed() {
         stateManager.initialize();
         // register the stores
@@ -409,8 +409,7 @@ public class GlobalStateManagerImplTest {
                 throw new RuntimeException("KABOOM!");
             }
         }, stateRestoreCallback);
-
-        stateManager.flush();
+        assertThrows(StreamsException.class, stateManager::flush);
     }
 
     @Test
@@ -427,7 +426,7 @@ public class GlobalStateManagerImplTest {
         assertFalse(store2.isOpen());
     }
 
-    @Test(expected = ProcessorStateException.class)
+    @Test
     public void shouldThrowProcessorStateStoreExceptionIfStoreCloseFailed() throws IOException {
         stateManager.initialize();
         initializeConsumer(1, 0, t1);
@@ -438,7 +437,7 @@ public class GlobalStateManagerImplTest {
             }
         }, stateRestoreCallback);
 
-        stateManager.close();
+        assertThrows(ProcessorStateException.class, stateManager::close);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicConfigTest.java
@@ -25,22 +25,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class InternalTopicConfigTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNpeIfTopicConfigIsNull() {
-        new RepartitionTopicConfig("topic", null);
+        assertThrows(NullPointerException.class, () -> new RepartitionTopicConfig("topic", null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfNameIsNull() {
-        new RepartitionTopicConfig(null, Collections.emptyMap());
+        assertThrows(NullPointerException.class, () -> new RepartitionTopicConfig(null, Collections.emptyMap()));
     }
 
-    @Test(expected = InvalidTopicException.class)
+    @Test
     public void shouldThrowIfNameIsInvalid() {
-        new RepartitionTopicConfig("foo bar baz", Collections.emptyMap());
+        assertThrows(InvalidTopicException.class, () -> new RepartitionTopicConfig("foo bar baz", Collections.emptyMap()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -120,9 +120,10 @@ public class InternalTopologyBuilderTest {
         assertEquals(builder.latestResetTopicsPattern().pattern(), "");
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowOffsetResetSourceWithoutTopics() {
-        builder.addSource(Topology.AutoOffsetReset.EARLIEST, "source", null, stringSerde.deserializer(), stringSerde.deserializer());
+        assertThrows(TopologyException.class, () -> builder.addSource(Topology.AutoOffsetReset.EARLIEST, "source",
+            null, stringSerde.deserializer(), stringSerde.deserializer()));
     }
 
     @Test
@@ -162,24 +163,25 @@ public class InternalTopologyBuilderTest {
         } catch (final TopologyException expected) { /* ok */ }
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddProcessorWithWrongParent() {
-        builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
+        assertThrows(TopologyException.class, () -> builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source"));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddProcessorWithSelfParent() {
-        builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "processor");
+        assertThrows(TopologyException.class, () -> builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "processor"));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddProcessorWithEmptyParents() {
-        builder.addProcessor("processor", new MockApiProcessorSupplier<>());
+        assertThrows(TopologyException.class, () -> builder.addProcessor("processor", new MockApiProcessorSupplier<>()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAddProcessorWithNullParents() {
-        builder.addProcessor("processor", new MockApiProcessorSupplier<>(), (String) null);
+        assertThrows(NullPointerException.class, () -> builder.addProcessor("processor",
+            new MockApiProcessorSupplier<>(), (String) null));
     }
 
     @Test
@@ -220,25 +222,26 @@ public class InternalTopologyBuilderTest {
         } catch (final TopologyException expected) { /* ok */ }
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddSinkWithWrongParent() {
-        builder.addSink("sink", "topic-2", null, null, null, "source");
+        assertThrows(TopologyException.class, () -> builder.addSink("sink", "topic-2", null, null, null, "source"));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddSinkWithSelfParent() {
-        builder.addSink("sink", "topic-2", null, null, null, "sink");
+        assertThrows(TopologyException.class, () -> builder.addSink("sink", "topic-2", null, null, null, "sink"));
     }
 
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddSinkWithEmptyParents() {
-        builder.addSink("sink", "topic", null, null, null);
+        assertThrows(TopologyException.class, () -> builder.addSink("sink", "topic", null, null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAddSinkWithNullParents() {
-        builder.addSink("sink", "topic", null, null, null, (String) null);
+        assertThrows(NullPointerException.class, () -> builder.addSink("sink", "topic", null,
+            null, null, (String) null));
     }
 
     @Test
@@ -384,9 +387,9 @@ public class InternalTopologyBuilderTest {
         } catch (final TopologyException expected) { /* ok */ }
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void testAddStateStoreWithNonExistingProcessor() {
-        builder.addStateStore(storeBuilder, "no-such-processor");
+        assertThrows(TopologyException.class, () -> builder.addStateStore(storeBuilder, "no-such-processor"));
     }
 
     @Test
@@ -709,64 +712,64 @@ public class InternalTopologyBuilderTest {
         assertNotEquals(oldNodeGroups, newNodeGroups);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingSink() {
-        builder.addSink(null, "topic", null, null, null);
+        assertThrows(NullPointerException.class, () -> builder.addSink(null, "topic", null, null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTopicWhenAddingSink() {
-        builder.addSink("name", (String) null, null, null, null);
+        assertThrows(NullPointerException.class, () -> builder.addSink("name", (String) null, null, null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullTopicChooserWhenAddingSink() {
-        builder.addSink("name", (TopicNameExtractor<Object, Object>) null, null, null, null);
+        assertThrows(NullPointerException.class, () -> builder.addSink("name", (TopicNameExtractor<Object, Object>) null, null, null, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingProcessor() {
-        builder.addProcessor(null, () -> null);
+        assertThrows(NullPointerException.class, () -> builder.addProcessor(null, () -> null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProcessorSupplier() {
-        builder.addProcessor("name", null);
+        assertThrows(NullPointerException.class, () -> builder.addProcessor("name", null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullNameWhenAddingSource() {
-        builder.addSource(null, null, null, null, null, Pattern.compile(".*"));
+        assertThrows(NullPointerException.class, () -> builder.addSource(null, null, null, null, null, Pattern.compile(".*")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProcessorNameWhenConnectingProcessorAndStateStores() {
-        builder.connectProcessorAndStateStores(null, "store");
+        assertThrows(NullPointerException.class, () -> builder.connectProcessorAndStateStores(null, "store"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullStateStoreNameWhenConnectingProcessorAndStateStores() {
-        builder.connectProcessorAndStateStores("processor", new String[]{null});
+        assertThrows(NullPointerException.class, () -> builder.connectProcessorAndStateStores("processor", new String[]{null}));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAddNullInternalTopic() {
-        builder.addInternalTopic(null, InternalTopicProperties.empty());
+        assertThrows(NullPointerException.class, () -> builder.addInternalTopic(null, InternalTopicProperties.empty()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAddNullInternalTopicProperties() {
-        builder.addInternalTopic("topic", null);
+        assertThrows(NullPointerException.class, () -> builder.addInternalTopic("topic", null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotSetApplicationIdToNull() {
-        builder.setApplicationId(null);
+        assertThrows(NullPointerException.class, () -> builder.setApplicationId(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAddNullStateStoreSupplier() {
-        builder.addStateStore(null);
+        assertThrows(NullPointerException.class, () -> builder.addStateStore(null));
     }
 
     private Set<String> nodeNames(final Collection<ProcessorNode<?, ?, ?, ?>> nodes) {
@@ -986,10 +989,10 @@ public class InternalTopologyBuilderTest {
         assertFalse(topics.contains("topic-A"));
     }
 
-    @Test(expected = TopologyException.class)
+    @Test
     public void shouldNotAllowToAddGlobalStoreWithSourceNameEqualsProcessorName() {
         final String sameNameForSourceAndProcessor = "sameName";
-        builder.addGlobalStore(
+        assertThrows(TopologyException.class, () -> builder.addGlobalStore(
             storeBuilder,
             sameNameForSourceAndProcessor,
             null,
@@ -998,7 +1001,7 @@ public class InternalTopologyBuilderTest {
             "anyTopicName",
             sameNameForSourceAndProcessor,
             new MockApiProcessorSupplier<>()
-        );
+        ));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -49,18 +49,17 @@ import static org.junit.Assert.assertTrue;
 public class ProcessorNodeTest {
 
     @SuppressWarnings("unchecked")
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowStreamsExceptionIfExceptionCaughtDuringInit() {
         final ProcessorNode node = new ProcessorNode("name", new ExceptionalProcessor(), Collections.emptySet());
-        node.init(null);
+        assertThrows(StreamsException.class, () -> node.init(null));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = StreamsException.class)
+    @Test
     public void shouldThrowStreamsExceptionIfExceptionCaughtDuringClose() {
         final ProcessorNode node = new ProcessorNode("name", new ExceptionalProcessor(), Collections.emptySet());
-        node.init(null);
-        node.close();
+        assertThrows(StreamsException.class, () -> node.init(null));
     }
 
     private static class ExceptionalProcessor implements Processor<Object, Object> {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestoreCallbackAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestoreCallbackAdapterTest.java
@@ -33,16 +33,17 @@ import static org.apache.kafka.streams.processor.internals.StateRestoreCallbackA
 import static org.easymock.EasyMock.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 
 public class StateRestoreCallbackAdapterTest {
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldThrowOnRestoreAll() {
-        adapt(mock(StateRestoreCallback.class)).restoreAll(null);
+        assertThrows(UnsupportedOperationException.class, () -> adapt(mock(StateRestoreCallback.class)).restoreAll(null));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldThrowOnRestore() {
-        adapt(mock(StateRestoreCallback.class)).restore(null, null);
+        assertThrows(UnsupportedOperationException.class, () -> adapt(mock(StateRestoreCallback.class)).restore(null, null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -191,8 +191,8 @@ public class StoreChangelogReaderTest extends EasyMockSupport {
     public void shouldNotRegisterStoreWithoutMetadata() {
         EasyMock.replay(stateManager, storeMetadata);
 
-        assertThrows(IllegalStateException.class, () ->
-            changelogReader.register(new TopicPartition("ChangelogWithoutStoreMetadata", 0), stateManager));
+        assertThrows(IllegalStateException.class,
+            () -> changelogReader.register(new TopicPartition("ChangelogWithoutStoreMetadata", 0), stateManager));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1512,10 +1512,10 @@ public class StreamTaskTest {
         assertThat(task.processorContext().currentNode(), nullValue());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowIllegalStateExceptionOnScheduleIfCurrentNodeIsNull() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.schedule(1, PunctuationType.STREAM_TIME, timestamp -> { });
+        assertThrows(IllegalStateException.class, () -> task.schedule(1, PunctuationType.STREAM_TIME, timestamp -> { }));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -49,6 +49,7 @@ import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
@@ -200,9 +201,9 @@ public class StreamsMetadataStateTest {
             actualAsMap.get(hostThree).standbyStateStoreNames().contains("table-one"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfStoreNameIsNullOnGetAllInstancesWithStore() {
-        metadataState.getAllMetadataForStore(null);
+        assertThrows(NullPointerException.class, () -> metadataState.getAllMetadataForStore(null));
     }
 
     @Test
@@ -274,25 +275,25 @@ public class StreamsMetadataStateTest {
         assertNull(actual);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowWhenKeyIsNull() {
-        metadataState.getKeyQueryMetadataForKey("table-three", null, Serdes.String().serializer());
+        assertThrows(NullPointerException.class, () -> metadataState.getKeyQueryMetadataForKey("table-three", null, Serdes.String().serializer()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowWhenSerializerIsNull() {
-        metadataState.getKeyQueryMetadataForKey("table-three", "key", (Serializer<Object>) null);
+        assertThrows(NullPointerException.class, () -> metadataState.getKeyQueryMetadataForKey("table-three", "key", (Serializer<Object>) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfStoreNameIsNull() {
-        metadataState.getKeyQueryMetadataForKey(null, "key", Serdes.String().serializer());
+        assertThrows(NullPointerException.class, () -> metadataState.getKeyQueryMetadataForKey(null, "key", Serdes.String().serializer()));
     }
 
     @SuppressWarnings("unchecked")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfStreamPartitionerIsNull() {
-        metadataState.getKeyQueryMetadataForKey(null, "key", (StreamPartitioner) null);
+        assertThrows(NullPointerException.class, () -> metadataState.getKeyQueryMetadataForKey(null, "key", (StreamPartitioner) null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -37,6 +37,7 @@ import static org.apache.kafka.streams.processor.internals.assignment.Assignment
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.LATEST_SUPPORTED_VERSION;
 import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class AssignmentInfoTest {
     private final List<TaskId> activeTasks = Arrays.asList(
@@ -76,14 +77,16 @@ public class AssignmentInfoTest {
         assertEquals(LATEST_SUPPORTED_VERSION, info.version());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowForUnknownVersion1() {
-        new AssignmentInfo(0, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
+        assertThrows(IllegalArgumentException.class, () -> new AssignmentInfo(0, activeTasks, standbyTasks,
+            activeAssignment, Collections.emptyMap(), 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowForUnknownVersion2() {
-        new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1, activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0);
+        assertThrows(IllegalArgumentException.class, () -> new AssignmentInfo(LATEST_SUPPORTED_VERSION + 1,
+            activeTasks, standbyTasks, activeAssignment, Collections.emptyMap(), 0));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -41,6 +41,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class SubscriptionInfoTest {
@@ -64,9 +65,9 @@ public class SubscriptionInfoTest {
     private static final int IGNORED_ERROR_CODE = 0;
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowForUnknownVersion1() {
-        new SubscriptionInfo(
+        assertThrows(IllegalArgumentException.class, () -> new SubscriptionInfo(
             0,
             LATEST_SUPPORTED_VERSION,
             UUID_1,
@@ -74,12 +75,12 @@ public class SubscriptionInfoTest {
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
             IGNORED_ERROR_CODE
-        );
+        ));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowForUnknownVersion2() {
-        new SubscriptionInfo(
+        assertThrows(IllegalArgumentException.class, () -> new SubscriptionInfo(
             LATEST_SUPPORTED_VERSION + 1,
             LATEST_SUPPORTED_VERSION,
             UUID_1,
@@ -87,7 +88,7 @@ public class SubscriptionInfoTest {
             TASK_OFFSET_SUMS,
             IGNORED_UNIQUE_FIELD,
             IGNORED_ERROR_CODE
-        );
+        ));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -684,14 +684,14 @@ public class StreamsMetricsImplTest {
         verify(metrics);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testNullMetrics() {
-        new StreamsMetricsImpl(null, "", VERSION, time);
+        assertThrows(NullPointerException.class, () -> new StreamsMetricsImpl(null, "", VERSION, time));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testRemoveNullSensor() {
-        streamsMetrics.removeSensor(null);
+        assertThrows(NullPointerException.class, () -> streamsMetrics.removeSensor(null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -32,19 +32,19 @@ import static org.junit.Assert.assertThrows;
 @SuppressWarnings("unchecked")
 public class StateSerdesTest {
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfTopicNameIsNullForBuiltinTypes() {
-        StateSerdes.withBuiltinTypes(null, byte[].class, byte[].class);
+        assertThrows(NullPointerException.class, () -> StateSerdes.withBuiltinTypes(null, byte[].class, byte[].class));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfKeyClassIsNullForBuiltinTypes() {
-        StateSerdes.withBuiltinTypes("anyName", null, byte[].class);
+        assertThrows(NullPointerException.class, () -> StateSerdes.withBuiltinTypes("anyName", null, byte[].class));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfValueClassIsNullForBuiltinTypes() {
-        StateSerdes.withBuiltinTypes("anyName", byte[].class, null);
+        assertThrows(NullPointerException.class, () -> StateSerdes.withBuiltinTypes("anyName", byte[].class, null));
     }
 
     @Test
@@ -68,29 +68,29 @@ public class StateSerdesTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowForUnknownKeyTypeForBuiltinTypes() {
-        StateSerdes.withBuiltinTypes("anyName", Class.class, byte[].class);
+        assertThrows(IllegalArgumentException.class, () -> StateSerdes.withBuiltinTypes("anyName", Class.class, byte[].class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldThrowForUnknownValueTypeForBuiltinTypes() {
-        StateSerdes.withBuiltinTypes("anyName", byte[].class, Class.class);
+        assertThrows(IllegalArgumentException.class, () -> StateSerdes.withBuiltinTypes("anyName", byte[].class, Class.class));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfTopicNameIsNull() {
-        new StateSerdes<>(null, Serdes.ByteArray(), Serdes.ByteArray());
+        assertThrows(NullPointerException.class, () -> new StateSerdes<>(null, Serdes.ByteArray(), Serdes.ByteArray()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfKeyClassIsNull() {
-        new StateSerdes<>("anyName", null, Serdes.ByteArray());
+        assertThrows(NullPointerException.class, () -> new StateSerdes<>("anyName", null, Serdes.ByteArray()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowIfValueClassIsNull() {
-        new StateSerdes<>("anyName", Serdes.ByteArray(), null);
+        assertThrows(NullPointerException.class, () -> new StateSerdes<>("anyName", Serdes.ByteArray(), null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 
@@ -687,44 +688,44 @@ public abstract class AbstractSessionBytesStoreTest {
         sessionStore.remove(new Windowed<>("a", new SessionWindow(0, 1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnFindSessionsNullKey() {
-        sessionStore.findSessions(null, 1L, 2L);
+        assertThrows(NullPointerException.class, () -> sessionStore.findSessions(null, 1L, 2L));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnFindSessionsNullFromKey() {
-        sessionStore.findSessions(null, "anyKeyTo", 1L, 2L);
+        assertThrows(NullPointerException.class, () -> sessionStore.findSessions(null, "anyKeyTo", 1L, 2L));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnFindSessionsNullToKey() {
-        sessionStore.findSessions("anyKeyFrom", null, 1L, 2L);
+        assertThrows(NullPointerException.class, () -> sessionStore.findSessions("anyKeyFrom", null, 1L, 2L));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnFetchNullFromKey() {
-        sessionStore.fetch(null, "anyToKey");
+        assertThrows(NullPointerException.class, () -> sessionStore.fetch(null, "anyToKey"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnFetchNullToKey() {
-        sessionStore.fetch("anyFromKey", null);
+        assertThrows(NullPointerException.class, () -> sessionStore.fetch("anyFromKey", null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnFetchNullKey() {
-        sessionStore.fetch(null);
+        assertThrows(NullPointerException.class, () -> sessionStore.fetch(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnRemoveNullKey() {
-        sessionStore.remove(null);
+        assertThrows(NullPointerException.class, () -> sessionStore.remove(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionOnPutNullKey() {
-        sessionStore.put(null, 1L);
+        assertThrows(NullPointerException.class, () -> sessionStore.put(null, 1L));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -40,6 +40,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 public class CompositeReadOnlySessionStoreTest {
@@ -108,7 +109,7 @@ public class CompositeReadOnlySessionStoreTest {
         assertFalse(result.hasNext());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStateStoreExceptionOnRebalance() {
         final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
         final CompositeReadOnlySessionStore<String, String> store =
@@ -118,7 +119,7 @@ public class CompositeReadOnlySessionStoreTest {
                 "whateva"
             );
 
-        store.fetch("a");
+        assertThrows(InvalidStateStoreException.class, () -> store.fetch("a"));
     }
 
     @Test
@@ -130,9 +131,9 @@ public class CompositeReadOnlySessionStoreTest {
         } catch (final InvalidStateStoreException e) { }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerExceptionIfFetchingNullKey() {
-        sessionStore.fetch(null);
+        assertThrows(NullPointerException.class, () -> sessionStore.fetch(null));
     }
 
     @Test
@@ -146,18 +147,18 @@ public class CompositeReadOnlySessionStoreTest {
         assertThat(results.size(), equalTo(2));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNPEIfKeyIsNull() {
-        underlyingSessionStore.fetch(null);
+        assertThrows(NullPointerException.class, () -> underlyingSessionStore.fetch(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNPEIfFromKeyIsNull() {
-        underlyingSessionStore.fetch(null, "a");
+        assertThrows(NullPointerException.class, () -> underlyingSessionStore.fetch(null, "a"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNPEIfToKeyIsNull() {
-        underlyingSessionStore.fetch("a", null);
+        assertThrows(NullPointerException.class, () -> underlyingSessionStore.fetch("a", null));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/FilteredCacheIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/FilteredCacheIteratorTest.java
@@ -33,6 +33,7 @@ import static org.apache.kafka.test.StreamsTestUtils.toList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class FilteredCacheIteratorTest {
@@ -125,9 +126,9 @@ public class FilteredCacheIteratorTest {
         assertThat(keyValues, equalTo(Collections.singletonList(firstEntry)));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void shouldThrowUnsupportedOperationExeceptionOnRemove() {
-        allIterator.remove();
+        assertThrows(UnsupportedOperationException.class, () -> allIterator.remove());
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProviderTest.java
@@ -52,6 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 
@@ -139,13 +140,14 @@ public class GlobalStateStoreProviderTest {
         assertTrue(stores.isEmpty());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionIfStoreIsntOpen() {
         final NoOpReadOnlyStore<Object, Object> store = new NoOpReadOnlyStore<>();
         store.close();
         final GlobalStateStoreProvider provider =
             new GlobalStateStoreProvider(Collections.singletonMap("global", store));
-        provider.stores("global", QueryableStoreTypes.keyValueStore());
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores("global",
+            QueryableStoreTypes.keyValueStore()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueStoreBuilderTest.java
@@ -120,24 +120,25 @@ public class KeyValueStoreBuilderTest {
     }
 
     @SuppressWarnings("all")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfInnerIsNull() {
-        new KeyValueStoreBuilder<>(null, Serdes.String(), Serdes.String(), new MockTime());
+        assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(null, Serdes.String(),
+            Serdes.String(), new MockTime()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfKeySerdeIsNull() {
-        new KeyValueStoreBuilder<>(supplier, null, Serdes.String(), new MockTime());
+        assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(supplier, null, Serdes.String(), new MockTime()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfValueSerdeIsNull() {
-        new KeyValueStoreBuilder<>(supplier, Serdes.String(), null, new MockTime());
+        assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), null, new MockTime()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfTimeIsNull() {
-        new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null);
+        assertThrows(NullPointerException.class, () -> new KeyValueStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -462,44 +462,44 @@ public class MeteredSessionStoreTest {
         assertNull(store.fetchSession("a", 0, Long.MAX_VALUE));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnPutIfKeyIsNull() {
-        store.put(null, "a");
+        assertThrows(NullPointerException.class, () -> store.put(null, "a"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnRemoveIfKeyIsNull() {
-        store.remove(null);
+        assertThrows(NullPointerException.class, () -> store.remove(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFetchIfKeyIsNull() {
-        store.fetch(null);
+        assertThrows(NullPointerException.class, () -> store.fetch(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFetchRangeIfFromIsNull() {
-        store.fetch(null, "to");
+        assertThrows(NullPointerException.class, () -> store.fetch(null, "to"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFetchRangeIfToIsNull() {
-        store.fetch("from", null);
+        assertThrows(NullPointerException.class, () -> store.fetch("from", null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFindSessionsIfKeyIsNull() {
-        store.findSessions(null, 0, 0);
+        assertThrows(NullPointerException.class, () -> store.findSessions(null, 0, 0));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFindSessionsRangeIfFromIsNull() {
-        store.findSessions(null, "a", 0, 0);
+        assertThrows(NullPointerException.class, () -> store.findSessions(null, "a", 0, 0));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerOnFindSessionsRangeIfToIsNull() {
-        store.findSessions("a", null, 0, 0);
+        assertThrows(NullPointerException.class, () -> store.findSessions("a", null, 0, 0));
     }
 
     private interface CachedSessionStore extends SessionStore<Bytes, byte[]>, CachedStateStore<byte[], byte[]> { }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class NamedCacheTest {
 
@@ -180,10 +181,11 @@ public class NamedCacheTest {
         cache.evict();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowIllegalStateExceptionWhenTryingToOverwriteDirtyEntryWithCleanEntry() {
         cache.put(Bytes.wrap(new byte[]{0}), new LRUCacheEntry(new byte[]{10}, headers, true, 0, 0, 0, ""));
-        cache.put(Bytes.wrap(new byte[]{0}), new LRUCacheEntry(new byte[]{10}, null, false, 0, 0, 0, ""));
+        assertThrows(IllegalStateException.class, () -> cache.put(Bytes.wrap(new byte[]{0}),
+            new LRUCacheEntry(new byte[]{10}, null, false, 0, 0, 0, "")));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -58,14 +58,16 @@ public class QueryableStoreProviderTest {
             );
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionIfKVStoreDoesntExist() {
-        storeProvider.getStore(StoreQueryParameters.fromNameAndType("not-a-store", QueryableStoreTypes.keyValueStore())).get("1");
+        assertThrows(InvalidStateStoreException.class, () -> storeProvider.getStore(
+            StoreQueryParameters.fromNameAndType("not-a-store", QueryableStoreTypes.keyValueStore())).get("1"));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionIfWindowStoreDoesntExist() {
-        storeProvider.getStore(StoreQueryParameters.fromNameAndType("not-a-store", QueryableStoreTypes.windowStore())).fetch("1", System.currentTimeMillis());
+        assertThrows(InvalidStateStoreException.class, () -> storeProvider.getStore(
+            StoreQueryParameters.fromNameAndType("not-a-store", QueryableStoreTypes.windowStore())).fetch("1", System.currentTimeMillis()));
     }
 
     @Test
@@ -78,14 +80,16 @@ public class QueryableStoreProviderTest {
         assertNotNull(storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore, QueryableStoreTypes.windowStore())));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionWhenLookingForWindowStoreWithDifferentType() {
-        storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore, QueryableStoreTypes.keyValueStore())).get("1");
+        assertThrows(InvalidStateStoreException.class, () -> storeProvider.getStore(StoreQueryParameters.fromNameAndType(windowStore,
+            QueryableStoreTypes.keyValueStore())).get("1"));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowExceptionWhenLookingForKVStoreWithDifferentType() {
-        storeProvider.getStore(StoreQueryParameters.fromNameAndType(keyValueStore, QueryableStoreTypes.windowStore())).fetch("1", System.currentTimeMillis());
+        assertThrows(InvalidStateStoreException.class, () -> storeProvider.getStore(StoreQueryParameters.fromNameAndType(keyValueStore,
+            QueryableStoreTypes.windowStore())).fetch("1", System.currentTimeMillis()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -300,39 +300,44 @@ public class StreamThreadStateStoreProviderTest {
         }
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("kv-store").close();
-        provider.stores(StoreQueryParameters.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()));
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores(StoreQueryParameters.fromNameAndType("kv-store",
+                QueryableStoreTypes.keyValueStore())));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfTsKVStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-kv-store").close();
-        provider.stores(StoreQueryParameters.fromNameAndType("timestamped-kv-store", QueryableStoreTypes.timestampedKeyValueStore()));
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores(StoreQueryParameters.fromNameAndType("timestamped-kv-store",
+                QueryableStoreTypes.timestampedKeyValueStore())));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("window-store").close();
-        provider.stores(StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.windowStore()));
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores(StoreQueryParameters.fromNameAndType("window-store",
+                QueryableStoreTypes.windowStore())));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfTsWindowStoreClosed() {
         mockThread(true);
         taskOne.getStore("timestamped-window-store").close();
-        provider.stores(StoreQueryParameters.fromNameAndType("timestamped-window-store", QueryableStoreTypes.timestampedWindowStore()));
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores(StoreQueryParameters.fromNameAndType("timestamped-window-store",
+                QueryableStoreTypes.timestampedWindowStore())));
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfSessionStoreClosed() {
         mockThread(true);
         taskOne.getStore("session-store").close();
-        provider.stores(StoreQueryParameters.fromNameAndType("session-store", QueryableStoreTypes.sessionStore()));
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores(StoreQueryParameters.fromNameAndType("session-store",
+                QueryableStoreTypes.sessionStore())));
     }
 
     @Test
@@ -381,10 +386,11 @@ public class StreamThreadStateStoreProviderTest {
         );
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfNotAllStoresAvailable() {
         mockThread(false);
-        provider.stores(StoreQueryParameters.fromNameAndType("kv-store", QueryableStoreTypes.keyValueStore()));
+        assertThrows(InvalidStateStoreException.class, () -> provider.stores(StoreQueryParameters.fromNameAndType("kv-store",
+                QueryableStoreTypes.keyValueStore())));
     }
 
     private StreamTask createStreamsTask(final StreamsConfig streamsConfig,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreBuilderTest.java
@@ -138,24 +138,26 @@ public class WindowStoreBuilderTest {
     }
 
     @SuppressWarnings("all")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfInnerIsNull() {
-        new WindowStoreBuilder<>(null, Serdes.String(), Serdes.String(), new MockTime());
+        assertThrows(NullPointerException.class, () -> new WindowStoreBuilder<>(null, Serdes.String(), Serdes.String(), new MockTime()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfKeySerdeIsNull() {
-        new WindowStoreBuilder<>(supplier, null, Serdes.String(), new MockTime());
+        assertThrows(NullPointerException.class, () -> new WindowStoreBuilder<>(supplier, null, Serdes.String(), new MockTime()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfValueSerdeIsNull() {
-        new WindowStoreBuilder<>(supplier, Serdes.String(), null, new MockTime());
+        assertThrows(NullPointerException.class, () -> new WindowStoreBuilder<>(supplier, Serdes.String(),
+            null, new MockTime()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowNullPointerIfTimeIsNull() {
-        new WindowStoreBuilder<>(supplier, Serdes.String(), Serdes.String(), null);
+        assertThrows(NullPointerException.class, () -> new WindowStoreBuilder<>(supplier, Serdes.String(),
+                Serdes.String(), null));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import static org.apache.kafka.streams.state.QueryableStoreTypes.windowStore;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class WrappingStoreProviderTest {
 
@@ -75,10 +76,10 @@ public class WrappingStoreProviderTest {
         assertEquals(2, windowStores.size());
     }
 
-    @Test(expected = InvalidStateStoreException.class)
+    @Test
     public void shouldThrowInvalidStoreExceptionIfNoStoreOfTypeFound() {
         wrappingStoreProvider.setStoreQueryParameters(StoreQueryParameters.fromNameAndType("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore()));
-        wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore());
+        assertThrows(InvalidStateStoreException.class, () -> wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.<String, String>keyValueStore()));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SystemTestUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SystemTestUtilTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class SystemTestUtilTest {
 
@@ -45,21 +46,21 @@ public class SystemTestUtilTest {
         assertEquals(sortedParsedMap, expectedParsedMap);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldThrowExceptionOnNull() {
-        SystemTestUtil.parseConfigs(null);
+        assertThrows(NullPointerException.class, () -> SystemTestUtil.parseConfigs(null));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionIfNotCorrectKeyValueSeparator() {
         final String badString = "foo:bar,baz:boo";
-        SystemTestUtil.parseConfigs(badString);
+        assertThrows(IllegalStateException.class, () -> SystemTestUtil.parseConfigs(badString));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldThrowExceptionIfNotCorrectKeyValuePairSeparator() {
         final String badString = "foo=bar;baz=boo";
-        SystemTestUtil.parseConfigs(badString);
+        assertThrows(IllegalStateException.class, () -> SystemTestUtil.parseConfigs(badString));
     }
 
     @Test

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockTimeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockTimeTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class MockTimeTest {
 
@@ -35,9 +36,10 @@ public class MockTimeTest {
         assertEquals(42L, time.hiResClockMs());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeSleep() {
-        new TopologyTestDriver.MockTime(42).sleep(-1L);
+        assertThrows(IllegalArgumentException.class,
+            () -> new TopologyTestDriver.MockTime(42).sleep(-1L));
     }
 
     @Test

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -356,34 +356,35 @@ public class TestTopicsTest {
         assertThrows("Unknown topic", IllegalArgumentException.class, () -> inputTopic.pipeInput(1L, "Hello"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicName() {
-        testDriver.createInputTopic(null, stringSerde.serializer(), stringSerde.serializer());
+        assertThrows(NullPointerException.class, () -> testDriver.createInputTopic(null, stringSerde.serializer(), stringSerde.serializer()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateWithNullDriver() {
-        new TestInputTopic<>(null, INPUT_TOPIC, stringSerde.serializer(), stringSerde.serializer(), Instant.now(), Duration.ZERO);
+        assertThrows(NullPointerException.class,
+            () -> new TestInputTopic<>(null, INPUT_TOPIC, stringSerde.serializer(), stringSerde.serializer(), Instant.now(), Duration.ZERO));
     }
 
 
-    @Test(expected = StreamsException.class)
+    @Test
     public void testWrongSerde() {
         final TestInputTopic<String, String> inputTopic =
             testDriver.createInputTopic(INPUT_TOPIC_MAP, stringSerde.serializer(), stringSerde.serializer());
-        inputTopic.pipeInput("1L", "Hello");
+        assertThrows(StreamsException.class, () -> inputTopic.pipeInput("1L", "Hello"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDuration() {
-        testDriver.createInputTopic(INPUT_TOPIC_MAP, stringSerde.serializer(), stringSerde.serializer(), testBaseTime, Duration.ofDays(-1));
+        assertThrows(IllegalArgumentException.class,
+            () -> testDriver.createInputTopic(INPUT_TOPIC_MAP, stringSerde.serializer(), stringSerde.serializer(), testBaseTime, Duration.ofDays(-1)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNegativeAdvance() {
-        final TestInputTopic<String, String> inputTopic =
-            testDriver.createInputTopic(INPUT_TOPIC_MAP, stringSerde.serializer(), stringSerde.serializer());
-        inputTopic.advanceTime(Duration.ofDays(-1));
+        final TestInputTopic<String, String> inputTopic = testDriver.createInputTopic(INPUT_TOPIC_MAP, stringSerde.serializer(), stringSerde.serializer());
+        assertThrows(IllegalArgumentException.class, () -> inputTopic.advanceTime(Duration.ofDays(-1)));
     }
 
     @Test
@@ -396,24 +397,24 @@ public class TestTopicsTest {
                 containsString("StringSerializer")));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateOutputTopicWithNullTopicName() {
-        testDriver.createOutputTopic(null, stringSerde.deserializer(), stringSerde.deserializer());
+        assertThrows(NullPointerException.class, () -> testDriver.createOutputTopic(null, stringSerde.deserializer(), stringSerde.deserializer()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateOutputWithNullDriver() {
-        new TestOutputTopic<>(null, OUTPUT_TOPIC, stringSerde.deserializer(), stringSerde.deserializer());
+        assertThrows(NullPointerException.class, () -> new TestOutputTopic<>(null, OUTPUT_TOPIC, stringSerde.deserializer(), stringSerde.deserializer()));
     }
 
-    @Test(expected = SerializationException.class)
+    @Test
     public void testOutputWrongSerde() {
         final TestInputTopic<Long, String> inputTopic =
             testDriver.createInputTopic(INPUT_TOPIC_MAP, longSerde.serializer(), stringSerde.serializer());
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC_MAP, longSerde.deserializer(), stringSerde.deserializer());
         inputTopic.pipeInput(1L, "Hello");
-        assertThat(outputTopic.readKeyValue(), equalTo(new KeyValue<>(1L, "Hello")));
+        assertThrows(SerializationException.class, outputTopic::readKeyValue);
     }
 
     @Test

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @Deprecated
 public class ConsumerRecordFactoryTest {
@@ -58,69 +59,70 @@ public class ConsumerRecordFactoryTest {
         verifyRecord(topicName, rawKey, rawValue, 5L, factory.create(topicName, rawKey, value));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicName() {
-        factory.create(null, rawKey, value, timestamp);
+        assertThrows(NullPointerException.class, () -> factory.create(null, rawKey, value, timestamp));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullHeaders() {
-        factory.create(topicName, rawKey, value, null, timestamp);
+        assertThrows(NullPointerException.class, () -> factory.create(topicName, rawKey, value, null, timestamp));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicNameWithDefaultTimestamp() {
-        factory.create(null, rawKey, value);
+        assertThrows(NullPointerException.class, () -> factory.create(null, rawKey, value));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicNameWithNullKey() {
-        factory.create((String) null, value, timestamp);
+        assertThrows(NullPointerException.class, () -> factory.create((String) null, value, timestamp));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicNameWithNullKeyAndDefaultTimestamp() {
-        factory.create((String) null, value);
+        assertThrows(NullPointerException.class, () -> factory.create((String) null, value));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicNameWithKeyValuePairs() {
-        factory.create(null, Collections.singletonList(KeyValue.pair(rawKey, value)));
+        assertThrows(NullPointerException.class, () -> factory.create(null, Collections.singletonList(KeyValue.pair(rawKey, value))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowToCreateTopicWithNullTopicNameWithKeyValuePairsAndCustomTimestamps() {
-        factory.create(null, Collections.singletonList(KeyValue.pair(rawKey, value)), timestamp, 2L);
+        assertThrows(NullPointerException.class,
+            () -> factory.create(null, Collections.singletonList(KeyValue.pair(rawKey, value)), timestamp, 2L));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldRequireCustomTopicNameIfNotDefaultFactoryTopicName() {
-        defaultFactory.create(rawKey, value, timestamp);
+        assertThrows(IllegalStateException.class, () -> defaultFactory.create(rawKey, value, timestamp));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldRequireCustomTopicNameIfNotDefaultFactoryTopicNameWithDefaultTimestamp() {
-        defaultFactory.create(rawKey, value);
+        assertThrows(IllegalStateException.class, () -> defaultFactory.create(rawKey, value));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldRequireCustomTopicNameIfNotDefaultFactoryTopicNameWithNullKey() {
-        defaultFactory.create(value, timestamp);
+        assertThrows(IllegalStateException.class, () -> defaultFactory.create(value, timestamp));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldRequireCustomTopicNameIfNotDefaultFactoryTopicNameWithNullKeyAndDefaultTimestamp() {
-        defaultFactory.create(value);
+        assertThrows(IllegalStateException.class, () -> defaultFactory.create(value));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldRequireCustomTopicNameIfNotDefaultFactoryTopicNameWithKeyValuePairs() {
-        defaultFactory.create(Collections.singletonList(KeyValue.pair(rawKey, value)));
+        assertThrows(IllegalStateException.class, () -> defaultFactory.create(Collections.singletonList(KeyValue.pair(rawKey, value))));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void shouldRequireCustomTopicNameIfNotDefaultFactoryTopicNameWithKeyValuePairsAndCustomTimestamps() {
-        defaultFactory.create(Collections.singletonList(KeyValue.pair(rawKey, value)), timestamp, 2L);
+        assertThrows(IllegalStateException.class, () -> defaultFactory.create(Collections.singletonList(KeyValue.pair(rawKey, value)), timestamp, 2L));
     }
 
     @Test

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
@@ -17,7 +17,10 @@
 package org.apache.kafka.streams.test;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+
 import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
 
 @Deprecated
 public class OutputVerifierTest {
@@ -40,64 +43,64 @@ public class OutputVerifierTest {
         null
     );
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordForCompareValue() {
-        OutputVerifier.compareValue(null, value);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareValue(null, value));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordWithExpectedRecordForCompareValue() {
-        OutputVerifier.compareValue((ProducerRecord<byte[], byte[]>) null, producerRecord);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareValue((ProducerRecord<byte[], byte[]>) null, producerRecord));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullExpectedRecordForCompareValue() {
-        OutputVerifier.compareValue(producerRecord, (ProducerRecord<byte[], byte[]>) null);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareValue(producerRecord, (ProducerRecord<byte[], byte[]>) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(null, key, value);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareKeyValue(null, key, value));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordWithExpectedRecordForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(null, producerRecord);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareKeyValue(null, producerRecord));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullExpectedRecordForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(producerRecord, null);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareKeyValue(producerRecord, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(null, value, 0L);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareValueTimestamp(null, value, 0L));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordWithExpectedRecordForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(null, producerRecord);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareValueTimestamp(null, producerRecord));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullExpectedRecordForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(producerRecord, null);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareValueTimestamp(producerRecord, null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(null, key, value, 0L);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareKeyValueTimestamp(null, key, value, 0L));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullProducerRecordWithExpectedRecordForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(null, producerRecord);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareKeyValueTimestamp(null, producerRecord));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void shouldNotAllowNullExpectedRecordForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, null);
+        assertThrows(NullPointerException.class, () -> OutputVerifier.compareKeyValueTimestamp(producerRecord, null));
     }
 
     @Test
@@ -110,19 +113,19 @@ public class OutputVerifierTest {
         OutputVerifier.compareValue(nullKeyValueRecord, (byte[]) null);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareValue() {
-        OutputVerifier.compareValue(producerRecord, key);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValue(producerRecord, key));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareValue() {
-        OutputVerifier.compareValue(producerRecord, (byte[]) null);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValue(producerRecord, (byte[]) null));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReverseForCompareValue() {
-        OutputVerifier.compareValue(nullKeyValueRecord, value);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValue(nullKeyValueRecord, value));
     }
 
     @Test
@@ -147,37 +150,22 @@ public class OutputVerifierTest {
         ));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareValueWithProducerRecord() {
-        OutputVerifier.compareValue(producerRecord, new ProducerRecord<>(
-            "sameTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            value,
-            key
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValue(producerRecord,
+            new ProducerRecord<>("sameTopic", Integer.MAX_VALUE, Long.MAX_VALUE, value, key)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareValueWithProducerRecord() {
-        OutputVerifier.compareValue(producerRecord, new ProducerRecord<byte[], byte[]>(
-            "sameTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            value,
-            null
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValue(producerRecord,
+            new ProducerRecord<byte[], byte[]>("sameTopic", Integer.MAX_VALUE, Long.MAX_VALUE, value, null)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReverseForCompareValueWithProducerRecord() {
-        OutputVerifier.compareValue(nullKeyValueRecord, new ProducerRecord<>(
-            "sameTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            value,
-            value
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValue(nullKeyValueRecord,
+            new ProducerRecord<>("sameTopic", Integer.MAX_VALUE, Long.MAX_VALUE, value, value)));
     }
 
     @Test
@@ -190,50 +178,36 @@ public class OutputVerifierTest {
         OutputVerifier.compareKeyValue(nullKeyValueRecord, null, null);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(producerRecord, value, value);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord, value, value));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(producerRecord, null, value);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord, null, value));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullReversForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                null,
-                value),
-            key,
-            value);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, null, value), key, value));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(producerRecord, key, key);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord, key, key));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(producerRecord, key, null);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord, key, null));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReversForCompareKeyValue() {
-        OutputVerifier.compareKeyValue(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                key,
-                null),
-            key,
-            value);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null), key, value));
     }
 
     @Test
@@ -256,68 +230,41 @@ public class OutputVerifierTest {
             null));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentForCompareKeyValueWithProducerRecord() {
-        OutputVerifier.compareKeyValue(producerRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            value,
-            value));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, value, value)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullForCompareKeyValueWithProducerRecord() {
-        OutputVerifier.compareKeyValue(producerRecord, new ProducerRecord<byte[], byte[]>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            null,
-            value));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, null, value)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullReversForCompareKeyValueWithProducerRecord() {
-        OutputVerifier.compareKeyValue(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                null,
-                value),
-            producerRecord);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, null, value), producerRecord));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareKeyValueWithProducerRecord() {
-        OutputVerifier.compareKeyValue(producerRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            key));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, key)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareKeyValueWithProducerRecord() {
-        OutputVerifier.compareKeyValue(producerRecord, new ProducerRecord<byte[], byte[]>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            null));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(producerRecord,
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReversForCompareKeyValueWithProducerRecord() {
-        OutputVerifier.compareKeyValue(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                key,
-                null),
-            producerRecord);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValue(
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null),
+                producerRecord));
     }
 
     @Test
@@ -330,19 +277,22 @@ public class OutputVerifierTest {
         OutputVerifier.compareValueTimestamp(nullKeyValueRecord, null, Long.MAX_VALUE);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(producerRecord, key, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareValueTimestamp(producerRecord, key, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(producerRecord, null, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareValueTimestamp(producerRecord, null, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReverseForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(nullKeyValueRecord, value, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareValueTimestamp(nullKeyValueRecord, value, Long.MAX_VALUE));
     }
 
     @Test
@@ -367,78 +317,41 @@ public class OutputVerifierTest {
         ));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareValueTimestampWithProducerRecord() {
-        OutputVerifier.compareValueTimestamp(producerRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            key
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValueTimestamp(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, key)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareValueTimestampWithProducerRecord() {
-        OutputVerifier.compareValueTimestamp(producerRecord, new ProducerRecord<byte[], byte[]>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            null
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValueTimestamp(producerRecord,
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReverseForCompareValueTimestampWithProducerRecord() {
-        OutputVerifier.compareValueTimestamp(nullKeyValueRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            value
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValueTimestamp(nullKeyValueRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, value)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfTimestampIsDifferentForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(producerRecord, value, 0);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareValueTimestamp(producerRecord, value, 0));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfTimestampDifferentWithNullReverseForCompareValueTimestamp() {
-        OutputVerifier.compareValueTimestamp(nullKeyValueRecord, null, 0);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareValueTimestamp(nullKeyValueRecord, null, 0));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfTimestampIsDifferentForCompareValueTimestampWithProducerRecord() {
-        OutputVerifier.compareValueTimestamp(producerRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            0L,
-            key,
-            value
-        ));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareValueTimestamp(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, 0L, key, value)));
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     @Test
     public void shouldPassIfKeyAndValueAndTimestampIsEqualForCompareKeyValueTimestamp() {
@@ -450,136 +363,90 @@ public class OutputVerifierTest {
         OutputVerifier.compareKeyValueTimestamp(nullKeyValueRecord, null, null, Long.MAX_VALUE);
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, value, value, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareKeyValueTimestamp(producerRecord, value, value, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, null, value, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareKeyValueTimestamp(producerRecord, null, value, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullReversForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                null,
-                value),
-            key,
-            value,
-            Long.MAX_VALUE);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, null, value),
+                key, value, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, key, key, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareKeyValueTimestamp(producerRecord, key, key, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, key, null, Long.MAX_VALUE);
+        assertThrows(AssertionError.class,
+            () -> OutputVerifier.compareKeyValueTimestamp(producerRecord, key, null, Long.MAX_VALUE));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReversForCompareKeyValueTimestamp() {
-        OutputVerifier.compareKeyValueTimestamp(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                key,
-                null),
-            key,
-            value,
-            Long.MAX_VALUE);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null),
+                key, value, Long.MAX_VALUE));
     }
 
     @Test
     public void shouldPassIfKeyAndValueAndTimestampIsEqualForCompareKeyValueTimestampWithProducerRecord() {
         OutputVerifier.compareKeyValueTimestamp(producerRecord, new ProducerRecord<>(
-            "otherTopic",
-            0,
-            Long.MAX_VALUE,
-            key,
-            value));
+            "otherTopic", 0, Long.MAX_VALUE, key, value));
     }
 
     @Test
     public void shouldPassIfKeyAndValueAndTimestampIsEqualWithNullForCompareKeyValueTimestampWithProducerRecord() {
         OutputVerifier.compareKeyValueTimestamp(nullKeyValueRecord, new ProducerRecord<byte[], byte[]>(
-            "otherTopic",
-            0,
-            Long.MAX_VALUE,
-            null,
-            null));
+            "otherTopic", 0, Long.MAX_VALUE, null, null));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentForCompareKeyValueTimestampWithProducerRecord() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            value,
-            value));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, value, value)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullForCompareKeyValueTimestampWithProducerRecord() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, new ProducerRecord<byte[], byte[]>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            null,
-            value));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, null, value)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfKeyIsDifferentWithNullReversForCompareKeyValueTimestampWithProducerRecord() {
-        OutputVerifier.compareKeyValueTimestamp(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                null,
-                value),
-            producerRecord);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, null, value), producerRecord));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentForCompareKeyValueTimestampWithProducerRecord() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, new ProducerRecord<>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            key));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(producerRecord,
+            new ProducerRecord<>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, key)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullForCompareKeyValueTimestampWithProducerRecord() {
-        OutputVerifier.compareKeyValueTimestamp(producerRecord, new ProducerRecord<byte[], byte[]>(
-            "someTopic",
-            Integer.MAX_VALUE,
-            Long.MAX_VALUE,
-            key,
-            null));
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(producerRecord,
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null)));
     }
 
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldFailIfValueIsDifferentWithNullReversForCompareKeyValueTimestampWithProducerRecord() {
-        OutputVerifier.compareKeyValueTimestamp(
-            new ProducerRecord<byte[], byte[]>(
-                "someTopic",
-                Integer.MAX_VALUE,
-                Long.MAX_VALUE,
-                key,
-                null),
-            producerRecord);
+        assertThrows(AssertionError.class, () -> OutputVerifier.compareKeyValueTimestamp(
+            new ProducerRecord<byte[], byte[]>("someTopic", Integer.MAX_VALUE, Long.MAX_VALUE, key, null), producerRecord));
     }
 
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
@@ -17,11 +17,8 @@
 package org.apache.kafka.streams.test;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
-
 import org.junit.Test;
-
 import static org.junit.Assert.assertThrows;
-
 @Deprecated
 public class OutputVerifierTest {
     private final byte[] key = new byte[0];

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
@@ -17,8 +17,11 @@
 package org.apache.kafka.streams.test;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
+
 import org.junit.Test;
+
 import static org.junit.Assert.assertThrows;
+
 @Deprecated
 public class OutputVerifierTest {
     private final byte[] key = new byte[0];

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 public class TestRecordTest {
     private final String key = "testKey";
@@ -132,9 +133,10 @@ public class TestRecordTest {
         assertThat(record4, equalTo(new TestRecord<>(key, value, null, recordMs)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testInvalidRecords() {
-        new TestRecord<>(key, value, headers,  -1L);
+        assertThrows(IllegalArgumentException.class,
+            () -> new TestRecord<>(key, value, headers,  -1L));
     }
 
     @Test


### PR DESCRIPTION
`assertThrows` can make checks in testing more flexible and accurate so I think it is worth substituting `assertThrows` for "expected" parameter.

This PR includes following changes.

1. ```@Test(expected = Exception.class)``` is replaced by ```assertThrows```
1. remove reference to ```org.scalatest.Assertions``` 
1. change the magic code from 1 to 2 for ```testAppendAtInvalidOffset``` to test ZSTD
1. rename ```testMaybeAddPartitionToTransactionXXXX``` to ```testNotReadyForSendXXX```
1. increase maxBlockMs from 1s to 3s to avoid unexpected timeout from ```TransactionsTest#testTimeout``` 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
