### PR TITLE
KAFKA-10345: Add ZK-notification based update for trust/key store paths

### DIFF
--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -203,7 +203,13 @@ class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
     if (brokerId == ConfigEntityName.Default)
       brokerConfig.dynamicConfig.updateDefaultConfig(properties)
     else if (brokerConfig.brokerId == brokerId.trim.toInt) {
-      brokerConfig.dynamicConfig.updateBrokerConfig(brokerConfig.brokerId, properties)
+      val persistentProps = brokerConfig.dynamicConfig.fromPersistentProps(properties, perBrokerConfig = true)
+      // The filepath was changed for equivalent replacement, which means we should reload
+      if (brokerConfig.dynamicConfig.trimSslStorePaths(persistentProps)) {
+        brokerConfig.dynamicConfig.reloadUpdatedFilesWithoutConfigChange(persistentProps)
+      }
+
+      brokerConfig.dynamicConfig.updateBrokerConfig(brokerConfig.brokerId, persistentProps, fromPersisted = true)
       quotaManagers.leader.updateQuota(upperBound(getOrDefault(LeaderReplicationThrottledRateProp).toDouble))
       quotaManagers.follower.updateQuota(upperBound(getOrDefault(FollowerReplicationThrottledRateProp).toDouble))
       quotaManagers.alterLogDirs.updateQuota(upperBound(getOrDefault(ReplicaAlterLogDirsIoMaxBytesPerSecondProp).toDouble))

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -360,6 +360,8 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
 
     // Test that we cannot create or delete ACLs when ALTER is denied.
     authorizationAdmin.addClusterAcl(DENY, ALTER)
+    // CLUSTER_ACTION shall also be forbid since the request goes to privilege listener
+    authorizationAdmin.addClusterAcl(DENY, CLUSTER_ACTION)
     testAclGet(expectAuth = true)
     testAclCreateGetDelete(expectAuth = false)
 

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -450,6 +450,8 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
       StandardCopyOption.REPLACE_EXISTING)
     TestUtils.incrementalAlterConfigs(servers, adminClients.head, oldTruststoreProps, perBrokerConfig = true).all.get()
     verifySslProduceConsume(sslProperties1, "alter-truststore-4")
+    // Sleep a short time to wait for config changes propagation
+    Thread.sleep(1000)
     verifySslProduceConsume(sslProperties2, "alter-truststore-5")
 
     // Update internal keystore/truststore and validate new client connections from broker (e.g. controller).
@@ -1239,7 +1241,9 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
 
   private def fetchBrokerConfigsFromZooKeeper(server: KafkaServer): Properties = {
     val props = adminZkClient.fetchEntityConfig(ConfigType.Broker, server.config.brokerId.toString)
-    server.config.dynamicConfig.fromPersistentProps(props, perBrokerConfig = true)
+    val persistentProps = server.config.dynamicConfig.fromPersistentProps(props, perBrokerConfig = true)
+    server.config.dynamicConfig.trimSslStorePaths(persistentProps)
+    persistentProps
   }
 
   private def awaitInitialPositions(consumer: KafkaConsumer[_, _]): Unit = {

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationWithForwardingIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationWithForwardingIntegrationTest.scala
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import java.util.Properties
+
+import org.junit.Test
+
+/**
+ * Integration test suite for forwarding mechanism applied on AlterConfigs.
+ * This class basically reused everything from {@link DynamicBrokerReconfigurationTest}
+ * with the KIP-500 mode enabled for trust store alter test.
+ */
+class DynamicBrokerReconfigurationWithForwardingIntegrationTest extends DynamicBrokerReconfigurationTest {
+
+  override def addExtraProps(props: Properties): Unit = {
+    props.put(KafkaConfig.EnableMetadataQuorumProp, true)
+  }
+
+  @Test
+  @Override
+  override def testTrustStoreAlter(): Unit = {
+     super.testTrustStoreAlter()
+  }
+}

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationWithForwardingIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationWithForwardingIntegrationTest.scala
@@ -34,8 +34,47 @@ class DynamicBrokerReconfigurationWithForwardingIntegrationTest extends DynamicB
   }
 
   @Test
-  @Override
+  override def testConfigDescribeUsingAdminClient(): Unit = {
+  }
+
+  @Test
+  override def testUpdatesUsingConfigProvider(): Unit = {
+  }
+
+  @Test
+  override def testLogCleanerConfig(): Unit = {
+  }
+
+  @Test
   override def testTrustStoreAlter(): Unit = {
-     super.testTrustStoreAlter()
+    super.testTrustStoreAlter()
+  }
+
+  @Test
+  override def testConsecutiveConfigChange(): Unit ={
+  }
+
+  @Test
+  override def testDefaultTopicConfig(): Unit = {
+  }
+
+  @Test
+  override def testUncleanLeaderElectionEnable(): Unit = {
+  }
+
+  @Test
+  override def testThreadPoolResize(): Unit = {
+  }
+
+  @Test
+  override def testMetricsReporterUpdate(): Unit = {
+  }
+
+  @Test
+  override def testAdvertisedListenerUpdate(): Unit = {
+  }
+
+  @Test
+  override def testAddRemoveSaslListeners(): Unit = {
   }
 }

--- a/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
+++ b/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
@@ -106,8 +106,7 @@ class InterBrokerSendThreadTest {
     EasyMock.expect(networkClient.newClientRequest(
       EasyMock.eq("1"),
       EasyMock.same(requestAndCompletionHandler.request),
-      EasyMock.anyLong(),
-      EasyMock.eq(true),
+      EasyMock.anyLong(), EasyMock.eq(true),
       EasyMock.eq(requestTimeoutMs),
       EasyMock.same(requestAndCompletionHandler.handler)))
       .andReturn(clientRequest)

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -26,7 +26,6 @@ import scala.collection.Seq
 import kafka.common.AdminCommandFailedException
 import kafka.security.authorizer.AclAuthorizer
 import kafka.server.{KafkaConfig, KafkaServer}
-import kafka.utils.TestUtils.createBrokerConfig
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.common.TopicPartition

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -26,6 +26,7 @@ import scala.collection.Seq
 import kafka.common.AdminCommandFailedException
 import kafka.security.authorizer.AclAuthorizer
 import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.utils.TestUtils.createBrokerConfig
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.common.TopicPartition

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -123,7 +123,7 @@ class ApiVersionTest {
       apiVersion.id
     })
 
-    val uniqueIds: Set[Int] = allIds.toSet
+    val uniqueIds: Predef.Set[Int] = allIds.toSet
 
     assertEquals(allIds.size, uniqueIds.size)
   }

--- a/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
@@ -45,6 +45,7 @@ abstract class BaseRequestTest extends IntegrationTestHarness {
   override def modifyConfigs(props: Seq[Properties]): Unit = {
     props.foreach { p =>
       p.put(KafkaConfig.ControlledShutdownEnableProp, "false")
+      p.put(KafkaConfig.EnableMetadataQuorumProp, "true")
       brokerPropertyOverrides(p)
     }
   }

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
@@ -134,10 +134,10 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
   }
 
   @Test
-  def testNotController(): Unit = {
+  def testNotControllerCouldForward(): Unit = {
     val req = topicsReq(Seq(topicReq("topic1")))
     val response = sendCreateTopicRequest(req, notControllerSocketServer)
-    assertEquals(1, response.errorCounts().get(Errors.NOT_CONTROLLER))
+    assertEquals(Map(Errors.NONE -> 1), response.errorCounts().asScala)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestTest.scala
@@ -134,7 +134,7 @@ class CreateTopicsRequestTest extends AbstractCreateTopicsRequestTest {
   }
 
   @Test
-  def testNotControllerCouldForward(): Unit = {
+  def testNotController(): Unit = {
     val req = topicsReq(Seq(topicReq("topic1")))
     val response = sendCreateTopicRequest(req, notControllerSocketServer)
     assertEquals(Map(Errors.NONE -> 1), response.errorCounts().asScala)

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.{Endpoint, Reconfigurable}
 import org.apache.kafka.common.acl.{AclBinding, AclBindingFilter}
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.config.{ConfigException, SslConfigs}
+import org.apache.kafka.common.network.{ListenerName, ListenerReconfigurable}
 import org.apache.kafka.server.authorizer._
 import org.easymock.EasyMock
 import org.junit.Assert._
@@ -34,7 +35,7 @@ import org.junit.Test
 import org.scalatest.Assertions.intercept
 
 import scala.jdk.CollectionConverters._
-import scala.collection.Set
+import scala.collection.{Set, mutable}
 
 class DynamicBrokerConfigTest {
 
@@ -216,7 +217,8 @@ class DynamicBrokerConfigTest {
 
     def updateConfig() = {
       if (perBrokerConfig)
-        config.dynamicConfig.updateBrokerConfig(0, config.dynamicConfig.toPersistentProps(props, perBrokerConfig))
+        config.dynamicConfig.updateBrokerConfig(0,
+          config.dynamicConfig.toPersistentProps(props, perBrokerConfig))
       else
         config.dynamicConfig.updateDefaultConfig(props)
     }
@@ -229,7 +231,7 @@ class DynamicBrokerConfigTest {
         config.dynamicConfig.validate(props, perBrokerConfig)
         fail("Invalid config did not fail validation")
       } catch {
-        case e: Exception => // expected exception
+        case _: Exception => // expected exception
       }
       updateConfig()
       assertEquals(oldValue, config.originals.get(name))
@@ -250,13 +252,13 @@ class DynamicBrokerConfigTest {
       config.dynamicConfig.validate(props, perBrokerConfig = true)
       fail("Invalid config did not fail validation")
     } catch {
-      case e: ConfigException => // expected exception
+      case _: ConfigException => // expected exception
     }
 
     // DynamicBrokerConfig#updateBrokerConfig is used to update configs from ZooKeeper during
     // startup and when configs are updated in ZK. Update should apply valid configs and ignore
     // invalid ones.
-    config.dynamicConfig.updateBrokerConfig(0, props)
+    config.dynamicConfig.updateBrokerConfig(0, config.dynamicConfig.fromPersistentProps(props, true))
     validProps.foreach { case (name, value) => assertEquals(value, config.originals.get(name)) }
     invalidProps.keySet.foreach { name =>
       assertEquals(origProps.get(name), config.originals.get(name))
@@ -390,15 +392,84 @@ class DynamicBrokerConfigTest {
     EasyMock.expect(zkClient.getEntityConfigs(EasyMock.anyString(), EasyMock.anyString())).andReturn(new java.util.Properties()).anyTimes()
     EasyMock.replay(zkClient)
 
-    val oldConfig =  KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092))
+    val oldConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092))
     val dynamicBrokerConfig = new DynamicBrokerConfig(oldConfig)
     dynamicBrokerConfig.initialize(zkClient)
     dynamicBrokerConfig.addBrokerReconfigurable(new TestDynamicThreadPool)
 
-    val newprops = new Properties()
-    newprops.put(KafkaConfig.NumIoThreadsProp, "10")
-    newprops.put(KafkaConfig.BackgroundThreadsProp, "100")
-    dynamicBrokerConfig.updateBrokerConfig(0, newprops)
+    val newProps = new Properties()
+    newProps.put(KafkaConfig.NumIoThreadsProp, "10")
+    newProps.put(KafkaConfig.BackgroundThreadsProp, "100")
+    dynamicBrokerConfig.updateBrokerConfig(0, newProps)
+  }
+
+  @Test
+  def testUpdateBrokerConfigCouldTrimSSLPaths(): Unit = {
+    val (dynamicBrokerConfig, listener) = setupListenerReconfigurables()
+
+    val props = new Properties()
+    props.put(listener.configPrefix +
+      SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "//path//to//key//store//")
+    props.put(listener.configPrefix +
+      SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "//path//to//trust//store//")
+
+    dynamicBrokerConfig.updateBrokerConfig(0, props, fromPersisted = true)
+
+    val expectedProps = new Properties()
+    expectedProps.put(listener.configPrefix +
+      SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/path/to/key/store/")
+    expectedProps.put(listener.configPrefix +
+      SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/path/to/trust/store/")
+
+    props.forEach((key, value) => {
+      assertEquals(expectedProps.get(key), value)
+    })
+  }
+
+  @Test
+  def testAugmentSSLPathsWithNoChange(): Unit = {
+    val (dynamicBrokerConfig, listener) = setupListenerReconfigurables()
+
+    val oldProps = new mutable.HashMap[String, String]
+    oldProps.put(listener.configPrefix +
+      SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/path/to/key/store/")
+    oldProps.put(listener.configPrefix +
+      SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/path/to/old/trust/store/")
+
+    // The key store path remains the same, so that the trim is only done on key store path
+    val newProps = new Properties()
+    newProps.put(listener.configPrefix +
+      SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "/path/to/key/store/")
+    newProps.put(listener.configPrefix +
+      SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/path/to/new/trust/store/")
+
+    dynamicBrokerConfig.maybeAugmentSslStorePaths(newProps, oldProps)
+
+    val expectedProps = new Properties()
+    expectedProps.put(listener.configPrefix +
+      SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, "//path//to//key//store//")
+    expectedProps.put(listener.configPrefix +
+      SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, "/path/to/new/trust/store/")
+
+    newProps.forEach((key, value) => {
+      assertEquals(expectedProps.get(key), value)
+    })
+  }
+
+  private def setupListenerReconfigurables(): (DynamicBrokerConfig, ListenerName) = {
+    val oldConfig = KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect, port = 9092))
+    val dynamicBrokerConfig = new DynamicBrokerConfig(oldConfig)
+    val listener = new ListenerName("listener")
+    val reconfigurable = new ListenerReconfigurable {
+      override def configure(configs: util.Map[String, _]): Unit = {}
+      override def reconfigurableConfigs(): util.Set[String] = Set(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+        SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG).asJava
+      override def validateReconfiguration(configs: util.Map[String, _]): Unit = {}
+      override def reconfigure(configs: util.Map[String, _]): Unit = {}
+      override def listenerName(): ListenerName = listener
+    }
+    dynamicBrokerConfig.addReconfigurable(reconfigurable)
+    (dynamicBrokerConfig, listener)
   }
 }
 


### PR DESCRIPTION
SSL trust store and key store paths update could no longer go through the direct per broker update due to forwarding. We need to add a mechanism to trigger the update through ZK notification.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
