### PR TITLE
KAFKA-10697 Remove ProduceResponse.responses

### DIFF
--- a/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/network/DynamicConnectionQuotaTest.scala
@@ -341,7 +341,7 @@ class DynamicConnectionQuotaTest extends BaseRequestTest {
   @nowarn("cat=deprecation")
   private def verifyConnection(socket: Socket): Unit = {
     val produceResponse = sendAndReceive[ProduceResponse](produceRequest, socket)
-    assertEquals(1, produceResponse.responses.size)
+    assertEquals(1, produceResponse.data.setResponses(produceResponse.data.responses))
     val (_, partitionResponse) = produceResponse.responses.asScala.head
     assertEquals(Errors.NONE, partitionResponse.error)
   }


### PR DESCRIPTION
issue : https://issues.apache.org/jira/browse/KAFKA-10697

Remove the old method Map <TopicPartition, PartitionResponse> responses() 
Use the new method public ProduceResponseData data() instead.