### PR TITLE
KAFKA-10130; Rewrite FeatureZNode struct with auto-generated protocol

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -830,7 +830,7 @@ project(':core') {
     args = [ "-p", "kafka.internals.generated",
              "-o", "src/generated/java/kafka/internals/generated",
              "-i", "src/main/resources/common/message",
-             "-m", "MessageDataGenerator"
+             "-m", "MessageDataGenerator", "JsonConverterGenerator"
     ]
     inputs.dir("src/main/resources/common/message")
     outputs.dir("src/generated/java/kafka/internals/generated")

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -21,7 +21,7 @@
               files="MessageGenerator.java"/>
 
     <!-- core -->
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport|ImportControl)"
               files="core[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <!-- Clients -->

--- a/core/src/main/resources/common/message/FeatureZNode.json
+++ b/core/src/main/resources/common/message/FeatureZNode.json
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "FeatureZNodeData",
+  "validVersions": "1",
+  "fields": [
+    { "name": "status", "type": "int32", "default": 0, "versions": "1+" },
+    { "name": "features", "type": "[]Feature", "versions": "1+", "fields": [
+      { "name": "featureName", "type": "string", "versions": "1+",
+        "about": "The feature name" },
+      {
+        "name": "versionRange", "type": "FinalizedVersionRange", "versions": "1+",
+        "fields": [
+          {"name": "minValue", "type": "int16", "versions": "1+" },
+          {"name": "maxValue", "type": "int16", "versions": "1+" }
+        ]
+      }
+    ]}
+  ]
+}

--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeUnit}
 
+import kafka.internals.generated.FeatureZNodeData
 import kafka.utils.{Logging, ShutdownableThread}
 import kafka.zk.{FeatureZNode, FeatureZNodeStatus, KafkaZkClient, ZkVersion}
 import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler}
@@ -89,7 +90,7 @@ class FinalizedFeatureChangeListener(private val finalizedFeatureCache: Finalize
         info(s"Feature ZK node at path: $featureZkNodePath does not exist")
         finalizedFeatureCache.clear()
       } else {
-        var maybeFeatureZNode: Option[FeatureZNode] = Option.empty
+        var maybeFeatureZNode: Option[FeatureZNodeData] = Option.empty
         try {
           maybeFeatureZNode = Some(FeatureZNode.decode(mayBeFeatureZNodeBytes.get))
         } catch {
@@ -98,16 +99,16 @@ class FinalizedFeatureChangeListener(private val finalizedFeatureCache: Finalize
             finalizedFeatureCache.clear()
           }
         }
-        maybeFeatureZNode.foreach(featureZNode => {
-          featureZNode.status match {
-            case FeatureZNodeStatus.Disabled => {
+        maybeFeatureZNode.foreach(featureZNodeData => {
+          featureZNodeData.status match {
+            case FeatureZNodeStatus.Disabled.id => {
               info(s"Feature ZK node at path: $featureZkNodePath is in disabled status.")
               finalizedFeatureCache.clear()
             }
-            case FeatureZNodeStatus.Enabled => {
-              finalizedFeatureCache.updateOrThrow(featureZNode.features, version)
+            case FeatureZNodeStatus.Enabled.id => {
+              finalizedFeatureCache.updateOrThrow(FeatureZNode.getFeatures(featureZNodeData), version)
             }
-            case _ => throw new IllegalStateException(s"Unexpected FeatureZNodeStatus found in $featureZNode")
+            case _ => throw new IllegalStateException(s"Unexpected FeatureZNodeStatus found in $featureZNodeData")
           }
         })
       }

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -22,6 +22,7 @@ import com.yammer.metrics.core.MetricName
 import kafka.api.LeaderAndIsr
 import kafka.cluster.Broker
 import kafka.controller.{KafkaController, LeaderIsrAndControllerEpoch, ReplicaAssignment}
+import kafka.internals.generated.FeatureZNodeData
 import kafka.log.LogConfig
 import kafka.metrics.KafkaMetricsGroup
 import kafka.security.authorizer.AclAuthorizer.{NoAcls, VersionedAcls}
@@ -1629,7 +1630,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     createRecursive(path, data = null, throwIfPathExists = false)
   }
 
-  def createFeatureZNode(nodeContents: FeatureZNode): Unit = {
+  def createFeatureZNode(nodeContents: FeatureZNodeData): Unit = {
     val createRequest = CreateRequest(
       FeatureZNode.path,
       FeatureZNode.encode(nodeContents),
@@ -1639,7 +1640,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     response.maybeThrow()
   }
 
-  def updateFeatureZNode(nodeContents: FeatureZNode): Int = {
+  def updateFeatureZNode(nodeContents: FeatureZNodeData): Int = {
     val setRequest = SetDataRequest(
       FeatureZNode.path,
       FeatureZNode.encode(nodeContents),

--- a/core/src/test/scala/unit/kafka/server/FinalizedFeatureChangeListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FinalizedFeatureChangeListenerTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import java.util.concurrent.{CountDownLatch, TimeoutException}
 
+import kafka.internals.generated.FeatureZNodeData
 import kafka.zk.{FeatureZNode, FeatureZNodeStatus, ZkVersion, ZooKeeperTestHarness}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.utils.Exit
@@ -44,7 +45,16 @@ class FinalizedFeatureChangeListenerTest extends ZooKeeperTestHarness {
     val finalizedFeaturesMap = Map[String, FinalizedVersionRange](
       "feature_1" -> new FinalizedVersionRange(2, 3))
     val finalizedFeatures = Features.finalizedFeatures(finalizedFeaturesMap.asJava)
-    zkClient.createFeatureZNode(FeatureZNode(FeatureZNodeStatus.Enabled, finalizedFeatures))
+    val newNodeData = new FeatureZNodeData()
+      .setStatus(FeatureZNodeStatus.Enabled.id)
+      .setFeatures(finalizedFeatures.features().asScala.map{case (featureName, versionRange) =>
+        new FeatureZNodeData.Feature()
+          .setFeatureName(featureName)
+          .setVersionRange(new FeatureZNodeData.FinalizedVersionRange()
+            .setMinValue(versionRange.min())
+            .setMaxValue(versionRange.max()))
+      }.toSeq.asJava)
+    zkClient.createFeatureZNode(newNodeData)
     val (mayBeFeatureZNodeBytes, version) = zkClient.getDataAndVersion(FeatureZNode.path)
     assertNotEquals(version, ZkVersion.UnknownVersion)
     assertFalse(mayBeFeatureZNodeBytes.isEmpty)
@@ -87,7 +97,16 @@ class FinalizedFeatureChangeListenerTest extends ZooKeeperTestHarness {
     val listener = createListener(cache, Some(initialFinalizedFeatures))
 
     def updateAndCheckCache(finalizedFeatures: Features[FinalizedVersionRange]): Unit = {
-      zkClient.updateFeatureZNode(FeatureZNode(FeatureZNodeStatus.Enabled, finalizedFeatures))
+      val newNodeData = new FeatureZNodeData()
+        .setStatus(FeatureZNodeStatus.Enabled.id)
+        .setFeatures(finalizedFeatures.features().asScala.map{case (featureName, versionRange) =>
+          new FeatureZNodeData.Feature()
+            .setFeatureName(featureName)
+            .setVersionRange(new FeatureZNodeData.FinalizedVersionRange()
+              .setMinValue(versionRange.min())
+              .setMaxValue(versionRange.max()))
+        }.toSeq.asJava)
+      zkClient.updateFeatureZNode(newNodeData)
       val (mayBeFeatureZNodeNewBytes, updatedVersion) = zkClient.getDataAndVersion(FeatureZNode.path)
       assertNotEquals(updatedVersion, ZkVersion.UnknownVersion)
       assertFalse(mayBeFeatureZNodeNewBytes.isEmpty)
@@ -147,7 +166,16 @@ class FinalizedFeatureChangeListenerTest extends ZooKeeperTestHarness {
 
     val updatedFinalizedFeaturesMap = Map[String, FinalizedVersionRange]()
     val updatedFinalizedFeatures = Features.finalizedFeatures(updatedFinalizedFeaturesMap.asJava)
-    zkClient.updateFeatureZNode(FeatureZNode(FeatureZNodeStatus.Disabled, updatedFinalizedFeatures))
+    val newNodeData = new FeatureZNodeData()
+      .setStatus(FeatureZNodeStatus.Enabled.id)
+      .setFeatures(updatedFinalizedFeatures.features().asScala.map{case (featureName, versionRange) =>
+        new FeatureZNodeData.Feature()
+          .setFeatureName(featureName)
+          .setVersionRange(new FeatureZNodeData.FinalizedVersionRange()
+            .setMinValue(versionRange.min())
+            .setMaxValue(versionRange.max()))
+      }.toSeq.asJava)
+    zkClient.updateFeatureZNode(newNodeData)
     val (mayBeFeatureZNodeNewBytes, updatedVersion) = zkClient.getDataAndVersion(FeatureZNode.path)
     assertNotEquals(updatedVersion, ZkVersion.UnknownVersion)
     assertFalse(mayBeFeatureZNodeNewBytes.isEmpty)
@@ -172,7 +200,16 @@ class FinalizedFeatureChangeListenerTest extends ZooKeeperTestHarness {
 
     val updatedFinalizedFeaturesMap = Map[String, FinalizedVersionRange]()
     val updatedFinalizedFeatures = Features.finalizedFeatures(updatedFinalizedFeaturesMap.asJava)
-    zkClient.updateFeatureZNode(FeatureZNode(FeatureZNodeStatus.Disabled, updatedFinalizedFeatures))
+    val newNodeData = new FeatureZNodeData()
+      .setStatus(FeatureZNodeStatus.Disabled.id)
+      .setFeatures(updatedFinalizedFeatures.features().asScala.map{case (featureName, versionRange) =>
+        new FeatureZNodeData.Feature()
+          .setFeatureName(featureName)
+          .setVersionRange(new FeatureZNodeData.FinalizedVersionRange()
+            .setMinValue(versionRange.min())
+            .setMaxValue(versionRange.max()))
+      }.toSeq.asJava)
+    zkClient.updateFeatureZNode(newNodeData)
     val (mayBeFeatureZNodeNewBytes, updatedVersion) = zkClient.getDataAndVersion(FeatureZNode.path)
     assertNotEquals(updatedVersion, ZkVersion.UnknownVersion)
     assertFalse(mayBeFeatureZNodeNewBytes.isEmpty)
@@ -197,7 +234,16 @@ class FinalizedFeatureChangeListenerTest extends ZooKeeperTestHarness {
     val incompatibleFinalizedFeaturesMap = Map[String, FinalizedVersionRange](
       "feature_1" -> new FinalizedVersionRange(2, 5))
     val incompatibleFinalizedFeatures = Features.finalizedFeatures(incompatibleFinalizedFeaturesMap.asJava)
-    zkClient.createFeatureZNode(FeatureZNode(FeatureZNodeStatus.Enabled, incompatibleFinalizedFeatures))
+    val newNodeData = new FeatureZNodeData()
+      .setStatus(FeatureZNodeStatus.Enabled.id)
+      .setFeatures(incompatibleFinalizedFeatures.features().asScala.map{case (featureName, versionRange) =>
+        new FeatureZNodeData.Feature()
+          .setFeatureName(featureName)
+          .setVersionRange(new FeatureZNodeData.FinalizedVersionRange()
+            .setMinValue(versionRange.min())
+            .setMaxValue(versionRange.max()))
+      }.toSeq.asJava)
+    zkClient.createFeatureZNode(newNodeData)
     val (mayBeFeatureZNodeBytes, initialVersion) = zkClient.getDataAndVersion(FeatureZNode.path)
     assertNotEquals(initialVersion, ZkVersion.UnknownVersion)
     assertFalse(mayBeFeatureZNodeBytes.isEmpty)
@@ -248,7 +294,16 @@ class FinalizedFeatureChangeListenerTest extends ZooKeeperTestHarness {
         brokerFeatures.supportedFeatures.get("feature_1").min(),
         (brokerFeatures.supportedFeatures.get("feature_1").max() + 1).asInstanceOf[Short]))
     val incompatibleFinalizedFeatures = Features.finalizedFeatures(incompatibleFinalizedFeaturesMap.asJava)
-    zkClient.updateFeatureZNode(FeatureZNode(FeatureZNodeStatus.Enabled, incompatibleFinalizedFeatures))
+    val newNodeData = new FeatureZNodeData()
+      .setStatus(FeatureZNodeStatus.Enabled.id)
+      .setFeatures(incompatibleFinalizedFeatures.features().asScala.map{case (featureName, versionRange) =>
+        new FeatureZNodeData.Feature()
+          .setFeatureName(featureName)
+          .setVersionRange(new FeatureZNodeData.FinalizedVersionRange()
+            .setMinValue(versionRange.min())
+            .setMaxValue(versionRange.max()))
+      }.toSeq.asJava)
+    zkClient.updateFeatureZNode(newNodeData)
     val (mayBeFeatureZNodeIncompatibleBytes, updatedVersion) = zkClient.getDataAndVersion(FeatureZNode.path)
     assertNotEquals(updatedVersion, ZkVersion.UnknownVersion)
     assertFalse(mayBeFeatureZNodeIncompatibleBytes.isEmpty)


### PR DESCRIPTION
*More detailed description of your change*

1. remove FeatureZNode and replace it with FeatureZNode.json
2. Change code where FeatureZNode is used
3. copy some code of `org.apache.kafka.raft.FileBasedStateStore` to generate json data from and to FeatureZNodeData
4. I will also replace the rest ZNode with auto-generated protocol if this was approved.


*Summary of testing strategy (including rationale)*
Replace FeatureZNode  in unit test and integration test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
