### PR TITLE
KAFKA-10833: Expose task configurations in Connect REST API (KIP-661)

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -269,7 +269,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         final ClusterConfigState configState = configBackingStore.snapshot();
 
         if (!configState.contains(connector))
-            return null;
+            return Collections.emptyMap();
 
         Map<ConnectorTaskId, Map<String, String>> configs = new HashMap<>();
         for (ConnectorTaskId cti : configState.tasks(connector)) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -265,6 +265,20 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         );
     }
 
+    protected Map<ConnectorTaskId, Map<String, String>> buildTasksConfig(String connector) {
+        final ClusterConfigState configState = configBackingStore.snapshot();
+
+        if (!configState.contains(connector))
+            return null;
+
+        Map<ConnectorTaskId, Map<String, String>> configs = new HashMap<>();
+        for (ConnectorTaskId cti : configState.tasks(connector)) {
+            configs.put(cti, configState.taskConfig(cti));
+        }
+
+        return configs;
+    }
+
     @Override
     public ConnectorStateInfo connectorStatus(String connName) {
         ConnectorStatus connector = statusBackingStore.get(connName);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -87,6 +87,13 @@ public interface Herder {
     void connectorConfig(String connName, Callback<Map<String, String>> callback);
 
     /**
+     * Get the configuration for all tasks.
+     * @param connName name of the connector
+     * @param callback callback to invoke with the configuration
+     */
+    void tasksConfig(String connName, Callback<Map<ConnectorTaskId, Map<String, String>>> callback);
+
+    /**
      * Set the configuration for a connector. This supports creation and updating.
      * @param connName name of the connector
      * @param config the connectors configuration, or null if deleting the connector

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -738,6 +738,26 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     }
 
     @Override
+    public void tasksConfig(String connName, final Callback<Map<ConnectorTaskId, Map<String, String>>> callback) {
+        log.trace("Submitting tasks config request {}", connName);
+
+        addRequest(
+            () -> {
+                if (checkRebalanceNeeded(callback))
+                    return null;
+
+                if (!configState.contains(connName)) {
+                    callback.onCompletion(new NotFoundException("Connector " + connName + " not found"), null);
+                } else {
+                    callback.onCompletion(null, buildTasksConfig(connName));
+                }
+                return null;
+            },
+            forwardErrorCallback(callback)
+        );
+    }
+
+    @Override
     protected Map<String, String> rawConfig(String connName) {
         return configState.rawConnectorConfig(connName);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -189,6 +189,16 @@ public class ConnectorsResource {
     }
 
     @GET
+    @Path("/{connector}/tasks-config")
+    public Map<ConnectorTaskId, Map<String, String>> getTasksConfig(final @PathParam("connector") String connector,
+                                                  final @Context HttpHeaders headers,
+                                                  final @QueryParam("forward") Boolean forward) throws Throwable {
+        FutureCallback<Map<ConnectorTaskId, Map<String, String>>> cb = new FutureCallback<>();
+        herder.tasksConfig(connector, cb);
+        return completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks-config", "GET", headers, null, forward);
+    }
+
+    @GET
     @Path("/{connector}/status")
     public ConnectorStateInfo getConnectorStatus(final @PathParam("connector") String connector) {
         return herder.connectorStatus(connector);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -190,9 +190,10 @@ public class ConnectorsResource {
 
     @GET
     @Path("/{connector}/tasks-config")
-    public Map<ConnectorTaskId, Map<String, String>> getTasksConfig(final @PathParam("connector") String connector,
-                                                  final @Context HttpHeaders headers,
-                                                  final @QueryParam("forward") Boolean forward) throws Throwable {
+    public Map<ConnectorTaskId, Map<String, String>> getTasksConfig(
+            final @PathParam("connector") String connector,
+            final @Context HttpHeaders headers,
+            final @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Map<ConnectorTaskId, Map<String, String>>> cb = new FutureCallback<>();
         herder.tasksConfig(connector, cb);
         return completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks-config", "GET", headers, null, forward);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -432,4 +432,15 @@ public class StandaloneHerder extends AbstractHerder {
             return Objects.hash(seq);
         }
     }
+
+    @Override
+    public void tasksConfig(String connName, Callback<Map<ConnectorTaskId, Map<String, String>>> callback) {
+        Map<ConnectorTaskId, Map<String, String>> tasksConfig = buildTasksConfig(connName);
+        if (tasksConfig == null) {
+            callback.onCompletion(new NotFoundException("Connector " + connName + " not found"), null);
+            return;
+        }
+        callback.onCompletion(null, tasksConfig);
+    }
+
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -436,8 +436,8 @@ public class StandaloneHerder extends AbstractHerder {
     @Override
     public void tasksConfig(String connName, Callback<Map<ConnectorTaskId, Map<String, String>>> callback) {
         Map<ConnectorTaskId, Map<String, String>> tasksConfig = buildTasksConfig(connName);
-        if (tasksConfig == null) {
-            callback.onCompletion(new NotFoundException("Connector " + connName + " not found"), null);
+        if (tasksConfig.isEmpty()) {
+            callback.onCompletion(new NotFoundException("Connector " + connName + " not found"), tasksConfig);
             return;
         }
         callback.onCompletion(null, tasksConfig);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -520,6 +520,38 @@ public class ConnectorsResourceTest {
     }
 
     @Test
+    public void testGetTasksConfig() throws Throwable {
+
+        final Map<ConnectorTaskId, Map<String, String>> expectedTasksConfig = new HashMap<>();
+        final ConnectorTaskId task0 = new ConnectorTaskId(CONNECTOR_NAME, 0);
+        expectedTasksConfig.put(task0, Collections.singletonMap("sample_task_config", "task_config"));
+
+        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb = Capture.newInstance();
+        herder.tasksConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
+        expectAndCallbackResult(cb, expectedTasksConfig);
+
+        PowerMock.replayAll();
+
+        Map<ConnectorTaskId, Map<String, String>> tasksConfig = connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+        assertEquals(expectedTasksConfig, tasksConfig);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testGetTasksConfigConnectorNotFound() throws Throwable {
+        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb = Capture.newInstance();
+        herder.tasksConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
+        expectAndCallbackException(cb, new NotFoundException("not found"));
+
+        PowerMock.replayAll();
+
+        connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
     public void testPutConnectorConfig() throws Throwable {
         final Capture<Callback<Herder.Created<ConnectorInfo>>> cb = Capture.newInstance();
         herder.putConnectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(CONNECTOR_CONFIG), EasyMock.eq(true), EasyMock.capture(cb));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -521,19 +521,36 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testGetTasksConfig() throws Throwable {
+        final ConnectorTaskId connectorTask0 = new ConnectorTaskId(CONNECTOR_NAME, 0);
+        final Map<String, String> connectorTask0Configs = new HashMap<>();
+        connectorTask0Configs.put("connector-task0-config0", "123");
+        connectorTask0Configs.put("connector-task0-config1", "456");
+        final ConnectorTaskId connectorTask1 = new ConnectorTaskId(CONNECTOR_NAME, 1);
+        final Map<String, String> connectorTask1Configs = new HashMap<>();
+        connectorTask0Configs.put("connector-task1-config0", "321");
+        connectorTask0Configs.put("connector-task1-config1", "654");
+        final ConnectorTaskId connector2Task0 = new ConnectorTaskId(CONNECTOR2_NAME, 0);
+        final Map<String, String> connector2Task0Configs = Collections.singletonMap("connector2-task0-config0", "789");
 
-        final Map<ConnectorTaskId, Map<String, String>> expectedTasksConfig = new HashMap<>();
-        final ConnectorTaskId task0 = new ConnectorTaskId(CONNECTOR_NAME, 0);
-        expectedTasksConfig.put(task0, Collections.singletonMap("sample_task_config", "task_config"));
+        final Map<ConnectorTaskId, Map<String, String>> expectedTasksConnector = new HashMap<>();
+        expectedTasksConnector.put(connectorTask0, connectorTask0Configs);
+        expectedTasksConnector.put(connectorTask1, connectorTask1Configs);
+        final Map<ConnectorTaskId, Map<String, String>> expectedTasksConnector2 = new HashMap<>();
+        expectedTasksConnector2.put(connector2Task0, connector2Task0Configs);
 
-        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb = Capture.newInstance();
-        herder.tasksConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
-        expectAndCallbackResult(cb, expectedTasksConfig);
+        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb1 = Capture.newInstance();
+        herder.tasksConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb1));
+        expectAndCallbackResult(cb1, expectedTasksConnector);
+        final Capture<Callback<Map<ConnectorTaskId, Map<String, String>>>> cb2 = Capture.newInstance();
+        herder.tasksConfig(EasyMock.eq(CONNECTOR2_NAME), EasyMock.capture(cb2));
+        expectAndCallbackResult(cb2, expectedTasksConnector2);
 
         PowerMock.replayAll();
 
         Map<ConnectorTaskId, Map<String, String>> tasksConfig = connectorsResource.getTasksConfig(CONNECTOR_NAME, NULL_HEADERS, FORWARD);
-        assertEquals(expectedTasksConfig, tasksConfig);
+        assertEquals(expectedTasksConnector, tasksConfig);
+        Map<ConnectorTaskId, Map<String, String>> tasksConfig2 = connectorsResource.getTasksConfig(CONNECTOR2_NAME, NULL_HEADERS, FORWARD);
+        assertEquals(expectedTasksConnector2, tasksConfig2);
 
         PowerMock.verifyAll();
     }


### PR DESCRIPTION
This PR adds a new REST endpoint to Connect: `GET /{connector}/tasks-config`, that returns the configuration of all tasks for the connector.

This changes is for [KIP-661](https://cwiki.apache.org/confluence/display/KAFKA/KIP-661%3A+Expose+task+configurations+in+Connect+REST+API)

Co-authored-by: Mickael Maison <mickael.maison@gmail.com>
Co-authored-by: Oliver Dineen <dineeno@uk.ibm.com>



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
