### PR TITLE
MINOR: Fix documentation for Kafka Quick Start Demo Code

### DIFF
--- a/docs/quickstart-docker.html
+++ b/docs/quickstart-docker.html
@@ -149,7 +149,7 @@ KTable<String, Long> wordCounts = textLines
             .groupBy((keyIgnored, word) -> word)
             .count();
 
-wordCounts.toStream().to("output-topic"), Produced.with(Serdes.String(), Serdes.Long()));</code></pre>
+wordCounts.toStream().to("output-topic", Produced.with(Serdes.String(), Serdes.Long()));</code></pre>
 <p>The <a href="/25/documentation/streams/quickstart" rel="nofollow">Kafka Streams demo</a> and the
 <a href="/25/documentation/streams/tutorial" rel="nofollow">app development tutorial</a> demonstrate how to code and run
 such a streaming application from start to finish.</p>

--- a/docs/quickstart-zookeeper.html
+++ b/docs/quickstart-zookeeper.html
@@ -196,7 +196,7 @@ KTable&lt;String, Long&gt; wordCounts = textLines
             .groupBy((keyIgnored, word) -&gt; word)
             .count();
 
-wordCounts.toStream().to("output-topic"), Produced.with(Serdes.String(), Serdes.Long()));</code></pre>
+wordCounts.toStream().to("output-topic", Produced.with(Serdes.String(), Serdes.Long()));</code></pre>
 
   <p>
       The <a href="/25/documentation/streams/quickstart">Kafka Streams demo</a>


### PR DESCRIPTION
In 1.3 Quick Start, STEP 7: PROCESS YOUR EVENTS WITH KAFKA STREAMS. There is a demo to implement the popular WordCount algorithm using Kafka Streams.

But these code can't run directly, because there is an extra `)` after `.to("output-topic"` .
This PR removed the extra brackets in the demo code.