### PR TITLE
Improve JavaDoc in KeyValueBytesStoreSupplier

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/KeyValueBytesStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/KeyValueBytesStoreSupplier.java
@@ -19,12 +19,14 @@ package org.apache.kafka.streams.state;
 import org.apache.kafka.common.utils.Bytes;
 
 /**
- * A store supplier that can be used to create one or more {@link KeyValueStore KeyValueStore&lt;Byte, byte[]&gt;} instances of type &lt;Byte, byte[]&gt;.
+ * A store supplier that can be used to create one or more {@link KeyValueStore KeyValueStore&lt;Bytes, byte[]&gt;} instances of type &lt;Bytes, byte[]&gt;.
  *
- * For any stores implementing the {@link KeyValueStore KeyValueStore&lt;Byte, byte[]&gt;} interface, null value bytes are considered as "not exist". This means:
+ * For any stores implementing the {@link KeyValueStore KeyValueStore&lt;Bytes, byte[]&gt;} interface, null value bytes are considered as "not exist". This means:
  *
- * 1. Null value bytes in put operations should be treated as delete.
- * 2. If the key does not exist, get operations should return null value bytes.
+ * <ol>
+ *   <li>Null value bytes in put operations should be treated as delete.</li>
+ *   <li>If the key does not exist, get operations should return null value bytes.</li>
+ * </ol>
  */
 public interface KeyValueBytesStoreSupplier extends StoreSupplier<KeyValueStore<Bytes, byte[]>> {
 


### PR DESCRIPTION
In the JavaDoc, the implemented interface was described inaccurately.
Also, the ordered list was formatted as plain text, not as html "ol".

No testing necessary since only a comment was changed.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
