### PR TITLE
KAFKA-9274: Handle TimeoutException on commit

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/TaskTimeoutExceptions.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/TaskTimeoutExceptions.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.streams.processor.internals.Task;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class TaskTimeoutExceptions extends StreamsException {
+    private static final long serialVersionUID = 1L;
+
+    private final TimeoutException timeoutException;
+    private final Map<Task, TimeoutException> exceptions;
+
+    public TaskTimeoutExceptions() {
+        super("");
+        timeoutException = null;
+        exceptions = new HashMap<>();
+    }
+
+    public TaskTimeoutExceptions(final TimeoutException timeoutException) {
+        super("");
+        this.timeoutException = timeoutException;
+        exceptions = null;
+    }
+
+    public void recordException(final Task task,
+                                final TimeoutException timeoutException) {
+        Objects.requireNonNull(exceptions)
+            .put(task, timeoutException);
+    }
+
+    public Map<Task, TimeoutException> exceptions() {
+        return exceptions;
+    }
+
+    public TimeoutException timeoutException() {
+        return timeoutException;
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -164,9 +164,9 @@ public class InternalTopicManager {
                                 "Error message was: {}", topicName, cause.toString());
                             throw new StreamsException(String.format("Could not create topic %s.", topicName), cause);
                         }
-                    } catch (final TimeoutException retryableException) {
+                    } catch (final TimeoutException retriableException) {
                         log.error("Creating topic {} timed out.\n" +
-                            "Error message was: {}", topicName, retryableException.toString());
+                            "Error message was: {}", topicName, retriableException.toString());
                     }
                 }
             }
@@ -234,10 +234,10 @@ public class InternalTopicManager {
                         "Error message was: {}", topicName, cause.toString());
                     throw new StreamsException(String.format("Could not create topic %s.", topicName), cause);
                 }
-            } catch (final TimeoutException retryableException) {
+            } catch (final TimeoutException retriableException) {
                 tempUnknownTopics.add(topicName);
                 log.debug("Describing topic {} (to get number of partitions) timed out.\n" +
-                    "Error message was: {}", topicName, retryableException.toString());
+                    "Error message was: {}", topicName, retriableException.toString());
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -817,13 +817,15 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                     .filter(e -> e.getValue() != null)
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             initializeTaskTime(offsetsAndMetadata);
-        } catch (final TimeoutException e) {
-            log.warn("Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop." +
-                            "\nConsider overwriting consumer config {} to a larger value to avoid timeout errors",
-                    e.toString(),
-                    ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
+        } catch (final TimeoutException timeoutException) {
+            log.warn(
+                "Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop." +
+                    "\nConsider overwriting consumer config {} to a larger value to avoid timeout errors",
+                time.toString(),
+                ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
 
-            throw e;
+            // re-throw to trigger `task.timeout.ms`
+            throw timeoutException;
         } catch (final KafkaException e) {
             throw new StreamsException(String.format("task [%s] Failed to initialize offsets for %s", id, inputPartitions()), e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -351,6 +351,7 @@ public class StreamThread extends Thread {
             log
         );
         final TaskManager taskManager = new TaskManager(
+            time,
             changelogReader,
             processId,
             logPrefix,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsProducer.java
@@ -151,7 +151,7 @@ public class StreamsProducer {
             try {
                 producer.initTransactions();
                 transactionInitialized = true;
-            } catch (final TimeoutException exception) {
+            } catch (final TimeoutException timeoutException) {
                 log.warn(
                     "Timeout exception caught trying to initialize transactions. " +
                         "The broker is either slow or in bad state (like not having enough replicas) in " +
@@ -162,7 +162,8 @@ public class StreamsProducer {
                     ProducerConfig.MAX_BLOCK_MS_CONFIG
                 );
 
-                throw exception;
+                // re-throw to trigger `task.timeout.ms`
+                throw timeoutException;
             } catch (final KafkaException exception) {
                 throw new StreamsException(
                     formatException("Error encountered trying to initialize transactions"),
@@ -249,9 +250,9 @@ public class StreamsProducer {
                 formatException("Producer got fenced trying to commit a transaction"),
                 error
             );
-        } catch (final TimeoutException error) {
-            // TODO KIP-447: we can consider treating it as non-fatal and retry on the thread level
-            throw new StreamsException(formatException("Timed out trying to commit a transaction"), error);
+        } catch (final TimeoutException timeoutException) {
+            // re-throw to trigger `task.timeout.ms`
+            throw timeoutException;
         } catch (final KafkaException error) {
             throw new StreamsException(
                 formatException("Error encountered trying to commit a transaction"),
@@ -263,13 +264,21 @@ public class StreamsProducer {
     /**
      * @throws IllegalStateException if EOS is disabled
      */
-    void abortTransaction() throws ProducerFencedException {
+    void abortTransaction() {
         if (!eosEnabled()) {
             throw new IllegalStateException(formatException("Exactly-once is not enabled"));
         }
         if (transactionInFlight) {
             try {
                 producer.abortTransaction();
+            } catch (final TimeoutException logAndSwallow) {
+                // no need to re-throw because we abort a TX only if we close a task dirty,
+                // and thus `task.timeout.ms` does not apply
+                log.warn(
+                    "Aborting transaction failed due to timeout." +
+                        " Will rely on broker to eventually abort the transaction after the transaction timeout passed.",
+                    logAndSwallow
+                );
             } catch (final ProducerFencedException error) {
                 // The producer is aborting the txn when there's still an ongoing one,
                 // which means that we did not commit the task while closing it, which

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsProducerTest.java
@@ -983,21 +983,6 @@ public class StreamsProducerTest {
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnEosCommitTxTimeout() {
-        // cannot use `eosMockProducer.fenceProducer()` because this would already trigger in `beginTransaction()`
-        eosAlphaMockProducer.commitTransactionException = new TimeoutException("KABOOM!");
-
-        final StreamsException thrown = assertThrows(
-            StreamsException.class,
-            () -> eosAlphaStreamsProducer.commitTransaction(offsetsAndMetadata, new ConsumerGroupMetadata("appId"))
-        );
-
-        assertThat(eosAlphaMockProducer.sentOffsets(), is(true));
-        assertThat(thrown.getCause(), is(eosAlphaMockProducer.commitTransactionException));
-        assertThat(thrown.getMessage(), is("Timed out trying to commit a transaction [test]"));
-    }
-
-    @Test
     public void shouldThrowStreamsExceptionOnEosCommitTxError() {
         eosAlphaMockProducer.commitTransactionException = new KafkaException("KABOOM!");
 


### PR DESCRIPTION
 - part of KIP-572
 - when KafkaStreams commit a task, a TimeoutException should not kill
   the thread but `task.timeout.ms` should be triggered and the commit
   should be retried in the next loop

Call for review @vvcephei 
