### PR TITLE
KAFKA-10674: Controller API version bond with forwardable APIs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
@@ -118,32 +118,29 @@ public class NodeApiVersions {
      * Return the most recent version supported by both the node and the local software.
      */
     public short latestUsableVersion(ApiKeys apiKey) {
-        return latestUsableVersion(apiKey, apiKey.oldestVersion(), apiKey.latestVersion());
+        return getSupportedVersion(apiKey).maxVersion;
     }
 
     /**
      * Get the latest version supported by the broker within an allowed range of versions
      */
     public short latestUsableVersion(ApiKeys apiKey, short oldestAllowedVersion, short latestAllowedVersion) {
-        return latestUsableVersion(apiKey, supportedVersions.get(apiKey), oldestAllowedVersion, latestAllowedVersion);
-    }
-
-    private short latestUsableVersion(ApiKeys apiKey,
-                                      ApiVersion supportedVersions,
-                                      short minAllowedVersion,
-                                      short maxAllowedVersion) {
-        if (supportedVersions == null)
-            throw new UnsupportedVersionException("The broker does not support " + apiKey);
-
-        Optional<ApiVersion> intersectVersion = supportedVersions.intersect(
-            new ApiVersion(apiKey.id, minAllowedVersion, maxAllowedVersion));
+        ApiVersion supportedVersion = getSupportedVersion(apiKey);
+        Optional<ApiVersion> intersectVersion = supportedVersion.intersect(
+            new ApiVersion(apiKey.id, oldestAllowedVersion, latestAllowedVersion));
 
         if (intersectVersion.isPresent())
             return intersectVersion.get().maxVersion;
         else
             throw new UnsupportedVersionException("The broker does not support " + apiKey +
-                " with version in range [" + minAllowedVersion + "," + maxAllowedVersion + "]. The supported" +
-                " range is [" + supportedVersions.minVersion + "," + supportedVersions.maxVersion + "].");
+                " with version in range [" + oldestAllowedVersion + "," + latestAllowedVersion + "]. The supported" +
+                " range is [" + supportedVersion.minVersion + "," + supportedVersion.maxVersion + "].");
+    }
+
+    private ApiVersion getSupportedVersion(ApiKeys apiKey) {
+        if (!supportedVersions.containsKey(apiKey))
+            throw new UnsupportedVersionException("The broker does not support " + apiKey);
+        return supportedVersions.get(apiKey);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
@@ -115,17 +115,19 @@ public class NodeApiVersions {
     }
 
     /**
-     * Return the most recent version supported by the local software.
+     * Return the most recent version supported by both the node and the local software.
      */
     public short latestUsableVersion(ApiKeys apiKey) {
-        return getSupportedVersion(apiKey).maxVersion;
+        return latestUsableVersion(apiKey, apiKey.oldestVersion(), apiKey.latestVersion());
     }
 
     /**
      * Get the latest version supported by the broker within an allowed range of versions
      */
     public short latestUsableVersion(ApiKeys apiKey, short oldestAllowedVersion, short latestAllowedVersion) {
-        ApiVersion supportedVersion = getSupportedVersion(apiKey);
+        if (!supportedVersions.containsKey(apiKey))
+            throw new UnsupportedVersionException("The broker does not support " + apiKey);
+        ApiVersion supportedVersion = supportedVersions.get(apiKey);
         Optional<ApiVersion> intersectVersion = supportedVersion.intersect(
             new ApiVersion(apiKey.id, oldestAllowedVersion, latestAllowedVersion));
 
@@ -135,12 +137,6 @@ public class NodeApiVersions {
             throw new UnsupportedVersionException("The broker does not support " + apiKey +
                 " with version in range [" + oldestAllowedVersion + "," + latestAllowedVersion + "]. The supported" +
                 " range is [" + supportedVersion.minVersion + "," + supportedVersion.maxVersion + "].");
-    }
-
-    private ApiVersion getSupportedVersion(ApiKeys apiKey) {
-        if (!supportedVersions.containsKey(apiKey))
-            throw new UnsupportedVersionException("The broker does not support " + apiKey);
-        return supportedVersions.get(apiKey);
     }
 
     /**
@@ -230,7 +226,7 @@ public class NodeApiVersions {
         return supportedVersions.get(apiKey);
     }
 
-    public Map<ApiKeys, ApiVersion> fullApiVersions() {
+    public Map<ApiKeys, ApiVersion> allSupportedApiVersions() {
         return supportedVersions;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NodeApiVersions.java
@@ -115,7 +115,7 @@ public class NodeApiVersions {
     }
 
     /**
-     * Return the most recent version supported by both the node and the local software.
+     * Return the most recent version supported by the local software.
      */
     public short latestUsableVersion(ApiKeys apiKey) {
         return getSupportedVersion(apiKey).maxVersion;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.apache.kafka.clients.ApiVersion;
+import org.apache.kafka.common.protocol.ApiVersion;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.FetchSessionHandler;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.producer.internals;
 
-import org.apache.kafka.clients.ApiVersion;
+import org.apache.kafka.common.protocol.ApiVersion;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.NodeApiVersions;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiVersion.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiVersion.java
@@ -14,10 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients;
+package org.apache.kafka.common.protocol;
 
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey;
-import org.apache.kafka.common.protocol.ApiKeys;
 
 /**
  * Represents the min version and max version of an api key.
@@ -52,5 +52,19 @@ public class ApiVersion {
             ", minVersion=" + minVersion +
             ", maxVersion= " + maxVersion +
             ")";
+    }
+
+    public static ApiVersion versionsInCommon(ApiKeys apiKey, ApiVersion supportedVersions,
+                                              short minAllowedVersion, short maxAllowedVersion) {
+        if (supportedVersions == null)
+            throw new UnsupportedVersionException("The broker does not support " + apiKey);
+
+        short minVersion = (short) Math.max(minAllowedVersion, supportedVersions.minVersion);
+        short maxVersion = (short) Math.min(maxAllowedVersion, supportedVersions.maxVersion);
+        if (minVersion > maxVersion)
+            throw new UnsupportedVersionException("The broker does not support " + apiKey +
+                                                      " with version in range [" + minAllowedVersion + "," + maxAllowedVersion + "]. The supported" +
+                                                      " range is [" + supportedVersions.minVersion + "," + supportedVersions.maxVersion + "].");
+        return new ApiVersion(apiKey.id, minVersion, maxVersion);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiVersion.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiVersion.java
@@ -16,8 +16,9 @@
  */
 package org.apache.kafka.common.protocol;
 
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey;
+
+import java.util.Optional;
 
 /**
  * Represents the min version and max version of an api key.
@@ -54,17 +55,13 @@ public class ApiVersion {
             ")";
     }
 
-    public static ApiVersion versionsInCommon(ApiKeys apiKey, ApiVersion supportedVersions,
-                                              short minAllowedVersion, short maxAllowedVersion) {
-        if (supportedVersions == null)
-            throw new UnsupportedVersionException("The broker does not support " + apiKey);
-
-        short minVersion = (short) Math.max(minAllowedVersion, supportedVersions.minVersion);
-        short maxVersion = (short) Math.min(maxAllowedVersion, supportedVersions.maxVersion);
-        if (minVersion > maxVersion)
-            throw new UnsupportedVersionException("The broker does not support " + apiKey +
-                                                      " with version in range [" + minAllowedVersion + "," + maxAllowedVersion + "]. The supported" +
-                                                      " range is [" + supportedVersions.minVersion + "," + supportedVersions.maxVersion + "].");
-        return new ApiVersion(apiKey.id, minVersion, maxVersion);
+    public Optional<ApiVersion> intersect(ApiVersion other) {
+        if (other == null) {
+            return Optional.empty();
+        }
+        short minVersion = (short) Math.max(this.minVersion, other.minVersion);
+        short maxVersion = (short) Math.min(this.maxVersion, other.maxVersion);
+        return minVersion > maxVersion ? Optional.empty() :
+            Optional.of(new ApiVersion(apiKey, minVersion, maxVersion));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -131,6 +131,13 @@ public class ApiVersionsResponse extends AbstractResponse {
         return apiKeys;
     }
 
+    /**
+     * Find the commonly agreed ApiVersions between local software and the controller.
+     *
+     * @param minMagic min inter broker magic
+     * @param activeControllerApiVersions controller ApiVersions
+     * @return commonly agreed ApiVersion collection
+     */
     public static ApiVersionsResponseKeyCollection intersectControllerApiVersions(final byte minMagic,
                                                                                   final Map<ApiKeys, ApiVersion> activeControllerApiVersions) {
         ApiVersionsResponseKeyCollection apiKeys = new ApiVersionsResponseKeyCollection();

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -131,8 +131,8 @@ public class ApiVersionsResponse extends AbstractResponse {
         return apiKeys;
     }
 
-    public static ApiVersionsResponseKeyCollection commonApiVersionsWithActiveController(final byte minMagic,
-                                                                                         final Map<ApiKeys, ApiVersion> activeControllerApiVersions) {
+    public static ApiVersionsResponseKeyCollection intersectControllerApiVersions(final byte minMagic,
+                                                                                  final Map<ApiKeys, ApiVersion> activeControllerApiVersions) {
         ApiVersionsResponseKeyCollection apiKeys = new ApiVersionsResponseKeyCollection();
         for (ApiKeys apiKey : ApiKeys.enabledApis()) {
             if (apiKey.minRequiredInterBrokerMagic <= minMagic) {

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKeyCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiVersion;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.junit.jupiter.api.Test;
 

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -127,6 +127,13 @@ public class NodeApiVersionsTest {
     }
 
     @Test
+    public void testLatestUsableVersionOutOfRange() {
+        NodeApiVersions apiVersions = NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 300, (short) 300);
+        assertThrows(UnsupportedVersionException.class,
+            () -> apiVersions.latestUsableVersion(ApiKeys.PRODUCE));
+    }
+
+    @Test
     public void testUsableVersionLatestVersions() {
         List<ApiVersion> versionList = new LinkedList<>();
         for (ApiVersionsResponseKey apiVersion: ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.data().apiKeys()) {

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -127,13 +127,6 @@ public class NodeApiVersionsTest {
     }
 
     @Test
-    public void testLatestUsableVersionOutOfRange() {
-        NodeApiVersions apiVersions = NodeApiVersions.create(ApiKeys.PRODUCE.id, (short) 300, (short) 300);
-        assertThrows(UnsupportedVersionException.class,
-            () -> apiVersions.latestUsableVersion(ApiKeys.PRODUCE));
-    }
-
-    @Test
     public void testUsableVersionLatestVersions() {
         List<ApiVersion> versionList = new LinkedList<>();
         for (ApiVersionsResponseKey apiVersion: ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.data().apiKeys()) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.clients.ApiVersion;
+import org.apache.kafka.common.protocol.ApiVersion;
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.MockClient;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.producer.internals;
 
-import org.apache.kafka.clients.ApiVersion;
+import org.apache.kafka.common.protocol.ApiVersion;
 import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.CommitFailedException;

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -17,12 +17,17 @@
 
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.protocol.ApiVersion;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey;
+import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKeyCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,6 +76,39 @@ public class ApiVersionsResponseTest {
         assertTrue(ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.data().supportedFeatures().isEmpty());
         assertTrue(ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.data().finalizedFeatures().isEmpty());
         assertEquals(ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH, ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.data().finalizedFeaturesEpoch());
+    }
+
+    @Test
+    public void shouldHaveCommonlyAgreedApiVersionResponseWithControllerOnForwardableAPIs() {
+        final ApiKeys forwardableAPIKey = ApiKeys.CREATE_ACLS;
+        final ApiKeys nonForwardableAPIKey = ApiKeys.JOIN_GROUP;
+        final short minVersion = 0;
+        final short maxVersion = 1;
+        Map<ApiKeys, ApiVersion> activeControllerApiVersions = Utils.mkMap(
+            Utils.mkEntry(forwardableAPIKey, new ApiVersion(forwardableAPIKey.id, minVersion, maxVersion)),
+            Utils.mkEntry(nonForwardableAPIKey, new ApiVersion(nonForwardableAPIKey.id, minVersion, maxVersion))
+        );
+
+        ApiVersionsResponseKeyCollection commonResponse = ApiVersionsResponse.commonApiVersionWithActiveController(
+            RecordBatch.CURRENT_MAGIC_VALUE,
+            activeControllerApiVersions);
+
+        verifyVersions(forwardableAPIKey.id, minVersion, maxVersion, commonResponse);
+
+        verifyVersions(nonForwardableAPIKey.id, ApiKeys.JOIN_GROUP.oldestVersion(),
+            ApiKeys.JOIN_GROUP.latestVersion(), commonResponse);
+    }
+
+    private void verifyVersions(short forwardableAPIKey,
+                                short minVersion,
+                                short maxVersion,
+                                ApiVersionsResponseKeyCollection commonResponse) {
+        ApiVersionsResponseKey expectedVersionsForForwardableAPI =
+            new ApiVersionsResponseKey()
+                .setApiKey(forwardableAPIKey)
+                .setMinVersion(minVersion)
+                .setMaxVersion(maxVersion);
+        assertEquals(expectedVersionsForForwardableAPI, commonResponse.find(forwardableAPIKey));
     }
 
     private Set<ApiKeys> apiKeysInResponse(final ApiVersionsResponse apiVersions) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -89,7 +89,7 @@ public class ApiVersionsResponseTest {
             Utils.mkEntry(nonForwardableAPIKey, new ApiVersion(nonForwardableAPIKey.id, minVersion, maxVersion))
         );
 
-        ApiVersionsResponseKeyCollection commonResponse = ApiVersionsResponse.commonApiVersionsWithActiveController(
+        ApiVersionsResponseKeyCollection commonResponse = ApiVersionsResponse.intersectControllerApiVersions(
             RecordBatch.CURRENT_MAGIC_VALUE,
             activeControllerApiVersions);
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -89,7 +89,7 @@ public class ApiVersionsResponseTest {
             Utils.mkEntry(nonForwardableAPIKey, new ApiVersion(nonForwardableAPIKey.id, minVersion, maxVersion))
         );
 
-        ApiVersionsResponseKeyCollection commonResponse = ApiVersionsResponse.commonApiVersionWithActiveController(
+        ApiVersionsResponseKeyCollection commonResponse = ApiVersionsResponse.commonApiVersionsWithActiveController(
             RecordBatch.CURRENT_MAGIC_VALUE,
             activeControllerApiVersions);
 

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -17,6 +17,7 @@
 
 package kafka.api
 
+import org.apache.kafka.clients.NodeApiVersions
 import org.apache.kafka.common.config.ConfigDef.Validator
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.feature.{Features, FinalizedVersionRange, SupportedVersionRange}
@@ -148,13 +149,15 @@ object ApiVersion {
 
   def apiVersionsResponse(throttleTimeMs: Int,
                           maxMagic: Byte,
-                          latestSupportedFeatures: Features[SupportedVersionRange]): ApiVersionsResponse = {
+                          latestSupportedFeatures: Features[SupportedVersionRange],
+                          controllerApiVersions: Option[NodeApiVersions]): ApiVersionsResponse = {
     apiVersionsResponse(
       throttleTimeMs,
       maxMagic,
       latestSupportedFeatures,
       Features.emptyFinalizedFeatures,
-      ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH
+      ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH,
+      controllerApiVersions
     )
   }
 
@@ -162,28 +165,33 @@ object ApiVersion {
                           maxMagic: Byte,
                           latestSupportedFeatures: Features[SupportedVersionRange],
                           finalizedFeatures: Features[FinalizedVersionRange],
-                          finalizedFeaturesEpoch: Long): ApiVersionsResponse = {
-    val apiKeys = ApiVersionsResponse.defaultApiKeys(maxMagic)
+                          finalizedFeaturesEpoch: Long,
+                          controllerApiVersions: Option[NodeApiVersions]): ApiVersionsResponse = {
+    val apiKeys = controllerApiVersions match {
+      case None => ApiVersionsResponse.defaultApiKeys(maxMagic)
+      case Some(controllerApiVersion) => ApiVersionsResponse.commonApiVersionWithActiveController(
+        maxMagic, controllerApiVersion.fullApiVersions())
+    }
+
     if (maxMagic == RecordBatch.CURRENT_MAGIC_VALUE &&
       throttleTimeMs == AbstractResponse.DEFAULT_THROTTLE_TIME)
-      return new ApiVersionsResponse(
+      new ApiVersionsResponse(
         ApiVersionsResponse.createApiVersionsResponseData(
           DEFAULT_API_VERSIONS_RESPONSE.throttleTimeMs,
           Errors.forCode(DEFAULT_API_VERSIONS_RESPONSE.data.errorCode),
           apiKeys,
           latestSupportedFeatures,
           finalizedFeatures,
+          finalizedFeaturesEpoch))
+    else
+      new ApiVersionsResponse(
+        ApiVersionsResponse.createApiVersionsResponseData(
+          throttleTimeMs,
+          Errors.NONE,
+          apiKeys,
+          latestSupportedFeatures,
+          finalizedFeatures,
           finalizedFeaturesEpoch)
-      )
-
-    new ApiVersionsResponse(
-      ApiVersionsResponse.createApiVersionsResponseData(
-        throttleTimeMs,
-        Errors.NONE,
-        apiKeys,
-        latestSupportedFeatures,
-        finalizedFeatures,
-        finalizedFeaturesEpoch)
     )
   }
 }

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -170,7 +170,7 @@ object ApiVersion {
     val apiKeys = controllerApiVersions match {
       case None => ApiVersionsResponse.defaultApiKeys(maxMagic)
       case Some(controllerApiVersion) => ApiVersionsResponse.intersectControllerApiVersions(
-        maxMagic, controllerApiVersion.fullApiVersions())
+        maxMagic, controllerApiVersion.allSupportedApiVersions())
     }
 
     if (maxMagic == RecordBatch.CURRENT_MAGIC_VALUE &&

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -169,12 +169,12 @@ object ApiVersion {
                           controllerApiVersions: Option[NodeApiVersions]): ApiVersionsResponse = {
     val apiKeys = controllerApiVersions match {
       case None => ApiVersionsResponse.defaultApiKeys(maxMagic)
-      case Some(controllerApiVersion) => ApiVersionsResponse.commonApiVersionsWithActiveController(
+      case Some(controllerApiVersion) => ApiVersionsResponse.intersectControllerApiVersions(
         maxMagic, controllerApiVersion.fullApiVersions())
     }
 
     if (maxMagic == RecordBatch.CURRENT_MAGIC_VALUE &&
-      throttleTimeMs == AbstractResponse.DEFAULT_THROTTLE_TIME)
+      throttleTimeMs == AbstractResponse.DEFAULT_THROTTLE_TIME) {
       new ApiVersionsResponse(
         ApiVersionsResponse.createApiVersionsResponseData(
           DEFAULT_API_VERSIONS_RESPONSE.throttleTimeMs,
@@ -183,7 +183,7 @@ object ApiVersion {
           latestSupportedFeatures,
           finalizedFeatures,
           finalizedFeaturesEpoch))
-    else
+    } else {
       new ApiVersionsResponse(
         ApiVersionsResponse.createApiVersionsResponseData(
           throttleTimeMs,
@@ -191,8 +191,8 @@ object ApiVersion {
           apiKeys,
           latestSupportedFeatures,
           finalizedFeatures,
-          finalizedFeaturesEpoch)
-    )
+          finalizedFeaturesEpoch))
+    }
   }
 }
 

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -169,7 +169,7 @@ object ApiVersion {
                           controllerApiVersions: Option[NodeApiVersions]): ApiVersionsResponse = {
     val apiKeys = controllerApiVersions match {
       case None => ApiVersionsResponse.defaultApiKeys(maxMagic)
-      case Some(controllerApiVersion) => ApiVersionsResponse.commonApiVersionWithActiveController(
+      case Some(controllerApiVersion) => ApiVersionsResponse.commonApiVersionsWithActiveController(
         maxMagic, controllerApiVersion.fullApiVersions())
     }
 

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -231,10 +231,10 @@ class BrokerToControllerRequestThread(
       requestQueue.putFirst(request)
     } else if (response.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
       // just close the controller connection and wait for metadata cache update in doWork
-      activeControllerAddress().foreach(controllerAddress => {
+      activeControllerAddress().foreach { controllerAddress => {
         networkClient.disconnect(controllerAddress.idString)
         updateControllerAddress(null)
-      })
+      }}
 
       requestQueue.putFirst(request)
     } else {

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 
 import kafka.network.RequestChannel
 import kafka.utils.Logging
-import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.clients.{ClientResponse, NodeApiVersions}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, EnvelopeRequest, EnvelopeResponse, RequestHeader}
@@ -35,6 +35,8 @@ trait ForwardingManager {
     request: RequestChannel.Request,
     responseCallback: AbstractResponse => Unit
   ): Unit
+
+  def controllerApiVersions(): Option[NodeApiVersions]
 
   def start(): Unit = {}
 
@@ -121,6 +123,9 @@ class ForwardingManagerImpl(
 
     channelManager.sendRequest(envelopeRequest, new ForwardingResponseHandler)
   }
+
+  override def controllerApiVersions(): Option[NodeApiVersions] =
+    channelManager.controllerApiVersions()
 
   private def parseResponse(
     buffer: ByteBuffer,

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -100,9 +100,10 @@ class ForwardingManagerImpl(
         val envelopeError = envelopeResponse.error()
         val requestBody = request.body[AbstractRequest]
 
-        // Unsupported version indicates an incompatibility between controller and client API versions. The
-        // forwarding broker should close the connection with the client and let it reinitialize the connection
-        // and refresh the controller API versions.
+        // Unsupported version indicates an incompatibility between controller and client API versions. This
+        // could happen when the controller changed after the connection was established. The forwarding broker
+        // should close the connection with the client and let it reinitialize the connection and refresh
+        // the controller API versions.
         if (envelopeError == Errors.UNSUPPORTED_VERSION) {
           responseCallback(Right(Errors.UNSUPPORTED_VERSION))
         } else {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -143,7 +143,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     }
 
     if (!request.isForwarded && !controller.isActive && isForwardingEnabled(request)) {
-      forwardingManager.forwardRequest(request, responseCallback)
+      forwardingManager.forwardRequest(request, responseCallback, closeConnection)
     } else {
       // When the KIP-500 mode is off or the principal serde is undefined, forwarding is not supported,
       // therefore requests are handled directly.

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1754,8 +1754,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         val finalizedFeaturesOpt = finalizedFeatureCache.get
         val controllerApiVersions = if (isForwardingEnabled(request)) {
           forwardingManager.controllerApiVersions()
-        } else
+        } else {
           None
+        }
 
         val apiVersionsResponse =
           finalizedFeaturesOpt match {
@@ -1771,7 +1772,6 @@ class KafkaApis(val requestChannel: RequestChannel,
               config.interBrokerProtocolVersion.recordVersion.value,
               supportedFeatures,
               controllerApiVersions)
-
           }
         if (request.context.fromPrivilegedListener) {
           apiVersionsResponse.data.apiKeys().add(

--- a/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/BrokerApiVersionsCommandTest.scala
@@ -34,7 +34,16 @@ import scala.jdk.CollectionConverters._
 
 class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
 
-  def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(1, zkConnect).map(KafkaConfig.fromProps)
+  def generateConfigs: Seq[KafkaConfig] =
+    TestUtils.createBrokerConfigs(1, zkConnect).map(props => {
+      // Configure control plane listener to make sure we have separate listeners from client,
+      // in order to avoid returning Envelope API version.
+      props.setProperty(KafkaConfig.ControlPlaneListenerNameProp, "CONTROLLER")
+      props.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+      props.setProperty("listeners", "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
+      props.setProperty(KafkaConfig.AdvertisedListenersProp, "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
+      props
+    }).map(KafkaConfig.fromProps)
 
   @Test(timeout=120000)
   def checkBrokerApiVersionCommandOutput(): Unit = {
@@ -55,13 +64,10 @@ class BrokerApiVersionsCommandTest extends KafkaServerTestHarness {
         if (apiVersion.minVersion == apiVersion.maxVersion) apiVersion.minVersion.toString
         else s"${apiVersion.minVersion} to ${apiVersion.maxVersion}"
       val usableVersion = nodeApiVersions.latestUsableVersion(apiKey)
-      // Admin client should not see ENVELOPE supported versions as its a broker-internal API.
-      val usableVersionInfo = if (apiKey == ApiKeys.ENVELOPE) "UNSUPPORTED" else
-        s"$versionRangeStr [usable: $usableVersion]"
 
       val terminator = if (apiKey == enabledApis.last) "" else ","
 
-      val line = s"\t${apiKey.name}(${apiKey.id}): $usableVersionInfo$terminator"
+      val line = s"\t${apiKey.name}(${apiKey.id}): $versionRangeStr [usable: $usableVersion]$terminator"
       assertTrue(lineIter.hasNext)
       assertEquals(line, lineIter.next())
     }

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kafka.cluster.{Broker, EndPoint}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.{ClientResponse, ManualMetadataUpdater, Metadata, MockClient}
+import org.apache.kafka.common.Node
 import org.apache.kafka.common.feature.Features
 import org.apache.kafka.common.feature.Features.emptySupportedFeatures
 import org.apache.kafka.common.message.MetadataRequestData
@@ -177,10 +178,11 @@ class BrokerToControllerRequestThreadTest {
 
     val metadataCache = mock(classOf[MetadataCache])
     val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    val port = 1234
     val oldController = new Broker(oldControllerId,
-      Seq(new EndPoint("host1", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+      Seq(new EndPoint("host1", port, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
     val newController = new Broker(2,
-      Seq(new EndPoint("host2", 1234, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
+      Seq(new EndPoint("host2", port, listenerName, SecurityProtocol.PLAINTEXT)), None, Features.emptySupportedFeatures)
 
     when(metadataCache.getControllerId).thenReturn(Some(oldControllerId), Some(newControllerId))
     when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
@@ -204,17 +206,25 @@ class BrokerToControllerRequestThreadTest {
     testRequestThread.enqueue(queueItem)
     // initialize to the controller
     testRequestThread.doWork()
+
+    val oldBrokerNode = new Node(oldControllerId, "host1", port)
+    assertEquals(Some(oldBrokerNode), testRequestThread.activeControllerAddress())
+
     // send and process the request
     mockClient.prepareResponse((body: AbstractRequest) => {
       body.isInstanceOf[MetadataRequest] &&
       body.asInstanceOf[MetadataRequest].allowAutoTopicCreation()
     }, responseWithNotControllerError)
     testRequestThread.doWork()
+    assertEquals(None, testRequestThread.activeControllerAddress())
     // reinitialize the controller to a different node
     testRequestThread.doWork()
     // process the request again
     mockClient.prepareResponse(expectedResponse)
     testRequestThread.doWork()
+
+    val newControllerNode = new Node(newControllerId, "host2", port)
+    assertEquals(Some(newControllerNode), testRequestThread.activeControllerAddress())
 
     assertTrue(completionHandler.completed.get())
   }

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -180,7 +180,8 @@ class ApiVersionTest {
     val response = ApiVersion.apiVersionsResponse(
       10,
       RecordBatch.MAGIC_VALUE_V1,
-      Features.emptySupportedFeatures
+      Features.emptySupportedFeatures,
+      None
     )
     verifyApiKeysForMagic(response, RecordBatch.MAGIC_VALUE_V1)
     assertEquals(10, response.throttleTimeMs)
@@ -198,7 +199,8 @@ class ApiVersionTest {
         Utils.mkMap(Utils.mkEntry("feature", new SupportedVersionRange(1.toShort, 4.toShort)))),
       Features.finalizedFeatures(
         Utils.mkMap(Utils.mkEntry("feature", new FinalizedVersionRange(2.toShort, 3.toShort)))),
-      10
+      10,
+      None
     )
 
     verifyApiKeysForMagic(response, RecordBatch.MAGIC_VALUE_V1)
@@ -227,7 +229,8 @@ class ApiVersionTest {
     val response = ApiVersion.apiVersionsResponse(
       AbstractResponse.DEFAULT_THROTTLE_TIME,
       RecordBatch.CURRENT_MAGIC_VALUE,
-      Features.emptySupportedFeatures
+      Features.emptySupportedFeatures,
+      None
     )
     assertEquals(new util.HashSet[ApiKeys](ApiKeys.enabledApis), apiKeysInResponse(response))
     assertEquals(AbstractResponse.DEFAULT_THROTTLE_TIME, response.throttleTimeMs)
@@ -241,7 +244,8 @@ class ApiVersionTest {
     val response = ApiVersion.apiVersionsResponse(
       AbstractResponse.DEFAULT_THROTTLE_TIME,
       RecordBatch.CURRENT_MAGIC_VALUE,
-      Features.emptySupportedFeatures
+      Features.emptySupportedFeatures,
+      None
     )
 
     // Ensure that APIs needed for the internal metadata quorum (KIP-500)

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -21,9 +21,9 @@ import java.util
 import java.util.Collections
 
 import org.apache.kafka.clients.MockClient.MockMetadataUpdater
-import org.apache.kafka.clients.{ApiVersion, MockClient, NodeApiVersions}
+import org.apache.kafka.clients.{MockClient, NodeApiVersions}
 import org.apache.kafka.common.message.{BeginQuorumEpochResponseData, EndQuorumEpochResponseData, FetchResponseData, VoteResponseData}
-import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
+import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, ApiVersion, Errors}
 import org.apache.kafka.common.requests.{AbstractResponse, BeginQuorumEpochRequest, BeginQuorumEpochResponse, EndQuorumEpochRequest, EndQuorumEpochResponse, FetchResponse, VoteRequest, VoteResponse}
 import org.apache.kafka.common.utils.{MockTime, Time}
 import org.apache.kafka.common.{Node, TopicPartition}

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -49,7 +49,7 @@ abstract class AbstractApiVersionsRequestTest extends BaseRequestTest {
 
   def validateApiVersionsResponse(apiVersionsResponse: ApiVersionsResponse, listenerName: ListenerName = interBrokerListenerName): Unit = {
     val expectedApis = ApiKeys.enabledApis()
-    if (listenerName.equals(controlPlaneListenerName) ) {
+    if (listenerName == controlPlaneListenerName) {
       expectedApis.add(ApiKeys.ENVELOPE)
     }
     assertEquals("API keys in ApiVersionsResponse must match API keys supported by broker.",

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -31,9 +31,9 @@ abstract class AbstractApiVersionsRequestTest extends BaseRequestTest {
   // in order to avoid returning Envelope API version.
   override def brokerPropertyOverrides(properties: Properties): Unit = {
     properties.setProperty(KafkaConfig.ControlPlaneListenerNameProp, "CONTROLLER")
-    properties.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
-    properties.setProperty("listeners", "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
-    properties.setProperty(KafkaConfig.AdvertisedListenersProp, "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
+    properties.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"CONTROLLER:$securityProtocol,$securityProtocol:$securityProtocol")
+    properties.setProperty("listeners", s"$securityProtocol://localhost:0,CONTROLLER://localhost:0")
+    properties.setProperty(KafkaConfig.AdvertisedListenersProp, s"$securityProtocol://localhost:0,CONTROLLER://localhost:0")
   }
 
   def sendUnsupportedApiVersionRequest(request: ApiVersionsRequest): ApiVersionsResponse = {

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -16,6 +16,8 @@
  */
 package kafka.server
 
+import java.util.Properties
+
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse}
@@ -24,6 +26,15 @@ import org.junit.Assert._
 import scala.jdk.CollectionConverters._
 
 abstract class AbstractApiVersionsRequestTest extends BaseRequestTest {
+
+  // Configure control plane listener to make sure we have separate listeners from client,
+  // in order to avoid returning Envelope API version.
+  override def brokerPropertyOverrides(properties: Properties): Unit = {
+    properties.setProperty(KafkaConfig.ControlPlaneListenerNameProp, "CONTROLLER")
+    properties.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+    properties.setProperty("listeners", "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
+    properties.setProperty(KafkaConfig.AdvertisedListenersProp, "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
+  }
 
   def sendUnsupportedApiVersionRequest(request: ApiVersionsRequest): ApiVersionsResponse = {
     val overrideHeader = nextRequestHeader(ApiKeys.API_VERSIONS, Short.MaxValue)

--- a/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
@@ -18,6 +18,7 @@
 package kafka.server
 
 import org.apache.kafka.common.message.ApiVersionsRequestData
+import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse}
 import org.junit.Assert._
@@ -32,6 +33,13 @@ class ApiVersionsRequestTest extends AbstractApiVersionsRequestTest {
     val request = new ApiVersionsRequest.Builder().build()
     val apiVersionsResponse = sendApiVersionsRequest(request)
     validateApiVersionsResponse(apiVersionsResponse)
+  }
+
+  @Test
+  def testApiVersionsRequestThroughControlPlaneListener(): Unit = {
+    val request = new ApiVersionsRequest.Builder().build()
+    val apiVersionsResponse = sendApiVersionsRequest(request, super.controlPlaneListenerName)
+    validateApiVersionsResponse(apiVersionsResponse, super.controlPlaneListenerName)
   }
 
   @Test
@@ -54,6 +62,13 @@ class ApiVersionsRequestTest extends AbstractApiVersionsRequestTest {
   }
 
   @Test
+  def testApiVersionsRequestValidationV0ThroughControlPlaneListener(): Unit = {
+    val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0.asInstanceOf[Short])
+    val apiVersionsResponse = sendApiVersionsRequest(apiVersionsRequest, super.controlPlaneListenerName)
+    validateApiVersionsResponse(apiVersionsResponse, super.controlPlaneListenerName)
+  }
+
+  @Test
   def testApiVersionsRequestValidationV3(): Unit = {
     // Invalid request because Name and Version are empty by default
     val apiVersionsRequest = new ApiVersionsRequest(new ApiVersionsRequestData(), 3.asInstanceOf[Short])
@@ -61,8 +76,8 @@ class ApiVersionsRequestTest extends AbstractApiVersionsRequestTest {
     assertEquals(Errors.INVALID_REQUEST.code(), apiVersionsResponse.data.errorCode())
   }
 
-  private def sendApiVersionsRequest(request: ApiVersionsRequest): ApiVersionsResponse = {
-    connectAndReceive[ApiVersionsResponse](request)
+  private def sendApiVersionsRequest(request: ApiVersionsRequest,
+                                     listenerName: ListenerName = super.listenerName): ApiVersionsResponse = {
+    connectAndReceive[ApiVersionsResponse](request, listenerName = listenerName)
   }
-
 }

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -18,7 +18,8 @@ package kafka.server
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
-import java.util.Optional
+import java.util.{Collections, Optional}
+import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.network
 import kafka.network.RequestChannel
@@ -73,10 +74,52 @@ class ForwardingManagerTest {
     })
 
     var response: AbstractResponse = null
-    forwardingManager.forwardRequest(request, res => response = res)
+    forwardingManager.forwardRequest(request, res => response = res, (_, _) => {})
 
     assertNotNull(response)
     assertEquals(Map(Errors.UNKNOWN_SERVER_ERROR -> 1).asJava, response.errorCounts())
+  }
+
+  @Test
+  def testUnsupportedVersions(): Unit = {
+    val forwardingManager = new ForwardingManagerImpl(brokerToController)
+    val requestCorrelationId = 27
+    val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "client")
+
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, "foo")
+    val configs = List(new AlterConfigsRequest.ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "1")).asJava
+    val requestBody = new AlterConfigsRequest.Builder(Map(
+      configResource -> new AlterConfigsRequest.Config(configs)
+    ).asJava, false).build()
+    val (requestHeader, requestBuffer) = buildRequest(requestBody, requestCorrelationId)
+    val request = buildRequest(requestHeader, requestBuffer, clientPrincipal)
+
+    val responseBody = new AlterConfigsResponse(new AlterConfigsResponseData()
+      .setResponses(Collections.singletonList(
+      new AlterConfigsResponseData.AlterConfigsResourceResponse()
+        .setErrorCode(Errors.UNSUPPORTED_VERSION.code()))))
+
+    val responseBuffer = RequestTestUtils.serializeResponseWithHeader(responseBody,
+      requestHeader.apiVersion, requestCorrelationId)
+
+    Mockito.when(brokerToController.sendRequest(
+      any(classOf[EnvelopeRequest.Builder]),
+      any(classOf[ControllerRequestCompletionHandler])
+    )).thenAnswer(invocation => {
+      val completionHandler = invocation.getArgument[RequestCompletionHandler](1)
+      val response = buildEnvelopeResponse(responseBuffer, 30, completionHandler)
+      response.onComplete()
+    })
+
+    var response: AbstractResponse = null
+    val connectionClosed = new AtomicBoolean(false)
+    forwardingManager.forwardRequest(request, res => response = res, (_, errorCounts) => {
+      assertEquals(Map(Errors.UNSUPPORTED_VERSION -> 1).asJava, errorCounts)
+      connectionClosed.set(true)
+    })
+
+    assertTrue(connectionClosed.get())
+    assertNull(response)
   }
 
   private def buildEnvelopeResponse(

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -74,7 +74,7 @@ class ForwardingManagerTest {
     })
 
     var response: AbstractResponse = null
-    forwardingManager.forwardRequest(request, result => response = result.swap.getOrElse(null))
+    forwardingManager.forwardRequest(request, result => response = result.orNull)
 
     assertNotNull(response)
     assertEquals(Map(Errors.UNKNOWN_SERVER_ERROR -> 1).asJava, response.errorCounts())
@@ -111,12 +111,10 @@ class ForwardingManagerTest {
 
     var response: AbstractResponse = null
     val connectionClosed = new AtomicBoolean(false)
-    forwardingManager.forwardRequest(request, result => result.fold(
-      res => response = res,
-      error => {
-      assertEquals(Errors.UNSUPPORTED_VERSION, error)
+    forwardingManager.forwardRequest(request, res => {
+      response = res.orNull
       connectionClosed.set(true)
-    }))
+    })
 
     assertTrue(connectionClosed.get())
     assertNull(response)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -750,7 +750,15 @@ class KafkaApisTest {
 
     val response = readResponse(apiVersionsRequest, capturedResponse)
       .asInstanceOf[ApiVersionsResponse]
-    assertEquals(Errors.UNSUPPORTED_VERSION, Errors.forCode(response.data().errorCode()))
+    assertEquals(Errors.NONE, Errors.forCode(response.data().errorCode()))
+
+    val expectedVersions = new ApiVersionsResponseData.ApiVersionsResponseKey()
+      .setApiKey(ApiKeys.ALTER_CONFIGS.id)
+      .setMaxVersion(ApiKeys.ALTER_CONFIGS.latestVersion())
+      .setMinVersion(ApiKeys.ALTER_CONFIGS.oldestVersion())
+
+    val alterConfigVersions = response.data().apiKeys().find(ApiKeys.ALTER_CONFIGS.id)
+    assertEquals(expectedVersions, alterConfigVersions)
 
     verify(authorizer, adminManager, forwardingManager)
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -520,7 +520,7 @@ class KafkaApisTest {
 
     EasyMock.expect(forwardingManager.forwardRequest(
       EasyMock.eq(request),
-      anyObject[Either[AbstractResponse, Errors] => Unit]()
+      anyObject[Option[AbstractResponse] => Unit]()
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, controller, forwardingManager)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -520,8 +520,7 @@ class KafkaApisTest {
 
     EasyMock.expect(forwardingManager.forwardRequest(
       EasyMock.eq(request),
-      anyObject[AbstractResponse => Unit](),
-      anyObject[(RequestChannel.Request, java.util.Map[Errors, Integer]) => Unit]()
+      anyObject[Either[AbstractResponse, Errors] => Unit]()
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, controller, forwardingManager)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -520,7 +520,8 @@ class KafkaApisTest {
 
     EasyMock.expect(forwardingManager.forwardRequest(
       EasyMock.eq(request),
-      anyObject[AbstractResponse => Unit]()
+      anyObject[AbstractResponse => Unit](),
+      anyObject[(RequestChannel.Request, java.util.Map[Errors, Integer]) => Unit]()
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, controller, forwardingManager)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -36,6 +36,7 @@ import kafka.network.RequestChannel.{CloseConnectionResponse, SendResponse}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.utils.{MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
+import org.apache.kafka.clients.NodeApiVersions
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.common.acl.AclOperation
@@ -688,6 +689,70 @@ class KafkaApisTest {
           assertEquals(thrown, expected(entity).exception())
         ).isDone
     }
+  }
+
+  @Test
+  def testHandleApiVersionsWithControllerApiVersions(): Unit = {
+    val authorizer: Authorizer = EasyMock.niceMock(classOf[Authorizer])
+
+    val requestHeader = new RequestHeader(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion, clientId, 0)
+
+    val permittedVersion: Short = 0
+    EasyMock.expect(forwardingManager.controllerApiVersions()).andReturn(
+      Some(NodeApiVersions.create(ApiKeys.ALTER_CONFIGS.id, permittedVersion, permittedVersion)))
+
+    val capturedResponse = expectNoThrottling()
+
+    val apiVersionsRequest = new ApiVersionsRequest.Builder()
+      .build(requestHeader.apiVersion)
+    val request = buildRequest(apiVersionsRequest,
+      fromPrivilegedListener = true, requestHeader = Option(requestHeader))
+
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, forwardingManager,
+      requestChannel, authorizer, adminManager, controller)
+
+    createKafkaApis(authorizer = Some(authorizer), enableForwarding = true).handleApiVersionsRequest(request)
+
+    val expectedVersions = new ApiVersionsResponseData.ApiVersionsResponseKey()
+      .setApiKey(ApiKeys.ALTER_CONFIGS.id)
+      .setMaxVersion(permittedVersion)
+      .setMinVersion(permittedVersion)
+
+    val response = readResponse(apiVersionsRequest, capturedResponse)
+      .asInstanceOf[ApiVersionsResponse]
+    assertEquals(Errors.NONE, Errors.forCode(response.data().errorCode()))
+
+    val alterConfigVersions = response.data().apiKeys().find(ApiKeys.ALTER_CONFIGS.id)
+    assertEquals(expectedVersions, alterConfigVersions)
+
+    verify(authorizer, adminManager, forwardingManager)
+  }
+
+  @Test
+  def testGetUnsupportedVersionsWhenControllerApiVersionsNotAvailable(): Unit = {
+    val authorizer: Authorizer = EasyMock.niceMock(classOf[Authorizer])
+
+    val requestHeader = new RequestHeader(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion, clientId, 0)
+
+    EasyMock.expect(forwardingManager.controllerApiVersions()).andReturn(None)
+
+    val capturedResponse = expectNoThrottling()
+
+    val apiVersionsRequest = new ApiVersionsRequest.Builder()
+      .build(requestHeader.apiVersion)
+    val request = buildRequest(apiVersionsRequest,
+      fromPrivilegedListener = true, requestHeader = Option(requestHeader))
+
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, forwardingManager,
+      requestChannel, authorizer, adminManager, controller)
+
+    createKafkaApis(authorizer = Some(authorizer), enableForwarding = true).handleApiVersionsRequest(request)
+
+    val response = readResponse(apiVersionsRequest, capturedResponse)
+      .asInstanceOf[ApiVersionsResponse]
+    assertEquals(Errors.UNSUPPORTED_VERSION, Errors.forCode(response.data().errorCode()))
+
+    verify(authorizer, adminManager, forwardingManager)
   }
 
   @Test


### PR DESCRIPTION
To make sure the forwarded request could be properly handled by the controller, when forwarding is enabled, we should acquire the controller API versions to enforce as joint constraints back to the client.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
