### PR TITLE
MINOR: Clarify config names for EOS versions 1 and 2

### DIFF
--- a/docs/streams/core-concepts.html
+++ b/docs/streams/core-concepts.html
@@ -300,7 +300,7 @@
 
         To enable exactly-once semantics when running Kafka Streams applications,
         set the <code>processing.guarantee</code> config value (default value is <b>at_least_once</b>)
-        to <b>exactly_once</b> (requires brokers version 0.11.0 or newer) or <b>exactly_once_beta</b> (requires brokers version 2.5 or newer).
+        to <b>exactly_once</b> for EOS version 1 (requires brokers version 0.11.0 or newer) or <b>exactly_once_beta</b> for EOS version 2 (requires brokers version 2.5 or newer).
         For more information, see the <a href="/{{version}}/documentation/streams/developer-guide/config-streams.html">Kafka Streams Configs</a> section.
     </p>
 

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -294,7 +294,7 @@
           <tr class="row-even"><td>processing.guarantee</td>
             <td>Medium</td>
             <td colspan="2">The processing mode. Can be either <code class="docutils literal"><span class="pre">"at_least_once"</span></code> (default),
-              <code class="docutils literal"><span class="pre">"exactly_once"</span></code> (for EOS version 1), or <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code> (for EOS version 2),</td>.
+              <code class="docutils literal"><span class="pre">"exactly_once"</span></code> (for EOS version 1), or <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code> (for EOS version 2)</td>.
             <td>See <a class="reference internal" href="#streams-developer-guide-processing-guarantedd"><span class="std std-ref">Processing Guarantee</span></a></td>
           </tr>
           <tr class="row-odd"><td>poll.ms</td>

--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -294,7 +294,7 @@
           <tr class="row-even"><td>processing.guarantee</td>
             <td>Medium</td>
             <td colspan="2">The processing mode. Can be either <code class="docutils literal"><span class="pre">"at_least_once"</span></code> (default),
-              <code class="docutils literal"><span class="pre">"exactly_once"</span></code>, or <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code></td>.
+              <code class="docutils literal"><span class="pre">"exactly_once"</span></code> (for EOS version 1), or <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code> (for EOS version 2),</td>.
             <td>See <a class="reference internal" href="#streams-developer-guide-processing-guarantedd"><span class="std std-ref">Processing Guarantee</span></a></td>
           </tr>
           <tr class="row-odd"><td>poll.ms</td>
@@ -662,8 +662,8 @@
           <blockquote>
             <div>The processing guarantee that should be used.
               Possible values are <code class="docutils literal"><span class="pre">"at_least_once"</span></code> (default),
-              <code class="docutils literal"><span class="pre">"exactly_once"</span></code>,
-              and <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code>.
+              <code class="docutils literal"><span class="pre">"exactly_once"</span></code> (for EOS version 1),
+              and <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code> (for EOS version 2).
               Using <code class="docutils literal"><span class="pre">"exactly_once"</span></code> requires broker
               version 0.11.0 or newer, while using <code class="docutils literal"><span class="pre">"exactly_once_beta"</span></code>
               requires broker version 2.5 or newer.

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -55,7 +55,7 @@
     <p>
         Starting in Kafka Streams 2.6.x, a new processing mode is available, named EOS version 2, which is configurable by setting 
         <code>processing.guarantee</code> to <code>"exactly_once_beta"</code>.
-        Note: The <code>"exactly_once_beta"</code> processing mode is ready for production (<i>i.e.</i>, it's not "beta" software). 
+        <b>NOTE:</b> The <code>"exactly_once_beta"</code> processing mode is ready for production (<i>i.e.</i>, it's not "beta" software). 
         To use this new feature, your brokers must be on version 2.5.x or newer.
         A switch from <code>"exactly_once"</code> to <code>"exactly_once_beta"</code> (or the other way around) is
         only possible if the application is on version 2.6.x.

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -53,8 +53,8 @@
     </ul>
 
     <p>
-        Starting in Kafka Streams 2.6.x, a new processing mode, EOS version 2, which is configurable by setting 
-        <code>processing.guarantee</code> to <code>"exactly_once_beta"</code>, is available.
+        Starting in Kafka Streams 2.6.x, a new processing mode is available, named EOS version 2, which is configurable by setting 
+        <code>processing.guarantee</code> to <code>"exactly_once_beta"</code>.
         Note: The <code>"exactly_once_beta"</code> processing mode is ready for production (<i>i.e.</i>, it's not "beta" software). 
         To use this new feature, your brokers must be on version 2.5.x or newer.
         A switch from <code>"exactly_once"</code> to <code>"exactly_once_beta"</code> (or the other way around) is

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -53,8 +53,9 @@
     </ul>
 
     <p>
-        Starting in Kafka Streams 2.6.x, a new processing mode <code>"exactly_once_beta"</code> (configurable via parameter
-        <code>processing.guarantee</code>) is available.
+        Starting in Kafka Streams 2.6.x, a new processing mode, EOS version 2, which is configurable by setting 
+        <code>processing.guarantee</code> to <code>"exactly_once_beta"</code>, is available.
+        Note: The <code>"exactly_once_beta"</code> processing mode is ready for production (<i>i.e.</i>, it's not "beta" software). 
         To use this new feature, your brokers must be on version 2.5.x or newer.
         A switch from <code>"exactly_once"</code> to <code>"exactly_once_beta"</code> (or the other way around) is
         only possible if the application is on version 2.6.x.
@@ -120,7 +121,7 @@
 
     <h3><a id="streams_api_changes_260" href="#streams_api_changes_260">Streams API changes in 2.6.0</a></h3>
     <p>
-        We added a new processing mode that improves application scalability using exactly-once guarantees
+        We added a new processing mode, EOS version 2, that improves application scalability using exactly-once guarantees
         (via <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics">KIP-447</a>).
         You can enable this new feature by setting the configuration parameter <code>processing.guarantee</code> to the
         new value <code>"exactly_once_beta"</code>.
@@ -847,9 +848,9 @@
 
     <p> Metrics using exactly-once semantics: </p>
     <p>
-        If <code>"exactly_once"</code> processing is enabled via the <code>processing.guarantee</code> parameter,
+        If <code>"exactly_once"</code> processing (EOS version 1) is enabled via the <code>processing.guarantee</code> parameter,
         internally Streams switches from a producer-per-thread to a producer-per-task runtime model.
-        Using <code>"exactly_once_beta"</code> does use a producer-per-thread, so <code>client.id</code> doesn't change,
+        Using <code>"exactly_once_beta"</code> (EOS version 2) does use a producer-per-thread, so <code>client.id</code> doesn't change,
         compared with <code>"at_least_once"</code> for this case).
         In order to distinguish the different producers, the producer's <code>client.id</code> additionally encodes the task-ID for this case.
         Because the producer's <code>client.id</code> is used to report JMX metrics, it might be required to update tools that receive those metrics.


### PR DESCRIPTION
Clarify that EOS "Alpha" is version 1 and EOS "Beta" is version 2. These names don't denote the readiness of the feature; both are good for production.