### PR TITLE
MINOR; Remove duplicate updateLeaderEndOffsetAndTimestamp

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -352,7 +352,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         // from the new leader's epoch. Hence we write a control message immediately
         // to ensure there is no delay committing pending data.
         appendLeaderChangeMessage(state, currentTimeMs);
-        updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
+        // updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
 
         resetConnections();
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -352,7 +352,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         // from the new leader's epoch. Hence we write a control message immediately
         // to ensure there is no delay committing pending data.
         appendLeaderChangeMessage(state, currentTimeMs);
-        // updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
 
         resetConnections();
 


### PR DESCRIPTION
The `KafkaRaftClient.onBecomeLeader` will invoke `appendLeaderChangeMessage`, the call stack are:
```
1. appendLeaderChangeMessage
    1.1 flushLeaderLog
        1.1.1 updateLeaderEndOffsetAndTimestamp
        1.1.2 log.flush()
```
so the `updateLeaderEndOffsetAndTimestamp ` is already invoked, and `updateLeaderEndOffsetAndTimestamp` should only be invoked after leo change(or time change), since `log.flush()` will not change leo(and time),  it's unnessary to invoke twice.