### PR TITLE
MONOR; Wrong command line suggestion

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -20,8 +20,8 @@ package kafka
 import java.util.Properties
 
 import joptsimple.OptionParser
+import kafka.server.KafkaServerStartable
 import kafka.utils.Implicits._
-import kafka.server.{KafkaServer, KafkaServerStartable}
 import kafka.utils.{CommandLineUtils, Exit, Logging}
 import org.apache.kafka.common.utils.{Java, LoggingSignalHandler, OperatingSystem, Utils}
 
@@ -41,7 +41,8 @@ object Kafka extends Logging {
     optionParser.accepts("version", "Print version information and exit.")
 
     if (args.length == 0 || args.contains("--help")) {
-      CommandLineUtils.printUsageAndDie(optionParser, "USAGE: java [options] %s server.properties [--override property=value]*".format(classOf[KafkaServer].getSimpleName()))
+      CommandLineUtils.printUsageAndDie(optionParser,
+        "USAGE: java [options] %s server.properties [--override property=value]*".format(this.getClass.getCanonicalName.split('$').head))
     }
 
     if (args.contains("--version")) {


### PR DESCRIPTION
When I launch Kafka in IDE or command line, it will print `USAGE: java [options] KafkaServer server.properties [--override property=value]*`, but the real command is `java [options] kafka.Kafka server.properties`. 