### PR TITLE
MINOR: add sudo to travis.yml to run ducktape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jdk:
 
 script:
   - ./gradlew rat
-  - ./gradlew systemTestLibs && /bin/bash ./tests/docker/run_tests.sh
+  - ./gradlew systemTestLibs && sudo /bin/bash ./tests/docker/run_tests.sh
 
 services:
   - docker


### PR DESCRIPTION
```
Traceback (most recent call last):
3157  File "/usr/local/bin/ducktape", line 8, in <module>
3158    sys.exit(main())
3159  File "/usr/local/lib/python3.7/dist-packages/ducktape/command_line/main.py", line 118, in main
3160    os.makedirs(ConsoleDefaults.METADATA_DIR)
3161  File "/usr/lib/python3.7/os.py", line 211, in makedirs
3162    makedirs(head, exist_ok=exist_ok)
3163  File "/usr/lib/python3.7/os.py", line 221, in makedirs
3164    mkdir(name, mode)
3165PermissionError: [Errno 13] Permission denied: '.ducktape'
3166ducker-ak test failed
```
Let see what will happen :)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
