### PR TITLE
MINOR: Remove redundant default parameter values in call to LogSegment.open

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -770,9 +770,7 @@ class Log(@volatile private var _dir: File,
             baseOffset = 0,
             config,
             time = time,
-            fileAlreadyExists = false,
-            initFileSize = this.initFileSize,
-            preallocate = false))
+            initFileSize = this.initFileSize))
        }
       0
     }
@@ -858,7 +856,6 @@ class Log(@volatile private var _dir: File,
         baseOffset = logStartOffset,
         config,
         time = time,
-        fileAlreadyExists = false,
         initFileSize = this.initFileSize,
         preallocate = config.preallocate))
     }
@@ -2124,7 +2121,6 @@ class Log(@volatile private var _dir: File,
           baseOffset = newOffset,
           config = config,
           time = time,
-          fileAlreadyExists = false,
           initFileSize = initFileSize,
           preallocate = config.preallocate))
         updateLogEndOffset(newOffset)


### PR DESCRIPTION
Few call sites in `Log.scala` were passing redundant default values in their calls to `LogSegment.open(...)`. In this PR, I've cleaned these up. For reference, here is a link to the definition of `LogSegment.open`: https://github.com/apache/kafka/blob/d2521855b8eb8a0dbb6f94cd9bb5093276fb7db2/core/src/main/scala/kafka/log/LogSegment.scala#L660-L661 

**Test plan:**
Relying on existing unit and integration tests.