### PR TITLE
KAFKA-10693: Close quota managers created in tests

### DIFF
--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -65,9 +65,10 @@ class HighwatermarkPersistenceTest {
     scheduler.startup()
     val metrics = new Metrics
     val time = new MockTime
+    val quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, zkClient, scheduler,
-      logManagers.head, new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time, ""),
+      logManagers.head, new AtomicBoolean(false), quotaManager,
       new BrokerTopicStats, new MetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
     replicaManager.startup()
     try {
@@ -99,6 +100,7 @@ class HighwatermarkPersistenceTest {
     } finally {
       // shutdown the replica manager upon test completion
       replicaManager.shutdown(false)
+      quotaManager.shutdown()
       metrics.close()
       scheduler.shutdown()
     }
@@ -115,9 +117,10 @@ class HighwatermarkPersistenceTest {
     scheduler.startup()
     val metrics = new Metrics
     val time = new MockTime
+    val quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, zkClient,
-      scheduler, logManagers.head, new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time, ""),
+      scheduler, logManagers.head, new AtomicBoolean(false), quotaManager,
       new BrokerTopicStats, new MetadataCache(configs.head.brokerId), logDirFailureChannels.head, alterIsrManager)
     replicaManager.startup()
     try {
@@ -169,6 +172,7 @@ class HighwatermarkPersistenceTest {
     } finally {
       // shutdown the replica manager upon test completion
       replicaManager.shutdown(false)
+      quotaManager.shutdown()
       metrics.close()
       scheduler.shutdown()
     }

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -72,8 +72,8 @@ class IsrExpirationTest {
 
   @After
   def tearDown(): Unit = {
-    replicaManager.shutdown(false)
-    quotaManager.shutdown()
+    Option(replicaManager).foreach(_.shutdown(false))
+    Option(quotaManager).foreach(_.shutdown())
     metrics.close()
   }
 

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.cluster.Partition
 import kafka.log.{Log, LogManager}
+import kafka.server.QuotaFactory.QuotaManagers
 import kafka.utils.TestUtils.MockAlterIsrManager
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
@@ -51,6 +52,7 @@ class IsrExpirationTest {
   val time = new MockTime
   val metrics = new Metrics
 
+  var quotaManager: QuotaManagers = null
   var replicaManager: ReplicaManager = null
 
   var alterIsrManager: MockAlterIsrManager = _
@@ -62,14 +64,16 @@ class IsrExpirationTest {
     EasyMock.replay(logManager)
 
     alterIsrManager = TestUtils.createAlterIsrManager()
+    quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     replicaManager = new ReplicaManager(configs.head, metrics, time, null, null, logManager, new AtomicBoolean(false),
-      QuotaFactory.instantiate(configs.head, metrics, time, ""), new BrokerTopicStats, new MetadataCache(configs.head.brokerId),
+      quotaManager, new BrokerTopicStats, new MetadataCache(configs.head.brokerId),
       new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager)
   }
 
   @After
   def tearDown(): Unit = {
     replicaManager.shutdown(false)
+    quotaManager.shutdown()
     metrics.close()
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRec
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.easymock.EasyMock
 import EasyMock._
+import kafka.server.QuotaFactory.QuotaManagers
 import org.junit.Assert._
 import org.junit.{After, Test}
 
@@ -45,6 +46,7 @@ class ReplicaManagerQuotasTest {
   val fetchInfo = Seq(
     topicPartition1 -> new PartitionData(0, 0, 100, Optional.empty()),
     topicPartition2 -> new PartitionData(0, 0, 100, Optional.empty()))
+  var quotaManager: QuotaManagers = _
   var replicaManager: ReplicaManager = _
 
   @Test
@@ -240,8 +242,9 @@ class ReplicaManagerQuotasTest {
     val alterIsrManager: AlterIsrManager = createMock(classOf[AlterIsrManager])
 
     val leaderBrokerId = configs.head.brokerId
+    quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     replicaManager = new ReplicaManager(configs.head, metrics, time, zkClient, scheduler, logManager,
-      new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time, ""),
+      new AtomicBoolean(false), quotaManager,
       new BrokerTopicStats, new MetadataCache(leaderBrokerId), new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager)
 
     //create the two replicas
@@ -264,6 +267,8 @@ class ReplicaManagerQuotasTest {
   def tearDown(): Unit = {
     if (replicaManager != null)
       replicaManager.shutdown(false)
+    if (quotaManager != null)
+      quotaManager.shutdown()
     metrics.close()
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -265,10 +265,8 @@ class ReplicaManagerQuotasTest {
 
   @After
   def tearDown(): Unit = {
-    if (replicaManager != null)
-      replicaManager.shutdown(false)
-    if (quotaManager != null)
-      quotaManager.shutdown()
+    Option(replicaManager).foreach(_.shutdown(false))
+    Option(quotaManager).foreach(_.shutdown())
     metrics.close()
   }
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -90,7 +90,7 @@ class ReplicaManagerTest {
   @After
   def tearDown(): Unit = {
     TestUtils.clearYammerMetrics()
-    quotaManager.shutdown()
+    Option(quotaManager).foreach(_.shutdown())
     metrics.close()
   }
 
@@ -1894,10 +1894,10 @@ class ReplicaManagerTest {
 
     // each replica manager is for a broker
     val rm0 = new ReplicaManager(config0, metrics, time, kafkaZkClient, new MockScheduler(time), mockLogMgr0,
-      new AtomicBoolean(false), QuotaFactory.instantiate(config0, metrics, time, ""),
+      new AtomicBoolean(false), quotaManager,
       brokerTopicStats1, metadataCache0, new LogDirFailureChannel(config0.logDirs.size), alterIsrManager)
     val rm1 = new ReplicaManager(config1, metrics, time, kafkaZkClient, new MockScheduler(time), mockLogMgr1,
-      new AtomicBoolean(false), QuotaFactory.instantiate(config1, metrics, time, ""),
+      new AtomicBoolean(false), quotaManager,
       brokerTopicStats2, metadataCache1, new LogDirFailureChannel(config1.logDirs.size), alterIsrManager)
 
     (rm0, rm1)
@@ -2137,7 +2137,7 @@ class ReplicaManagerTest {
       val config = KafkaConfig.fromProps(props)
       val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
       new ReplicaManager(config, metrics, time, kafkaZkClient, new MockScheduler(time), mockLogMgr,
-        new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
+        new AtomicBoolean(false), quotaManager, new BrokerTopicStats,
         new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager) {
         override def getPartitionOrException(topicPartition: TopicPartition): Partition = {
           throw Errors.NOT_LEADER_OR_FOLLOWER.exception()

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -123,8 +123,8 @@ class OffsetsForLeaderEpochTest {
 
   @After
   def tearDown(): Unit = {
-    replicaManager.shutdown(checkpointHW = false)
-    quotaManager.shutdown()
+    Option(replicaManager).foreach(_.shutdown(checkpointHW = false))
+    Option(quotaManager).foreach(_.shutdown())
     metrics.close()
   }
 }

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -21,6 +21,7 @@ import java.util.Optional
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.log.{Log, LogManager}
+import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server._
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.TopicPartition
@@ -30,7 +31,7 @@ import org.apache.kafka.common.requests.{EpochEndOffset, OffsetsForLeaderEpochRe
 import org.apache.kafka.common.requests.EpochEndOffset._
 import org.easymock.EasyMock._
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{After, Before, Test}
 
 class OffsetsForLeaderEpochTest {
   private val config = TestUtils.createBrokerConfigs(1, TestUtils.MockZkConnect).map(KafkaConfig.fromProps).head
@@ -38,6 +39,13 @@ class OffsetsForLeaderEpochTest {
   private val metrics = new Metrics
   private val alterIsrManager = TestUtils.createAlterIsrManager()
   private val tp = new TopicPartition("topic", 1)
+  private var replicaManager: ReplicaManager = _
+  private var quotaManager: QuotaManagers = _
+
+  @Before
+  def setUp(): Unit = {
+    quotaManager = QuotaFactory.instantiate(config, metrics, time, "")
+  }
 
   @Test
   def shouldGetEpochsFromReplica(): Unit = {
@@ -54,8 +62,8 @@ class OffsetsForLeaderEpochTest {
     replay(mockLog, logManager)
 
     // create a replica manager with 1 partition that has 1 replica
-    val replicaManager = new ReplicaManager(config, metrics, time, null, null, logManager, new AtomicBoolean(false),
-      QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
+    replicaManager = new ReplicaManager(config, metrics, time, null, null, logManager, new AtomicBoolean(false),
+      quotaManager, new BrokerTopicStats,
       new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
     val partition = replicaManager.createPartition(tp)
     partition.setLog(mockLog, isFutureLog = false)
@@ -75,8 +83,8 @@ class OffsetsForLeaderEpochTest {
     replay(logManager)
 
     //create a replica manager with 1 partition that has 0 replica
-    val replicaManager = new ReplicaManager(config, metrics, time, null, null, logManager, new AtomicBoolean(false),
-      QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
+    replicaManager = new ReplicaManager(config, metrics, time, null, null, logManager, new AtomicBoolean(false),
+      quotaManager, new BrokerTopicStats,
       new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
     replicaManager.createPartition(tp)
 
@@ -98,8 +106,8 @@ class OffsetsForLeaderEpochTest {
     replay(logManager)
 
     //create a replica manager with 0 partition
-    val replicaManager = new ReplicaManager(config, metrics, time, null, null, logManager, new AtomicBoolean(false),
-      QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
+    replicaManager = new ReplicaManager(config, metrics, time, null, null, logManager, new AtomicBoolean(false),
+      quotaManager, new BrokerTopicStats,
       new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), alterIsrManager)
 
     //Given
@@ -111,5 +119,12 @@ class OffsetsForLeaderEpochTest {
 
     //Then
     assertEquals(new EpochEndOffset(Errors.UNKNOWN_TOPIC_OR_PARTITION, UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET), response(tp))
+  }
+
+  @After
+  def tearDown(): Unit = {
+    replicaManager.shutdown(checkpointHW = false)
+    quotaManager.shutdown()
+    metrics.close()
   }
 }


### PR DESCRIPTION
We have various tests that call `QuotaFactory.instantiate()`, but don't close the returned `QuotaManagers`. This results in dangling threads from `ClientQuotaManager` and friends in test runs.

After these changes, I ran the unit tests locally and they passed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
