### PR TITLE
KAFKA-10661; Add new resigned state for graceful shutdown/initialization

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EndQuorumEpochRequest.java
@@ -70,16 +70,14 @@ public class EndQuorumEpochRequest extends AbstractRequest {
     }
 
     public static EndQuorumEpochRequestData singletonRequest(TopicPartition topicPartition,
-                                                             int replicaId,
                                                              int leaderEpoch,
                                                              int leaderId,
                                                              List<Integer> preferredSuccessors) {
-        return singletonRequest(topicPartition, null, replicaId, leaderEpoch, leaderId, preferredSuccessors);
+        return singletonRequest(topicPartition, null, leaderEpoch, leaderId, preferredSuccessors);
     }
 
     public static EndQuorumEpochRequestData singletonRequest(TopicPartition topicPartition,
                                                              String clusterId,
-                                                             int replicaId,
                                                              int leaderEpoch,
                                                              int leaderId,
                                                              List<Integer> preferredSuccessors) {
@@ -91,7 +89,6 @@ public class EndQuorumEpochRequest extends AbstractRequest {
                            .setPartitions(Collections.singletonList(
                                new EndQuorumEpochRequestData.PartitionData()
                                    .setPartitionIndex(topicPartition.partition())
-                                   .setReplicaId(replicaId)
                                    .setLeaderEpoch(leaderEpoch)
                                    .setLeaderId(leaderId)
                                    .setPreferredSuccessors(preferredSuccessors))))

--- a/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
+++ b/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
@@ -29,10 +29,8 @@
         "versions": "0+", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
-        { "name": "ReplicaId", "type": "int32", "versions": "0+",
-          "about": "The ID of the replica sending this request"},
         { "name": "LeaderId", "type": "int32", "versions": "0+",
-          "about": "The current leader ID or -1 if there is a vote in progress"},
+          "about": "The current leader ID that is resigning"},
         { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
           "about": "The current epoch"},
         { "name": "PreferredSuccessors", "type": "[]int32", "versions": "0+",

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -163,7 +163,6 @@ class KafkaNetworkChannelTest {
         BeginQuorumEpochRequest.singletonRequest(topicPartition, clusterId, leaderEpoch, leaderId)
 
       case ApiKeys.END_QUORUM_EPOCH =>
-        val replicaId = 1
         EndQuorumEpochRequest.singletonRequest(topicPartition, clusterId, leaderId,
           leaderEpoch, Collections.singletonList(2))
 

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -164,8 +164,8 @@ class KafkaNetworkChannelTest {
 
       case ApiKeys.END_QUORUM_EPOCH =>
         val replicaId = 1
-        EndQuorumEpochRequest.singletonRequest(topicPartition, clusterId, replicaId,
-          leaderId, leaderEpoch, Collections.singletonList(2))
+        EndQuorumEpochRequest.singletonRequest(topicPartition, clusterId, leaderId,
+          leaderEpoch, Collections.singletonList(2))
 
       case ApiKeys.VOTE =>
         val lastEpoch = 4

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -578,7 +578,7 @@ class RequestQuotaTest extends BaseRequestTest {
 
         case ApiKeys.END_QUORUM_EPOCH =>
           new EndQuorumEpochRequest.Builder(EndQuorumEpochRequest.singletonRequest(
-            tp, 10, 2, 5, Collections.singletonList(3)))
+            tp, 10, 5, Collections.singletonList(3)))
 
         case ApiKeys.ALTER_ISR =>
           new AlterIsrRequest.Builder(new AlterIsrRequestData())

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -21,7 +21,9 @@ import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Random;
@@ -29,10 +31,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * This class is responsible for managing the current state of this node and ensuring only
- * valid state transitions.
+ * This class is responsible for managing the current state of this node and ensuring
+ * only valid state transitions. Below we define the possible state transitions and
+ * how they are triggered:
  *
- * Unattached =>
+ * Unattached|Resigned =>
  *    Unattached: After learning of a new election with a higher epoch
  *    Voted: After granting a vote to a candidate
  *    Candidate: After expiration of the election timeout
@@ -46,18 +49,20 @@ import java.util.stream.Collectors;
  *    Unattached: After learning of a new election with a higher epoch
  *    Candidate: After expiration of the election timeout
  *    Leader: After receiving a majority of votes
+ *    Resigned: When shutting down gracefully
  *
  * Leader =>
  *    Unattached: After learning of a new election with a higher epoch
+ *    Resigned: When shutting down gracefully
  *
  * Follower =>
  *    Unattached: After learning of a new election with a higher epoch
  *    Candidate: After expiration of the fetch timeout
  *    Follower: After discovering a leader with a larger epoch
  *
- * Observers follow a simpler state machine. The Voted/Candidate/Leader states
- * are not possible for observers, so the only transitions that are possible are
- * between Unattached and Follower.
+ * Observers follow a simpler state machine. The Voted/Candidate/Leader/Resigned
+ * states are not possible for observers, so the only transitions that are possible
+ * are between Unattached and Follower.
  *
  * Unattached =>
  *    Unattached: After learning of a new election with a higher epoch
@@ -136,26 +141,30 @@ public class QuorumState {
                 randomElectionTimeoutMs()
             );
         } else if (election.isLeader(localId)) {
-            // If we were previously a leader, then we will start out as unattached
-            // in the same epoch. This protects the invariant that each record
-            // is uniquely identified by offset and epoch, which might otherwise
-            // be violated if unflushed data is lost after restarting.
-            initialState = new UnattachedState(
-                time,
-                election.epoch,
-                voters,
-                Optional.empty(),
-                randomElectionTimeoutMs()
-            );
-        } else if (election.isVotedCandidate(localId)) {
-            initialState = new CandidateState(
+            // If we were previously a leader, then we will start out as resigned
+            // in the same epoch. This serves two purposes:
+            // 1. It ensures that we cannot vote for another leader in the same epoch.
+            // 2. It protects the invariant that each record is uniquely identified by
+            //    offset and epoch, which might otherwise be violated if unflushed data
+            //    is lost after restarting.
+            initialState = new ResignedState(
                 time,
                 localId,
-                election.epoch,
-                voters,
-                Optional.empty(),
-                1,
-                randomElectionTimeoutMs()
+                randomElectionTimeoutMs(),
+                election,
+                Collections.emptyList()
+            );
+        } else if (election.isVotedCandidate(localId)) {
+            // If we were previously a candidate, then we will start out as resigned
+            // in the same epoch. This is mainly just to ensure a consistent state
+            // machine following restart since we will have resigned if we were a
+            // candidate at the time of shutdown.
+            initialState = new ResignedState(
+                time,
+                localId,
+                randomElectionTimeoutMs(),
+                election,
+                Collections.emptyList()
             );
         } else if (election.hasVoted()) {
             initialState = new VotedState(
@@ -232,9 +241,27 @@ public class QuorumState {
         return !isVoter();
     }
 
+    public void transitionToResigned(List<Integer> preferredSuccessors) {
+        if (!isLeader() && !isCandidate()) {
+            throw new IllegalStateException("Invalid transition to Resigned state from " + state);
+        }
+
+        // The Resigned state is a soft state which does not affect the current
+        // persisted election status.
+        ElectionState currentElection = state.election();
+        this.state = new ResignedState(
+            time,
+            localId,
+            randomElectionTimeoutMs(),
+            currentElection,
+            preferredSuccessors
+        );
+        log.info("Completed transition to {}", state);
+    }
+
     /**
-     * Transition to the "unattached" state. This means we have found an epoch strictly larger
-     * than what is currently known, but wo do not yet know of an elected leader.
+     * Transition to the "unattached" state. This means we have found an epoch greater than
+     * or equal to the current epoch, but wo do not yet know of the elected leader.
      */
     public void transitionToUnattached(int epoch) throws IOException {
         int currentEpoch = state.epoch();
@@ -434,6 +461,12 @@ public class QuorumState {
         throw new IllegalStateException("Expected to be Leader, but current state is " + state);
     }
 
+    public ResignedState resignedStateOrThrow() {
+        if (isResigned())
+            return (ResignedState) state;
+        throw new IllegalStateException("Expected to be Resigned, but current state is " + state);
+    }
+
     public CandidateState candidateStateOrThrow() {
         if (isCandidate())
             return (CandidateState) state;
@@ -459,6 +492,10 @@ public class QuorumState {
 
     public boolean isLeader() {
         return state instanceof LeaderState;
+    }
+
+    public boolean isResigned() {
+        return state instanceof ResignedState;
     }
 
     public boolean isCandidate() {

--- a/raft/src/main/java/org/apache/kafka/raft/ResignedState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ResignedState.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Timer;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A leader or candidate may gracefully resign in the current epoch by sending
+ * an `EndQuorumEpoch` request to all of the voters. This state is used to track
+ * delivery of this request. A voter will remain in the `Resigned` state until
+ * we either learn about another election, or our own election timeout expires
+ * and we become a Candidate.
+ *
+ * Note that vote requests in the same epoch that we have resigned from must be
+ * rejected.
+ */
+public class ResignedState implements EpochState {
+    private final ElectionState election;
+    private final int localId;
+    private final long electionTimeoutMs;
+    private final Set<Integer> unackedVoters;
+    private final Timer electionTimer;
+    private final List<Integer> preferredSuccessors;
+
+    public ResignedState(
+        Time time,
+        int localId,
+        long electionTimeoutMs,
+        ElectionState election,
+        List<Integer> preferredSuccessors
+    ) {
+        this.localId = localId;
+        this.election = election;
+        this.unackedVoters = new HashSet<>(election.voters());
+        this.unackedVoters.remove(localId);
+        this.electionTimeoutMs = electionTimeoutMs;
+        this.electionTimer = time.timer(electionTimeoutMs);
+        this.preferredSuccessors = preferredSuccessors;
+    }
+
+    @Override
+    public ElectionState election() {
+        return election;
+    }
+
+    @Override
+    public int epoch() {
+        return election.epoch;
+    }
+
+    /**
+     * Get the set of voters which have yet to acknowledge the resignation.
+     * This node will send `EndQuorumEpoch` requests to this set until these
+     * voters acknowledge the request or we transition to another state.
+     *
+     * @return the set of unacknowledged voters
+     */
+    public Set<Integer> unackedVoters() {
+        return unackedVoters;
+    }
+
+    /**
+     * Invoked after receiving a successful `EndQuorumEpoch` response. This
+     * is in order to prevent unnecessary retries.
+     *
+     * @param voterId the ID of the voter that send the successful response
+     */
+    public void acknowledgeResignation(int voterId) {
+        if (!election.voters().contains(voterId)) {
+            throw new IllegalArgumentException("Attempt to acknowledge delivery of `EndQuorumEpoch` " +
+                "by a non-voter " + voterId);
+        }
+        unackedVoters.remove(voterId);
+    }
+
+    /**
+     * Check whether the timeout has expired.
+     *
+     * @param currentTimeMs current time in milliseconds
+     * @return true if the timeout has expired, false otherwise
+     */
+    public boolean hasElectionTimeoutExpired(long currentTimeMs) {
+        electionTimer.update(currentTimeMs);
+        return electionTimer.isExpired();
+    }
+
+    /**
+     * Check the time remaining until the timeout expires.
+     *
+     * @param currentTimeMs current time in milliseconds
+     * @return the duration in milliseconds from the current time before the timeout expires
+     */
+    public long remainingElectionTimeMs(long currentTimeMs) {
+        electionTimer.update(currentTimeMs);
+        return electionTimer.remainingMs();
+    }
+
+    public List<Integer> preferredSuccessors() {
+        return preferredSuccessors;
+    }
+
+    @Override
+    public String name() {
+        return "Resigned";
+    }
+
+    @Override
+    public String toString() {
+        return "ResignedState{" +
+            "election=" + election +
+            ", localId=" + localId +
+            ", unackedVoters=" + unackedVoters +
+            ", expirationTimeoutMs=" + electionTimeoutMs +
+            ", preferredSuccessors=" + preferredSuccessors +
+            '}';
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.requests.BeginQuorumEpochRequest;
 import org.apache.kafka.common.requests.BeginQuorumEpochResponse;
 import org.apache.kafka.common.requests.DescribeQuorumResponse;
 import org.apache.kafka.common.requests.EndQuorumEpochRequest;
+import org.apache.kafka.common.requests.EndQuorumEpochResponse;
 import org.apache.kafka.common.requests.VoteRequest;
 import org.apache.kafka.common.requests.VoteResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -624,6 +625,19 @@ final class RaftClientTestContext {
 
     private static InetSocketAddress mockAddress(int id) {
         return new InetSocketAddress("localhost", 9990 + id);
+    }
+
+    EndQuorumEpochResponseData endEpochResponse(
+        int epoch,
+        OptionalInt leaderId
+    ) {
+        return EndQuorumEpochResponse.singletonResponse(
+            Errors.NONE,
+            metadataPartition,
+            Errors.NONE,
+            epoch,
+            leaderId.orElse(-1)
+        );
     }
 
     EndQuorumEpochRequestData endEpochRequest(

--- a/raft/src/test/java/org/apache/kafka/raft/ResignedStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/ResignedStateTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResignedStateTest {
+
+    private final MockTime time = new MockTime();
+
+    @Test
+    public void testResignedState() {
+        int electionTimeoutMs = 5000;
+        int localId = 0;
+        int remoteId = 1;
+        int epoch = 5;
+        Set<Integer> voters = Utils.mkSet(localId, remoteId);
+        ElectionState election = ElectionState.withVotedCandidate(epoch, localId, voters);
+
+        ResignedState state = new ResignedState(
+            time,
+            localId,
+            electionTimeoutMs,
+            election,
+            Collections.emptyList()
+        );
+
+        assertEquals(election, state.election());
+        assertEquals(epoch, state.epoch());
+
+        assertEquals(Collections.singleton(remoteId), state.unackedVoters());
+        state.acknowledgeResignation(remoteId);
+        assertEquals(Collections.emptySet(), state.unackedVoters());
+
+        assertEquals(electionTimeoutMs, state.remainingElectionTimeMs(time.milliseconds()));
+        assertFalse(state.hasElectionTimeoutExpired(time.milliseconds()));
+        time.sleep(electionTimeoutMs / 2);
+        assertEquals(electionTimeoutMs / 2, state.remainingElectionTimeMs(time.milliseconds()));
+        assertFalse(state.hasElectionTimeoutExpired(time.milliseconds()));
+        time.sleep(electionTimeoutMs / 2);
+        assertEquals(0, state.remainingElectionTimeMs(time.milliseconds()));
+        assertTrue(state.hasElectionTimeoutExpired(time.milliseconds()));
+    }
+
+}

--- a/raft/src/test/java/org/apache/kafka/raft/ResignedStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/ResignedStateTest.java
@@ -38,17 +38,17 @@ class ResignedStateTest {
         int remoteId = 1;
         int epoch = 5;
         Set<Integer> voters = Utils.mkSet(localId, remoteId);
-        ElectionState election = ElectionState.withVotedCandidate(epoch, localId, voters);
 
         ResignedState state = new ResignedState(
             time,
             localId,
+            epoch,
+            voters,
             electionTimeoutMs,
-            election,
             Collections.emptyList()
         );
 
-        assertEquals(election, state.election());
+        assertEquals(ElectionState.withElectedLeader(epoch, localId, voters), state.election());
         assertEquals(epoch, state.epoch());
 
         assertEquals(Collections.singleton(remoteId), state.unackedVoters());


### PR DESCRIPTION
When initializing the raft state machine after shutting down as a leader, we were previously entering the "unattached" state, which means we have no leader and no voted candidate. This was a bug because it allowed a reinitialized leader to cast a vote for a candidate in the same epoch that it was already the leader of. This patch fixes the problem by introducing a new "resigned" state which allows us to retain the leader state so that we cannot change our vote and we will not accept additional appends.

This patch also revamps the shutdown logic to make use of the new "resigned" state. Previously we had a separate path in `KafkaRaftClient.poll` for the shutdown logic which resulted in some duplication. Instead now we incorporate shutdown behavior into each state's respective logic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
