### PR TITLE
MINOR: add "flush=True" to all print in system tests

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -55,7 +55,7 @@ def run_command(node, cmd, ssh_log_file):
                 f.write(line)
         except Exception as e:
             f.write("** Command failed!")
-            print(e)
+            print(e, flush=True)
             raise
 
 

--- a/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_produce_consume_test.py
@@ -66,7 +66,7 @@ class ClientCompatibilityProduceConsumeTest(ProduceConsumeValidateTest):
     @parametrize(broker_version=str(LATEST_2_4))
     @parametrize(broker_version=str(LATEST_2_5))
     def test_produce_consume(self, broker_version):
-        print("running producer_consumer_compat with broker_version = %s" % broker_version)
+        print("running producer_consumer_compat with broker_version = %s" % broker_version, flush=True)
         self.kafka.set_version(KafkaVersion(broker_version))
         self.kafka.security_protocol = "PLAINTEXT"
         self.kafka.interbroker_security_protocol = self.kafka.security_protocol

--- a/tests/kafkatest/tests/core/replica_scale_test.py
+++ b/tests/kafkatest/tests/core/replica_scale_test.py
@@ -51,7 +51,7 @@ class ReplicaScaleTest(Test):
         topics_create_start_time = time.time()
         for i in range(topic_count):
             topic = "replicas_produce_consume_%d" % i
-            print("Creating topic %s" % topic)  # Force some stdout for Jenkins
+            print("Creating topic %s" % topic, flush=True)  # Force some stdout for Jenkins
             topic_cfg = {
                 "topic": topic,
                 "partitions": partition_count,
@@ -106,7 +106,7 @@ class ReplicaScaleTest(Test):
         topics_create_start_time = time.time()
         for i in range(topic_count):
             topic = "topic-%04d" % i
-            print("Creating topic %s" % topic)  # Force some stdout for Jenkins
+            print("Creating topic %s" % topic, flush=True)  # Force some stdout for Jenkins
             topic_cfg = {
                 "topic": topic,
                 "partitions": partition_count,


### PR DESCRIPTION
That makes the behavior of ```print``` equal to pyhton2.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
