### PR TITLE
MINOR: Reduce sends created by `SendBuilder`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/ByteBufferSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ByteBufferSend.java
@@ -27,9 +27,9 @@ import java.nio.channels.GatheringByteChannel;
 public class ByteBufferSend implements Send {
 
     private final String destination;
-    private final int size;
+    private final long size;
     protected final ByteBuffer[] buffers;
-    private int remaining;
+    private long remaining;
     private boolean pending = false;
 
     public ByteBufferSend(String destination, ByteBuffer... buffers) {
@@ -38,6 +38,13 @@ public class ByteBufferSend implements Send {
         for (ByteBuffer buffer : buffers)
             remaining += buffer.remaining();
         this.size = remaining;
+    }
+
+    public ByteBufferSend(String destination, ByteBuffer[] buffers, long size) {
+        this.destination = destination;
+        this.buffers = buffers;
+        this.size = size;
+        this.remaining = size;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/protocol/SendBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/SendBuilder.java
@@ -41,7 +41,7 @@ import java.util.Queue;
  * for example usage.
  */
 public class SendBuilder implements Writable {
-    private final Queue<Send> sends = new ArrayDeque<>();
+    private final Queue<Send> sends = new ArrayDeque<>(1);
     private final List<ByteBuffer> buffers = new ArrayList<>();
     private final ByteBuffer buffer;
     private final String destinationId;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/SendBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/SendBuilder.java
@@ -41,29 +41,19 @@ import java.util.Queue;
  * for example usage.
  */
 public class SendBuilder implements Writable {
-    private final Queue<Send> sends = new ArrayDeque<>(1);
-    private final List<ByteBuffer> buffers = new ArrayList<>();
     private final ByteBuffer buffer;
     private final String destinationId;
+
+    private final Queue<Send> sends = new ArrayDeque<>(1);
+    private long sizeOfSends = 0;
+
+    private final List<ByteBuffer> buffers = new ArrayList<>();
+    private long sizeOfBuffers = 0;
 
     SendBuilder(String destinationId, int size) {
         this.destinationId = destinationId;
         this.buffer = ByteBuffer.allocate(size);
         this.buffer.mark();
-    }
-
-    private void flushPendingBuffer() {
-        int latestPosition = buffer.position();
-        buffer.reset();
-
-        if (latestPosition > buffer.position()) {
-            buffer.limit(latestPosition);
-            buffers.add(buffer.slice());
-
-            buffer.position(latestPosition);
-            buffer.limit(buffer.capacity());
-            buffer.mark();
-        }
     }
 
     @Override
@@ -110,7 +100,7 @@ public class SendBuilder implements Writable {
     @Override
     public void writeByteBuffer(ByteBuffer buf) {
         flushPendingBuffer();
-        buffers.add(buf.duplicate());
+        addBuffer(buf.duplicate());
     }
 
     @Override
@@ -123,12 +113,19 @@ public class SendBuilder implements Writable {
         ByteUtils.writeVarlong(i, buffer);
     }
 
-    private void flushPendingSend() {
-        if (!buffers.isEmpty()) {
-            ByteBuffer[] byteBufferArray = buffers.toArray(new ByteBuffer[0]);
-            sends.add(new ByteBufferSend(destinationId, byteBufferArray));
-            buffers.clear();
-        }
+    private void addBuffer(ByteBuffer buffer) {
+        buffers.add(buffer);
+        sizeOfBuffers += buffer.remaining();
+    }
+
+    private void addSend(Send send) {
+        sends.add(send);
+        sizeOfSends += send.size();
+    }
+
+    private void clearBuffers() {
+        buffers.clear();
+        sizeOfBuffers = 0;
     }
 
     /**
@@ -139,24 +136,45 @@ public class SendBuilder implements Writable {
      */
     @Override
     public void writeRecords(BaseRecords records) {
-        flushPendingBuffer();
-
         if (records instanceof MemoryRecords) {
-            buffers.add(((MemoryRecords) records).buffer());
+            flushPendingBuffer();
+            addBuffer(((MemoryRecords) records).buffer());
         } else {
             flushPendingSend();
-            sends.add(records.toSend(destinationId));
+            addSend(records.toSend(destinationId));
+        }
+    }
+
+    private void flushPendingSend() {
+        flushPendingBuffer();
+        if (!buffers.isEmpty()) {
+            ByteBuffer[] byteBufferArray = buffers.toArray(new ByteBuffer[0]);
+            addSend(new ByteBufferSend(destinationId, byteBufferArray, sizeOfBuffers));
+            clearBuffers();
+        }
+    }
+
+    private void flushPendingBuffer() {
+        int latestPosition = buffer.position();
+        buffer.reset();
+
+        if (latestPosition > buffer.position()) {
+            buffer.limit(latestPosition);
+            addBuffer(buffer.slice());
+
+            buffer.position(latestPosition);
+            buffer.limit(buffer.capacity());
+            buffer.mark();
         }
     }
 
     public Send build() {
-        flushPendingBuffer();
         flushPendingSend();
 
         if (sends.size() == 1) {
             return sends.poll();
         } else {
-            return new MultiRecordsSend(destinationId, sends);
+            return new MultiRecordsSend(destinationId, sends, sizeOfSends);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
@@ -62,7 +62,7 @@ public abstract class AbstractRecords implements Records {
     }
 
     @Override
-    public RecordsSend toSend(String destination) {
+    public DefaultRecordsSend toSend(String destination) {
         return new DefaultRecordsSend(destination, this);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/BaseRecords.java
@@ -30,5 +30,5 @@ public interface BaseRecords {
      * Encapsulate this {@link BaseRecords} object into {@link RecordsSend}
      * @return Initialized {@link RecordsSend} object
      */
-    RecordsSend toSend(String destination);
+    RecordsSend<? extends BaseRecords> toSend(String destination);
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/MultiRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MultiRecordsSend.java
@@ -58,6 +58,13 @@ public class MultiRecordsSend implements Send {
         this.current = sendQueue.poll();
     }
 
+    public MultiRecordsSend(String dest, Queue<Send> sends, long size) {
+        this.dest = dest;
+        this.sendQueue = sends;
+        this.size = size;
+        this.current = sendQueue.poll();
+    }
+
     @Override
     public long size() {
         return size;

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -170,7 +170,7 @@ public class ReplicaFetcherThreadBenchmark {
                 }
 
                 @Override
-                public RecordsSend toSend(String destination) {
+                public RecordsSend<? extends BaseRecords> toSend(String destination) {
                     return null;
                 }
             };


### PR DESCRIPTION
In #9401, I observed some strange latency behavior when testing locally (on macos). The behavior seemed to be caused by slightly different write behavior as a result of the new `SendBuilder` class. After the change, we were making several calls down to both `GatheringByteChannel.write(ByteBuffer[])` as well as `WritableByteChannel.write(ByteBuffer)` whereas previously there would be just one path through the former. The difference is clearly seen in the flame graphs posted here: https://github.com/apache/kafka/pull/9401#issuecomment-729258346. 

This patch changes the grouping of `Send` objects created by `SendBuilder` to try and restore the previous write behavior. Rather than creating a single `ByteBufferSend` for each `ByteBuffer`, we attempt to group consecutive buffers into a single `ByteBufferSend`. I confirmed that did indeed address the latency issue I observed using the same test setup with a single broker that was discussed in #9401.

```
bin/kafka-topics.sh --create --topic foo --replication-factor 1 --partitions 10 --bootstrap-server $BROKER
bin/kafka-producer-perf-test.sh --topic foo --num-records 250000000 --throughput -1  --record-size 256 --producer-props bootstrap.servers=$BROKER
```

Here are the results:

```
Before KAFKA-9628:
250000000 records sent, 1398546.630342 records/sec (341.44 MB/sec), 39.71 ms avg latency, 424.00 ms max latency, 16 ms 50th, 137 ms 95th, 194 ms 99th, 270 ms 99.9th.

Trunk:
250000000 records sent, 1413619.374502 records/sec (345.12 MB/sec), 87.72 ms avg latency, 2058.00 ms max latency, 64 ms 50th, 247 ms 95th, 429 ms 99th, 790 ms 99.9th.                                             

This patch:
250000000 records sent, 1469723.691946 records/sec (358.82 MB/sec), 12.72 ms avg latency, 320.00 ms max latency, 2 ms 50th, 83 ms 95th, 162 ms 99th, 256 ms 99.9th.                                                
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
