### PR TITLE
KAFKA-10793: move handling of FindCoordinatorFuture to fix race condition

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -860,7 +860,7 @@ public abstract class AbstractCoordinator implements Closeable {
 
         @Override
         public void onFailure(RuntimeException e, RequestFuture<Void> future) {
-            log.debug("FindCoordinator request failed due to {}", e.getMessage());
+            log.debug("FindCoordinator request failed due to {}", e);
 
             if (!(e instanceof RetriableException)) {
                 // Remember the exception if fatal so we can ensure it gets thrown by the main thread

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1369,10 +1369,8 @@ public abstract class AbstractCoordinator implements Closeable {
 
                         if (coordinatorUnknown()) {
                             if (findCoordinatorFuture != null) {
-                                // if it has failed, clear it so that hb thread can try discover again in the next loop in case main thread is busy
-                                if (findCoordinatorFuture.failed()) {
-                                    clearFindCoordinatorFuture();
-                                }
+                                // clear it so that hb thread can try discover again in the next loop in case main thread cannot
+                                clearFindCoordinatorFuture();
 
                                 // backoff properly
                                 AbstractCoordinator.this.wait(rebalanceConfig.retryBackoffMs);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1368,16 +1368,16 @@ public abstract class AbstractCoordinator implements Closeable {
                         long now = time.milliseconds();
 
                         if (coordinatorUnknown()) {
-                            if (findCoordinatorFuture != null || lookupCoordinator().failed()) {
-                                if (findCoordinatorFuture != null && findCoordinatorFuture.failed()) {
-                                    // if the future did complete and has failed, clear it so that the hb thread
-                                    // can send a new FindCoordinator request in case the main thread is busy
+                            if (findCoordinatorFuture != null) {
+                                // if it has failed, clear it so that hb thread can try discover again in the next loop in case main thread is busy
+                                if (findCoordinatorFuture.failed()) {
                                     clearFindCoordinatorFuture();
                                 }
 
-                                // the immediate future check ensures that we backoff properly in the case that no
-                                // brokers are available to connect to.
+                                // backoff properly
                                 AbstractCoordinator.this.wait(rebalanceConfig.retryBackoffMs);
+                            } else {
+                                lookupCoordinator();
                             }
                         } else if (heartbeat.sessionTimeoutExpired(now)) {
                             // the session timeout has expired without seeing a successful heartbeat, so we should

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1368,13 +1368,17 @@ public abstract class AbstractCoordinator implements Closeable {
                         long now = time.milliseconds();
 
                         if (coordinatorUnknown()) {
-                            if (findCoordinatorFuture != null || lookupCoordinator().failed())
+                            if (findCoordinatorFuture != null || lookupCoordinator().failed()) {
                                 if (findCoordinatorFuture != null && findCoordinatorFuture.failed()) {
+                                    // if the future did complete and has failed, clear it so that the hb thread
+                                    // can send a new FindCoordinator request in case the main thread is busy
                                     clearFindCoordinatorFuture();
                                 }
+
                                 // the immediate future check ensures that we backoff properly in the case that no
                                 // brokers are available to connect to.
                                 AbstractCoordinator.this.wait(rebalanceConfig.retryBackoffMs);
+                            }
                         } else if (heartbeat.sessionTimeoutExpired(now)) {
                             // the session timeout has expired without seeing a successful heartbeat, so we should
                             // probably make sure the coordinator is still healthy.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1369,7 +1369,8 @@ public abstract class AbstractCoordinator implements Closeable {
 
                         if (coordinatorUnknown()) {
                             if (findCoordinatorFuture != null) {
-                                // clear it so that hb thread can try discover again in the next loop in case main thread cannot
+                                // clear the future so that after the backoff, if the hb still sees coordinator unknown in
+                                // the next iteration it will try to re-discover the coordinator in case the main thread cannot
                                 clearFindCoordinatorFuture();
 
                                 // backoff properly


### PR DESCRIPTION
A race condition between the consumer and hb thread can lead to a failed but non-null `findCoordinatorFuture`, causing the AbstractCoordinator to wait endlessly on the request which it thinks is still in flight. We should move the handling of this future out of the listener callbacks and into the `ensureCoordinatorReady()` method where we can check the exception and clear the future all in one place.  

See ticket for full analysis.

Also starts logging a warning if the consumer is unable to connect to the coordinator for longer than the max poll interval.
