### PR TITLE
KAFKA-10723: Fix LogManager shutdown error handling

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -479,17 +479,14 @@ class LogManager(logDirs: Seq[File],
 
     try {
       for ((dir, dirJobs) <- jobs) {
-        val hasErrors = dirJobs.exists {
-          future =>
-            try {
-              future.get
-              false
-            } catch {
-              case e: ExecutionException =>
-                warn(s"There was an error in one of the threads during LogManager shutdown: ${e.getCause}")
-                true
-            }
-        }
+        val hasErrors = dirJobs.map { future =>
+          Try(future.get) match {
+            case Success(_) => false
+            case Failure(e) =>
+              warn(s"There was an error in one of the threads during LogManager shutdown: ${e.getCause}")
+              true
+          }
+        }.contains(true)
 
         if (!hasErrors) {
           val logs = logsInDir(localLogsByDir, dir)

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io._
+import java.nio.file.Files
 import java.util.{Collections, Properties}
 
 import com.yammer.metrics.core.MetricName
@@ -25,7 +26,8 @@ import kafka.metrics.KafkaYammerMetrics
 import kafka.server.{FetchDataInfo, FetchLogEnd}
 import kafka.server.checkpoints.OffsetCheckpointFile
 import kafka.utils._
-import org.apache.kafka.common.errors.OffsetOutOfRangeException
+import org.apache.directory.api.util.FileUtils
+import org.apache.kafka.common.errors.{KafkaStorageException, OffsetOutOfRangeException}
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.easymock.EasyMock
@@ -33,6 +35,7 @@ import org.junit.Assert._
 import org.junit.{After, Before, Test}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doAnswer, spy}
+import org.scalatest.Assertions.assertThrows
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
@@ -67,7 +70,8 @@ class LogManagerTest {
       logManager.shutdown()
     Utils.delete(logDir)
     // Some tests assign a new LogManager
-    logManager.liveLogDirs.foreach(Utils.delete)
+    if (logManager != null)
+      logManager.liveLogDirs.foreach(Utils.delete)
   }
 
   /**
@@ -81,6 +85,51 @@ class LogManagerTest {
     val logFile = new File(logDir, name + "-0")
     assertTrue(logFile.exists)
     log.appendAsLeader(TestUtils.singletonRecords("test".getBytes()), leaderEpoch = 0)
+  }
+
+  /**
+   * Tests that all internal futures are completed before LogManager.shutdown() returns to the
+   * caller during error situations.
+   */
+  @Test
+  def testHandlingExceptionsDuringShutdown(): Unit = {
+    logManager.shutdown()
+
+    // We create two directories logDir1 and logDir2 to help effectively test error handling
+    // during LogManager.shutdown().
+    val logDir1 = TestUtils.tempDir()
+    val logDir2 = TestUtils.tempDir()
+    logManager = createLogManager(Seq(logDir1, logDir2))
+    assertEquals(2, logManager.liveLogDirs.size)
+    logManager.startup()
+
+    val log1 = logManager.getOrCreateLog(new TopicPartition(name, 0), () => logConfig)
+    val log2 = logManager.getOrCreateLog(new TopicPartition(name, 1), () => logConfig)
+
+    val logFile1 = new File(logDir1, name + "-0")
+    assertTrue(logFile1.exists)
+    val logFile2 = new File(logDir2, name + "-1")
+    assertTrue(logFile2.exists)
+
+    log1.appendAsLeader(TestUtils.singletonRecords("test1".getBytes()), leaderEpoch = 0)
+    log1.takeProducerSnapshot()
+    log1.appendAsLeader(TestUtils.singletonRecords("test1".getBytes()), leaderEpoch = 0)
+
+    log2.appendAsLeader(TestUtils.singletonRecords("test2".getBytes()), leaderEpoch = 0)
+    log2.takeProducerSnapshot()
+    log2.appendAsLeader(TestUtils.singletonRecords("test2".getBytes()), leaderEpoch = 0)
+
+    // This should cause log1.close() to fail during LogManger shutdown sequence.
+    FileUtils.deleteDirectory(logFile1)
+
+    assertThrows[KafkaStorageException] {
+      logManager.shutdown()
+    }
+    assertFalse(Files.exists(new File(logDir1, Log.CleanShutdownFile).toPath))
+    assertTrue(Files.exists(new File(logDir2, Log.CleanShutdownFile).toPath))
+
+    logManager.liveLogDirs.foreach(Utils.delete)
+    logManager = null
   }
 
   /**


### PR DESCRIPTION
The asynchronous shutdown in `LogManager` has the shortcoming that if during shutdown any of the internal futures fail, then we do not always ensure that all futures are completed before `LogManager.shutdown` returns. This is because, [this line](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/log/LogManager.scala#L502) in the `finally` clause shuts down the thread pools asynchronously. As a result, despite the `shut down completed` message from KafkaServer is seen in the error logs, some futures continue to run from inside `LogManager` attempting to close some logs. This is misleading during debugging. Also sometimes it introduces an avoidable post-shutdown activity where resources (such as file handles) are released or persistent state is checkpointed in the Broker.

In this PR, we fix the above behavior such that we prevent leakage of threads. If any of the futures throw an error, we  skip creating of checkpoint and clean shutdown file only for the affected log directory. We continue to wait for all futures to complete for all the directories.

**Test plan:**

Added a new unit test: `LogManager.testHandlingExceptionsDuringShutdown`.