### PR TITLE
MINOR: optimize EvictableKey/LastUsedKey compareTo function

### DIFF
--- a/core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchSessionTest.scala
@@ -698,4 +698,43 @@ class FetchSessionTest {
     assertEquals(resp1.sessionId, resp4.sessionId)
     assertEquals(Utils.mkSet(tp1, tp2), resp4.responseData.keySet)
   }
+
+  @Test
+  def testKeyComparison(): Unit = {
+    assertEquals(-1, EvictableKey(false, 0, 0)
+      .compareTo(EvictableKey(true, 0, 0)))
+
+    assertEquals(1, EvictableKey(true, 0, 0)
+      .compareTo(EvictableKey(false, 0, 0)))
+
+    assertEquals(0, EvictableKey(true, 0, 0)
+      .compareTo(EvictableKey(true, 0, 0)))
+
+    assertEquals(-1, EvictableKey(true, -1, 0)
+      .compareTo(EvictableKey(true, 0, 0)))
+
+    assertEquals(1, EvictableKey(true, 10, 0)
+      .compareTo(EvictableKey(true, 0, 0)))
+
+    assertEquals(-1, EvictableKey(true, 0, -1)
+      .compareTo(EvictableKey(true, 0, 0)))
+
+    assertEquals(1, EvictableKey(true, 0, 10)
+      .compareTo(EvictableKey(true, 0, 0)))
+
+    assertEquals(0, LastUsedKey(0, 10)
+      .compareTo(LastUsedKey(0, 10)))
+
+    assertEquals(-1, LastUsedKey(-1, 10)
+      .compareTo(LastUsedKey(0, 10)))
+
+    assertEquals(1, LastUsedKey(10, 10)
+      .compareTo(LastUsedKey(0, 10)))
+
+    assertEquals(-1, LastUsedKey(0, 5)
+      .compareTo(LastUsedKey(0, 10)))
+
+    assertEquals(1, LastUsedKey(0, 12)
+      .compareTo(LastUsedKey(0, 10)))
+  }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/FetchKeyBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/FetchKeyBenchmark.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.server;
+
+import kafka.server.EvictableKey;
+import kafka.server.LastUsedKey;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FetchKeyBenchmark {
+
+    private static final EvictableKey EVICTABLE_KEY_0 = new EvictableKey(true, 1000, 1000);
+    private static final EvictableKey EVICTABLE_KEY_1 = new EvictableKey(true, 1000, 1000);
+
+    private static final LastUsedKey LAST_USED_KEY_0 = new LastUsedKey(1000, 1000);
+    private static final LastUsedKey LAST_USED_KEY_1 = new LastUsedKey(1000, 1000);
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int compareEvictableKey() {
+        return EVICTABLE_KEY_0.compareTo(EVICTABLE_KEY_1);
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public int compareLastUsedKey() {
+        return LAST_USED_KEY_0.compareTo(LAST_USED_KEY_1);
+    }
+
+}


### PR DESCRIPTION
The previous implementation create two object wraps. 

1. tuple
2. primitive type -> object type

As ```compareTo``` is hot method in fetch path, it should be worth rewriting them by java code to avoid useless wrap.

**BEFORE**
```
FetchKeyBenchmark.compareEvictableKey                               avgt   15    12.156 ±   0.010   ns/op
FetchKeyBenchmark.compareEvictableKey:·gc.alloc.rate.norm           avgt   15   112.000 ±   0.001    B/op
FetchKeyBenchmark.compareLastUsedKey                                avgt   15    13.929 ±   0.088   ns/op
FetchKeyBenchmark.compareLastUsedKey:·gc.alloc.rate.norm            avgt   15   136.000 ±   0.001    B/op
```

**AFTER**
```
FetchKeyBenchmark.compareEvictableKey                      avgt   15   2.351 ±  0.001   ns/op
FetchKeyBenchmark.compareEvictableKey:·gc.alloc.rate.norm  avgt   15  ≈ 10⁻⁷             B/op
FetchKeyBenchmark.compareLastUsedKey                       avgt   15   2.154 ±  0.001   ns/op
FetchKeyBenchmark.compareLastUsedKey:·gc.alloc.rate.norm   avgt   15  ≈ 10⁻⁷             B/op
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
