### PR TITLE
MINOR: Do not print log4j for memberId required

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -465,7 +465,11 @@ public abstract class AbstractCoordinator implements Closeable {
                 }
             } else {
                 final RuntimeException exception = future.exception();
-                log.info("Rebalance failed.", exception);
+
+                if (!(exception instanceof MemberIdRequiredException)) {
+                    log.info("Rebalance failed.", exception);
+                }
+
                 resetJoinGroupFuture();
                 if (exception instanceof UnknownMemberIdException ||
                     exception instanceof RebalanceInProgressException ||

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -466,6 +466,8 @@ public abstract class AbstractCoordinator implements Closeable {
             } else {
                 final RuntimeException exception = future.exception();
 
+                // we do not need to log error for memberId required,
+                // since it is not really an error and is transient
                 if (!(exception instanceof MemberIdRequiredException)) {
                     log.info("Rebalance failed.", exception);
                 }


### PR DESCRIPTION
For MemberIdRequiredException, we would not print the exception at INFO with a full exception message since it may introduce more confusion that clearance.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
