### PR TITLE
KAFKA-10826; Ensure raft io thread respects linger timeout

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1800,8 +1800,15 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             return Long.MAX_VALUE;
         }
 
+        boolean isFirstAppend = accumulator.isEmpty();
         Long offset = accumulator.append(epoch, records);
-        if (accumulator.needsDrain(time.milliseconds())) {
+
+        // Wakeup the network channel if either this is the first append
+        // or the accumulator is ready to drain now. Checking for the first
+        // append ensures that we give the IO thread a chance to observe
+        // the linger timeout so that it can schedule its own wakeup in case
+        // there are no additional appends.
+        if (isFirstAppend || accumulator.needsDrain(time.milliseconds())) {
             channel.wakeup();
         }
         return offset;

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -280,8 +280,8 @@ public class BatchAccumulator<T> implements Closeable {
     }
 
     /**
-     * Get the number of batches including the one that is currently being
-     * written to (if it exists).
+     * Get the number of completed batches which are ready to be drained.
+     * This does not include the batch that is currently being filled.
      */
     public int numCompletedBatches() {
         return completed.size();

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -141,6 +141,7 @@ public class BatchAccumulator<T> implements Closeable {
             startNewBatch();
         } else if (!currentBatch.hasRoomFor(batchSize)) {
             completeCurrentBatch();
+            startNewBatch();
         }
         return currentBatch;
     }
@@ -271,22 +272,19 @@ public class BatchAccumulator<T> implements Closeable {
         }
     }
 
+    public boolean isEmpty() {
+        // The linger timer begins running when we have pending batches.
+        // We use this to infer when the accumulator is empty to avoid the
+        // need to acquire the append lock.
+        return !lingerTimer.isRunning();
+    }
+
     /**
      * Get the number of batches including the one that is currently being
      * written to (if it exists).
      */
-    public int count() {
-        appendLock.lock();
-        try {
-            int count = completed.size();
-            if (currentBatch != null) {
-                return count + 1;
-            } else {
-                return count;
-            }
-        } finally {
-            appendLock.unlock();
-        }
+    public int numCompletedBatches() {
+        return completed.size();
     }
 
     @Override

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -502,11 +502,11 @@ public class KafkaRaftClientTest {
         context.client.poll();
         assertEquals(OptionalLong.of(lingerMs), context.channel.lastReceiveTimeout());
 
-        context.time.sleep(25);
+        context.time.sleep(20);
         context.client.poll();
-        assertEquals(OptionalLong.of(25), context.channel.lastReceiveTimeout());
+        assertEquals(OptionalLong.of(30), context.channel.lastReceiveTimeout());
 
-        context.time.sleep(25);
+        context.time.sleep(30);
         context.client.poll();
         assertEquals(2L, context.log.endOffset().offset);
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -478,6 +478,74 @@ public class KafkaRaftClientTest {
     }
 
     @Test
+    public void testChannelWokenUpIfLingerTimeoutReachedWithoutAppend() throws Exception {
+        // This test verifies that the client will set its poll timeout accounting
+        // for the lingerMs of a pending append
+
+        int localId = 0;
+        int otherNodeId = 1;
+        int lingerMs = 50;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withAppendLingerMs(lingerMs)
+            .build();
+
+        context.becomeLeader();
+        assertEquals(OptionalInt.of(localId), context.currentLeader());
+        assertEquals(1L, context.log.endOffset().offset);
+
+        int epoch = context.currentEpoch();
+        assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
+        assertTrue(context.channel.wakeupRequested());
+
+        context.client.poll();
+        assertEquals(OptionalLong.of(lingerMs), context.channel.lastReceiveTimeout());
+
+        context.time.sleep(25);
+        context.client.poll();
+        assertEquals(OptionalLong.of(25), context.channel.lastReceiveTimeout());
+
+        context.time.sleep(25);
+        context.client.poll();
+        assertEquals(2L, context.log.endOffset().offset);
+    }
+
+    @Test
+    public void testChannelWokenUpIfLingerTimeoutReachedDuringAppend() throws Exception {
+        // This test verifies that the client will get woken up immediately
+        // if the linger timeout has expired during an append
+
+        int localId = 0;
+        int otherNodeId = 1;
+        int lingerMs = 50;
+        Set<Integer> voters = Utils.mkSet(localId, otherNodeId);
+
+        RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
+            .withAppendLingerMs(lingerMs)
+            .build();
+
+        context.becomeLeader();
+        assertEquals(OptionalInt.of(localId), context.currentLeader());
+        assertEquals(1L, context.log.endOffset().offset);
+
+        int epoch = context.currentEpoch();
+        assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
+        assertTrue(context.channel.wakeupRequested());
+
+        context.client.poll();
+        assertFalse(context.channel.wakeupRequested());
+        assertEquals(OptionalLong.of(lingerMs), context.channel.lastReceiveTimeout());
+
+        context.time.sleep(lingerMs);
+        assertEquals(2L, context.client.scheduleAppend(epoch, singletonList("b")));
+        assertTrue(context.channel.wakeupRequested());
+
+        context.client.poll();
+        assertEquals(3L, context.log.endOffset().offset);
+    }
+
+    @Test
     public void testHandleEndQuorumRequest() throws Exception {
         int localId = 0;
         int oldLeaderId = 1;


### PR DESCRIPTION
When there are no pending operations, the raft IO thread can block indefinitely waiting for a network event. We rely on asynchronous wakeups in order to break the blocking wait in order to respond to a scheduled append. The current logic already does this, but only for the case when the linger time has been completed during the call to `scheduleAppend`. It is possible instead that after making one call to `scheduleAppend` to start the linger timer, the application does not do any additional appends. In this case, we still need the IO thread to wakeup when the linger timer expires. This patch fixes the problem by ensuring that the IO thread gets woken up after the first append which begins the linger timer.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
