### PR TITLE
Linking to config parameters

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -86,3 +86,4 @@
 
 <!--#include virtual="../includes/_footer.htm" -->
 <!--#include virtual="../includes/_docs_footer.htm" -->
+<script><!--#include virtual="js/kafkaConfigs.js" --></script>

--- a/docs/js/kafkaConfigs.js
+++ b/docs/js/kafkaConfigs.js
@@ -1,0 +1,28 @@
+$(document).ready(function() {
+    $.each([ "brokerconfig", "topicconfig", "producerconfig", "consumerconfig", 
+    "connectconfig", "streamsconfig", "adminclientconfig" ], function( index, value ) {
+        $("code." + value).each(function (index) {
+            const text = $(this).text();
+            //console.log(text)
+            const re = /(?<!#.*)([a-z0-9.]+)(=.*)?/g;
+            var replaced = text.replaceAll(re, function() {
+                var frag = `${value}s_${arguments[1]}`;
+                //console.log(`Frag ${frag}`);
+                if (document.getElementById(frag)) {
+                    //console.log(`Arguments: ${arguments.length}`);
+                    var rest = arguments[2] === undefined ? "" : arguments[2];
+                    return `<a href='#${frag}'>${arguments[1]}</a>${rest}`;
+                } else {
+                    return arguments[0];
+                }
+            });
+            //console.log(`Replaced ${replaced}`);
+            
+            $(this).html(replaced)
+            // var link = "<a href='#" + value + "s_" + text + "' />"
+            // console.log(link)
+            // $(this).wrap(link)
+        })
+    })
+})
+

--- a/docs/security.html
+++ b/docs/security.html
@@ -677,7 +677,7 @@ keyUsage               = digitalSignature, keyEncipherment</code></pre>
             <li>Configure the JAAS configuration property for each client in producer.properties or consumer.properties.
                 The login module describes how the clients like producer and consumer can connect to the Kafka Broker.
                 The following is an example configuration for a client for the PLAIN mechanism:
-                <pre class="line-numbers"><code class="language-text">    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+                <pre class="line-numbers"><code class="producerconfig">    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
         username="alice" \
         password="alice-secret";</code></pre>
                 <p>The options <tt>username</tt> and <tt>password</tt> are used by clients to configure

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -34,8 +34,8 @@
         overridden the message format version, you should keep its current value. Alternatively, if you are upgrading from a version prior
         to 0.11.0.x, then CURRENT_MESSAGE_FORMAT_VERSION should be set to match CURRENT_KAFKA_VERSION.
         <ul>
-            <li>inter.broker.protocol.version=CURRENT_KAFKA_VERSION (e.g., <code>2.6</code>, <code>2.5</code>, etc.)</li>
-            <li>log.message.format.version=CURRENT_MESSAGE_FORMAT_VERSION  (See <a href="#upgrade_10_performance_impact">potential performance impact
+            <li><code class="brokerconfig">inter.broker.protocol.version=CURRENT_KAFKA_VERSION</code> (e.g., <code>2.6</code>, <code>2.5</code>, etc.)</li>
+            <li><code class="brokerconfig">log.message.format.version=CURRENT_MESSAGE_FORMAT_VERSION</code>  (See <a href="#upgrade_10_performance_impact">potential performance impact
                 following the upgrade</a> for the details on what this configuration does.)</li>
         </ul>
         If you are upgrading from version 0.11.0.x or above, and you have not overridden the message format, then you only need to override


### PR DESCRIPTION
This demos an idea I had for improving the website docs. 

The docs often mention config parameters. With recent changes it's now possible to deep link directly to the the doc for a given config parameter. It would be useful for readers if we made use of this in our own docs, so when talking about `listeners` in prose we link to the doc for it. 

This PR achieves that in a relatively easy-to-author way using a CSS class on the `<code>` used to wrap some config parameters and some JS which takes the class and the included text and turns it into one or more links. For example `<code class="brokerconfig">listeners</code>` gets turned into a link to the doc for [`listeners`](https://kafka.apache.org/27/documentation.html#brokerconfigs_listeners), with similar classes for topic, producer consumer etc. configs.

Here a're some screenshots of what the markup changes in the patch result in, first from the upgrade section:

![Screenshot from 2020-11-27 12-05-57](https://user-images.githubusercontent.com/879487/100448489-467b6e80-30aa-11eb-8794-5db0a7e4bd9f.png)

The script knows to ignore whatever is after the `=` sign. Here's another example from the security section (please excuse the magenta find-in-page highlighting):

![Screenshot from 2020-11-27 12-06-58](https://user-images.githubusercontent.com/879487/100448544-5c892f00-30aa-11eb-99c2-17a07734bd97.png)

Because the script checks for the existence of the link before generating the link it doesn't linkify the `username` or `password` (the regex isn't powerful enough to properly understand that lines ending with `\` are continuation lines). This is a bit of a hack, but it works well enough.

There's two potential issues I can see with this:

1. Lots of client configs are shared between both producer and consumer (and admin client...), so which should we link to? Probably a link is better than no link, but equally we could chose not to link such configs.
2. This is not really compatible with https://issues.apache.org/jira/browse/KAFKA-2967 though it might be possible to do something similar in ReStructuredText with custom roles.
