### PR TITLE
MINOR: Log resource pattern of ACL updates at INFO level

### DIFF
--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -530,7 +530,8 @@ class AclAuthorizer extends Authorizer with Logging {
       throw new IllegalStateException(s"Failed to update ACLs for $resource after trying a maximum of $maxUpdateRetries times")
 
     if (newVersionedAcls.acls != currentVersionedAcls.acls) {
-      debug(s"Updated ACLs for $resource to ${newVersionedAcls.acls} with version ${newVersionedAcls.zkVersion}")
+      info(s"Updated ACLs for $resource with new version ${newVersionedAcls.zkVersion}")
+      debug(s"Updated ACLs for $resource to $newVersionedAcls")
       updateCache(resource, newVersionedAcls)
       updateAclChangedFlag(resource)
       true


### PR DESCRIPTION
At the moment, we have one log entry for ACL updates that says:
```
Processing notification(s) to /kafka-acl-changes
```
For other updates like broker configuration updates, we have an additional entry at INFO level that shows what was updated when the change notification was processed. Since every resource pattern may have 100s or 1000s of access control entries associated with it, we don't want to log the entire contents on ACL update at INFO level. But it would be useful to log the resource pattern. This shows that we processed the notification in AclAuthorizer and gives the resource and version that was refreshed from ZK. This PR adds an additional INFO-level log entry for ACL updates in AclAuthorizer and retains the existing DEBUG level entry with full details.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
