### PR TITLE
MINOR: Align the UID inside/outside container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-sudo: required
-dist: trusty
+arch: amd64
+os: linux
+dist: bionic
 language: java
+
+services:
+  - docker
+
+jdk:
+  - openjdk8
 
 env:
   - _DUCKTAPE_OPTIONS="--subset 0  --subsets 15"
@@ -31,19 +38,14 @@ env:
   - _DUCKTAPE_OPTIONS="--subset 13 --subsets 15"
   - _DUCKTAPE_OPTIONS="--subset 14 --subsets 15"
 
-jdk:
-  - oraclejdk8
-
 script:
   - ./gradlew rat
   - ./gradlew systemTestLibs && /bin/bash ./tests/docker/run_tests.sh
 
-services:
-  - docker
-
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - "$HOME/.m2/repository"

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -81,12 +81,23 @@ RUN curl -s "$KAFKA_MIRROR/kafka-streams-2.6.0-test.jar" -o /opt/kafka-2.6.0/lib
 # If you update this, also update vagrant/base.sh
 ARG KIBOSH_VERSION="8841dd392e6fbf02986e2fb1f1ebf04df344b65a"
 
+# Aligning uid inside/outside docker enables containers to modify files of kafka source (mounted in /opt/kafka-dev")
+# By default, the outside user id is 1000 (UID_MIN). The known exception in QA is travis which gives non-1000 id.
+ARG UID="1000"
+
 # Install Kibosh
 RUN apt-get install fuse
 RUN cd /opt && git clone -q  https://github.com/confluentinc/kibosh.git && cd "/opt/kibosh" && git reset --hard $KIBOSH_VERSION && mkdir "/opt/kibosh/build" && cd "/opt/kibosh/build" && ../configure && make -j 2
 
 # Set up the ducker user.
-RUN useradd -ms /bin/bash ducker && mkdir -p /home/ducker/ && rsync -aiq /root/.ssh/ /home/ducker/.ssh && chown -R ducker /home/ducker/ /mnt/ /var/log/ && echo "PATH=$(runuser -l ducker -c 'echo $PATH'):$JAVA_HOME/bin" >> /home/ducker/.ssh/environment && echo 'PATH=$PATH:'"$JAVA_HOME/bin" >> /home/ducker/.profile && echo 'ducker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN useradd -u $UID -ms /bin/bash ducker \
+  && mkdir -p /home/ducker/ \
+  && rsync -aiq /root/.ssh/ /home/ducker/.ssh \
+  && chown -R ducker /home/ducker/ /mnt/ /var/log/ \
+  && echo "PATH=$(runuser -l ducker -c 'echo $PATH'):$JAVA_HOME/bin" >> /home/ducker/.ssh/environment \
+  && echo 'PATH=$PATH:'"$JAVA_HOME/bin" >> /home/ducker/.profile \
+  && echo 'ducker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+
 USER ducker
 
 CMD sudo service ssh start && tail -f /dev/null

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -226,7 +226,10 @@ ducker_build() {
     # Tip: if you are scratching your head for some dependency problems that are referring to an old code version
     # (for example java.lang.NoClassDefFoundError), add --no-cache flag to the build shall give you a clean start.
     must_do -v -o docker build --memory="${docker_build_memory_limit}" \
-        --build-arg "ducker_creator=${user_name}" --build-arg "jdk_version=${jdk_version}" -t "${image_name}" \
+        --build-arg "ducker_creator=${user_name}" \
+        --build-arg "jdk_version=${jdk_version}" \
+        --build-arg "UID=${UID}" \
+        -t "${image_name}" \
         -f "${ducker_dir}/Dockerfile" ${docker_args} -- .
     docker_status=$?
     must_popd


### PR DESCRIPTION
The root cause of causing permission issue is that the uid outside container is not 1000 so container (has uid 1000) can't modify the file of ```/opt/kafka-dev```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
