### PR TITLE
KAFKA-6687: restrict DSL to allow only Streams from the same source topics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -25,7 +25,7 @@ import org.apache.kafka.streams.kstream.ValueTransformer;
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -49,7 +49,7 @@ public abstract class AbstractStream<K, V> {
     protected final Serde<K> keySerde;
     protected final Serde<V> valueSerde;
     protected final Set<String> subTopologySourceNodes;
-    protected final StreamsGraphNode streamsGraphNode;
+    protected final GraphNode graphNode;
     protected final InternalStreamsBuilder builder;
 
     // This copy-constructor will allow to extend KStream
@@ -60,14 +60,14 @@ public abstract class AbstractStream<K, V> {
         this.keySerde = stream.keySerde;
         this.valueSerde = stream.valueSerde;
         this.subTopologySourceNodes = stream.subTopologySourceNodes;
-        this.streamsGraphNode = stream.streamsGraphNode;
+        this.graphNode = stream.graphNode;
     }
 
     AbstractStream(final String name,
                    final Serde<K> keySerde,
                    final Serde<V> valueSerde,
                    final Set<String> subTopologySourceNodes,
-                   final StreamsGraphNode streamsGraphNode,
+                   final GraphNode graphNode,
                    final InternalStreamsBuilder builder) {
         if (subTopologySourceNodes == null || subTopologySourceNodes.isEmpty()) {
             throw new IllegalArgumentException("parameter <sourceNodes> must not be null or empty");
@@ -78,7 +78,7 @@ public abstract class AbstractStream<K, V> {
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
         this.subTopologySourceNodes = subTopologySourceNodes;
-        this.streamsGraphNode = streamsGraphNode;
+        this.graphNode = graphNode;
     }
 
     // This method allows to expose the InternalTopologyBuilder instance

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -129,7 +129,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             subTopologySourceNodes,
             name,
             aggregateBuilder,
-                                                         graphNode,
+            graphNode,
             groupPatterns);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImpl.java
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.kstream.SlidingWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windows;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.LinkedHashMap;
@@ -48,9 +48,9 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
 
     CogroupedKStreamImpl(final String name,
                          final Set<String> subTopologySourceNodes,
-                         final StreamsGraphNode streamsGraphNode,
+                         final GraphNode graphNode,
                          final InternalStreamsBuilder builder) {
-        super(name, null, null, subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, null, null, subTopologySourceNodes, graphNode, builder);
         groupPatterns = new LinkedHashMap<>();
         aggregateBuilder = new CogroupedStreamAggregateBuilder<>(builder);
     }
@@ -104,7 +104,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             subTopologySourceNodes,
             name,
             aggregateBuilder,
-            streamsGraphNode,
+            graphNode,
             groupPatterns);
     }
 
@@ -117,7 +117,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             subTopologySourceNodes,
             name,
             aggregateBuilder,
-            streamsGraphNode,
+            graphNode,
             groupPatterns);
     }
 
@@ -129,7 +129,7 @@ public class CogroupedKStreamImpl<K, VOut> extends AbstractStream<K, VOut> imple
             subTopologySourceNodes,
             name,
             aggregateBuilder,
-            streamsGraphNode,
+                                                         graphNode,
             groupPatterns);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -37,13 +37,13 @@ import org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNo
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 class CogroupedStreamAggregateBuilder<K, VOut> {
     private final InternalStreamsBuilder builder;
-    private final Map<KGroupedStreamImpl<K, ?>, StreamsGraphNode> parentNodes = new LinkedHashMap<>();
+    private final Map<KGroupedStreamImpl<K, ?>, GraphNode> parentNodes = new LinkedHashMap<>();
 
     CogroupedStreamAggregateBuilder(final InternalStreamsBuilder builder) {
         this.builder = builder;
@@ -56,7 +56,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final Serde<VOut> valueSerde,
                                 final String queryableName) {
         processRepartitions(groupPatterns, storeBuilder);
-        final Collection<StreamsGraphNode> processors = new ArrayList<>();
+        final Collection<GraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
@@ -85,7 +85,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                                   final Windows<W> windows) {
         processRepartitions(groupPatterns, storeBuilder);
 
-        final Collection<StreamsGraphNode> processors = new ArrayList<>();
+        final Collection<GraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
@@ -114,7 +114,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final SessionWindows sessionWindows,
                                 final Merger<? super K, VOut> sessionMerger) {
         processRepartitions(groupPatterns, storeBuilder);
-        final Collection<StreamsGraphNode> processors = new ArrayList<>();
+        final Collection<GraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
@@ -142,7 +142,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final String queryableName,
                                 final SlidingWindows slidingWindows) {
         processRepartitions(groupPatterns, storeBuilder);
-        final Collection<StreamsGraphNode> processors = new ArrayList<>();
+        final Collection<GraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
@@ -175,12 +175,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                 createRepartitionSource(repartionNamePrefix, repartitionNodeBuilder, repartitionReqs.keySerde, repartitionReqs.valueSerde);
 
                 if (!parentNodes.containsKey(repartitionReqs)) {
-                    final StreamsGraphNode repartitionNode = repartitionNodeBuilder.build();
-                    builder.addGraphNode(repartitionReqs.streamsGraphNode, repartitionNode);
+                    final GraphNode repartitionNode = repartitionNodeBuilder.build();
+                    builder.addGraphNode(repartitionReqs.graphNode, repartitionNode);
                     parentNodes.put(repartitionReqs, repartitionNode);
                 }
             } else {
-                parentNodes.put(repartitionReqs, repartitionReqs.streamsGraphNode);
+                parentNodes.put(repartitionReqs, repartitionReqs.graphNode);
             }
         }
 
@@ -191,7 +191,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     }
 
-    <KR, VIn> KTable<KR, VOut> createTable(final Collection<StreamsGraphNode> processors,
+    <KR, VIn> KTable<KR, VOut> createTable(final Collection<GraphNode> processors,
                                            final NamedInternal named,
                                            final Serde<KR> keySerde,
                                            final Serde<VOut> valueSerde,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -22,7 +22,7 @@ import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Collections;
@@ -40,8 +40,8 @@ class GroupedStreamAggregateBuilder<K, V> {
     private final String userProvidedRepartitionTopicName;
     private final Set<String> subTopologySourceNodes;
     private final String name;
-    private final StreamsGraphNode streamsGraphNode;
-    private StreamsGraphNode repartitionNode;
+    private final GraphNode graphNode;
+    private GraphNode repartitionNode;
 
     final Initializer<Long> countInitializer = () -> 0L;
 
@@ -54,7 +54,7 @@ class GroupedStreamAggregateBuilder<K, V> {
                                   final boolean repartitionRequired,
                                   final Set<String> subTopologySourceNodes,
                                   final String name,
-                                  final StreamsGraphNode streamsGraphNode) {
+                                  final GraphNode graphNode) {
 
         this.builder = builder;
         this.keySerde = groupedInternal.keySerde();
@@ -62,7 +62,7 @@ class GroupedStreamAggregateBuilder<K, V> {
         this.repartitionRequired = repartitionRequired;
         this.subTopologySourceNodes = subTopologySourceNodes;
         this.name = name;
-        this.streamsGraphNode = streamsGraphNode;
+        this.graphNode = graphNode;
         this.userProvidedRepartitionTopicName = groupedInternal.name();
     }
 
@@ -77,7 +77,7 @@ class GroupedStreamAggregateBuilder<K, V> {
         final String aggFunctionName = functionName.name();
 
         String sourceName = this.name;
-        StreamsGraphNode parentNode = streamsGraphNode;
+        GraphNode parentNode = graphNode;
 
         if (repartitionRequired) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -32,7 +32,7 @@ import org.apache.kafka.streams.kstream.SlidingWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedKStream;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windows;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.Objects;
@@ -51,9 +51,9 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
                        final Set<String> subTopologySourceNodes,
                        final GroupedInternal<K, V> groupedInternal,
                        final boolean repartitionRequired,
-                       final StreamsGraphNode streamsGraphNode,
+                       final GraphNode graphNode,
                        final InternalStreamsBuilder builder) {
-        super(name, groupedInternal.keySerde(), groupedInternal.valueSerde(), subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, groupedInternal.keySerde(), groupedInternal.valueSerde(), subTopologySourceNodes, graphNode, builder);
         this.repartitionRequired = repartitionRequired;
         this.userProvidedRepartitionTopicName = groupedInternal.name();
         this.aggregateBuilder = new GroupedStreamAggregateBuilder<>(
@@ -62,7 +62,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
             repartitionRequired,
             subTopologySourceNodes,
             name,
-            streamsGraphNode
+            graphNode
         );
     }
 
@@ -199,7 +199,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
             keySerde,
             valueSerde,
             aggregateBuilder,
-            streamsGraphNode
+            graphNode
         );
     }
 
@@ -214,7 +214,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
                 keySerde,
                 valueSerde,
                 aggregateBuilder,
-                streamsGraphNode
+                graphNode
         );
     }
 
@@ -229,7 +229,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
             keySerde,
             valueSerde,
             aggregateBuilder,
-            streamsGraphNode
+            graphNode
         );
     }
 
@@ -248,7 +248,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K, V> implements KGroupedS
     @Override
     public <VOut> CogroupedKStream<K, VOut> cogroup(final Aggregator<? super K, ? super V, VOut> aggregator) {
         Objects.requireNonNull(aggregator, "aggregator can't be null");
-        return new CogroupedKStreamImpl<K, VOut>(name, subTopologySourceNodes, streamsGraphNode, builder)
+        return new CogroupedKStreamImpl<K, VOut>(name, subTopologySourceNodes, graphNode, builder)
             .cogroup(this, aggregator);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -28,7 +28,7 @@ import org.apache.kafka.streams.kstream.Reducer;
 import org.apache.kafka.streams.kstream.internals.graph.GroupedTableOperationRepartitionNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -56,14 +56,14 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K, V> implements KGr
 
     private final Aggregator<K, V, Long> countSubtractor = (aggKey, value, aggregate) -> aggregate - 1L;
 
-    private StreamsGraphNode repartitionGraphNode;
+    private GraphNode repartitionGraphNode;
 
     KGroupedTableImpl(final InternalStreamsBuilder builder,
                       final String name,
                       final Set<String> subTopologySourceNodes,
                       final GroupedInternal<K, V> groupedInternal,
-                      final StreamsGraphNode streamsGraphNode) {
-        super(name, groupedInternal.keySerde(), groupedInternal.valueSerde(), subTopologySourceNodes, streamsGraphNode, builder);
+                      final GraphNode graphNode) {
+        super(name, groupedInternal.keySerde(), groupedInternal.valueSerde(), subTopologySourceNodes, graphNode, builder);
 
         this.userProvidedRepartitionTopicName = groupedInternal.name();
     }
@@ -85,7 +85,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K, V> implements KGr
 
 
         // the passed in StreamsGraphNode must be the parent of the repartition node
-        builder.addGraphNode(this.streamsGraphNode, repartitionGraphNode);
+        builder.addGraphNode(this.graphNode, repartitionGraphNode);
 
         final StatefulProcessorNode statefulProcessorNode = new StatefulProcessorNode<>(
             funcName,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -52,7 +52,7 @@ import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSinkNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamTableJoinNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamToTableNode;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.UnoptimizableRepartitionNode;
 import org.apache.kafka.streams.kstream.internals.graph.UnoptimizableRepartitionNode.UnoptimizableRepartitionNodeBuilder;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
@@ -137,9 +137,9 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                 final Serde<V> valueSerde,
                 final Set<String> subTopologySourceNodes,
                 final boolean repartitionRequired,
-                final StreamsGraphNode streamsGraphNode,
+                final GraphNode graphNode,
                 final InternalStreamsBuilder builder) {
-        super(name, keySerde, valueSerde, subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
         this.repartitionRequired = repartitionRequired;
     }
 
@@ -160,7 +160,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<? super K, ? super V> filterProcessorNode =
             new ProcessorGraphNode<>(name, processorParameters);
 
-        builder.addGraphNode(streamsGraphNode, filterProcessorNode);
+        builder.addGraphNode(graphNode, filterProcessorNode);
 
         return new KStreamImpl<>(
             name,
@@ -189,7 +189,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<? super K, ? super V> filterNotProcessorNode =
             new ProcessorGraphNode<>(name, processorParameters);
 
-        builder.addGraphNode(streamsGraphNode, filterNotProcessorNode);
+        builder.addGraphNode(graphNode, filterNotProcessorNode);
 
         return new KStreamImpl<>(
             name,
@@ -215,7 +215,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<K, V> selectKeyProcessorNode = internalSelectKey(mapper, new NamedInternal(named));
         selectKeyProcessorNode.keyChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, selectKeyProcessorNode);
+        builder.addGraphNode(graphNode, selectKeyProcessorNode);
 
         // key serde cannot be preserved
         return new KStreamImpl<>(
@@ -256,7 +256,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             new ProcessorGraphNode<>(name, processorParameters);
         mapProcessorNode.keyChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, mapProcessorNode);
+        builder.addGraphNode(graphNode, mapProcessorNode);
 
         // key and value serde cannot be preserved
         return new KStreamImpl<>(
@@ -298,7 +298,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             new ProcessorGraphNode<>(name, processorParameters);
         mapValuesProcessorNode.setValueChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, mapValuesProcessorNode);
+        builder.addGraphNode(graphNode, mapValuesProcessorNode);
 
         // value serde cannot be preserved
         return new KStreamImpl<>(
@@ -329,7 +329,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             new ProcessorGraphNode<>(name, processorParameters);
         flatMapNode.keyChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, flatMapNode);
+        builder.addGraphNode(graphNode, flatMapNode);
 
         // key and value serde cannot be preserved
         return new KStreamImpl<>(name, null, null, subTopologySourceNodes, true, flatMapNode, builder);
@@ -364,7 +364,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             new ProcessorGraphNode<>(name, processorParameters);
         flatMapValuesNode.setValueChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, flatMapValuesNode);
+        builder.addGraphNode(graphNode, flatMapValuesNode);
 
         // value serde cannot be preserved
         return new KStreamImpl<>(
@@ -388,7 +388,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<? super K, ? super V> printNode =
             new ProcessorGraphNode<>(name, processorParameters);
 
-        builder.addGraphNode(streamsGraphNode, printNode);
+        builder.addGraphNode(graphNode, printNode);
     }
 
     @Override
@@ -408,7 +408,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<? super K, ? super V> foreachNode =
             new ProcessorGraphNode<>(name, processorParameters);
 
-        builder.addGraphNode(streamsGraphNode, foreachNode);
+        builder.addGraphNode(graphNode, foreachNode);
     }
 
     @Override
@@ -428,7 +428,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<? super K, ? super V> peekNode =
             new ProcessorGraphNode<>(name, processorParameters);
 
-        builder.addGraphNode(streamsGraphNode, peekNode);
+        builder.addGraphNode(graphNode, peekNode);
 
         return new KStreamImpl<>(
             name,
@@ -476,7 +476,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<K, V> branchNode =
             new ProcessorGraphNode<>(branchName, processorParameters);
 
-        builder.addGraphNode(streamsGraphNode, branchNode);
+        builder.addGraphNode(graphNode, branchNode);
 
         final KStream<K, V>[] branchChildren = (KStream<K, V>[]) Array.newInstance(KStream.class, predicates.length);
         for (int i = 0; i < predicates.length; i++) {
@@ -522,7 +522,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             new ProcessorGraphNode<>(name, processorParameters);
         mergeNode.setMergeNode(true);
 
-        builder.addGraphNode(Arrays.asList(streamsGraphNode, streamImpl.streamsGraphNode), mergeNode);
+        builder.addGraphNode(Arrays.asList(graphNode, streamImpl.graphNode), mergeNode);
 
         // drop the serde as we cannot safely use either one to represent both streams
         return new KStreamImpl<>(
@@ -605,7 +605,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final UnoptimizableRepartitionNode<K, V> unoptimizableRepartitionNode = unoptimizableRepartitionNodeBuilder.build();
 
-        builder.addGraphNode(streamsGraphNode, unoptimizableRepartitionNode);
+        builder.addGraphNode(graphNode, unoptimizableRepartitionNode);
 
         final Set<String> sourceNodes = new HashSet<>();
         sourceNodes.add(unoptimizableRepartitionNode.nodeName());
@@ -672,7 +672,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             produced
         );
 
-        builder.addGraphNode(streamsGraphNode, sinkNode);
+        builder.addGraphNode(graphNode, sinkNode);
     }
 
     @Override
@@ -710,7 +710,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             : materializedInternal.valueSerde();
 
         final Set<String> subTopologySourceNodes;
-        final StreamsGraphNode tableParentNode;
+        final GraphNode tableParentNode;
 
         if (repartitionRequired) {
             final OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder = optimizableRepartitionNodeBuilder();
@@ -724,10 +724,10 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             );
 
             tableParentNode = repartitionNodeBuilder.build();
-            builder.addGraphNode(streamsGraphNode, tableParentNode);
+            builder.addGraphNode(graphNode, tableParentNode);
             subTopologySourceNodes = Collections.singleton(sourceName);
         } else {
-            tableParentNode = streamsGraphNode;
+            tableParentNode = graphNode;
             subTopologySourceNodes = this.subTopologySourceNodes;
         }
 
@@ -736,7 +736,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             materializedInternal.queryableStoreName()
         );
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, name);
-        final StreamsGraphNode tableNode = new StreamToTableNode<>(
+        final GraphNode tableNode = new StreamToTableNode<>(
             name,
             processorParameters,
             materializedInternal
@@ -783,7 +783,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final ProcessorGraphNode<K, V> selectKeyMapNode = internalSelectKey(keySelector, new NamedInternal(groupedInternal.name()));
         selectKeyMapNode.keyChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, selectKeyMapNode);
+        builder.addGraphNode(graphNode, selectKeyMapNode);
 
         return new KGroupedStreamImpl<>(
             selectKeyMapNode.nodeName(),
@@ -819,7 +819,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             subTopologySourceNodes,
             groupedInternal,
             repartitionRequired,
-            streamsGraphNode,
+            graphNode,
             builder);
     }
 
@@ -999,7 +999,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         if (repartitionNode == null || !name.equals(repartitionName)) {
             repartitionNode = optimizableRepartitionNodeBuilder.build();
-            builder.addGraphNode(streamsGraphNode, repartitionNode);
+            builder.addGraphNode(graphNode, repartitionNode);
         }
 
         return new KStreamImpl<>(
@@ -1171,7 +1171,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         final StreamTableJoinNode<K, V> streamTableJoinNode =
             new StreamTableJoinNode<>(name, processorParameters, new String[] {}, null);
 
-        builder.addGraphNode(streamsGraphNode, streamTableJoinNode);
+        builder.addGraphNode(graphNode, streamTableJoinNode);
 
         // do not have serde for joined result
         return new KStreamImpl<>(
@@ -1211,7 +1211,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             this.name
         );
 
-        builder.addGraphNode(streamsGraphNode, streamTableJoinNode);
+        builder.addGraphNode(graphNode, streamTableJoinNode);
 
         // do not have serde for joined result
         return new KStreamImpl<>(
@@ -1267,7 +1267,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             stateStoreNames);
         transformNode.keyChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, transformNode);
+        builder.addGraphNode(graphNode, transformNode);
 
         // cannot inherit key and value serde
         return new KStreamImpl<>(
@@ -1334,7 +1334,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             stateStoreNames);
         transformNode.setValueChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, transformNode);
+        builder.addGraphNode(graphNode, transformNode);
 
         // cannot inherit value serde
         return new KStreamImpl<>(
@@ -1399,7 +1399,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             stateStoreNames);
         transformNode.setValueChangingOperation(true);
 
-        builder.addGraphNode(streamsGraphNode, transformNode);
+        builder.addGraphNode(graphNode, transformNode);
 
         // cannot inherit value serde
         return new KStreamImpl<>(
@@ -1436,6 +1436,6 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
             new ProcessorParameters<>(processorSupplier, name),
             stateStoreNames);
 
-        builder.addGraphNode(streamsGraphNode, processNode);
+        builder.addGraphNode(graphNode, processNode);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
@@ -77,8 +77,8 @@ class KStreamImplJoin {
         final String joinMergeName = renamed.suffixWithOrElseGet(
             "-merge", builder, KStreamImpl.MERGE_NAME);
 
-        final StreamsGraphNode thisStreamsGraphNode = ((AbstractStream<?, ?>) lhs).streamsGraphNode;
-        final StreamsGraphNode otherStreamsGraphNode = ((AbstractStream<?, ?>) other).streamsGraphNode;
+        final GraphNode thisGraphNode = ((AbstractStream<?, ?>) lhs).graphNode;
+        final GraphNode otherGraphNode = ((AbstractStream<?, ?>) other).graphNode;
 
         final StoreBuilder<WindowStore<K1, V1>> thisWindowStore;
         final StoreBuilder<WindowStore<K1, V2>> otherWindowStore;
@@ -109,13 +109,13 @@ class KStreamImplJoin {
 
         final ProcessorParameters<K1, V1, ?, ?> thisWindowStreamProcessorParams = new ProcessorParameters<>(thisWindowedStream, thisWindowStreamProcessorName);
         final ProcessorGraphNode<K1, V1> thisWindowedStreamsNode = new ProcessorGraphNode<>(thisWindowStreamProcessorName, thisWindowStreamProcessorParams);
-        builder.addGraphNode(thisStreamsGraphNode, thisWindowedStreamsNode);
+        builder.addGraphNode(thisGraphNode, thisWindowedStreamsNode);
 
         final KStreamJoinWindow<K1, V2> otherWindowedStream = new KStreamJoinWindow<>(otherWindowStore.name());
 
         final ProcessorParameters<K1, V2, ?, ?> otherWindowStreamProcessorParams = new ProcessorParameters<>(otherWindowedStream, otherWindowStreamProcessorName);
         final ProcessorGraphNode<K1, V2> otherWindowedStreamsNode = new ProcessorGraphNode<>(otherWindowStreamProcessorName, otherWindowStreamProcessorParams);
-        builder.addGraphNode(otherStreamsGraphNode, otherWindowedStreamsNode);
+        builder.addGraphNode(otherGraphNode, otherWindowedStreamsNode);
 
         final KStreamKStreamJoin<K1, R, V1, V2> joinThis = new KStreamKStreamJoin<>(
             otherWindowStore.name(),
@@ -151,9 +151,9 @@ class KStreamImplJoin {
                    .withValueJoiner(joiner)
                    .withNodeName(joinMergeName);
 
-        final StreamsGraphNode joinGraphNode = joinBuilder.build();
+        final GraphNode joinGraphNode = joinBuilder.build();
 
-        builder.addGraphNode(Arrays.asList(thisStreamsGraphNode, otherStreamsGraphNode), joinGraphNode);
+        builder.addGraphNode(Arrays.asList(thisGraphNode, otherGraphNode), joinGraphNode);
 
         final Set<String> allSourceNodes = new HashSet<>(((KStreamImpl<K1, V1>) lhs).subTopologySourceNodes);
         allSourceNodes.addAll(((KStreamImpl<K1, V2>) other).subTopologySourceNodes);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -52,7 +52,7 @@ import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSinkNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamSourceNode;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.TableProcessorNode;
 import org.apache.kafka.streams.kstream.internals.suppress.FinalResultsSuppressionBuilder;
 import org.apache.kafka.streams.kstream.internals.suppress.KTableSuppressProcessorSupplier;
@@ -136,9 +136,9 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                       final Set<String> subTopologySourceNodes,
                       final String queryableStoreName,
                       final ProcessorSupplier<?, ?> processorSupplier,
-                      final StreamsGraphNode streamsGraphNode,
+                      final GraphNode graphNode,
                       final InternalStreamsBuilder builder) {
-        super(name, keySerde, valueSerde, subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
         this.processorSupplier = processorSupplier;
         this.queryableStoreName = queryableStoreName;
     }
@@ -186,13 +186,13 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             new ProcessorParameters<>(processorSupplier, name)
         );
 
-        final StreamsGraphNode tableNode = new TableProcessorNode<>(
+        final GraphNode tableNode = new TableProcessorNode<>(
             name,
             processorParameters,
             storeBuilder
         );
 
-        builder.addGraphNode(this.streamsGraphNode, tableNode);
+        builder.addGraphNode(this.graphNode, tableNode);
 
         return new KTableImpl<>(
             name,
@@ -299,13 +299,13 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorParameters<K, VR, ?, ?> processorParameters = unsafeCastProcessorParametersToCompletelyDifferentType(
             new ProcessorParameters<>(processorSupplier, name)
         );
-        final StreamsGraphNode tableNode = new TableProcessorNode<>(
+        final GraphNode tableNode = new TableProcessorNode<>(
             name,
             processorParameters,
             storeBuilder
         );
 
-        builder.addGraphNode(this.streamsGraphNode, tableNode);
+        builder.addGraphNode(this.graphNode, tableNode);
 
         // don't inherit parent value serde, since this operation may change the value type, more specifically:
         // we preserve the key following the order of 1) materialized, 2) parent, 3) null
@@ -454,14 +454,14 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             new ProcessorParameters<>(processorSupplier, name)
         );
 
-        final StreamsGraphNode tableNode = new TableProcessorNode<>(
+        final GraphNode tableNode = new TableProcessorNode<>(
             name,
             processorParameters,
             storeBuilder,
             stateStoreNames
         );
 
-        builder.addGraphNode(this.streamsGraphNode, tableNode);
+        builder.addGraphNode(this.graphNode, tableNode);
 
         return new KTableImpl<>(
             name,
@@ -494,7 +494,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             processorParameters
         );
 
-        builder.addGraphNode(this.streamsGraphNode, toStreamNode);
+        builder.addGraphNode(this.graphNode, toStreamNode);
 
         // we can inherit parent key and value serde
         return new KStreamImpl<>(name, keySerde, valueSerde, subTopologySourceNodes, false, toStreamNode, builder);
@@ -555,7 +555,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             storeBuilder
         );
 
-        builder.addGraphNode(streamsGraphNode, node);
+        builder.addGraphNode(graphNode, node);
 
         return new KTableImpl<K, S, V>(
             name,
@@ -572,7 +572,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
     @SuppressWarnings("unchecked")
     private SuppressedInternal<K> buildSuppress(final Suppressed<? super K> suppress, final String name) {
         if (suppress instanceof FinalResultsSuppressionBuilder) {
-            final long grace = findAndVerifyWindowGrace(streamsGraphNode);
+            final long grace = findAndVerifyWindowGrace(graphNode);
             LOG.info("Using grace period of [{}] as the suppress duration for node [{}].",
                      Duration.ofMillis(grace), name);
 
@@ -761,7 +761,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 .withQueryableStoreName(queryableStoreName)
                 .withStoreBuilder(storeBuilder)
                 .build();
-        builder.addGraphNode(this.streamsGraphNode, kTableKTableJoinNode);
+        builder.addGraphNode(this.graphNode, kTableKTableJoinNode);
 
         // we can inherit parent key serde if user do not provide specific overrides
         return new KTableImpl<K, Change<VR>, VR>(
@@ -805,7 +805,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         // select the aggregate key and values (old and new), it would require parent to send old values
         final ProcessorGraphNode<K, Change<V>> groupByMapNode = new ProcessorGraphNode<>(selectName, processorParameters);
 
-        builder.addGraphNode(this.streamsGraphNode, groupByMapNode);
+        builder.addGraphNode(this.graphNode, groupByMapNode);
 
         this.enableSendingOldValues(true);
         return new KGroupedTableImpl<>(
@@ -1027,7 +1027,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
                 renamed.suffixWithOrElseGet("-subscription-registration-processor", builder, SUBSCRIPTION_REGISTRATION)
             )
         );
-        builder.addGraphNode(streamsGraphNode, subscriptionNode);
+        builder.addGraphNode(graphNode, subscriptionNode);
 
 
         final StreamSinkNode<KO, SubscriptionWrapper<K>> subscriptionSink = new StreamSinkNode<>(
@@ -1094,7 +1094,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
             Collections.singleton(subscriptionStore),
             Collections.emptySet()
         );
-        builder.addGraphNode(((KTableImpl<KO, VO, ?>) foreignKeyTable).streamsGraphNode, foreignJoinSubscriptionNode);
+        builder.addGraphNode(((KTableImpl<KO, VO, ?>) foreignKeyTable).graphNode, foreignJoinSubscriptionNode);
 
 
         final String finalRepartitionTopicName = renamed.suffixWithOrElseGet("-subscription-response", builder, SUBSCRIPTION_RESPONSE) + TOPIC_SUFFIX;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedCogroupedKStreamImpl.java
@@ -28,7 +28,7 @@ import org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -51,9 +51,9 @@ public class SessionWindowedCogroupedKStreamImpl<K, V> extends
                                         final Set<String> subTopologySourceNodes,
                                         final String name,
                                         final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder,
-                                        final StreamsGraphNode streamsGraphNode,
+                                        final GraphNode graphNode,
                                         final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns) {
-        super(name, null, null, subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, null, null, subTopologySourceNodes, graphNode, builder);
         //keySerde and valueSerde are null because there are many different groupStreams that they could be from
         this.sessionWindows = sessionWindows;
         this.aggregateBuilder = aggregateBuilder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.kstream.SessionWindowedKStream;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.StoreBuilder;
@@ -55,8 +55,8 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                                final Serde<K> keySerde,
                                final Serde<V> valueSerde,
                                final GroupedStreamAggregateBuilder<K, V> aggregateBuilder,
-                               final StreamsGraphNode streamsGraphNode) {
-        super(name, keySerde, valueSerde, subTopologySourceNodes, streamsGraphNode, builder);
+                               final GraphNode graphNode) {
+        super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
         Objects.requireNonNull(windows, "windows can't be null");
         this.windows = windows;
         this.aggregateBuilder = aggregateBuilder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedCogroupedKStreamImpl.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.SlidingWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -47,9 +47,9 @@ public class SlidingWindowedCogroupedKStreamImpl<K, V> extends AbstractStream<K,
                                         final Set<String> subTopologySourceNodes,
                                         final String name,
                                         final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder,
-                                        final StreamsGraphNode streamsGraphNode,
+                                        final GraphNode graphNode,
                                         final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns) {
-        super(name, null, null, subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, null, null, subTopologySourceNodes, graphNode, builder);
         //keySerde and valueSerde are null because there are many different groupStreams that they could be from
         this.windows = windows;
         this.aggregateBuilder = aggregateBuilder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SlidingWindowedKStreamImpl.java
@@ -28,7 +28,7 @@ import org.apache.kafka.streams.kstream.Reducer;
 import org.apache.kafka.streams.kstream.SlidingWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedKStream;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -51,8 +51,8 @@ public class SlidingWindowedKStreamImpl<K, V> extends AbstractStream<K, V> imple
                                final Serde<K> keySerde,
                                final Serde<V> valueSerde,
                                final GroupedStreamAggregateBuilder<K, V> aggregateBuilder,
-                               final StreamsGraphNode streamsGraphNode) {
-        super(name, keySerde, valueSerde, subTopologySourceNodes, streamsGraphNode, builder);
+                               final GraphNode graphNode) {
+        super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
         this.windows = Objects.requireNonNull(windows, "windows can't be null");
         this.aggregateBuilder = aggregateBuilder;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedCogroupedKStreamImpl.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -52,9 +52,9 @@ public class TimeWindowedCogroupedKStreamImpl<K, V, W extends Window> extends Ab
                                      final Set<String> subTopologySourceNodes,
                                      final String name,
                                      final CogroupedStreamAggregateBuilder<K, V> aggregateBuilder,
-                                     final StreamsGraphNode streamsGraphNode,
+                                     final GraphNode graphNode,
                                      final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, V>> groupPatterns) {
-        super(name, null, null, subTopologySourceNodes, streamsGraphNode, builder);
+        super(name, null, null, subTopologySourceNodes, graphNode, builder);
         //keySerde and valueSerde are null because there are many different groupStreams that they could be from
         this.windows = windows;
         this.aggregateBuilder = aggregateBuilder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImpl.java
@@ -29,7 +29,7 @@ import org.apache.kafka.streams.kstream.TimeWindowedKStream;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
-import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
@@ -56,8 +56,8 @@ public class TimeWindowedKStreamImpl<K, V, W extends Window> extends AbstractStr
                             final Serde<K> keySerde,
                             final Serde<V> valueSerde,
                             final GroupedStreamAggregateBuilder<K, V> aggregateBuilder,
-                            final StreamsGraphNode streamsGraphNode) {
-        super(name, keySerde, valueSerde, subTopologySourceNodes, streamsGraphNode, builder);
+                            final GraphNode graphNode) {
+        super(name, keySerde, valueSerde, subTopologySourceNodes, graphNode, builder);
         this.windows = Objects.requireNonNull(windows, "windows can't be null");
         this.aggregateBuilder = aggregateBuilder;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseJoinProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseJoinProcessorNode.java
@@ -23,7 +23,7 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
  * Utility base class containing the common fields between
  * a Stream-Stream join and a Table-Table join
  */
-abstract class BaseJoinProcessorNode<K, V1, V2, VR> extends StreamsGraphNode {
+abstract class BaseJoinProcessorNode<K, V1, V2, VR> extends GraphNode {
 
     private final ProcessorParameters<K, V1, ?, ?> joinThisProcessorParameters;
     private final ProcessorParameters<K, V2, ?, ?> joinOtherProcessorParameters;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseRepartitionNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseRepartitionNode.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.internals.InternalTopicProperties;
 
-public abstract class BaseRepartitionNode<K, V> extends StreamsGraphNode {
+public abstract class BaseRepartitionNode<K, V> extends GraphNode {
 
     protected final Serde<K> keySerde;
     protected final Serde<V> valueSerde;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GraphNode.java
@@ -24,10 +24,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
-public abstract class StreamsGraphNode {
+public abstract class GraphNode {
 
-    private final Collection<StreamsGraphNode> childNodes = new LinkedHashSet<>();
-    private final Collection<StreamsGraphNode> parentNodes = new LinkedHashSet<>();
+    private final Collection<GraphNode> childNodes = new LinkedHashSet<>();
+    private final Collection<GraphNode> parentNodes = new LinkedHashSet<>();
     private final String nodeName;
     private boolean keyChangingOperation;
     private boolean valueChangingOperation;
@@ -35,25 +35,25 @@ public abstract class StreamsGraphNode {
     private Integer buildPriority;
     private boolean hasWrittenToTopology = false;
 
-    public StreamsGraphNode(final String nodeName) {
+    public GraphNode(final String nodeName) {
         this.nodeName = nodeName;
     }
 
-    public Collection<StreamsGraphNode> parentNodes() {
+    public Collection<GraphNode> parentNodes() {
         return parentNodes;
     }
 
     String[] parentNodeNames() {
         final String[] parentNames = new String[parentNodes.size()];
         int index = 0;
-        for (final StreamsGraphNode parentNode : parentNodes) {
+        for (final GraphNode parentNode : parentNodes) {
             parentNames[index++] = parentNode.nodeName();
         }
         return parentNames;
     }
 
     public boolean allParentsWrittenToTopology() {
-        for (final StreamsGraphNode parentNode : parentNodes) {
+        for (final GraphNode parentNode : parentNodes) {
             if (!parentNode.hasWrittenToTopology()) {
                 return false;
             }
@@ -61,22 +61,22 @@ public abstract class StreamsGraphNode {
         return true;
     }
 
-    public Collection<StreamsGraphNode> children() {
+    public Collection<GraphNode> children() {
         return new LinkedHashSet<>(childNodes);
     }
 
     public void clearChildren() {
-        for (final StreamsGraphNode childNode : childNodes) {
+        for (final GraphNode childNode : childNodes) {
             childNode.parentNodes.remove(this);
         }
         childNodes.clear();
     }
 
-    public boolean removeChild(final StreamsGraphNode child) {
+    public boolean removeChild(final GraphNode child) {
         return childNodes.remove(child) && child.parentNodes.remove(this);
     }
 
-    public void addChild(final StreamsGraphNode childNode) {
+    public void addChild(final GraphNode childNode) {
         this.childNodes.add(childNode);
         childNode.parentNodes.add(this);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/ProcessorGraphNode.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
  *
  * map, mapValues, flatMap, flatMapValues, filter, filterNot, branch
  */
-public class ProcessorGraphNode<K, V> extends StreamsGraphNode {
+public class ProcessorGraphNode<K, V> extends GraphNode {
 
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
+
+abstract public class SourceGraphNode<K, V> extends StreamsGraphNode {
+
+    private Collection<String> topicNames;
+    private Pattern topicPattern;
+    private final ConsumedInternal<K, V> consumedInternal;
+
+    public SourceGraphNode(final String nodeName,
+                            final Collection<String> topicNames,
+                            final ConsumedInternal<K, V> consumedInternal) {
+        super(nodeName);
+
+        this.topicNames = topicNames;
+        this.consumedInternal = consumedInternal;
+    }
+
+    public SourceGraphNode(final String nodeName,
+                            final Pattern topicPattern,
+                            final ConsumedInternal<K, V> consumedInternal) {
+
+        super(nodeName);
+
+        this.topicPattern = topicPattern;
+        this.consumedInternal = consumedInternal;
+    }
+
+    public Set<String> topicNames() {
+        return new HashSet<>(topicNames);
+    }
+
+    public Pattern topicPattern() {
+        return topicPattern;
+    }
+
+    public ConsumedInternal<K, V> consumedInternal() {
+        return consumedInternal;
+    }
+
+    public Serde<K> keySerde() {
+        return consumedInternal.keySerde();
+    }
+
+    public Serde<V> valueSerde() {
+        return consumedInternal.valueSerde();
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
@@ -18,13 +18,15 @@ package org.apache.kafka.streams.kstream.internals.graph;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 
 abstract public class SourceGraphNode<K, V> extends GraphNode {
 
-    private final Collection<String> topicNames;
+    private final Set<String> topicNames;
     private final Pattern topicPattern;
     private final ConsumedInternal<K, V> consumedInternal;
 
@@ -33,7 +35,7 @@ abstract public class SourceGraphNode<K, V> extends GraphNode {
                            final ConsumedInternal<K, V> consumedInternal) {
         super(nodeName);
 
-        this.topicNames = topicNames;
+        this.topicNames = new HashSet<>(topicNames);
         this.topicPattern = null;
         this.consumedInternal = consumedInternal;
     }
@@ -49,8 +51,8 @@ abstract public class SourceGraphNode<K, V> extends GraphNode {
         this.consumedInternal = consumedInternal;
     }
 
-    public Collection<String> topicNames() {
-        return Collections.unmodifiableCollection(topicNames);
+    public Set<String> topicNames() {
+        return Collections.unmodifiableSet(topicNames);
     }
 
     public Pattern topicPattern() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
@@ -22,7 +22,7 @@ import java.util.regex.Pattern;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 
-abstract public class SourceGraphNode<K, V> extends StreamsGraphNode {
+abstract public class SourceGraphNode<K, V> extends GraphNode {
 
     private final Collection<String> topicNames;
     private final Pattern topicPattern;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/SourceGraphNode.java
@@ -17,39 +17,40 @@
 package org.apache.kafka.streams.kstream.internals.graph;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Collections;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 
 abstract public class SourceGraphNode<K, V> extends StreamsGraphNode {
 
-    private Collection<String> topicNames;
-    private Pattern topicPattern;
+    private final Collection<String> topicNames;
+    private final Pattern topicPattern;
     private final ConsumedInternal<K, V> consumedInternal;
 
     public SourceGraphNode(final String nodeName,
-                            final Collection<String> topicNames,
-                            final ConsumedInternal<K, V> consumedInternal) {
+                           final Collection<String> topicNames,
+                           final ConsumedInternal<K, V> consumedInternal) {
         super(nodeName);
 
         this.topicNames = topicNames;
+        this.topicPattern = null;
         this.consumedInternal = consumedInternal;
     }
 
     public SourceGraphNode(final String nodeName,
-                            final Pattern topicPattern,
-                            final ConsumedInternal<K, V> consumedInternal) {
+                           final Pattern topicPattern,
+                           final ConsumedInternal<K, V> consumedInternal) {
 
         super(nodeName);
 
+        this.topicNames = null;
         this.topicPattern = topicPattern;
         this.consumedInternal = consumedInternal;
     }
 
-    public Set<String> topicNames() {
-        return new HashSet<>(topicNames);
+    public Collection<String> topicNames() {
+        return Collections.unmodifiableCollection(topicNames);
     }
 
     public Pattern topicPattern() {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -20,7 +20,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.StoreBuilder;
 
-public class StateStoreNode<S extends StateStore> extends StreamsGraphNode {
+public class StateStoreNode<S extends StateStore> extends GraphNode {
 
     protected final StoreBuilder<S> storeBuilder;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSinkNode.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.StaticTopicNameExtractor;
 
-public class StreamSinkNode<K, V> extends StreamsGraphNode {
+public class StreamSinkNode<K, V> extends GraphNode {
 
     private final TopicNameExtractor<K, V> topicNameExtractor;
     private final ProducedInternal<K, V> producedInternal;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -17,9 +17,6 @@
 
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import java.util.HashSet;
-import java.util.Set;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
@@ -30,56 +27,25 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class StreamSourceNode<K, V> extends StreamsGraphNode {
+public class StreamSourceNode<K, V> extends SourceGraphNode<K, V> {
 
     private final Logger log = LoggerFactory.getLogger(StreamSourceNode.class);
-
-    private Collection<String> topicNames;
-    private Pattern topicPattern;
-    private final ConsumedInternal<K, V> consumedInternal;
-
 
     public StreamSourceNode(final String nodeName,
                             final Collection<String> topicNames,
                             final ConsumedInternal<K, V> consumedInternal) {
-        super(nodeName);
-
-        this.topicNames = topicNames;
-        this.consumedInternal = consumedInternal;
+        super(nodeName, topicNames, consumedInternal);
     }
 
     public StreamSourceNode(final String nodeName,
                             final Pattern topicPattern,
                             final ConsumedInternal<K, V> consumedInternal) {
 
-        super(nodeName);
-
-        this.topicPattern = topicPattern;
-        this.consumedInternal = consumedInternal;
-    }
-
-    public Set<String> topicNames() {
-        return new HashSet<>(topicNames);
-    }
-
-    public Pattern topicPattern() {
-        return topicPattern;
-    }
-
-    public ConsumedInternal<K, V> consumedInternal() {
-        return consumedInternal;
-    }
-
-    public Serde<K> keySerde() {
-        return consumedInternal.keySerde();
-    }
-
-    public Serde<V> valueSerde() {
-        return consumedInternal.valueSerde();
+        super(nodeName, topicPattern, consumedInternal);
     }
 
     public void merge(final StreamSourceNode<?, ?> other) {
-        final AutoOffsetReset resetPolicy = consumedInternal.offsetResetPolicy();
+        final AutoOffsetReset resetPolicy = consumedInternal().offsetResetPolicy();
         final AutoOffsetReset otherResetPolicy = other.consumedInternal().offsetResetPolicy();
         if (resetPolicy != null && !resetPolicy.equals(otherResetPolicy)
             || otherResetPolicy != null && !otherResetPolicy.equals(resetPolicy)) {
@@ -96,29 +62,29 @@ public class StreamSourceNode<K, V> extends StreamsGraphNode {
     @Override
     public String toString() {
         return "StreamSourceNode{" +
-               "topicNames=" + topicNames +
-               ", topicPattern=" + topicPattern +
-               ", consumedInternal=" + consumedInternal +
+               "topicNames=" + topicNames() +
+               ", topicPattern=" + topicPattern() +
+               ", consumedInternal=" + consumedInternal() +
                "} " + super.toString();
     }
 
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
 
-        if (topicPattern != null) {
-            topologyBuilder.addSource(consumedInternal.offsetResetPolicy(),
+        if (topicPattern() != null) {
+            topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
                                       nodeName(),
-                                      consumedInternal.timestampExtractor(),
-                                      consumedInternal.keyDeserializer(),
-                                      consumedInternal.valueDeserializer(),
-                                      topicPattern);
+                                      consumedInternal().timestampExtractor(),
+                                      consumedInternal().keyDeserializer(),
+                                      consumedInternal().valueDeserializer(),
+                                      topicPattern());
         } else {
-            topologyBuilder.addSource(consumedInternal.offsetResetPolicy(),
+            topologyBuilder.addSource(consumedInternal().offsetResetPolicy(),
                                       nodeName(),
-                                      consumedInternal.timestampExtractor(),
-                                      consumedInternal.keyDeserializer(),
-                                      consumedInternal.valueDeserializer(),
-                                      topicNames.toArray(new String[topicNames.size()]));
+                                      consumedInternal().timestampExtractor(),
+                                      consumedInternal().keyDeserializer(),
+                                      consumedInternal().valueDeserializer(),
+                                      topicNames().toArray(new String[topicNames().size()]));
 
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamSourceNode.java
@@ -53,7 +53,7 @@ public class StreamSourceNode<K, V> extends SourceGraphNode<K, V> {
                           + "the offset reset policies do not match", this, other);
             throw new TopologyException("Can't configure different offset reset policies on the same input topic(s)");
         }
-        for (final StreamsGraphNode otherChild : other.children()) {
+        for (final GraphNode otherChild : other.children()) {
             other.removeChild(otherChild);
             addChild(otherChild);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamTableJoinNode.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
  * Represents a join between a KStream and a KTable or GlobalKTable
  */
 
-public class StreamTableJoinNode<K, V> extends StreamsGraphNode {
+public class StreamTableJoinNode<K, V> extends GraphNode {
 
     private final String[] storeNames;
     private final ProcessorParameters<K, V, ?, ?> processorParameters;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamToTableNode.java
@@ -29,7 +29,7 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 /**
  * Represents a KTable convert From KStream
  */
-public class StreamToTableNode<K, V> extends StreamsGraphNode {
+public class StreamToTableNode<K, V> extends GraphNode {
 
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
     private final MaterializedInternal<K, V, ?> materializedInternal;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableProcessorNode.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class TableProcessorNode<K, V> extends StreamsGraphNode {
+public class TableProcessorNode<K, V> extends GraphNode {
 
     private final ProcessorParameters<K, V, ?, ?> processorParameters;
     private final StoreBuilder<TimestampedKeyValueStore<K, V>> storeBuilder;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNode.java
@@ -34,7 +34,7 @@ import java.util.Collections;
  * Used to represent either a KTable source or a GlobalKTable source. A boolean flag is used to indicate if this represents a GlobalKTable a {@link
  * org.apache.kafka.streams.kstream.GlobalKTable}
  */
-public class TableSourceNode<K, V> extends StreamSourceNode<K, V> {
+public class TableSourceNode<K, V> extends SourceGraphNode<K, V> {
 
     private final MaterializedInternal<K, V, ?> materializedInternal;
     private final ProcessorParameters<K, V, ?, ?> processorParameters;

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -907,20 +907,6 @@ public class StreamsBuilderTest {
     }
 
     @Test
-    public void shouldAllowTablesFromSameTopic() {
-        builder.table("topic");
-        builder.table("topic");
-        assertBuildDoesNotThrow(builder);
-    }
-
-    @Test
-    public void shouldAllowStreamAndTableFromSameTopic() {
-        builder.stream("topic");
-        builder.table("topic");
-        assertBuildDoesNotThrow(builder);
-    }
-
-    @Test
     public void shouldAllowSubscribingToSamePattern() {
         builder.stream(Pattern.compile("some-regex"));
         builder.stream(Pattern.compile("some-regex"));
@@ -973,6 +959,20 @@ public class StreamsBuilderTest {
     public void shouldThrowWhenSubscribedToAPatternWithSetAndUnsetResetPolicies() {
         builder.stream(Pattern.compile("some-regex"), Consumed.with(AutoOffsetReset.EARLIEST));
         builder.stream(Pattern.compile("some-regex"));
+        assertThrows(TopologyException.class, builder::build);
+    }
+
+    @Test
+    public void shouldNotAllowTablesFromSameTopic() {
+        builder.table("topic");
+        builder.table("topic");
+        assertThrows(TopologyException.class, builder::build);
+    }
+
+    @Test
+    public void shouldNowAllowStreamAndTableFromSameTopic() {
+        builder.stream("topic");
+        builder.table("topic");
         assertThrows(TopologyException.class, builder::build);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/AbstractStreamTest.java
@@ -109,7 +109,7 @@ public class AbstractStreamTest {
             final ProcessorGraphNode<K, V> processorNode = new ProcessorGraphNode<>(
                 name,
                 new ProcessorParameters<>(new ExtendedKStreamDummy<>(), name));
-            builder.addGraphNode(this.streamsGraphNode, processorNode);
+            builder.addGraphNode(this.graphNode, processorNode);
             return new KStreamImpl<>(name, null, null, subTopologySourceNodes, false, processorNode, builder);
         }
     }


### PR DESCRIPTION
Followup to https://github.com/apache/kafka/pull/9582

Will leave the ability to create multiple KTables from the same source topic as followup work. Similarly, creating a KStream and a KTable from the same topic can be tackled later if need be
