### PR TITLE
KAFKA-10691: AlterIsr Respond with wrong Error Id

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2261,7 +2261,7 @@ class KafkaController(val config: KafkaConfig,
     val brokerEpochOpt = controllerContext.liveBrokerIdAndEpochs.get(brokerId)
     if (brokerEpochOpt.isEmpty) {
       info(s"Ignoring AlterIsr due to unknown broker $brokerId")
-      callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+      callback.apply(Right(Errors.UNKNOWN_MEMBER_ID))
       return
     }
 


### PR DESCRIPTION
AlterIsr send by an unknown broker will respond with a STALE_BROKER_EPOCH, which should be UNKNOWN_MEMBER_ID.
