### PR TITLE
[KAFKA-10705]: Make state stores not readable by others

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -34,10 +34,14 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
@@ -104,6 +108,27 @@ public class StateDirectoryTest {
         assertTrue(stateDir.isDirectory());
         assertTrue(appDir.exists());
         assertTrue(appDir.isDirectory());
+    }
+
+    @Test
+    public void shouldHaveSecurePermissions() {
+        final Set<PosixFilePermission> expectedPermissions = EnumSet.of(
+            PosixFilePermission.OWNER_EXECUTE,
+            PosixFilePermission.GROUP_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.GROUP_EXECUTE,
+            PosixFilePermission.OWNER_READ);
+
+        final Path statePath = Paths.get(stateDir.getPath());
+        final Path basePath = Paths.get(appDir.getPath());
+        try {
+            final Set<PosixFilePermission> baseFilePermissions = Files.getPosixFilePermissions(statePath);
+            final Set<PosixFilePermission> appFilePermissions = Files.getPosixFilePermissions(basePath);
+            assertEquals(expectedPermissions, baseFilePermissions);
+            assertEquals(expectedPermissions, appFilePermissions);
+        } catch (final IOException e) {
+            // okay
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -66,6 +66,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 
 public class StateDirectoryTest {
 
@@ -124,10 +126,10 @@ public class StateDirectoryTest {
         try {
             final Set<PosixFilePermission> baseFilePermissions = Files.getPosixFilePermissions(statePath);
             final Set<PosixFilePermission> appFilePermissions = Files.getPosixFilePermissions(basePath);
-            assertEquals(expectedPermissions, baseFilePermissions);
-            assertEquals(expectedPermissions, appFilePermissions);
+            assertThat(expectedPermissions.equals(baseFilePermissions), is(true));
+            assertThat(expectedPermissions.equals(appFilePermissions), is(true));
         } catch (final IOException e) {
-            // okay
+            fail("Should create correct files and set correct permissions");
         }
     }
 


### PR DESCRIPTION
Change permissions on the folders for the state store so they're no readable or writable by "others", but still accessible by owner and group members.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
