### PR TITLE
MINOR: Fix param doc in FinalizedFeatureChangeListener.initOrThrow

### DIFF
--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -207,7 +207,7 @@ class FinalizedFeatureChangeListener(private val finalizedFeatureCache: Finalize
    * will exit eventually.
    *
    * @param waitOnceForCacheUpdateMs   # of milli seconds to wait for feature cache to be updated once.
-   *                                   If this parameter <= 0, no wait operation happens.
+   *                                   (should be > 0)
    *
    * @throws Exception if feature incompatibility check could not be finished in a timely manner
    */


### PR DESCRIPTION
Fixed the param doc in `FinalizedFeatureChangeListener.initOrThrow` method. The parameter `waitOnceForCacheUpdateMs` is expected to be > 0, but the doc was incorrect.