### PR TITLE
KAFKA-10500: Makes the Stream thread list resizable

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -718,7 +718,7 @@ public class KafkaStreams implements AutoCloseable {
         }
 
         // create the stream thread, global update thread, and cleanup thread
-        threads = new LinkedList<>();
+        threads = Collections.synchronizedList(new LinkedList<>());
         globalTaskTopology = internalTopologyBuilder.buildGlobalStateTopology();
         final boolean hasGlobalTopology = globalTaskTopology != null;
 
@@ -781,9 +781,9 @@ public class KafkaStreams implements AutoCloseable {
                 stateDirectory,
                 delegatingStateRestoreListener,
                 i + 1);
-            threads.add(i, streamThread);
+            threads.add(streamThread);
             threadState.put(streamThread.getId(), streamThread.state());
-            storeProviders.add(new StreamThreadStateStoreProvider(threads.get(i)));
+            storeProviders.add(new StreamThreadStateStoreProvider(streamThread));
         }
 
         ClientMetrics.addNumAliveStreamThreadMetric(streamsMetrics, (metricsConfig, now) ->

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -145,7 +145,7 @@ public class KafkaStreams implements AutoCloseable {
     private final String clientId;
     private final Metrics metrics;
     private final StreamsConfig config;
-    protected final StreamThread[] threads;
+    protected final ArrayList<StreamThread> threads;
     private final StateDirectory stateDirectory;
     private final StreamsMetadataState streamsMetadataState;
     private final ScheduledExecutorService stateDirCleaner;
@@ -659,7 +659,6 @@ public class KafkaStreams implements AutoCloseable {
                          final Time time) throws StreamsException {
         this.config = config;
         this.time = time;
-
         // The application ID is a required config and hence should always have value
         final UUID processId = UUID.randomUUID();
         final String userClientId = config.getString(StreamsConfig.CLIENT_ID_CONFIG);
@@ -719,8 +718,7 @@ public class KafkaStreams implements AutoCloseable {
         }
 
         // create the stream thread, global update thread, and cleanup thread
-        threads = new StreamThread[numStreamThreads];
-
+        threads = new ArrayList<>(numStreamThreads);
         globalTaskTopology = internalTopologyBuilder.buildGlobalStateTopology();
         final boolean hasGlobalTopology = globalTaskTopology != null;
 
@@ -735,7 +733,7 @@ public class KafkaStreams implements AutoCloseable {
             totalCacheSize = 0;
             log.warn("Negative cache size passed in. Reverting to cache size of 0 bytes.");
         }
-        final long cacheSizePerThread = totalCacheSize / (threads.length + (hasGlobalTopology ? 1 : 0));
+        final long cacheSizePerThread = totalCacheSize / (numStreamThreads + (hasGlobalTopology ? 1 : 0));
         final boolean hasPersistentStores = taskTopology.hasPersistentLocalStore() ||
                 (hasGlobalTopology && globalTaskTopology.hasPersistentGlobalStore());
 
@@ -766,10 +764,10 @@ public class KafkaStreams implements AutoCloseable {
         // use client id instead of thread client id since this admin client may be shared among threads
         adminClient = clientSupplier.getAdmin(config.getAdminConfigs(ClientUtils.getSharedAdminClientId(clientId)));
 
-        final Map<Long, StreamThread.State> threadState = new HashMap<>(threads.length);
+        final Map<Long, StreamThread.State> threadState = new HashMap<>(numStreamThreads);
         final ArrayList<StreamThreadStateStoreProvider> storeProviders = new ArrayList<>();
-        for (int i = 0; i < threads.length; i++) {
-            threads[i] = StreamThread.create(
+        for (int i = 0; i < numStreamThreads; i++) {
+            final StreamThread streamThread = StreamThread.create(
                 internalTopologyBuilder,
                 config,
                 clientSupplier,
@@ -783,12 +781,13 @@ public class KafkaStreams implements AutoCloseable {
                 stateDirectory,
                 delegatingStateRestoreListener,
                 i + 1);
-            threadState.put(threads[i].getId(), threads[i].state());
-            storeProviders.add(new StreamThreadStateStoreProvider(threads[i]));
+            threads.add(i, streamThread);
+            threadState.put(threads.get(i).getId(), threads.get(i).state());
+            storeProviders.add(new StreamThreadStateStoreProvider(threads.get(i)));
         }
 
         ClientMetrics.addNumAliveStreamThreadMetric(streamsMetrics, (metricsConfig, now) ->
-            Math.toIntExact(Arrays.stream(threads).filter(thread -> thread.state().isAlive()).count()));
+            Math.toIntExact(Arrays.stream(threads.toArray(new StreamThread[numStreamThreads])).filter(thread -> thread.state().isAlive()).count()));
 
         final StreamStateListener streamStateListener = new StreamStateListener(threadState, globalThreadState);
         if (hasGlobalTopology) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -377,12 +377,12 @@ public class KafkaStreamsTest {
         Assert.assertEquals(KafkaStreams.State.REBALANCING, streams.state());
 
         threadStatelistenerCapture.getValue().onChange(
-            streams.threads[NUM_THREADS - 1],
+            streams.threads.get(NUM_THREADS - 1),
             StreamThread.State.PENDING_SHUTDOWN,
             StreamThread.State.PARTITIONS_ASSIGNED);
 
         threadStatelistenerCapture.getValue().onChange(
-            streams.threads[NUM_THREADS - 1],
+            streams.threads.get(NUM_THREADS - 1),
             StreamThread.State.DEAD,
             StreamThread.State.PENDING_SHUTDOWN);
 
@@ -390,7 +390,7 @@ public class KafkaStreamsTest {
         Assert.assertEquals(KafkaStreams.State.REBALANCING, streams.state());
 
         for (final StreamThread thread : streams.threads) {
-            if (thread != streams.threads[NUM_THREADS - 1]) {
+            if (thread != streams.threads.get(NUM_THREADS - 1)) {
                 threadStatelistenerCapture.getValue().onChange(
                     thread,
                     StreamThread.State.RUNNING,
@@ -435,12 +435,12 @@ public class KafkaStreamsTest {
         Assert.assertEquals(KafkaStreams.State.REBALANCING, streams.state());
 
         threadStatelistenerCapture.getValue().onChange(
-            streams.threads[NUM_THREADS - 1],
+            streams.threads.get(NUM_THREADS - 1),
             StreamThread.State.PENDING_SHUTDOWN,
             StreamThread.State.PARTITIONS_REVOKED);
 
         threadStatelistenerCapture.getValue().onChange(
-            streams.threads[NUM_THREADS - 1],
+            streams.threads.get(NUM_THREADS - 1),
             StreamThread.State.DEAD,
             StreamThread.State.PENDING_SHUTDOWN);
 
@@ -448,7 +448,7 @@ public class KafkaStreamsTest {
         Assert.assertEquals(KafkaStreams.State.REBALANCING, streams.state());
 
         for (final StreamThread thread : streams.threads) {
-            if (thread != streams.threads[NUM_THREADS - 1]) {
+            if (thread != streams.threads.get(NUM_THREADS - 1)) {
                 threadStatelistenerCapture.getValue().onChange(
                     thread,
                     StreamThread.State.PENDING_SHUTDOWN,
@@ -500,7 +500,7 @@ public class KafkaStreamsTest {
         final KafkaStreams streams = new KafkaStreams(builder.build(), props, supplier, time);
 
         try {
-            assertEquals(NUM_THREADS, streams.threads.length);
+            assertEquals(NUM_THREADS, streams.threads.size());
             assertEquals(streams.state(), KafkaStreams.State.CREATED);
 
             streams.start();
@@ -509,11 +509,11 @@ public class KafkaStreamsTest {
                 "Streams never started.");
 
             for (int i = 0; i < NUM_THREADS; i++) {
-                final StreamThread tmpThread = streams.threads[i];
+                final StreamThread tmpThread = streams.threads.get(i);
                 tmpThread.shutdown();
                 TestUtils.waitForCondition(() -> tmpThread.state() == StreamThread.State.DEAD,
                     "Thread never stopped.");
-                streams.threads[i].join();
+                streams.threads.get(i).join();
             }
             TestUtils.waitForCondition(
                 () -> streams.state() == KafkaStreams.State.ERROR,
@@ -912,7 +912,7 @@ public class KafkaStreamsTest {
         builder.globalTable("anyTopic");
         final KafkaStreams streams = new KafkaStreams(builder.build(), props, supplier, time);
 
-        assertThat(streams.threads.length, equalTo(0));
+        assertThat(streams.threads.size(), equalTo(0));
     }
 
     @Test
@@ -921,7 +921,7 @@ public class KafkaStreamsTest {
         builder.globalTable("anyTopic");
         final KafkaStreams streams = new KafkaStreams(builder.build(), props, supplier, time);
 
-        assertThat(streams.threads.length, equalTo(0));
+        assertThat(streams.threads.size(), equalTo(0));
         assertEquals(streams.state(), KafkaStreams.State.CREATED);
 
         streams.start();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
@@ -38,7 +38,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -112,7 +111,7 @@ public class TaskAssignorIntegrationTest {
 
             final Field threads = KafkaStreams.class.getDeclaredField("threads");
             threads.setAccessible(true);
-            final  ArrayList<StreamThread> streamThreads = (ArrayList<StreamThread>) threads.get(kafkaStreams);
+            final  List<StreamThread> streamThreads = (List<StreamThread>) threads.get(kafkaStreams);
             final StreamThread streamThread = streamThreads.get(0);
 
             final Field mainConsumer = StreamThread.class.getDeclaredField("mainConsumer");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskAssignorIntegrationTest.java
@@ -38,6 +38,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -111,8 +112,8 @@ public class TaskAssignorIntegrationTest {
 
             final Field threads = KafkaStreams.class.getDeclaredField("threads");
             threads.setAccessible(true);
-            final StreamThread[] streamThreads = (StreamThread[]) threads.get(kafkaStreams);
-            final StreamThread streamThread = streamThreads[0];
+            final  ArrayList<StreamThread> streamThreads = (ArrayList<StreamThread>) threads.get(kafkaStreams);
+            final StreamThread streamThread = streamThreads.get(0);
 
             final Field mainConsumer = StreamThread.class.getDeclaredField("mainConsumer");
             mainConsumer.setAccessible(true);


### PR DESCRIPTION
Changes the StreamThreads to be held in a ArrayList so that we can dynamically change the number of threads easily.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
