### PR TITLE
KAFKA-10701 : First line of detailed stats from consumer-perf-test.sh incorrect

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -106,7 +106,7 @@ object ConsumerPerformance extends LazyLogging {
     var messagesRead = 0L
     var lastBytesRead = 0L
     var lastMessagesRead = 0L
-    var joinStart = 0L
+    var joinStart = System.currentTimeMillis
     var joinTimeMsInSingleRound = 0L
 
     consumer.subscribe(topics.asJava, new ConsumerRebalanceListener {


### PR DESCRIPTION
Corrected the initialization of joinStart variable to fix the first line of the consumer performance stats. Since the joinStart was initialized with 0 , so when the first time onPartitionAssigned method is called it makes the joinTime as System.currentTimeMillis which inturn made the fetchTimeMs incorrect (-ve)
