### PR TITLE
MINOR: Fix group_mode_transactions_test

### DIFF
--- a/tests/kafkatest/tests/core/group_mode_transactions_test.py
+++ b/tests/kafkatest/tests/core/group_mode_transactions_test.py
@@ -153,8 +153,9 @@ class GroupModeTransactionsTest(Test):
         """
         try:
             splitted_msg = msg.split('\t')
-            tuple = [int(splitted_msg[0]), int(splitted_msg[1])]
-            return tuple
+            value = int(splitted_msg[1])
+            partition = int(splitted_msg[0].split(":")[1])
+            return [value, partition]
 
         except ValueError:
             raise Exception("Unexpected message format (expected a tab separated [value, partition] tuple). Message: %s" % (msg))


### PR DESCRIPTION
### What
#9099 changed the format of console consumer output to 
`Partition:$PARTITION\t$VALUE`
whereas previously the output format was
`$VALUE\t$PARTITION`
This PR updates the message verifier to accommodate the updated console consumer output format.

After this change, the group transaction tests pass locally.

this should be cherry-picked to 2.7 as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
