### PR TITLE
MINOR: remove "gradle wrapper" from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,6 @@ env:
 jdk:
   - oraclejdk8
 
-before_install:
-  - gradle wrapper
-
 script:
   - ./gradlew rat
   - ./gradlew systemTestLibs && /bin/bash ./tests/docker/run_tests.sh


### PR DESCRIPTION
```
> Failed to apply plugin [class 'com.github.spotbugs.snom.SpotBugsBasePlugin']
   > Gradle version Gradle 5.1.1 is unsupported. Please use Gradle 5.6 or later.
```

```com.github.spotbugs.snom.SpotBugsBasePlugin``` requires gradle 5.6+ but the gradle supported by travis is 4.0 or 5.1.1 (https://docs.travis-ci.com/user/reference/trusty/#gradle-version and https://docs.travis-ci.com/user/reference/xenial/)

However, we don't need to call ```gradle wrapper``` since ```gradlew``` already exists in our project. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
