### PR TITLE
[mm2] Allow Checkpoints for consumers using static partition assignments

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -145,7 +145,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
         knownConsumerGroups = findConsumerGroups();
     }
 
-    private List<String> findConsumerGroups()
+    List<String> findConsumerGroups()
             throws InterruptedException, ExecutionException {
         return listConsumerGroups().stream()
                 .map(x -> x.groupId())
@@ -153,7 +153,7 @@ public class MirrorCheckpointConnector extends SourceConnector {
                 .collect(Collectors.toList());
     }
 
-    private Collection<ConsumerGroupListing> listConsumerGroups()
+    Collection<ConsumerGroupListing> listConsumerGroups()
             throws InterruptedException, ExecutionException {
         return sourceAdminClient.listConsumerGroups().valid().get();
     }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorCheckpointConnector.java
@@ -148,7 +148,6 @@ public class MirrorCheckpointConnector extends SourceConnector {
     private List<String> findConsumerGroups()
             throws InterruptedException, ExecutionException {
         return listConsumerGroups().stream()
-                .filter(x -> !x.isSimpleConsumerGroup())
                 .map(x -> x.groupId())
                 .filter(this::shouldReplicate)
                 .collect(Collectors.toList());


### PR DESCRIPTION
Currently mm2 is not generating checkpoints for upstream consumers using static partition assignments. The reason is that these consumers are being explicitly filtered out. I couldn't find why this filter is being applied. This PR removes this limitation.

I've tested this change (but only in one direction: source->target) and it does not break any functionality. Even KAFKA-9076 continues working fine and allows consumer offset sync for consumers using static assignments.