### PR TITLE
[KAFKA-10708]: Add "group-id" Tag to Kafka Consumer Metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -872,8 +872,13 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 .timeWindow(config.getLong(ConsumerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
                 .recordLevel(Sensor.RecordingLevel.forName(config.getString(ConsumerConfig.METRICS_RECORDING_LEVEL_CONFIG)))
                 .tags(metricsTags);
+        final Map<String, Object> reporterConfigOverrides = new HashMap<>();
+        reporterConfigOverrides.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
+        if (groupId != null && !groupId.isEmpty()) {
+            reporterConfigOverrides.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        }
         List<MetricsReporter> reporters = config.getConfiguredInstances(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG,
-                MetricsReporter.class, Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, clientId));
+                MetricsReporter.class, reporterConfigOverrides);
         JmxReporter jmxReporter = new JmxReporter();
         jmxReporter.configure(config.originals());
         reporters.add(jmxReporter);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -669,8 +669,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
                     GroupRebalanceConfig.ProtocolType.CONSUMER);
 
-            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId)
-                    .filter(group -> group.trim().length() > 0);
+            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
             this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
 
             LogContext logContext;
@@ -734,7 +733,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             Set<String> metricTags = new HashSet<>();
             metricTags.add(CLIENT_ID_METRIC_TAG);
-            groupId.ifPresent(group -> metricTags.add(GROUP_ID_METRIC_TAG));
+            groupId.filter(group -> group.trim().length() > 0).ifPresent(group -> metricTags.add(GROUP_ID_METRIC_TAG));
             FetcherMetricsRegistry metricsRegistry = new FetcherMetricsRegistry(metricTags, metricGrpPrefix);
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
             IsolationLevel isolationLevel = IsolationLevel.valueOf(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -865,7 +865,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private static Metrics buildMetrics(ConsumerConfig config, Time time, String clientId, String groupId) {
         Map<String, String> metricsTags = new HashMap<>();
         metricsTags.put(CLIENT_ID_METRIC_TAG, clientId);
-        if (groupId != null && !groupId.isEmpty()) {
+        if (groupId != null && !groupId.trim().isEmpty()) {
             metricsTags.put(GROUP_ID_METRIC_TAG, groupId);
         }
         MetricConfig metricConfig = new MetricConfig().samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
@@ -874,7 +874,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 .tags(metricsTags);
         final Map<String, Object> reporterConfigOverrides = new HashMap<>();
         reporterConfigOverrides.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
-        if (groupId != null && !groupId.isEmpty()) {
+        if (groupId != null && !groupId.trim().isEmpty()) {
             reporterConfigOverrides.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         }
         List<MetricsReporter> reporters = config.getConfiguredInstances(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -669,7 +669,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             GroupRebalanceConfig groupRebalanceConfig = new GroupRebalanceConfig(config,
                     GroupRebalanceConfig.ProtocolType.CONSUMER);
 
-            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId);
+            this.groupId = Optional.ofNullable(groupRebalanceConfig.groupId)
+                    .filter(group -> group.trim().length() > 0);
             this.clientId = config.getString(CommonClientConfigs.CLIENT_ID_CONFIG);
 
             LogContext logContext;
@@ -733,7 +734,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
             Set<String> metricTags = new HashSet<>();
             metricTags.add(CLIENT_ID_METRIC_TAG);
-            groupId.ifPresent(groupIdValue -> metricTags.add(GROUP_ID_METRIC_TAG));
+            groupId.ifPresent(group -> metricTags.add(GROUP_ID_METRIC_TAG));
             FetcherMetricsRegistry metricsRegistry = new FetcherMetricsRegistry(metricTags, metricGrpPrefix);
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
             IsolationLevel isolationLevel = IsolationLevel.valueOf(

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -731,7 +731,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.metadata.bootstrap(addresses);
             String metricGrpPrefix = "consumer";
 
-            FetcherMetricsRegistry metricsRegistry = new FetcherMetricsRegistry(Collections.singleton(CLIENT_ID_METRIC_TAG), metricGrpPrefix);
+            Set<String> metricTags = new HashSet<>();
+            metricTags.add(CLIENT_ID_METRIC_TAG);
+            groupId.ifPresent(groupIdValue -> metricTags.add(GROUP_ID_METRIC_TAG));
+            FetcherMetricsRegistry metricsRegistry = new FetcherMetricsRegistry(metricTags, metricGrpPrefix);
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
             IsolationLevel isolationLevel = IsolationLevel.valueOf(
                     config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -865,7 +865,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private static Metrics buildMetrics(ConsumerConfig config, Time time, String clientId, String groupId) {
         Map<String, String> metricsTags = new HashMap<>();
         metricsTags.put(CLIENT_ID_METRIC_TAG, clientId);
-        if (groupId != null && !groupId.trim().isEmpty()) {
+        if (groupId != null) {
             metricsTags.put(GROUP_ID_METRIC_TAG, groupId);
         }
         MetricConfig metricConfig = new MetricConfig().samples(config.getInt(ConsumerConfig.METRICS_NUM_SAMPLES_CONFIG))
@@ -874,7 +874,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 .tags(metricsTags);
         final Map<String, Object> reporterConfigOverrides = new HashMap<>();
         reporterConfigOverrides.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
-        if (groupId != null && !groupId.trim().isEmpty()) {
+        if (groupId != null) {
             reporterConfigOverrides.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         }
         List<MetricsReporter> reporters = config.getConfiguredInstances(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG,

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -329,6 +329,7 @@ abstract class QuotaTestClients(topic: String,
   def verifyConsumerClientThrottleTimeMetric(expectThrottle: Boolean, maxThrottleTime: Option[Double] = None): Unit = {
     val tags = new HashMap[String, String]
     tags.put("client-id", consumerClientId)
+    tags.put("group-id", "QuotasTest")
     val avgMetric = consumer.metrics.get(new MetricName("fetch-throttle-time-avg", "consumer-fetch-manager-metrics", "", tags))
     val maxMetric = consumer.metrics.get(new MetricName("fetch-throttle-time-max", "consumer-fetch-manager-metrics", "", tags))
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -1398,11 +1398,13 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Verify the metric exist.
     val tags1 = new util.HashMap[String, String]()
     tags1.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
+    tags1.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags1.put("topic", tp.topic())
     tags1.put("partition", String.valueOf(tp.partition()))
 
     val tags2 = new util.HashMap[String, String]()
     tags2.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
+    tags2.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags2.put("topic", tp2.topic())
     tags2.put("partition", String.valueOf(tp2.partition()))
     val fetchLead0 = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1))
@@ -1437,11 +1439,13 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Verify the metric exist.
     val tags1 = new util.HashMap[String, String]()
     tags1.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
+    tags1.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags1.put("topic", tp.topic())
     tags1.put("partition", String.valueOf(tp.partition()))
 
     val tags2 = new util.HashMap[String, String]()
     tags2.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
+    tags2.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags2.put("topic", tp2.topic())
     tags2.put("partition", String.valueOf(tp2.partition()))
     val fetchLag0 = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1))
@@ -1474,6 +1478,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Verify the metric exist.
     val tags = new util.HashMap[String, String]()
     tags.put("client-id", "testPerPartitionLeadMetricsCleanUpWithAssign")
+    tags.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))
     val fetchLead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
@@ -1503,6 +1508,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Verify the metric exist.
     val tags = new util.HashMap[String, String]()
     tags.put("client-id", "testPerPartitionLagMetricsCleanUpWithAssign")
+    tags.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))
     val fetchLag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
@@ -1534,6 +1540,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // Verify the metric exist.
     val tags = new util.HashMap[String, String]()
     tags.put("client-id", "testPerPartitionLagMetricsCleanUpWithAssign")
+    tags.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))
     val fetchLag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
@@ -1556,6 +1563,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val tags = new util.HashMap[String, String]()
     tags.put("client-id", "testPerPartitionLeadWithMaxPollRecords")
+    tags.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))
     val lead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
@@ -1578,6 +1586,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     val tags = new util.HashMap[String, String]()
     tags.put("client-id", "testPerPartitionLagWithMaxPollRecords")
+    tags.put("group-id", consumerConfig.getProperty(ConsumerConfig.GROUP_ID_CONFIG))
     tags.put("topic", tp.topic())
     tags.put("partition", String.valueOf(tp.partition()))
     val lag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))


### PR DESCRIPTION
Add the "group-id" to the metrics created during instantiation of the `KafkaConsumer`

https://issues.apache.org/jira/browse/KAFKA-10708

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
