### PR TITLE
KAFKA-10675: Add schema name to ConnectSchema.validateValue() error message

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -224,9 +224,7 @@ public class ConnectSchema implements Schema {
         List<Class<?>> expectedClasses = expectedClassesFor(schema);
 
         if (expectedClasses == null)
-            throw new DataException("Invalid Java object for schema type " + schema.type()
-                    + ": " + value.getClass()
-                    + " for field: \"" + name + "\"");
+            throw new DataException(buildNotFoundExpectedClassExceptionMessage(name, schema, value));
 
         boolean foundMatch = false;
         for (Class<?> expectedClass : expectedClasses) {
@@ -237,9 +235,7 @@ public class ConnectSchema implements Schema {
         }
 
         if (!foundMatch)
-            throw new DataException("Invalid Java object for schema type " + schema.type()
-                    + ": " + value.getClass()
-                    + " for field: \"" + name + "\"");
+            throw new DataException(buildNotFoundExpectedClassExceptionMessage(name, schema, value));
 
         switch (schema.type()) {
             case STRUCT:
@@ -268,6 +264,20 @@ public class ConnectSchema implements Schema {
         if (expectedClasses == null)
             expectedClasses = SCHEMA_TYPE_CLASSES.get(schema.type());
         return expectedClasses;
+    }
+
+    private static String buildNotFoundExpectedClassExceptionMessage(String name, Schema schema, Object value) {
+        return String.format("Invalid Java object for %s: %s for field: \"%s\"",
+            buildSchemaInfo(schema), value.getClass(), name);
+    }
+
+    private static String buildSchemaInfo(Schema schema) {
+        StringBuilder schemaInfo = new StringBuilder("schema");
+        if (schema.name() != null) {
+            schemaInfo.append(" \"").append(schema.name()).append("\"");
+        }
+        schemaInfo.append(" with type ").append(schema.type());
+        return schemaInfo.toString();
     }
 
     /**

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -221,11 +221,7 @@ public class ConnectSchema implements Schema {
             return;
         }
 
-        List<Class<?>> expectedClasses = expectedClassesFor(schema);
-
-        if (expectedClasses == null)
-            throw new DataException(buildNotFoundExpectedClassExceptionMessage(name, schema, value));
-
+        List<Class> expectedClasses = expectedClassesFor(schema);
         boolean foundMatch = false;
         for (Class<?> expectedClass : expectedClasses) {
             if (expectedClass.isInstance(value)) {
@@ -234,8 +230,11 @@ public class ConnectSchema implements Schema {
             }
         }
 
-        if (!foundMatch)
-            throw new DataException(buildNotFoundExpectedClassExceptionMessage(name, schema, value));
+        if (!foundMatch) {
+            throw new DataException(String.format("Invalid Java object for %s: %s for field: \"%s\"",
+                buildSchemaInfo(schema), value.getClass(), name)
+            );
+        }
 
         switch (schema.type()) {
             case STRUCT:
@@ -262,13 +261,8 @@ public class ConnectSchema implements Schema {
     private static List<Class<?>> expectedClassesFor(Schema schema) {
         List<Class<?>> expectedClasses = LOGICAL_TYPE_CLASSES.get(schema.name());
         if (expectedClasses == null)
-            expectedClasses = SCHEMA_TYPE_CLASSES.get(schema.type());
+            expectedClasses = SCHEMA_TYPE_CLASSES.getOrDefault(schema.type(), Collections.emptyList());
         return expectedClasses;
-    }
-
-    private static String buildNotFoundExpectedClassExceptionMessage(String name, Schema schema, Object value) {
-        return String.format("Invalid Java object for %s: %s for field: \"%s\"",
-            buildSchemaInfo(schema), value.getClass(), name);
     }
 
     private static String buildSchemaInfo(Schema schema) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -221,7 +221,7 @@ public class ConnectSchema implements Schema {
             return;
         }
 
-        List<Class> expectedClasses = expectedClassesFor(schema);
+        List<Class<?>> expectedClasses = expectedClassesFor(schema);
         boolean foundMatch = false;
         for (Class<?> expectedClass : expectedClasses) {
             if (expectedClass.isInstance(value)) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -231,9 +231,15 @@ public class ConnectSchema implements Schema {
         }
 
         if (!foundMatch) {
-            throw new DataException(String.format("Invalid Java object for %s: %s for field: \"%s\"",
-                buildSchemaInfo(schema), value.getClass(), name)
-            );
+            StringBuilder exceptionMessage = new StringBuilder("Invalid Java object for schema");
+            if (schema.name() != null) {
+                exceptionMessage.append(" \"").append(schema.name()).append("\"");
+            }
+            exceptionMessage.append(" with type ").append(schema.type()).append(": ").append(value.getClass());
+            if (name != null) {
+                exceptionMessage.append(" for field: \"").append(name).append("\"");
+            }
+            throw new DataException(exceptionMessage.toString());
         }
 
         switch (schema.type()) {
@@ -263,15 +269,6 @@ public class ConnectSchema implements Schema {
         if (expectedClasses == null)
             expectedClasses = SCHEMA_TYPE_CLASSES.getOrDefault(schema.type(), Collections.emptyList());
         return expectedClasses;
-    }
-
-    private static String buildSchemaInfo(Schema schema) {
-        StringBuilder schemaInfo = new StringBuilder("schema");
-        if (schema.name() != null) {
-            schemaInfo.append(" \"").append(schema.name()).append("\"");
-        }
-        schemaInfo.append(" with type ").append(schema.type());
-        return schemaInfo.toString();
     }
 
     /**

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -318,6 +318,9 @@ public class StructTest {
             Schema.INT8_SCHEMA, new Object()));
         assertEquals("Invalid Java object for schema with type INT8: class java.lang.Object for field: \"field\"",
             e.getMessage());
+
+        e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(Schema.INT8_SCHEMA, new Object()));
+        assertEquals("Invalid Java object for schema with type INT8: class java.lang.Object", e.getMessage());
     }
 
     @Test
@@ -325,7 +328,7 @@ public class StructTest {
         String fieldName = "field";
         long longValue = 1000L;
 
-        // Does not throw​
+        // Does not throw
         ConnectSchema.validateValue(fieldName, Schema.INT64_SCHEMA, longValue);
 
         Exception e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -311,13 +311,27 @@ public class StructTest {
 
         Exception e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,
             fakeSchema, new Object()));
-        assertEquals("Invalid Java object for schema type null: class java.lang.Object for field: \"field\"",
+        assertEquals("Invalid Java object for schema \"fake\" with type null: class java.lang.Object for field: \"field\"",
             e.getMessage());
 
         e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,
             Schema.INT8_SCHEMA, new Object()));
-        assertEquals("Invalid Java object for schema type INT8: class java.lang.Object for field: \"field\"",
+        assertEquals("Invalid Java object for schema with type INT8: class java.lang.Object for field: \"field\"",
             e.getMessage());
+    }
+
+    @Test
+    public void testValidateFieldWithInvalidValueMismatchTimestamp() {
+        String fieldName = "field";
+        long longValue = 1000L;
+
+        // Does not throw​
+        ConnectSchema.validateValue(fieldName, Schema.INT64_SCHEMA, longValue);
+
+        Exception e = assertThrows(DataException.class, () -> ConnectSchema.validateValue(fieldName,
+            Timestamp.SCHEMA, longValue));
+        assertEquals("Invalid Java object for schema \"org.apache.kafka.connect.data.Timestamp\" " +
+                "with type INT64: class java.lang.Long for field: \"field\"", e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10675

The following error message
```java
org.apache.kafka.connect.errors.DataException: Invalid Java object for schema type INT64: class java.lang.Long for field: "moderate_time"
```
can be confusing because `java.lang.Long` is acceptable type for schema `INT64`. 

In fact, in this case `org.apache.kafka.connect.data.Timestamp` is used but this info is not logged.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
