### PR TITLE
KAFKA-10677; Complete fetches in purgatory immediately after resigning

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1807,15 +1807,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         return offset;
     }
 
-    // For testing only
-    public int numWaitingFetch() {
-        return fetchPurgatory.numWaiting();
-    }
-
-    public QuorumState quorumState() {
-        return quorum;
-    }
-
     @Override
     public CompletableFuture<Void> shutdown(int timeoutMs) {
         logger.info("Beginning graceful shutdown");

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -435,6 +435,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private void transitionToResigned(List<Integer> preferredSuccessors) {
+        fetchPurgatory.completeAllExceptionally(Errors.BROKER_NOT_AVAILABLE.exception("The broker is shutting down"));
         quorum.transitionToResigned(preferredSuccessors);
         resetConnections();
     }
@@ -1804,6 +1805,15 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             channel.wakeup();
         }
         return offset;
+    }
+
+    // For testing only
+    public int numWaitingFetch() {
+        return fetchPurgatory.numWaiting();
+    }
+
+    public QuorumState quorumState() {
+        return quorum;
     }
 
     @Override

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -234,11 +234,12 @@ public class KafkaRaftClientTest {
         context.client.poll();
         assertTrue(context.client.quorumState().isResigned());
         assertEquals(context.client.numWaitingFetch(), 0);
-        context.assertSentFetchResponse(Errors.NOT_LEADER_OR_FOLLOWER, epoch, OptionalInt.of(localId));
+        context.assertSentFetchResponse(Errors.BROKER_NOT_AVAILABLE, epoch, OptionalInt.of(localId));
 
         // shutting down finished
         context.time.sleep(1000);
         context.client.poll();
+        assertFalse(context.client.isRunning());
         assertFalse(context.client.isShuttingDown());
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -220,7 +220,7 @@ final class RaftClientTestContext {
                 channel,
                 time,
                 quorumStateStore,
-                    quorum,
+                quorum,
                 voters,
                 metrics,
                 listener

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -90,6 +90,7 @@ final class RaftClientTestContext {
     final int retryBackoffMs = Builder.RETRY_BACKOFF_MS;
 
     private final QuorumStateStore quorumStateStore;
+    private final QuorumState quorum;
     final int localId;
     final KafkaRaftClient<String> client;
     final Metrics metrics;
@@ -219,6 +220,7 @@ final class RaftClientTestContext {
                 channel,
                 time,
                 quorumStateStore,
+                    quorum,
                 voters,
                 metrics,
                 listener
@@ -233,6 +235,7 @@ final class RaftClientTestContext {
         MockNetworkChannel channel,
         MockTime time,
         QuorumStateStore quorumStateStore,
+        QuorumState quorum,
         Set<Integer> voters,
         Metrics metrics,
         MockListener listener
@@ -243,6 +246,7 @@ final class RaftClientTestContext {
         this.channel = channel;
         this.time = time;
         this.quorumStateStore = quorumStateStore;
+        this.quorum = quorum;
         this.voters = voters;
         this.metrics = metrics;
         this.listener = listener;
@@ -364,6 +368,11 @@ final class RaftClientTestContext {
 
     void assertUnknownLeader(int epoch) throws IOException {
         assertEquals(ElectionState.withUnknownLeader(epoch, voters), quorumStateStore.readElectionState());
+    }
+
+    void assertResignedLeader(int epoch, int leaderId) throws IOException {
+        assertTrue(quorum.isResigned());
+        assertEquals(ElectionState.withElectedLeader(epoch, leaderId, voters), quorumStateStore.readElectionState());
     }
 
     int assertSentDescribeQuorumResponse(int leaderId,


### PR DESCRIPTION
*More detailed description of your change*

If the condition of fetch is satisfied, `BROKER_NOT_AVAILABLE` or `NOT_LEADER_OR_FOLLOWER` is returned when the leader is shutting down. so we just return `BROKER_NOT_AVAILABLE` with a message.

*Summary of testing strategy*
A simple unit test to verify fetches in purgatory is completed after resigning.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
