### PR TITLE
[KAFKA-10417] Update Cogrouped processor to work with suppress() and joins

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -62,7 +62,8 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor = new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue());
+            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor =
+                new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue());
             parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
@@ -95,7 +96,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?>  parentProcessor = (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamWindowAggregate<K, K, VOut, W>(windows, storeBuilder.name(), initializer, kGroupedStream.getValue());
+            final KStreamAggProcessorSupplier<K, K, ?, ?>  parentProcessor =
+                (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamWindowAggregate<K, K, VOut, W>(
+                    windows,
+                    storeBuilder.name(),
+                    initializer,
+                    kGroupedStream.getValue());
             parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
@@ -128,7 +134,13 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor = (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSessionWindowAggregate<K, K, VOut>(sessionWindows, storeBuilder.name(), initializer, kGroupedStream.getValue(), sessionMerger);
+            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor =
+                (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSessionWindowAggregate<K, K, VOut>(
+                    sessionWindows,
+                    storeBuilder.name(),
+                    initializer,
+                    kGroupedStream.getValue(),
+                    sessionMerger);
             parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
@@ -160,7 +172,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
-            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor = (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSlidingWindowAggregate<K, K, VOut>(slidingWindows, storeBuilder.name(), initializer, kGroupedStream.getValue());
+            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor =
+                (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSlidingWindowAggregate<K, K, VOut>(
+                    slidingWindows,
+                    storeBuilder.name(),
+                    initializer,
+                    kGroupedStream.getValue());
             parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -219,7 +219,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             "-cogroup-merge",
             builder,
             CogroupedKStreamImpl.MERGE_NAME);
-        final KTableProcessorSupplier<K, VOut, VOut> passThrough = new KTablePassThrough<>(parentProcessors);
+        final KTableProcessorSupplier<K, VOut, VOut> passThrough = new KTablePassThrough<>(parentProcessors, queryableName);
         final ProcessorParameters<K, VOut, ?, ?> processorParameters = new ProcessorParameters(passThrough, mergeProcessorName);
         final ProcessorGraphNode<K, VOut> mergeNode =
             new ProcessorGraphNode<>(mergeProcessorName, processorParameters);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -48,6 +48,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
     CogroupedStreamAggregateBuilder(final InternalStreamsBuilder builder) {
         this.builder = builder;
     }
+    @SuppressWarnings("unchecked")
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
@@ -57,9 +58,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final String queryableName) {
         processRepartitions(groupPatterns, storeBuilder);
         final Collection<GraphNode> processors = new ArrayList<>();
+        final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
+            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor = new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue());
+            parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
                     "-cogroup-agg-" + counter++,
@@ -67,14 +71,15 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
                 storeBuilder,
-                new KStreamAggregate<>(storeBuilder.name(), initializer, kGroupedStream.getValue()));
+                parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
     }
 
+    @SuppressWarnings("unchecked")
     <KR, W extends Window> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                                   final Initializer<VOut> initializer,
                                                   final NamedInternal named,
@@ -86,9 +91,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
         processRepartitions(groupPatterns, storeBuilder);
 
         final Collection<GraphNode> processors = new ArrayList<>();
+        final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
+            final KStreamAggProcessorSupplier<K, K, ?, ?>  parentProcessor = (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamWindowAggregate<K, K, VOut, W>(windows, storeBuilder.name(), initializer, kGroupedStream.getValue());
+            parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
                     "-cogroup-agg-" + counter++,
@@ -96,14 +104,15 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
                 storeBuilder,
-                new KStreamWindowAggregate<>(windows, storeBuilder.name(), initializer, kGroupedStream.getValue()));
+                parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
     }
 
+    @SuppressWarnings("unchecked")
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
@@ -115,9 +124,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final Merger<? super K, VOut> sessionMerger) {
         processRepartitions(groupPatterns, storeBuilder);
         final Collection<GraphNode> processors = new ArrayList<>();
+        final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
+            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor = (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSessionWindowAggregate<K, K, VOut>(sessionWindows, storeBuilder.name(), initializer, kGroupedStream.getValue(), sessionMerger);
+            parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
                     "-cogroup-agg-" + counter++,
@@ -125,14 +137,15 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
                 storeBuilder,
-                new KStreamSessionWindowAggregate<>(sessionWindows, storeBuilder.name(), initializer, kGroupedStream.getValue(), sessionMerger));
+                parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
     }
 
+    @SuppressWarnings("unchecked")
     <KR> KTable<KR, VOut> build(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
                                 final Initializer<VOut> initializer,
                                 final NamedInternal named,
@@ -142,10 +155,13 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                 final String queryableName,
                                 final SlidingWindows slidingWindows) {
         processRepartitions(groupPatterns, storeBuilder);
+        final Collection<KStreamAggProcessorSupplier> parentProcessors = new ArrayList<>();
         final Collection<GraphNode> processors = new ArrayList<>();
         boolean stateCreated = false;
         int counter = 0;
         for (final Entry<KGroupedStreamImpl<K, ?>, Aggregator<? super K, Object, VOut>> kGroupedStream : groupPatterns.entrySet()) {
+            final KStreamAggProcessorSupplier<K, K, ?, ?> parentProcessor = (KStreamAggProcessorSupplier<K, K, ?, ?>) new KStreamSlidingWindowAggregate<K, K, VOut>(slidingWindows, storeBuilder.name(), initializer, kGroupedStream.getValue());
+            parentProcessors.add(parentProcessor);
             final StatefulProcessorNode<K, ?> statefulProcessorNode = getStatefulProcessorNode(
                 named.suffixWithOrElseGet(
                     "-cogroup-agg-" + counter++,
@@ -153,12 +169,12 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                     CogroupedKStreamImpl.AGGREGATE_NAME),
                 stateCreated,
                 storeBuilder,
-                new KStreamSlidingWindowAggregate<>(slidingWindows, storeBuilder.name(), initializer, kGroupedStream.getValue()));
+                parentProcessor);
             stateCreated = true;
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
     }
 
     private void processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
@@ -191,7 +207,9 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
 
     }
 
+    @SuppressWarnings("unchecked")
     <KR, VIn> KTable<KR, VOut> createTable(final Collection<GraphNode> processors,
+                                           final Collection<KStreamAggProcessorSupplier> parentProcessors,
                                            final NamedInternal named,
                                            final Serde<KR> keySerde,
                                            final Serde<VOut> valueSerde,
@@ -201,9 +219,10 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             "-cogroup-merge",
             builder,
             CogroupedKStreamImpl.MERGE_NAME);
-        final ProcessorSupplier<K, VOut> passThrough = new PassThrough<>();
+        final KTableProcessorSupplier<K, VOut, VOut> passThrough = new KTablePassThrough<>(parentProcessors);
+        final ProcessorParameters<K, VOut, ?, ?> processorParameters = new ProcessorParameters(passThrough, mergeProcessorName);
         final ProcessorGraphNode<K, VOut> mergeNode =
-            new ProcessorGraphNode<>(mergeProcessorName, new ProcessorParameters<>(passThrough, mergeProcessorName));
+            new ProcessorGraphNode<>(mergeProcessorName, processorParameters);
 
         builder.addGraphNode(processors, mergeNode);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/CogroupedStreamAggregateBuilder.java
@@ -77,7 +77,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
     }
 
     @SuppressWarnings("unchecked")
@@ -115,7 +115,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
     }
 
     @SuppressWarnings("unchecked")
@@ -154,7 +154,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
     }
 
     @SuppressWarnings("unchecked")
@@ -191,7 +191,7 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
             processors.add(statefulProcessorNode);
             builder.addGraphNode(parentNodes.get(kGroupedStream.getKey()), statefulProcessorNode);
         }
-        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName);
+        return createTable(processors, parentProcessors, named, keySerde, valueSerde, queryableName, storeBuilder.name());
     }
 
     private void processRepartitions(final Map<KGroupedStreamImpl<K, ?>, Aggregator<? super K, ? super Object, VOut>> groupPatterns,
@@ -230,13 +230,14 @@ class CogroupedStreamAggregateBuilder<K, VOut> {
                                            final NamedInternal named,
                                            final Serde<KR> keySerde,
                                            final Serde<VOut> valueSerde,
-                                           final String queryableName) {
+                                           final String queryableName,
+                                           final String storeName) {
 
         final String mergeProcessorName = named.suffixWithOrElseGet(
             "-cogroup-merge",
             builder,
             CogroupedKStreamImpl.MERGE_NAME);
-        final KTableProcessorSupplier<K, VOut, VOut> passThrough = new KTablePassThrough<>(parentProcessors, queryableName);
+        final KTableProcessorSupplier<K, VOut, VOut> passThrough = new KTablePassThrough<>(parentProcessors, storeName);
         final ProcessorParameters<K, VOut, ?, ?> processorParameters = new ProcessorParameters(passThrough, mergeProcessorName);
         final ProcessorGraphNode<K, VOut> mergeNode =
             new ProcessorGraphNode<>(mergeProcessorName, processorParameters);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+
+import java.util.Collection;
+
+public class KTablePassThrough<K, V> implements KTableProcessorSupplier<K, V, V> {
+    private final Collection<KStreamAggProcessorSupplier> parents;
+
+    KTablePassThrough(final Collection<KStreamAggProcessorSupplier> parents) {
+        this.parents = parents;
+    }
+
+    @Override
+    public Processor<K, Change<V>> get() {
+        return new KTablePassThroughProcessor<>();
+    }
+
+    @Override
+    public boolean enableSendingOldValues(final boolean forceMaterialization) {
+        for (final KStreamAggProcessorSupplier parent : parents) {
+            parent.enableSendingOldValues();
+        }
+        return true;
+    }
+
+    @Override
+    public KTableValueGetterSupplier<K, V> view() {
+
+        return new KTableValueGetterSupplier<K, V>() {
+
+            public KTableValueGetter<K, V> get() {
+                return new KTablePassThroughValueGetter();
+            }
+
+            @Override
+            public String[] storeNames() {
+                return new String[2];
+            }
+        };
+    }
+
+    private static final class KTablePassThroughProcessor<K, V> extends AbstractProcessor<K, V> {
+        @Override
+        public void process(final K key, final V value) {
+            context().forward(key, value);
+        }
+    }
+
+    private class KTablePassThroughValueGetter implements KTableValueGetter<K, V> {
+        //private final KTableValueGetter<K, V> parentGetter;
+        private final ValueAndTimestamp<V> timestamp = ValueAndTimestamp.make(null, 50L);
+
+        KTablePassThroughValueGetter() {
+        }
+
+        @Override
+        public void init(final ProcessorContext context) {
+            //parentGetter.init(context);
+        }
+
+        @Override
+        public ValueAndTimestamp<V> get(final K key) {
+            //return parentGetter.get(key);
+            return timestamp;
+        }
+
+        @Override
+        public void close() {
+            //parentGetter.close();
+        }
+
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
@@ -41,6 +41,7 @@ public class KTablePassThrough<K, V> implements KTableProcessorSupplier<K, V, V>
 
     @Override
     public boolean enableSendingOldValues(final boolean forceMaterialization) {
+        // We require sending old values for joins and suppression, will always be materialized
         for (final KStreamAggProcessorSupplier parent : parents) {
             parent.enableSendingOldValues();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTablePassThrough.java
@@ -41,7 +41,7 @@ public class KTablePassThrough<K, V> implements KTableProcessorSupplier<K, V, V>
 
     @Override
     public boolean enableSendingOldValues(final boolean forceMaterialization) {
-        // We require sending old values for joins and suppression, will always be materialized
+        // Aggregation requires materialization so we will always enable sending old values
         for (final KStreamAggProcessorSupplier parent : parents) {
             parent.enableSendingOldValues();
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -51,6 +52,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
+import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -1199,6 +1201,46 @@ public class CogroupedKStreamImplTest {
             assertOutputKeyValueTimestamp(testOutputTopic, "k1", "AABB", 500);
             assertOutputKeyValueTimestamp(testOutputTopic, "k2", "AABBBB", 500);
             assertOutputKeyValueTimestamp(testOutputTopic, "k3", "B", 500);
+        }
+    }
+
+    @Test
+    public void testCogroupWithKTableKTableInnerJoin() {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KGroupedStream<String, String> grouped1 = builder.stream("one", stringConsumed).groupByKey();
+        final KGroupedStream<String, String> grouped2 = builder.stream("two", stringConsumed).groupByKey();
+
+        final KTable<String, String> table1 = grouped1
+            .cogroup(STRING_AGGREGATOR)
+            .cogroup(grouped2, STRING_AGGREGATOR)
+            .aggregate(STRING_INITIALIZER, Named.as("name"), Materialized.as("store"));
+
+        final KTable<String, String> table2 = builder.table("three", stringConsumed);
+        final KTable<String, String> joined = table1.join(table2, MockValueJoiner.TOSTRING_JOINER, Materialized.with(Serdes.String(), Serdes.String()));
+        joined.toStream().to(OUTPUT);
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<String, String> testInputTopic =
+                driver.createInputTopic("one", new StringSerializer(), new StringSerializer());
+            final TestInputTopic<String, String> testInputTopic2 =
+                driver.createInputTopic("two", new StringSerializer(), new StringSerializer());
+            final TestInputTopic<String, String> testInputTopic3 =
+                driver.createInputTopic("three", new StringSerializer(), new StringSerializer());
+            final TestOutputTopic<String, String> testOutputTopic =
+                driver.createOutputTopic(OUTPUT, new StringDeserializer(), new StringDeserializer());
+
+            testInputTopic.pipeInput("k1", "A", 5L);
+            testInputTopic2.pipeInput("k2", "B", 6L);
+
+            assertTrue(testOutputTopic.isEmpty());
+
+            testInputTopic3.pipeInput("k1", "C", 0L);
+            testInputTopic3.pipeInput("k2", "D", 10L);
+
+            assertOutputKeyValueTimestamp(testOutputTopic, "k1", "A+C", 5L);
+            assertOutputKeyValueTimestamp(testOutputTopic, "k2", "B+D", 10L);
+            assertTrue(testOutputTopic.isEmpty());
         }
     }
 


### PR DESCRIPTION
Changes the cogrouped processor from `PassThrough` to `KTablePassThrough` to allow for sending old values. `KTablePassThrough` extends `KTableProcessorSupplier` instead of `ProcessorSupplier` to implement sending old values and the `view()` method.