### PR TITLE
MINOR: Include connector name in error message

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1365,9 +1365,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // from the HTTP request forwarding thread.
                 if (error != null) {
                     if (isPossibleExpiredKeyException(initialRequestTime, error)) {
-                        log.debug("Failed to reconfigure connector's tasks, possibly due to expired session key. Retrying after backoff");
+                        log.debug("Failed to reconfigure connector's tasks ({}), possibly due to expired session key. Retrying after backoff", connName);
                     } else {
-                        log.error("Failed to reconfigure connector's tasks, retrying after backoff:", error);
+                        log.error("Failed to reconfigure connector's tasks ({}), retrying after backoff:", connName, error);
                     }
                     addRequest(RECONFIGURE_CONNECTOR_TASKS_BACKOFF_MS,
                             new Callable<Void>() {


### PR DESCRIPTION
These log messages aren't triggered very frequently, but when they are it can indicate a serious problem with the connector, and it'd be nice to know exactly which connector is having that problem without having to dig through other log messages and try to correlate the stack trace here with existing connector configs.