### PR TITLE
MINOR: ApiKey DESCRIBE_QUORUM missing in parseRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -255,6 +255,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return new BeginQuorumEpochRequest(struct, apiVersion);
             case END_QUORUM_EPOCH:
                 return new EndQuorumEpochRequest(struct, apiVersion);
+            case DESCRIBE_QUORUM:
+                return new DescribeQuorumRequest(struct, apiVersion);
             case ALTER_ISR:
                 return new AlterIsrRequest(new AlterIsrRequestData(struct, apiVersion), apiVersion);
             case UPDATE_FEATURES:


### PR DESCRIPTION
Missing the ApiKey `DESCRIBE_QUORUM` in `AbstractRequest.parseRequest`.