### PR TITLE
KAFKA-10757; resolve compile problems brought by KAFKA-10755

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -756,7 +756,7 @@ public class StreamThreadTest {
             new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);
 
         final AtomicBoolean committed = new AtomicBoolean(false);
-        final TaskManager taskManager = new TaskManager(
+        final TaskManager taskManager = new TaskManager(null,
             null,
             null,
             null,


### PR DESCRIPTION
The #9634 calls new TaskManager with 9 params 
```
final TaskManager taskManager = new TaskManager(
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null,
            null
        )
```
but `new TaskManager` has 10 params, which brought compile problems
