### PR TITLE
KAFKA-10667: add timeout for forwarding requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/RequestCompletionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/RequestCompletionHandler.java
@@ -23,5 +23,4 @@ package org.apache.kafka.clients;
 public interface RequestCompletionHandler {
 
     void onComplete(ClientResponse response);
-
 }

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -96,11 +96,11 @@ class AlterIsrManagerImpl(val controllerChannelManager: BrokerToControllerChanne
       }
     }
 
-    class AlterIsrResponseHandler extends BrokerToControllerRequestCompletionHandler {
+    class AlterIsrResponseHandler extends ControllerRequestCompletionHandler {
       override def onComplete(response: ClientResponse): Unit = {
         try {
           val body = response.responseBody().asInstanceOf[AlterIsrResponse]
-          handleAlterIsrResponse(body, message.brokerEpoch(), inflightAlterIsrItems)
+          handleAlterIsrResponse(body, message.brokerEpoch, inflightAlterIsrItems)
         } finally {
           clearInflightRequests()
         }
@@ -112,7 +112,8 @@ class AlterIsrManagerImpl(val controllerChannelManager: BrokerToControllerChanne
     }
 
     debug(s"Sending AlterIsr to controller $message")
-    // We will not timeout AlterISR request, instead letting it retry indefinitely.
+    // We will not timeout AlterISR request, instead letting it retry indefinitely
+    // until a response is received or the request is cancelled after receiving new LeaderAndIsr state.
     controllerChannelManager.sendRequest(new AlterIsrRequest.Builder(message),
       new AlterIsrResponseHandler, Long.MaxValue)
   }

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -88,20 +88,33 @@ class AlterIsrManagerImpl(val controllerChannelManager: BrokerToControllerChanne
 
   private def sendRequest(inflightAlterIsrItems: Seq[AlterIsrItem]): Unit = {
     val message = buildRequest(inflightAlterIsrItems)
-    def responseHandler(response: ClientResponse): Unit = {
-      try {
-        val body = response.responseBody().asInstanceOf[AlterIsrResponse]
-        handleAlterIsrResponse(body, message.brokerEpoch(), inflightAlterIsrItems)
-      } finally {
-        // Be sure to clear the in-flight flag to allow future AlterIsr requests
-        if (!inflightRequest.compareAndSet(true, false)) {
-          throw new IllegalStateException("AlterIsr response callback called when no requests were in flight")
+
+    def clearInflightRequests(): Unit = {
+      // Be sure to clear the in-flight flag to allow future AlterIsr requests
+      if (!inflightRequest.compareAndSet(true, false)) {
+        throw new IllegalStateException("AlterIsr response callback called when no requests were in flight")
+      }
+    }
+
+    class AlterIsrResponseHandler extends BrokerToControllerRequestCompletionHandler {
+      override def onComplete(response: ClientResponse): Unit = {
+        try {
+          val body = response.responseBody().asInstanceOf[AlterIsrResponse]
+          handleAlterIsrResponse(body, message.brokerEpoch(), inflightAlterIsrItems)
+        } finally {
+          clearInflightRequests()
         }
+      }
+
+      override def onTimeout(): Unit = {
+        warn(s"Encountered request when sending AlterIsr to the controller")
       }
     }
 
     debug(s"Sending AlterIsr to controller $message")
-    controllerChannelManager.sendRequest(new AlterIsrRequest.Builder(message), responseHandler)
+    // We will not timeout AlterISR request, instead letting it retry indefinitely.
+    controllerChannelManager.sendRequest(new AlterIsrRequest.Builder(message),
+      new AlterIsrResponseHandler, Long.MaxValue)
   }
 
   private def buildRequest(inflightAlterIsrItems: Seq[AlterIsrItem]): AlterIsrRequestData = {

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -107,7 +107,7 @@ class AlterIsrManagerImpl(val controllerChannelManager: BrokerToControllerChanne
       }
 
       override def onTimeout(): Unit = {
-        warn(s"Encountered request when sending AlterIsr to the controller")
+        throw new IllegalStateException("Encountered unexpected timeout when sending AlterIsr to the controller")
       }
     }
 

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManagerImpl.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManagerImpl.scala
@@ -35,8 +35,15 @@ import scala.jdk.CollectionConverters._
 
 trait BrokerToControllerChannelManager {
 
-  // The retry deadline will only be checked after receiving a response. This means that in the worst case,
-  // the total timeout would be twice of the configured timeout.
+  /**
+   * Send request to the controller.
+   *
+   * @param request         The request to be sent.
+   * @param callback        Request completion callback.
+   * @param retryDeadlineMs The retry deadline which will only be checked after receiving a response.
+   *                        This means that in the worst case, the total timeout would be twice of
+   *                        the configured timeout.
+   */
   def sendRequest(request: AbstractRequest.Builder[_ <: AbstractRequest],
                   callback: ControllerRequestCompletionHandler,
                   retryDeadlineMs: Long): Unit
@@ -140,7 +147,7 @@ abstract class ControllerRequestCompletionHandler extends RequestCompletionHandl
 
   /**
    * Fire when the request transmission time passes the caller defined deadline on the channel queue.
-   * This is different from the original request's timeout.
+   * It covers the total waiting time including retries which might be the result of individual request timeout.
    */
   def onTimeout(): Unit
 }

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -48,7 +48,7 @@ class ForwardingManager(channelManager: BrokerToControllerChannelManager,
       request.context.clientAddress.getAddress
     )
 
-    class ForwardingResponseHandler extends BrokerToControllerRequestCompletionHandler {
+    class ForwardingResponseHandler extends ControllerRequestCompletionHandler {
       override def onComplete(clientResponse: ClientResponse): Unit = {
         val envelopeResponse = clientResponse.responseBody.asInstanceOf[EnvelopeResponse]
         val envelopeError = envelopeResponse.error()

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -335,7 +335,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           forwardingChannelManager = new BrokerToControllerChannelManagerImpl(metadataCache, time, metrics,
             config, "forwardingChannel", threadNamePrefix)
           forwardingChannelManager.start()
-          forwardingManager = new ForwardingManager(forwardingChannelManager, config.requestTimeoutMs.longValue())
+          forwardingManager = new ForwardingManager(forwardingChannelManager, time, config.requestTimeoutMs.longValue())
         }
 
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -335,7 +335,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           forwardingChannelManager = new BrokerToControllerChannelManagerImpl(metadataCache, time, metrics,
             config, "forwardingChannel", threadNamePrefix)
           forwardingChannelManager.start()
-          forwardingManager = new ForwardingManager(forwardingChannelManager)
+          forwardingManager = new ForwardingManager(forwardingChannelManager, config.requestTimeoutMs.longValue())
         }
 
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -223,7 +223,7 @@ class BrokerToControllerRequestThreadTest {
         override def onTimeout(): Unit = {
           responseLatch.countDown()
         }
-      }, requestTimeout)
+      }, requestTimeout + time.milliseconds())
     requestQueue.put(queueItem)
 
     // initialize to the controller

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -23,14 +23,14 @@ import java.util.Collections
 import kafka.cluster.{Broker, EndPoint}
 import kafka.utils.TestUtils
 import org.apache.kafka.test.{TestUtils => ClientsTestUtils}
-import org.apache.kafka.clients.{ManualMetadataUpdater, Metadata, MockClient}
+import org.apache.kafka.clients.{ClientResponse, ManualMetadataUpdater, Metadata, MockClient}
 import org.apache.kafka.common.feature.Features
 import org.apache.kafka.common.feature.Features.emptySupportedFeatures
-import org.apache.kafka.common.utils.SystemTime
+import org.apache.kafka.common.utils.{MockTime, SystemTime}
 import org.apache.kafka.common.message.MetadataRequestData
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{AbstractRequest, MetadataRequest}
+import org.apache.kafka.common.requests.{AbstractRequest, MetadataRequest, MetadataResponse}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
@@ -65,10 +65,9 @@ class BrokerToControllerRequestThreadTest {
 
     val responseLatch = new CountDownLatch(1)
     val queueItem = BrokerToControllerQueueItem(
-      new MetadataRequest.Builder(new MetadataRequestData()), response => {
-        assertEquals(expectedResponse, response.responseBody())
-        responseLatch.countDown()
-      })
+      new MetadataRequest.Builder(new MetadataRequestData()),
+      new TestRequestCompletionHandler(expectedResponse, responseLatch),
+      Long.MaxValue)
     requestQueue.put(queueItem)
     // initialize to the controller
     testRequestThread.doWork()
@@ -110,10 +109,9 @@ class BrokerToControllerRequestThreadTest {
     val responseLatch = new CountDownLatch(1)
 
     val queueItem = BrokerToControllerQueueItem(
-      new MetadataRequest.Builder(new MetadataRequestData()), response => {
-        assertEquals(expectedResponse, response.responseBody())
-        responseLatch.countDown()
-      })
+      new MetadataRequest.Builder(new MetadataRequestData()),
+      new TestRequestCompletionHandler(expectedResponse, responseLatch),
+      Long.MaxValue)
     requestQueue.put(queueItem)
     mockClient.prepareResponse(expectedResponse)
     // initialize the thread with oldController
@@ -169,10 +167,9 @@ class BrokerToControllerRequestThreadTest {
     val responseLatch = new CountDownLatch(1)
     val queueItem = BrokerToControllerQueueItem(
       new MetadataRequest.Builder(new MetadataRequestData()
-        .setAllowAutoTopicCreation(true)), response => {
-        assertEquals(expectedResponse, response.responseBody())
-        responseLatch.countDown()
-      })
+        .setAllowAutoTopicCreation(true)),
+      new TestRequestCompletionHandler(expectedResponse, responseLatch),
+      Long.MaxValue)
     requestQueue.put(queueItem)
     // initialize to the controller
     testRequestThread.doWork()
@@ -189,5 +186,74 @@ class BrokerToControllerRequestThreadTest {
     testRequestThread.doWork()
 
     assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
+  }
+
+  @Test
+  def testRequestTimeout(): Unit = {
+    val time = new MockTime()
+    val config = new KafkaConfig(TestUtils.createBrokerConfig(1, "localhost:2181"))
+    val controllerId = 1
+
+    val metadata = mock(classOf[Metadata])
+    val mockClient = new MockClient(time, metadata)
+
+    val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
+    val metadataCache = mock(classOf[MetadataCache])
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val controller = new Broker(controllerId,
+      Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+
+    when(metadataCache.getControllerId).thenReturn(Some(controllerId))
+    when(metadataCache.getAliveBrokers).thenReturn(Seq(controller))
+    when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(controller))
+
+    val responseWithNotControllerError = ClientsTestUtils.metadataUpdateWith("cluster1", 2,
+      Collections.singletonMap("a", Errors.NOT_CONTROLLER),
+      Collections.singletonMap("a", new Integer(2)))
+    val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
+      config, listenerName, time, "")
+
+    val responseLatch = new CountDownLatch(1)
+    val requestTimeout = config.requestTimeoutMs.longValue()
+    val queueItem = BrokerToControllerQueueItem(
+      new MetadataRequest.Builder(new MetadataRequestData()
+        .setAllowAutoTopicCreation(true)), new BrokerToControllerRequestCompletionHandler {
+        override def onComplete(response: ClientResponse): Unit = {}
+
+        override def onTimeout(): Unit = {
+          responseLatch.countDown()
+        }
+      }, requestTimeout)
+    requestQueue.put(queueItem)
+
+    // initialize to the controller
+    testRequestThread.doWork()
+    // send and process the request
+    mockClient.prepareResponse((body: AbstractRequest) => {
+      // Advance time to timeout the response
+      time.sleep(requestTimeout + 1)
+
+      body.isInstanceOf[MetadataRequest] &&
+        body.asInstanceOf[MetadataRequest].allowAutoTopicCreation()
+    }, responseWithNotControllerError)
+
+    testRequestThread.doWork()
+
+    // The queued item should be timed out, instead of
+    // re-enqueue by NOT_CONTROLLER error.
+    assertEquals(0, requestQueue.size())
+
+    assertTrue(responseLatch.await(10, TimeUnit.SECONDS))
+  }
+
+  class TestRequestCompletionHandler(expectedResponse: MetadataResponse,
+                                     responseLatch: CountDownLatch) extends BrokerToControllerRequestCompletionHandler {
+    override def onComplete(response: ClientResponse): Unit = {
+      assertEquals(expectedResponse, response.responseBody())
+      responseLatch.countDown()
+    }
+
+    override def onTimeout(): Unit = {
+    }
   }
 }

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -217,7 +217,7 @@ class BrokerToControllerRequestThreadTest {
     val requestTimeout = config.requestTimeoutMs.longValue()
     val queueItem = BrokerToControllerQueueItem(
       new MetadataRequest.Builder(new MetadataRequestData()
-        .setAllowAutoTopicCreation(true)), new BrokerToControllerRequestCompletionHandler {
+        .setAllowAutoTopicCreation(true)), new ControllerRequestCompletionHandler {
         override def onComplete(response: ClientResponse): Unit = {}
 
         override def onTimeout(): Unit = {
@@ -247,7 +247,7 @@ class BrokerToControllerRequestThreadTest {
   }
 
   class TestRequestCompletionHandler(expectedResponse: MetadataResponse,
-                                     responseLatch: CountDownLatch) extends BrokerToControllerRequestCompletionHandler {
+                                     responseLatch: CountDownLatch) extends ControllerRequestCompletionHandler {
     override def onComplete(response: ClientResponse): Unit = {
       assertEquals(expectedResponse, response.responseBody())
       responseLatch.countDown()

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -21,9 +21,9 @@ import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 
 import kafka.api.LeaderAndIsr
-import kafka.server.{AlterIsrItem, AlterIsrManager, AlterIsrManagerImpl, BrokerToControllerChannelManager}
+import kafka.server.{AlterIsrItem, AlterIsrManager, AlterIsrManagerImpl, BrokerToControllerChannelManager, BrokerToControllerRequestCompletionHandler}
 import kafka.utils.{MockScheduler, MockTime}
-import org.apache.kafka.clients.{ClientResponse, RequestCompletionHandler}
+import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.AlterIsrResponseData
 import org.apache.kafka.common.metrics.Metrics
@@ -40,6 +40,7 @@ class AlterIsrManagerTest {
   val time = new MockTime
   val metrics = new Metrics
   val brokerId = 1
+  val requestTimeout = Long.MaxValue
 
   var brokerToController: BrokerToControllerChannelManager = _
 
@@ -54,7 +55,7 @@ class AlterIsrManagerTest {
 
   @Test
   def testBasic(): Unit = {
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.anyObject())).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -70,7 +71,7 @@ class AlterIsrManagerTest {
   @Test
   def testOverwriteWithinBatch(): Unit = {
     val capture = EasyMock.newCapture[AbstractRequest.Builder[AlterIsrRequest]]()
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject())).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject(), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -94,7 +95,7 @@ class AlterIsrManagerTest {
   @Test
   def testSingleBatch(): Unit = {
     val capture = EasyMock.newCapture[AbstractRequest.Builder[AlterIsrRequest]]()
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject())).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject(), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -146,9 +147,9 @@ class AlterIsrManagerTest {
   }
 
   def testTopLevelError(isrs: Seq[AlterIsrItem], error: Errors): AlterIsrManager = {
-    val callbackCapture = EasyMock.newCapture[RequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
 
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -179,9 +180,9 @@ class AlterIsrManagerTest {
   }
 
   def testPartitionError(tp: TopicPartition, error: Errors): AlterIsrManager = {
-    val callbackCapture = EasyMock.newCapture[RequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -221,9 +222,9 @@ class AlterIsrManagerTest {
 
   @Test
   def testOneInFlight(): Unit = {
-    val callbackCapture = EasyMock.newCapture[RequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -250,7 +251,7 @@ class AlterIsrManagerTest {
     callbackCapture.getValue.onComplete(resp)
 
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     time.sleep(100)
@@ -260,9 +261,9 @@ class AlterIsrManagerTest {
 
   @Test
   def testPartitionMissingInResponse(): Unit = {
-    val callbackCapture = EasyMock.newCapture[RequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -21,7 +21,7 @@ import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 
 import kafka.api.LeaderAndIsr
-import kafka.server.{AlterIsrItem, AlterIsrManager, AlterIsrManagerImpl, BrokerToControllerChannelManager, BrokerToControllerRequestCompletionHandler}
+import kafka.server.{AlterIsrItem, AlterIsrManager, AlterIsrManagerImpl, BrokerToControllerChannelManager, ControllerRequestCompletionHandler}
 import kafka.utils.{MockScheduler, MockTime}
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
@@ -147,7 +147,7 @@ class AlterIsrManagerTest {
   }
 
   def testTopLevelError(isrs: Seq[AlterIsrItem], error: Errors): AlterIsrManager = {
-    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
 
     EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
@@ -180,7 +180,7 @@ class AlterIsrManagerTest {
   }
 
   def testPartitionError(tp: TopicPartition, error: Errors): AlterIsrManager = {
-    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
     EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
@@ -222,7 +222,7 @@ class AlterIsrManagerTest {
 
   @Test
   def testOneInFlight(): Unit = {
-    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
     EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)
@@ -261,7 +261,7 @@ class AlterIsrManagerTest {
 
   @Test
   def testPartitionMissingInResponse(): Unit = {
-    val callbackCapture = EasyMock.newCapture[BrokerToControllerRequestCompletionHandler]()
+    val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
     EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
     EasyMock.replay(brokerToController)

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -46,7 +46,7 @@ class ForwardingManagerTest {
 
   @Test
   def testResponseCorrelationIdMismatch(): Unit = {
-    val forwardingManager = new ForwardingManager(brokerToController)
+    val forwardingManager = new ForwardingManager(brokerToController, Long.MaxValue)
     val requestCorrelationId = 27
     val envelopeCorrelationId = 39
     val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "client")
@@ -65,7 +65,8 @@ class ForwardingManagerTest {
 
     Mockito.when(brokerToController.sendRequest(
       any(classOf[EnvelopeRequest.Builder]),
-      any(classOf[RequestCompletionHandler])
+      any(classOf[BrokerToControllerRequestCompletionHandler]),
+      anyLong()
     )).thenAnswer(invocation => {
       val completionHandler = invocation.getArgument[RequestCompletionHandler](1)
       val response = buildEnvelopeResponse(responseBuffer, envelopeCorrelationId, completionHandler)

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -65,7 +65,7 @@ class ForwardingManagerTest {
 
     Mockito.when(brokerToController.sendRequest(
       any(classOf[EnvelopeRequest.Builder]),
-      any(classOf[BrokerToControllerRequestCompletionHandler]),
+      any(classOf[ControllerRequestCompletionHandler]),
       ArgumentMatchers.eq(Long.MaxValue)
     )).thenAnswer(invocation => {
       val completionHandler = invocation.getArgument[RequestCompletionHandler](1)

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -35,7 +35,7 @@ import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuild
 import org.junit.Assert._
 import org.junit.Test
 import org.mockito.ArgumentMatchers._
-import org.mockito.Mockito
+import org.mockito.{ArgumentMatchers, Mockito}
 
 import scala.jdk.CollectionConverters._
 
@@ -46,7 +46,7 @@ class ForwardingManagerTest {
 
   @Test
   def testResponseCorrelationIdMismatch(): Unit = {
-    val forwardingManager = new ForwardingManager(brokerToController, Long.MaxValue)
+    val forwardingManager = new ForwardingManager(brokerToController, time, Long.MaxValue)
     val requestCorrelationId = 27
     val envelopeCorrelationId = 39
     val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "client")
@@ -66,7 +66,7 @@ class ForwardingManagerTest {
     Mockito.when(brokerToController.sendRequest(
       any(classOf[EnvelopeRequest.Builder]),
       any(classOf[BrokerToControllerRequestCompletionHandler]),
-      anyLong()
+      ArgumentMatchers.eq(Long.MaxValue)
     )).thenAnswer(invocation => {
       val completionHandler = invocation.getArgument[RequestCompletionHandler](1)
       val response = buildEnvelopeResponse(responseBuffer, envelopeCorrelationId, completionHandler)


### PR DESCRIPTION
Right now the forwarding request will retry indefinitely, which is not the ideal behavior. We should timeout the enqueued request when it hits the request timeout.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
