### PR TITLE
KAFKA-10091: KIP-695: Deterministic semantics for task idling

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -100,7 +100,10 @@
               files="RequestResponseTest.java|FetcherTest.java|KafkaAdminClientTest.java"/>
 
     <suppress checks="NPathComplexity"
-              files="MemoryRecordsTest|MetricsTest|TestSslUtils"/>
+              files="MemoryRecordsTest|MetricsTest|TestSslUtils|MockConsumer"/>
+
+    <suppress checks="CyclomaticComplexity"
+              files="MockConsumer"/>
 
     <suppress checks="(WhitespaceAround|LocalVariableName|ImportControl|AvoidStarImport)"
               files="Murmur3Test.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -96,6 +96,11 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
         return metadata;
     }
 
+    public ConsumerRecords(final Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
+        this.records = records;
+        this.metadata = new HashMap<>();
+    }
+
     public ConsumerRecords(final Map<TopicPartition, List<ConsumerRecord<K, V>>> records,
                            final Map<TopicPartition, Metadata> metadata) {
         this.records = records;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerCoordinator;
 import org.apache.kafka.clients.consumer.internals.ConsumerInterceptors;
 import org.apache.kafka.clients.consumer.internals.ConsumerMetadata;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
+import org.apache.kafka.clients.consumer.internals.FetchedRecords;
 import org.apache.kafka.clients.consumer.internals.Fetcher;
 import org.apache.kafka.clients.consumer.internals.FetcherMetricsRegistry;
 import org.apache.kafka.clients.consumer.internals.KafkaConsumerMetrics;
@@ -1234,7 +1235,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     }
                 }
 
-                final Map<TopicPartition, List<ConsumerRecord<K, V>>> records = pollForFetches(timer);
+                final FetchedRecords<K, V> records = pollForFetches(timer);
                 if (!records.isEmpty()) {
                     // before returning the fetched records, we can send off the next round of fetches
                     // and avoid block waiting for their responses to enable pipelining while the user
@@ -1267,13 +1268,14 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
 
     /**
      * @throws KafkaException if the rebalance callback throws exception
+     * @return
      */
-    private Map<TopicPartition, List<ConsumerRecord<K, V>>> pollForFetches(Timer timer) {
+    private FetchedRecords<K, V> pollForFetches(Timer timer) {
         long pollTimeout = coordinator == null ? timer.remainingMs() :
                 Math.min(coordinator.timeToNextPoll(timer.currentTimeMs()), timer.remainingMs());
 
         // if data is available already, return it immediately
-        final Map<TopicPartition, List<ConsumerRecord<K, V>>> records = fetcher.fetchedRecords();
+        final FetchedRecords<K, V> records = fetcher.fetchedRecords();
         if (!records.isEmpty()) {
             return records;
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -218,7 +218,22 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         }
 
         toClear.forEach(p -> this.records.remove(p));
-        return new ConsumerRecords<>(results);
+
+        final Map<TopicPartition, ConsumerRecords.Metadata> metadata = new HashMap<>();
+        for (final TopicPartition partition : subscriptions.assignedPartitions()) {
+            if (subscriptions.hasValidPosition(partition) && beginningOffsets.containsKey(partition) && endOffsets.containsKey(partition)) {
+                final SubscriptionState.FetchPosition position = subscriptions.position(partition);
+                final long offset = position.offset;
+                final long startOffset = beginningOffsets.get(partition);
+                final long endOffset = endOffsets.get(partition);
+                metadata.put(
+                    partition,
+                    new ConsumerRecords.Metadata(System.currentTimeMillis(), offset, startOffset, endOffset)
+                );
+            }
+        }
+
+        return new ConsumerRecords<>(results, metadata);
     }
 
     public synchronized void addRecord(ConsumerRecord<K, V> record) {
@@ -229,6 +244,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
             throw new IllegalStateException("Cannot add records for a partition that is not assigned to the consumer");
         List<ConsumerRecord<K, V>> recs = this.records.computeIfAbsent(tp, k -> new ArrayList<>());
         recs.add(record);
+        this.endOffsets.compute(tp, (ignore, offset) -> offset == null ? record.offset() : Math.max(offset, record.offset()));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchedRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetchedRecords.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FetchedRecords<K, V> {
+    private final Map<TopicPartition, List<ConsumerRecord<K, V>>> records;
+    private final Map<TopicPartition, FetchMetadata> metadata;
+
+    public static final class FetchMetadata {
+
+        private final long receivedTimestamp;
+        private final long startOffset;
+        private final SubscriptionState.FetchPosition position;
+        private final long endOffset;
+
+        public FetchMetadata(final long receivedTimestamp,
+                             final SubscriptionState.FetchPosition position,
+                             final long startOffset,
+                             final long endOffset) {
+            this.receivedTimestamp = receivedTimestamp;
+            this.position = position;
+            this.startOffset = startOffset;
+            this.endOffset = endOffset;
+        }
+
+        public long receivedTimestamp() {
+            return receivedTimestamp;
+        }
+
+        public SubscriptionState.FetchPosition position() {
+            return position;
+        }
+
+        public long beginningOffset() {
+            return startOffset;
+        }
+
+        public long endOffset() {
+            return endOffset;
+        }
+    }
+
+    public FetchedRecords() {
+        records = new HashMap<>();
+        metadata = new HashMap<>();
+    }
+
+    public Map<TopicPartition, List<ConsumerRecord<K, V>>> records() {
+        return records;
+    }
+
+    public Map<TopicPartition, FetchMetadata> metadata() {
+        return metadata;
+    }
+
+    public boolean isEmpty() {
+        return records.isEmpty() && metadata.isEmpty();
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -16,17 +16,19 @@
  */
 package org.apache.kafka.clients.consumer;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class ConsumerRecordsTest {
 
@@ -42,7 +44,7 @@ public class ConsumerRecordsTest {
         records.put(new TopicPartition(topic, 1), Arrays.asList(record1, record2));
         records.put(new TopicPartition(topic, 2), new ArrayList<ConsumerRecord<Integer, String>>());
 
-        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, Collections.emptyMap());
         Iterator<ConsumerRecord<Integer, String>> iter = consumerRecords.iterator();
 
         int c = 0;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -44,7 +44,7 @@ public class ConsumerRecordsTest {
         records.put(new TopicPartition(topic, 1), Arrays.asList(record1, record2));
         records.put(new TopicPartition(topic, 2), new ArrayList<ConsumerRecord<Integer, String>>());
 
-        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, Collections.emptyMap());
+        ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records);
         Iterator<ConsumerRecord<Integer, String>> iter = consumerRecords.iterator();
 
         int c = 0;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptorsTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -76,7 +77,7 @@ public class ConsumerInterceptorsTest {
                 if (tp.partition() != filterPartition)
                     recordMap.put(tp, records.records(tp));
             }
-            return new ConsumerRecords<K, V>(recordMap);
+            return new ConsumerRecords<K, V>(recordMap, Collections.emptyMap());
         }
 
         @Override
@@ -125,7 +126,7 @@ public class ConsumerInterceptorsTest {
         records.put(tp, list1);
         records.put(filterTopicPart1, list2);
         records.put(filterTopicPart2, list3);
-        ConsumerRecords<Integer, Integer> consumerRecords = new ConsumerRecords<>(records);
+        ConsumerRecords<Integer, Integer> consumerRecords = new ConsumerRecords<>(records, Collections.emptyMap());
         ConsumerRecords<Integer, Integer> interceptedRecords = interceptors.onConsume(consumerRecords);
         assertEquals(1, interceptedRecords.count());
         assertTrue(interceptedRecords.partitions().contains(tp));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptorsTest.java
@@ -77,7 +77,7 @@ public class ConsumerInterceptorsTest {
                 if (tp.partition() != filterPartition)
                     recordMap.put(tp, records.records(tp));
             }
-            return new ConsumerRecords<K, V>(recordMap, Collections.emptyMap());
+            return new ConsumerRecords<K, V>(recordMap);
         }
 
         @Override
@@ -126,7 +126,7 @@ public class ConsumerInterceptorsTest {
         records.put(tp, list1);
         records.put(filterTopicPart1, list2);
         records.put(filterTopicPart2, list3);
-        ConsumerRecords<Integer, Integer> consumerRecords = new ConsumerRecords<>(records, Collections.emptyMap());
+        ConsumerRecords<Integer, Integer> consumerRecords = new ConsumerRecords<>(records);
         ConsumerRecords<Integer, Integer> interceptedRecords = interceptors.onConsume(consumerRecords);
         assertEquals(1, interceptedRecords.count());
         assertTrue(interceptedRecords.partitions().contains(tp));

--- a/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
@@ -76,7 +76,7 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
             }
             recordMap.put(tp, lst);
         }
-        return new ConsumerRecords<String, String>(recordMap, Collections.emptyMap());
+        return new ConsumerRecords<String, String>(recordMap);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockConsumerInterceptor.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -75,7 +76,7 @@ public class MockConsumerInterceptor implements ClusterResourceListener, Consume
             }
             recordMap.put(tp, lst);
         }
-        return new ConsumerRecords<String, String>(recordMap);
+        return new ConsumerRecords<String, String>(recordMap, Collections.emptyMap());
     }
 
     @Override

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -21,7 +21,7 @@ import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
-import kafka.utils.CommandLineUtils;
+//import kafka.utils.CommandLineUtils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConsumerGroupsOptions;
@@ -258,17 +258,17 @@ public class StreamsResetter {
         try {
             options = optionParser.parse(args);
             if (args.length == 0 || options.has(helpOption)) {
-                CommandLineUtils.printUsageAndDie(optionParser, USAGE);
+//                CommandLineUtils.printUsageAndDie(optionParser, USAGE);
             }
             if (options.has(versionOption)) {
-                CommandLineUtils.printVersionAndDie();
+//                CommandLineUtils.printVersionAndDie();
             }
         } catch (final OptionException e) {
-            CommandLineUtils.printUsageAndDie(optionParser, e.getMessage());
+//            CommandLineUtils.printUsageAndDie(optionParser, e.getMessage());
         }
 
         if (options.has(executeOption) && options.has(dryRunOption)) {
-            CommandLineUtils.printUsageAndDie(optionParser, "Only one of --dry-run and --execute can be specified");
+//            CommandLineUtils.printUsageAndDie(optionParser, "Only one of --dry-run and --execute can be specified");
         }
 
         final Set<OptionSpec<?>> allScenarioOptions = new HashSet<>();
@@ -295,11 +295,11 @@ public class StreamsResetter {
                                       final OptionSpec<T> option) {
         final Set<OptionSpec<?>> invalidOptions = new HashSet<>(allOptions);
         invalidOptions.remove(option);
-        CommandLineUtils.checkInvalidArgs(
-            optionParser,
-            options,
-            option,
-            JavaConverters.asScalaSetConverter(invalidOptions).asScala());
+//        CommandLineUtils.checkInvalidArgs(
+//            optionParser,
+//            options,
+//            option,
+//            JavaConverters.asScalaSetConverter(invalidOptions).asScala());
     }
 
     private int maybeResetInputAndSeekToEndIntermediateTopicOffsets(final Map<Object, Object> consumerConfig,

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -134,6 +134,8 @@ import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 @SuppressWarnings("deprecation")
 public class StreamsConfig extends AbstractConfig {
 
+    public static final long MAX_TASK_IDLE_MS_DISABLED = -1;
+
     private final static Logger log = LoggerFactory.getLogger(StreamsConfig.class);
 
     private static final ConfigDef CONFIG;
@@ -662,7 +664,7 @@ public class StreamsConfig extends AbstractConfig {
                     DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS_DOC)
             .define(MAX_TASK_IDLE_MS_CONFIG,
                     Type.LONG,
-                    0L,
+                    MAX_TASK_IDLE_MS_DISABLED,
                     Importance.MEDIUM,
                     MAX_TASK_IDLE_MS_DOC)
             .define(MAX_WARMUP_REPLICAS_CONFIG,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreator.java
@@ -51,6 +51,7 @@ import static org.apache.kafka.streams.processor.internals.StreamThread.Processi
 class ActiveTaskCreator {
     private final InternalTopologyBuilder builder;
     private final StreamsConfig config;
+    private final long metadataStalenessBound;
     private final StreamsMetricsImpl streamsMetrics;
     private final StateDirectory stateDirectory;
     private final ChangelogReader storeChangelogReader;
@@ -66,6 +67,7 @@ class ActiveTaskCreator {
 
     ActiveTaskCreator(final InternalTopologyBuilder builder,
                       final StreamsConfig config,
+                      final long metadataStalenessBound,
                       final StreamsMetricsImpl streamsMetrics,
                       final StateDirectory stateDirectory,
                       final ChangelogReader storeChangelogReader,
@@ -77,6 +79,7 @@ class ActiveTaskCreator {
                       final Logger log) {
         this.builder = builder;
         this.config = config;
+        this.metadataStalenessBound = metadataStalenessBound;
         this.streamsMetrics = streamsMetrics;
         this.stateDirectory = stateDirectory;
         this.storeChangelogReader = storeChangelogReader;
@@ -234,6 +237,7 @@ class ActiveTaskCreator {
             topology,
             consumer,
             config,
+            metadataStalenessBound,
             streamsMetrics,
             stateDirectory,
             cache,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Sensor;
@@ -284,6 +285,11 @@ public class StandbyTask extends AbstractTask implements Task {
     @Override
     public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
         throw new IllegalStateException("Attempted to add records to task " + id() + " for invalid input partition " + partition);
+    }
+
+    @Override
+    public void addFetchedMetadata(final TopicPartition partition, final ConsumerRecords.Metadata metadata) {
+        throw new IllegalStateException("Attempted to update metadata for standby task " + id());
     }
 
     InternalProcessorContext processorContext() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
@@ -67,6 +68,8 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
  */
 public class StreamTask extends AbstractTask implements ProcessorNodePunctuator, Task {
 
+    private static final long IDLE_START_TIME_NOT_SET = -1;
+
     // visible for testing
     static final byte LATEST_MAGIC_BYTE = 1;
 
@@ -78,8 +81,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     // leaked into this class, which is to checkpoint after committing if EOS is not enabled.
     private final boolean eosEnabled;
 
-    private final long maxTaskIdleMs;
     private final int maxBufferedSize;
+    private final long metadataStalenessBound;
     private final PartitionGroup partitionGroup;
     private final RecordCollector recordCollector;
     private final PartitionGroup.RecordInfo recordInfo;
@@ -95,12 +98,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private final Sensor processLatencySensor;
     private final Sensor punctuateLatencySensor;
     private final Sensor bufferedRecordsSensor;
-    private final Sensor enforcedProcessingSensor;
     private final Map<String, Sensor> e2eLatencySensors = new HashMap<>();
     private final InternalProcessorContext processorContext;
     private final RecordQueueCreator recordQueueCreator;
 
-    private long idleStartTimeMs;
     private boolean commitNeeded = false;
     private boolean commitRequested = false;
 
@@ -109,6 +110,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                       final ProcessorTopology topology,
                       final Consumer<byte[], byte[]> mainConsumer,
                       final StreamsConfig config,
+                      final long metadataStalenessBound,
                       final StreamsMetricsImpl streamsMetrics,
                       final StateDirectory stateDirectory,
                       final ThreadCache cache,
@@ -139,12 +141,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         this.streamsMetrics = streamsMetrics;
         closeTaskSensor = ThreadMetrics.closeTaskSensor(threadId, streamsMetrics);
         final String taskId = id.toString();
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            final Sensor parent = ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
-            enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics, parent);
-        } else {
-            enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
-        }
         processRatioSensor = TaskMetrics.activeProcessRatioSensor(threadId, taskId, streamsMetrics);
         processLatencySensor = TaskMetrics.processLatencySensor(threadId, taskId, streamsMetrics);
         punctuateLatencySensor = TaskMetrics.punctuateSensor(threadId, taskId, streamsMetrics);
@@ -167,8 +163,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
         streamTimePunctuationQueue = new PunctuationQueue();
         systemTimePunctuationQueue = new PunctuationQueue();
-        maxTaskIdleMs = config.getLong(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
         maxBufferedSize = config.getInt(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG);
+        this.metadataStalenessBound = metadataStalenessBound;
 
         // initialize the consumed and committed offset cache
         consumedOffsets = new HashMap<>();
@@ -176,8 +172,21 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         recordQueueCreator = new RecordQueueCreator(logContext, config.defaultTimestampExtractor(), config.defaultDeserializationExceptionHandler());
 
         recordInfo = new PartitionGroup.RecordInfo();
-        partitionGroup = new PartitionGroup(createPartitionQueues(),
-                TaskMetrics.recordLatenessSensor(threadId, taskId, streamsMetrics));
+
+        final Sensor enforcedProcessingSensor;
+        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
+            final Sensor parent = ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
+            enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics, parent);
+        } else {
+            enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
+        }
+        final long maxTaskIdleMs = config.getLong(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
+        partitionGroup = new PartitionGroup(id,
+                                            createPartitionQueues(),
+                                            TaskMetrics.recordLatenessSensor(threadId, taskId, streamsMetrics),
+                                            enforcedProcessingSensor,
+                                            maxTaskIdleMs,
+                                            metadataStalenessBound);
 
         stateMgr.registerGlobalStateStores(topology.globalStateStores());
     }
@@ -233,7 +242,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 initializeMetadata();
                 initializeTopology();
                 processorContext.initialize();
-                idleStartTimeMs = RecordQueue.UNKNOWN;
 
                 transitionTo(State.RUNNING);
 
@@ -633,26 +641,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             return false;
         }
 
-        if (partitionGroup.allPartitionsBuffered()) {
-            idleStartTimeMs = RecordQueue.UNKNOWN;
-            return true;
-        } else if (partitionGroup.numBuffered() > 0) {
-            if (idleStartTimeMs == RecordQueue.UNKNOWN) {
-                idleStartTimeMs = wallClockTime;
-            }
-
-            if (wallClockTime - idleStartTimeMs >= maxTaskIdleMs) {
-                enforcedProcessingSensor.record(1.0d, wallClockTime);
-                return true;
-            } else {
-                return false;
-            }
-        } else {
-            // there's no data in any of the topics; we should reset the enforced
-            // processing timer
-            idleStartTimeMs = RecordQueue.UNKNOWN;
-            return false;
-        }
+        return partitionGroup.readyToProcess(wallClockTime);
     }
 
     /**
@@ -719,13 +708,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         } catch (final RuntimeException e) {
             final String stackTrace = getStacktraceString(e);
             throw new StreamsException(String.format("Exception caught in process. taskId=%s, " +
-                                                  "processor=%s, topic=%s, partition=%d, offset=%d, stacktrace=%s",
-                                              id(),
-                                              processorContext.currentNode().name(),
-                                              record.topic(),
-                                              record.partition(),
-                                              record.offset(),
-                                              stackTrace
+                                                         "processor=%s, topic=%s, partition=%d, offset=%d, stacktrace=%s",
+                                                     id(),
+                                                     processorContext.currentNode().name(),
+                                                     record.topic(),
+                                                     record.partition(),
+                                                     record.offset(),
+                                                     stackTrace
             ), e);
         } finally {
             processorContext.setCurrentNode(null);
@@ -814,14 +803,14 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private void initializeMetadata() {
         try {
             final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = mainConsumer.committed(inputPartitions()).entrySet().stream()
-                    .filter(e -> e.getValue() != null)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                                                                                          .filter(e -> e.getValue() != null)
+                                                                                          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             initializeTaskTime(offsetsAndMetadata);
         } catch (final TimeoutException timeoutException) {
             log.warn(
                 "Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop." +
                     "\nConsider overwriting consumer config {} to a larger value to avoid timeout errors",
-                time.toString(),
+                time,
                 ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
 
             // re-throw to trigger `task.timeout.ms`
@@ -840,7 +829,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
                 final long committedTimestamp = decodeTimestamp(metadata.metadata());
                 partitionGroup.setPartitionTime(partition, committedTimestamp);
                 log.debug("A committed timestamp was detected: setting the partition time of partition {}"
-                    + " to {} in stream task {}", partition, committedTimestamp, id);
+                              + " to {} in stream task {}", partition, committedTimestamp, id);
             } else {
                 log.debug("No committed timestamp was found in metadata for partition {}", partition);
             }
@@ -899,6 +888,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         if (newQueueSize > maxBufferedSize) {
             mainConsumer.pause(singleton(partition));
         }
+    }
+
+    @Override
+    public void addFetchedMetadata(final TopicPartition partition, final ConsumerRecords.Metadata metadata) {
+        partitionGroup.addFetchedMetadata(partition, metadata);
     }
 
     /**
@@ -1137,21 +1131,21 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
             final SourceNode<?, ?, ?, ?> source = topology.source(partition.topic());
             if (source == null) {
                 throw new TopologyException(
-                        "Topic is unknown to the topology. " +
-                                "This may happen if different KafkaStreams instances of the same application execute different Topologies. " +
-                                "Note that Topologies are only identical if all operators are added in the same order."
+                    "Topic is unknown to the topology. " +
+                        "This may happen if different KafkaStreams instances of the same application execute different Topologies. " +
+                        "Note that Topologies are only identical if all operators are added in the same order."
                 );
             }
 
             final TimestampExtractor sourceTimestampExtractor = source.getTimestampExtractor();
             final TimestampExtractor timestampExtractor = sourceTimestampExtractor != null ? sourceTimestampExtractor : defaultTimestampExtractor;
             return new RecordQueue(
-                    partition,
-                    source,
-                    timestampExtractor,
-                    defaultDeserializationExceptionHandler,
-                    processorContext,
-                    logContext
+                partition,
+                source,
+                timestampExtractor,
+                defaultDeserializationExceptionHandler,
+                processorContext,
+                logContext
             );
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -331,9 +331,29 @@ public class StreamThread extends Thread {
 
         final ThreadCache cache = new ThreadCache(logContext, cacheSizeBytes, streamsMetrics);
 
+        log.info("Creating consumer client");
+        final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+        final Map<String, Object> consumerConfigs = config.getMainConsumerConfigs(applicationId, getConsumerClientId(threadId), threadIdx);
+        consumerConfigs.put(StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
+
+        final String originalReset = (String) consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+        // If there are any overrides, we never fall through to the consumer, but only handle offset management ourselves.
+        if (!builder.latestResetTopicsPattern().pattern().isEmpty() || !builder.earliestResetTopicsPattern().pattern().isEmpty()) {
+            consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+        }
+
+        final int maxPollTimeMs =
+            new InternalConsumerConfig(config.getMainConsumerConfigs("", "", 0))
+                .getInt(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
+
+        // Heuristically bound the topic-partition metadata staleness at twice the max poll interval.
+        // This should typically mean that we get at least four chances to refresh the metadata before it expires.
+        final long metadataStalenessBoundMs = 2L * maxPollTimeMs;
+
         final ActiveTaskCreator activeTaskCreator = new ActiveTaskCreator(
             builder,
             config,
+            metadataStalenessBoundMs,
             streamsMetrics,
             stateDirectory,
             changelogReader,
@@ -363,20 +383,9 @@ public class StreamThread extends Thread {
             builder,
             adminClient,
             stateDirectory,
-            StreamThread.processingMode(config)
+            processingMode(config)
         );
         referenceContainer.taskManager = taskManager;
-
-        log.info("Creating consumer client");
-        final String applicationId = config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-        final Map<String, Object> consumerConfigs = config.getMainConsumerConfigs(applicationId, getConsumerClientId(threadId), threadIdx);
-        consumerConfigs.put(StreamsConfig.InternalConfig.REFERENCE_CONTAINER_PARTITION_ASSIGNOR, referenceContainer);
-
-        final String originalReset = (String) consumerConfigs.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
-        // If there are any overrides, we never fall through to the consumer, but only handle offset management ourselves.
-        if (!builder.latestResetTopicsPattern().pattern().isEmpty() || !builder.earliestResetTopicsPattern().pattern().isEmpty()) {
-            consumerConfigs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
-        }
 
         final Consumer<byte[], byte[]> mainConsumer = clientSupplier.getConsumer(consumerConfigs);
         changelogReader.setMainConsumer(mainConsumer);
@@ -400,7 +409,8 @@ public class StreamThread extends Thread {
             referenceContainer.nextScheduledRebalanceMs,
             shutdownErrorHook,
             streamsUncaughtExceptionHandler,
-            cacheSize -> cache.resize(cacheSize)
+            cacheSize -> cache.resize(cacheSize),
+            maxPollTimeMs
         );
 
         taskManager.setPartitionResetter(partitions -> streamThread.resetOffsets(partitions, null));
@@ -454,7 +464,8 @@ public class StreamThread extends Thread {
                         final AtomicLong nextProbingRebalanceMs,
                         final Runnable shutdownErrorHook,
                         final java.util.function.Consumer<Throwable> streamsUncaughtExceptionHandler,
-                        final java.util.function.Consumer<Long> cacheResizer) {
+                        final java.util.function.Consumer<Long> cacheResizer,
+                        final int maxPollTimeMs) {
         super(threadId);
         this.stateLock = new Object();
 
@@ -503,9 +514,7 @@ public class StreamThread extends Thread {
         this.nextProbingRebalanceMs = nextProbingRebalanceMs;
 
         this.pollTime = Duration.ofMillis(config.getLong(StreamsConfig.POLL_MS_CONFIG));
-        final int dummyThreadIdx = 1;
-        this.maxPollTimeMs = new InternalConsumerConfig(config.getMainConsumerConfigs("dummyGroupId", "dummyClientId", dummyThreadIdx))
-            .getInt(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
+        this.maxPollTimeMs = maxPollTimeMs;
         this.commitTimeMs = config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG);
 
         this.numIterations = 1;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -122,6 +123,8 @@ public interface Task {
     void completeRestoration();
 
     void addRecords(TopicPartition partition, Iterable<ConsumerRecord<byte[], byte[]>> records);
+
+    void addFetchedMetadata(TopicPartition partition, ConsumerRecords.Metadata metadata);
 
     boolean commitNeeded();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1025,7 +1025,7 @@ public class TaskManager {
      * @param records Records, can be null
      */
     void addRecordsToTasks(final ConsumerRecords<byte[], byte[]> records) {
-        for (final TopicPartition partition : records.partitions()) {
+        for (final TopicPartition partition : union(HashSet::new, records.partitions(), records.metadata().keySet())) {
             final Task task = partitionToTask.get(partition);
 
             if (task == null) {
@@ -1035,6 +1035,7 @@ public class TaskManager {
             }
 
             task.addRecords(partition, records.records(partition));
+            task.addFetchedMetadata(partition, records.metadata().get(partition));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ConsumerIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ConsumerIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+
+@Category(IntegrationTest.class)
+public class ConsumerIntegrationTest {
+    private static final int NUM_BROKERS = 1;
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
+        NUM_BROKERS,
+        Utils.mkProperties(Collections.singletonMap("auto.create.topics.enable", "false"))
+    );
+
+    @Rule
+    public TestName testName = new TestName();
+    private String topic1;
+    private String topic2;
+
+    @Before
+    public void createTopics() throws Exception {
+        final String uniqueTestName = IntegrationTestUtils.safeUniqueTestName(getClass(), testName);
+        topic1 = uniqueTestName + "A";
+        CLUSTER.createTopic(topic1, 1, 1);
+        topic2 = uniqueTestName + "B";
+        CLUSTER.createTopic(topic2, 1, 1);
+    }
+
+    @After
+    public void deleteTopics() throws Exception {
+        CLUSTER.deleteAllTopicsAndWait(IntegrationTestUtils.DEFAULT_TIMEOUT);
+    }
+
+    @Deprecated
+    @Test
+    public void asdf() throws Exception {
+        final KafkaConsumer<byte[], byte[]> kafkaConsumer = new KafkaConsumer<>(mkMap(
+            mkEntry(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+            mkEntry(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class),
+            mkEntry(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class)
+        ));
+        final TopicPartition topicPartition1 = new TopicPartition(topic1, 0);
+        final TopicPartition topicPartition2 = new TopicPartition(topic2, 0);
+        kafkaConsumer.assign(Arrays.asList(topicPartition1, topicPartition2));
+        final long position = kafkaConsumer.position(topicPartition1);
+        System.out.println(position);
+        System.out.println(kafkaConsumer.position(topicPartition2));
+        final ConsumerRecords<byte[], byte[]> poll = kafkaConsumer.poll(Duration.ZERO);
+        System.out.println(poll);
+        final ConsumerRecords<byte[], byte[]> poll1 = kafkaConsumer.poll(0L);
+        System.out.println(poll1);
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -457,6 +457,7 @@ public class ActiveTaskCreatorTest {
         activeTaskCreator = new ActiveTaskCreator(
             builder,
             new StreamsConfig(properties),
+            0L,
             streamsMetrics,
             stateDirectory,
             changeLogReader,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PartitionGroupTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
@@ -29,33 +30,41 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockSourceNode;
 import org.apache.kafka.test.MockTimestampExtractor;
-import org.junit.Before;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.hamcrest.CoreMatchers.is;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class PartitionGroupTest {
+    private final TaskId id = new TaskId(0, 0);
+
+    private final long maxTaskIdleMs = StreamsConfig.MAX_TASK_IDLE_MS_DISABLED;
     private final LogContext logContext = new LogContext();
     private final Time time = new MockTime();
     private final Serializer<Integer> intSerializer = new IntegerSerializer();
@@ -73,9 +82,9 @@ public class PartitionGroupTest {
     private final byte[] recordKey = intSerializer.serialize(null, 1);
 
     private final Metrics metrics = new Metrics();
+    private final Sensor enforcedProcessingSensor = metrics.sensor(UUID.randomUUID().toString());
     private final MetricName lastLatenessValue = new MetricName("record-lateness-last-value", "", "", mkMap());
 
-    private PartitionGroup group;
 
     private static Sensor getValueSensor(final Metrics metrics, final MetricName metricName) {
         final Sensor lastRecordedValue = metrics.sensor(metricName.name());
@@ -83,39 +92,33 @@ public class PartitionGroupTest {
         return lastRecordedValue;
     }
 
-    @Before
-    public void setUp() {
-        group = new PartitionGroup(
-                mkMap(mkEntry(partition1, queue1), mkEntry(partition2, queue2)),
-                getValueSensor(metrics, lastLatenessValue)
-        );
-    }
-
     @Test
     public void testTimeTracking() {
-        testFirstBatch();
-        testSecondBatch();
+        final PartitionGroup group = getBasicGroup();
+
+        testFirstBatch(group);
+        testSecondBatch(group);
     }
 
     private RecordQueue createQueue1() {
         return new RecordQueue(
-                partition1,
-                new MockSourceNode<>(intDeserializer, intDeserializer),
-                timestampExtractor,
-                new LogAndContinueExceptionHandler(),
-                new InternalMockProcessorContext(),
-                logContext
+            partition1,
+            new MockSourceNode<>(intDeserializer, intDeserializer),
+            timestampExtractor,
+            new LogAndContinueExceptionHandler(),
+            new InternalMockProcessorContext(),
+            logContext
         );
     }
 
     private RecordQueue createQueue2() {
         return new RecordQueue(
-                partition2,
-                new MockSourceNode<>(intDeserializer, intDeserializer),
-                timestampExtractor,
-                new LogAndContinueExceptionHandler(),
-                new InternalMockProcessorContext(),
-                logContext
+            partition2,
+            new MockSourceNode<>(intDeserializer, intDeserializer),
+            timestampExtractor,
+            new LogAndContinueExceptionHandler(),
+            new InternalMockProcessorContext(),
+            logContext
         );
     }
 
@@ -127,31 +130,31 @@ public class PartitionGroupTest {
         return new TopicPartition(topics[0], 2);
     }
 
-    private void testFirstBatch() {
+    private void testFirstBatch(final PartitionGroup group) {
         StampedRecord record;
         final PartitionGroup.RecordInfo info = new PartitionGroup.RecordInfo();
         assertThat(group.numBuffered(), is(0));
 
         // add three 3 records with timestamp 1, 3, 5 to partition-1
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
 
         group.addRawRecords(partition1, list1);
 
         // add three 3 records with timestamp 2, 4, 6 to partition-2
         final List<ConsumerRecord<byte[], byte[]>> list2 = Arrays.asList(
-                new ConsumerRecord<>("topic", 2, 2L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 2, 4L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 2, 6L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 2, 2L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 4L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 6L, recordKey, recordValue));
 
         group.addRawRecords(partition2, list2);
         // 1:[1, 3, 5]
         // 2:[2, 4, 6]
         // st: -1 since no records was being processed yet
 
-        verifyBuffered(6, 3, 3);
+        verifyBuffered(6, 3, 3, group);
         assertThat(group.partitionTimestamp(partition1), is(RecordQueue.UNKNOWN));
         assertThat(group.partitionTimestamp(partition2), is(RecordQueue.UNKNOWN));
         assertThat(group.headRecordOffset(partition1), is(1L));
@@ -169,7 +172,7 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(RecordQueue.UNKNOWN));
         assertThat(group.headRecordOffset(partition1), is(3L));
         assertThat(group.headRecordOffset(partition2), is(2L));
-        verifyTimes(record, 1L, 1L);
+        verifyTimes(record, 1L, 1L, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one record, now the time should be advanced
@@ -182,25 +185,25 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(2L));
         assertThat(group.headRecordOffset(partition1), is(3L));
         assertThat(group.headRecordOffset(partition2), is(4L));
-        verifyTimes(record, 2L, 2L);
-        verifyBuffered(4, 2, 2);
+        verifyTimes(record, 2L, 2L, group);
+        verifyBuffered(4, 2, 2, group);
         assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
     }
 
-    private void testSecondBatch() {
+    private void testSecondBatch(final PartitionGroup group) {
         StampedRecord record;
         final PartitionGroup.RecordInfo info = new PartitionGroup.RecordInfo();
 
         // add 2 more records with timestamp 2, 4 to partition-1
         final List<ConsumerRecord<byte[], byte[]>> list3 = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 2L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 4L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 2L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 4L, recordKey, recordValue));
 
         group.addRawRecords(partition1, list3);
         // 1:[3, 5, 2, 4]
         // 2:[4, 6]
         // st: 2 (just adding records shouldn't change it)
-        verifyBuffered(6, 4, 2);
+        verifyBuffered(6, 4, 2, group);
         assertThat(group.partitionTimestamp(partition1), is(1L));
         assertThat(group.partitionTimestamp(partition2), is(2L));
         assertThat(group.headRecordOffset(partition1), is(3L));
@@ -218,8 +221,8 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(2L));
         assertThat(group.headRecordOffset(partition1), is(5L));
         assertThat(group.headRecordOffset(partition2), is(4L));
-        verifyTimes(record, 3L, 3L);
-        verifyBuffered(5, 3, 2);
+        verifyTimes(record, 3L, 3L, group);
+        verifyBuffered(5, 3, 2, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one record, time should be advanced
@@ -232,8 +235,8 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(4L));
         assertThat(group.headRecordOffset(partition1), is(5L));
         assertThat(group.headRecordOffset(partition2), is(6L));
-        verifyTimes(record, 4L, 4L);
-        verifyBuffered(4, 3, 1);
+        verifyTimes(record, 4L, 4L, group);
+        verifyBuffered(4, 3, 1, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one more record, time should be advanced
@@ -246,8 +249,8 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(4L));
         assertThat(group.headRecordOffset(partition1), is(2L));
         assertThat(group.headRecordOffset(partition2), is(6L));
-        verifyTimes(record, 5L, 5L);
-        verifyBuffered(3, 2, 1);
+        verifyTimes(record, 5L, 5L, group);
+        verifyBuffered(3, 2, 1, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
 
         // get one more record, time should not be advanced
@@ -260,8 +263,8 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(4L));
         assertThat(group.headRecordOffset(partition1), is(4L));
         assertThat(group.headRecordOffset(partition2), is(6L));
-        verifyTimes(record, 2L, 5L);
-        verifyBuffered(2, 1, 1);
+        verifyTimes(record, 2L, 5L, group);
+        verifyBuffered(2, 1, 1, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(3.0));
 
         // get one more record, time should not be advanced
@@ -274,8 +277,8 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(4L));
         assertNull(group.headRecordOffset(partition1));
         assertThat(group.headRecordOffset(partition2), is(6L));
-        verifyTimes(record, 4L, 5L);
-        verifyBuffered(1, 0, 1);
+        verifyTimes(record, 4L, 5L, group);
+        verifyBuffered(1, 0, 1, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(1.0));
 
         // get one more record, time should be advanced
@@ -288,24 +291,26 @@ public class PartitionGroupTest {
         assertThat(group.partitionTimestamp(partition2), is(6L));
         assertNull(group.headRecordOffset(partition1));
         assertNull(group.headRecordOffset(partition2));
-        verifyTimes(record, 6L, 6L);
-        verifyBuffered(0, 0, 0);
+        verifyTimes(record, 6L, 6L, group);
+        verifyBuffered(0, 0, 0, group);
         assertThat(metrics.metric(lastLatenessValue).metricValue(), is(0.0));
     }
 
     @Test
     public void shouldChooseNextRecordBasedOnHeadTimestamp() {
+        final PartitionGroup group = getBasicGroup();
+
         assertEquals(0, group.numBuffered());
 
         // add three 3 records with timestamp 1, 5, 3 to partition-1
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue));
 
         group.addRawRecords(partition1, list1);
 
-        verifyBuffered(3, 3, 0);
+        verifyBuffered(3, 3, 0, group);
         assertEquals(-1L, group.streamTime());
         assertEquals(0.0, metrics.metric(lastLatenessValue).metricValue());
 
@@ -320,9 +325,9 @@ public class PartitionGroupTest {
 
         // add three 3 records with timestamp 2, 4, 6 to partition-2
         final List<ConsumerRecord<byte[], byte[]>> list2 = Arrays.asList(
-                new ConsumerRecord<>("topic", 2, 2L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 2, 4L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 2, 6L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 2, 2L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 4L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 6L, recordKey, recordValue));
 
         group.addRawRecords(partition2, list2);
         // 1:[3]
@@ -341,12 +346,12 @@ public class PartitionGroupTest {
         assertEquals(record.timestamp, 3L);
     }
 
-    private void verifyTimes(final StampedRecord record, final long recordTime, final long streamTime) {
+    private void verifyTimes(final StampedRecord record, final long recordTime, final long streamTime, final PartitionGroup group) {
         assertThat(record.timestamp, is(recordTime));
         assertThat(group.streamTime(), is(streamTime));
     }
 
-    private void verifyBuffered(final int totalBuffered, final int partitionOneBuffered, final int partitionTwoBuffered) {
+    private void verifyBuffered(final int totalBuffered, final int partitionOneBuffered, final int partitionTwoBuffered, final PartitionGroup group) {
         assertEquals(totalBuffered, group.numBuffered());
         assertEquals(partitionOneBuffered, group.numBuffered(partition1));
         assertEquals(partitionTwoBuffered, group.numBuffered(partition2));
@@ -354,6 +359,8 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldSetPartitionTimestampAndStreamTime() {
+        final PartitionGroup group = getBasicGroup();
+
         group.setPartitionTime(partition1, 100L);
         assertEquals(100L, group.partitionTimestamp(partition1));
         assertEquals(100L, group.streamTime());
@@ -364,6 +371,8 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldThrowIllegalStateExceptionUponAddRecordsIfPartitionUnknown() {
+        final PartitionGroup group = getBasicGroup();
+
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.addRawRecords(unknownPartition, null));
@@ -372,6 +381,8 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldThrowIllegalStateExceptionUponNumBufferedIfPartitionUnknown() {
+        final PartitionGroup group = getBasicGroup();
+
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.numBuffered(unknownPartition));
@@ -380,6 +391,8 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldThrowIllegalStateExceptionUponSetPartitionTimestampIfPartitionUnknown() {
+        final PartitionGroup group = getBasicGroup();
+
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.setPartitionTime(unknownPartition, 0L));
@@ -388,6 +401,8 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldThrowIllegalStateExceptionUponGetPartitionTimestampIfPartitionUnknown() {
+        final PartitionGroup group = getBasicGroup();
+
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.partitionTimestamp(unknownPartition));
@@ -396,6 +411,8 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldThrowIllegalStateExceptionUponGetHeadRecordOffsetIfPartitionUnknown() {
+        final PartitionGroup group = getBasicGroup();
+
         final IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> group.headRecordOffset(unknownPartition));
@@ -404,10 +421,12 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldEmptyPartitionsOnClear() {
+        final PartitionGroup group = getBasicGroup();
+
         final List<ConsumerRecord<byte[], byte[]>> list = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 3L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list);
         group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds());
         group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds());
@@ -424,17 +443,19 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldUpdatePartitionQueuesShrink() {
+        final PartitionGroup group = getBasicGroup();
+
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list1);
         final List<ConsumerRecord<byte[], byte[]>> list2 = Arrays.asList(
-                new ConsumerRecord<>("topic", 2, 2L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 2, 4L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 2, 6L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 2, 2L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 4L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 6L, recordKey, recordValue));
         group.addRawRecords(partition2, list2);
         assertEquals(list1.size() + list2.size(), group.numBuffered());
-        assertTrue(group.allPartitionsBuffered());
+        assertTrue(group.allPartitionsBufferedLocally());
         group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds());
 
         // shrink list of queues
@@ -443,7 +464,7 @@ public class PartitionGroupTest {
             return null;
         });
 
-        assertTrue(group.allPartitionsBuffered());  // because didn't add any new partitions
+        assertTrue(group.allPartitionsBufferedLocally());  // because didn't add any new partitions
         assertEquals(list2.size(), group.numBuffered());
         assertEquals(1, group.streamTime());
         assertThrows(IllegalStateException.class, () -> group.partitionTimestamp(partition1));
@@ -453,17 +474,21 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldUpdatePartitionQueuesExpand() {
-        group = new PartitionGroup(
-                mkMap(mkEntry(partition1, queue1)),
-                getValueSensor(metrics, lastLatenessValue)
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(mkEntry(partition1, queue1)),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            maxTaskIdleMs,
+            0L
         );
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list1);
 
         assertEquals(list1.size(), group.numBuffered());
-        assertTrue(group.allPartitionsBuffered());
+        assertTrue(group.allPartitionsBufferedLocally());
         group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds());
 
         // expand list of queues
@@ -472,7 +497,7 @@ public class PartitionGroupTest {
             return createQueue2();
         });
 
-        assertFalse(group.allPartitionsBuffered());  // because added new partition
+        assertFalse(group.allPartitionsBufferedLocally());  // because added new partition
         assertEquals(1, group.numBuffered());
         assertEquals(1, group.streamTime());
         assertThat(group.partitionTimestamp(partition1), equalTo(1L));
@@ -482,16 +507,20 @@ public class PartitionGroupTest {
 
     @Test
     public void shouldUpdatePartitionQueuesShrinkAndExpand() {
-        group = new PartitionGroup(
-                mkMap(mkEntry(partition1, queue1)),
-                getValueSensor(metrics, lastLatenessValue)
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(mkEntry(partition1, queue1)),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            maxTaskIdleMs,
+            0L
         );
         final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
-                new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
-                new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
         group.addRawRecords(partition1, list1);
         assertEquals(list1.size(), group.numBuffered());
-        assertTrue(group.allPartitionsBuffered());
+        assertTrue(group.allPartitionsBufferedLocally());
         group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds());
 
         // expand and shrink list of queues
@@ -500,11 +529,281 @@ public class PartitionGroupTest {
             return createQueue2();
         });
 
-        assertFalse(group.allPartitionsBuffered());  // because added new partition
+        assertFalse(group.allPartitionsBufferedLocally());  // because added new partition
         assertEquals(0, group.numBuffered());
         assertEquals(1, group.streamTime());
         assertThrows(IllegalStateException.class, () -> group.partitionTimestamp(partition1));
         assertThat(group.partitionTimestamp(partition2), equalTo(RecordQueue.UNKNOWN));
         assertThat(group.nextRecord(new PartitionGroup.RecordInfo(), time.milliseconds()), nullValue());  // all available records removed
+    }
+
+    @Test
+    public void shouldNeverWaitIfIdlingIsDisabled() {
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            StreamsConfig.MAX_TASK_IDLE_MS_DISABLED,
+            0L
+        );
+
+        final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+        group.addRawRecords(partition1, list1);
+
+        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(0L), is(true));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("TRACE")),
+                    Matchers.hasProperty("message", equalTo(
+                        "[0_0] Ready for processing because max.task.idle.ms is disabled.\n" +
+                            "\tThere may be out-of-order processing for this task as a result.\n" +
+                            "\tBuffered partitions: [topic-1]\n" +
+                            "\tNon-buffered partitions: [topic-2]"
+                    ))
+                ))
+            );
+        }
+    }
+
+    @Test
+    public void shouldBeReadyIfAllPartitionsAreBuffered() {
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            0L,
+            0L
+        );
+
+        final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+        group.addRawRecords(partition1, list1);
+
+        final List<ConsumerRecord<byte[], byte[]>> list2 = Arrays.asList(
+            new ConsumerRecord<>("topic", 2, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 2, 5L, recordKey, recordValue));
+        group.addRawRecords(partition2, list2);
+
+        assertThat(group.allPartitionsBufferedLocally(), is(true));
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(0L), is(true));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("DEBUG")),
+                    Matchers.hasProperty("message", equalTo("[0_0] All partitions were buffered locally, so this task is ready for processing."))
+                ))
+            );
+        }
+    }
+
+    @Test
+    public void shouldWaitForFetchesWhenMetadataIsIncomplete() {
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            0L,
+            0L
+        );
+
+        final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+        group.addRawRecords(partition1, list1);
+
+        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(0L), is(false));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("TRACE")),
+                    Matchers.hasProperty("message", equalTo("[0_0] Waiting to fetch data for topic-2"))
+                ))
+            );
+        }
+        group.addFetchedMetadata(partition2, new ConsumerRecords.Metadata(0L, 0L, 0L, 0L));
+        assertThat(group.readyToProcess(0L), is(true));
+    }
+
+    @Test
+    public void shouldWaitForFetchesWhenMetadataIsStale() {
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            0L,
+            100_000L
+        );
+
+        final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+        group.addRawRecords(partition1, list1);
+        group.addFetchedMetadata(partition2, new ConsumerRecords.Metadata(0L, 0L, 0L, 0L));
+
+        assertThat(group.allPartitionsBufferedLocally(), is(false));
+        assertThat(group.readyToProcess(100_000L), is(true));
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(100_001L), is(false));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("TRACE")),
+                    Matchers.hasProperty("message", equalTo("[0_0] Waiting to fetch data for topic-2"))
+                ))
+            );
+        }
+        group.addFetchedMetadata(partition2, new ConsumerRecords.Metadata(100_002L, 0L, 0L, 0L));
+        assertThat(group.readyToProcess(100_002L), is(true));
+    }
+
+    @Test
+    public void shouldWaitForPollWhenLagIsNonzero() {
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            0L,
+            0L
+        );
+
+        final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+        group.addRawRecords(partition1, list1);
+        group.addFetchedMetadata(partition2, new ConsumerRecords.Metadata(0L, 0L, 0L, 1L));
+
+        assertThat(group.allPartitionsBufferedLocally(), is(false));
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(0L), is(false));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("DEBUG")),
+                    Matchers.hasProperty("message", equalTo("[0_0] Lag for topic-2 is currently 1, but no data is buffered locally. Waiting to buffer some records."))
+                ))
+            );
+        }
+    }
+
+    @Test
+    public void shouldIdleAsSpecifiedWhenLagIsZero() {
+        final PartitionGroup group = new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            1L,
+            10L
+        );
+
+        final List<ConsumerRecord<byte[], byte[]>> list1 = Arrays.asList(
+            new ConsumerRecord<>("topic", 1, 1L, recordKey, recordValue),
+            new ConsumerRecord<>("topic", 1, 5L, recordKey, recordValue));
+        group.addRawRecords(partition1, list1);
+        group.addFetchedMetadata(partition2, new ConsumerRecords.Metadata(0L, 0L, 0L, 0L));
+
+        assertThat(group.allPartitionsBufferedLocally(), is(false));
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(0L), is(false));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("DEBUG")),
+                    Matchers.hasProperty("message", equalTo("[0_0] Lag for topic-2 is currently 0 and current time is 0. Waiting for new data to be produced for configured idle time 1 (deadline is 1)."))
+                ))
+            );
+        }
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(1L), is(true));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("INFO")),
+                    Matchers.hasProperty("message", equalTo(
+                        "[0_0] Continuing to process although some partition timestamps were not buffered locally.\n" +
+                            "\tThere may be out-of-order processing for this task as a result.\n" +
+                            "\tPartitions with local data: [topic-1].\n" +
+                            "\tPartitions we gave up waiting for, with their corresponding deadlines: {topic-2=1}.\n" +
+                            "\tConfigured max.task.idle.ms: 1.\n" +
+                            "\tCurrent wall-clock time: 1."
+                    ))
+                ))
+            );
+        }
+
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(PartitionGroup.class)) {
+            LogCaptureAppender.setClassLoggerToTrace(PartitionGroup.class);
+            assertThat(group.readyToProcess(2L), is(true));
+            assertThat(
+                appender.getEvents(),
+                hasItem(Matchers.allOf(
+                    Matchers.hasProperty("level", equalTo("INFO")),
+                    Matchers.hasProperty("message", equalTo(
+                        "[0_0] Continuing to process although some partition timestamps were not buffered locally.\n" +
+                            "\tThere may be out-of-order processing for this task as a result.\n" +
+                            "\tPartitions with local data: [topic-1].\n" +
+                            "\tPartitions we gave up waiting for, with their corresponding deadlines: {topic-2=1}.\n" +
+                            "\tConfigured max.task.idle.ms: 1.\n" +
+                            "\tCurrent wall-clock time: 2."
+                    ))
+                ))
+            );
+        }
+    }
+
+    private PartitionGroup getBasicGroup() {
+        return new PartitionGroup(
+            id,
+            mkMap(
+                mkEntry(partition1, queue1),
+                mkEntry(partition2, queue2)
+            ),
+            getValueSensor(metrics, lastLatenessValue),
+            enforcedProcessingSensor,
+            maxTaskIdleMs,
+            0L
+        );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateConsumerTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,6 +59,7 @@ public class StateConsumerTest {
 
     @Test
     public void shouldAssignPartitionsToConsumer() {
+        assertEquals(Collections.emptySet(), consumer.assignment());
         stateConsumer.initialize();
         assertEquals(Utils.mkSet(topicOne, topicTwo), consumer.assignment());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -490,7 +490,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         );
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
@@ -730,7 +731,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         );
         thread.setNow(mockTime.milliseconds());
         thread.maybeCommit();
@@ -795,7 +797,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         );
 
         thread.setNow(mockTime.milliseconds());
@@ -999,7 +1002,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.setStateListener(
             (t, newState, oldState) -> {
@@ -1061,7 +1065,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         final IllegalStateException thrown = assertThrows(
@@ -1101,7 +1106,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.shutdown();
         verify(taskManager);
@@ -1134,7 +1140,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
         thread.shutdown();
         // Execute the run method. Verification of the mock will check that shutdown was only done once
@@ -2041,7 +2048,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         consumer.schedulePollTask(() -> {
@@ -2088,7 +2096,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ).updateThreadMetadata(getSharedAdminClientId(CLIENT_ID));
 
         consumer.schedulePollTask(() -> {
@@ -2141,7 +2150,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ) {
             @Override
             void runOnce() {
@@ -2202,7 +2212,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         ) {
             @Override
             void runOnce() {
@@ -2264,7 +2275,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         );
 
         EasyMock.replay(task1, task2, task3, taskManager);
@@ -2433,7 +2445,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         );
 
         assertThat(dummyProducerMetrics, is(thread.producerMetrics()));
@@ -2470,7 +2483,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             HANDLER,
-            null
+            null,
+            Integer.MAX_VALUE
         );
         final MetricName testMetricName = new MetricName("test_metric", "", "", new HashMap<>());
         final Metric testMetric = new KafkaMetric(
@@ -2519,7 +2533,8 @@ public class StreamThreadTest {
             new AtomicLong(Long.MAX_VALUE),
             null,
             e -> { },
-            null
+            null,
+            Integer.MAX_VALUE
         ) {
             @Override
             void runOnce() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
@@ -176,8 +177,7 @@ public class TaskManagerTest {
             topologyBuilder,
             adminClient,
             stateDirectory,
-            processingMode
-        );
+            processingMode);
         taskManager.setMainConsumer(consumer);
     }
 
@@ -2999,6 +2999,11 @@ public class TaskManagerTest {
             } else {
                 throw new IllegalStateException("Can't add records to an inactive task.");
             }
+        }
+
+        @Override
+        public void addFetchedMetadata(final TopicPartition partition, final ConsumerRecords.Metadata metadata) {
+            // do nothing
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/testutil/LogCaptureAppender.java
@@ -69,6 +69,10 @@ public class LogCaptureAppender extends AppenderSkeleton implements AutoCloseabl
         Logger.getLogger(clazz).setLevel(Level.DEBUG);
     }
 
+    public static void setClassLoggerToTrace(final Class<?> clazz) {
+        Logger.getLogger(clazz).setLevel(Level.TRACE);
+    }
+
     public static void unregister(final LogCaptureAppender logCaptureAppender) {
         Logger.getRootLogger().removeAppender(logCaptureAppender);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -435,6 +435,7 @@ public class StreamThreadStateStoreProviderTest {
             topology,
             clientSupplier.consumer,
             streamsConfig,
+            Long.MAX_VALUE,
             streamsMetrics,
             stateDirectory,
             EasyMock.createNiceMock(ThreadCache.class),


### PR DESCRIPTION
Expose fetched metadata per partition so that Streams
can enqueue records for each input and select among
them for processing in timestamp order.

Implements KIP-695

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
