### PR TITLE
MINOR: Remove unnecessary statement from WorkerConnector#doRun

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -143,7 +143,6 @@ public class WorkerConnector implements Runnable {
                 if (pendingTargetStateChange.get() != null || stopping) {
                     // An update occurred before we entered the synchronized block; no big deal,
                     // just start the loop again until we've handled everything
-                    continue;
                 } else {
                     try {
                         wait();


### PR DESCRIPTION
Continue is unnecessary as the last statement in a loop.
So I remove it from WorkerConnector.