### PR TITLE
KAFKA-10720: Document prohibition on header mutation by SMTs

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -33,8 +33,10 @@ public interface Transformation<R extends ConnectRecord<R>> extends Configurable
      * Apply transformation to the {@code record} and return another record object (which may be {@code record} itself) or {@code null},
      * corresponding to a map or filter operation respectively.
      *
-     * A transformation must not mutate the headers of a given {@code record}. If the headers need to be changed
-     * a new record with different headers should be created and returned.
+     * A transformation must not mutate objects reachable from the given {@code record}
+     * (including, but not limited to, {@link org.apache.kafka.connect.header.Headers},
+     * {@link org.apache.kafka.connect.data.Struct Structs}, {@code Lists}, and {@code Maps}).
+     * If such objects need to be changed, a new ConnectRecord should be created and returned.
      *
      * The implementation must be thread-safe.
      */

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -33,6 +33,9 @@ public interface Transformation<R extends ConnectRecord<R>> extends Configurable
      * Apply transformation to the {@code record} and return another record object (which may be {@code record} itself) or {@code null},
      * corresponding to a map or filter operation respectively.
      *
+     * A transformation must not mutate the headers of a given {@code record}. If the headers need to be changed
+     * a new record with different headers should be created and returned.
+     *
      * The implementation must be thread-safe.
      */
     R apply(R record);

--- a/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/transforms/Transformation.java
@@ -34,7 +34,7 @@ public interface Transformation<R extends ConnectRecord<R>> extends Configurable
      * corresponding to a map or filter operation respectively.
      *
      * A transformation must not mutate objects reachable from the given {@code record}
-     * (including, but not limited to, {@link org.apache.kafka.connect.header.Headers},
+     * (including, but not limited to, {@link org.apache.kafka.connect.header.Headers Headers},
      * {@link org.apache.kafka.connect.data.Struct Structs}, {@code Lists}, and {@code Maps}).
      * If such objects need to be changed, a new ConnectRecord should be created and returned.
      *


### PR DESCRIPTION
Adds a sentence to the Javadoc for `Transformation` about not mutating headers. See [KAFKA-10720](https://issues.apache.org/jira/browse/KAFKA-10720).