### PR TITLE
KAFKA-6687: rewrite topology to allow reading the same topic multiple times in the DSL

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
@@ -289,6 +290,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     public void buildAndOptimizeTopology(final Properties props) {
 
+        mergeDuplicateSourceNodes();
         maybePerformOptimizations(props);
 
         final PriorityQueue<StreamsGraphNode> graphNodePriorityQueue = new PriorityQueue<>(5, Comparator.comparing(StreamsGraphNode::buildPriority));
@@ -312,6 +314,43 @@ public class InternalStreamsBuilder implements InternalNameProvider {
             }
         }
         internalTopologyBuilder.validateCopartition();
+    }
+
+    private void mergeDuplicateSourceNodes() {
+        final Map<String, StreamSourceNode<?, ?>> topicsToSourceNodes = new HashMap<>();
+        final Map<Pattern, StreamSourceNode<?, ?>> patternsToSourceNodes = new HashMap<>();
+
+        for (final StreamsGraphNode graphNode : root.children()) {
+            final StreamSourceNode<?, ?> currentSourceNode = (StreamSourceNode<?, ?>) graphNode;
+
+            if (currentSourceNode.topicPattern() != null) {
+                if (!patternsToSourceNodes.containsKey(currentSourceNode.topicPattern())) {
+                    patternsToSourceNodes.put(currentSourceNode.topicPattern(), currentSourceNode);
+                } else {
+                    final StreamSourceNode<?, ?> mainSourceNode = patternsToSourceNodes.get(currentSourceNode.topicPattern());
+                    mainSourceNode.merge(currentSourceNode);
+                    root.removeChild(graphNode);
+                }
+            } else {
+                for (final String topic : currentSourceNode.topicNames()) {
+                    if (!topicsToSourceNodes.containsKey(topic)) {
+                        topicsToSourceNodes.put(topic, currentSourceNode);
+                    } else {
+                        final StreamSourceNode<?, ?> mainSourceNode = topicsToSourceNodes.get(topic);
+                        // TODO we only merge source nodes if the subscribed topic(s) are an exact match, so it's still not
+                        // possible to subscribe to topicA in one KStream and topicA + topicB in another. We could achieve
+                        // this by splitting these source nodes into one topic per node and routing to the subscribed children
+                        if (!mainSourceNode.topicNames().equals(currentSourceNode.topicNames())) {
+                            LOG.error("Topic {} was found in  subscription for non-equal source nodes {} and {}",
+                                      topic, mainSourceNode, currentSourceNode);
+                            throw new TopologyException("Two source nodes are subscribed to overlapping but not equal input topics");
+                        }
+                        mainSourceNode.merge(currentSourceNode);
+                        root.removeChild(graphNode);
+                    }
+                }
+            }
+        }
     }
 
     private void maybePerformOptimizations(final Properties props) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -78,16 +78,16 @@ public class StreamSourceNode<K, V> extends StreamsGraphNode {
         return consumedInternal.valueSerde();
     }
 
-    // We "merge" source nodes into a single node under the hood if a user tries to read in a source topic multiple times
     public void merge(final StreamSourceNode<?, ?> other) {
         final AutoOffsetReset resetPolicy = consumedInternal.offsetResetPolicy();
-        if (resetPolicy != null && !resetPolicy.equals(other.consumedInternal().offsetResetPolicy())) {
+        final AutoOffsetReset otherResetPolicy = other.consumedInternal().offsetResetPolicy();
+        if (resetPolicy != null && !resetPolicy.equals(otherResetPolicy)
+            || otherResetPolicy != null && !otherResetPolicy.equals(resetPolicy)) {
             log.error("Tried to merge source nodes {} and {} which are subscribed to the same topic/pattern, but "
                           + "the offset reset policies do not match", this, other);
             throw new TopologyException("Can't configure different offset reset policies on the same input topic(s)");
         }
         for (final StreamsGraphNode otherChild : other.children()) {
-            // Move children from other to this, these calls take care of resetting the child's parents to this
             other.removeChild(otherChild);
             addChild(otherChild);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.streams.kstream.internals.graph;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.errors.TopologyException;
@@ -57,8 +59,8 @@ public class StreamSourceNode<K, V> extends StreamsGraphNode {
         this.consumedInternal = consumedInternal;
     }
 
-    public Collection<String> topicNames() {
-        return new ArrayList<>(topicNames);
+    public Set<String> topicNames() {
+        return new HashSet<>(topicNames);
     }
 
     public Pattern topicPattern() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -114,8 +114,6 @@ public class InternalTopologyBuilder {
 
     private final Set<Pattern> latestResetPatterns = new HashSet<>();
 
-    private final Set<Pattern> allPatterns = new HashSet<>();
-
     private final QuickUnion<String> nodeGrouper = new QuickUnion<>();
 
     // Used to capture subscribed topics via Patterns discovered during the partition assignment process.
@@ -412,14 +410,7 @@ public class InternalTopologyBuilder {
             }
         }
 
-        for (final Pattern otherPattern : allPatterns) {
-            if (topicPattern.pattern().contains(otherPattern.pattern()) || otherPattern.pattern().contains(topicPattern.pattern())) {
-                throw new TopologyException("Pattern " + topicPattern + " will overlap with another pattern " + otherPattern + " already been registered by another source");
-            }
-        }
-
         maybeAddToResetList(earliestResetPatterns, latestResetPatterns, offsetReset, topicPattern);
-        allPatterns.add(topicPattern);
 
         nodeFactories.put(name, new SourceNodeFactory<>(name, null, topicPattern, timestampExtractor, keyDeserializer, valDeserializer));
         nodeToSourcePatterns.put(name, topicPattern);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -1135,7 +1135,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             final SourceNode<?, ?, ?, ?> source = topology.source(partition.topic());
             if (source == null) {
                 throw new TopologyException(
-                        "Topic is unkown to the topology. " +
+                        "Topic is unknown to the topology. " +
                                 "This may happen if different KafkaStreams instances of the same application execute different Topologies. " +
                                 "Note that Topologies are only identical if all operators are added in the same order."
                 );

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -435,11 +435,6 @@ public class TaskManager {
                 partitionToTask.remove(inputPartition);
             }
             for (final TopicPartition topicPartition : topicPartitions) {
-                if (partitionToTask.containsKey(topicPartition)) {
-                    log.warn("Topic {} was assigned to task {} but was already associated with task {}, " +
-                        "it's possible this arose due to multiple matching regex subscriptions in the topology.",
-                             topicPartition, task.id(), partitionToTask.get(topicPartition));
-                }
                 partitionToTask.put(topicPartition, task);
             }
             task.update(topicPartitions, builder.nodeToSourceTopics());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -435,6 +435,11 @@ public class TaskManager {
                 partitionToTask.remove(inputPartition);
             }
             for (final TopicPartition topicPartition : topicPartitions) {
+                if (partitionToTask.containsKey(topicPartition)) {
+                    log.warn("Topic {} was assigned to task {} but was already associated with task {}, " +
+                        "it's possible this arose due to multiple matching regex subscriptions in the topology.",
+                             topicPartition, task.id(), partitionToTask.get(topicPartition));
+                }
                 partitionToTask.put(topicPartition, task);
             }
             task.update(topicPartitions, builder.nodeToSourceTopics());

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams;
 
+import java.util.regex.Pattern;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -894,6 +895,22 @@ public class StreamsBuilderTest {
             STREAM_OPERATION_NAME + "-source",
             STREAM_OPERATION_NAME);
     }
+
+    @Test
+    public void shouldAllowReadingFromSameTopic() {
+        builder.stream("topic");
+        builder.stream("topic");
+        builder.build();
+    }
+
+    @Test
+    public void shouldAllowSubscribingToSamePattern() {
+        builder.stream(Pattern.compile("some-regex"));
+        builder.stream(Pattern.compile("some-regex"));
+        builder.build();
+    }
+
+
 
     private static void assertNamesForOperation(final ProcessorTopology topology, final String... expected) {
         final List<ProcessorNode<?, ?, ?, ?>> processors = topology.processors();

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -67,6 +67,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class StreamsBuilderTest {
@@ -910,7 +911,19 @@ public class StreamsBuilderTest {
         builder.build();
     }
 
+    @Test
+    public void shouldAllowReadingFromSameCollectionOfTopics() {
+        builder.stream(Collections.singletonList("topic"));
+        builder.stream(Collections.singletonList("topic"));
+        builder.build();
+    }
 
+    @Test
+    public void shouldNotAllowReadingFromOverlappingAndUnequalCollectionOfTopics() {
+        builder.stream(Collections.singletonList("topic"));
+        builder.stream(asList("topic", "otherTopic"));
+        assertThrows(TopologyException.class, builder::build);
+    }
 
     private static void assertNamesForOperation(final ProcessorTopology topology, final String... expected) {
         final List<ProcessorNode<?, ?, ?, ?>> processors = topology.processors();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -371,9 +371,4 @@ public class InternalStreamsBuilderTest {
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    // TODO: this static functions are added because some non-TopologyBuilder unit tests need to access the internal topology builder,
-    //       which is usually a bad sign of design patterns between TopologyBuilder and StreamThread. We need to consider getting rid of them later
-    public static InternalTopologyBuilder internalTopologyBuilder(final InternalStreamsBuilder internalStreamsBuilder) {
-        return internalStreamsBuilder.internalTopologyBuilder;
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -2070,7 +2070,7 @@ public class StreamTaskTest {
         );
 
         assertThat(exception.getMessage(), equalTo("Invalid topology: " +
-                "Topic is unkown to the topology. This may happen if different KafkaStreams instances of the same " +
+                "Topic is unknown to the topology. This may happen if different KafkaStreams instances of the same " +
                 "application execute different Topologies. Note that Topologies are only identical if all operators " +
                 "are added in the same order."));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -149,15 +149,14 @@ public class StreamThreadTest {
     private final ConsumedInternal<Object, Object> consumed = new ConsumedInternal<>();
     private final ChangelogReader changelogReader = new MockChangelogReader();
     private final StateDirectory stateDirectory = new StateDirectory(config, mockTime, true);
-    private final InternalStreamsBuilder internalStreamsBuilder = new InternalStreamsBuilder(new InternalTopologyBuilder());
+    private final InternalTopologyBuilder internalTopologyBuilder = new InternalTopologyBuilder();
+    private final InternalStreamsBuilder internalStreamsBuilder = new InternalStreamsBuilder(internalTopologyBuilder);
 
     private StreamsMetadataState streamsMetadataState;
-    private InternalTopologyBuilder internalTopologyBuilder;
 
     @Before
     public void setUp() {
         Thread.currentThread().setName(CLIENT_ID + "-StreamThread-" + threadIdx);
-        internalTopologyBuilder = InternalStreamsBuilderTest.internalTopologyBuilder(internalStreamsBuilder);
         internalTopologyBuilder.setApplicationId(APPLICATION_ID);
         streamsMetadataState = new StreamsMetadataState(internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST);
     }
@@ -957,7 +956,7 @@ public class StreamThreadTest {
     public void shouldNotReturnDataAfterTaskMigrated() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
 
-        internalTopologyBuilder = EasyMock.createNiceMock(InternalTopologyBuilder.class);
+        final InternalTopologyBuilder internalTopologyBuilder = EasyMock.createNiceMock(InternalTopologyBuilder.class);
 
         expect(internalTopologyBuilder.sourceTopicCollection()).andReturn(Collections.singletonList(topic1)).times(2);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -54,7 +54,6 @@ import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.InternalStreamsBuilder;
-import org.apache.kafka.streams.kstream.internals.InternalStreamsBuilderTest;
 import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.PunctuationType;


### PR DESCRIPTION
Needed to fix this on the side in order to more easily set up some experiments, so here's the PR.

Allows a user to create multiple KStreams ~and/or KTables~ from the same topic, collection of topics, or pattern. At the moment this isn't possible since we can only consume from a topic once, and each source topic maps to a single source node in the topology. The "fix" is just to rewrite the logical plan and merge any duplicate source nodes into a single node before it gets compiled into the physical topology.

The one exception is when the stream/table are subscribed to an overlapping-but-unequal collection of topics, which I left as future work (with a TODO in the comments describing a possible solution). If the offset reset policy doesn't match we just throw a TopologyException.

edit: tables are much more complicated so I opted to restrict things to just multiple KStreams for now on and consider allowing multiple KTables (or KStream+KTable) as followup work