### PR TITLE
MINOR: Always return partitions with diverging epochs in fetch response

### DIFF
--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -154,6 +154,10 @@ class CachedPartition(val topic: String,
         highWatermark = -1
       mustRespond = true
     }
+    if (respData.divergingEpoch.isPresent) {
+      // Partitions with diverging epoch are always included in response to trigger truncation.
+      mustRespond = true
+    }
     mustRespond
   }
 


### PR DESCRIPTION
This is required to ensure that followers can truncate based on diverging epochs returned in fetch responses.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
