### PR TITLE
KAFKA-10656: Log the feature flags received by the client

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -918,6 +918,10 @@ public class NetworkClient implements KafkaClient {
         apiVersions.update(node, nodeVersionInfo);
         this.connectionStates.ready(node);
         log.debug("Recorded API versions for node {}: {}", node, nodeVersionInfo);
+        log.debug("Node {} has finalizedFeaturesEpoch: {}, finalizedFeatures: {}, supportedFeatures: {}", node,
+                apiVersionsResponse.data.finalizedFeaturesEpoch(),
+                apiVersionsResponse.data.finalizedFeatures(),
+                apiVersionsResponse.data.supportedFeatures());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -917,11 +917,10 @@ public class NetworkClient implements KafkaClient {
         NodeApiVersions nodeVersionInfo = new NodeApiVersions(apiVersionsResponse.data.apiKeys());
         apiVersions.update(node, nodeVersionInfo);
         this.connectionStates.ready(node);
-        log.debug("Recorded API versions for node {}: {}", node, nodeVersionInfo);
-        log.debug("Node {} has finalizedFeaturesEpoch: {}, finalizedFeatures: {}, supportedFeatures: {}", node,
-                apiVersionsResponse.data.finalizedFeaturesEpoch(),
-                apiVersionsResponse.data.finalizedFeatures(),
-                apiVersionsResponse.data.supportedFeatures());
+        log.debug("Node {} has finalized features epoch: {}, finalized features: {}, supported features: {}, API versions: {}.",
+                node,
+                apiVersionsResponse.data.finalizedFeaturesEpoch(), apiVersionsResponse.data.finalizedFeatures(),
+                apiVersionsResponse.data.supportedFeatures(), nodeVersionInfo);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -918,8 +918,7 @@ public class NetworkClient implements KafkaClient {
         apiVersions.update(node, nodeVersionInfo);
         this.connectionStates.ready(node);
         log.debug("Node {} has finalized features epoch: {}, finalized features: {}, supported features: {}, API versions: {}.",
-                node,
-                apiVersionsResponse.data.finalizedFeaturesEpoch(), apiVersionsResponse.data.finalizedFeatures(),
+                node, apiVersionsResponse.data.finalizedFeaturesEpoch(), apiVersionsResponse.data.finalizedFeatures(),
                 apiVersionsResponse.data.supportedFeatures(), nodeVersionInfo);
     }
 


### PR DESCRIPTION
Example log line:

[2020-11-03 17:47:17,076] DEBUG Node 0 has finalizedFeaturesEpoch: 42, finalizedFeatures: [FinalizedFeatureKey(name='feature_1', maxVersionLevel=2, minVersionLevel=1), FinalizedFeatureKey(name='feature_2', maxVersionLevel=4, minVersionLevel=3)], supportedFeatures: [SupportedFeatureKey(name='feature_1', minVersion=1, maxVersion=2), SupportedFeatureKey(name='feature_2', minVersion=3, maxVersion=4)] (org.apache.kafka.clients.NetworkClient:926)

