### PR TITLE
MINOR: Factor out common response parsing logic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.requests.CorrelationIdMismatchException;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
-import org.apache.kafka.common.requests.ResponseHeader;
 import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -967,21 +966,6 @@ public class NetworkClient implements KafkaClient {
                 doSend(clientRequest, true, now);
                 iter.remove();
             }
-        }
-    }
-
-    /**
-     * Validate that the response corresponds to the request we expect or else explode
-     */
-    private static void correlate(RequestHeader requestHeader, ResponseHeader responseHeader) {
-        if (requestHeader.correlationId() != responseHeader.correlationId()) {
-            if (SaslClientAuthenticator.isReserved(requestHeader.correlationId())
-                    && !SaslClientAuthenticator.isReserved(responseHeader.correlationId()))
-                throw new SchemaException("the response is unrelated to Sasl request since its correlation id is " + responseHeader.correlationId()
-                    + " and the reserved range for Sasl request is [ "
-                    + SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID + "," + SaslClientAuthenticator.MAX_RESERVED_CORRELATION_ID + "]");
-            throw new IllegalStateException("Correlation id for response (" + responseHeader.correlationId()
-                    + ") does not match request (" + requestHeader.correlationId() + "), request header: " + requestHeader);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -84,11 +84,18 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
      * Parse a response from the provided buffer. The buffer is expected to hold both
      * the {@link ResponseHeader} as well as the response payload.
      */
-    public static AbstractResponse parseResponse(ByteBuffer byteBuffer, RequestHeader header) {
-        ApiKeys apiKey = header.apiKey();
-        short apiVersion = header.apiVersion();
+    public static AbstractResponse parseResponse(ByteBuffer byteBuffer, RequestHeader requestHeader) {
+        ApiKeys apiKey = requestHeader.apiKey();
+        short apiVersion = requestHeader.apiVersion();
 
-        ResponseHeader.parse(byteBuffer, apiKey.responseHeaderVersion(apiVersion));
+        ResponseHeader responseHeader = ResponseHeader.parse(byteBuffer, apiKey.responseHeaderVersion(apiVersion));
+        if (requestHeader.correlationId() != responseHeader.correlationId()) {
+            throw new CorrelationIdMismatchException("Correlation id for response ("
+                + responseHeader.correlationId() + ") does not match request ("
+                + requestHeader.correlationId() + "), request header: " + requestHeader,
+                requestHeader.correlationId(), responseHeader.correlationId());
+        }
+
         Struct struct = apiKey.parseResponse(apiVersion, byteBuffer);
         return AbstractResponse.parseResponse(apiKey, struct, apiVersion);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CorrelationIdMismatchException.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CorrelationIdMismatchException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+/**
+ * Raised if the correlationId in a response header does not match
+ * the expected value from the request header.
+ */
+public class CorrelationIdMismatchException extends IllegalStateException {
+    private final int requestCorrelationId;
+    private final int responseCorrelationId;
+
+    public CorrelationIdMismatchException(
+        String message,
+        int requestCorrelationId,
+        int responseCorrelationId
+    ) {
+        super(message);
+        this.requestCorrelationId = requestCorrelationId;
+        this.responseCorrelationId = responseCorrelationId;
+    }
+
+    public int requestCorrelationId() {
+        return requestCorrelationId;
+    }
+
+    public int responseCorrelationId() {
+        return responseCorrelationId;
+    }
+
+}

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManagerImpl.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManagerImpl.scala
@@ -55,7 +55,7 @@ class BrokerToControllerChannelManagerImpl(metadataCache: kafka.server.MetadataC
                                            config: KafkaConfig,
                                            channelName: String,
                                            threadNamePrefix: Option[String] = None) extends BrokerToControllerChannelManager with Logging {
-  protected val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]
+  private val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]
   private val logContext = new LogContext(s"[broker-${config.brokerId}-to-controller] ")
   private val manualMetadataUpdater = new ManualMetadataUpdater()
   private val requestThread = newRequestThread

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -168,7 +168,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
   var kafkaController: KafkaController = null
 
-  var forwardingManager: ForwardingManager = null
+  var forwardingChannelManager: BrokerToControllerChannelManager = null
 
   var alterIsrChannelManager: BrokerToControllerChannelManager = null
 
@@ -329,10 +329,13 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, brokerFeatures, featureCache, threadNamePrefix)
         kafkaController.startup()
 
+        var forwardingManager: ForwardingManager = null
         if (config.metadataQuorumEnabled) {
           /* start forwarding manager */
-          forwardingManager = new ForwardingManager(metadataCache, time, metrics, config, threadNamePrefix)
-          forwardingManager.start()
+          forwardingChannelManager = new BrokerToControllerChannelManagerImpl(metadataCache, time, metrics,
+            config, "forwardingChannel", threadNamePrefix)
+          forwardingChannelManager.start()
+          forwardingManager = new ForwardingManager(forwardingChannelManager)
         }
 
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)
@@ -725,8 +728,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         if (alterIsrChannelManager != null)
           CoreUtils.swallow(alterIsrChannelManager.shutdown(), this)
 
-        if (forwardingManager != null)
-          CoreUtils.swallow(forwardingManager.shutdown(), this)
+        if (forwardingChannelManager != null)
+          CoreUtils.swallow(forwardingChannelManager.shutdown(), this)
 
         if (logManager != null)
           CoreUtils.swallow(logManager.shutdown(), this)

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.net.InetAddress
+import java.nio.ByteBuffer
+import java.util.Optional
+
+import kafka.network
+import kafka.network.RequestChannel
+import kafka.utils.MockTime
+import org.apache.kafka.clients.{ClientResponse, RequestCompletionHandler}
+import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
+import org.apache.kafka.common.memory.MemoryPool
+import org.apache.kafka.common.message.AlterConfigsResponseData
+import org.apache.kafka.common.network.{ClientInformation, ListenerName}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, AlterConfigsRequest, AlterConfigsResponse, EnvelopeRequest, EnvelopeResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
+import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder
+import org.junit.Assert._
+import org.junit.Test
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito
+
+import scala.jdk.CollectionConverters._
+
+class ForwardingManagerTest {
+  private val brokerToController = Mockito.mock(classOf[BrokerToControllerChannelManager])
+  private val time = new MockTime()
+  private val principalBuilder = new DefaultKafkaPrincipalBuilder(null, null)
+
+  @Test
+  def testResponseCorrelationIdMismatch(): Unit = {
+    val forwardingManager = new ForwardingManager(brokerToController)
+    val requestCorrelationId = 27
+    val envelopeCorrelationId = 39
+    val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "client")
+
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, "foo")
+    val configs = List(new AlterConfigsRequest.ConfigEntry(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "1")).asJava
+    val requestBody = new AlterConfigsRequest.Builder(Map(
+      configResource -> new AlterConfigsRequest.Config(configs)
+    ).asJava, false).build()
+    val (requestHeader, requestBuffer) = buildRequest(requestBody, requestCorrelationId)
+    val request = buildRequest(requestHeader, requestBuffer, clientPrincipal)
+
+    val responseBody = new AlterConfigsResponse(new AlterConfigsResponseData())
+    val responseBuffer = responseBody.serialize(ApiKeys.ALTER_CONFIGS,
+      requestBody.version, requestCorrelationId + 1)
+
+    Mockito.when(brokerToController.sendRequest(
+      any(classOf[EnvelopeRequest.Builder]),
+      any(classOf[RequestCompletionHandler])
+    )).thenAnswer(invocation => {
+      val completionHandler = invocation.getArgument[RequestCompletionHandler](1)
+      val response = buildEnvelopeResponse(responseBuffer, envelopeCorrelationId, completionHandler)
+      response.onComplete()
+    })
+
+    var response: AbstractResponse = null
+    forwardingManager.forwardRequest(request, res => response = res)
+
+    assertNotNull(response)
+    assertEquals(Map(Errors.UNKNOWN_SERVER_ERROR -> 1).asJava, response.errorCounts())
+  }
+
+  private def buildEnvelopeResponse(
+    responseBuffer: ByteBuffer,
+    correlationId: Int,
+    completionHandler: RequestCompletionHandler
+  ): ClientResponse = {
+    val envelopeRequestHeader = new RequestHeader(
+      ApiKeys.ENVELOPE,
+      ApiKeys.ENVELOPE.latestVersion(),
+      "clientId",
+      correlationId
+    )
+    val envelopeResponse = new EnvelopeResponse(
+      responseBuffer,
+      Errors.NONE
+    )
+
+    new ClientResponse(
+      envelopeRequestHeader,
+      completionHandler,
+      "1",
+      time.milliseconds(),
+      time.milliseconds(),
+      false,
+      null,
+      null,
+      envelopeResponse
+    )
+  }
+
+  private def buildRequest(
+    body: AbstractRequest,
+    correlationId: Int
+  ): (RequestHeader, ByteBuffer) = {
+    val header = new RequestHeader(
+      body.api,
+      body.version,
+      "clientId",
+      correlationId
+    )
+    val buffer = body.serialize(header)
+
+    // Fast-forward buffer to start of the request as `RequestChannel.Request` expects
+    RequestHeader.parse(buffer)
+
+    (header, buffer)
+  }
+
+  private def buildRequest(
+    requestHeader: RequestHeader,
+    requestBuffer: ByteBuffer,
+    principal: KafkaPrincipal
+  ): RequestChannel.Request = {
+    val requestContext = new RequestContext(
+      requestHeader,
+      "1",
+      InetAddress.getLocalHost,
+      principal,
+      new ListenerName("client"),
+      SecurityProtocol.SASL_PLAINTEXT,
+      ClientInformation.EMPTY,
+      false,
+      Optional.of(principalBuilder)
+    )
+
+    new network.RequestChannel.Request(
+      processor = 1,
+      context = requestContext,
+      startTimeNanos = time.nanoseconds(),
+      memoryPool = MemoryPool.NONE,
+      buffer = requestBuffer,
+      metrics = new RequestChannel.Metrics(allowDisabledApis = true),
+      envelope = None
+    )
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -327,8 +327,10 @@ class KafkaApisTest {
 
     assertEquals(Errors.NONE, response.error)
 
-    val innerResponse = AbstractResponse.parseResponse(response.responseData(),
-      requestHeader).asInstanceOf[AlterConfigsResponse]
+    val innerResponse = AbstractResponse.parseResponse(
+      response.responseData(),
+      requestHeader
+    ).asInstanceOf[AlterConfigsResponse]
 
     val responseMap = innerResponse.data.responses().asScala.map { resourceResponse =>
       resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)


### PR DESCRIPTION
This patch factors out some common parsing logic from `NetworkClient.parseResponse` and `AbstractResponse.parseResponse`. As a result of this refactor, we are now verifying the correlationId in forwarded requests. This patch also adds a test case to verify handling in this case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
