### PR TITLE
KAFKA-9630; Replace OffsetsForLeaderEpoch request/response with automated protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
@@ -65,8 +65,9 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
         Set<String> unauthorizedTopics = new HashSet<>();
         Map<TopicPartition, EpochEndOffset> endOffsets = new HashMap<>();
 
+        Map<TopicPartition, EpochEndOffset> responses = response.responses();
         for (TopicPartition topicPartition : requestData.keySet()) {
-            EpochEndOffset epochEndOffset = response.responses().get(topicPartition);
+            EpochEndOffset epochEndOffset = responses.get(topicPartition);
             if (epochEndOffset == null) {
                 logger().warn("Missing partition {} from response, ignoring", topicPartition);
                 partitionsToRetry.add(topicPartition);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/OffsetsForLeaderEpochClient.java
@@ -57,11 +57,11 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
             fetchPosition.offsetEpoch.ifPresent(fetchEpoch -> {
                 OffsetForLeaderTopic topic = topics.find(topicPartition.topic());
                 if (topic == null) {
-                    topic = new OffsetForLeaderTopic().setName(topicPartition.topic());
+                    topic = new OffsetForLeaderTopic().setTopic(topicPartition.topic());
                     topics.add(topic);
                 }
                 topic.partitions().add(new OffsetForLeaderPartition()
-                    .setPartitionIndex(topicPartition.partition())
+                    .setPartition(topicPartition.partition())
                     .setLeaderEpoch(fetchEpoch)
                     .setCurrentLeaderEpoch(fetchPosition.currentLeader.epoch
                         .orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
@@ -84,7 +84,7 @@ public class OffsetsForLeaderEpochClient extends AsyncClient<
 
         for (OffsetForLeaderTopicResult topic : response.data().topics()) {
             for (OffsetForLeaderPartitionResult partition : topic.partitions()) {
-                TopicPartition topicPartition = new TopicPartition(topic.name(), partition.partitionIndex());
+                TopicPartition topicPartition = new TopicPartition(topic.topic(), partition.partition());
                 missingPartitions.remove(topicPartition);
 
                 if (!requestData.containsKey(topicPartition)) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -26,7 +26,7 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.PartitionStates;
-import org.apache.kafka.common.requests.EpochEndOffset;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderPartitionResult;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
@@ -47,6 +47,8 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static org.apache.kafka.clients.consumer.internals.Fetcher.hasUsableOffsetForLeaderEpochVersion;
+import static org.apache.kafka.common.requests.EpochEndOffset.UNDEFINED_EPOCH;
+import static org.apache.kafka.common.requests.EpochEndOffset.UNDEFINED_EPOCH_OFFSET;
 
 /**
  * A class for tracking the topics, partitions, and offsets for the consumer. A partition
@@ -473,7 +475,7 @@ public class SubscriptionState {
      */
     public synchronized Optional<LogTruncation> maybeCompleteValidation(TopicPartition tp,
                                                                         FetchPosition requestPosition,
-                                                                        EpochEndOffset epochEndOffset) {
+                                                                        OffsetForLeaderPartitionResult epochEndOffset) {
         TopicPartitionState state = assignedStateOrNull(tp);
         if (state == null) {
             log.debug("Skipping completed validation for partition {} which is not currently assigned.", tp);
@@ -483,17 +485,17 @@ public class SubscriptionState {
             SubscriptionState.FetchPosition currentPosition = state.position;
             if (!currentPosition.equals(requestPosition)) {
                 log.debug("Skipping completed validation for partition {} since the current position {} " +
-                                "no longer matches the position {} when the request was sent",
-                        tp, currentPosition, requestPosition);
-            } else if (epochEndOffset.hasUndefinedEpochOrOffset()) {
+                          "no longer matches the position {} when the request was sent",
+                          tp, currentPosition, requestPosition);
+            } else if (epochEndOffset.endOffset() == UNDEFINED_EPOCH_OFFSET ||
+                        epochEndOffset.leaderEpoch() == UNDEFINED_EPOCH) {
                 if (hasDefaultOffsetResetPolicy()) {
                     log.info("Truncation detected for partition {} at offset {}, resetting offset",
-                        tp, currentPosition);
-
+                             tp, currentPosition);
                     requestOffsetReset(tp);
                 } else {
                     log.warn("Truncation detected for partition {} at offset {}, but no reset policy is set",
-                        tp, currentPosition);
+                             tp, currentPosition);
                     return Optional.of(new LogTruncation(tp, requestPosition, Optional.empty()));
                 }
             } else if (epochEndOffset.endOffset() < currentPosition.offset) {
@@ -502,14 +504,13 @@ public class SubscriptionState {
                             epochEndOffset.endOffset(), Optional.of(epochEndOffset.leaderEpoch()),
                             currentPosition.currentLeader);
                     log.info("Truncation detected for partition {} at offset {}, resetting offset to " +
-                            "the first offset known to diverge {}", tp, currentPosition, newPosition);
+                             "the first offset known to diverge {}", tp, currentPosition, newPosition);
                     state.seekValidated(newPosition);
                 } else {
                     OffsetAndMetadata divergentOffset = new OffsetAndMetadata(epochEndOffset.endOffset(),
                         Optional.of(epochEndOffset.leaderEpoch()), null);
                     log.warn("Truncation detected for partition {} at offset {} (the end offset from the " +
-                            "broker is {}), but no reset policy is set",
-                        tp, currentPosition, divergentOffset);
+                             "broker is {}), but no reset policy is set", tp, currentPosition, divergentOffset);
                     return Optional.of(new LogTruncation(tp, requestPosition, Optional.of(divergentOffset)));
                 }
             } else {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -111,6 +111,8 @@ import org.apache.kafka.common.message.OffsetDeleteRequestData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetFetchRequestData;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
@@ -138,8 +140,6 @@ import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.protocol.types.Type;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.requests.OffsetsForLeaderEpochRequest;
-import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -191,8 +191,8 @@ public enum ApiKeys {
     DELETE_TOPICS(20, "DeleteTopics", DeleteTopicsRequestData.SCHEMAS, DeleteTopicsResponseData.SCHEMAS, true),
     DELETE_RECORDS(21, "DeleteRecords", DeleteRecordsRequestData.SCHEMAS, DeleteRecordsResponseData.SCHEMAS),
     INIT_PRODUCER_ID(22, "InitProducerId", InitProducerIdRequestData.SCHEMAS, InitProducerIdResponseData.SCHEMAS),
-    OFFSET_FOR_LEADER_EPOCH(23, "OffsetForLeaderEpoch", false, OffsetsForLeaderEpochRequest.schemaVersions(),
-            OffsetsForLeaderEpochResponse.schemaVersions()),
+    OFFSET_FOR_LEADER_EPOCH(23, "OffsetForLeaderEpoch", false, OffsetForLeaderEpochRequestData.SCHEMAS,
+        OffsetForLeaderEpochResponseData.SCHEMAS),
     ADD_PARTITIONS_TO_TXN(24, "AddPartitionsToTxn", false, RecordBatch.MAGIC_VALUE_V2,
             AddPartitionsToTxnRequestData.SCHEMAS, AddPartitionsToTxnResponseData.SCHEMAS),
     ADD_OFFSETS_TO_TXN(25, "AddOffsetsToTxn", false, RecordBatch.MAGIC_VALUE_V2, AddOffsetsToTxnRequestData.SCHEMAS,

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -143,7 +143,7 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
             case INIT_PRODUCER_ID:
                 return new InitProducerIdResponse(struct, version);
             case OFFSET_FOR_LEADER_EPOCH:
-                return new OffsetsForLeaderEpochResponse(struct);
+                return new OffsetsForLeaderEpochResponse(struct, version);
             case ADD_PARTITIONS_TO_TXN:
                 return new AddPartitionsToTxnResponse(struct, version);
             case ADD_OFFSETS_TO_TXN:

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -75,11 +75,11 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
             epochsByPartition.forEach((partitionKey, partitionValue) -> {
                 OffsetForLeaderTopic topic = data.topics().find(partitionKey.topic());
                 if (topic == null) {
-                    topic = new OffsetForLeaderTopic().setName(partitionKey.topic());
+                    topic = new OffsetForLeaderTopic().setTopic(partitionKey.topic());
                     data.topics().add(topic);
                 }
                 topic.partitions().add(new OffsetForLeaderPartition()
-                    .setPartitionIndex(partitionKey.partition())
+                    .setPartition(partitionKey.partition())
                     .setLeaderEpoch(partitionValue.leaderEpoch)
                     .setCurrentLeaderEpoch(partitionValue.currentLeaderEpoch
                         .orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
@@ -122,7 +122,7 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
         data.topics().forEach(topic ->
             topic.partitions().forEach(partition ->
                 epochsByTopicPartition.put(
-                    new TopicPartition(topic.name(), partition.partitionIndex()),
+                    new TopicPartition(topic.topic(), partition.partition()),
                     new PartitionData(
                         RequestUtils.getLeaderEpoch(partition.currentLeaderEpoch()),
                         partition.leaderEpoch()))));
@@ -150,10 +150,10 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
         OffsetForLeaderEpochResponseData responseData = new OffsetForLeaderEpochResponseData();
         data.topics().forEach(topic -> {
             OffsetForLeaderTopicResult topicData = new OffsetForLeaderTopicResult()
-                .setName(topic.name());
+                .setTopic(topic.topic());
             topic.partitions().forEach(partition ->
                 topicData.partitions().add(new OffsetForLeaderPartitionResult()
-                    .setPartitionIndex(partition.partitionIndex())
+                    .setPartition(partition.partition())
                     .setErrorCode(error.code())
                     .setLeaderEpoch(EpochEndOffset.UNDEFINED_EPOCH)
                     .setEndOffset(EpochEndOffset.UNDEFINED_EPOCH_OFFSET)));

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -18,28 +18,24 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderPartitionResult;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.utils.CollectionUtils;
+import org.apache.kafka.common.record.RecordBatch;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.kafka.common.protocol.CommonFields.CURRENT_LEADER_EPOCH;
-import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
-import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
-
 public class OffsetsForLeaderEpochRequest extends AbstractRequest {
-    private static final Field.Int32 REPLICA_ID = new Field.Int32("replica_id",
-            "Broker id of the follower. For normal consumers, use -1.");
-
     /**
      * Sentinel replica_id value to indicate a regular consumer rather than another broker
      */
@@ -51,57 +47,7 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
      */
     public static final int DEBUGGING_REPLICA_ID = -2;
 
-    private static final Field.ComplexArray TOPICS = new Field.ComplexArray("topics",
-            "An array of topics to get epochs for");
-    private static final Field.ComplexArray PARTITIONS = new Field.ComplexArray("partitions",
-            "An array of partitions to get epochs for");
-
-    private static final Field.Int32 LEADER_EPOCH = new Field.Int32("leader_epoch",
-            "The epoch to lookup an offset for.");
-
-    private static final Field PARTITIONS_V0 = PARTITIONS.withFields(
-            PARTITION_ID,
-            LEADER_EPOCH);
-    private static final Field TOPICS_V0 = TOPICS.withFields(
-            TOPIC_NAME,
-            PARTITIONS_V0);
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_REQUEST_V0 = new Schema(
-            TOPICS_V0);
-
-    // V1 request is the same as v0. Per-partition leader epoch has been added to response
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_REQUEST_V1 = OFFSET_FOR_LEADER_EPOCH_REQUEST_V0;
-
-    // V2 adds the current leader epoch to support fencing and the addition of the throttle time in the response
-    private static final Field PARTITIONS_V2 = PARTITIONS.withFields(
-            PARTITION_ID,
-            CURRENT_LEADER_EPOCH,
-            LEADER_EPOCH);
-    private static final Field TOPICS_V2 = TOPICS.withFields(
-            TOPIC_NAME,
-            PARTITIONS_V2);
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_REQUEST_V2 = new Schema(
-            TOPICS_V2);
-
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_REQUEST_V3 = new Schema(
-            REPLICA_ID,
-            TOPICS_V2);
-
-    public static Schema[] schemaVersions() {
-        return new Schema[]{OFFSET_FOR_LEADER_EPOCH_REQUEST_V0, OFFSET_FOR_LEADER_EPOCH_REQUEST_V1,
-            OFFSET_FOR_LEADER_EPOCH_REQUEST_V2, OFFSET_FOR_LEADER_EPOCH_REQUEST_V3};
-    }
-
-    private final Map<TopicPartition, PartitionData> epochsByPartition;
-
-    private final int replicaId;
-
-    public Map<TopicPartition, PartitionData> epochsByTopicPartition() {
-        return epochsByPartition;
-    }
-
-    public int replicaId() {
-        return replicaId;
-    }
+    private final OffsetForLeaderEpochRequestData data;
 
     public static class Builder extends AbstractRequest.Builder<OffsetsForLeaderEpochRequest> {
         private final Map<TopicPartition, PartitionData> epochsByPartition;
@@ -130,11 +76,27 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
         public OffsetsForLeaderEpochRequest build(short version) {
             if (version < oldestAllowedVersion() || version > latestAllowedVersion())
                 throw new UnsupportedVersionException("Cannot build " + this + " with version " + version);
-            return new OffsetsForLeaderEpochRequest(epochsByPartition, replicaId, version);
-        }
 
-        public static OffsetsForLeaderEpochRequest parse(ByteBuffer buffer, short version) {
-            return new OffsetsForLeaderEpochRequest(ApiKeys.OFFSET_FOR_LEADER_EPOCH.parseRequest(version, buffer), version);
+            OffsetForLeaderEpochRequestData data = new OffsetForLeaderEpochRequestData();
+            data.setReplicaId(replicaId);
+
+            OffsetForLeaderTopicCollection topics = new OffsetForLeaderTopicCollection();
+            epochsByPartition.forEach((partitionKey, partitionValue) -> {
+                OffsetForLeaderTopic topic = topics.find(partitionKey.topic());
+                if (topic == null) {
+                    topic = new OffsetForLeaderTopic().setName(partitionKey.topic());
+                    topics.add(topic);
+                }
+                topic.partitions().add(new OffsetForLeaderPartition()
+                    .setPartitionIndex(partitionKey.partition())
+                    .setLeaderEpoch(partitionValue.leaderEpoch)
+                    .setCurrentLeaderEpoch(partitionValue.currentLeaderEpoch
+                        .orElse(RecordBatch.NO_PARTITION_LEADER_EPOCH))
+                );
+            });
+            data.setTopics(topics);
+
+            return new OffsetsForLeaderEpochRequest(data, version);
         }
 
         @Override
@@ -147,73 +109,61 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
         }
     }
 
-    public OffsetsForLeaderEpochRequest(Map<TopicPartition, PartitionData> epochsByPartition, int replicaId, short version) {
+    public OffsetsForLeaderEpochRequest(OffsetForLeaderEpochRequestData data, short version) {
         super(ApiKeys.OFFSET_FOR_LEADER_EPOCH, version);
-        this.epochsByPartition = epochsByPartition;
-        this.replicaId = replicaId;
+        this.data = data;
     }
 
     public OffsetsForLeaderEpochRequest(Struct struct, short version) {
         super(ApiKeys.OFFSET_FOR_LEADER_EPOCH, version);
-        replicaId = struct.getOrElse(REPLICA_ID, DEBUGGING_REPLICA_ID);
-        epochsByPartition = new HashMap<>();
-        for (Object topicAndEpochsObj : struct.get(TOPICS)) {
-            Struct topicAndEpochs = (Struct) topicAndEpochsObj;
-            String topic = topicAndEpochs.get(TOPIC_NAME);
-            for (Object partitionAndEpochObj : topicAndEpochs.get(PARTITIONS)) {
-                Struct partitionAndEpoch = (Struct) partitionAndEpochObj;
-                int partitionId = partitionAndEpoch.get(PARTITION_ID);
-                int leaderEpoch = partitionAndEpoch.get(LEADER_EPOCH);
-                Optional<Integer> currentEpoch = RequestUtils.getLeaderEpoch(partitionAndEpoch, CURRENT_LEADER_EPOCH);
-                TopicPartition tp = new TopicPartition(topic, partitionId);
-                epochsByPartition.put(tp, new PartitionData(currentEpoch, leaderEpoch));
-            }
-        }
+        this.data = new OffsetForLeaderEpochRequestData(struct, version);
     }
 
-    public static OffsetsForLeaderEpochRequest parse(ByteBuffer buffer, short versionId) {
-        return new OffsetsForLeaderEpochRequest(ApiKeys.OFFSET_FOR_LEADER_EPOCH.parseRequest(versionId, buffer), versionId);
+    public Map<TopicPartition, PartitionData> epochsByTopicPartition() {
+        Map<TopicPartition, PartitionData> epochsByTopicPartition = new HashMap<>();
+
+        data.topics().forEach(topic ->
+            topic.partitions().forEach(partition ->
+                epochsByTopicPartition.put(
+                    new TopicPartition(topic.name(), partition.partitionIndex()),
+                    new PartitionData(
+                        RequestUtils.getLeaderEpoch(partition.currentLeaderEpoch()),
+                        partition.leaderEpoch()))));
+
+        return epochsByTopicPartition;
+    }
+
+    public int replicaId() {
+        return data.replicaId();
+    }
+
+    public static OffsetsForLeaderEpochRequest parse(ByteBuffer buffer, short version) {
+        return new OffsetsForLeaderEpochRequest(ApiKeys.OFFSET_FOR_LEADER_EPOCH.parseRequest(version, buffer), version);
     }
 
     @Override
     protected Struct toStruct() {
-        Struct requestStruct = new Struct(ApiKeys.OFFSET_FOR_LEADER_EPOCH.requestSchema(version()));
-        requestStruct.setIfExists(REPLICA_ID, replicaId);
-
-        Map<String, Map<Integer, PartitionData>> topicsToPartitionEpochs = CollectionUtils.groupPartitionDataByTopic(epochsByPartition);
-
-        List<Struct> topics = new ArrayList<>();
-        for (Map.Entry<String, Map<Integer, PartitionData>> topicToEpochs : topicsToPartitionEpochs.entrySet()) {
-            Struct topicsStruct = requestStruct.instance(TOPICS);
-            topicsStruct.set(TOPIC_NAME, topicToEpochs.getKey());
-            List<Struct> partitions = new ArrayList<>();
-            for (Map.Entry<Integer, PartitionData> partitionEpoch : topicToEpochs.getValue().entrySet()) {
-                Struct partitionStruct = topicsStruct.instance(PARTITIONS);
-                partitionStruct.set(PARTITION_ID, partitionEpoch.getKey());
-
-                PartitionData partitionData = partitionEpoch.getValue();
-                partitionStruct.set(LEADER_EPOCH, partitionData.leaderEpoch);
-
-                // Current leader epoch introduced in v2
-                RequestUtils.setLeaderEpochIfExists(partitionStruct, CURRENT_LEADER_EPOCH, partitionData.currentLeaderEpoch);
-                partitions.add(partitionStruct);
-            }
-            topicsStruct.set(PARTITIONS, partitions.toArray());
-            topics.add(topicsStruct);
-        }
-        requestStruct.set(TOPICS, topics.toArray());
-        return requestStruct;
+        return data.toStruct(version());
     }
 
     @Override
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         Errors error = Errors.forException(e);
-        Map<TopicPartition, EpochEndOffset> errorResponse = new HashMap<>();
-        for (TopicPartition tp : epochsByPartition.keySet()) {
-            errorResponse.put(tp, new EpochEndOffset(
-                error, EpochEndOffset.UNDEFINED_EPOCH, EpochEndOffset.UNDEFINED_EPOCH_OFFSET));
-        }
-        return new OffsetsForLeaderEpochResponse(throttleTimeMs, errorResponse);
+
+        OffsetForLeaderEpochResponseData responseData = new OffsetForLeaderEpochResponseData();
+        data.topics().forEach(topic -> {
+            OffsetForLeaderTopicResult topicData = new OffsetForLeaderTopicResult()
+                .setName(topic.name());
+            topic.partitions().forEach(partition ->
+                topicData.partitions().add(new OffsetForLeaderPartitionResult()
+                    .setPartitionIndex(partition.partitionIndex())
+                    .setErrorCode(error.code())
+                    .setLeaderEpoch(EpochEndOffset.UNDEFINED_EPOCH)
+                    .setEndOffset(EpochEndOffset.UNDEFINED_EPOCH_OFFSET)));
+            responseData.topics().add(topicData);
+        });
+
+        return new OffsetsForLeaderEpochResponse(responseData);
     }
 
     public static class PartitionData {
@@ -242,5 +192,4 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
     public static boolean supportsTopicPermission(short latestUsableVersion) {
         return latestUsableVersion >= 3;
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -63,11 +63,11 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
         offsets.forEach((tp, offset) -> {
             OffsetForLeaderTopicResult topic = data.topics().find(tp.topic());
             if (topic == null) {
-                topic = new OffsetForLeaderTopicResult().setName(tp.topic());
+                topic = new OffsetForLeaderTopicResult().setTopic(tp.topic());
                 data.topics().add(topic);
             }
             topic.partitions().add(new OffsetForLeaderPartitionResult()
-                .setPartitionIndex(tp.partition())
+                .setPartition(tp.partition())
                 .setErrorCode(offset.error().code())
                 .setLeaderEpoch(offset.leaderEpoch())
                 .setEndOffset(offset.endOffset()));
@@ -84,7 +84,7 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
         data.topics().forEach(topic ->
             topic.partitions().forEach(partition ->
                 epochEndOffsetsByPartition.put(
-                    new TopicPartition(topic.name(), partition.partitionIndex()),
+                    new TopicPartition(topic.topic(), partition.partition()),
                     new EpochEndOffset(
                         Errors.forCode(partition.errorCode()),
                         partition.leaderEpoch(),

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -96,9 +96,9 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        responses().values().forEach(response ->
-            updateErrorCounts(errorCounts, response.error())
-        );
+        data.topics().forEach(topic ->
+            topic.partitions().forEach(partition ->
+                updateErrorCounts(errorCounts, Errors.forCode(partition.errorCode()))));
         return errorCounts;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -74,6 +74,10 @@ public class OffsetsForLeaderEpochResponse extends AbstractResponse {
         });
     }
 
+    public OffsetForLeaderEpochResponseData data() {
+        return data;
+    }
+
     public Map<TopicPartition, EpochEndOffset> responses() {
         Map<TopicPartition, EpochEndOffset> epochEndOffsetsByPartition = new HashMap<>();
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochResponse.java
@@ -17,29 +17,19 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderPartitionResult;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.utils.CollectionUtils;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
-import static org.apache.kafka.common.protocol.CommonFields.LEADER_EPOCH;
-import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
-import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
-import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
 
 /**
  * Possible error codes:
- *
  * - {@link Errors#TOPIC_AUTHORIZATION_FAILED} If the user does not have DESCRIBE access to a requested topic
  * - {@link Errors#REPLICA_NOT_AVAILABLE} If the request is received by a broker with version < 2.6 which is not a replica
  * - {@link Errors#NOT_LEADER_OR_FOLLOWER} If the broker is not a leader or follower and either the provided leader epoch
@@ -51,133 +41,78 @@ import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
  * - {@link Errors#UNKNOWN_SERVER_ERROR} For any unexpected errors
  */
 public class OffsetsForLeaderEpochResponse extends AbstractResponse {
-    private static final Field.ComplexArray TOPICS = new Field.ComplexArray("topics",
-            "An array of topics for which we have leader offsets for some requested partition leader epoch");
-    private static final Field.ComplexArray PARTITIONS = new Field.ComplexArray("partitions",
-            "An array of offsets by partition");
-    private static final Field.Int64 END_OFFSET = new Field.Int64("end_offset", "The end offset");
 
-    private static final Field PARTITIONS_V0 = PARTITIONS.withFields(
-            ERROR_CODE,
-            PARTITION_ID,
-            END_OFFSET);
-    private static final Field TOPICS_V0 = TOPICS.withFields(
-            TOPIC_NAME,
-            PARTITIONS_V0);
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_RESPONSE_V0 = new Schema(
-            TOPICS_V0);
+    private final OffsetForLeaderEpochResponseData data;
 
-    // V1 added a per-partition leader epoch field which specifies which leader epoch the end offset belongs to
-    private static final Field PARTITIONS_V1 = PARTITIONS.withFields(
-            ERROR_CODE,
-            PARTITION_ID,
-            LEADER_EPOCH,
-            END_OFFSET);
-    private static final Field TOPICS_V1 = TOPICS.withFields(
-            TOPIC_NAME,
-            PARTITIONS_V1);
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_RESPONSE_V1 = new Schema(
-            TOPICS_V1);
-
-    // V2 bumped for addition of current leader epoch to the request schema and the addition of the throttle
-    // time in the response
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_RESPONSE_V2 = new Schema(
-            THROTTLE_TIME_MS,
-            TOPICS_V1);
-
-    private static final Schema OFFSET_FOR_LEADER_EPOCH_RESPONSE_V3 = OFFSET_FOR_LEADER_EPOCH_RESPONSE_V2;
-
-
-    public static Schema[] schemaVersions() {
-        return new Schema[]{OFFSET_FOR_LEADER_EPOCH_RESPONSE_V0, OFFSET_FOR_LEADER_EPOCH_RESPONSE_V1,
-            OFFSET_FOR_LEADER_EPOCH_RESPONSE_V2, OFFSET_FOR_LEADER_EPOCH_RESPONSE_V3};
+    public OffsetsForLeaderEpochResponse(OffsetForLeaderEpochResponseData data) {
+        this.data = data;
     }
 
-    private final int throttleTimeMs;
-    private final Map<TopicPartition, EpochEndOffset> epochEndOffsetsByPartition;
+    public OffsetsForLeaderEpochResponse(Struct struct, short version) {
+        data = new OffsetForLeaderEpochResponseData(struct, version);
+    }
 
-    public OffsetsForLeaderEpochResponse(Struct struct) {
-        this.throttleTimeMs = struct.getOrElse(THROTTLE_TIME_MS, DEFAULT_THROTTLE_TIME);
-        this.epochEndOffsetsByPartition = new HashMap<>();
-        for (Object topicAndEpocsObj : struct.get(TOPICS)) {
-            Struct topicAndEpochs = (Struct) topicAndEpocsObj;
-            String topic = topicAndEpochs.get(TOPIC_NAME);
-            for (Object partitionAndEpochObj : topicAndEpochs.get(PARTITIONS)) {
-                Struct partitionAndEpoch = (Struct) partitionAndEpochObj;
-                Errors error = Errors.forCode(partitionAndEpoch.get(ERROR_CODE));
-                int partitionId = partitionAndEpoch.get(PARTITION_ID);
-                TopicPartition tp = new TopicPartition(topic, partitionId);
-                int leaderEpoch = partitionAndEpoch.getOrElse(LEADER_EPOCH, RecordBatch.NO_PARTITION_LEADER_EPOCH);
-                long endOffset = partitionAndEpoch.get(END_OFFSET);
-                epochEndOffsetsByPartition.put(tp, new EpochEndOffset(error, leaderEpoch, endOffset));
+    public OffsetsForLeaderEpochResponse(Map<TopicPartition, EpochEndOffset> offsets) {
+        this(0, offsets);
+    }
+
+    public OffsetsForLeaderEpochResponse(int throttleTimeMs, Map<TopicPartition, EpochEndOffset> offsets) {
+        data = new OffsetForLeaderEpochResponseData();
+        data.setThrottleTimeMs(throttleTimeMs);
+
+        offsets.forEach((tp, offset) -> {
+            OffsetForLeaderTopicResult topic = data.topics().find(tp.topic());
+            if (topic == null) {
+                topic = new OffsetForLeaderTopicResult().setName(tp.topic());
+                data.topics().add(topic);
             }
-        }
-    }
-
-    public OffsetsForLeaderEpochResponse(Map<TopicPartition, EpochEndOffset> epochsByTopic) {
-        this(DEFAULT_THROTTLE_TIME, epochsByTopic);
-    }
-
-    public OffsetsForLeaderEpochResponse(int throttleTimeMs, Map<TopicPartition, EpochEndOffset> epochsByTopic) {
-        this.throttleTimeMs = throttleTimeMs;
-        this.epochEndOffsetsByPartition = epochsByTopic;
+            topic.partitions().add(new OffsetForLeaderPartitionResult()
+                .setPartitionIndex(tp.partition())
+                .setErrorCode(offset.error().code())
+                .setLeaderEpoch(offset.leaderEpoch())
+                .setEndOffset(offset.endOffset()));
+        });
     }
 
     public Map<TopicPartition, EpochEndOffset> responses() {
+        Map<TopicPartition, EpochEndOffset> epochEndOffsetsByPartition = new HashMap<>();
+
+        data.topics().forEach(topic ->
+            topic.partitions().forEach(partition ->
+                epochEndOffsetsByPartition.put(
+                    new TopicPartition(topic.name(), partition.partitionIndex()),
+                    new EpochEndOffset(
+                        Errors.forCode(partition.errorCode()),
+                        partition.leaderEpoch(),
+                        partition.endOffset()))));
+
         return epochEndOffsetsByPartition;
     }
 
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> errorCounts = new HashMap<>();
-        epochEndOffsetsByPartition.values().forEach(response ->
+        responses().values().forEach(response ->
             updateErrorCounts(errorCounts, response.error())
         );
         return errorCounts;
     }
 
     public int throttleTimeMs() {
-        return throttleTimeMs;
+        return data.throttleTimeMs();
     }
 
-    public static OffsetsForLeaderEpochResponse parse(ByteBuffer buffer, short versionId) {
-        return new OffsetsForLeaderEpochResponse(ApiKeys.OFFSET_FOR_LEADER_EPOCH.responseSchema(versionId).read(buffer));
+    public static OffsetsForLeaderEpochResponse parse(ByteBuffer buffer, short version) {
+        return new OffsetsForLeaderEpochResponse(ApiKeys.OFFSET_FOR_LEADER_EPOCH.responseSchema(version).read(buffer), version);
     }
 
     @Override
     protected Struct toStruct(short version) {
-        Struct responseStruct = new Struct(ApiKeys.OFFSET_FOR_LEADER_EPOCH.responseSchema(version));
-        responseStruct.setIfExists(THROTTLE_TIME_MS, throttleTimeMs);
-
-        Map<String, Map<Integer, EpochEndOffset>> endOffsetsByTopic = CollectionUtils.groupPartitionDataByTopic(epochEndOffsetsByPartition);
-        List<Struct> topics = new ArrayList<>(endOffsetsByTopic.size());
-        for (Map.Entry<String, Map<Integer, EpochEndOffset>> topicToPartitionEpochs : endOffsetsByTopic.entrySet()) {
-            Struct topicStruct = responseStruct.instance(TOPICS);
-            topicStruct.set(TOPIC_NAME, topicToPartitionEpochs.getKey());
-            Map<Integer, EpochEndOffset> partitionEpochs = topicToPartitionEpochs.getValue();
-            List<Struct> partitions = new ArrayList<>();
-            for (Map.Entry<Integer, EpochEndOffset> partitionEndOffset : partitionEpochs.entrySet()) {
-                Struct partitionStruct = topicStruct.instance(PARTITIONS);
-                partitionStruct.set(ERROR_CODE, partitionEndOffset.getValue().error().code());
-                partitionStruct.set(PARTITION_ID, partitionEndOffset.getKey());
-                partitionStruct.setIfExists(LEADER_EPOCH, partitionEndOffset.getValue().leaderEpoch());
-                partitionStruct.set(END_OFFSET, partitionEndOffset.getValue().endOffset());
-                partitions.add(partitionStruct);
-            }
-            topicStruct.set(PARTITIONS, partitions.toArray());
-            topics.add(topicStruct);
-        }
-        responseStruct.set(TOPICS, topics.toArray());
-        return responseStruct;
+        return data.toStruct(version);
     }
 
     @Override
     public String toString() {
-        StringBuilder bld = new StringBuilder();
-        bld.append("(type=OffsetsForLeaderEpochResponse, ")
-            .append(", throttleTimeMs=").append(throttleTimeMs)
-            .append(", epochEndOffsetsByPartition=").append(epochEndOffsetsByPartition)
-            .append(")");
-        return bld.toString();
+        return data.toString();
     }
 }

--- a/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+++ b/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
@@ -32,13 +32,13 @@
     { "name": "Topics", "type": "[]OffsetForLeaderTopic", "versions": "0+",
       "about": "Each topic to get offsets for.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
-        "about": "The topic name." },
+        "mapKey": true, "about": "The topic name." },
       { "name": "Partitions", "type": "[]OffsetForLeaderPartition", "versions": "0+",
         "about": "Each partition to get offsets for.", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "2+", "default": "-1", "ignorable": true,
-          "about": "An epoch used to fence consumers/replicas with old metadata.  If the epoch provided by the client is larger than the current epoch known to the broker, then the UNKNOWN_LEADER_EPOCH error code will be returned. If the provided epoch is smaller, then the FENCED_LEADER_EPOCH error code will be returned." },
+          "about": "An epoch used to fence consumers/replicas with old metadata. If the epoch provided by the client is larger than the current epoch known to the broker, then the UNKNOWN_LEADER_EPOCH error code will be returned. If the provided epoch is smaller, then the FENCED_LEADER_EPOCH error code will be returned." },
         { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
           "about": "The epoch to look up an offset for." }
       ]}

--- a/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+++ b/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
@@ -31,11 +31,11 @@
       "about": "The broker ID of the follower, of -1 if this request is from a consumer." },
     { "name": "Topics", "type": "[]OffsetForLeaderTopic", "versions": "0+",
       "about": "Each topic to get offsets for.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
         "mapKey": true, "about": "The topic name." },
       { "name": "Partitions", "type": "[]OffsetForLeaderPartition", "versions": "0+",
         "about": "Each partition to get offsets for.", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "Partition", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "CurrentLeaderEpoch", "type": "int32", "versions": "2+", "default": "-1", "ignorable": true,
           "about": "An epoch used to fence consumers/replicas with old metadata. If the epoch provided by the client is larger than the current epoch known to the broker, then the UNKNOWN_LEADER_EPOCH error code will be returned. If the provided epoch is smaller, then the FENCED_LEADER_EPOCH error code will be returned." },

--- a/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+++ b/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
@@ -29,13 +29,13 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "Topics", "type": "[]OffsetForLeaderTopicResult", "versions": "0+",
       "about": "Each topic we fetched offsets for.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Topic", "type": "string", "versions": "0+", "entityType": "topicName",
         "mapKey": true, "about": "The topic name." },
       { "name": "Partitions", "type": "[]OffsetForLeaderPartitionResult", "versions": "0+",
         "about": "Each partition in the topic we fetched offsets for.", "fields": [
         { "name": "ErrorCode", "type": "int16", "versions": "0+",
           "about": "The error code 0, or if there was no error." },
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "Partition", "type": "int32", "versions": "0+",
           "about": "The partition index." },
         { "name": "LeaderEpoch", "type": "int32", "versions": "1+", "default": "-1", "ignorable": true,
           "about": "The leader epoch of the partition." },

--- a/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+++ b/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
@@ -18,7 +18,10 @@
   "type": "response",
   "name": "OffsetForLeaderEpochResponse",
   // Version 1 added the leader epoch to the response.
+  //
   // Version 2 added the throttle time.
+  //
+  // Version 3 is the same as version 2.
   "validVersions": "0-3",
   "flexibleVersions": "none",
   "fields": [
@@ -27,7 +30,7 @@
     { "name": "Topics", "type": "[]OffsetForLeaderTopicResult", "versions": "0+",
       "about": "Each topic we fetched offsets for.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
-        "about": "The topic name." },
+        "mapKey": true, "about": "The topic name." },
       { "name": "Partitions", "type": "[]OffsetForLeaderPartitionResult", "versions": "0+",
         "about": "Each partition in the topic we fetched offsets for.", "fields": [
         { "name": "ErrorCode", "type": "int16", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -105,7 +105,7 @@ public class OffsetForLeaderEpochClientTest {
         OffsetsForLeaderEpochClient.OffsetForEpochResult result = future.value();
         assertTrue(result.partitionsToRetry().isEmpty());
         assertTrue(result.endOffsets().containsKey(tp0));
-        assertEquals(result.endOffsets().get(tp0).error(), Errors.NONE);
+        assertEquals(result.endOffsets().get(tp0).errorCode(), Errors.NONE.code());
         assertEquals(result.endOffsets().get(tp0).leaderEpoch(), 1);
         assertEquals(result.endOffsets().get(tp0).endOffset(), 10L);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -169,10 +169,10 @@ public class OffsetForLeaderEpochClientTest {
             TopicPartition tp, Errors error, int leaderEpoch, long endOffset) {
         OffsetForLeaderEpochResponseData data = new OffsetForLeaderEpochResponseData();
         OffsetForLeaderTopicResult topic = new OffsetForLeaderTopicResult()
-            .setName(tp.topic());
+            .setTopic(tp.topic());
         data.topics().add(topic);
         topic.partitions().add(new OffsetForLeaderPartitionResult()
-            .setPartitionIndex(tp.partition())
+            .setPartition(tp.partition())
             .setErrorCode(error.code())
             .setLeaderEpoch(leaderEpoch)
             .setEndOffset(endOffset));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -23,8 +23,10 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderPartitionResult;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderTopicResult;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.EpochEndOffset;
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -56,7 +58,8 @@ public class OffsetForLeaderEpochClientTest {
         RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), Collections.emptyMap());
 
-        OffsetsForLeaderEpochResponse resp = new OffsetsForLeaderEpochResponse(Collections.emptyMap());
+        OffsetsForLeaderEpochResponse resp = new OffsetsForLeaderEpochResponse(
+            new OffsetForLeaderEpochResponseData());
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
@@ -75,7 +78,8 @@ public class OffsetForLeaderEpochClientTest {
         RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
-        OffsetsForLeaderEpochResponse resp = new OffsetsForLeaderEpochResponse(Collections.emptyMap());
+        OffsetsForLeaderEpochResponse resp = new OffsetsForLeaderEpochResponse(
+            new OffsetForLeaderEpochResponseData());
         client.prepareResponse(resp);
         consumerClient.pollNoWakeup();
 
@@ -94,9 +98,8 @@ public class OffsetForLeaderEpochClientTest {
         RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
-        Map<TopicPartition, EpochEndOffset> endOffsetMap = new HashMap<>();
-        endOffsetMap.put(tp0, new EpochEndOffset(Errors.NONE, 1, 10L));
-        client.prepareResponse(new OffsetsForLeaderEpochResponse(endOffsetMap));
+        client.prepareResponse(prepareOffsetForLeaderEpochResponse(
+            tp0, Errors.NONE, 1, 10L));
         consumerClient.pollNoWakeup();
 
         OffsetsForLeaderEpochClient.OffsetForEpochResult result = future.value();
@@ -117,9 +120,8 @@ public class OffsetForLeaderEpochClientTest {
         RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
-        Map<TopicPartition, EpochEndOffset> endOffsetMap = new HashMap<>();
-        endOffsetMap.put(tp0, new EpochEndOffset(Errors.TOPIC_AUTHORIZATION_FAILED, -1, -1));
-        client.prepareResponse(new OffsetsForLeaderEpochResponse(endOffsetMap));
+        client.prepareResponse(prepareOffsetForLeaderEpochResponse(
+            tp0, Errors.TOPIC_AUTHORIZATION_FAILED, -1, -1));
         consumerClient.pollNoWakeup();
 
         assertTrue(future.failed());
@@ -137,9 +139,8 @@ public class OffsetForLeaderEpochClientTest {
         RequestFuture<OffsetsForLeaderEpochClient.OffsetForEpochResult> future =
                 offsetClient.sendAsyncRequest(Node.noNode(), positionMap);
 
-        Map<TopicPartition, EpochEndOffset> endOffsetMap = new HashMap<>();
-        endOffsetMap.put(tp0, new EpochEndOffset(Errors.LEADER_NOT_AVAILABLE, -1, -1));
-        client.prepareResponse(new OffsetsForLeaderEpochResponse(endOffsetMap));
+        client.prepareResponse(prepareOffsetForLeaderEpochResponse(
+            tp0, Errors.LEADER_NOT_AVAILABLE, -1, -1));
         consumerClient.pollNoWakeup();
 
         assertFalse(future.failed());
@@ -162,5 +163,19 @@ public class OffsetForLeaderEpochClientTest {
         client = new MockClient(time, metadata);
         consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time,
                 100, 1000, Integer.MAX_VALUE);
+    }
+
+    private static OffsetsForLeaderEpochResponse prepareOffsetForLeaderEpochResponse(
+            TopicPartition tp, Errors error, int leaderEpoch, long endOffset) {
+        OffsetForLeaderEpochResponseData data = new OffsetForLeaderEpochResponseData();
+        OffsetForLeaderTopicResult topic = new OffsetForLeaderTopicResult()
+            .setName(tp.topic());
+        data.topics().add(topic);
+        topic.partitions().add(new OffsetForLeaderPartitionResult()
+            .setPartitionIndex(tp.partition())
+            .setErrorCode(error.code())
+            .setLeaderEpoch(leaderEpoch)
+            .setEndOffset(endOffset));
+        return new OffsetsForLeaderEpochResponse(data);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.consumer.internals.SubscriptionState.LogTruncation;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.OffsetForLeaderPartitionResult;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.EpochEndOffset;
 import org.apache.kafka.common.utils.LogContext;
@@ -519,7 +520,9 @@ public class SubscriptionStateTest {
         assertTrue(state.awaitingValidation(tp0));
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-                new EpochEndOffset(initialOffsetEpoch, initialOffset + 5));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(initialOffsetEpoch)
+                    .setEndOffset(initialOffset + 5));
         assertEquals(Optional.empty(), truncationOpt);
         assertFalse(state.awaitingValidation(tp0));
         assertEquals(initialPosition, state.position(tp0));
@@ -574,7 +577,9 @@ public class SubscriptionStateTest {
         state.seekUnvalidated(tp0, updatePosition);
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-                new EpochEndOffset(initialOffsetEpoch, initialOffset + 5));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(initialOffsetEpoch)
+                    .setEndOffset(initialOffset + 5));
         assertEquals(Optional.empty(), truncationOpt);
         assertTrue(state.awaitingValidation(tp0));
         assertEquals(updatePosition, state.position(tp0));
@@ -597,7 +602,9 @@ public class SubscriptionStateTest {
         state.requestOffsetReset(tp0);
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-            new EpochEndOffset(initialOffsetEpoch, initialOffset + 5));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(initialOffsetEpoch)
+                    .setEndOffset(initialOffset + 5));
         assertEquals(Optional.empty(), truncationOpt);
         assertFalse(state.awaitingValidation(tp0));
         assertTrue(state.isOffsetResetNeeded(tp0));
@@ -621,7 +628,9 @@ public class SubscriptionStateTest {
         assertTrue(state.awaitingValidation(tp0));
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-                new EpochEndOffset(divergentOffsetEpoch, divergentOffset));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(divergentOffsetEpoch)
+                    .setEndOffset(divergentOffset));
         assertEquals(Optional.empty(), truncationOpt);
         assertFalse(state.awaitingValidation(tp0));
 
@@ -648,7 +657,9 @@ public class SubscriptionStateTest {
         assertTrue(state.awaitingValidation(tp0));
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-                new EpochEndOffset(divergentOffsetEpoch, divergentOffset));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(divergentOffsetEpoch)
+                    .setEndOffset(divergentOffset));
         assertTrue(truncationOpt.isPresent());
         LogTruncation truncation = truncationOpt.get();
 
@@ -674,7 +685,9 @@ public class SubscriptionStateTest {
         assertTrue(state.awaitingValidation(tp0));
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-            new EpochEndOffset(EpochEndOffset.UNDEFINED_EPOCH, EpochEndOffset.UNDEFINED_EPOCH_OFFSET));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(EpochEndOffset.UNDEFINED_EPOCH)
+                    .setEndOffset(EpochEndOffset.UNDEFINED_EPOCH_OFFSET));
         assertEquals(Optional.empty(), truncationOpt);
         assertFalse(state.awaitingValidation(tp0));
         assertTrue(state.isOffsetResetNeeded(tp0));
@@ -697,7 +710,9 @@ public class SubscriptionStateTest {
         assertTrue(state.awaitingValidation(tp0));
 
         Optional<LogTruncation> truncationOpt = state.maybeCompleteValidation(tp0, initialPosition,
-            new EpochEndOffset(EpochEndOffset.UNDEFINED_EPOCH, EpochEndOffset.UNDEFINED_EPOCH_OFFSET));
+                new OffsetForLeaderPartitionResult()
+                    .setLeaderEpoch(EpochEndOffset.UNDEFINED_EPOCH)
+                    .setEndOffset(EpochEndOffset.UNDEFINED_EPOCH_OFFSET));
         assertTrue(truncationOpt.isPresent());
         LogTruncation truncation = truncationOpt.get();
 

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -358,12 +358,12 @@ public final class MessageTest {
                         .setPartitionIndex(0)
                         .setLeaderEpoch(3)
                         .setCurrentLeaderEpoch(5);
+        OffsetForLeaderEpochRequestData data = new OffsetForLeaderEpochRequestData();
+        data.topics().add(new OffsetForLeaderEpochRequestData.OffsetForLeaderTopic()
+                .setName("foo")
+                .setPartitions(singletonList(partitionDataNoCurrentEpoch)));
 
-        testAllMessageRoundTrips(new OffsetForLeaderEpochRequestData().setTopics(singletonList(
-                new OffsetForLeaderEpochRequestData.OffsetForLeaderTopic()
-                        .setName("foo")
-                        .setPartitions(singletonList(partitionDataNoCurrentEpoch)))
-        ));
+        testAllMessageRoundTrips(data);
         testAllMessageRoundTripsBeforeVersion((short) 2, partitionDataWithCurrentEpoch, partitionDataNoCurrentEpoch);
         testAllMessageRoundTripsFromVersion((short) 2, partitionDataWithCurrentEpoch);
 

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -351,16 +351,16 @@ public final class MessageTest {
         // Version 2 adds optional current leader epoch
         OffsetForLeaderEpochRequestData.OffsetForLeaderPartition partitionDataNoCurrentEpoch =
                 new OffsetForLeaderEpochRequestData.OffsetForLeaderPartition()
-                        .setPartitionIndex(0)
+                        .setPartition(0)
                         .setLeaderEpoch(3);
         OffsetForLeaderEpochRequestData.OffsetForLeaderPartition partitionDataWithCurrentEpoch =
                 new OffsetForLeaderEpochRequestData.OffsetForLeaderPartition()
-                        .setPartitionIndex(0)
+                        .setPartition(0)
                         .setLeaderEpoch(3)
                         .setCurrentLeaderEpoch(5);
         OffsetForLeaderEpochRequestData data = new OffsetForLeaderEpochRequestData();
         data.topics().add(new OffsetForLeaderEpochRequestData.OffsetForLeaderTopic()
-                .setName("foo")
+                .setTopic("foo")
                 .setPartitions(singletonList(partitionDataNoCurrentEpoch)));
 
         testAllMessageRoundTrips(data);

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequestTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.Test;
 
@@ -29,7 +30,7 @@ public class OffsetsForLeaderEpochRequestTest {
 
     @Test
     public void testForConsumerRequiresVersion3() {
-        OffsetsForLeaderEpochRequest.Builder builder = OffsetsForLeaderEpochRequest.Builder.forConsumer(Collections.emptyMap());
+        OffsetsForLeaderEpochRequest.Builder builder = OffsetsForLeaderEpochRequest.Builder.forConsumer(new OffsetForLeaderTopicCollection());
         for (short version = 0; version < 3; version++) {
             final short v = version;
             assertThrows(UnsupportedVersionException.class, () -> builder.build(v));

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1799,21 +1799,21 @@ public class RequestResponseTest {
     private OffsetForLeaderTopicCollection createOffsetForLeaderTopicCollection() {
         OffsetForLeaderTopicCollection topics = new OffsetForLeaderTopicCollection();
         topics.add(new OffsetForLeaderTopic()
-            .setName("topic1")
+            .setTopic("topic1")
             .setPartitions(Arrays.asList(
                 new OffsetForLeaderPartition()
-                    .setPartitionIndex(0)
+                    .setPartition(0)
                     .setLeaderEpoch(1)
                     .setCurrentLeaderEpoch(0),
                 new OffsetForLeaderPartition()
-                    .setPartitionIndex(1)
+                    .setPartition(1)
                     .setLeaderEpoch(1)
                     .setCurrentLeaderEpoch(0))));
         topics.add(new OffsetForLeaderTopic()
-            .setName("topic2")
+            .setTopic("topic2")
             .setPartitions(Arrays.asList(
                 new OffsetForLeaderPartition()
-                    .setPartitionIndex(2)
+                    .setPartition(2)
                     .setLeaderEpoch(3)
                     .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH))));
         return topics;

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -131,6 +131,9 @@ import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResp
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponsePartitionCollection;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponseTopic;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponseTopicCollection;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic;
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenRequestData;
 import org.apache.kafka.common.message.RenewDelegationTokenResponseData;
@@ -1793,8 +1796,31 @@ public class RequestResponseTest {
         return epochs;
     }
 
+    private OffsetForLeaderTopicCollection createOffsetForLeaderTopicCollection() {
+        OffsetForLeaderTopicCollection topics = new OffsetForLeaderTopicCollection();
+        topics.add(new OffsetForLeaderTopic()
+            .setName("topic1")
+            .setPartitions(Arrays.asList(
+                new OffsetForLeaderPartition()
+                    .setPartitionIndex(0)
+                    .setLeaderEpoch(1)
+                    .setCurrentLeaderEpoch(0),
+                new OffsetForLeaderPartition()
+                    .setPartitionIndex(1)
+                    .setLeaderEpoch(1)
+                    .setCurrentLeaderEpoch(0))));
+        topics.add(new OffsetForLeaderTopic()
+            .setName("topic2")
+            .setPartitions(Arrays.asList(
+                new OffsetForLeaderPartition()
+                    .setPartitionIndex(2)
+                    .setLeaderEpoch(3)
+                    .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH))));
+        return topics;
+    }
+
     private OffsetsForLeaderEpochRequest createLeaderEpochRequestForConsumer() {
-        Map<TopicPartition, OffsetsForLeaderEpochRequest.PartitionData> epochs = createOffsetForLeaderEpochPartitionData();
+        OffsetForLeaderTopicCollection epochs = createOffsetForLeaderTopicCollection();
         return OffsetsForLeaderEpochRequest.Builder.forConsumer(epochs).build();
     }
 

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -334,9 +334,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   private def offsetsForLeaderEpochRequest: OffsetsForLeaderEpochRequest = {
     val epochs = new OffsetForLeaderTopicCollection()
     epochs.add(new OffsetForLeaderTopic()
-      .setName(tp.topic())
+      .setTopic(tp.topic())
       .setPartitions(List(new OffsetForLeaderPartition()
-          .setPartitionIndex(tp.partition())
+          .setPartition(tp.partition())
           .setLeaderEpoch(7)
           .setCurrentLeaderEpoch(27)).asJava))
     OffsetsForLeaderEpochRequest.Builder.forConsumer(epochs).build()

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -14,6 +14,7 @@ package kafka.api
 
 import java.time.Duration
 import java.util
+import java.util
 import java.util.concurrent.ExecutionException
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}
@@ -43,6 +44,9 @@ import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProt
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
 import org.apache.kafka.common.message.ListOffsetRequestData.{ListOffsetPartition, ListOffsetTopic}
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
 import org.apache.kafka.common.network.ListenerName
@@ -329,8 +333,14 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   }
 
   private def offsetsForLeaderEpochRequest: OffsetsForLeaderEpochRequest = {
-    val epochs = Map(tp -> new OffsetsForLeaderEpochRequest.PartitionData(Optional.of(27), 7))
-    OffsetsForLeaderEpochRequest.Builder.forConsumer(epochs.asJava).build()
+    val epochs = new OffsetForLeaderTopicCollection()
+    epochs.add(new OffsetForLeaderTopic()
+      .setName(tp.topic())
+      .setPartitions(List(new OffsetForLeaderPartition()
+          .setPartitionIndex(tp.partition())
+          .setLeaderEpoch(7)
+          .setCurrentLeaderEpoch(27)).asJava))
+    OffsetsForLeaderEpochRequest.Builder.forConsumer(epochs).build()
   }
 
   private def createOffsetFetchRequest = {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -14,7 +14,6 @@ package kafka.api
 
 import java.time.Duration
 import java.util
-import java.util
 import java.util.concurrent.ExecutionException
 import java.util.regex.Pattern
 import java.util.{Collections, Optional, Properties}

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -416,9 +416,9 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.OFFSET_FOR_LEADER_EPOCH =>
           val epochs = new OffsetForLeaderTopicCollection()
           epochs.add(new OffsetForLeaderTopic()
-            .setName(tp.topic())
+            .setTopic(tp.topic())
             .setPartitions(List(new OffsetForLeaderPartition()
-              .setPartitionIndex(tp.partition())
+              .setPartition(tp.partition())
               .setLeaderEpoch(0)
               .setCurrentLeaderEpoch(15)).asJava))
           OffsetsForLeaderEpochRequest.Builder.forConsumer(epochs)

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -32,6 +32,9 @@ import org.apache.kafka.common.message.JoinGroupRequestData.JoinGroupRequestProt
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity
 import org.apache.kafka.common.message.ListOffsetRequestData.{ListOffsetPartition, ListOffsetTopic}
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic
+import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
 import org.apache.kafka.common.message.{AddOffsetsToTxnRequestData, _}
@@ -411,8 +414,14 @@ class RequestQuotaTest extends BaseRequestTest {
           new InitProducerIdRequest.Builder(requestData)
 
         case ApiKeys.OFFSET_FOR_LEADER_EPOCH =>
-          OffsetsForLeaderEpochRequest.Builder.forConsumer(Map(tp ->
-            new OffsetsForLeaderEpochRequest.PartitionData(Optional.of(15), 0)).asJava)
+          val epochs = new OffsetForLeaderTopicCollection()
+          epochs.add(new OffsetForLeaderTopic()
+            .setName(tp.topic())
+            .setPartitions(List(new OffsetForLeaderPartition()
+              .setPartitionIndex(tp.partition())
+              .setLeaderEpoch(0)
+              .setCurrentLeaderEpoch(15)).asJava))
+          OffsetsForLeaderEpochRequest.Builder.forConsumer(epochs)
 
         case ApiKeys.ADD_PARTITIONS_TO_TXN =>
           new AddPartitionsToTxnRequest.Builder("test-transactional-id", 1, 0, List(tp).asJava)


### PR DESCRIPTION
This PR migrates the `OffsetsForLeaderEpoch` request/response to the automated protocol. It also refactors the `OffsetsForLeaderEpochClient` to use directly the internal structs generated by the automated protocol. It relies on the existing tests.

It seems that we could also refactor the broker (api layer, fetcher) to directly use the internal structs of the generated protocol but, as it is more involved, I propose to address it in a separate PR.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
