### PR TITLE
KAFKA-10780; Rewrite ControllerZNode struct with auto-generated protocol

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -830,7 +830,7 @@ project(':core') {
     args = [ "-p", "kafka.internals.generated",
              "-o", "src/generated/java/kafka/internals/generated",
              "-i", "src/main/resources/common/message",
-             "-m", "MessageDataGenerator"
+             "-m", "MessageDataGenerator", "JsonConverterGenerator"
     ]
     inputs.dir("src/main/resources/common/message")
     outputs.dir("src/generated/java/kafka/internals/generated")

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -21,7 +21,7 @@
               files="MessageGenerator.java"/>
 
     <!-- core -->
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport|ImportControl)"
               files="core[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <!-- Clients -->

--- a/core/src/main/resources/common/message/ControllerZNode.json
+++ b/core/src/main/resources/common/message/ControllerZNode.json
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "ControllerZNodeData",
+  "validVersions": "1",
+  "fields": [
+    { "name": "brokerid", "type": "int32", "versions": "1+" },
+    { "name": "timestamp", "type": "string", "versions": "1+" }
+  ]
+}

--- a/core/src/test/scala/kafka/zk/ControllerZNodeTest.scala
+++ b/core/src/test/scala/kafka/zk/ControllerZNodeTest.scala
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk
+
+import java.nio.charset.StandardCharsets
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ControllerZNodeTest {
+
+  @Test
+  def testEncodeDecode(): Unit = {
+    val brokerId = 1
+    val timestamp = 1500000000000L
+    assertEquals(brokerId, ControllerZNode.decode(ControllerZNode.encode(brokerId, timestamp)).get)
+  }
+
+  @Test
+  def testDecodeFailed(): Unit = {
+    assertEquals("malformed json", None,
+      ControllerZNode.decode("""{"brokerid":1, "timestamp":"1",}""".getBytes(StandardCharsets.UTF_8)))
+    assertEquals("no version", None,
+      ControllerZNode.decode("""{"brokerid":1, "timestamp":"1"}""".getBytes(StandardCharsets.UTF_8)))
+  }
+}


### PR DESCRIPTION
*More detailed description of your change*
1. The #9662 rewrite FeatureZNode struct with auto-generated protocol, but it's a non-trivial change, so we can just review this simple pr first.
2. Copy some code of `org.apache.kafka.raft.FileBasedStateStore` to generate json data from and to FeatureZNodeData

*Summary of testing strategy (including rationale)*
unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
