### PR TITLE
KAFKA-10724:Command to run single quorum in raft is missing "--config…

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -9,7 +9,7 @@ we have a standalone test server which can be used for performance testing.
 Below we describe the details to set this up.
 
 ### Run Single Quorum ###
-    bin/test-raft-server-start.sh config/raft.properties
+    bin/test-raft-server-start.sh --config config/raft.properties
 
 ### Run Multi Node Quorum ###
 Create 3 separate raft quorum properties as the following


### PR DESCRIPTION
When I run "bin/test-raft-server-start.sh config/raft.properties", I get an error：
[2020-11-14 23:00:38,742] ERROR Exiting Kafka due to fatal exception (kafka.tools.TestRaftServer$)
org.apache.kafka.common.config.ConfigException: Missing required configuration "zookeeper.connect" which has no default value.
at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:478)
at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:468)
at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:108)
at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:142)
at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:1314)
at kafka.server.KafkaConfig.<init>(KafkaConfig.scala:1317)
at kafka.tools.TestRaftServer$.main(TestRaftServer.scala:607)
at kafka.tools.TestRaftServer.main(TestRaftServer.scala)

 “ ./bin/test-raft-server-start.sh --config ./config/raft.properties” is work.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
