### PR TITLE
MINOR: Remove redundant argument from TaskMetricsGroup#recordCommit

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -298,7 +298,7 @@ abstract class WorkerTask implements Runnable {
      * @param duration the length of time in milliseconds for the commit attempt to complete
      */
     protected void recordCommitSuccess(long duration) {
-        taskMetricsGroup.recordCommit(duration, true, null);
+        taskMetricsGroup.recordCommit(duration, null);
     }
 
     /**
@@ -308,7 +308,7 @@ abstract class WorkerTask implements Runnable {
      * @param error the unexpected error that occurred; may be null in the case of timeouts or interruptions
      */
     protected void recordCommitFailure(long duration, Throwable error) {
-        taskMetricsGroup.recordCommit(duration, false, error);
+        taskMetricsGroup.recordCommit(duration, error);
     }
 
     /**
@@ -385,8 +385,8 @@ abstract class WorkerTask implements Runnable {
             metricGroup.close();
         }
 
-        void recordCommit(long duration, boolean success, Throwable error) {
-            if (success) {
+        void recordCommit(long duration, Throwable error) {
+            if (error == null) {
                 commitTime.record(duration);
                 commitAttempts.record(1.0d);
             } else {


### PR DESCRIPTION
Replace the boolean value success with Throwable error.