### PR TITLE
KAFKA-10706; Ensure leader epoch cache is cleaned after truncation to end offset

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2069,6 +2069,14 @@ class Log(@volatile private var _dir: File,
         throw new IllegalArgumentException(s"Cannot truncate partition $topicPartition to a negative offset (%d).".format(targetOffset))
       if (targetOffset >= logEndOffset) {
         info(s"Truncating to $targetOffset has no effect as the largest offset in the log is ${logEndOffset - 1}")
+        if (targetOffset == logEndOffset) {
+          // We may have a conflicting epoch entry at the end of the log. This could happen
+          // if this broker was a leader and inserted the first start offset entry, but then
+          // failed to append any entries before another leader was elected.
+          lock synchronized {
+            leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
+          }
+        }
         false
       } else {
         info(s"Truncating to offset $targetOffset")

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2069,14 +2069,15 @@ class Log(@volatile private var _dir: File,
         throw new IllegalArgumentException(s"Cannot truncate partition $topicPartition to a negative offset (%d).".format(targetOffset))
       if (targetOffset >= logEndOffset) {
         info(s"Truncating to $targetOffset has no effect as the largest offset in the log is ${logEndOffset - 1}")
-        if (targetOffset == logEndOffset) {
-          // We may have a conflicting epoch entry at the end of the log. This could happen
-          // if this broker was a leader and inserted the first start offset entry, but then
-          // failed to append any entries before another leader was elected.
-          lock synchronized {
-            leaderEpochCache.foreach(_.truncateFromEnd(targetOffset))
-          }
+
+        // Always truncate epoch cache since we may have a conflicting epoch entry at the
+        // end of the log from the leader. This could happen if this broker was a leader
+        // and inserted the first start offset entry, but then failed to append any entries
+        // before another leader was elected.
+        lock synchronized {
+          leaderEpochCache.foreach(_.truncateFromEnd(logEndOffset))
         }
+
         false
       } else {
         info(s"Truncating to offset $targetOffset")


### PR DESCRIPTION
This patch fixes a liveness bug which prevents follower truncation from completing after a leader election. If there are consecutive leader elections without writing any data entries, then the leader and follower may have conflicting epoch entries at the end of the log. The JIRA explains a specific scenario in more detail: https://issues.apache.org/jira/browse/KAFKA-10706.

The problem is the shortcut return in `Log.truncateTo` when the truncation offset is larger than or equal to the end offset, which prevents the conflicting entries from being resolved. Here we change this case to ensure `LeaderEpochFileCache.truncateFromEnd` is still called.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
