### PR TITLE
KAFKA-10822 Force some stdout from system tests for Travis

### DIFF
--- a/tests/kafkatest/tests/core/downgrade_test.py
+++ b/tests/kafkatest/tests/core/downgrade_test.py
@@ -120,11 +120,11 @@ class TestDowngrade(EndToEndTest):
         self.setup_services(kafka_version, compression_types, security_protocol, static_membership)
         self.await_startup()
 
-        self.logger.info("First pass bounce - rolling upgrade")
+        print("First pass bounce - rolling upgrade", flush=True) # Force some stdout for Travis
         self.upgrade_from(kafka_version)
         self.run_validation()
 
-        self.logger.info("Second pass bounce - rolling downgrade")
+        print("Second pass bounce - rolling downgrade", flush=True) # Force some stdout for Travis
         self.downgrade_to(kafka_version)
         self.run_validation()
         assert self.kafka.check_protocol_errors(self)

--- a/tests/kafkatest/tests/core/replication_test.py
+++ b/tests/kafkatest/tests/core/replication_test.py
@@ -52,6 +52,7 @@ def clean_bounce(test, broker_type):
     """Chase the leader of one partition and restart it cleanly."""
     for i in range(5):
         prev_broker_node = broker_node(test, broker_type)
+        print("clean_bounce on " + str(prev_broker_node.account), flush=True) # Force some stdout for Travis
         test.kafka.restart_node(prev_broker_node, clean_shutdown=True)
 
 
@@ -59,6 +60,7 @@ def hard_bounce(test, broker_type):
     """Chase the leader and restart it with a hard kill."""
     for i in range(5):
         prev_broker_node = broker_node(test, broker_type)
+        print("hard_bounce on " + str(prev_broker_node.account), flush=True) # Force some stdout for Travis
         test.kafka.signal_node(prev_broker_node, sig=signal.SIGKILL)
 
         # Since this is a hard kill, we need to make sure the process is down and that

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -65,6 +65,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         # Roll cluster to include inter broker security protocol.
         self.kafka.setup_interbroker_listener(broker_protocol)
         self.bounce()
+        print("succeed in bouncing kafka cluster to include inter broker security protocol", flush=True) # Force some stdout for Travis
 
         # Roll cluster to disable PLAINTEXT port
         self.kafka.close_port(SecurityConfig.PLAINTEXT)

--- a/tests/kafkatest/tests/core/upgrade_test.py
+++ b/tests/kafkatest/tests/core/upgrade_test.py
@@ -55,8 +55,8 @@ class TestUpgrade(ProduceConsumeValidateTest):
         # Not trying to detect a problem here leads to failure in the ensuing Kafka roll, which would be a less
         # intuitive failure than seeing a problem here, so detect ZooKeeper upgrade problems before involving Kafka.
         self.zk.describe(self.topic)
-        self.logger.info("First pass bounce - rolling upgrade")
         for node in self.kafka.nodes:
+            print("First pass bounce - rolling upgrade on " + str(node.account), flush=True) # Force some stdout for Travis
             self.kafka.stop_node(node)
             node.version = DEV_BRANCH
             node.config[config_property.INTER_BROKER_PROTOCOL_VERSION] = from_kafka_version
@@ -64,8 +64,8 @@ class TestUpgrade(ProduceConsumeValidateTest):
             self.kafka.start_node(node)
             self.wait_until_rejoin()
 
-        self.logger.info("Second pass bounce - remove inter.broker.protocol.version config")
         for node in self.kafka.nodes:
+            print("Second pass bounce - remove inter.broker.protocol.version config from " + str(node.account), flush=True) # Force some stdout for Travis
             self.kafka.stop_node(node)
             del node.config[config_property.INTER_BROKER_PROTOCOL_VERSION]
             if to_message_format_version is None:


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-10822

downgrade_test.py/upgrade_test.py does upgrade/downgrade for each tests. the upgrade/downgrade tasks take 10+ mins in Travis env so we ought to print something in order to avoid timeout caused by Travis.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
