### PR TITLE
MINOR: Update jetty to 9.4.33

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ versions += [
   easymock: "4.2",
   jackson: "2.10.5",
   jacoco: "0.8.5",
-  jetty: "9.4.30.v20200611",
+  jetty: "9.4.33.v20201020",
   jersey: "2.31",
   jmh: "1.23",
   hamcrest: "2.2",


### PR DESCRIPTION
Jetty 9.4.32 and before are affected by CVE-2020-27216. This vulnerability is fixed in Jetty 9.4.33, please see the jetty project security advisory for details: https://github.com/eclipse/jetty.project/security/advisories/GHSA-g3wg-6mcf-8jj6#advisory-comment-63053

Unit tests and integration tests pass locally after the upgrade.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
