### PR TITLE
KAFKA-9837: KIP-589 new RPC for notifying controller log dir failure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/UnknownReplicaStateException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnknownReplicaStateException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class UnknownReplicaStateException extends ApiException {
+    public UnknownReplicaStateException(String message) {
+        super(message);
+    }
+
+    public UnknownReplicaStateException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -108,7 +108,8 @@ public enum ApiKeys {
     UNREGISTER_BROKER(ApiMessageType.UNREGISTER_BROKER, false, RecordBatch.MAGIC_VALUE_V0, true),
     DESCRIBE_TRANSACTIONS(ApiMessageType.DESCRIBE_TRANSACTIONS),
     LIST_TRANSACTIONS(ApiMessageType.LIST_TRANSACTIONS),
-    ALLOCATE_PRODUCER_IDS(ApiMessageType.ALLOCATE_PRODUCER_IDS, true, true);
+    ALLOCATE_PRODUCER_IDS(ApiMessageType.ALLOCATE_PRODUCER_IDS, true, true),
+    ALTER_REPLICA_STATE(ApiMessageType.ALTER_REPLICA_STATE, true);
 
     private static final Map<ApiMessageType.ListenerType, EnumSet<ApiKeys>> APIS_BY_LISTENER =
         new EnumMap<>(ApiMessageType.ListenerType.class);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -116,6 +116,7 @@ import org.apache.kafka.common.errors.UnacceptableCredentialException;
 import org.apache.kafka.common.errors.UnknownLeaderEpochException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.errors.UnknownProducerIdException;
+import org.apache.kafka.common.errors.UnknownReplicaStateException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
@@ -364,7 +365,8 @@ public enum Errors {
     INCONSISTENT_TOPIC_ID(103, "The log's topic ID did not match the topic ID in the request", InconsistentTopicIdException::new),
     INCONSISTENT_CLUSTER_ID(104, "The clusterId in the request does not match that found on the server", InconsistentClusterIdException::new),
     TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found", TransactionalIdNotFoundException::new),
-    FETCH_SESSION_TOPIC_ID_ERROR(106, "The fetch session encountered inconsistent topic ID usage", FetchSessionTopicIdException::new);
+    FETCH_SESSION_TOPIC_ID_ERROR(106, "The fetch session encountered inconsistent topic ID usage", FetchSessionTopicIdException::new),
+    UNKNOWN_REPLICA_STATE(107, "Replica state change only support OfflineState, see ReplicaState.state ", UnknownReplicaStateException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -366,7 +366,10 @@ public enum Errors {
     INCONSISTENT_CLUSTER_ID(104, "The clusterId in the request does not match that found on the server", InconsistentClusterIdException::new),
     TRANSACTIONAL_ID_NOT_FOUND(105, "The transactionalId could not be found", TransactionalIdNotFoundException::new),
     FETCH_SESSION_TOPIC_ID_ERROR(106, "The fetch session encountered inconsistent topic ID usage", FetchSessionTopicIdException::new),
-    UNKNOWN_REPLICA_STATE(107, "Replica state change only support OfflineState, see ReplicaState.state ", UnknownReplicaStateException::new);
+    UNKNOWN_REPLICA_STATE(
+        107,
+        "Replica state change only supports OfflineState, see AlterReplicaStateRequest.OFFLINE_REPLICA_STATE",
+         UnknownReplicaStateException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -303,6 +303,8 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
                 return ListTransactionsRequest.parse(buffer, apiVersion);
             case ALLOCATE_PRODUCER_IDS:
                 return AllocateProducerIdsRequest.parse(buffer, apiVersion);
+            case ALTER_REPLICA_STATE:
+                return AlterReplicaStateRequest.parse(buffer, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -247,6 +247,8 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
                 return ListTransactionsResponse.parse(responseBuffer, version);
             case ALLOCATE_PRODUCER_IDS:
                 return AllocateProducerIdsResponse.parse(responseBuffer, version);
+            case ALTER_REPLICA_STATE:
+                return AlterReplicaStateResponse.parse(responseBuffer, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaStateRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaStateRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AlterReplicaStateRequestData;
+import org.apache.kafka.common.message.AlterReplicaStateResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+
+
+public class AlterReplicaStateRequest extends AbstractRequest {
+
+    public static final byte OFFLINE_REPLICA_STATE = (byte) 1;
+
+    private final AlterReplicaStateRequestData data;
+
+    public AlterReplicaStateRequest(AlterReplicaStateRequestData data, short apiVersion) {
+        super(ApiKeys.ALTER_REPLICA_STATE, apiVersion);
+        this.data = data;
+    }
+
+    public AlterReplicaStateRequestData data() {
+        return data;
+    }
+
+    public static AlterReplicaStateRequest parse(ByteBuffer buffer, short version) {
+        return new AlterReplicaStateRequest(new AlterReplicaStateRequestData(new ByteBufferAccessor(buffer), version), version);
+    }
+
+    /**
+     * Get an error response for a request with specified throttle time in the response if applicable
+     */
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        return new AlterReplicaStateResponse(new AlterReplicaStateResponseData()
+                .setThrottleTimeMs(throttleTimeMs)
+                .setErrorCode(Errors.forException(e).code()));
+    }
+
+    public static class Builder extends AbstractRequest.Builder<AlterReplicaStateRequest> {
+
+        private final AlterReplicaStateRequestData data;
+
+        public Builder(AlterReplicaStateRequestData data) {
+            super(ApiKeys.ALTER_REPLICA_STATE);
+            this.data = data;
+        }
+
+        @Override
+        public AlterReplicaStateRequest build(short version) {
+            return new AlterReplicaStateRequest(data, version);
+        }
+
+        @Override
+        public String toString() {
+            return data.toString();
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaStateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterReplicaStateResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AlterReplicaStateResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AlterReplicaStateResponse extends AbstractResponse {
+    private final AlterReplicaStateResponseData data;
+
+    public AlterReplicaStateResponse(AlterReplicaStateResponseData data) {
+        super(ApiKeys.ALTER_REPLICA_STATE);
+        this.data = data;
+    }
+
+    public AlterReplicaStateResponseData data() {
+        return data;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> counts = new HashMap<>();
+        updateErrorCounts(counts, Errors.forCode(data.errorCode()));
+        data.topics().forEach(topicResponse -> topicResponse.partitions().forEach(partitionResponse -> {
+            updateErrorCounts(counts, Errors.forCode(partitionResponse.errorCode()));
+        }));
+        return counts;
+    }
+
+    public static AlterReplicaStateResponse parse(ByteBuffer buffer, short version) {
+        return new AlterReplicaStateResponse(new AlterReplicaStateResponseData(new ByteBufferAccessor(buffer), version));
+    }
+
+    @Override
+    public int throttleTimeMs() {
+        return data.throttleTimeMs();
+    }
+}

--- a/clients/src/main/resources/common/message/AlterReplicaStateRequest.json
+++ b/clients/src/main/resources/common/message/AlterReplicaStateRequest.json
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implie
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 68,
+  "type": "request",
+  "listeners": ["zkBroker", "controller"],
+  "name": "AlterReplicaStateRequest",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
+      "about": "The ID of the requesting broker" },
+    { "name": "BrokerEpoch", "type": "int64", "versions": "0+", "default": "-1",
+      "about": "The epoch of the requesting broker" },
+    { "name": "NewState", "type": "int8", "versions": "0+", "default": "-1",
+      "about": "new state of the replica, value 0x1 represent offline" },
+    { "name": "Reason", "type": "string", "versions": "0+", "default": "",
+      "about": "description of why the event is being sent" },
+    { "name": "Topics", "type": "[]TopicData", "versions": "0+", "fields": [
+      { "name":  "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The name of the topic to change state" },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index" }
+      ]}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/AlterReplicaStateResponse.json
+++ b/clients/src/main/resources/common/message/AlterReplicaStateResponse.json
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 68,
+  "type": "response",
+  "name": "AlterReplicaStateResponse",
+  "validVersions": "0",
+  "flexibleVersions": "0+",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ErrorCode", "type": "int16", "versions": "0+",
+      "about": "The top level response error code" },
+    { "name": "Topics", "type": "[]TopicData", "versions": "0+", "fields": [
+      { "name":  "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The name of the topic" },
+      { "name": "Partitions", "type": "[]PartitionData", "versions": "0+", "fields": [
+        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+          "about": "The partition index" },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The partition level error code" }
+      ]}
+    ]}
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -48,6 +48,11 @@ public class ApiKeysTest {
         assertTrue(ApiKeys.ALTER_ISR.clusterAction);
     }
 
+    @Test
+    public void testAlterReplicaStateIsClusterAction() {
+        assertTrue(ApiKeys.ALTER_REPLICA_STATE.clusterAction);
+    }
+
     /**
      * All valid client responses which may be throttled should have a field named
      * 'throttle_time_ms' to return the throttle time to the client. Exclusions are
@@ -62,7 +67,7 @@ public class ApiKeysTest {
     public void testResponseThrottleTime() {
         Set<ApiKeys> authenticationKeys = EnumSet.of(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_AUTHENTICATE);
         // Newer protocol apis include throttle time ms even for cluster actions
-        Set<ApiKeys> clusterActionsWithThrottleTimeMs = EnumSet.of(ApiKeys.ALTER_ISR, ApiKeys.ALLOCATE_PRODUCER_IDS);
+        Set<ApiKeys> clusterActionsWithThrottleTimeMs = EnumSet.of(ApiKeys.ALTER_ISR, ApiKeys.ALLOCATE_PRODUCER_IDS, ApiKeys.ALTER_REPLICA_STATE);
         for (ApiKeys apiKey: ApiKeys.zkBrokerApis()) {
             Schema responseSchema = apiKey.messageType.responseSchemas()[apiKey.latestVersion()];
             BoundField throttleTimeField = responseSchema.get("throttle_time_ms");

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -49,6 +49,8 @@ import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData;
 import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData.AlterReplicaLogDirTopic;
 import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData.AlterReplicaLogDirTopicCollection;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData;
+import org.apache.kafka.common.message.AlterReplicaStateRequestData;
+import org.apache.kafka.common.message.AlterReplicaStateResponseData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.ApiMessageType;
@@ -1040,6 +1042,7 @@ public class RequestResponseTest {
             case DESCRIBE_TRANSACTIONS: return createDescribeTransactionsRequest(version);
             case LIST_TRANSACTIONS: return createListTransactionsRequest(version);
             case ALLOCATE_PRODUCER_IDS: return createAllocateProducerIdsRequest(version);
+            case ALTER_REPLICA_STATE: return createAlterReplicaStateRequest(version);
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -1114,6 +1117,7 @@ public class RequestResponseTest {
             case DESCRIBE_TRANSACTIONS: return createDescribeTransactionsResponse();
             case LIST_TRANSACTIONS: return createListTransactionsResponse();
             case ALLOCATE_PRODUCER_IDS: return createAllocateProducerIdsResponse();
+            case ALTER_REPLICA_STATE: return createAlterReplicaStateResponse();
             default: throw new IllegalArgumentException("Unknown API key " + apikey);
         }
     }
@@ -3338,6 +3342,38 @@ public class RequestResponseTest {
                 .setTransactionState("PrepareAbort")
         ));
         return new ListTransactionsResponse(response);
+    }
+
+    private AlterReplicaStateRequest createAlterReplicaStateRequest(short version) {
+        AlterReplicaStateRequestData data = new AlterReplicaStateRequestData()
+                .setBrokerEpoch(123L)
+                .setBrokerId(1)
+                .setNewState(AlterReplicaStateRequest.OFFLINE_REPLICA_STATE)
+                .setReason("unitTest")
+                .setTopics(singletonList(
+                        new AlterReplicaStateRequestData.TopicData()
+                                .setName("topic1")
+                                .setPartitions(singletonList(
+                                        new AlterReplicaStateRequestData.PartitionData()
+                                                .setPartitionIndex(1)
+                                ))));
+        return new AlterReplicaStateRequest.Builder(data).build(version);
+    }
+
+    private AlterReplicaStateResponse createAlterReplicaStateResponse() {
+        AlterReplicaStateResponseData data = new AlterReplicaStateResponseData()
+                .setErrorCode(Errors.NONE.code())
+                .setThrottleTimeMs(123)
+                .setTopics(singletonList(
+                        new AlterReplicaStateResponseData.TopicData()
+                                .setName("topic1")
+                                .setPartitions(singletonList(
+                                        new AlterReplicaStateResponseData.PartitionData()
+                                                .setPartitionIndex(1)
+                                                .setErrorCode(Errors.NONE.code())
+                                ))
+                ));
+        return new AlterReplicaStateResponse(data);
     }
 
 }

--- a/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
+++ b/core/src/main/java/kafka/server/builders/ReplicaManagerBuilder.java
@@ -26,6 +26,7 @@ import kafka.server.DelayedFetch;
 import kafka.server.DelayedOperationPurgatory;
 import kafka.server.DelayedProduce;
 import kafka.server.KafkaConfig;
+import kafka.server.LogDirEventManager;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory.QuotaManagers;
@@ -51,6 +52,7 @@ public class ReplicaManagerBuilder {
     private MetadataCache metadataCache = null;
     private LogDirFailureChannel logDirFailureChannel = null;
     private AlterIsrManager alterIsrManager = null;
+    private LogDirEventManager logDirEventManager = null;
     private BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
     private AtomicBoolean isShuttingDown = new AtomicBoolean(false);
     private Optional<KafkaZkClient> zkClient = Optional.empty();
@@ -145,6 +147,11 @@ public class ReplicaManagerBuilder {
         return this;
     }
 
+    public ReplicaManagerBuilder setLogDirEventManager(LogDirEventManager logDirEventManager) {
+        this.logDirEventManager = logDirEventManager;
+        return this;
+    }
+
     public ReplicaManager build() {
         if (config == null) config = new KafkaConfig(Collections.emptyMap());
         if (metrics == null) metrics = new Metrics();
@@ -168,6 +175,7 @@ public class ReplicaManagerBuilder {
                              OptionConverters.toScala(delayedFetchPurgatory),
                              OptionConverters.toScala(delayedDeleteRecordsPurgatory),
                              OptionConverters.toScala(delayedElectLeaderPurgatory),
-                             OptionConverters.toScala(threadNamePrefix));
+                             OptionConverters.toScala(threadNamePrefix),
+                             logDirEventManager);
     }
 }

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -206,9 +206,12 @@ sealed trait ApiVersion extends Ordered[ApiVersion] {
 
   def isAlterIsrSupported: Boolean = this >= KAFKA_2_7_IV2
 
+  def isAllocateProducerIdsSupported: Boolean = this >= KAFKA_3_0_IV0
+
   def isAlterReplicaStateSupported: Boolean = this >= KAFKA_3_1_IV1
 
-  def isAllocateProducerIdsSupported: Boolean = this >= KAFKA_3_0_IV0
+  // to be enabled after KAFKA-13005
+  def isKRaftAlterReplicaStateSupported: Boolean = false
 
   override def compare(that: ApiVersion): Int =
     ApiVersion.orderingByVersion.compare(this, that)

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -119,7 +119,9 @@ object ApiVersion {
     // Assume message format version is 3.0 (KIP-724)
     KAFKA_3_0_IV1,
     // Adds topic IDs to Fetch requests/responses (KIP-516)
-    KAFKA_3_1_IV0
+    KAFKA_3_1_IV0,
+    // Introduced AlterReplicaState (KIP-589)
+    KAFKA_3_1_IV1
   )
 
   // Map keys are the union of the short and full versions
@@ -203,6 +205,8 @@ sealed trait ApiVersion extends Ordered[ApiVersion] {
   def id: Int
 
   def isAlterIsrSupported: Boolean = this >= KAFKA_2_7_IV2
+
+  def isAlterReplicaStateSupported: Boolean = this >= KAFKA_3_1_IV1
 
   def isAllocateProducerIdsSupported: Boolean = this >= KAFKA_3_0_IV0
 
@@ -475,6 +479,13 @@ case object KAFKA_3_1_IV0 extends DefaultApiVersion {
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
   val id: Int = 35
+}
+
+case object KAFKA_3_1_IV1 extends DefaultApiVersion {
+  val shortVersion: String = "3.1"
+  val subVersion = "IV1"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 36
 }
 
 object ApiVersionValidator extends Validator {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -21,36 +21,35 @@ import java.util.concurrent.TimeUnit
 import kafka.admin.AdminOperationException
 import kafka.api._
 import kafka.common._
-import kafka.controller.KafkaController.AlterIsrCallback
-import kafka.cluster.Broker
-import kafka.controller.KafkaController.{AlterReassignmentsCallback, ElectLeadersCallback, ListReassignmentsCallback, UpdateFeaturesCallback}
+import kafka.controller.KafkaController.{AlterIsrCallback, AlterReassignmentsCallback, ElectLeadersCallback, ListReassignmentsCallback, LogDirChangeCallback, UpdateFeaturesCallback}
+import kafka.controller.{ReplicaState => CReplicaState}
 import kafka.coordinator.transaction.ZkProducerIdManager
+import kafka.cluster.Broker
 import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
 import kafka.server._
-import kafka.utils._
 import kafka.utils.Implicits._
+import kafka.utils._
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicZNode.TopicIdReplicaAssignment
 import kafka.zk.{FeatureZNodeStatus, _}
 import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler, ZNodeChildChangeHandler}
-import org.apache.kafka.common.ElectionType
-import org.apache.kafka.common.KafkaException
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{ElectionType, KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, StaleBrokerEpochException}
-import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, AllocateProducerIdsResponseData, AlterIsrRequestData, AlterIsrResponseData, UpdateFeaturesRequestData}
 import org.apache.kafka.common.feature.{Features, FinalizedVersionRange}
+import org.apache.kafka.common.message.{AllocateProducerIdsRequestData, AllocateProducerIdsResponseData, AlterIsrRequestData, AlterIsrResponseData, AlterReplicaStateResponseData, UpdateFeaturesRequestData}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.{AbstractControlRequest, ApiError, LeaderAndIsrResponse, UpdateFeaturesRequest, UpdateMetadataResponse}
+import org.apache.kafka.common.requests.{AbstractControlRequest, AlterReplicaStateRequest, ApiError, LeaderAndIsrResponse, UpdateFeaturesRequest, UpdateMetadataResponse}
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.server.common.ProducerIdsBlock
 import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.Code
 
-import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.{Map, Seq, Set, immutable, mutable}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
+
 
 sealed trait ElectionTrigger
 final case object AutoTriggered extends ElectionTrigger
@@ -66,6 +65,7 @@ object KafkaController extends Logging {
   type AlterReassignmentsCallback = Either[Map[TopicPartition, ApiError], ApiError] => Unit
   type AlterIsrCallback = Either[Map[TopicPartition, Either[Errors, LeaderAndIsr]], Errors] => Unit
   type UpdateFeaturesCallback = Either[ApiError, Map[String, ApiError]] => Unit
+  type LogDirChangeCallback = Either[Map[TopicPartition, Either[Errors, CReplicaState]], Errors] => Unit
 }
 
 class KafkaController(val config: KafkaConfig,
@@ -2443,6 +2443,117 @@ class KafkaController(val config: KafkaConfig,
     }
   }
 
+  def alterReplicaState(alterReplicaStateRequest: AlterReplicaStateRequest,
+                        callback: AlterReplicaStateResponseData => Unit): Unit = {
+    val alterReplicaStateRequestDataData = alterReplicaStateRequest.data()
+    val newState = alterReplicaStateRequestDataData.newState()
+    val reason = alterReplicaStateRequestDataData.reason()
+    val replicasToAlterState = mutable.Set[TopicPartition]()
+    alterReplicaStateRequestDataData.topics.forEach { topicReq =>
+      topicReq.partitions.forEach { partitionReq =>
+        val tp = new TopicPartition(topicReq.name, partitionReq.partitionIndex)
+        replicasToAlterState.add(tp)
+      }
+    }
+
+    def responseCallback(results: Either[Map[TopicPartition, Either[Errors, CReplicaState]], Errors]): Unit = {
+      val resp = new AlterReplicaStateResponseData()
+      results match {
+        case Right(error) =>
+          resp.setErrorCode(error.code)
+        case Left(partitionResults) =>
+          resp.setTopics(new util.ArrayList())
+          partitionResults
+            .groupBy { case (tp, _) => tp.topic }   // Group by topic
+            .foreach { case (topic, partitions) =>
+
+              val topicResp = new AlterReplicaStateResponseData.TopicData()
+                .setName(topic)
+                .setPartitions(new util.ArrayList())
+              resp.topics.add(topicResp)
+              partitions.foreach { case (tp, errorOrPartition) =>
+                // Add each partition part to the response (partition or error)
+                errorOrPartition match {
+                  case Left(error) => topicResp.partitions.add(
+                    new AlterReplicaStateResponseData.PartitionData()
+                      .setPartitionIndex(tp.partition)
+                      .setErrorCode(error.code))
+                  case Right(_) => topicResp.partitions.add(
+                    new AlterReplicaStateResponseData.PartitionData()
+                      .setPartitionIndex(tp.partition))
+                }
+              }
+            }
+      }
+      callback.apply(resp)
+    }
+
+    eventManager.put(AlterReplicaStateReceived(alterReplicaStateRequestDataData.brokerId,
+      alterReplicaStateRequestDataData.brokerEpoch, replicasToAlterState, newState, reason, responseCallback))
+  }
+
+  def processAlterReplicaState(brokerId: Int, brokerEpoch: Long,
+                               topicPartitionsToAlterState: Set[TopicPartition], newStateByte: Byte, reason: String,
+                               callback: LogDirChangeCallback): Unit = {
+    if (!isActive) {
+      callback.apply(Right(Errors.NOT_CONTROLLER))
+      return
+    }
+
+    val newState = newStateByte match {
+      case AlterReplicaStateRequest.OFFLINE_REPLICA_STATE => OfflineReplica
+      case _ =>
+        callback.apply(Right(Errors.UNKNOWN_REPLICA_STATE))
+        info(s"Ignoring AlterReplicaState due to unknown replica state $newStateByte")
+        return
+    }
+
+    val brokerEpochOpt = controllerContext.liveBrokerIdAndEpochs.get(brokerId)
+    if (brokerEpochOpt.isEmpty) {
+      info(s"Ignoring AlterReplicaState due to unknown broker $brokerId")
+      callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+      return
+    }
+
+    if (!brokerEpochOpt.contains(brokerEpoch)) {
+      info(s"Ignoring AlterReplicaState due to stale broker epoch $brokerEpoch for broker $brokerId")
+      callback.apply(Right(Errors.STALE_BROKER_EPOCH))
+      return
+    }
+
+    val response = try {
+      val partitionResponses = mutable.HashMap[TopicPartition, Either[Errors, CReplicaState]]()
+
+      debug(s"Updating Replica State for partitions: $topicPartitionsToAlterState to $newState on broker: $brokerId due to $reason.")
+
+      val replicasToAlterState = topicPartitionsToAlterState.flatMap { tp =>
+        val replicaToAlterState = PartitionAndReplica(new TopicPartition(tp.topic, tp.partition), brokerId)
+        controllerContext.replicaStates.get(replicaToAlterState) match {
+          case Some(replicaState) =>
+            partitionResponses(tp) = Right(newState)
+            // If a replica is already in the desired state, just return it
+            if (replicaState == newState) {
+              None
+            } else {
+              Some(replicaToAlterState)
+            }
+
+          case None =>
+            partitionResponses(tp) = Left(Errors.UNKNOWN_TOPIC_OR_PARTITION)
+            None
+        }
+      }
+
+      replicaStateMachine.handleStateChanges(replicasToAlterState.toSeq, OfflineReplica)
+      Left(partitionResponses)
+    } catch {
+      case e: Throwable =>
+        error(s"Error when processing AlterReplicaState for partitions: ${topicPartitionsToAlterState.toSeq}", e)
+        Right(Errors.UNKNOWN_SERVER_ERROR)
+    }
+    callback(response)
+  }
+
   private def processControllerChange(): Unit = {
     maybeResign()
   }
@@ -2523,6 +2634,8 @@ class KafkaController(val config: KafkaConfig,
           processAlterIsr(brokerId, brokerEpoch, isrsToAlter, callback)
         case AllocateProducerIds(brokerId, brokerEpoch, callback) =>
           processAllocateProducerIds(brokerId, brokerEpoch, callback)
+        case AlterReplicaStateReceived(brokerId, brokerEpoch, replicasToAlterState, newState, reason, responseCallback) =>
+          processAlterReplicaState(brokerId, brokerEpoch, replicasToAlterState, newState, reason, responseCallback)
         case Startup =>
           processStartup()
       }
@@ -2784,6 +2897,13 @@ case object IsrChangeNotification extends ControllerEvent {
 case class AlterIsrReceived(brokerId: Int, brokerEpoch: Long, isrsToAlter: Map[TopicPartition, LeaderAndIsr],
                             callback: AlterIsrCallback) extends ControllerEvent {
   override def state: ControllerState = ControllerState.IsrChange
+  override def preempt(): Unit = {}
+}
+
+case class AlterReplicaStateReceived(brokerId: Int, brokerEpoch: Long, replicasToAlterState: Set[TopicPartition],
+                                     newState: Byte, reason: String,
+                                     callback: LogDirChangeCallback) extends ControllerEvent {
+  override def state: ControllerState = ControllerState.LogDirChange
   override def preempt(): Unit = {}
 }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2445,11 +2445,11 @@ class KafkaController(val config: KafkaConfig,
 
   def alterReplicaState(alterReplicaStateRequest: AlterReplicaStateRequest,
                         callback: AlterReplicaStateResponseData => Unit): Unit = {
-    val alterReplicaStateRequestDataData = alterReplicaStateRequest.data()
-    val newState = alterReplicaStateRequestDataData.newState()
-    val reason = alterReplicaStateRequestDataData.reason()
+    val alterReplicaStateRequestData = alterReplicaStateRequest.data()
+    val newState = alterReplicaStateRequestData.newState()
+    val reason = alterReplicaStateRequestData.reason()
     val replicasToAlterState = mutable.Set[TopicPartition]()
-    alterReplicaStateRequestDataData.topics.forEach { topicReq =>
+    alterReplicaStateRequestData.topics.forEach { topicReq =>
       topicReq.partitions.forEach { partitionReq =>
         val tp = new TopicPartition(topicReq.name, partitionReq.partitionIndex)
         replicasToAlterState.add(tp)
@@ -2488,8 +2488,8 @@ class KafkaController(val config: KafkaConfig,
       callback.apply(resp)
     }
 
-    eventManager.put(AlterReplicaStateReceived(alterReplicaStateRequestDataData.brokerId,
-      alterReplicaStateRequestDataData.brokerEpoch, replicasToAlterState, newState, reason, responseCallback))
+    eventManager.put(AlterReplicaStateReceived(alterReplicaStateRequestData.brokerId,
+      alterReplicaStateRequestData.brokerEpoch, replicasToAlterState, newState, reason, responseCallback))
   }
 
   def processAlterReplicaState(brokerId: Int, brokerEpoch: Long,

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -1199,7 +1199,7 @@ class LogManager(logDirs: Seq[File],
   /**
    * Map of log dir to logs by topic and partitions in that dir
    */
-  private def logsByDir: Map[String, Map[TopicPartition, UnifiedLog]] = {
+  private[kafka] def logsByDir: Map[String, Map[TopicPartition, UnifiedLog]] = {
     // This code is called often by checkpoint processes and is written in a way that reduces
     // allocations and CPU with many topic partitions.
     // When changing this code please measure the changes with org.apache.kafka.jmh.server.CheckpointBench

--- a/core/src/main/scala/kafka/network/RequestConvertToJson.scala
+++ b/core/src/main/scala/kafka/network/RequestConvertToJson.scala
@@ -95,6 +95,7 @@ object RequestConvertToJson {
       case req: DescribeProducersRequest => DescribeProducersRequestDataJsonConverter.write(req.data, request.version)
       case req: DescribeTransactionsRequest => DescribeTransactionsRequestDataJsonConverter.write(req.data, request.version)
       case req: ListTransactionsRequest => ListTransactionsRequestDataJsonConverter.write(req.data, request.version)
+      case req: AlterReplicaStateRequest => AlterReplicaStateRequestDataJsonConverter.write(req.data, request.version)
       case _ => throw new IllegalStateException(s"ApiKey ${request.apiKey} is not currently handled in `request`, the " +
         "code should be updated to do so.");
     }
@@ -170,6 +171,7 @@ object RequestConvertToJson {
       case res: DescribeProducersResponse => DescribeProducersResponseDataJsonConverter.write(res.data, version)
       case res: DescribeTransactionsResponse => DescribeTransactionsResponseDataJsonConverter.write(res.data, version)
       case res: ListTransactionsResponse => ListTransactionsResponseDataJsonConverter.write(res.data, version)
+      case req: AlterReplicaStateResponse => AlterReplicaStateResponseDataJsonConverter.write(req.data, version)
       case _ => throw new IllegalStateException(s"ApiKey ${response.apiKey} is not currently handled in `response`, the " +
         "code should be updated to do so.");
     }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -259,15 +259,15 @@ class BrokerServer(
       )
       alterIsrManager.start()
 
-      val alterReplicaStateChannelManager = new BrokerToControllerChannelManagerImpl(
+      val alterReplicaStateChannelManager = BrokerToControllerChannelManager(
         controllerNodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache),
         time = time,
         metrics = metrics,
         config = config,
-        channelName = "alterReplicaStateChannel",
+        channelName = "alterReplicaState",
         threadNamePrefix = threadNamePrefix,
         retryTimeoutMs = Long.MaxValue)
-      if (config.interBrokerProtocolVersion.isAlterReplicaStateSupported) {
+      if (config.interBrokerProtocolVersion.isKRaftAlterReplicaStateSupported) {
         alterReplicaStateChannelManager.start()
       }
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -139,6 +139,8 @@ class KafkaServer(
 
   var alterIsrManager: AlterIsrManager = null
 
+  var logDirEventManager: LogDirEventManager = null
+
   var kafkaScheduler: KafkaScheduler = null
 
   @volatile var metadataCache: ZkMetadataCache = null
@@ -317,6 +319,21 @@ class KafkaServer(
         }
         alterIsrManager.start()
 
+        val alterReplicaStateChannelManager = new BrokerToControllerChannelManagerImpl(
+          controllerNodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache),
+          time = time,
+          metrics = metrics,
+          config = config,
+          channelName = "alterReplicaStateChannel",
+          threadNamePrefix = threadNamePrefix,
+          retryTimeoutMs = Long.MaxValue)
+        if (config.interBrokerProtocolVersion >= kafka.api.KAFKA_3_0_IV1) {
+          alterReplicaStateChannelManager.start()
+        }
+
+        logDirEventManager = new LogDirEventManagerImpl(alterReplicaStateChannelManager, kafkaScheduler, time,
+          config.brokerId, () => kafkaController.brokerEpoch)
+
         _replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
 
@@ -473,7 +490,8 @@ class KafkaServer(
       brokerTopicStats = brokerTopicStats,
       isShuttingDown = isShuttingDown,
       zkClient = Some(zkClient),
-      threadNamePrefix = threadNamePrefix)
+      threadNamePrefix = threadNamePrefix,
+      logDirEventManager = logDirEventManager)
   }
 
   private def initZkClient(time: Time): Unit = {
@@ -751,6 +769,10 @@ class KafkaServer(
 
         if (clientToControllerChannelManager != null)
           CoreUtils.swallow(clientToControllerChannelManager.shutdown(), this)
+
+        if (logDirEventManager != null) {
+          CoreUtils.swallow(logDirEventManager.shutdown(), this)
+        }
 
         if (logManager != null)
           CoreUtils.swallow(logManager.shutdown(), this)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -319,15 +319,15 @@ class KafkaServer(
         }
         alterIsrManager.start()
 
-        val alterReplicaStateChannelManager = new BrokerToControllerChannelManagerImpl(
+        val alterReplicaStateChannelManager = BrokerToControllerChannelManager(
           controllerNodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache),
           time = time,
           metrics = metrics,
           config = config,
-          channelName = "alterReplicaStateChannel",
+          channelName = "alterReplicaState",
           threadNamePrefix = threadNamePrefix,
           retryTimeoutMs = Long.MaxValue)
-        if (config.interBrokerProtocolVersion >= kafka.api.KAFKA_3_0_IV1) {
+        if (config.interBrokerProtocolVersion.isAlterReplicaStateSupported) {
           alterReplicaStateChannelManager.start()
         }
 

--- a/core/src/main/scala/kafka/server/LogDirEventManagerImpl.scala
+++ b/core/src/main/scala/kafka/server/LogDirEventManagerImpl.scala
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.util
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+
+import kafka.metrics.KafkaMetricsGroup
+import kafka.utils.{Logging, Scheduler}
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.{AlterReplicaStateRequestData, AlterReplicaStateResponseData}
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AlterReplicaStateRequest, AlterReplicaStateResponse}
+import org.apache.kafka.common.utils.Time
+
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+/**
+ * Handles the sending of AlterReplicaState requests to the controller when LogDirFailure.
+ */
+abstract class LogDirEventManager {
+
+  def start(): Unit
+
+  def handleAlterReplicaStateChanges(logDirEventItem: AlterReplicaStateItem): Unit
+
+  def pendingAlterReplicaStateItemCount(): Int
+
+  def shutdown(): Unit
+}
+
+case class AlterReplicaStateItem(topicPartitions: util.List[TopicPartition],
+                                 newState: Byte,
+                                 reason: String,
+                                 callback: Either[Errors, TopicPartition] => Unit)
+
+class LogDirEventManagerImpl(val controllerChannelManager: BrokerToControllerChannelManager,
+                             val scheduler: Scheduler,
+                             val time: Time,
+                             val brokerId: Int,
+                             val brokerEpochSupplier: () => Long) extends LogDirEventManager with Logging with KafkaMetricsGroup {
+
+  // Used to allow only one in-flight request at a time
+  private val inflightRequest: AtomicBoolean = new AtomicBoolean(false)
+
+  private val pendingReplicaStateUpdates: LinkedBlockingQueue[AlterReplicaStateItem] = new LinkedBlockingQueue[AlterReplicaStateItem]()
+
+  private val lastSentMs = new AtomicLong(0)
+
+  def start(): Unit = {
+    scheduler.schedule("send-alter-replica-state", propagateReplicaStateChanges, 50, 50, TimeUnit.MILLISECONDS)
+  }
+
+  override def pendingAlterReplicaStateItemCount(): Int = pendingReplicaStateUpdates.size()
+
+  private def propagateReplicaStateChanges(): Unit = {
+    if (!pendingReplicaStateUpdates.isEmpty && inflightRequest.compareAndSet(false, true)) {
+      // Copy current unsent items and remove from the queue, will be inserted if failed
+      val inflightAlterIsrItem = pendingReplicaStateUpdates.poll()
+
+      lastSentMs.set(time.milliseconds())
+      sendRequest(inflightAlterIsrItem)
+    }
+  }
+
+  def handleAlterReplicaStateChanges(logDirEventItem: AlterReplicaStateItem): Unit = {
+    pendingReplicaStateUpdates.put(logDirEventItem)
+  }
+
+  def sendRequest(logDirEventItem: AlterReplicaStateItem): Unit = {
+
+    val message = buildRequest(logDirEventItem)
+
+    debug(s"Sending AlterReplicaState to controller $message")
+    controllerChannelManager.sendRequest(new AlterReplicaStateRequest.Builder(message),
+      new ControllerRequestCompletionHandler {
+        override def onComplete(response: ClientResponse): Unit = {
+          try {
+            val body = response.responseBody().asInstanceOf[AlterReplicaStateResponse]
+            handleAlterReplicaStateResponse(body, message.brokerEpoch, logDirEventItem)
+          } finally {
+            inflightRequest.set(false)
+          }
+        }
+
+        override def onTimeout(): Unit = {
+          throw new IllegalStateException("Encountered unexpected timeout when sending AlterIsr to the controller")
+        }
+      })
+  }
+
+  private def buildRequest(logDirEventItem: AlterReplicaStateItem): AlterReplicaStateRequestData = {
+    val message = new AlterReplicaStateRequestData()
+      .setBrokerId(brokerId)
+      .setBrokerEpoch(brokerEpochSupplier.apply())
+      .setNewState(logDirEventItem.newState)
+      .setReason(logDirEventItem.reason)
+      .setTopics(new java.util.ArrayList())
+
+    logDirEventItem.topicPartitions.asScala.groupBy(_.topic).foreach(entry => {
+      val topicPart = new AlterReplicaStateRequestData.TopicData()
+        .setName(entry._1)
+        .setPartitions(new java.util.ArrayList())
+      message.topics().add(topicPart)
+      entry._2.foreach(item => {
+        topicPart.partitions().add(new AlterReplicaStateRequestData.PartitionData()
+          .setPartitionIndex(item.partition)
+        )
+      })
+    })
+    message
+  }
+
+  private def handleAlterReplicaStateResponse(alterReplicaStateResponse: AlterReplicaStateResponse,
+                                              sentBrokerEpoch: Long,
+                                              logDirEventItem: AlterReplicaStateItem): Unit = {
+    val data: AlterReplicaStateResponseData = alterReplicaStateResponse.data
+
+    Errors.forCode(data.errorCode) match {
+      case Errors.STALE_BROKER_EPOCH =>
+        warn(s"Broker had a stale broker epoch ($sentBrokerEpoch), broker could have been repaired and restarted, ignore")
+        pendingReplicaStateUpdates.put(logDirEventItem)
+
+      case Errors.NOT_CONTROLLER =>
+        warn(s"Remote broker is not controller, ignore")
+        pendingReplicaStateUpdates.put(logDirEventItem)
+
+      case Errors.CLUSTER_AUTHORIZATION_FAILED =>
+        val exception = Errors.CLUSTER_AUTHORIZATION_FAILED.exception("Broker is not authorized to send AlterReplicaState to controller")
+        error(s"Broker is not authorized to send AlterReplicaState to controller", exception)
+        pendingReplicaStateUpdates.put(logDirEventItem)
+
+      case Errors.UNKNOWN_REPLICA_STATE =>
+        val exception = Errors.CLUSTER_AUTHORIZATION_FAILED.exception("ReplicaStateChange failed with an unknown replica state")
+        error(s"ReplicaStateChange failed with an unknown replica state", exception)
+        pendingReplicaStateUpdates.put(logDirEventItem)
+
+      case Errors.NONE =>
+        // success is a flag to indicate whether all the partitions had successfully alter state
+        val failedPartitions = new util.ArrayList[TopicPartition]()
+        // Collect partition-level responses to pass to the callbacks
+        val partitionResponses: mutable.Map[TopicPartition, Either[Errors, TopicPartition]] =
+          new mutable.HashMap[TopicPartition, Either[Errors, TopicPartition]]()
+        data.topics.forEach { topic =>
+          topic.partitions().forEach(partition => {
+            val tp = new TopicPartition(topic.name, partition.partitionIndex)
+            val error = Errors.forCode(partition.errorCode())
+            debug(s"Controller successfully handled AlterReplicaState request for $tp: $partition")
+            if (error == Errors.NONE) {
+              partitionResponses(tp) = Right(tp)
+            } else {
+              failedPartitions.add(new TopicPartition(topic.name(), partition.partitionIndex()))
+              partitionResponses(tp) = Left(error)
+            }
+          })
+        }
+
+        // Iterate across the items we sent rather than what we received to ensure we run the callback even if a
+        // partition was somehow erroneously excluded from the response.
+        logDirEventItem.topicPartitions.asScala.foreach(topicPartition =>
+          if (partitionResponses.contains(topicPartition)) {
+            logDirEventItem.callback.apply(partitionResponses(topicPartition))
+          } else {
+            // Don't remove this partition so it will get re-sent
+            warn(s"Partition $topicPartition was sent but not included in the response")
+          }
+        )
+        if (failedPartitions.size() > 0) {
+          pendingReplicaStateUpdates.put(logDirEventItem.copy(topicPartitions = failedPartitions))
+        }
+
+      case e: Errors =>
+        warn(s"Controller returned an unexpected top-level error when handling AlterReplicaState request: $e")
+        pendingReplicaStateUpdates.put(logDirEventItem)
+    }
+  }
+
+  override def shutdown(): Unit = {
+    controllerChannelManager.shutdown()
+  }
+}

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -2299,10 +2299,7 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 
-  /**
-   * Visible for testing
-   * @return true if we need not to retry, which means the response contains no error or only UNKNOWN_TOPIC_OR_PARTITION error
-   */
+  // Visible for testing
   def handleAlterReplicaStateResponse(result: Either[Errors, TopicPartition]): Unit = {
     result match {
       case Left(error: Errors) => error match {

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -124,8 +124,9 @@ class ApiVersionTest {
     assertEquals(KAFKA_3_0_IV0, ApiVersion("3.0-IV0"))
     assertEquals(KAFKA_3_0_IV1, ApiVersion("3.0-IV1"))
 
-    assertEquals(KAFKA_3_1_IV0, ApiVersion("3.1"))
+    assertEquals(KAFKA_3_1_IV1, ApiVersion("3.1"))
     assertEquals(KAFKA_3_1_IV0, ApiVersion("3.1-IV0"))
+    assertEquals(KAFKA_3_1_IV1, ApiVersion("3.1-IV1"))
   }
 
   @Test
@@ -178,6 +179,7 @@ class ApiVersionTest {
     assertEquals("3.0", KAFKA_3_0_IV0.shortVersion)
     assertEquals("3.0", KAFKA_3_0_IV1.shortVersion)
     assertEquals("3.1", KAFKA_3_1_IV0.shortVersion)
+    assertEquals("3.1", KAFKA_3_1_IV1.shortVersion)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -158,7 +158,7 @@ object AbstractCoordinatorConcurrencyTest {
   }
 
   class TestReplicaManager extends ReplicaManager(
-    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null) {
+    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None, null, null) {
 
     @volatile var logs: mutable.Map[TopicPartition, (UnifiedLog, Long)] = _
     var producePurgatory: DelayedOperationPurgatory[DelayedProduce] = _

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -22,7 +22,7 @@ import java.util.Properties
 import kafka.cluster.Partition
 import kafka.log.{UnifiedLog, LogManager}
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.utils.TestUtils.MockAlterIsrManager
+import kafka.utils.TestUtils.{MockAlterIsrManager, MockLogDirEventManager}
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
@@ -55,6 +55,7 @@ class IsrExpirationTest {
   var replicaManager: ReplicaManager = null
 
   var alterIsrManager: MockAlterIsrManager = _
+  var logDirEventManagerManager: MockLogDirEventManager = _
 
   @BeforeEach
   def setUp(): Unit = {
@@ -73,7 +74,8 @@ class IsrExpirationTest {
       quotaManagers = quotaManager,
       metadataCache = MetadataCache.zkMetadataCache(configs.head.brokerId),
       logDirFailureChannel = new LogDirFailureChannel(configs.head.logDirs.size),
-      alterIsrManager = alterIsrManager)
+      alterIsrManager = alterIsrManager,
+      logDirEventManager = logDirEventManagerManager)
   }
 
   @AfterEach

--- a/core/src/test/scala/unit/kafka/server/LogDirEventManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirEventManagerTest.scala
@@ -1,0 +1,318 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package unit.kafka.server
+
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+import kafka.server.{AlterReplicaStateItem, BrokerToControllerChannelManager, ControllerRequestCompletionHandler, LogDirEventManager, LogDirEventManagerImpl}
+import kafka.utils.{MockScheduler, MockTime}
+import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.message.AlterReplicaStateResponseData
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.{AbstractRequest, AlterReplicaStateRequest, AlterReplicaStateResponse}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{BeforeEach, Test}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.times
+import org.mockito.{ArgumentCaptor, Mockito}
+
+import scala.jdk.CollectionConverters._
+
+class LogDirEventManagerTest {
+
+  var brokerToController: BrokerToControllerChannelManager = _
+  val time = new MockTime
+  val metrics = new Metrics
+  val brokerId = 1
+  val offlineStateByte: Byte = kafka.controller.OfflineReplica.state
+
+  val topic = "test-topic"
+  val reason = "unit-test"
+  val tp0 = new TopicPartition(topic, 0)
+  val tp1 = new TopicPartition(topic, 1)
+  val tp2 = new TopicPartition(topic, 2)
+
+  @BeforeEach
+  def setup(): Unit = {
+    brokerToController = Mockito.mock(classOf[BrokerToControllerChannelManager])
+  }
+
+  @Test
+  def testOnlyOneRequestInFlight(): Unit = {
+    val callbackCapture: ArgumentCaptor[ControllerRequestCompletionHandler] =
+      ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+    logDirEventManager.start()
+
+    // Enqueue more updates
+    val stateChangeItems1 = AlterReplicaStateItem(Collections.singletonList(tp0),offlineStateByte, reason, _ => {})
+    val stateChangeItems2 = AlterReplicaStateItem(Collections.singletonList(tp1),offlineStateByte, reason, _ => {})
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItems1)
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItems2)
+
+    time.sleep(50)
+    scheduler.tick()
+
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), callbackCapture.capture())
+
+    // Even an empty response will clear the in-flight
+    val alterReplicaStateResp = new AlterReplicaStateResponse(new AlterReplicaStateResponseData())
+    val resp = new ClientResponse(null, null, "", 0L, 0L,
+      false, null, null, alterReplicaStateResp)
+    callbackCapture.getValue.onComplete(resp)
+
+    Mockito.reset(brokerToController)
+
+    time.sleep(100)
+    scheduler.tick()
+
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), any())
+  }
+
+  @Test
+  def testBuildRequest(): Unit = {
+    Mockito.reset(brokerToController)
+
+    val capture: ArgumentCaptor[AbstractRequest.Builder[AlterReplicaStateRequest]] =
+      ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[AlterReplicaStateRequest]])
+
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+    logDirEventManager.start()
+
+    val stateChangeItem = AlterReplicaStateItem(Range(0, 10).map(new TopicPartition(topic, _)).asJava, offlineStateByte, reason, _ => {})
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItem)
+
+    time.sleep(50)
+    scheduler.tick()
+
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(capture.capture(), any())
+
+    val request = capture.getValue.build()
+    assertEquals(request.data().topics().size(), 1)
+    assertEquals(request.data().topics().get(0).partitions().size(), 10)
+  }
+
+  @Test
+  def testTopError(): Unit = {
+    val errors = Array(Errors.CLUSTER_AUTHORIZATION_FAILED,
+      Errors.STALE_BROKER_EPOCH,
+      Errors.NOT_CONTROLLER,
+      Errors.UNKNOWN_REPLICA_STATE,
+      Errors.UNKNOWN_SERVER_ERROR)
+
+    for (error <- errors) {
+      val stateChangeItem = AlterReplicaStateItem(Collections.singletonList(tp0), offlineStateByte, reason, _ => {})
+      val manager = testTopLevelError(stateChangeItem, error)
+      // On stale broker epoch, we want to retry
+      assertEquals(1, manager.pendingAlterReplicaStateItemCount())
+    }
+  }
+
+  private def testTopLevelError(stateChangeItems: AlterReplicaStateItem, error: Errors): LogDirEventManager = {
+    Mockito.reset(brokerToController)
+
+    val callbackCapture: ArgumentCaptor[ControllerRequestCompletionHandler] =
+      ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+    logDirEventManager.start()
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItems)
+
+    time.sleep(50)
+    scheduler.tick()
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), callbackCapture.capture())
+
+    val alterReplicaStateResp = new AlterReplicaStateResponse(new AlterReplicaStateResponseData().setErrorCode(error.code))
+    val resp = new ClientResponse(null, null, "", 0L, 0L,
+      false, null, null, alterReplicaStateResp)
+    callbackCapture.getValue.onComplete(resp)
+    logDirEventManager
+  }
+
+  @Test
+  def testPartitionLevelError(): Unit = {
+    val errors = Seq(Errors.UNKNOWN_TOPIC_OR_PARTITION,
+      Errors.UNKNOWN_SERVER_ERROR)
+
+    errors.foreach(error => {
+      val manager = testPartitionError(tp0, error)
+      // Any partition-level error should also retry
+      assertEquals(1, manager.pendingAlterReplicaStateItemCount())
+    })
+  }
+
+  private def testPartitionError(tp: TopicPartition, error: Errors): LogDirEventManager = {
+    Mockito.reset(brokerToController)
+
+    val callbackCapture: ArgumentCaptor[ControllerRequestCompletionHandler] =
+      ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+
+    val stateChangeItem = AlterReplicaStateItem(Collections.singletonList(tp0), offlineStateByte, reason, _ => {})
+    logDirEventManager.start()
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItem)
+
+    time.sleep(50)
+    scheduler.tick()
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), callbackCapture.capture())
+
+    val alterReplicaStateResp = new AlterReplicaStateResponse(new AlterReplicaStateResponseData()
+      .setTopics(Collections.singletonList(
+        new AlterReplicaStateResponseData.TopicData()
+          .setName(tp.topic())
+          .setPartitions(Collections.singletonList(
+            new AlterReplicaStateResponseData.PartitionData()
+              .setPartitionIndex(tp.partition())
+              .setErrorCode(error.code))))))
+    val resp = new ClientResponse(null, null, "", 0L, 0L, false, null, null, alterReplicaStateResp)
+    callbackCapture.getValue.onComplete(resp)
+    logDirEventManager
+  }
+
+  @Test
+  def testNoError(): Unit = {
+    Mockito.reset(brokerToController)
+
+    val callbackCapture: ArgumentCaptor[ControllerRequestCompletionHandler] =
+      ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+
+    val stateChangeItem = AlterReplicaStateItem(Collections.singletonList(tp0), offlineStateByte, reason, _ => {})
+    logDirEventManager.start()
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItem)
+
+    time.sleep(50)
+    scheduler.tick()
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), callbackCapture.capture())
+
+    val alterReplicaStateResp = new AlterReplicaStateResponse(new AlterReplicaStateResponseData()
+      .setTopics(Collections.singletonList(
+        new AlterReplicaStateResponseData.TopicData()
+          .setName(tp0.topic())
+          .setPartitions(Collections.singletonList(
+            new AlterReplicaStateResponseData.PartitionData()
+              .setPartitionIndex(tp0.partition()))))))
+    val resp = new ClientResponse(null, null, "", 0L, 0L, false, null, null, alterReplicaStateResp)
+    callbackCapture.getValue.onComplete(resp)
+    assertEquals(0, logDirEventManager.pendingAlterReplicaStateItemCount())
+  }
+
+  @Test
+  def testPartialSuccess(): Unit = {
+    Mockito.reset(brokerToController)
+
+    val callbackCapture: ArgumentCaptor[ControllerRequestCompletionHandler] =
+      ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+
+    val stateChangeItem = AlterReplicaStateItem(Collections.singletonList(tp0), offlineStateByte, reason, _ => {})
+    logDirEventManager.start()
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItem)
+
+    time.sleep(50)
+    scheduler.tick()
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), callbackCapture.capture())
+
+    val alterReplicaStateResp = new AlterReplicaStateResponse(new AlterReplicaStateResponseData()
+      .setTopics(Collections.singletonList(
+        new AlterReplicaStateResponseData.TopicData()
+          .setName(tp0.topic())
+          .setPartitions(
+            Seq(new AlterReplicaStateResponseData.PartitionData().setPartitionIndex(tp0.partition()),
+              new AlterReplicaStateResponseData.PartitionData().setPartitionIndex(tp0.partition())
+                .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())).asJava )
+      )))
+    val resp = new ClientResponse(null, null, "", 0L, 0L, false, null, null, alterReplicaStateResp)
+    callbackCapture.getValue.onComplete(resp)
+    assertEquals(1, logDirEventManager.pendingAlterReplicaStateItemCount())
+
+    val requestCapture: ArgumentCaptor[AbstractRequest.Builder[AlterReplicaStateRequest]] =
+      ArgumentCaptor.forClass(classOf[AbstractRequest.Builder[AlterReplicaStateRequest]])
+    Mockito.reset(brokerToController)
+
+    time.sleep(50)
+    scheduler.tick()
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(requestCapture.capture(), any())
+
+    val request = requestCapture.getValue.build()
+    assertEquals(request.data().topics().size(), 1)
+    // new request only contains 1 partition
+    assertEquals(request.data().topics().get(0).partitions().size(), 1)
+  }
+
+  @Test
+  def testPartitionMissingInResponse(): Unit = {
+    Mockito.reset(brokerToController)
+
+    val callbackCapture: ArgumentCaptor[ControllerRequestCompletionHandler] =
+      ArgumentCaptor.forClass(classOf[ControllerRequestCompletionHandler])
+
+    val scheduler = new MockScheduler(time)
+    val logDirEventManager = new LogDirEventManagerImpl(brokerToController, scheduler, time, brokerId, () => 2)
+    logDirEventManager.start()
+
+    val count = new AtomicInteger(0)
+    val callback = (_:  Either[Errors, TopicPartition]) => {
+      count.incrementAndGet()
+      return
+    }
+
+    val stateChangeItem = AlterReplicaStateItem(Seq(tp0, tp1, tp2).asJava, offlineStateByte, reason, callback)
+
+    logDirEventManager.handleAlterReplicaStateChanges(stateChangeItem)
+    time.sleep(50)
+    scheduler.tick()
+
+    Mockito.verify(brokerToController, times(1))
+      .sendRequest(any(), callbackCapture.capture())
+
+    // Three partitions were sent, but only one returned
+    val alterReplicaStateResp = new AlterReplicaStateResponse(new AlterReplicaStateResponseData()
+      .setTopics(Collections.singletonList(
+        new AlterReplicaStateResponseData.TopicData()
+          .setName(tp0.topic())
+          .setPartitions(Collections.singletonList(
+            new AlterReplicaStateResponseData.PartitionData()
+              .setPartitionIndex(tp0.partition())
+              .setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code()))))))
+    val resp = new ClientResponse(null, null, "", 0L, 0L,
+      false, null, null, alterReplicaStateResp)
+    callbackCapture.getValue.onComplete(resp)
+
+    assertEquals(count.get, 3, "Expected all callbacks to run")
+    assertEquals(1, logDirEventManager.pendingAlterReplicaStateItemCount())
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -16,9 +16,6 @@
  */
 package kafka.server
 
-import java.io.File
-import java.util.Collections
-import java.util.concurrent.{ExecutionException, TimeUnit}
 import kafka.api.IntegrationTestHarness
 import kafka.controller.{OfflineReplica, PartitionAndReplica}
 import kafka.utils.TestUtils.{Checkpoint, LogDirFailureType, Roll}
@@ -31,6 +28,9 @@ import org.apache.kafka.common.utils.Utils
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test, TestInfo}
 
+import java.io.File
+import java.util.Collections
+import java.util.concurrent.{ExecutionException, TimeUnit}
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
@@ -160,7 +160,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
   def testProduceAfterLogDirFailureOnLeader(failureType: LogDirFailureType): Unit = {
     val consumer = createConsumer()
     subscribeAndWaitForAssignment(topic, consumer)
-
+    this.producerConfig.setProperty(ProducerConfig.RETRIES_CONFIG, "0")
     val producer = createProducer()
 
     val partition = new TopicPartition(topic, 0)
@@ -178,11 +178,12 @@ class LogDirFailureTest extends IntegrationTestHarness {
     TestUtils.waitUntilTrue(() => {
       // ProduceResponse may contain KafkaStorageException and trigger metadata update
       producer.send(record)
-      producer.partitionsFor(topic).asScala.find(_.partition() == 0).get.leader().id() != leaderServerId
-    }, "Expected new leader for the partition", 6000L)
+      val partitionInfo = producer.partitionsFor(topic).asScala.find(_.partition() == 0).get
+      partitionInfo.leader() != null && partitionInfo.leader().id() != leaderServerId
+    }, "Expected new leader for the partition")
 
     // Block on send to ensure that new leader accepts a message.
-    producer.send(record).get(6000L, TimeUnit.MILLISECONDS)
+    producer.send(record).get(15000L, TimeUnit.MILLISECONDS)
 
     // Consumer should receive some messages
     TestUtils.pollUntilAtLeastNumRecords(consumer, 1)

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -168,7 +168,8 @@ class ReplicaManagerConcurrencyTest {
       quotaManagers = QuotaFactory.instantiate(config, metrics, time, ""),
       metadataCache = MetadataCache.kRaftMetadataCache(config.brokerId),
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
-      alterIsrManager = new MockAlterIsrManager(channel)
+      alterIsrManager = new MockAlterIsrManager(channel),
+      logDirEventManager = TestUtils.createMockLogDirEventManager()
     ) {
       override def createReplicaFetcherManager(
         metrics: Metrics,

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -242,6 +242,7 @@ class ReplicaManagerQuotasTest {
     replay(logManager)
 
     val alterIsrManager: AlterIsrManager = createMock(classOf[AlterIsrManager])
+    val logDirEventManagerManager: LogDirEventManager = TestUtils.createMockLogDirEventManager()
 
     val leaderBrokerId = configs.head.brokerId
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
@@ -254,7 +255,8 @@ class ReplicaManagerQuotasTest {
       quotaManagers = quotaManager,
       metadataCache = MetadataCache.zkMetadataCache(leaderBrokerId),
       logDirFailureChannel = new LogDirFailureChannel(configs.head.logDirs.size),
-      alterIsrManager = alterIsrManager)
+      alterIsrManager = alterIsrManager,
+      logDirEventManager = logDirEventManagerManager)
 
     //create the two replicas
     for ((p, _) <- fetchInfo) {

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -643,6 +643,10 @@ class RequestQuotaTest extends BaseRequestTest {
 
         case ApiKeys.ALLOCATE_PRODUCER_IDS =>
           new AllocateProducerIdsRequest.Builder(new AllocateProducerIdsRequestData())
+
+        case ApiKeys.ALTER_REPLICA_STATE =>
+          new AlterReplicaStateRequest.Builder(new AlterReplicaStateRequestData())
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -40,6 +40,7 @@ class OffsetsForLeaderEpochTest {
   private val time = new MockTime
   private val metrics = new Metrics
   private val alterIsrManager = TestUtils.createAlterIsrManager()
+  private val logDirEventManagerManager = TestUtils.createMockLogDirEventManager()
   private val tp = new TopicPartition("topic", 1)
   private var replicaManager: ReplicaManager = _
   private var quotaManager: QuotaManagers = _
@@ -73,7 +74,8 @@ class OffsetsForLeaderEpochTest {
       quotaManagers = quotaManager,
       metadataCache = MetadataCache.zkMetadataCache(config.brokerId),
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
-      alterIsrManager = alterIsrManager)
+      alterIsrManager = alterIsrManager,
+      logDirEventManager = logDirEventManagerManager)
     val partition = replicaManager.createPartition(tp)
     partition.setLog(mockLog, isFutureLog = false)
     partition.leaderReplicaIdOpt = Some(config.brokerId)
@@ -103,7 +105,8 @@ class OffsetsForLeaderEpochTest {
       quotaManagers = quotaManager,
       metadataCache = MetadataCache.zkMetadataCache(config.brokerId),
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
-      alterIsrManager = alterIsrManager)
+      alterIsrManager = alterIsrManager,
+      logDirEventManager = logDirEventManagerManager)
     replicaManager.createPartition(tp)
 
     //Given
@@ -135,7 +138,8 @@ class OffsetsForLeaderEpochTest {
       quotaManagers = quotaManager,
       metadataCache = MetadataCache.zkMetadataCache(config.brokerId),
       logDirFailureChannel = new LogDirFailureChannel(config.logDirs.size),
-      alterIsrManager = alterIsrManager)
+      alterIsrManager = alterIsrManager,
+      logDirEventManager = logDirEventManagerManager)
 
     //Given
     val epochRequested: Integer = 5

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1300,6 +1300,17 @@ object TestUtils extends Logging {
     new MockIsrChangeListener()
   }
 
+  class MockLogDirEventManager extends LogDirEventManager {
+    override def start(): Unit = {}
+    override def pendingAlterReplicaStateItemCount(): Int = 0
+    override def handleAlterReplicaStateChanges(logDirEventItem: AlterReplicaStateItem): Unit = {}
+    override def shutdown(): Unit = {}
+  }
+
+  def createMockLogDirEventManager(): MockLogDirEventManager = {
+    new MockLogDirEventManager
+  }
+
   def produceMessages[B <: KafkaBroker](
       brokers: Seq[B],
       records: Seq[ProducerRecord[Array[Byte], Array[Byte]]],

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -228,6 +228,7 @@ public class ReplicaFetcherThreadBenchmark {
             setMetadataCache(metadataCache).
             setLogDirFailureChannel(new LogDirFailureChannel(logDirs.size())).
             setAlterIsrManager(TestUtils.createAlterIsrManager()).
+            setLogDirEventManager(TestUtils.createMockLogDirEventManager()).
             build();
         fetcher = new ReplicaFetcherBenchThread(config, replicaManager, pool);
         fetcher.addPartitions(initialFetchStates);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -24,6 +24,7 @@ import kafka.log.LogManager;
 import kafka.server.AlterIsrManager;
 import kafka.server.BrokerTopicStats;
 import kafka.server.KafkaConfig;
+import kafka.server.LogDirEventManager;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
@@ -89,6 +90,7 @@ public class CheckpointBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
+    private LogDirEventManager logDirEventManagerManager;
 
 
     @SuppressWarnings("deprecation")
@@ -118,6 +120,7 @@ public class CheckpointBench {
                         this.time, "");
 
         this.alterIsrManager = TestUtils.createAlterIsrManager();
+        this.logDirEventManagerManager = TestUtils.createMockLogDirEventManager();
         this.replicaManager = new ReplicaManagerBuilder().
             setConfig(brokerProperties).
             setMetrics(metrics).
@@ -129,6 +132,7 @@ public class CheckpointBench {
             setMetadataCache(metadataCache).
             setLogDirFailureChannel(failureChannel).
             setAlterIsrManager(alterIsrManager).
+            setLogDirEventManager(logDirEventManagerManager).
             build();
         replicaManager.startup();
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/PartitionCreationBench.java
@@ -25,6 +25,7 @@ import kafka.log.LogManager;
 import kafka.server.AlterIsrManager;
 import kafka.server.BrokerTopicStats;
 import kafka.server.KafkaConfig;
+import kafka.server.LogDirEventManager;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
@@ -95,6 +96,7 @@ public class PartitionCreationBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
+    private LogDirEventManager logDirEventManager;
     private List<TopicPartition> topicPartitions;
 
     @SuppressWarnings("deprecation")
@@ -150,6 +152,7 @@ public class PartitionCreationBench {
             }
         };
         this.alterIsrManager = TestUtils.createAlterIsrManager();
+        this.logDirEventManager = TestUtils.createMockLogDirEventManager();
         this.replicaManager = new ReplicaManagerBuilder().
             setConfig(brokerProperties).
             setMetrics(metrics).
@@ -162,6 +165,7 @@ public class PartitionCreationBench {
             setMetadataCache(new ZkMetadataCache(this.brokerProperties.brokerId())).
             setLogDirFailureChannel(failureChannel).
             setAlterIsrManager(alterIsrManager).
+            setLogDirEventManager(logDirEventManager).
             build();
         replicaManager.startup();
         replicaManager.checkpointHighWatermarks();


### PR DESCRIPTION
This patch implements [KIP-589](https://cwiki.apache.org/confluence/display/KAFKA/KIP-589+Add+API+to+update+Replica+state+in+Controller), which introduces an asynchronous API for brokers to notifying the controller of log dir failure.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
1. Unit test for LogDirEventManagerImpl
2. Integration test for new behavior

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
