### PR TITLE
MINOR: KIP-584: Remove admin client facility to read features from controller

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1381,10 +1381,8 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
-     * Describes finalized as well as supported features. By default, the request is issued to any
-     * broker. It can be optionally directed only to the controller via DescribeFeaturesOptions
-     * parameter. This is particularly useful if the user requires strongly consistent reads of
-     * finalized features.
+     * Describes finalized as well as supported features. The request is issued to any random
+     * broker.
      * <p>
      * The following exceptions can be anticipated when calling {@code get()} on the future from the
      * returned {@link DescribeFeaturesResult}:

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1433,7 +1433,7 @@ public interface Admin extends AutoCloseable {
      *   This means there was an unexpected error encountered when the update was applied on
      *   the controller. There is no guarantee on whether the update succeeded or failed. The best
      *   way to find out is to issue a {@link Admin#describeFeatures(DescribeFeaturesOptions)}
-     *   request to the controller to get the latest features.</li>
+     *   request.</li>
      * </ul>
      * <p>
      * This operation is supported by brokers with version 2.7.0 or higher.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeFeaturesOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeFeaturesOptions.java
@@ -25,24 +25,4 @@ import org.apache.kafka.common.annotation.InterfaceStability;
  */
 @InterfaceStability.Evolving
 public class DescribeFeaturesOptions extends AbstractOptions<DescribeFeaturesOptions> {
-
-    /**
-     * - True means the {@link Admin#describeFeatures(DescribeFeaturesOptions)} request must be
-     *   issued only to the controller.
-     * - False means the {@link Admin#describeFeatures(DescribeFeaturesOptions)} request can be
-     *   issued to any random broker.
-     */
-    private boolean sendRequestToController = false;
-
-    /**
-     * Sets a flag indicating that the describe features request must be issued only to the controller.
-     */
-    public DescribeFeaturesOptions sendRequestToController(boolean sendRequestToController) {
-        this.sendRequestToController = sendRequestToController;
-        return this;
-    }
-
-    public boolean sendRequestToController() {
-        return sendRequestToController;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4350,6 +4350,7 @@ public class KafkaAdminClient extends AdminClient {
                 .hi(password, salt, iterations);
     }
 
+    @Override
     public DescribeFeaturesResult describeFeatures(final DescribeFeaturesOptions options) {
         final KafkaFutureImpl<FeatureMetadata> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4353,11 +4353,8 @@ public class KafkaAdminClient extends AdminClient {
     public DescribeFeaturesResult describeFeatures(final DescribeFeaturesOptions options) {
         final KafkaFutureImpl<FeatureMetadata> future = new KafkaFutureImpl<>();
         final long now = time.milliseconds();
-        final NodeProvider provider =
-            options.sendRequestToController() ? new ControllerNodeProvider() : new LeastLoadedNodeProvider();
-
         final Call call = new Call(
-            "describeFeatures", calcDeadlineMs(now, options.timeoutMs()), provider) {
+            "describeFeatures", calcDeadlineMs(now, options.timeoutMs()), new LeastLoadedNodeProvider()) {
 
             private FeatureMetadata createFeatureMetadata(final ApiVersionsResponse response) {
                 final Map<String, FinalizedVersionRange> finalizedFeatures = new HashMap<>();
@@ -4390,9 +4387,6 @@ public class KafkaAdminClient extends AdminClient {
                 final ApiVersionsResponse apiVersionsResponse = (ApiVersionsResponse) response;
                 if (apiVersionsResponse.data.errorCode() == Errors.NONE.code()) {
                     future.complete(createFeatureMetadata(apiVersionsResponse));
-                } else if (options.sendRequestToController() &&
-                           apiVersionsResponse.data.errorCode() == Errors.NOT_CONTROLLER.code()) {
-                    handleNotControllerError(Errors.NOT_CONTROLLER);
                 } else {
                     future.completeExceptionally(Errors.forCode(apiVersionsResponse.data.errorCode()).exception());
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4096,24 +4096,16 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testDescribeFeaturesHandleNotControllerException() throws Exception {
+    public void testDescribeFeaturesFailure() throws Exception {
         try (final AdminClientUnitTestEnv env = mockClientEnv()) {
-            env.kafkaClient().prepareResponseFrom(
-                prepareApiVersionsResponseForDescribeFeatures(Errors.NOT_CONTROLLER),
-                env.cluster().nodeById(0));
-            env.kafkaClient().prepareResponse(MetadataResponse.prepareResponse(env.cluster().nodes(),
-                env.cluster().clusterResource().clusterId(),
-                1,
-                Collections.emptyList()));
-            env.kafkaClient().prepareResponseFrom(
-                prepareApiVersionsResponseForDescribeFeatures(Errors.NONE),
-                env.cluster().nodeById(1));
+            env.kafkaClient().prepareResponse(
+                body -> body instanceof ApiVersionsRequest,
+                prepareApiVersionsResponseForDescribeFeatures(Errors.INVALID_REQUEST));
             final DescribeFeaturesOptions options = new DescribeFeaturesOptions();
-            options.sendRequestToController(true);
             options.timeoutMs(10000);
-            final KafkaFuture<FeatureMetadata> future
-                = env.adminClient().describeFeatures(options).featureMetadata();
-            future.get();
+            final KafkaFuture<FeatureMetadata> future = env.adminClient().describeFeatures(options).featureMetadata();
+            final ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+            assertEquals(e.getCause().getClass(), Errors.INVALID_REQUEST.exception().getClass());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -4096,7 +4096,7 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testDescribeFeaturesFailure() throws Exception {
+    public void testDescribeFeaturesFailure() {
         try (final AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().prepareResponse(
                 body -> body instanceof ApiVersionsRequest,

--- a/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/FeatureCommandTest.scala
@@ -76,7 +76,7 @@ class FeatureCommandTest extends BaseRequestTest {
   @Test
   def testDescribeFeaturesSuccess(): Unit = {
     updateSupportedFeaturesInAllBrokers(defaultSupportedFeatures)
-    val featureApis = new FeatureApis(new FeatureCommandOptions(Array("--bootstrap-server", brokerList, "--describe", "--from-controller")))
+    val featureApis = new FeatureApis(new FeatureCommandOptions(Array("--bootstrap-server", brokerList, "--describe")))
     featureApis.setSupportedFeatures(defaultSupportedFeatures)
     try {
       val initialDescribeOutput = TestUtils.grabConsoleOutput(featureApis.describeFeatures())

--- a/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
+++ b/core/src/test/scala/unit/kafka/server/UpdateFeaturesTest.scala
@@ -24,7 +24,7 @@ import kafka.api.KAFKA_2_7_IV0
 import kafka.utils.TestUtils
 import kafka.zk.{FeatureZNode, FeatureZNodeStatus, ZkVersion}
 import kafka.utils.TestUtils.waitUntilTrue
-import org.apache.kafka.clients.admin.{Admin, DescribeFeaturesOptions, FeatureUpdate, UpdateFeaturesOptions, UpdateFeaturesResult}
+import org.apache.kafka.clients.admin.{Admin, FeatureUpdate, UpdateFeaturesOptions, UpdateFeaturesResult}
 import org.apache.kafka.common.errors.InvalidRequestException
 import org.apache.kafka.common.feature.FinalizedVersionRange
 import org.apache.kafka.common.feature.{Features, SupportedVersionRange}
@@ -121,8 +121,7 @@ class UpdateFeaturesTest extends BaseRequestTest {
                             expectedFinalizedFeaturesEpoch: Long,
                             expectedSupportedFeatures: Features[SupportedVersionRange]): Unit = {
     assertEquals(expectedNode, getFeatureZNode())
-    val featureMetadata = client.describeFeatures(
-      new DescribeFeaturesOptions().sendRequestToController(true)).featureMetadata.get
+    val featureMetadata = client.describeFeatures.featureMetadata.get
     assertEquals(expectedFinalizedFeatures, finalizedFeatures(featureMetadata.finalizedFeatures))
     assertEquals(expectedSupportedFeatures, supportedFeatures(featureMetadata.supportedFeatures))
     assertEquals(Optional.of(expectedFinalizedFeaturesEpoch), featureMetadata.finalizedFeaturesEpoch)


### PR DESCRIPTION
In this PR, I have eliminated the facility in `Admin#describeFeatures` API and it's implementation to be able to optionally send a `describeFeatures` request to the controller. This feature was not seen to be particularly useful, and besides it also poses some hindrance to post KIP-500 world where no client would be able to access the controller directly.

**Test plan:**

Rely on existing unit & integration tests.