### PR TITLE
KAFKA-10565: Only print console producer prompt with a tty

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -266,6 +266,7 @@ object ConsoleProducer {
     var keySeparator = "\t"
     var ignoreError = false
     var lineNumber = 0
+    var printPrompt = System.console != null
 
     override def init(inputStream: InputStream, props: Properties): Unit = {
       topic = props.getProperty("topic")
@@ -280,7 +281,8 @@ object ConsoleProducer {
 
     override def readMessage() = {
       lineNumber += 1
-      print(">")
+      if (printPrompt)
+        print(">")
       (reader.readLine(), parseKey) match {
         case (null, _) => null
         case (line, true) =>


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/KAFKA-10565 by using `System.console` to determine whether we're connected to a TTY before printing the `kafka-console-producer.sh` prompt. That's not a perfect solution (since stdin might be connected to the tty but not stdout, or vice versa), but it's still better that printing many prompts when reading from a pipe.