### PR TITLE
MINOR: Change the input type of DescribeAclsResponse#aclsResources from Collection to Iterable to avoid creating useless collection

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeAclsResponse.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +125,7 @@ public class DescribeAclsResponse extends AbstractResponse {
         return resources.stream().flatMap(DescribeAclsResponse::aclBindings).collect(Collectors.toList());
     }
 
-    public static List<DescribeAclsResource> aclsResources(Collection<AclBinding> acls) {
+    public static List<DescribeAclsResource> aclsResources(Iterable<AclBinding> acls) {
         Map<ResourcePattern, List<AccessControlEntry>> patternToEntries = new HashMap<>();
         for (AclBinding acl : acls) {
             patternToEntries.computeIfAbsent(acl.pattern(), v -> new ArrayList<>()).add(acl.entry());

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2509,12 +2509,10 @@ class KafkaApis(val requestChannel: RequestChannel,
             .setThrottleTimeMs(requestThrottleMs)))
       case Some(auth) =>
         val filter = describeAclsRequest.filter
-        val returnedAcls = new util.HashSet[AclBinding]()
-        auth.acls(filter).forEach(returnedAcls.add)
         sendResponseMaybeThrottle(request, requestThrottleMs =>
           new DescribeAclsResponse(new DescribeAclsResponseData()
             .setThrottleTimeMs(requestThrottleMs)
-            .setResources(DescribeAclsResponse.aclsResources(returnedAcls))))
+            .setResources(DescribeAclsResponse.aclsResources(auth.acls(filter)))))
     }
   }
 


### PR DESCRIPTION
Modify DescribeAclsResponse, remove Collection and change to Iterable,
Modify KafkaApis, aclsResources method