### PR TITLE
KAFKA-10624: For FeatureZNodeStatus, use sealed trait instead of Enumeration

### DIFF
--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -798,12 +798,25 @@ object DelegationTokenInfoZNode {
  *             written by the controller to the FeatureZNode only when the broker IBP config
  *             is less than KAFKA_2_7_IV0.
  */
-object FeatureZNodeStatus extends Enumeration {
-  type FeatureZNodeStatus = Value
-  val Disabled, Enabled = Value
+sealed trait FeatureZNodeStatus {
+  def id: Int
+}
 
-  def withNameOpt(value: Int): Option[Value] = {
-    values.find(_.id == value)
+object FeatureZNodeStatus {
+  case object Disabled extends FeatureZNodeStatus {
+    val id: Int = 0
+  }
+
+  case object Enabled extends FeatureZNodeStatus {
+    val id: Int = 1
+  }
+
+  def withNameOpt(id: Int): Option[FeatureZNodeStatus] = {
+    id match {
+      case Disabled.id => Some(Disabled)
+      case Enabled.id => Some(Enabled)
+      case _ => Option.empty
+    }
   }
 }
 
@@ -813,7 +826,7 @@ object FeatureZNodeStatus extends Enumeration {
  * @param status     the status of the ZK node
  * @param features   the cluster-wide finalized features
  */
-case class FeatureZNode(status: FeatureZNodeStatus.FeatureZNodeStatus, features: Features[FinalizedVersionRange]) {
+case class FeatureZNode(status: FeatureZNodeStatus, features: Features[FinalizedVersionRange]) {
 }
 
 object FeatureZNode {

--- a/core/src/test/scala/kafka/zk/FeatureZNodeTest.scala
+++ b/core/src/test/scala/kafka/zk/FeatureZNodeTest.scala
@@ -75,7 +75,7 @@ class FeatureZNodeTest {
       classOf[IllegalArgumentException],
       () => FeatureZNode.decode(
         featureZNodeStrTemplate.format(FeatureZNode.V1 - 1, 1).getBytes(StandardCharsets.UTF_8)))
-    val invalidStatus = FeatureZNodeStatus.values.map(_.id).toList.max + 1
+    val invalidStatus = FeatureZNodeStatus.Enabled.id + 1
     assertThrows(
       classOf[IllegalArgumentException],
       () => FeatureZNode.decode(


### PR DESCRIPTION
This is a follow-up to initial KIP-584 development. In this PR, I've switched the `FeatureZNodeStatus` enum to be a sealed trait. In Scala, we prefer sealed traits over Enumeration since the former gives you exhaustiveness checking. With Scala enumeration, you don't get a warning if you add a new value that is not handled in a given pattern match.

**Test plan:**
Rely on existing tests.