### PR TITLE
[MINOR] adjust the log level to error

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -477,7 +477,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           val exceptionsSummary = mergedResponseStatus.map { case (topicPartition, status) =>
             topicPartition -> status.error.exceptionName
           }.mkString(", ")
-          info(
+          error(
             s"Closing connection due to error during produce request with correlation id ${request.header.correlationId} " +
               s"from client id ${request.header.clientId} with ack=0\n" +
               s"Topic and partition to exceptions: $exceptionsSummary"


### PR DESCRIPTION
we recently encounter this log which should be more of a warn, or error message. Even though it checks acks=0, it still should bring people's attention on
```
[2020-11-17 01:05:17,005] INFO [KafkaApi-2] Closing connection due to error during produce request with correlation id 1159730542 from client id -0 with ack=0
Topic and partition to exceptions:some-topic-name-30 -> org.apache.kafka.common.errors.RecordTooLargeException (kafka.server.KafkaApis)
```