### PR TITLE
MINOR: fix reading SSH output in Streams system tests

### DIFF
--- a/tests/kafkatest/tests/streams/base_streams_test.py
+++ b/tests/kafkatest/tests/streams/base_streams_test.py
@@ -100,6 +100,6 @@ class BaseStreamsTest(KafkaTest):
         try:
           return int(result)
         except ValueError:
-          self.logger.warn("Command failed with ValueError: " + result)
+          self.logger.warn("Command failed with ValueError: " + str(result, errors='strict'))
           return 0
 


### PR DESCRIPTION
SSH outputs in system tests originating from paramiko are bytes. However, the logger in the system tests does not accept bytes and instead throws an exception. That means, the bytes returned as SSH output from paramiko need to converted to a type that the logger (or other objects) can process.    

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
