### PR TITLE
KAFKA-10803: Fix improper removal of bad dynamic config

### DIFF
--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -467,9 +467,7 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
             case _: Exception => true
           }
         }
-        invalidProps.foreach {
-          case (k,v) => props.remove(k)
-        }
+        invalidProps.keys.foreach(props.remove)
         val configSource = if (perBrokerConfig) "broker" else "default cluster"
         error(s"Dynamic $configSource config contains invalid values: $invalidProps, these configs will be ignored", e)
     }

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -467,7 +467,9 @@ class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging 
             case _: Exception => true
           }
         }
-        invalidProps.foreach(props.remove)
+        invalidProps.foreach {
+          case (k,v) => props.remove(k)
+        }
         val configSource = if (perBrokerConfig) "broker" else "default cluster"
         error(s"Dynamic $configSource config contains invalid values: $invalidProps, these configs will be ignored", e)
     }

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -400,6 +400,33 @@ class DynamicBrokerConfigTest {
     newprops.put(KafkaConfig.BackgroundThreadsProp, "100")
     dynamicBrokerConfig.updateBrokerConfig(0, newprops)
   }
+
+  @Test
+  def testImproperConfigsAreRemoved(): Unit = {
+    val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect)
+    val configs = KafkaConfig(props)
+
+    assertEquals(Int.MaxValue, configs.maxConnections)
+    assertEquals(1048588, configs.messageMaxBytes)
+
+    var newProps = new Properties()
+    newProps.put(KafkaConfig.MaxConnectionsProp, "9999")
+    newProps.put(KafkaConfig.MessageMaxBytesProp, "2222")
+
+    configs.dynamicConfig.updateDefaultConfig(newProps)
+    assertEquals(9999, configs.maxConnections)
+    assertEquals(2222, configs.messageMaxBytes)
+
+    newProps = new Properties()
+    newProps.put(KafkaConfig.MaxConnectionsProp, "INVALID_INT")
+    newProps.put(KafkaConfig.MessageMaxBytesProp, "1111")
+
+    configs.dynamicConfig.updateDefaultConfig(newProps)
+    // Invalid value should be skipped and reassigned as Originals
+    assertEquals(Int.MaxValue, configs.maxConnections)
+    // Even if One property is invalid, the below should get correctly updated.
+    assertEquals(1111, configs.messageMaxBytes)
+  }
 }
 
 class TestDynamicThreadPool() extends BrokerReconfigurable {

--- a/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicBrokerConfigTest.scala
@@ -406,8 +406,8 @@ class DynamicBrokerConfigTest {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect)
     val configs = KafkaConfig(props)
 
-    assertEquals(Int.MaxValue, configs.maxConnections)
-    assertEquals(1048588, configs.messageMaxBytes)
+    assertEquals(Defaults.MaxConnections, configs.maxConnections)
+    assertEquals(Defaults.MessageMaxBytes, configs.messageMaxBytes)
 
     var newProps = new Properties()
     newProps.put(KafkaConfig.MaxConnectionsProp, "9999")
@@ -422,8 +422,8 @@ class DynamicBrokerConfigTest {
     newProps.put(KafkaConfig.MessageMaxBytesProp, "1111")
 
     configs.dynamicConfig.updateDefaultConfig(newProps)
-    // Invalid value should be skipped and reassigned as Originals
-    assertEquals(Int.MaxValue, configs.maxConnections)
+    // Invalid value should be skipped and reassigned as default value
+    assertEquals(Defaults.MaxConnections, configs.maxConnections)
     // Even if One property is invalid, the below should get correctly updated.
     assertEquals(1111, configs.messageMaxBytes)
   }


### PR DESCRIPTION
There is [a bug](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala#L470) in how incorrect dynamic config keys are removed from the original Properties list, resulting in persisting the improper configs in the properties list.

This eventually results in exception being thrown while parsing the list by [KafkaConfig ctor](https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala#L531), resulting in skipping of the complete dynamic list (including the correct ones).

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)

reviewers: @rajinisivaram @omkreddy 