### PR TITLE
Fix memory leak in JmxReporter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -83,8 +83,12 @@ public class JmxReporter implements MetricsReporter {
         synchronized (LOCK) {
             KafkaMbean mbean = removeAttribute(metric);
             if (mbean != null) {
-                if (mbean.metrics.isEmpty())
+                if (mbean.metrics.isEmpty()){
                     unregister(mbean);
+                    MetricName metricName = metric.metricName();
+                    String mBeanName = getMBeanName(metricName);
+                    mbeans.remove(mBeanName);
+                }
                 else
                     reregister(mbean);
             }


### PR DESCRIPTION
JmxReporter should remove the KafkaMbean from "mbeans"  when it becomes empty metrics during metricRemoval,not only unregister the metrics.
"mbeans"  will grow bigger and bigger if not removing the KafkaMbean,finally jvm memory runs out.