### PR TITLE
KAFKA-10815 EosTestDriver#verifyAllTransactionFinished should break loop if all partitions are verified

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -598,7 +598,7 @@ public class EosTestDriver extends SmokeTestUtil {
 
         final long maxWaitTime = System.currentTimeMillis() + MAX_IDLE_TIME_MS;
         try (final KafkaConsumer<byte[], byte[]> consumerUncommitted = new KafkaConsumer<>(consumerProps)) {
-            while (System.currentTimeMillis() < maxWaitTime) {
+            while (!partitions.isEmpty() && System.currentTimeMillis() < maxWaitTime) {
                 consumer.seekToEnd(partitions);
                 final Map<TopicPartition, Long> topicEndOffsets = consumerUncommitted.endOffsets(partitions);
 


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-10815
If we don't break it when all partitions are verified, the loop will take 10 mins ...

see https://travis-ci.com/github/apache/kafka/jobs/455103274 for related timeout

```

2994[INFO:2020-12-06 06:06:35,755]: Triggering test 10 of 32...
2995[INFO:2020-12-06 06:06:35,765]: RunnerClient: Loading test {'directory': '/opt/kafka-dev/tests/kafkatest/tests/streams', 'file_name': 'streams_eos_test.py', 'cls_name': 'StreamsEosTest', 'method_name': 'test_rebalance_complex', 'injected_args': {'processing_guarantee': 'exactly_once'}}
2996[INFO:2020-12-06 06:06:35,771]: RunnerClient: kafkatest.tests.streams.streams_eos_test.StreamsEosTest.test_rebalance_complex.processing_guarantee=exactly_once: Setting up...
2997[INFO:2020-12-06 06:07:12,200]: RunnerClient: kafkatest.tests.streams.streams_eos_test.StreamsEosTest.test_rebalance_complex.processing_guarantee=exactly_once: Running...
2998
2999
3000No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
3001Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received
```

this issue is related to https://github.com/apache/kafka/commit/cb88be45ebc400069c03ad8b9a2332da0aecc7b8

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
