### PR TITLE
Disable inlining of Scala library methods.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -515,7 +515,7 @@ subprojects {
     // Kafka project in that case.
     List<String> inlineFrom
     if (project.name.equals('core'))
-      inlineFrom = ["-opt-inline-from:scala.**", "-opt-inline-from:kafka.**", "-opt-inline-from:org.apache.kafka.**"]
+      inlineFrom = ["-opt-inline-from:scala.util.Either.**", "-opt-inline-from:scala.Option.**", "-opt-inline-from:kafka.**", "-opt-inline-from:org.apache.kafka.**"]
     else
       inlineFrom = ["-opt-inline-from:org.apache.kafka.**"]
 


### PR DESCRIPTION
Previously, the Scala compiler was configured to inline all usages of
symbols in under the `scala` package. This is problematic because it
means that published Kafka jars must run with the exact same version of
the Scala library that the Kafka jar was compiled with.  If the runtime
uses a different version of the Scala library then users risk getting a
crash like this:

```
java.lang.NoClassDefFoundError: scala/math/Ordering$$anon$7
```

This commit disables inlining from the `scala` package to prevent
crashes like this. The downside to this change is it may introduce
performance regressions.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
