### PR TITLE
MINOR: Move lock method outside try block

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -254,8 +254,8 @@ public class RoundTripWorker implements TaskWorker {
                         spec.valueGenerator().generate(messageIndex));
                     producer.send(record, (metadata, exception) -> {
                         if (exception == null) {
+                            lock.lock();
                             try {
-                                lock.lock();
                                 unackedSends -= 1;
                                 if (unackedSends <= 0)
                                     unackedSendsAreZero.signalAll();
@@ -272,8 +272,8 @@ public class RoundTripWorker implements TaskWorker {
             } catch (Throwable e) {
                 WorkerUtils.abort(log, "ProducerRunnable", e, doneFuture);
             } finally {
+                lock.lock();
                 try {
-                    lock.lock();
                     log.info("{}: ProducerRunnable is exiting.  messagesSent={}; uniqueMessagesSent={}; " +
                                     "ackedSends={}/{}.", id, messagesSent, uniqueMessagesSent,
                             spec.maxMessages() - unackedSends, spec.maxMessages());
@@ -359,8 +359,8 @@ public class RoundTripWorker implements TaskWorker {
                             if (toReceiveTracker.removePending(messageIndex)) {
                                 uniqueMessagesReceived++;
                                 if (uniqueMessagesReceived >= spec.maxMessages()) {
+                                    lock.lock();
                                     try {
-                                        lock.lock();
                                         log.info("{}: Consumer received the full count of {} unique messages.  " +
                                             "Waiting for all {} sends to be acked...", id, spec.maxMessages(), unackedSends);
                                         while (unackedSends > 0)


### PR DESCRIPTION
The `Lock.lock` in the try block may cause `Lock.unlock`  throw exception when it throw exception .
I think it's nice to move  outside although` ReentrantLock.lock` impl doesn't throw exception.

```
 class X {
   private final ReentrantLock lock = new ReentrantLock();
   // ...

   public void m() {
     lock.lock();  // block until condition holds
     try {
       // ... method body
     } finally {
       lock.unlock()
     }
   }
 }
```
pattern recommended by 
https://docs.oracle.com/javase/10/docs/api/java/util/concurrent/locks/ReentrantLock.html