### PR TITLE
KAFKA-10673: Cache inter broker listener name used in connection quotas

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -1278,6 +1278,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   @volatile private var defaultMaxConnectionsPerIp: Int = config.maxConnectionsPerIp
   @volatile private var maxConnectionsPerIpOverrides = config.maxConnectionsPerIpOverrides.map { case (host, count) => (InetAddress.getByName(host), count) }
   @volatile private var brokerMaxConnections = config.maxConnections
+  private val interBrokerListenerName = config.interBrokerListenerName
   private val counts = mutable.Map[InetAddress, Int]()
 
   // Listener counts and configs are synchronized on `counts`
@@ -1415,7 +1416,7 @@ class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extend
   }
 
   private def protectedListener(listenerName: ListenerName): Boolean =
-    config.interBrokerListenerName == listenerName && config.listeners.size > 1
+    interBrokerListenerName == listenerName && listenerCounts.size > 1
 
   private def maxListenerConnections(listenerName: ListenerName): Int =
     maxConnectionsPerListener.get(listenerName).map(_.maxConnections).getOrElse(Int.MaxValue)


### PR DESCRIPTION
A profile from a moderately busy cluster shows that calls to `protectedListener` can make up more than 1% of the allocations on a broker.

`config.interBrokerListenerName` is a relatively expensive call that both makes a copy of the `KafkaConfig`'s backing map and performs string/regex parsing. Given that we call `protectedListener()` multiple times per call to `ConnectionQuotas.inc()`, we end up performing a lot of unnecessary allocations, particularly given that the inter broker listener is not reconfigurable. We can instead store the inter broker listener name and check against it rather than recompute from the config.

An additional, smaller optimization included is to check the size of listener counts instead of `config.listeners`, as `config.listeners()` does some additional string csv parsing to recompute the listeners each time.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
