### PR TITLE
MINOR: remove duplicate code from resetByDuration

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -491,17 +491,8 @@ public class StreamsResetter {
                                  final Duration duration) {
         final Instant now = Instant.now();
         final long timestamp = now.minus(duration).toEpochMilli();
-
-        final Map<TopicPartition, Long> topicPartitionsAndTimes = new HashMap<>(inputTopicPartitions.size());
-        for (final TopicPartition topicPartition : inputTopicPartitions) {
-            topicPartitionsAndTimes.put(topicPartition, timestamp);
-        }
-
-        final Map<TopicPartition, OffsetAndTimestamp> topicPartitionsAndOffset = client.offsetsForTimes(topicPartitionsAndTimes);
-
-        for (final TopicPartition topicPartition : inputTopicPartitions) {
-            client.seek(topicPartition, topicPartitionsAndOffset.get(topicPartition).offset());
-        }
+        
+        resetToDatetime(client, inputTopicPartitions, timestamp);
     }
 
     private void resetToDatetime(final Consumer<byte[], byte[]> client,

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -489,10 +489,7 @@ public class StreamsResetter {
     private void resetByDuration(final Consumer<byte[], byte[]> client,
                                  final Set<TopicPartition> inputTopicPartitions,
                                  final Duration duration) {
-        final Instant now = Instant.now();
-        final long timestamp = now.minus(duration).toEpochMilli();
-        
-        resetToDatetime(client, inputTopicPartitions, timestamp);
+        resetToDatetime(client, inputTopicPartitions, Instant.now().minus(duration).toEpochMilli());
     }
 
     private void resetToDatetime(final Consumer<byte[], byte[]> client,


### PR DESCRIPTION
There is a request for putting topicPartition and timestamp into topicPartitionsAndTimes's container from inputTopicPartitions.
And then take topicPartition and topicPartition's offset to call client's seek in the resetByDuration.

Beacuse I find some code in the resetToDatetime, so I would like to remove them from resetByDuration.
And then I would like to take client, inputTopicPartitions and timestamp to call resetToDatetime from resetByDuration.
where client is Consumer, inputTopicPartitions is container and timestamp is Duration's EpochMilli.

Finally, I found some error information in the Checks' Tab. I think these problems aren't relative to my pull request. As below information.

Log tail
…398 lines…
[2020-12-05T01ː06ː29.710Z] > Task ːstreamsːtest-utils:testClasses
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːtest-utils:checkstyleTest
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0100:processTestResources NO-SOURCE
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0100:testClasses
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0100:checkstyleTest
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0101:processTestResources NO-SOURCE
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0101:testClasses
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0101:checkstyleTest
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0102:processTestResources NO-SOURCE
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0102:testClasses
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0102:checkstyleTest
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0110:processTestResources NO-SOURCE
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0110:testClasses
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-0110:checkstyleTest
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-10:processTestResources NO-SOURCE
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-10:testClasses
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-10:checkstyleTest
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-11:processTestResources NO-SOURCE
[2020-12-05T01ː06ː30.837Z] > Task ːstreamsːupgrade-system-tests-11:testClasses
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-11:checkstyleTest
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-20:processTestResources NO-SOURCE
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-20:testClasses
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-20:checkstyleTest
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-21:processTestResources NO-SOURCE
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-21:testClasses
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-21:checkstyleTest
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-22:processTestResources NO-SOURCE
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-22:testClasses
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-22:checkstyleTest
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-23:processTestResources NO-SOURCE
[2020-12-05T01ː06ː31.789Z] > Task ːstreamsːupgrade-system-tests-23:testClasses
[2020-12-05T01ː06ː31.790Z] > Task ːstreamsːupgrade-system-tests-23:checkstyleTest
[2020-12-05T01ː06ː31.790Z] > Task ːstreamsːupgrade-system-tests-24:processTestResources NO-SOURCE
[2020-12-05T01ː06ː31.790Z] > Task ːstreamsːupgrade-system-tests-24:testClasses
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-24:checkstyleTest
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-25:processTestResources NO-SOURCE
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-25:testClasses
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-25:checkstyleTest
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-26:processTestResources NO-SOURCE
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-26:testClasses
[2020-12-05T01ː06ː32.743Z] > Task ːstreamsːupgrade-system-tests-26:checkstyleTest
[2020-12-05T01ː06ː33.697Z] > Task ːconnectːspotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-0100:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-0101:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-0102:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-0110:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-10:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-11:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-20:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-21:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-22:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-23:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-24:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-25:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː34.655Z] > Task ːstreamsːupgrade-system-tests-26:spotbugsMain NO-SOURCE
[2020-12-05T01ː06ː40.856Z] 
[2020-12-05T01ː06ː40.856Z] > Task :rat
[2020-12-05T01ː06ː40.856Z] Rat report: /home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-9699/build/rat/rat-report.html
[2020-12-05T01ː07ː03.231Z] 
[2020-12-05T01ː07ː03.231Z] > Task ːclientsːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːcoreːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːexamplesːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːgeneratorːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːjmh-benchmarksːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːlog4j-appenderːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːraftːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːstreamsːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːtoolsːspotbugsMain
[2020-12-05T01ː07ː03.231Z] > Task ːconnectːapi:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːbasic-auth-extension:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːfile:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːjson:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːmirror:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːmirror-client:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːruntime:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːconnectːtransforms:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːstreamsːexamples:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːstreamsːstreams-scala:spotbugsMain
[2020-12-05T01ː07ː04.183Z] > Task ːstreamsːtest-utils:spotbugsMain
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] FAILURE: Build failed with an exception.
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] * What went wrong:
[2020-12-05T01ː09ː09.077Z] Execution failed for task 'ːstreamsːcompileTestJava'.
[2020-12-05T01ː09ː09.077Z] > Compilation failed; see the compiler error output for details.
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] * Try:
[2020-12-05T01ː09ː09.077Z] Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] * Get more help at https://help.gradle.org
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
[2020-12-05T01ː09ː09.077Z] Use '--warning-mode all' to show the individual deprecation warnings.
[2020-12-05T01ː09ː09.077Z] See https://docs.gradle.org/6.7.1/userguide/command_line_interface.html#sec:command_line_warnings
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] BUILD FAILED in 9m 15s
[2020-12-05T01ː09ː09.077Z] 203 actionable tasks: 169 executed, 34 up-to-date
[2020-12-05T01ː09ː09.077Z] 
[2020-12-05T01ː09ː09.077Z] See the profiling report at: file:///home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-9699/build/reports/profile/profile-2020-12-05-00-59-52.html
[2020-12-05T01ː09ː09.077Z] A fine-grained performance profile is available: use the --scan option.
