### PR TITLE
MINOR: Enable testLogCleanerStats

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1450,9 +1450,9 @@ class LogCleanerTest {
   @Test
   def testBuildPartialOffsetMap(): Unit = {
     // because loadFactor is 0.75, this means we can fit 2 messages in the map
-    val map = new FakeOffsetMap(3)
     val log = makeLog()
-    val cleaner = makeCleaner(2)
+    val cleaner = makeCleaner(3)
+    val map = cleaner.offsetMap
 
     log.appendAsLeader(record(0,0), leaderEpoch = 0)
     log.appendAsLeader(record(1,1), leaderEpoch = 0)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -815,9 +815,10 @@ class LogCleanerTest {
                (0 until leo.toInt by 2).forall(!keys.contains(_)))
   }
 
+  @Test
   def testLogCleanerStats(): Unit = {
-    // because loadFactor is 0.75, this means we can fit 2 messages in the map
-    val cleaner = makeCleaner(2)
+    // because loadFactor is 0.75, this means we can fit 3 messages in the map
+    val cleaner = makeCleaner(4)
     val logProps = new Properties()
     logProps.put(LogConfig.SegmentBytesProp, 1024: java.lang.Integer)
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -902,7 +902,7 @@ class LogCleanerTest {
 
   @Test
   def testPartialSegmentClean(): Unit = {
-    // because loadFactor is 0.75, this means we can fit 2 messages in the map
+    // because loadFactor is 0.75, this means we can fit 1 message in the map
     val cleaner = makeCleaner(2)
     val logProps = new Properties()
     logProps.put(LogConfig.SegmentBytesProp, 1024: java.lang.Integer)


### PR DESCRIPTION
The `testLogCleanerStats` test in `LogCleanerTest.scala` was not enabled but it was implemented. This PR adds the `@Test` annotation, and also gives it a larger map to allow the test to pass as intended.