### PR TITLE
KIP-145: Add SMTs, HeaderFrom, DropHeaders and InsertHeader

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
@@ -18,11 +18,15 @@ package org.apache.kafka.connect.tools;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.transforms.Cast;
+import org.apache.kafka.connect.transforms.DropHeaders;
 import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.Filter;
 import org.apache.kafka.connect.transforms.Flatten;
+import org.apache.kafka.connect.transforms.HeaderFrom;
+import org.apache.kafka.connect.transforms.HeaderTo;
 import org.apache.kafka.connect.transforms.HoistField;
 import org.apache.kafka.connect.transforms.InsertField;
+import org.apache.kafka.connect.transforms.InsertHeader;
 import org.apache.kafka.connect.transforms.MaskField;
 import org.apache.kafka.connect.transforms.RegexRouter;
 import org.apache.kafka.connect.transforms.ReplaceField;
@@ -62,7 +66,10 @@ public class TransformationDoc {
             new DocInfo(Flatten.class.getName(), Flatten.OVERVIEW_DOC, Flatten.CONFIG_DEF),
             new DocInfo(Cast.class.getName(), Cast.OVERVIEW_DOC, Cast.CONFIG_DEF),
             new DocInfo(TimestampConverter.class.getName(), TimestampConverter.OVERVIEW_DOC, TimestampConverter.CONFIG_DEF),
-            new DocInfo(Filter.class.getName(), Filter.OVERVIEW_DOC, Filter.CONFIG_DEF)
+            new DocInfo(Filter.class.getName(), Filter.OVERVIEW_DOC, Filter.CONFIG_DEF),
+            new DocInfo(InsertHeader.class.getName(), InsertHeader.OVERVIEW_DOC, InsertHeader.CONFIG_DEF),
+            new DocInfo(DropHeaders.class.getName(), DropHeaders.OVERVIEW_DOC, DropHeaders.CONFIG_DEF),
+            new DocInfo(HeaderFrom.class.getName(), HeaderFrom.OVERVIEW_DOC, HeaderFrom.CONFIG_DEF)
     );
 
     private static void printTransformationHtml(PrintStream out, DocInfo docInfo) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/TransformationDoc.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.Filter;
 import org.apache.kafka.connect.transforms.Flatten;
 import org.apache.kafka.connect.transforms.HeaderFrom;
-import org.apache.kafka.connect.transforms.HeaderTo;
 import org.apache.kafka.connect.transforms.HoistField;
 import org.apache.kafka.connect.transforms.InsertField;
 import org.apache.kafka.connect.transforms.InsertHeader;

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/DropHeaders.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/DropHeaders.java
@@ -29,7 +29,7 @@ public class DropHeaders<R extends ConnectRecord<R>> implements Transformation<R
     public static final String OVERVIEW_DOC =
             "Removes one or more headers from each record.";
 
-    public static final String HEADERS_FIELD = "header.names";
+    public static final String HEADERS_FIELD = "headers";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(HEADERS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/DropHeaders.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/DropHeaders.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.List;
+import java.util.Map;
+
+public class DropHeaders<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String OVERVIEW_DOC =
+            "Removes one or more headers from each record.";
+
+    public static final String HEADERS_FIELD = "header.names";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(HEADERS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
+                    "The name of the headers to be removed.");
+
+    private List<String> headers;
+
+    @Override
+    public R apply(R record) {
+        Headers updatedHeaders = record.headers().duplicate();
+        for (String name : headers) {
+            updatedHeaders.remove(name);
+        }
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                record.valueSchema(), record.value(), record.timestamp(), updatedHeaders);
+    }
+
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        headers = config.getList(HEADERS_FIELD);
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/DropHeaders.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/DropHeaders.java
@@ -18,11 +18,17 @@ package org.apache.kafka.connect.transforms;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.NonEmptyListValidator;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
 
 public class DropHeaders<R extends ConnectRecord<R>> implements Transformation<R> {
 
@@ -32,21 +38,24 @@ public class DropHeaders<R extends ConnectRecord<R>> implements Transformation<R
     public static final String HEADERS_FIELD = "headers";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(HEADERS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
+            .define(HEADERS_FIELD, ConfigDef.Type.LIST,
+                    NO_DEFAULT_VALUE, new NonEmptyListValidator(),
+                    ConfigDef.Importance.HIGH,
                     "The name of the headers to be removed.");
 
-    private List<String> headers;
+    private Set<String> headers;
 
     @Override
     public R apply(R record) {
-        Headers updatedHeaders = record.headers().duplicate();
-        for (String name : headers) {
-            updatedHeaders.remove(name);
+        Headers updatedHeaders = new ConnectHeaders();
+        for (Header header : record.headers()) {
+            if (!headers.contains(header.key())) {
+                updatedHeaders.add(header);
+            }
         }
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
                 record.valueSchema(), record.value(), record.timestamp(), updatedHeaders);
     }
-
 
     @Override
     public ConfigDef config() {
@@ -55,12 +64,11 @@ public class DropHeaders<R extends ConnectRecord<R>> implements Transformation<R
 
     @Override
     public void close() {
-
     }
 
     @Override
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
-        headers = config.getList(HEADERS_FIELD);
+        headers = new HashSet<>(config.getList(HEADERS_FIELD));
     }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -28,6 +28,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.NonEmptyListValidator;
 import org.apache.kafka.connect.transforms.util.Requirements;
 import org.apache.kafka.connect.transforms.util.SchemaUtil;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
@@ -56,12 +57,16 @@ public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transfor
                     "key (<code>" + Key.class.getName() + "</code>) or value (<code>" + Value.class.getName() + "</code>).";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(FIELDS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
+            .define(FIELDS_FIELD, ConfigDef.Type.LIST,
+                    NO_DEFAULT_VALUE, new NonEmptyListValidator(),
+                    ConfigDef.Importance.HIGH,
                     "Field names in the record whose values are to be copied or moved to headers.")
-            .define(HEADERS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
+            .define(HEADERS_FIELD, ConfigDef.Type.LIST,
+                    NO_DEFAULT_VALUE, new NonEmptyListValidator(),
+                    ConfigDef.Importance.HIGH,
                     "Header names, in the same order as the field names listed in the fields configuration property.")
             .define(OPERATION_FIELD, ConfigDef.Type.STRING, NO_DEFAULT_VALUE,
-                    ConfigDef.ValidString.in("move", "copy"), ConfigDef.Importance.HIGH,
+                    ConfigDef.ValidString.in(MOVE_OPERATION, COPY_OPERATION), ConfigDef.Importance.HIGH,
                     "Either <code>move</code> if the fields are to be moved to the headers (removed from the key/value), " +
                             "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).");
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/HeaderFrom.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.Requirements;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
+
+public abstract class HeaderFrom<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String FIELDS_FIELD = "fields";
+    public static final String HEADERS_FIELD = "headers";
+    public static final String OPERATION_FIELD = "operation";
+
+    public static final String OVERVIEW_DOC =
+            "Moves or copies fields in the key/value of a record into that record's headers. " +
+                    "Corresponding elements of <code>" + FIELDS_FIELD + "</code> and " +
+                    "<code>" + HEADERS_FIELD + "</code> together identify a field and the header it should be " +
+                    "moved or copied to. " +
+                    "Use the concrete transformation type designed for the record " +
+                    "key (<code>" + Key.class.getName() + "</code>) or value (<code>" + Value.class.getName() + "</code>).";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(FIELDS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
+                    "Field names in the record whose values are to be copied or moved to headers.")
+            .define(HEADERS_FIELD, ConfigDef.Type.LIST, ConfigDef.Importance.HIGH,
+                    "Header names, in the same order as the field names listed in the fields configuration property.")
+            .define(OPERATION_FIELD, ConfigDef.Type.STRING, NO_DEFAULT_VALUE,
+                    ConfigDef.ValidString.in("move", "copy"), ConfigDef.Importance.HIGH,
+                    "Either <code>move</code> if the fields are to be moved to the headers (removed from the key/value), " +
+                            "or <code>copy</code> if the fields are to be copied to the headers (retained in the key/value).");
+
+    enum Operation {
+        MOVE("move"),
+        COPY("copy");
+
+        private final String name;
+
+        Operation(String name) {
+            this.name = name;
+        }
+
+        static Operation fromName(String name) {
+            switch (name) {
+                case "move":
+                    return MOVE;
+                case "copy":
+                    return COPY;
+                default:
+                    throw new IllegalArgumentException();
+            }
+        }
+
+        public String toString() {
+            return name;
+        }
+    }
+
+    private List<String> fields;
+
+    private List<String> headers;
+
+    private Operation operation;
+
+    @Override
+    public R apply(R record) {
+        Object operatingValue = operatingValue(record);
+        Schema operatingSchema = operatingSchema(record);
+
+        if (operatingSchema == null) {
+            return applySchemaless(record, operatingValue);
+        } else {
+            return applyWithSchema(record, operatingValue, operatingSchema);
+        }
+    }
+
+    private R applyWithSchema(R record, Object operatingValue, Schema operatingSchema) {
+        Headers updatedHeaders = record.headers().duplicate();
+        Struct value = Requirements.requireStruct(operatingValue, "header " + operation);
+        final Schema updatedSchema;
+        if (operation == Operation.MOVE) {
+            updatedSchema = moveSchema(operatingSchema);
+        } else {
+            updatedSchema = operatingSchema;
+        }
+        final Struct updatedValue = new Struct(updatedSchema);
+        for (Field field : updatedSchema.fields()) {
+            updatedValue.put(field, value.get(field.name()));
+        }
+        for (int i = 0; i < fields.size(); i++) {
+            String fieldName = fields.get(i);
+            String headerName = headers.get(i);
+            Object fieldValue = value.get(fieldName);
+            Schema fieldSchema = operatingSchema.field(fieldName).schema();
+            updatedHeaders.add(headerName, fieldValue, fieldSchema);
+        }
+        return newRecord(record, updatedSchema, updatedValue, updatedHeaders);
+    }
+
+    private Schema moveSchema(Schema operatingSchema) {
+        final Schema updatedSchema;
+        final SchemaBuilder builder = SchemaUtil.copySchemaBasics(operatingSchema, SchemaBuilder.struct());
+        for (Field field : operatingSchema.fields()) {
+            if (!fields.contains(field.name())) {
+                builder.field(field.name(), field.schema());
+            }
+        }
+        updatedSchema = builder.build();
+        return updatedSchema;
+    }
+
+    private R applySchemaless(R record, Object operatingValue) {
+        Headers updatedHeaders = record.headers().duplicate();
+        Map<String, Object> value = Requirements.requireMap(operatingValue, "header " + operation);
+        Map<String, Object> updatedValue = new HashMap<>(value);
+        for (int i = 0; i < fields.size(); i++) {
+            String fieldName = fields.get(i);
+            Object fieldValue = value.get(fieldName);
+            String headerName = headers.get(i);
+            if (operation == Operation.MOVE) {
+                updatedValue.remove(fieldName);
+            }
+            updatedHeaders.add(headerName, fieldValue, null);
+        }
+        return newRecord(record, null, updatedValue, updatedHeaders);
+    }
+
+    protected abstract Object operatingValue(R record);
+    protected abstract Schema operatingSchema(R record);
+    protected abstract R newRecord(R record, Schema updatedSchema, Object updatedValue, Iterable<Header> updatedHeaders);
+
+    public static class Key<R extends ConnectRecord<R>> extends HeaderFrom<R> {
+
+        @Override
+        public Object operatingValue(R record) {
+            return record.key();
+        }
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.keySchema();
+        }
+
+        @Override
+        protected R newRecord(R record, Schema updatedSchema, Object updatedValue, Iterable<Header> updatedHeaders) {
+            return record.newRecord(record.topic(), record.kafkaPartition(), updatedSchema, updatedValue,
+                    record.valueSchema(), record.value(), record.timestamp(), updatedHeaders);
+        }
+    }
+
+    public static class Value<R extends ConnectRecord<R>> extends HeaderFrom<R> {
+
+        @Override
+        public Object operatingValue(R record) {
+            return record.value();
+        }
+
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.valueSchema();
+        }
+
+        @Override
+        protected R newRecord(R record, Schema updatedSchema, Object updatedValue, Iterable<Header> updatedHeaders) {
+            return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                    updatedSchema, updatedValue, record.timestamp(), updatedHeaders);
+        }
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        fields = config.getList(FIELDS_FIELD);
+        headers = config.getList(HEADERS_FIELD);
+        if (headers.size() != fields.size()) {
+            throw new ConfigException("'fields' config must have the same number of elements as 'headers' config.");
+        }
+        operation = Operation.fromName(config.getString(OPERATION_FIELD));
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
@@ -19,6 +19,8 @@ package org.apache.kafka.connect.transforms;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Values;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
@@ -40,12 +42,12 @@ public class InsertHeader<R extends ConnectRecord<R>> implements Transformation<
 
     private String header;
 
-    private String literalValue;
+    private SchemaAndValue literalValue;
 
     @Override
     public R apply(R record) {
         Headers updatedHeaders = record.headers().duplicate();
-        updatedHeaders.add(header, literalValue, Schema.STRING_SCHEMA);
+        updatedHeaders.add(header, literalValue);
         return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
                 record.valueSchema(), record.value(), record.timestamp(), updatedHeaders);
     }
@@ -65,6 +67,6 @@ public class InsertHeader<R extends ConnectRecord<R>> implements Transformation<
     public void configure(Map<String, ?> props) {
         final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
         header = config.getString(HEADER_FIELD);
-        literalValue = config.getString(VALUE_LITERAL_FIELD);
+        literalValue = Values.parseString(config.getString(VALUE_LITERAL_FIELD));
     }
 }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
@@ -18,13 +18,14 @@ package org.apache.kafka.connect.transforms;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Values;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 import java.util.Map;
+
+import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
 
 public class InsertHeader<R extends ConnectRecord<R>> implements Transformation<R> {
 
@@ -35,9 +36,13 @@ public class InsertHeader<R extends ConnectRecord<R>> implements Transformation<
     public static final String VALUE_LITERAL_FIELD = "value.literal";
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
-            .define(HEADER_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
+            .define(HEADER_FIELD, ConfigDef.Type.STRING,
+                    NO_DEFAULT_VALUE, new ConfigDef.NonNullValidator(),
+                    ConfigDef.Importance.HIGH,
                     "The name of the header.")
-            .define(VALUE_LITERAL_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
+            .define(VALUE_LITERAL_FIELD, ConfigDef.Type.STRING,
+                    NO_DEFAULT_VALUE, new ConfigDef.NonNullValidator(),
+                    ConfigDef.Importance.HIGH,
                     "The literal value that is to be set as the header value on all records.");
 
     private String header;

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/InsertHeader.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.Map;
+
+public class InsertHeader<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String OVERVIEW_DOC =
+            "Add a header to each record.";
+
+    public static final String HEADER_FIELD = "header";
+    public static final String VALUE_LITERAL_FIELD = "value.literal";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(HEADER_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
+                    "The name of the header.")
+            .define(VALUE_LITERAL_FIELD, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
+                    "The literal value that is to be set as the header value on all records.");
+
+    private String header;
+
+    private String literalValue;
+
+    @Override
+    public R apply(R record) {
+        Headers updatedHeaders = record.headers().duplicate();
+        updatedHeaders.add(header, literalValue, Schema.STRING_SCHEMA);
+        return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(),
+                record.valueSchema(), record.value(), record.timestamp(), updatedHeaders);
+    }
+
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        header = config.getString(HEADER_FIELD);
+        literalValue = config.getString(VALUE_LITERAL_FIELD);
+    }
+}

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/DropHeadersTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/DropHeadersTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
+public class DropHeadersTest {
+
+    private DropHeaders<SourceRecord> xform = new DropHeaders<>();
+
+    private Map<String, ?> config(String... headers) {
+        Map<String, Object> result = new HashMap<>();
+        result.put(DropHeaders.HEADERS_FIELD, asList(headers));
+        return result;
+    }
+
+    @Test
+    public void dropExistingHeader() {
+        xform.configure(config("to-drop"));
+        ConnectHeaders expected = new ConnectHeaders();
+        expected.addString("existing", "existing-value");
+        ConnectHeaders headers = expected.duplicate();
+        headers.addString("to-drop", "existing-value");
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expected, xformed.headers());
+    }
+
+    @Test
+    public void dropExistingHeaderWithMultipleValues() {
+        xform.configure(config("to-drop"));
+        ConnectHeaders expected = new ConnectHeaders();
+        expected.addString("existing", "existing-value");
+        ConnectHeaders headers = expected.duplicate();
+        headers.addString("to-drop", "existing-value");
+        headers.addString("to-drop", "existing-other-value");
+
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expected, xformed.headers());
+    }
+
+    @Test
+    public void dropNonExistingHeader() {
+        xform.configure(config("to-drop"));
+        ConnectHeaders expected = new ConnectHeaders();
+        expected.addString("existing", "existing-value");
+        ConnectHeaders headers = expected.duplicate();
+
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expected, xformed.headers());
+    }
+
+    private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {
+        assertEquals(original.sourcePartition(), xformed.sourcePartition());
+        assertEquals(original.sourceOffset(), xformed.sourceOffset());
+        assertEquals(original.topic(), xformed.topic());
+        assertEquals(original.kafkaPartition(), xformed.kafkaPartition());
+        assertEquals(original.keySchema(), xformed.keySchema());
+        assertEquals(original.key(), xformed.key());
+        assertEquals(original.valueSchema(), xformed.valueSchema());
+        assertEquals(original.value(), xformed.value());
+        assertEquals(original.timestamp(), xformed.timestamp());
+    }
+
+    private SourceRecord sourceRecord(ConnectHeaders headers) {
+        Map<String, ?> sourcePartition = singletonMap("foo", "bar");
+        Map<String, ?> sourceOffset = singletonMap("baz", "quxx");
+        String topic = "topic";
+        Integer partition = 0;
+        Schema keySchema = null;
+        Object key = "key";
+        Schema valueSchema = null;
+        Object value = "value";
+        Long timestamp = 0L;
+
+        SourceRecord record = new SourceRecord(sourcePartition, sourceOffset, topic, partition,
+                keySchema, key, valueSchema, value, timestamp, headers);
+        return record;
+    }
+}
+

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/DropHeadersTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/DropHeadersTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.transforms;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -77,6 +78,11 @@ public class DropHeadersTest {
         SourceRecord xformed = xform.apply(original);
         assertNonHeaders(original, xformed);
         assertEquals(expected, xformed.headers());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void configRejectsEmptyList() {
+        xform.configure(config());
     }
 
     private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/DropHeadersTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/DropHeadersTest.java
@@ -20,14 +20,15 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DropHeadersTest {
 
@@ -80,9 +81,9 @@ public class DropHeadersTest {
         assertEquals(expected, xformed.headers());
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void configRejectsEmptyList() {
-        xform.configure(config());
+        assertThrows(ConfigException.class, () -> xform.configure(config()));
     }
 
     private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class HeaderFromTest {
+
+    private final boolean keyTransform;
+
+    static class RecordBuilder {
+        private final List<String> fields = new ArrayList<>(2);
+        private final List<Schema> fieldSchemas = new ArrayList<>(2);
+        private final List<Object> fieldValues = new ArrayList<>(2);
+        private final ConnectHeaders headers = new ConnectHeaders();
+
+        public RecordBuilder() {
+        }
+
+        public RecordBuilder withField(String name, Schema schema, Object value) {
+            fields.add(name);
+            fieldSchemas.add(schema);
+            fieldValues.add(value);
+            return this;
+        }
+
+        public RecordBuilder addHeader(String name, Schema schema, Object value) {
+            headers.add(name, new SchemaAndValue(schema, value));
+            return this;
+        }
+
+        public SourceRecord schemaless(boolean keyTransform) {
+            Map<String, Object> map = new HashMap<>();
+            for (int i = 0; i < this.fields.size(); i++) {
+                String fieldName = this.fields.get(i);
+                map.put(fieldName, this.fieldValues.get(i));
+
+            }
+            return sourceRecord(keyTransform, null, map);
+        }
+
+        private Schema schema() {
+            SchemaBuilder schemaBuilder = new SchemaBuilder(Schema.Type.STRUCT);
+            for (int i = 0; i < this.fields.size(); i++) {
+                String fieldName = this.fields.get(i);
+                schemaBuilder.field(fieldName, this.fieldSchemas.get(i));
+
+            }
+            return schemaBuilder.build();
+        }
+
+        private Struct struct(Schema schema) {
+            Struct struct = new Struct(schema);
+            for (int i = 0; i < this.fields.size(); i++) {
+                String fieldName = this.fields.get(i);
+                struct.put(fieldName, this.fieldValues.get(i));
+            }
+            return struct;
+        }
+
+        public SourceRecord withSchema(boolean keyTransform) {
+            Schema schema = schema();
+            Struct struct = struct(schema);
+            return sourceRecord(keyTransform, schema, struct);
+        }
+
+        private SourceRecord sourceRecord(boolean keyTransform, Schema keyOrValueSchema, Object keyOrValue) {
+            Map<String, ?> sourcePartition = singletonMap("foo", "bar");
+            Map<String, ?> sourceOffset = singletonMap("baz", "quxx");
+            String topic = "topic";
+            Integer partition = 0;
+            Long timestamp = 0L;
+
+            ConnectHeaders headers = this.headers;
+            if (keyOrValueSchema == null) {
+                // When doing a schemaless transformation we don't expect the header to have a schema
+                headers = new ConnectHeaders();
+                for (Header header : this.headers) {
+                    headers.add(header.key(), new SchemaAndValue(null, header.value()));
+                }
+            }
+            return new SourceRecord(sourcePartition, sourceOffset, topic, partition,
+                    keyTransform ? keyOrValueSchema : null,
+                    keyTransform ? keyOrValue : "key",
+                    !keyTransform ? keyOrValueSchema : null,
+                    !keyTransform ? keyOrValue : "value",
+                    timestamp, headers);
+        }
+
+        @Override
+        public String toString() {
+            return "RecordBuilder(" +
+                    "fields=" + fields +
+                    ", fieldSchemas=" + fieldSchemas +
+                    ", fieldValues=" + fieldValues +
+                    ", headers=" + headers +
+                    ')';
+        }
+    }
+
+    @Parameterized.Parameters(name = "{0}: testKey={1}, xformFields={3}, xformHeaders={4}, operation={5}")
+    public static Collection<Object[]> data() {
+
+        List<Object[]> result = new ArrayList<>();
+
+
+
+        for (Boolean testKeyTransform : asList(true, false)) {
+            result.add(
+                new Object[]{
+                    "basic copy",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                });
+            result.add(
+                new Object[]{
+                    "basic move",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
+                    new RecordBuilder()
+                        // field1 got moved
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                });
+            result.add(
+                new Object[]{
+                    "copy with preexisting header",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                });
+            result.add(
+                new Object[]{
+                    "move with preexisting header",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "existing-value"),
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
+                    new RecordBuilder()
+                        // field1 got moved
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                });
+            Schema schema = new SchemaBuilder(Schema.Type.STRUCT).field("foo", STRING_SCHEMA).build();
+            Struct struct = new Struct(schema).put("foo", "foo-value");
+            result.add(
+                new Object[]{
+                    "copy with struct value",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", schema, struct)
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.COPY,
+                    new RecordBuilder()
+                        .withField("field1", schema, struct)
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", schema, struct)
+                });
+            result.add(
+                new Object[]{
+                    "move with struct value",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", schema, struct)
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                    singletonList("field1"), singletonList("inserted1"), HeaderFrom.Operation.MOVE,
+                    new RecordBuilder()
+                        // field1 got moved
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", schema, struct)
+                });
+            result.add(
+                new Object[]{
+                    "two headers from same field",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                    // two headers from the same field
+                    asList("field1", "field1"), asList("inserted1", "inserted2"), HeaderFrom.Operation.MOVE,
+                    new RecordBuilder()
+                        // field1 got moved
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                        .addHeader("inserted2", STRING_SCHEMA, "field1-value")
+                });
+            result.add(
+                new Object[]{
+                    "two fields to same header",
+                    testKeyTransform,
+                    new RecordBuilder()
+                        .withField("field1", STRING_SCHEMA, "field1-value")
+                        .withField("field2", STRING_SCHEMA, "field2-value")
+                        .addHeader("header1", STRING_SCHEMA, "existing-value"),
+                    // two headers from the same field
+                    asList("field1", "field2"), asList("inserted1", "inserted1"), HeaderFrom.Operation.MOVE,
+                    new RecordBuilder()
+                        // field1 and field2 got moved
+                        .addHeader("header1", STRING_SCHEMA, "existing-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field1-value")
+                        .addHeader("inserted1", STRING_SCHEMA, "field2-value")
+                });
+        }
+        return result;
+    }
+
+    private final HeaderFrom<SourceRecord> xform;
+
+    private final RecordBuilder originalRecordBuilder;
+    private final RecordBuilder expectedRecordBuilder;
+    private final List<String> transformFields;
+    private final List<String> headers;
+    private final HeaderFrom.Operation operation;
+
+    public HeaderFromTest(String description,
+                          boolean keyTransform,
+                          RecordBuilder originalBuilder,
+                          List<String> transformFields, List<String> headers, HeaderFrom.Operation operation,
+                          RecordBuilder expectedBuilder) {
+        this.keyTransform = keyTransform;
+        this.xform = keyTransform ? new HeaderFrom.Key<>() : new HeaderFrom.Value<>();
+        this.originalRecordBuilder = originalBuilder;
+        this.expectedRecordBuilder = expectedBuilder;
+        this.transformFields = transformFields;
+        this.headers = headers;
+        this.operation = operation;
+    }
+
+    private Map<String, Object> config() {
+        Map<String, Object> result = new HashMap<>();
+        result.put(HeaderFrom.HEADERS_FIELD, headers);
+        result.put(HeaderFrom.FIELDS_FIELD, transformFields);
+        result.put(HeaderFrom.OPERATION_FIELD, operation.toString());
+        return result;
+    }
+
+    @Test
+    public void schemaless() {
+        xform.configure(config());
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+
+        SourceRecord originalRecord = originalRecordBuilder.schemaless(keyTransform);
+        SourceRecord expectedRecord = expectedRecordBuilder.schemaless(keyTransform);
+        SourceRecord xformed = xform.apply(originalRecord);
+        assertSameRecord(expectedRecord, xformed);
+    }
+
+    @Test
+    public void withSchema() {
+        xform.configure(config());
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+        Headers expect = headers.duplicate();
+        for (int i = 0; i < this.headers.size(); i++) {
+            expect.add(this.headers.get(i), originalRecordBuilder.fieldValues.get(i), originalRecordBuilder.fieldSchemas.get(i));
+        }
+
+        SourceRecord originalRecord = originalRecordBuilder.withSchema(keyTransform);
+        SourceRecord expectedRecord = expectedRecordBuilder.withSchema(keyTransform);
+        SourceRecord xformed = xform.apply(originalRecord);
+        assertSameRecord(expectedRecord, xformed);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void invalidConfig() {
+        Map<String, Object> config = config();
+        List<String> headers = new ArrayList<>(this.headers);
+        headers.add("unexpected");
+        config.put(HeaderFrom.HEADERS_FIELD, headers);
+        xform.configure(config);
+    }
+
+    private static void assertSameRecord(SourceRecord expected, SourceRecord xformed) {
+        assertEquals(expected.sourcePartition(), xformed.sourcePartition());
+        assertEquals(expected.sourceOffset(), xformed.sourceOffset());
+        assertEquals(expected.topic(), xformed.topic());
+        assertEquals(expected.kafkaPartition(), xformed.kafkaPartition());
+        assertEquals(expected.keySchema(), xformed.keySchema());
+        assertEquals(expected.key(), xformed.key());
+        assertEquals(expected.valueSchema(), xformed.valueSchema());
+        assertEquals(expected.value(), xformed.value());
+        assertEquals(expected.timestamp(), xformed.timestamp());
+        assertEquals(expected.headers(), xformed.headers());
+    }
+
+}
+

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HeaderFromTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
@@ -332,11 +333,28 @@ public class HeaderFromTest {
     }
 
     @Test(expected = ConfigException.class)
-    public void invalidConfig() {
+    public void invalidConfigExtraHeaderConfig() {
         Map<String, Object> config = config();
         List<String> headers = new ArrayList<>(this.headers);
         headers.add("unexpected");
         config.put(HeaderFrom.HEADERS_FIELD, headers);
+        xform.configure(config);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void invalidConfigExtraFieldConfig() {
+        Map<String, Object> config = config();
+        List<String> fields = new ArrayList<>(this.transformFields);
+        fields.add("unexpected");
+        config.put(HeaderFrom.FIELDS_FIELD, fields);
+        xform.configure(config);
+    }
+
+    @Test(expected = ConfigException.class)
+    public void invalidConfigEmptyHeadersAndFieldsConfig() {
+        Map<String, Object> config = config();
+        config.put(HeaderFrom.HEADERS_FIELD, emptyList());
+        config.put(HeaderFrom.FIELDS_FIELD, emptyList());
         xform.configure(config);
     }
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
@@ -21,13 +21,14 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InsertHeaderTest {
 
@@ -79,14 +80,14 @@ public class InsertHeaderTest {
         assertEquals(expect, xformed.headers());
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void configRejectsNullHeaderKey() {
-        xform.configure(config(null, "1"));
+        assertThrows(ConfigException.class, () -> xform.configure(config(null, "1")));
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void configRejectsNullHeaderValue() {
-        xform.configure(config("inserted", null));
+        assertThrows(ConfigException.class, () -> xform.configure(config("inserted", null)));
     }
 
     private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+
+public class InsertHeaderTest {
+
+    private InsertHeader<SourceRecord> xform = new InsertHeader<>();
+
+    private Map<String, ?> config(String header, String valueLiteral) {
+        Map<String, String> result = new HashMap<>();
+        result.put(InsertHeader.HEADER_FIELD, header);
+        result.put(InsertHeader.VALUE_LITERAL_FIELD, valueLiteral);
+        return result;
+    }
+
+    @Test
+    public void insertionWithExistingOtherHeader() {
+        xform.configure(config("inserted", "inserted-value"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+        Headers expect = headers.duplicate().addString("inserted", "inserted-value");
+
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expect, xformed.headers());
+    }
+
+    @Test
+    public void insertionWithExistingSameHeader() {
+        xform.configure(config("existing", "inserted-value"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "preexisting-value");
+        Headers expect = headers.duplicate().addString("existing", "inserted-value");
+
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expect, xformed.headers());
+    }
+
+    private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {
+        assertEquals(original.sourcePartition(), xformed.sourcePartition());
+        assertEquals(original.sourceOffset(), xformed.sourceOffset());
+        assertEquals(original.topic(), xformed.topic());
+        assertEquals(original.kafkaPartition(), xformed.kafkaPartition());
+        assertEquals(original.keySchema(), xformed.keySchema());
+        assertEquals(original.key(), xformed.key());
+        assertEquals(original.valueSchema(), xformed.valueSchema());
+        assertEquals(original.value(), xformed.value());
+        assertEquals(original.timestamp(), xformed.timestamp());
+    }
+
+    private SourceRecord sourceRecord(ConnectHeaders headers) {
+        Map<String, ?> sourcePartition = singletonMap("foo", "bar");
+        Map<String, ?> sourceOffset = singletonMap("baz", "quxx");
+        String topic = "topic";
+        Integer partition = 0;
+        Schema keySchema = null;
+        Object key = "key";
+        Schema valueSchema = null;
+        Object value = "value";
+        Long timestamp = 0L;
+
+        SourceRecord record = new SourceRecord(sourcePartition, sourceOffset, topic, partition,
+                keySchema, key, valueSchema, value, timestamp, headers);
+        return record;
+    }
+}
+

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
@@ -65,6 +65,19 @@ public class InsertHeaderTest {
         assertEquals(expect, xformed.headers());
     }
 
+    @Test
+    public void insertionWithByteHeader() {
+        xform.configure(config("inserted", "1"));
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("existing", "existing-value");
+        Headers expect = headers.duplicate().addByte("inserted", (byte) 1);
+
+        SourceRecord original = sourceRecord(headers);
+        SourceRecord xformed = xform.apply(original);
+        assertNonHeaders(original, xformed);
+        assertEquals(expect, xformed.headers());
+    }
+
     private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {
         assertEquals(original.sourcePartition(), xformed.sourcePartition());
         assertEquals(original.sourceOffset(), xformed.sourceOffset());

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertHeaderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.transforms;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Headers;
@@ -76,6 +77,16 @@ public class InsertHeaderTest {
         SourceRecord xformed = xform.apply(original);
         assertNonHeaders(original, xformed);
         assertEquals(expect, xformed.headers());
+    }
+
+    @Test(expected = ConfigException.class)
+    public void configRejectsNullHeaderKey() {
+        xform.configure(config(null, "1"));
+    }
+
+    @Test(expected = ConfigException.class)
+    public void configRejectsNullHeaderValue() {
+        xform.configure(config("inserted", null));
     }
 
     private void assertNonHeaders(SourceRecord original, SourceRecord xformed) {

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -183,6 +183,9 @@
         <li>TimestampRouter - Modify the topic of a record based on original topic and timestamp. Useful when using a sink that needs to write to different tables or indexes based on timestamps</li>
         <li>RegexRouter - modify the topic of a record based on original topic, replacement string and a regular expression</li>
         <li>Filter - Removes messages from all further processing. This is used with a <a href="#connect_predicates">predicate</a> to selectively filter certain messages.</li>
+        <li>InsertHeader - Add a header using static data</li>
+        <li>HeadersFrom - Copy or move fields in the key or value to the record headers</li>
+        <li>DropHeaders - Remove headers by name</li>
     </ul>
 
     <p>Details on how to configure each transformation are listed below:</p>


### PR DESCRIPTION
These SMTs were originally specified in [KIP-145](https://cwiki.apache.org/confluence/display/KAFKA/KIP-145+-+Expose+Record+Headers+in+Kafka+Connect#KIP145ExposeRecordHeadersinKafkaConnect-Transformations) but never implemented at the time.

`HeaderTo` is not included since its original specification doesn't deal with the fact that there can be >1 header with the same name, but a field can only have a single value (while you could use an array, that doesn't work if the headers for the given name had different schemas).

