### PR TITLE
KAFKA-9892: Producer state snapshot needs to be forced to disk

### DIFF
--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -436,8 +436,12 @@ object ProducerStateManager {
     ByteUtils.writeUnsignedInt(buffer, CrcOffset, crc)
 
     val fileChannel = FileChannel.open(file.toPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
-    try fileChannel.write(buffer)
-    finally fileChannel.force(true)
+    try {
+      fileChannel.write(buffer)
+      fileChannel.force(true)
+    } finally {
+      fileChannel.close()
+    }
   }
 
   private def isSnapshotFile(file: File): Boolean = file.getName.endsWith(Log.ProducerSnapshotFileSuffix)

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -437,7 +437,7 @@ object ProducerStateManager {
 
     val fileChannel = FileChannel.open(file.toPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
     try fileChannel.write(buffer)
-    finally fileChannel.close()
+    finally fileChannel.force(true)
   }
 
   private def isSnapshotFile(file: File): Boolean = file.getName.endsWith(Log.ProducerSnapshotFileSuffix)


### PR DESCRIPTION

FileChannel.close() does not guarantee modified buffer would be written on the file system. We are changing  it with force() semantics to enforce file buffer and metadata written to filesystem ( FileChannel.force(true) updates buffer and metadata).

*Summary of testing strategy (including rationale)
I have run unittests after making the changes.


