### PR TITLE
MINOR: remove redundant return statement

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -361,7 +361,6 @@ class GroupMetadataManager(brokerId: Int,
       // compute the final error codes for the commit response
       val commitStatus = offsetMetadata.map { case (k, _) => k -> Errors.OFFSET_METADATA_TOO_LARGE }
       responseCallback(commitStatus)
-      None
     } else {
       getMagic(partitionFor(group.groupId)) match {
         case Some(magicValue) =>
@@ -477,7 +476,6 @@ class GroupMetadataManager(brokerId: Int,
             (topicPartition, Errors.NOT_COORDINATOR)
           }
           responseCallback(commitStatus)
-          None
       }
     }
   }


### PR DESCRIPTION
the result of `GroupMetadataManager.storeOffsets` is Unit, so remove the redundant return statement