### PR TITLE
KAFKA-9126: KIP-689: StreamJoined changelog configuration

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -219,8 +219,7 @@ public class Materialized<K, V, S extends StateStore> {
 
     /**
      * Enable caching for the materialized {@link StateStore}.
-     * @return itself
-     */
+     * @return itself     */
     public Materialized<K, V, S> withCachingEnabled() {
         cachingEnabled = true;
         return this;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -219,7 +219,8 @@ public class Materialized<K, V, S extends StateStore> {
 
     /**
      * Enable caching for the materialized {@link StateStore}.
-     * @return itself     */
+     * @return itself
+     */
     public Materialized<K, V, S> withCachingEnabled() {
         cachingEnabled = true;
         return this;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/StreamJoined.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/StreamJoined.java
@@ -338,7 +338,7 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             name,
             storeName,
             false,
-            null
+            new HashMap<>()
         );
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/StreamJoined.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/StreamJoined.java
@@ -36,6 +36,8 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
     protected final WindowBytesStoreSupplier otherStoreSupplier;
     protected final String name;
     protected final String storeName;
+    protected boolean loggingEnabled = true;
+    protected boolean cachingEnabled = true;
 
     protected StreamJoined(final StreamJoined<K, V1, V2> streamJoined) {
         this(streamJoined.keySerde,
@@ -44,7 +46,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             streamJoined.thisStoreSupplier,
             streamJoined.otherStoreSupplier,
             streamJoined.name,
-            streamJoined.storeName);
+            streamJoined.storeName,
+            streamJoined.loggingEnabled,
+            streamJoined.cachingEnabled);
     }
 
     private StreamJoined(final Serde<K> keySerde,
@@ -53,7 +57,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
                          final WindowBytesStoreSupplier thisStoreSupplier,
                          final WindowBytesStoreSupplier otherStoreSupplier,
                          final String name,
-                         final String storeName) {
+                         final String storeName,
+                         final boolean loggingEnabled,
+                         final boolean cachingEnabled) {
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
         this.otherValueSerde = otherValueSerde;
@@ -61,6 +67,8 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
         this.otherStoreSupplier = otherStoreSupplier;
         this.name = name;
         this.storeName = storeName;
+        this.loggingEnabled = loggingEnabled;
+        this.cachingEnabled = cachingEnabled;
     }
 
     /**
@@ -84,7 +92,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             storeSupplier,
             otherStoreSupplier,
             null,
-            null
+            null,
+            true,
+            true
         );
     }
 
@@ -109,7 +119,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             null,
             null,
             null,
-            storeName
+            storeName,
+            true,
+            true
         );
     }
 
@@ -136,7 +148,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             null,
             null,
             null,
-            null
+            null,
+            true,
+            true
         );
     }
 
@@ -154,7 +168,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
         );
     }
 
@@ -176,7 +192,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
         );
     }
 
@@ -193,7 +211,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
         );
     }
 
@@ -210,7 +230,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
         );
     }
 
@@ -227,7 +249,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
         );
     }
 
@@ -247,7 +271,9 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
         );
     }
 
@@ -267,7 +293,65 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             thisStoreSupplier,
             otherStoreSupplier,
             name,
-            storeName
+            storeName,
+            loggingEnabled,
+            cachingEnabled
+        );
+    }
+
+    public StreamJoined<K, V1, V2> withLoggingEnabled() {
+        return new StreamJoined<>(
+            keySerde,
+            valueSerde,
+            otherValueSerde,
+            thisStoreSupplier,
+            otherStoreSupplier,
+            name,
+            storeName,
+            true,
+            cachingEnabled
+        );
+    }
+
+    public StreamJoined<K, V1, V2> withLoggingDisabled() {
+        return new StreamJoined<>(
+            keySerde,
+            valueSerde,
+            otherValueSerde,
+            thisStoreSupplier,
+            otherStoreSupplier,
+            name,
+            storeName,
+            false,
+            cachingEnabled
+        );
+    }
+
+    public StreamJoined<K, V1, V2> withCachingEnabled(final WindowBytesStoreSupplier otherStoreSupplier) {
+        return new StreamJoined<>(
+            keySerde,
+            valueSerde,
+            otherValueSerde,
+            thisStoreSupplier,
+            otherStoreSupplier,
+            name,
+            storeName,
+            loggingEnabled,
+            true
+        );
+    }
+
+    public StreamJoined<K, V1, V2> withCachingDisabled(final WindowBytesStoreSupplier otherStoreSupplier) {
+        return new StreamJoined<>(
+            keySerde,
+            valueSerde,
+            otherValueSerde,
+            thisStoreSupplier,
+            otherStoreSupplier,
+            name,
+            storeName,
+            loggingEnabled,
+            false
         );
     }
 
@@ -281,6 +365,8 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
             ", otherStoreSupplier=" + otherStoreSupplier +
             ", name='" + name + '\'' +
             ", storeName='" + storeName + '\'' +
+            ", loggingEnabled=" + loggingEnabled +
+            ", cachingEnabled=" + cachingEnabled +
             '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/StreamJoined.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/StreamJoined.java
@@ -39,8 +39,8 @@ public class StreamJoined<K, V1, V2> implements NamedOperation<StreamJoined<K, V
     protected final WindowBytesStoreSupplier otherStoreSupplier;
     protected final String name;
     protected final String storeName;
-    protected boolean loggingEnabled;
-    protected Map<String, String> topicConfig;
+    protected final boolean loggingEnabled;
+    protected final Map<String, String> topicConfig;
 
     protected StreamJoined(final StreamJoined<K, V1, V2> streamJoined) {
         this(streamJoined.keySerde,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamJoinedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamJoinedInternal.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.StreamJoined;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 
+import java.util.Map;
+
 public class StreamJoinedInternal<K, V1, V2> extends StreamJoined<K, V1, V2> {
 
     //Needs to be public for testing
@@ -60,8 +62,8 @@ public class StreamJoinedInternal<K, V1, V2> extends StreamJoined<K, V1, V2> {
         return loggingEnabled;
     }
 
-    public boolean cachingEnabled() {
-        return cachingEnabled;
+    Map<String, String> logConfig() {
+        return topicConfig;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamJoinedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/StreamJoinedInternal.java
@@ -56,5 +56,12 @@ public class StreamJoinedInternal<K, V1, V2> extends StreamJoined<K, V1, V2> {
         return otherStoreSupplier;
     }
 
+    public boolean loggingEnabled() {
+        return loggingEnabled;
+    }
+
+    public boolean cachingEnabled() {
+        return cachingEnabled;
+    }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.state.Stores;
@@ -45,12 +46,14 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -150,6 +153,52 @@ public class KStreamKStreamJoinTest {
                 );
             }
         }
+    }
+
+    @Test
+    public void shouldDisableLoggingOnStreamJoined() {
+
+        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100)).grace(Duration.ofMillis(50));
+        final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer()).withStoreName("store").withLoggingDisabled();
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
+        final KStream<String, Integer> right = builder.stream("right", Consumed.with(Serdes.String(), Serdes.Integer()));
+
+        left.join(
+            right,
+            (value1, value2) -> value1 + value2,
+            joinWindows,
+            streamJoined);
+
+        final Topology topology = builder.build();
+        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
+
+        assertThat(internalTopologyBuilder.stateStores().get("store-this-join-store").loggingEnabled(), equalTo(false));
+        assertThat(internalTopologyBuilder.stateStores().get("store-other-join-store").loggingEnabled(), equalTo(false));
+    }
+
+    @Test
+    public void shouldEnableLoggingWithCustomConfigOnStreamJoined() {
+
+        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100)).grace(Duration.ofMillis(50));
+        final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer()).withStoreName("store").withLoggingEnabled(Collections.emptyMap());
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
+        final KStream<String, Integer> right = builder.stream("right", Consumed.with(Serdes.String(), Serdes.Integer()));
+
+        left.join(
+            right,
+            (value1, value2) -> value1 + value2,
+            joinWindows,
+            streamJoined);
+
+        final Topology topology = builder.build();
+        final InternalTopologyBuilder internalTopologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
+
+        assertThat(internalTopologyBuilder.stateStores().get("store-this-join-store").loggingEnabled(), equalTo(true));
+        assertThat(internalTopologyBuilder.stateStores().get("store-other-join-store").loggingEnabled(), equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
Adds `withLoggingEnabled` and `withLoggingDisabled` for `StreamJoined` to give `StreamJoined` the same flexibility as `Materialized`