### PR TITLE
KAFKA-10776: update the doc to add version attribute in RequstsPerSec metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -737,7 +737,7 @@
       </tr>
       <tr>
         <td>Request rate</td>
-        <td>kafka.network:type=RequestMetrics,name=RequestsPerSec,request={Produce|FetchConsumer|FetchFollower}</td>
+        <td>kafka.network:type=RequestMetrics,name=RequestsPerSec,request={Produce|FetchConsumer|FetchFollower},version=([0-9]+)</td>
         <td></td>
       </tr>
       <tr>


### PR DESCRIPTION
This is actually a documentation miss, the version attribute is required to match the Kafka version. Thanks.

See https://cwiki.apache.org/confluence/display/KAFKA/KIP-272%3A+Add+API+version+tag+to+broker%27s+RequestsPerSec+metric


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
