### PR TITLE
KAFKA-10756; Add missing unit test for `UnattachedState`

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/UnattachedStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/UnattachedStateTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UnattachedStateTest {
+
+    private final MockTime time = new MockTime();
+
+    @Test
+    public void testElectionTimeout() {
+        Set<Integer> voters = Utils.mkSet(1, 2, 3);
+        int epoch = 1;
+        int electionTimeoutMs = 10000;
+
+        UnattachedState state = new UnattachedState(
+                time,
+                epoch,
+                voters,
+                Optional.empty(),
+                electionTimeoutMs
+        );
+
+        assertEquals(epoch, state.epoch());
+
+        assertEquals(ElectionState.withUnknownLeader(epoch, voters), state.election());
+        assertEquals(electionTimeoutMs, state.remainingElectionTimeMs(time.milliseconds()));
+        assertFalse(state.hasElectionTimeoutExpired(time.milliseconds()));
+
+        time.sleep(electionTimeoutMs / 2);
+        assertEquals(electionTimeoutMs / 2, state.remainingElectionTimeMs(time.milliseconds()));
+        assertFalse(state.hasElectionTimeoutExpired(time.milliseconds()));
+
+        time.sleep(electionTimeoutMs / 2);
+        assertEquals(0, state.remainingElectionTimeMs(time.milliseconds()));
+        assertTrue(state.hasElectionTimeoutExpired(time.milliseconds()));
+    }
+}


### PR DESCRIPTION
Accidentally find that there is no unit test for UnattachedState, We should add missing unit tests, code is similar to ResignedStateTest and VotedStateTest.