### PR TITLE
KAFKA-10842; Use `InterBrokerSendThread` for raft's outbound network channel

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -28,7 +28,7 @@
     <suppress id="dontUseSystemExit"
               files="Exit.java"/>
     <suppress checks="ClassFanOutComplexity"
-              files="(Fetcher|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|KafkaProducer|Utils|TransactionManager|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin|KafkaRaftClient|KafkaRaftClientTest).java"/>
+              files="(Fetcher|Sender|SenderTest|ConsumerCoordinator|KafkaConsumer|KafkaProducer|Utils|TransactionManager|TransactionManagerTest|KafkaAdminClient|NetworkClient|Admin|KafkaRaftClient|KafkaRaftClientTest|RaftClientTestContext).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="(SaslServerAuthenticator|SaslAuthenticatorTest).java"/>
     <suppress checks="ClassFanOutComplexity"

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.SendBuilder;
@@ -101,8 +100,6 @@ public abstract class AbstractRequest implements AbstractRequestResponse {
     public final Send toSend(RequestHeader header) {
         return SendBuilder.buildRequestSend(header, data());
     }
-
-    public abstract Message data();
 
     // Visible for testing
     public final ByteBuffer serialize() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequestResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequestResponse.java
@@ -16,4 +16,9 @@
  */
 package org.apache.kafka.common.requests;
 
-public interface AbstractRequestResponse { }
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public interface AbstractRequestResponse {
+
+    ApiMessage data();
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.SendBuilder;
 
@@ -89,8 +88,6 @@ public abstract class AbstractResponse implements AbstractRequestResponse {
         Integer count = errorCounts.getOrDefault(error, 0);
         errorCounts.put(error, count + 1);
     }
-
-    protected abstract Message data();
 
     /**
      * Parse a response from the provided buffer. The buffer is expected to hold both

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -55,12 +55,12 @@ import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.LogDirNotFoundException;
-import org.apache.kafka.common.errors.ThrottlingQuotaExceededException;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.ThrottlingQuotaExceededException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
@@ -75,9 +75,9 @@ import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterRepl
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirTopicResult;
 import org.apache.kafka.common.message.AlterUserScramCredentialsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.CreateAclsResponseData;
 import org.apache.kafka.common.message.CreatePartitionsResponseData;
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
-import org.apache.kafka.common.message.CreateAclsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResultCollection;
@@ -108,16 +108,16 @@ import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
-import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponsePartition;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponsePartitionCollection;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponseTopic;
 import org.apache.kafka.common.message.OffsetDeleteResponseData.OffsetDeleteResponseTopicCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.quota.ClientQuotaFilter;
@@ -4937,7 +4937,7 @@ public class KafkaAdminClientTest {
             }
 
             @Override
-            protected Message data() {
+            public ApiMessage data() {
                 return null;
             }
 

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -54,7 +54,11 @@ class InterBrokerSendThread(
   }
 
   def sendRequest(request: RequestAndCompletionHandler): Unit = {
-    inboundQueue.offer(request)
+    sendRequests(Seq(request))
+  }
+
+  def sendRequests(requests: Iterable[RequestAndCompletionHandler]): Unit = {
+    inboundQueue.addAll(requests.asJavaCollection)
     wakeup()
   }
 

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -17,7 +17,6 @@
 package kafka.common
 
 import java.util.Map.Entry
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.{ArrayDeque, ArrayList, Collection, Collections, HashMap, Iterator}
 
 import kafka.utils.ShutdownableThread
@@ -33,7 +32,7 @@ import scala.jdk.CollectionConverters._
 /**
  *  Class for inter-broker send thread that utilize a non-blocking network client.
  */
-class InterBrokerSendThread(
+abstract class InterBrokerSendThread(
   name: String,
   networkClient: KafkaClient,
   requestTimeoutMs: Int,
@@ -41,8 +40,9 @@ class InterBrokerSendThread(
   isInterruptible: Boolean = true
 ) extends ShutdownableThread(name, isInterruptible) {
 
-  private val inboundQueue = new ConcurrentLinkedQueue[RequestAndCompletionHandler]()
   private val unsentRequests = new UnsentRequests
+
+  def generateRequests(): Iterable[RequestAndCompletionHandler]
 
   def hasUnsentRequests: Boolean = unsentRequests.iterator().hasNext
 
@@ -53,35 +53,25 @@ class InterBrokerSendThread(
     awaitShutdown()
   }
 
-  def sendRequest(request: RequestAndCompletionHandler): Unit = {
-    sendRequests(Seq(request))
-  }
-
-  def sendRequests(requests: Iterable[RequestAndCompletionHandler]): Unit = {
-    inboundQueue.addAll(requests.asJavaCollection)
-    wakeup()
-  }
-
-  private def drainInboundQueue(): Unit = {
-    while (!inboundQueue.isEmpty) {
-      val request = inboundQueue.poll()
-      val completionHandler = request.handler
+  private def drainGeneratedRequests(): Unit = {
+    generateRequests().foreach { request =>
       unsentRequests.put(request.destination,
         networkClient.newClientRequest(
           request.destination.idString,
           request.request,
-          time.milliseconds(),
+          request.creationTimeMs,
           true,
           requestTimeoutMs,
-          completionHandler))
+          request.handler
+        ))
     }
   }
 
-  override def doWork(): Unit = {
+  protected def pollOnce(maxTimeoutMs: Long): Unit = {
     try {
+      drainGeneratedRequests()
       var now = time.milliseconds()
-      drainInboundQueue()
-      val timeout = sendRequests(now)
+      val timeout = sendRequests(now, maxTimeoutMs)
       networkClient.poll(timeout, now)
       now = time.milliseconds()
       checkDisconnects(now)
@@ -99,8 +89,12 @@ class InterBrokerSendThread(
     }
   }
 
-  private def sendRequests(now: Long): Long = {
-    var pollTimeout = Long.MaxValue
+  override def doWork(): Unit = {
+    pollOnce(Long.MaxValue)
+  }
+
+  private def sendRequests(now: Long, maxTimeoutMs: Long): Long = {
+    var pollTimeout = maxTimeoutMs
     for (node <- unsentRequests.nodes.asScala) {
       val requestIterator = unsentRequests.requestIterator(node)
       while (requestIterator.hasNext) {
@@ -157,9 +151,12 @@ class InterBrokerSendThread(
   def wakeup(): Unit = networkClient.wakeup()
 }
 
-case class RequestAndCompletionHandler(destination: Node,
-                                       request: AbstractRequest.Builder[_ <: AbstractRequest],
-                                       handler: RequestCompletionHandler)
+case class RequestAndCompletionHandler(
+  creationTimeMs: Long,
+  destination: Node,
+  request: AbstractRequest.Builder[_ <: AbstractRequest],
+  handler: RequestCompletionHandler
+)
 
 private class UnsentRequests {
   private val unsent = new HashMap[Node, ArrayDeque[ClientRequest]]

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -16,8 +16,9 @@
  */
 package kafka.common
 
-import java.util.{ArrayDeque, ArrayList, Collection, Collections, HashMap, Iterator}
 import java.util.Map.Entry
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.{ArrayDeque, ArrayList, Collection, Collections, HashMap, Iterator}
 
 import kafka.utils.ShutdownableThread
 import org.apache.kafka.clients.{ClientRequest, ClientResponse, KafkaClient, RequestCompletionHandler}
@@ -32,17 +33,18 @@ import scala.jdk.CollectionConverters._
 /**
  *  Class for inter-broker send thread that utilize a non-blocking network client.
  */
-abstract class InterBrokerSendThread(name: String,
-                                     networkClient: KafkaClient,
-                                     time: Time,
-                                     isInterruptible: Boolean = true)
-  extends ShutdownableThread(name, isInterruptible) {
+class InterBrokerSendThread(
+  name: String,
+  networkClient: KafkaClient,
+  requestTimeoutMs: Int,
+  time: Time,
+  isInterruptible: Boolean = true
+) extends ShutdownableThread(name, isInterruptible) {
 
-  def generateRequests(): Iterable[RequestAndCompletionHandler]
-  def requestTimeoutMs: Int
+  private val inboundQueue = new ConcurrentLinkedQueue[RequestAndCompletionHandler]()
   private val unsentRequests = new UnsentRequests
 
-  def hasUnsentRequests = unsentRequests.iterator().hasNext
+  def hasUnsentRequests: Boolean = unsentRequests.iterator().hasNext
 
   override def shutdown(): Unit = {
     initiateShutdown()
@@ -51,22 +53,30 @@ abstract class InterBrokerSendThread(name: String,
     awaitShutdown()
   }
 
-  override def doWork(): Unit = {
-    var now = time.milliseconds()
+  def sendRequest(request: RequestAndCompletionHandler): Unit = {
+    inboundQueue.offer(request)
+    wakeup()
+  }
 
-    generateRequests().foreach { request =>
+  private def drainInboundQueue(): Unit = {
+    while (!inboundQueue.isEmpty) {
+      val request = inboundQueue.poll()
       val completionHandler = request.handler
       unsentRequests.put(request.destination,
         networkClient.newClientRequest(
           request.destination.idString,
           request.request,
-          now,
+          time.milliseconds(),
           true,
           requestTimeoutMs,
           completionHandler))
     }
+  }
 
+  override def doWork(): Unit = {
     try {
+      var now = time.milliseconds()
+      drainInboundQueue()
       val timeout = sendRequests(now)
       networkClient.poll(timeout, now)
       now = time.milliseconds()
@@ -198,5 +208,5 @@ private class UnsentRequests {
       requests.iterator
   }
 
-  def nodes = unsent.keySet
+  def nodes: java.util.Set[Node] = unsent.keySet
 }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -127,11 +127,14 @@ class TxnMarkerQueue(@volatile var destination: Node) {
   def totalNumMarkers(txnTopicPartition: Int): Int = markersPerTxnTopicPartition.get(txnTopicPartition).fold(0)(_.size)
 }
 
-class TransactionMarkerChannelManager(config: KafkaConfig,
-                                      metadataCache: MetadataCache,
-                                      networkClient: NetworkClient,
-                                      txnStateManager: TransactionStateManager,
-                                      time: Time) extends InterBrokerSendThread("TxnMarkerSenderThread-" + config.brokerId, networkClient, time) with Logging with KafkaMetricsGroup {
+class TransactionMarkerChannelManager(
+  config: KafkaConfig,
+  metadataCache: MetadataCache,
+  networkClient: NetworkClient,
+  txnStateManager: TransactionStateManager,
+  time: Time
+) extends InterBrokerSendThread("TxnMarkerSenderThread-" + config.brokerId, networkClient, config.requestTimeoutMs, time)
+  with Logging with KafkaMetricsGroup {
 
   this.logIdent = "[Transaction Marker Channel Manager " + config.brokerId + "]: "
 
@@ -145,8 +148,6 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
 
   private val transactionsWithPendingMarkers = new ConcurrentHashMap[String, PendingCompleteTxn]
 
-  override val requestTimeoutMs: Int = config.requestTimeoutMs
-
   val writeTxnMarkersRequestVersion: Short =
     if (config.interBrokerProtocolVersion >= KAFKA_2_8_IV0) 1
     else 0
@@ -154,7 +155,10 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
   newGauge("UnknownDestinationQueueSize", () => markersQueueForUnknownBroker.totalNumMarkers)
   newGauge("LogAppendRetryQueueSize", () => txnLogAppendRetryQueue.size)
 
-  override def generateRequests() = drainQueuedTransactionMarkers()
+  override def doWork(): Unit = {
+    drainQueuedTransactionMarkers().foreach(super.sendRequest)
+    super.doWork()
+  }
 
   override def shutdown(): Unit = {
     super.shutdown()

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -156,7 +156,7 @@ class TransactionMarkerChannelManager(
   newGauge("LogAppendRetryQueueSize", () => txnLogAppendRetryQueue.size)
 
   override def doWork(): Unit = {
-    drainQueuedTransactionMarkers().foreach(super.sendRequest)
+    super.sendRequests(drainQueuedTransactionMarkers())
     super.doWork()
   }
 

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -17,38 +17,21 @@
 package kafka.raft
 
 import java.net.InetSocketAddress
-import java.util
-import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.atomic.AtomicInteger
 
+import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.utils.Logging
-import org.apache.kafka.clients.{ClientRequest, ClientResponse, KafkaClient}
+import org.apache.kafka.clients.{ClientResponse, KafkaClient}
+import org.apache.kafka.common.Node
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.{KafkaException, Node}
-import org.apache.kafka.raft.{NetworkChannel, RaftMessage, RaftRequest, RaftResponse, RaftUtil}
+import org.apache.kafka.raft.{NetworkChannel, RaftRequest, RaftResponse, RaftUtil}
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
 
 object KafkaNetworkChannel {
-
-  private[raft] def buildResponse(responseData: ApiMessage): AbstractResponse = {
-    responseData match {
-      case voteResponse: VoteResponseData =>
-        new VoteResponse(voteResponse)
-      case beginEpochResponse: BeginQuorumEpochResponseData =>
-        new BeginQuorumEpochResponse(beginEpochResponse)
-      case endEpochResponse: EndQuorumEpochResponseData =>
-        new EndQuorumEpochResponse(endEpochResponse)
-      case fetchResponse: FetchResponseData =>
-        new FetchResponse(fetchResponse)
-      case _ =>
-        throw new IllegalArgumentException(s"Unexpected type for responseData: $responseData")
-    }
-  }
 
   private[raft] def buildRequest(requestData: ApiMessage): AbstractRequest.Builder[_ <: AbstractRequest] = {
     requestData match {
@@ -68,161 +51,76 @@ object KafkaNetworkChannel {
     }
   }
 
-  private[raft] def responseData(response: AbstractResponse): ApiMessage = {
-    response match {
-      case voteResponse: VoteResponse => voteResponse.data
-      case beginEpochResponse: BeginQuorumEpochResponse => beginEpochResponse.data
-      case endEpochResponse: EndQuorumEpochResponse => endEpochResponse.data
-      case fetchResponse: FetchResponse[_] => fetchResponse.data
-      case _ => throw new IllegalArgumentException(s"Unexpected type for response: $response")
-    }
-  }
-
-  private[raft] def requestData(request: AbstractRequest): ApiMessage = {
-    request match {
-      case voteRequest: VoteRequest => voteRequest.data
-      case beginEpochRequest: BeginQuorumEpochRequest => beginEpochRequest.data
-      case endEpochRequest: EndQuorumEpochRequest => endEpochRequest.data
-      case fetchRequest: FetchRequest => fetchRequest.data
-      case _ => throw new IllegalArgumentException(s"Unexpected type for request: $request")
-    }
-  }
-
 }
 
-class KafkaNetworkChannel(time: Time,
-                          client: KafkaClient,
-                          clientId: String,
-                          retryBackoffMs: Int,
-                          requestTimeoutMs: Int) extends NetworkChannel with Logging {
+class KafkaNetworkChannel(
+  time: Time,
+  client: KafkaClient,
+  requestTimeoutMs: Int
+) extends NetworkChannel with Logging {
   import KafkaNetworkChannel._
 
   type ResponseHandler = AbstractResponse => Unit
 
   private val correlationIdCounter = new AtomicInteger(0)
-  private val pendingInbound = mutable.Map.empty[Long, ResponseHandler]
-  private val undelivered = new ArrayBlockingQueue[RaftMessage](10)
-  private val pendingOutbound = new ArrayBlockingQueue[RaftRequest.Outbound](10)
   private val endpoints = mutable.HashMap.empty[Int, Node]
 
-  override def newCorrelationId(): Int = correlationIdCounter.getAndIncrement()
+  private val requestThread = new InterBrokerSendThread(
+    name = "raft-outbound-request-thread",
+    networkClient = client,
+    requestTimeoutMs = requestTimeoutMs,
+    time = time,
+    isInterruptible = false
+  )
 
-  private def buildClientRequest(req: RaftRequest.Outbound): ClientRequest = {
-    val destination = req.destinationId.toString
-    val request = buildRequest(req.data)
-    val correlationId = req.correlationId
-    val createdTimeMs = req.createdTimeMs
-    new ClientRequest(destination, request, correlationId, clientId, createdTimeMs, true,
-      requestTimeoutMs, null)
-  }
-
-  override def send(message: RaftMessage): Unit = {
-    message match {
-      case request: RaftRequest.Outbound =>
-        if (!pendingOutbound.offer(request))
-          throw new KafkaException("Pending outbound queue is full")
-
-      case response: RaftResponse.Outbound =>
-        pendingInbound.remove(response.correlationId).foreach { onResponseReceived: ResponseHandler =>
-          onResponseReceived(buildResponse(response.data))
-        }
-      case _ =>
-        throw new IllegalArgumentException("Unhandled message type " + message)
+  override def send(request: RaftRequest.Outbound): Unit = {
+    def completeFuture(message: ApiMessage): Unit = {
+      val response = new RaftResponse.Inbound(
+        request.correlationId,
+        message,
+        request.destinationId
+      )
+      request.completion.complete(response)
     }
-  }
 
-  private def sendOutboundRequests(currentTimeMs: Long): Unit = {
-    while (!pendingOutbound.isEmpty) {
-      val request = pendingOutbound.peek()
-      endpoints.get(request.destinationId) match {
-        case Some(node) =>
-          if (client.connectionFailed(node)) {
-            pendingOutbound.poll()
-            val apiKey = ApiKeys.forId(request.data.apiKey)
-            val disconnectResponse = RaftUtil.errorResponse(apiKey, Errors.BROKER_NOT_AVAILABLE)
-            val success = undelivered.offer(new RaftResponse.Inbound(
-              request.correlationId, disconnectResponse, request.destinationId))
-            if (!success) {
-              throw new KafkaException("Undelivered queue is full")
-            }
-
-            // Make sure to reset the connection state
-            client.ready(node, currentTimeMs)
-          } else if (client.ready(node, currentTimeMs)) {
-            pendingOutbound.poll()
-            val clientRequest = buildClientRequest(request)
-            client.send(clientRequest, currentTimeMs)
-          } else {
-            // We will retry this request on the next poll
-            return
-          }
-
-        case None =>
-          pendingOutbound.poll()
-          val apiKey = ApiKeys.forId(request.data.apiKey)
-          val responseData = RaftUtil.errorResponse(apiKey, Errors.BROKER_NOT_AVAILABLE)
-          val response = new RaftResponse.Inbound(request.correlationId, responseData, request.destinationId)
-          if (!undelivered.offer(response))
-            throw new KafkaException("Undelivered queue is full")
+    def onComplete(clientResponse: ClientResponse): Unit = {
+      val response = if (clientResponse.authenticationException != null) {
+        errorResponse(request.data, Errors.CLUSTER_AUTHORIZATION_FAILED)
+      } else if (clientResponse.wasDisconnected()) {
+        errorResponse(request.data, Errors.BROKER_NOT_AVAILABLE)
+      } else {
+        clientResponse.responseBody.data
       }
+      completeFuture(response)
+    }
+
+    endpoints.get(request.destinationId) match {
+      case Some(node) =>
+        requestThread.sendRequest(RequestAndCompletionHandler(
+          destination = node,
+          request = buildRequest(request.data),
+          handler = onComplete
+        ))
+
+      case None =>
+        completeFuture(errorResponse(request.data, Errors.BROKER_NOT_AVAILABLE))
     }
   }
 
-  def getConnectionInfo(nodeId: Int): Node = {
-    if (!endpoints.contains(nodeId))
-      null
-    else
-      endpoints(nodeId)
+  def pollOnce(): Unit = {
+    requestThread.doWork()
   }
 
-  def allConnections(): Set[Node] = {
-    endpoints.values.toSet
+  override def newCorrelationId(): Int = {
+    correlationIdCounter.getAndIncrement()
   }
 
-  private def buildInboundRaftResponse(response: ClientResponse): RaftResponse.Inbound = {
-    val header = response.requestHeader()
-    val data = if (response.authenticationException != null) {
-      RaftUtil.errorResponse(header.apiKey, Errors.CLUSTER_AUTHORIZATION_FAILED)
-    } else if (response.wasDisconnected) {
-      RaftUtil.errorResponse(header.apiKey, Errors.BROKER_NOT_AVAILABLE)
-    } else {
-      responseData(response.responseBody)
-    }
-    new RaftResponse.Inbound(header.correlationId, data, response.destination.toInt)
-  }
-
-  private def pollInboundResponses(timeoutMs: Long, inboundMessages: util.List[RaftMessage]): Unit = {
-    val responses = client.poll(timeoutMs, time.milliseconds())
-    for (response <- responses.asScala) {
-      inboundMessages.add(buildInboundRaftResponse(response))
-    }
-  }
-
-  private def drainInboundRequests(inboundMessages: util.List[RaftMessage]): Unit = {
-    undelivered.drainTo(inboundMessages)
-  }
-
-  private def pollInboundMessages(timeoutMs: Long): util.List[RaftMessage] = {
-    val pollTimeoutMs = if (!undelivered.isEmpty) {
-      0L
-    } else if (!pendingOutbound.isEmpty) {
-      retryBackoffMs
-    } else {
-      timeoutMs
-    }
-    val messages = new util.ArrayList[RaftMessage]
-    pollInboundResponses(pollTimeoutMs, messages)
-    drainInboundRequests(messages)
-    messages
-  }
-
-  override def receive(timeoutMs: Long): util.List[RaftMessage] = {
-    sendOutboundRequests(time.milliseconds())
-    pollInboundMessages(timeoutMs)
-  }
-
-  override def wakeup(): Unit = {
-    client.wakeup()
+  private def errorResponse(
+    request: ApiMessage,
+    error: Errors
+  ): ApiMessage = {
+    val apiKey = ApiKeys.forId(request.apiKey)
+    RaftUtil.errorResponse(apiKey, error)
   }
 
   override def updateEndpoint(id: Int, address: InetSocketAddress): Unit = {
@@ -230,17 +128,16 @@ class KafkaNetworkChannel(time: Time,
     endpoints.put(id, node)
   }
 
-  def postInboundRequest(request: AbstractRequest, onResponseReceived: ResponseHandler): Unit = {
-    val data = requestData(request)
-    val correlationId = newCorrelationId()
-    val req = new RaftRequest.Inbound(correlationId, data, time.milliseconds())
-    pendingInbound.put(correlationId, onResponseReceived)
-    if (!undelivered.offer(req))
-      throw new KafkaException("Undelivered queue is full")
-    wakeup()
+  def start(): Unit = {
+    requestThread.start()
+  }
+
+  def initiateShutdown(): Unit = {
+    requestThread.initiateShutdown()
   }
 
   override def close(): Unit = {
+    requestThread.shutdown()
     client.close()
   }
 

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -17,6 +17,7 @@
 package kafka.raft
 
 import java.net.InetSocketAddress
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
@@ -53,6 +54,41 @@ object KafkaNetworkChannel {
 
 }
 
+private[raft] class RaftSendThread(
+  name: String,
+  networkClient: KafkaClient,
+  requestTimeoutMs: Int,
+  time: Time,
+  isInterruptible: Boolean = true
+) extends InterBrokerSendThread(
+  name,
+  networkClient,
+  requestTimeoutMs,
+  time,
+  isInterruptible
+) {
+  private val queue = new ConcurrentLinkedQueue[RequestAndCompletionHandler]()
+
+  def generateRequests(): Iterable[RequestAndCompletionHandler] = {
+    val buffer =  mutable.Buffer[RequestAndCompletionHandler]()
+    while (true) {
+      val request = queue.poll()
+      if (request == null) {
+        return buffer
+      } else {
+        buffer += request
+      }
+    }
+    buffer
+  }
+
+  def sendRequest(request: RequestAndCompletionHandler): Unit = {
+    queue.add(request)
+  }
+
+}
+
+
 class KafkaNetworkChannel(
   time: Time,
   client: KafkaClient,
@@ -65,7 +101,7 @@ class KafkaNetworkChannel(
   private val correlationIdCounter = new AtomicInteger(0)
   private val endpoints = mutable.HashMap.empty[Int, Node]
 
-  private val requestThread = new InterBrokerSendThread(
+  private val requestThread = new RaftSendThread(
     name = "raft-outbound-request-thread",
     networkClient = client,
     requestTimeoutMs = requestTimeoutMs,
@@ -97,6 +133,7 @@ class KafkaNetworkChannel(
     endpoints.get(request.destinationId) match {
       case Some(node) =>
         requestThread.sendRequest(RequestAndCompletionHandler(
+          request.createdTimeMs,
           destination = node,
           request = buildRequest(request.data),
           handler = onComplete
@@ -107,7 +144,8 @@ class KafkaNetworkChannel(
     }
   }
 
-  def pollOnce(): Unit = {
+  // Visible for testing
+  private[raft] def pollOnce(): Unit = {
     requestThread.doWork()
   }
 

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -168,6 +168,7 @@ class DefaultAlterIsrManager(
       new ControllerRequestCompletionHandler {
         override def onComplete(response: ClientResponse): Unit = {
           try {
+            debug(s"Received AlterIsr response $response")
             val body = response.responseBody().asInstanceOf[AlterIsrResponse]
             handleAlterIsrResponse(body, message.brokerEpoch, inflightAlterIsrItems)
           } finally {

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -22,11 +22,12 @@ import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import kafka.api.LeaderAndIsr
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{Logging, Scheduler}
+import kafka.utils.{KafkaScheduler, Logging, Scheduler}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.{AlterIsrRequestData, AlterIsrResponseData}
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AlterIsrRequest, AlterIsrResponse}
 import org.apache.kafka.common.utils.Time
@@ -44,7 +45,9 @@ import scala.jdk.CollectionConverters._
  * requests.
  */
 trait AlterIsrManager {
-  def start(): Unit
+  def start(): Unit = {}
+
+  def shutdown(): Unit = {}
 
   def submit(alterIsrItem: AlterIsrItem): Boolean
 
@@ -57,30 +60,57 @@ case class AlterIsrItem(topicPartition: TopicPartition,
                         controllerEpoch: Int) // controllerEpoch needed for Zk impl
 
 object AlterIsrManager {
+
   /**
    * Factory to AlterIsr based implementation, used when IBP >= 2.7-IV2
    */
-  def apply(controllerChannelManager: BrokerToControllerChannelManager,
-            scheduler: Scheduler,
-            time: Time,
-            brokerId: Int,
-            brokerEpochSupplier: () => Long): AlterIsrManager = {
-    new DefaultAlterIsrManager(controllerChannelManager, scheduler, time, brokerId, brokerEpochSupplier)
+  def apply(
+    config: KafkaConfig,
+    metadataCache: MetadataCache,
+    scheduler: KafkaScheduler,
+    time: Time,
+    metrics: Metrics,
+    threadNamePrefix: Option[String],
+    brokerEpochSupplier: () => Long
+  ): AlterIsrManager = {
+    val channelManager = new BrokerToControllerChannelManager(
+      metadataCache = metadataCache,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = "forwardingChannel",
+      threadNamePrefix = threadNamePrefix,
+      retryTimeoutMs = Long.MaxValue
+    )
+    new DefaultAlterIsrManager(
+      controllerChannelManager = channelManager,
+      scheduler = scheduler,
+      time = time,
+      brokerId = config.brokerId,
+      brokerEpochSupplier = brokerEpochSupplier
+    )
   }
 
   /**
    * Factory for ZK based implementation, used when IBP < 2.7-IV2
    */
-  def apply(scheduler: Scheduler, time: Time, zkClient: KafkaZkClient): AlterIsrManager = {
+  def apply(
+    scheduler: Scheduler,
+    time: Time,
+    zkClient: KafkaZkClient
+  ): AlterIsrManager = {
     new ZkIsrManager(scheduler, time, zkClient)
   }
+
 }
 
-class DefaultAlterIsrManager(val controllerChannelManager: BrokerToControllerChannelManager,
-                             val scheduler: Scheduler,
-                             val time: Time,
-                             val brokerId: Int,
-                             val brokerEpochSupplier: () => Long) extends AlterIsrManager with Logging with KafkaMetricsGroup {
+class DefaultAlterIsrManager(
+  val controllerChannelManager: BrokerToControllerChannelManager,
+  val scheduler: Scheduler,
+  val time: Time,
+  val brokerId: Int,
+  val brokerEpochSupplier: () => Long
+) extends AlterIsrManager with Logging with KafkaMetricsGroup {
 
   // Used to allow only one pending ISR update per partition
   private val unsentIsrUpdates: util.Map[TopicPartition, AlterIsrItem] = new ConcurrentHashMap[TopicPartition, AlterIsrItem]()
@@ -91,7 +121,12 @@ class DefaultAlterIsrManager(val controllerChannelManager: BrokerToControllerCha
   private val lastIsrPropagationMs = new AtomicLong(0)
 
   override def start(): Unit = {
+    controllerChannelManager.start()
     scheduler.schedule("send-alter-isr", propagateIsrChanges, 50, 50, TimeUnit.MILLISECONDS)
+  }
+
+  override def shutdown(): Unit = {
+    controllerChannelManager.shutdown()
   }
 
   override def submit(alterIsrItem: AlterIsrItem): Boolean = {
@@ -125,6 +160,7 @@ class DefaultAlterIsrManager(val controllerChannelManager: BrokerToControllerCha
     }
 
     debug(s"Sending AlterIsr to controller $message")
+
     // We will not timeout AlterISR request, instead letting it retry indefinitely
     // until a response is received, or a new LeaderAndIsr overwrites the existing isrState
     // which causes the inflight requests to be ignored.
@@ -142,7 +178,7 @@ class DefaultAlterIsrManager(val controllerChannelManager: BrokerToControllerCha
         override def onTimeout(): Unit = {
           throw new IllegalStateException("Encountered unexpected timeout when sending AlterIsr to the controller")
         }
-      }, Long.MaxValue)
+      })
   }
 
   private def buildRequest(inflightAlterIsrItems: Seq[AlterIsrItem]): AlterIsrRequestData = {

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -78,7 +78,7 @@ object AlterIsrManager {
       time = time,
       metrics = metrics,
       config = config,
-      channelName = "forwardingChannel",
+      channelName = "alterIsrChannel",
       threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = Long.MaxValue
     )

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -178,15 +178,20 @@ class BrokerToControllerRequestThread(
     }
   }
 
+  def queueSize: Int = {
+    requestQueue.size
+  }
+
   override def generateRequests(): Iterable[RequestAndCompletionHandler] = {
     val currentTimeMs = time.milliseconds()
     val requestIter = requestQueue.iterator()
     while (requestIter.hasNext) {
       val request = requestIter.next
       if (currentTimeMs - request.createdTimeMs >= retryTimeoutMs) {
-        request.callback.onTimeout()
         requestIter.remove()
+        request.callback.onTimeout()
       } else if (activeController.isDefined) {
+        requestIter.remove()
         return Some(RequestAndCompletionHandler(
           time.milliseconds(),
           activeController.get,

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -204,7 +204,7 @@ class BrokerToControllerRequestThread(
       requestQueue.putFirst(request)
     } else if (response.responseBody().errorCounts().containsKey(Errors.NOT_CONTROLLER)) {
       // just close the controller connection and wait for metadata cache update in doWork
-      networkClient.close(activeController.get.idString)
+      networkClient.disconnect(activeController.get.idString)
       activeController = None
       requestQueue.putFirst(request)
     } else {

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer
 import kafka.network.RequestChannel
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, EnvelopeRequest, EnvelopeResponse, RequestHeader}
 import org.apache.kafka.common.utils.Time
@@ -29,12 +30,55 @@ import org.apache.kafka.common.utils.Time
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.TimeoutException
 
-class ForwardingManager(channelManager: BrokerToControllerChannelManager,
-                        time: Time,
-                        retryTimeoutMs: Long) extends Logging {
+trait ForwardingManager {
+  def forwardRequest(
+    request: RequestChannel.Request,
+    responseCallback: AbstractResponse => Unit
+  ): Unit
 
-  def forwardRequest(request: RequestChannel.Request,
-                     responseCallback: AbstractResponse => Unit): Unit = {
+  def start(): Unit = {}
+
+  def shutdown(): Unit = {}
+}
+
+object ForwardingManager {
+  private val ThreadNamePrefix = "controller-forwarder"
+
+  def apply(
+    config: KafkaConfig,
+    metadataCache: MetadataCache,
+    time: Time,
+    metrics: Metrics
+  ): ForwardingManager = {
+    val channelManager = new BrokerToControllerChannelManager(
+      metadataCache = metadataCache,
+      time = time,
+      metrics = metrics,
+      config = config,
+      channelName = "forwardingChannel",
+      threadNamePrefix = Some(ThreadNamePrefix),
+      retryTimeoutMs = config.requestTimeoutMs.longValue
+    )
+    new ForwardingManagerImpl(channelManager)
+  }
+}
+
+class ForwardingManagerImpl(
+  channelManager: BrokerToControllerChannelManager
+) extends ForwardingManager with Logging {
+
+  override def start(): Unit = {
+    channelManager.start()
+  }
+
+  override def shutdown(): Unit = {
+    channelManager.shutdown()
+  }
+
+  override def forwardRequest(
+    request: RequestChannel.Request,
+    responseCallback: AbstractResponse => Unit
+  ): Unit = {
     val principalSerde = request.context.principalSerde.asScala.getOrElse(
       throw new IllegalArgumentException(s"Cannot deserialize principal from request $request " +
         "since there is no serde defined")
@@ -75,14 +119,7 @@ class ForwardingManager(channelManager: BrokerToControllerChannelManager,
       }
     }
 
-    val currentTime = time.milliseconds()
-    val deadlineMs =
-      if (Long.MaxValue - currentTime < retryTimeoutMs)
-        Long.MaxValue
-      else
-        currentTime + retryTimeoutMs
-
-    channelManager.sendRequest(envelopeRequest, new ForwardingResponseHandler, deadlineMs)
+    channelManager.sendRequest(envelopeRequest, new ForwardingResponseHandler)
   }
 
   private def parseResponse(

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -42,13 +42,13 @@ trait ForwardingManager {
 }
 
 object ForwardingManager {
-  private val ThreadNamePrefix = "controller-forwarder"
 
   def apply(
     config: KafkaConfig,
     metadataCache: MetadataCache,
     time: Time,
-    metrics: Metrics
+    metrics: Metrics,
+    threadNamePrefix: Option[String]
   ): ForwardingManager = {
     val channelManager = new BrokerToControllerChannelManager(
       metadataCache = metadataCache,
@@ -56,7 +56,7 @@ object ForwardingManager {
       metrics = metrics,
       config = config,
       channelName = "forwardingChannel",
-      threadNamePrefix = Some(ThreadNamePrefix),
+      threadNamePrefix = threadNamePrefix,
       retryTimeoutMs = config.requestTimeoutMs.longValue
     )
     new ForwardingManagerImpl(channelManager)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -346,7 +346,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
             config,
             metadataCache,
             time,
-            metrics
+            metrics,
+            threadNamePrefix
           )
           forwardingManager.start()
         }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -309,7 +309,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         socketServer.startup(startProcessingRequests = false)
 
         /* start replica manager */
-        alterIsrChannelManager = new BrokerToControllerChannelManagerImpl(
+        alterIsrChannelManager = new BrokerToControllerChannelManager(
           metadataCache, time, metrics, config, "alterIsrChannel", threadNamePrefix)
         replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
@@ -332,7 +332,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         var forwardingManager: ForwardingManager = null
         if (config.metadataQuorumEnabled) {
           /* start forwarding manager */
-          forwardingChannelManager = new BrokerToControllerChannelManagerImpl(metadataCache, time, metrics,
+          forwardingChannelManager = new BrokerToControllerChannelManager(metadataCache, time, metrics,
             config, "forwardingChannel", threadNamePrefix)
           forwardingChannelManager.start()
           forwardingManager = new ForwardingManager(forwardingChannelManager, time, config.requestTimeoutMs.longValue())

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -50,8 +50,8 @@ import org.apache.kafka.common.{ClusterResource, Endpoint, Node}
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.zookeeper.client.ZKClientConfig
 
-import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, mutable}
+import scala.jdk.CollectionConverters._
 
 object KafkaServer {
   // Copy the subset of properties that are relevant to Logs
@@ -168,9 +168,9 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
 
   var kafkaController: KafkaController = null
 
-  var forwardingChannelManager: BrokerToControllerChannelManager = null
+  var forwardingManager: ForwardingManager = null
 
-  var alterIsrChannelManager: BrokerToControllerChannelManager = null
+  var alterIsrManager: AlterIsrManager = null
 
   var kafkaScheduler: KafkaScheduler = null
 
@@ -309,11 +309,23 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         socketServer.startup(startProcessingRequests = false)
 
         /* start replica manager */
-        alterIsrChannelManager = new BrokerToControllerChannelManager(
-          metadataCache, time, metrics, config, "alterIsrChannel", threadNamePrefix)
+        alterIsrManager = if (config.interBrokerProtocolVersion.isAlterIsrSupported) {
+          AlterIsrManager(
+            config = config,
+            metadataCache = metadataCache,
+            scheduler = kafkaScheduler,
+            time = time,
+            metrics = metrics,
+            threadNamePrefix = threadNamePrefix,
+            brokerEpochSupplier = () => kafkaController.brokerEpoch
+          )
+        } else {
+          AlterIsrManager(kafkaScheduler, time, zkClient)
+        }
+        alterIsrManager.start()
+
         replicaManager = createReplicaManager(isShuttingDown)
         replicaManager.startup()
-        alterIsrChannelManager.start()
 
         val brokerInfo = createBrokerInfo
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
@@ -329,13 +341,14 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         kafkaController = new KafkaController(config, zkClient, time, metrics, brokerInfo, brokerEpoch, tokenManager, brokerFeatures, featureCache, threadNamePrefix)
         kafkaController.startup()
 
-        var forwardingManager: ForwardingManager = null
         if (config.metadataQuorumEnabled) {
-          /* start forwarding manager */
-          forwardingChannelManager = new BrokerToControllerChannelManager(metadataCache, time, metrics,
-            config, "forwardingChannel", threadNamePrefix)
-          forwardingChannelManager.start()
-          forwardingManager = new ForwardingManager(forwardingChannelManager, time, config.requestTimeoutMs.longValue())
+          forwardingManager = ForwardingManager(
+            config,
+            metadataCache,
+            time,
+            metrics
+          )
+          forwardingManager.start()
         }
 
         adminManager = new AdminManager(config, metrics, metadataCache, zkClient)
@@ -444,12 +457,6 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
   }
 
   protected def createReplicaManager(isShuttingDown: AtomicBoolean): ReplicaManager = {
-    val alterIsrManager: AlterIsrManager = if (config.interBrokerProtocolVersion.isAlterIsrSupported) {
-      AlterIsrManager(alterIsrChannelManager, kafkaScheduler,
-        time, config.brokerId, () => kafkaController.brokerEpoch)
-    } else {
-      AlterIsrManager(kafkaScheduler, time, zkClient)
-    }
     new ReplicaManager(config, metrics, time, zkClient, kafkaScheduler, logManager, isShuttingDown, quotaManagers,
       brokerTopicStats, metadataCache, logDirFailureChannel, alterIsrManager)
   }
@@ -730,11 +737,11 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         if (replicaManager != null)
           CoreUtils.swallow(replicaManager.shutdown(), this)
 
-        if (alterIsrChannelManager != null)
-          CoreUtils.swallow(alterIsrChannelManager.shutdown(), this)
+        if (alterIsrManager != null)
+          CoreUtils.swallow(alterIsrManager.shutdown(), this)
 
-        if (forwardingChannelManager != null)
-          CoreUtils.swallow(forwardingChannelManager.shutdown(), this)
+        if (forwardingManager != null)
+          CoreUtils.swallow(forwardingManager.shutdown(), this)
 
         if (logManager != null)
           CoreUtils.swallow(logManager.shutdown(), this)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -293,7 +293,6 @@ class ReplicaManager(val config: KafkaConfig,
     // A follower can lag behind leader for up to config.replicaLagTimeMaxMs x 1.5 before it is removed from ISR
     scheduler.schedule("isr-expiration", maybeShrinkIsr _, period = config.replicaLagTimeMaxMs / 2, unit = TimeUnit.MILLISECONDS)
     scheduler.schedule("shutdown-idle-replica-alter-log-dirs-thread", shutdownIdleReplicaAlterLogDirsThread _, period = 10000L, unit = TimeUnit.MILLISECONDS)
-    alterIsrManager.start()
 
     // If inter-broker protocol (IBP) < 1.0, the controller will send LeaderAndIsrRequest V0 which does not include isNew field.
     // In this case, the broker receiving the request cannot determine whether it is safe to create a partition if a log directory has failed.

--- a/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
@@ -19,13 +19,15 @@ package kafka.tools
 
 import kafka.network.RequestChannel
 import kafka.network.RequestConvertToJson
-import kafka.raft.KafkaNetworkChannel
 import kafka.server.ApiRequestHandler
 import kafka.utils.Logging
 import org.apache.kafka.common.internals.FatalExitError
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
-import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse}
+import org.apache.kafka.common.message.{BeginQuorumEpochResponseData, EndQuorumEpochResponseData, FetchResponseData, VoteResponseData}
+import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
+import org.apache.kafka.common.record.BaseRecords
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, BeginQuorumEpochResponse, EndQuorumEpochResponse, FetchResponse, VoteResponse}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.raft.{KafkaRaftClient, RaftRequest}
 
 import scala.jdk.CollectionConverters._
 
@@ -33,7 +35,7 @@ import scala.jdk.CollectionConverters._
  * Simple request handler implementation for use by [[TestRaftServer]].
  */
 class TestRaftRequestHandler(
-  networkChannel: KafkaNetworkChannel,
+  raftClient: KafkaRaftClient[_],
   requestChannel: RequestChannel,
   time: Time,
 ) extends ApiRequestHandler with Logging {
@@ -43,13 +45,10 @@ class TestRaftRequestHandler(
       trace(s"Handling request:${request.requestDesc(true)} from connection ${request.context.connectionId};" +
         s"securityProtocol:${request.context.securityProtocol},principal:${request.context.principal}")
       request.header.apiKey match {
-        case ApiKeys.VOTE
-             | ApiKeys.BEGIN_QUORUM_EPOCH
-             | ApiKeys.END_QUORUM_EPOCH
-             | ApiKeys.FETCH =>
-          val requestBody = request.body[AbstractRequest]
-          networkChannel.postInboundRequest(requestBody, response =>
-            sendResponse(request, Some(response)))
+        case ApiKeys.VOTE => handleVote(request)
+        case ApiKeys.BEGIN_QUORUM_EPOCH => handleBeginQuorumEpoch(request)
+        case ApiKeys.END_QUORUM_EPOCH => handleEndQuorumEpoch(request)
+        case ApiKeys.FETCH => handleFetch(request)
 
         case _ => throw new IllegalArgumentException(s"Unsupported api key: ${request.header.apiKey}")
       }
@@ -61,6 +60,45 @@ class TestRaftRequestHandler(
       if (request.apiLocalCompleteTimeNanos < 0)
         request.apiLocalCompleteTimeNanos = time.nanoseconds
     }
+  }
+
+  private def handleVote(request: RequestChannel.Request): Unit = {
+    handle(request, response => new VoteResponse(response.asInstanceOf[VoteResponseData]))
+  }
+
+  private def handleBeginQuorumEpoch(request: RequestChannel.Request): Unit = {
+    handle(request, response => new BeginQuorumEpochResponse(response.asInstanceOf[BeginQuorumEpochResponseData]))
+  }
+
+  private def handleEndQuorumEpoch(request: RequestChannel.Request): Unit = {
+    handle(request, response => new EndQuorumEpochResponse(response.asInstanceOf[EndQuorumEpochResponseData]))
+  }
+
+  private def handleFetch(request: RequestChannel.Request): Unit = {
+    handle(request, response => new FetchResponse[BaseRecords](response.asInstanceOf[FetchResponseData]))
+  }
+
+  private def handle(
+    request: RequestChannel.Request,
+    buildResponse: ApiMessage => AbstractResponse
+  ): Unit = {
+    val requestBody = request.body[AbstractRequest]
+    val inboundRequest = new RaftRequest.Inbound(
+      request.header.correlationId,
+      requestBody.data,
+      time.milliseconds()
+    )
+
+    inboundRequest.completion.whenComplete((response, exception) => {
+      val res = if (exception != null) {
+        requestBody.getErrorResponse(exception)
+      } else {
+        buildResponse(response.data)
+      }
+      sendResponse(request, Some(res))
+    })
+
+    raftClient.handle(inboundRequest)
   }
 
   private def handleError(request: RequestChannel.Request, err: Throwable): Unit = {

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -95,6 +95,8 @@ class TestRaftServer(
     val metadataLog = buildMetadataLog(logDir)
     val networkChannel = buildNetworkChannel(raftConfig, logContext)
 
+    networkChannel.start()
+
     val raftClient = buildRaftClient(
       raftConfig,
       metadataLog,
@@ -114,7 +116,7 @@ class TestRaftServer(
     raftClient.initialize()
 
     val requestHandler = new TestRaftRequestHandler(
-      networkChannel,
+      raftClient,
       socketServer.dataPlaneRequestChannel,
       time
     )
@@ -163,9 +165,7 @@ class TestRaftServer(
   private def buildNetworkChannel(raftConfig: RaftConfig,
                                   logContext: LogContext): KafkaNetworkChannel = {
     val netClient = buildNetworkClient(raftConfig, logContext)
-    val clientId = s"Raft-${config.brokerId}"
-    new KafkaNetworkChannel(time, netClient, clientId,
-      raftConfig.retryBackoffMs, raftConfig.requestTimeoutMs)
+    new KafkaNetworkChannel(time, netClient, raftConfig.requestTimeoutMs)
   }
 
   private def buildMetadataLog(logDir: File): KafkaMetadataLog = {

--- a/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
+++ b/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
@@ -27,8 +27,6 @@ import org.apache.kafka.common.requests.AbstractRequest
 import org.easymock.EasyMock
 import org.junit.{Assert, Test}
 
-import scala.collection.mutable
-
 class InterBrokerSendThreadTest {
   private val time = new MockTime()
   private val networkClient: NetworkClient = EasyMock.createMock(classOf[NetworkClient])
@@ -37,10 +35,7 @@ class InterBrokerSendThreadTest {
 
   @Test
   def shouldNotSendAnythingWhenNoRequests(): Unit = {
-    val sendThread = new InterBrokerSendThread("name", networkClient, time) {
-      override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
-      override def generateRequests() = mutable.Iterable.empty
-    }
+    val sendThread = new InterBrokerSendThread("name", networkClient, requestTimeoutMs, time)
 
     // poll is always called but there should be no further invocations on NetworkClient
     EasyMock.expect(networkClient.poll(EasyMock.anyLong(), EasyMock.anyLong()))
@@ -59,12 +54,11 @@ class InterBrokerSendThreadTest {
     val request = new StubRequestBuilder()
     val node = new Node(1, "", 8080)
     val handler = RequestAndCompletionHandler(node, request, completionHandler)
-    val sendThread = new InterBrokerSendThread("name", networkClient, time) {
-      override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
-      override def generateRequests() = List[RequestAndCompletionHandler](handler)
-    }
+    val sendThread = new InterBrokerSendThread("name", networkClient, requestTimeoutMs, time)
 
     val clientRequest = new ClientRequest("dest", request, 0, "1", 0, true, requestTimeoutMs, handler.handler)
+
+    EasyMock.expect(networkClient.wakeup())
 
     EasyMock.expect(networkClient.newClientRequest(
       EasyMock.eq("1"),
@@ -85,6 +79,7 @@ class InterBrokerSendThreadTest {
 
     EasyMock.replay(networkClient)
 
+    sendThread.sendRequest(handler)
     sendThread.doWork()
 
     EasyMock.verify(networkClient)
@@ -95,21 +90,20 @@ class InterBrokerSendThreadTest {
   def shouldCallCompletionHandlerWithDisconnectedResponseWhenNodeNotReady(): Unit = {
     val request = new StubRequestBuilder
     val node = new Node(1, "", 8080)
-    val requestAndCompletionHandler = RequestAndCompletionHandler(node, request, completionHandler)
-    val sendThread = new InterBrokerSendThread("name", networkClient, time) {
-      override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
-      override def generateRequests() = List[RequestAndCompletionHandler](requestAndCompletionHandler)
-    }
+    val handler = RequestAndCompletionHandler(node, request, completionHandler)
+    val sendThread = new InterBrokerSendThread("name", networkClient, requestTimeoutMs, time)
 
-    val clientRequest = new ClientRequest("dest", request, 0, "1", 0, true, requestTimeoutMs, requestAndCompletionHandler.handler)
+    val clientRequest = new ClientRequest("dest", request, 0, "1", 0, true, requestTimeoutMs, handler.handler)
+
+    EasyMock.expect(networkClient.wakeup())
 
     EasyMock.expect(networkClient.newClientRequest(
       EasyMock.eq("1"),
-      EasyMock.same(requestAndCompletionHandler.request),
+      EasyMock.same(handler.request),
       EasyMock.anyLong(),
       EasyMock.eq(true),
       EasyMock.eq(requestTimeoutMs),
-      EasyMock.same(requestAndCompletionHandler.handler)))
+      EasyMock.same(handler.handler)))
       .andReturn(clientRequest)
 
     EasyMock.expect(networkClient.ready(node, time.milliseconds()))
@@ -129,6 +123,7 @@ class InterBrokerSendThreadTest {
 
     EasyMock.replay(networkClient)
 
+    sendThread.sendRequest(handler)
     sendThread.doWork()
 
     EasyMock.verify(networkClient)
@@ -140,10 +135,7 @@ class InterBrokerSendThreadTest {
     val request = new StubRequestBuilder()
     val node = new Node(1, "", 8080)
     val handler = RequestAndCompletionHandler(node, request, completionHandler)
-    val sendThread = new InterBrokerSendThread("name", networkClient, time) {
-      override val requestTimeoutMs: Int = InterBrokerSendThreadTest.this.requestTimeoutMs
-      override def generateRequests() = List[RequestAndCompletionHandler](handler)
-    }
+    val sendThread = new InterBrokerSendThread("name", networkClient, requestTimeoutMs, time)
 
     val clientRequest = new ClientRequest("dest",
       request,
@@ -154,6 +146,8 @@ class InterBrokerSendThreadTest {
       requestTimeoutMs,
       handler.handler)
     time.sleep(1500)
+
+    EasyMock.expect(networkClient.wakeup())
 
     EasyMock.expect(networkClient.newClientRequest(
       EasyMock.eq("1"),
@@ -180,6 +174,7 @@ class InterBrokerSendThreadTest {
 
     EasyMock.replay(networkClient)
 
+    sendThread.sendRequest(handler)
     sendThread.doWork()
 
     EasyMock.verify(networkClient)

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -61,10 +61,11 @@ class BrokerToControllerRequestThreadTest {
 
     testRequestThread.enqueue(queueItem)
     testRequestThread.doWork()
+    assertEquals(1, testRequestThread.queueSize)
 
     time.sleep(retryTimeoutMs)
     testRequestThread.doWork()
-
+    assertEquals(0, testRequestThread.queueSize)
     assertTrue(completionHandler.timedOut.get)
   }
 
@@ -100,11 +101,14 @@ class BrokerToControllerRequestThreadTest {
     )
 
     testRequestThread.enqueue(queueItem)
+    assertEquals(1, testRequestThread.queueSize)
+
     // initialize to the controller
     testRequestThread.doWork()
     // send and process the request
     testRequestThread.doWork()
 
+    assertEquals(0, testRequestThread.queueSize)
     assertTrue(completionHandler.completed.get())
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -385,7 +385,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
       new WriteTxnMarkersResponse(pidErrorMap)
     }
     synchronized {
-      txnMarkerChannelManager.drainQueuedTransactionMarkers().foreach { requestAndHandler =>
+      txnMarkerChannelManager.generateRequests().foreach { requestAndHandler =>
         val request = requestAndHandler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build()
         val response = createResponse(request)
         requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -385,7 +385,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
       new WriteTxnMarkersResponse(pidErrorMap)
     }
     synchronized {
-      txnMarkerChannelManager.generateRequests().foreach { requestAndHandler =>
+      txnMarkerChannelManager.drainQueuedTransactionMarkers().foreach { requestAndHandler =>
         val request = requestAndHandler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build()
         val response = createResponse(request)
         requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -156,7 +156,7 @@ class TransactionMarkerChannelManagerTest {
 
   @Test
   def shouldGenerateEmptyMapWhenNoRequestsOutstanding(): Unit = {
-    assertTrue(channelManager.generateRequests().isEmpty)
+    assertTrue(channelManager.drainQueuedTransactionMarkers().isEmpty)
   }
 
   @Test
@@ -194,12 +194,12 @@ class TransactionMarkerChannelManagerTest {
     val expectedBroker2Request = new WriteTxnMarkersRequest.Builder(ApiKeys.WRITE_TXN_MARKERS.latestVersion(),
       asList(new WriteTxnMarkersRequest.TxnMarkerEntry(producerId1, producerEpoch, coordinatorEpoch, txnResult, asList(partition2)))).build()
 
-    val requests: Map[Node, WriteTxnMarkersRequest] = channelManager.generateRequests().map { handler =>
+    val requests: Map[Node, WriteTxnMarkersRequest] = channelManager.drainQueuedTransactionMarkers().map { handler =>
       (handler.destination, handler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build())
     }.toMap
 
     assertEquals(Map(broker1 -> expectedBroker1Request, broker2 -> expectedBroker2Request), requests)
-    assertTrue(channelManager.generateRequests().isEmpty)
+    assertTrue(channelManager.drainQueuedTransactionMarkers().isEmpty)
   }
 
   @Test
@@ -270,13 +270,13 @@ class TransactionMarkerChannelManagerTest {
     val expectedBroker2Request = new WriteTxnMarkersRequest.Builder(ApiKeys.WRITE_TXN_MARKERS.latestVersion(),
       asList(new WriteTxnMarkersRequest.TxnMarkerEntry(producerId1, producerEpoch, coordinatorEpoch, txnResult, asList(partition2)))).build()
 
-    val firstDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.generateRequests().map { handler =>
+    val firstDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.drainQueuedTransactionMarkers().map { handler =>
       (handler.destination, handler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build())
     }.toMap
 
     assertEquals(Map(broker2 -> expectedBroker2Request), firstDrainedRequests)
 
-    val secondDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.generateRequests().map { handler =>
+    val secondDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.drainQueuedTransactionMarkers().map { handler =>
       (handler.destination, handler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build())
     }.toMap
 
@@ -354,7 +354,7 @@ class TransactionMarkerChannelManagerTest {
 
     channelManager.addTxnMarkersToSend(coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
 
-    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.generateRequests()
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.drainQueuedTransactionMarkers()
 
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
@@ -401,7 +401,7 @@ class TransactionMarkerChannelManagerTest {
 
     channelManager.addTxnMarkersToSend(coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
 
-    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.generateRequests()
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.drainQueuedTransactionMarkers()
 
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
@@ -450,7 +450,7 @@ class TransactionMarkerChannelManagerTest {
 
     channelManager.addTxnMarkersToSend(coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
 
-    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.generateRequests()
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.drainQueuedTransactionMarkers()
 
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
@@ -459,7 +459,7 @@ class TransactionMarkerChannelManagerTest {
     }
 
     // call this again so that append log will be retried
-    channelManager.generateRequests()
+    channelManager.drainQueuedTransactionMarkers()
 
     EasyMock.verify(txnStateManager)
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -132,7 +132,7 @@ class TransactionMarkerChannelManagerTest {
         response)
 
       TestUtils.waitUntilTrue(() => {
-        val requests = channelManager.drainQueuedTransactionMarkers()
+        val requests = channelManager.generateRequests()
         if (requests.nonEmpty) {
           assertEquals(1, requests.size)
           val request = requests.head
@@ -156,7 +156,7 @@ class TransactionMarkerChannelManagerTest {
 
   @Test
   def shouldGenerateEmptyMapWhenNoRequestsOutstanding(): Unit = {
-    assertTrue(channelManager.drainQueuedTransactionMarkers().isEmpty)
+    assertTrue(channelManager.generateRequests().isEmpty)
   }
 
   @Test
@@ -194,12 +194,12 @@ class TransactionMarkerChannelManagerTest {
     val expectedBroker2Request = new WriteTxnMarkersRequest.Builder(ApiKeys.WRITE_TXN_MARKERS.latestVersion(),
       asList(new WriteTxnMarkersRequest.TxnMarkerEntry(producerId1, producerEpoch, coordinatorEpoch, txnResult, asList(partition2)))).build()
 
-    val requests: Map[Node, WriteTxnMarkersRequest] = channelManager.drainQueuedTransactionMarkers().map { handler =>
+    val requests: Map[Node, WriteTxnMarkersRequest] = channelManager.generateRequests().map { handler =>
       (handler.destination, handler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build())
     }.toMap
 
     assertEquals(Map(broker1 -> expectedBroker1Request, broker2 -> expectedBroker2Request), requests)
-    assertTrue(channelManager.drainQueuedTransactionMarkers().isEmpty)
+    assertTrue(channelManager.generateRequests().isEmpty)
   }
 
   @Test
@@ -270,13 +270,13 @@ class TransactionMarkerChannelManagerTest {
     val expectedBroker2Request = new WriteTxnMarkersRequest.Builder(ApiKeys.WRITE_TXN_MARKERS.latestVersion(),
       asList(new WriteTxnMarkersRequest.TxnMarkerEntry(producerId1, producerEpoch, coordinatorEpoch, txnResult, asList(partition2)))).build()
 
-    val firstDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.drainQueuedTransactionMarkers().map { handler =>
+    val firstDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.generateRequests().map { handler =>
       (handler.destination, handler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build())
     }.toMap
 
     assertEquals(Map(broker2 -> expectedBroker2Request), firstDrainedRequests)
 
-    val secondDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.drainQueuedTransactionMarkers().map { handler =>
+    val secondDrainedRequests: Map[Node, WriteTxnMarkersRequest] = channelManager.generateRequests().map { handler =>
       (handler.destination, handler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build())
     }.toMap
 
@@ -354,7 +354,7 @@ class TransactionMarkerChannelManagerTest {
 
     channelManager.addTxnMarkersToSend(coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
 
-    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.drainQueuedTransactionMarkers()
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.generateRequests()
 
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
@@ -401,7 +401,7 @@ class TransactionMarkerChannelManagerTest {
 
     channelManager.addTxnMarkersToSend(coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
 
-    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.drainQueuedTransactionMarkers()
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.generateRequests()
 
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
@@ -450,7 +450,7 @@ class TransactionMarkerChannelManagerTest {
 
     channelManager.addTxnMarkersToSend(coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
 
-    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.drainQueuedTransactionMarkers()
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = channelManager.generateRequests()
 
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
@@ -459,7 +459,7 @@ class TransactionMarkerChannelManagerTest {
     }
 
     // call this again so that append log will be retried
-    channelManager.drainQueuedTransactionMarkers()
+    channelManager.generateRequests()
 
     EasyMock.verify(txnStateManager)
 

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -19,16 +19,15 @@ package kafka.raft
 import java.net.InetSocketAddress
 import java.util
 import java.util.Collections
-import java.util.concurrent.atomic.AtomicReference
 
 import org.apache.kafka.clients.MockClient.MockMetadataUpdater
 import org.apache.kafka.clients.{ApiVersion, MockClient, NodeApiVersions}
 import org.apache.kafka.common.message.{BeginQuorumEpochResponseData, EndQuorumEpochResponseData, FetchResponseData, VoteResponseData}
 import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
-import org.apache.kafka.common.requests.{AbstractResponse, BeginQuorumEpochRequest, EndQuorumEpochRequest, VoteRequest, VoteResponse}
+import org.apache.kafka.common.requests.{AbstractResponse, BeginQuorumEpochRequest, BeginQuorumEpochResponse, EndQuorumEpochRequest, EndQuorumEpochResponse, FetchResponse, VoteRequest, VoteResponse}
 import org.apache.kafka.common.utils.{MockTime, Time}
 import org.apache.kafka.common.{Node, TopicPartition}
-import org.apache.kafka.raft.{RaftRequest, RaftResponse, RaftUtil}
+import org.apache.kafka.raft.{RaftRequest, RaftUtil}
 import org.junit.Assert._
 import org.junit.{Before, Test}
 
@@ -38,13 +37,11 @@ class KafkaNetworkChannelTest {
   import KafkaNetworkChannelTest._
 
   private val clusterId = "clusterId"
-  private val clientId = "clientId"
-  private val retryBackoffMs = 100
   private val requestTimeoutMs = 30000
   private val time = new MockTime()
   private val client = new MockClient(time, new StubMetadataUpdater)
   private val topicPartition = new TopicPartition("topic", 0)
-  private val channel = new KafkaNetworkChannel(time, client, clientId, retryBackoffMs, requestTimeoutMs)
+  private val channel = new KafkaNetworkChannel(time, client, requestTimeoutMs)
 
   @Before
   def setupSupportedApis(): Unit = {
@@ -74,7 +71,7 @@ class KafkaNetworkChannelTest {
     channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
 
     for (apiKey <- RaftApis) {
-      val response = KafkaNetworkChannel.buildResponse(buildTestErrorResponse(apiKey, Errors.INVALID_REQUEST))
+      val response = buildResponse(buildTestErrorResponse(apiKey, Errors.INVALID_REQUEST))
       client.prepareResponseFrom(response, destinationNode, true)
       sendAndAssertErrorResponse(apiKey, destinationId, Errors.BROKER_NOT_AVAILABLE)
     }
@@ -109,30 +106,9 @@ class KafkaNetworkChannelTest {
 
     for (apiKey <- RaftApis) {
       val expectedError = Errors.INVALID_REQUEST
-      val response = KafkaNetworkChannel.buildResponse(buildTestErrorResponse(apiKey, expectedError))
+      val response = buildResponse(buildTestErrorResponse(apiKey, expectedError))
       client.prepareResponseFrom(response, destinationNode)
       sendAndAssertErrorResponse(apiKey, destinationId, expectedError)
-    }
-  }
-
-  @Test
-  def testReceiveAndSendInboundRequest(): Unit = {
-    for (apiKey <- RaftApis) {
-      val request = KafkaNetworkChannel.buildRequest(buildTestRequest(apiKey)).build()
-      val responseRef = new AtomicReference[AbstractResponse]()
-
-      channel.postInboundRequest(request, responseRef.set)
-      val inbound = channel.receive(1000).asScala
-      assertEquals(1, inbound.size)
-
-      val inboundRequest = inbound.head.asInstanceOf[RaftRequest.Inbound]
-      val errorResponse = buildTestErrorResponse(apiKey, Errors.INVALID_REQUEST)
-      val outboundResponse = new RaftResponse.Outbound(inboundRequest.correlationId, errorResponse)
-      channel.send(outboundResponse)
-      channel.receive(1000)
-
-      assertNotNull(responseRef.get)
-      assertEquals(Errors.INVALID_REQUEST, extractError(KafkaNetworkChannel.responseData(responseRef.get)))
     }
   }
 
@@ -145,10 +121,11 @@ class KafkaNetworkChannelTest {
     val request = new RaftRequest.Outbound(correlationId, apiRequest, destinationId, createdTimeMs)
 
     channel.send(request)
-    val responses = channel.receive(1000).asScala
-    assertEquals(1, responses.size)
+    channel.pollOnce()
 
-    val response = responses.head.asInstanceOf[RaftResponse.Inbound]
+    assertTrue(request.completion.isDone)
+
+    val response = request.completion.get()
     assertEquals(destinationId, response.sourceId)
     assertEquals(correlationId, response.correlationId)
     assertEquals(apiKey, ApiKeys.forId(response.data.apiKey))
@@ -214,6 +191,22 @@ class KafkaNetworkChannelTest {
       case res: VoteResponseData => res.errorCode
     }
     Errors.forCode(code)
+  }
+
+
+  def buildResponse(responseData: ApiMessage): AbstractResponse = {
+    responseData match {
+      case voteResponse: VoteResponseData =>
+        new VoteResponse(voteResponse)
+      case beginEpochResponse: BeginQuorumEpochResponseData =>
+        new BeginQuorumEpochResponse(beginEpochResponse)
+      case endEpochResponse: EndQuorumEpochResponseData =>
+        new EndQuorumEpochResponse(endEpochResponse)
+      case fetchResponse: FetchResponseData =>
+        new FetchResponse(fetchResponse)
+      case _ =>
+        throw new IllegalArgumentException(s"Unexpected type for responseData: $responseData")
+    }
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterIsrManagerTest.scala
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-package unit.kafka.server
+package kafka.server
 
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 import kafka.api.LeaderAndIsr
-import kafka.server.{AlterIsrItem, AlterIsrManager, BrokerToControllerChannelManager, ControllerRequestCompletionHandler, DefaultAlterIsrManager, ZkIsrManager}
 import kafka.utils.{MockScheduler, MockTime}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.ClientResponse
@@ -42,7 +41,6 @@ class AlterIsrManagerTest {
   val time = new MockTime
   val metrics = new Metrics
   val brokerId = 1
-  val requestTimeout = Long.MaxValue
 
   var brokerToController: BrokerToControllerChannelManager = _
 
@@ -57,7 +55,8 @@ class AlterIsrManagerTest {
 
   @Test
   def testBasic(): Unit = {
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.anyObject())).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -73,7 +72,8 @@ class AlterIsrManagerTest {
   @Test
   def testOverwriteWithinBatch(): Unit = {
     val capture = EasyMock.newCapture[AbstractRequest.Builder[AlterIsrRequest]]()
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject(), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject())).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -97,7 +97,8 @@ class AlterIsrManagerTest {
   @Test
   def testSingleBatch(): Unit = {
     val capture = EasyMock.newCapture[AbstractRequest.Builder[AlterIsrRequest]]()
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject(), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.capture(capture), EasyMock.anyObject())).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -151,7 +152,8 @@ class AlterIsrManagerTest {
   def testTopLevelError(isrs: Seq[AlterIsrItem], error: Errors): AlterIsrManager = {
     val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
 
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -184,7 +186,8 @@ class AlterIsrManagerTest {
   def testPartitionError(tp: TopicPartition, error: Errors): AlterIsrManager = {
     val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -226,7 +229,8 @@ class AlterIsrManagerTest {
   def testOneInFlight(): Unit = {
     val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)
@@ -253,7 +257,7 @@ class AlterIsrManagerTest {
     callbackCapture.getValue.onComplete(resp)
 
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
     EasyMock.replay(brokerToController)
 
     time.sleep(100)
@@ -265,7 +269,8 @@ class AlterIsrManagerTest {
   def testPartitionMissingInResponse(): Unit = {
     val callbackCapture = EasyMock.newCapture[ControllerRequestCompletionHandler]()
     EasyMock.reset(brokerToController)
-    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture), EasyMock.eq(requestTimeout))).once()
+    EasyMock.expect(brokerToController.start())
+    EasyMock.expect(brokerToController.sendRequest(EasyMock.anyObject(), EasyMock.capture(callbackCapture))).once()
     EasyMock.replay(brokerToController)
 
     val scheduler = new MockScheduler(time)

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -19,6 +19,7 @@ package kafka.server
 import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.util.Optional
+
 import kafka.network
 import kafka.network.RequestChannel
 import kafka.utils.MockTime
@@ -34,7 +35,7 @@ import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuild
 import org.junit.Assert._
 import org.junit.Test
 import org.mockito.ArgumentMatchers._
-import org.mockito.{ArgumentMatchers, Mockito}
+import org.mockito.Mockito
 
 import scala.jdk.CollectionConverters._
 
@@ -45,7 +46,7 @@ class ForwardingManagerTest {
 
   @Test
   def testResponseCorrelationIdMismatch(): Unit = {
-    val forwardingManager = new ForwardingManager(brokerToController, time, Long.MaxValue)
+    val forwardingManager = new ForwardingManagerImpl(brokerToController)
     val requestCorrelationId = 27
     val envelopeCorrelationId = 39
     val clientPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "client")
@@ -64,8 +65,7 @@ class ForwardingManagerTest {
 
     Mockito.when(brokerToController.sendRequest(
       any(classOf[EnvelopeRequest.Builder]),
-      any(classOf[ControllerRequestCompletionHandler]),
-      ArgumentMatchers.eq(Long.MaxValue)
+      any(classOf[ControllerRequestCompletionHandler])
     )).thenAnswer(invocation => {
       val completionHandler = invocation.getArgument[RequestCompletionHandler](1)
       val response = buildEnvelopeResponse(responseBuffer, envelopeCorrelationId, completionHandler)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1082,8 +1082,6 @@ object TestUtils extends Logging {
       inFlight.set(false);
     }
 
-    override def start(): Unit = { }
-
     def completeIsrUpdate(newZkVersion: Int): Unit = {
       if (inFlight.compareAndSet(true, false)) {
         val item = isrUpdates.head

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1413,7 +1413,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
                     );
                 }
 
-                messageQueue.offer(response);
+                messageQueue.add(response);
             });
 
             channel.send(requestMessage);
@@ -1826,7 +1826,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
      * @param request The inbound request
      */
     public void handle(RaftRequest.Inbound request) {
-        messageQueue.offer(Objects.requireNonNull(request));
+        messageQueue.add(Objects.requireNonNull(request));
     }
 
     /**

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -23,14 +23,14 @@ import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.BeginQuorumEpochRequestData;
 import org.apache.kafka.common.message.BeginQuorumEpochResponseData;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
-import org.apache.kafka.common.message.DescribeQuorumResponseData.ReplicaState;
 import org.apache.kafka.common.message.DescribeQuorumResponseData;
+import org.apache.kafka.common.message.DescribeQuorumResponseData.ReplicaState;
 import org.apache.kafka.common.message.EndQuorumEpochRequestData;
 import org.apache.kafka.common.message.EndQuorumEpochResponseData;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
-import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 import org.apache.kafka.common.message.VoteRequestData;
 import org.apache.kafka.common.message.VoteResponseData;
 import org.apache.kafka.common.metrics.Metrics;
@@ -55,6 +55,7 @@ import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.raft.RequestManager.ConnectionState;
 import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.apache.kafka.raft.internals.BatchMemoryPool;
+import org.apache.kafka.raft.internals.BlockingMessageQueue;
 import org.apache.kafka.raft.internals.CloseListener;
 import org.apache.kafka.raft.internals.FuturePurgatory;
 import org.apache.kafka.raft.internals.KafkaRaftMetrics;
@@ -71,6 +72,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -141,6 +143,8 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     private final FuturePurgatory<Long> fetchPurgatory;
     private final RecordSerde<T> serde;
     private final MemoryPool memoryPool;
+    private final RaftMessageQueue messageQueue;
+
     private final List<ListenerContext> listenerContexts = new ArrayList<>();
     private final ConcurrentLinkedQueue<Listener<T>> pendingListeners = new ConcurrentLinkedQueue<>();
 
@@ -158,6 +162,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     ) {
         this(serde,
             channel,
+            new BlockingMessageQueue(),
             log,
             quorum,
             new BatchMemoryPool(5, MAX_BATCH_SIZE),
@@ -177,6 +182,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     public KafkaRaftClient(
         RecordSerde<T> serde,
         NetworkChannel channel,
+        RaftMessageQueue messageQueue,
         ReplicatedLog log,
         QuorumState quorum,
         MemoryPool memoryPool,
@@ -194,6 +200,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     ) {
         this.serde = serde;
         this.channel = channel;
+        this.messageQueue = messageQueue;
         this.log = log;
         this.quorum = quorum;
         this.memoryPool = memoryPool;
@@ -333,7 +340,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     @Override
     public void register(Listener<T> listener) {
         pendingListeners.add(listener);
-        channel.wakeup();
+        wakeup();
     }
 
     private OffsetAndEpoch endOffset() {
@@ -779,9 +786,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             FollowerState state = quorum.followerStateOrThrow();
             if (state.leaderId() == requestLeaderId) {
                 List<Integer> preferredSuccessors = partitionRequest.preferredSuccessors();
-                if (!preferredSuccessors.contains(quorum.localId)) {
-                    return buildEndQuorumEpochResponse(Errors.INCONSISTENT_VOTER_SET);
-                }
                 long electionBackoffMs = endEpochElectionBackoff(preferredSuccessors);
                 logger.debug("Overriding follower fetch timeout to {} after receiving " +
                     "EndQuorumEpoch request from leader {} in epoch {}", electionBackoffMs,
@@ -798,7 +802,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         // voter has a higher chance to be elected. If the node's priority is highest, become
         // candidate immediately instead of waiting for next poll.
         int position = preferredSuccessors.indexOf(quorum.localId);
-        if (position == 0) {
+        if (position <= 0) {
             return 0;
         } else {
             return strictExponentialElectionBackoffMs(position, preferredSuccessors.size());
@@ -932,6 +936,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
                 }
             }
 
+            // FIXME: `completionTimeMs`, which can be null
             logger.trace("Completing delayed fetch from {} starting at offset {} at {}",
                 request.replicaId(), fetchPartition.fetchOffset(), completionTimeMs);
 
@@ -967,6 +972,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             return buildFetchResponse(Errors.NONE, MemoryRecords.EMPTY, divergingEpoch, state.highWatermark());
         } else {
             LogFetchInfo info = log.read(fetchOffset, Isolation.UNCOMMITTED);
+
             if (state.updateReplicaState(replicaId, currentTimeMs, info.startOffsetMetadata)) {
                 onUpdateLeaderHighWatermark(state, currentTimeMs);
             }
@@ -1231,7 +1237,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
     private boolean handleUnexpectedError(Errors error, RaftResponse.Inbound response) {
         logger.error("Unexpected error {} in {} response: {}",
-            error, response.data.apiKey(), response);
+            error, ApiKeys.forId(response.data.apiKey()), response);
         return false;
     }
 
@@ -1263,7 +1269,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
         ConnectionState connection = requestManager.getOrCreate(response.sourceId());
         if (handledSuccessfully) {
-            connection.onResponseReceived(response.correlationId, currentTimeMs);
+            connection.onResponseReceived(response.correlationId);
         } else {
             connection.onResponseError(response.correlationId, currentTimeMs);
         }
@@ -1343,7 +1349,10 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             } else {
                 message = RaftUtil.errorResponse(apiKey, Errors.forException(exception));
             }
-            sendOutboundMessage(new RaftResponse.Outbound(request.correlationId(), message));
+
+            RaftResponse.Outbound responseMessage = new RaftResponse.Outbound(request.correlationId(), message);
+            request.completion.complete(responseMessage);
+            logger.trace("Sent response {} to inbound request {}", responseMessage, request);
         });
     }
 
@@ -1355,15 +1364,15 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             handleRequest(request, currentTimeMs);
         } else if (message instanceof RaftResponse.Inbound) {
             RaftResponse.Inbound response = (RaftResponse.Inbound) message;
-            handleResponse(response, currentTimeMs);
+            ConnectionState connection = requestManager.getOrCreate(response.sourceId());
+            if (connection.isResponseExpected(response.correlationId)) {
+                handleResponse(response, currentTimeMs);
+            } else {
+                logger.debug("Ignoring response {} since it is no longer needed", response);
+            }
         } else {
             throw new IllegalArgumentException("Unexpected message " + message);
         }
-    }
-
-    private void sendOutboundMessage(RaftMessage message) {
-        channel.send(message);
-        logger.trace("Sent outbound message: {}", message);
     }
 
     /**
@@ -1383,7 +1392,32 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         if (connection.isReady(currentTimeMs)) {
             int correlationId = channel.newCorrelationId();
             ApiMessage request = requestSupplier.get();
-            sendOutboundMessage(new RaftRequest.Outbound(correlationId, request, destinationId, currentTimeMs));
+
+            RaftRequest.Outbound requestMessage = new RaftRequest.Outbound(
+                correlationId,
+                request,
+                destinationId,
+                currentTimeMs
+            );
+
+            requestMessage.completion.whenComplete((response, exception) -> {
+                if (exception != null) {
+                    ApiKeys api = ApiKeys.forId(request.apiKey());
+                    Errors error = Errors.forException(exception);
+                    ApiMessage errorResponse = RaftUtil.errorResponse(api, error);
+
+                    response = new RaftResponse.Inbound(
+                        correlationId,
+                        errorResponse,
+                        destinationId
+                    );
+                }
+
+                messageQueue.offer(response);
+            });
+
+            channel.send(requestMessage);
+            logger.trace("Sent outbound request: {}", requestMessage);
             connection.onRequestSent(correlationId, currentTimeMs);
             return Long.MAX_VALUE;
         }
@@ -1781,6 +1815,26 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         return false;
     }
 
+    private void wakeup() {
+        messageQueue.wakeup();
+    }
+
+    /**
+     * Handle an inbound request. The response will be returned through
+     * {@link RaftRequest.Inbound#completion}.
+     *
+     * @param request The inbound request
+     */
+    public void handle(RaftRequest.Inbound request) {
+        messageQueue.offer(Objects.requireNonNull(request));
+    }
+
+    /**
+     * Poll for new events. This allows the client to handle inbound
+     * requests and send any needed outbound requests.
+     *
+     * @throws IOException for any IO errors encountered
+     */
     public void poll() throws IOException {
         pollListeners();
 
@@ -1792,14 +1846,13 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         long pollTimeoutMs = pollCurrentState(currentTimeMs);
         kafkaRaftMetrics.updatePollStart(currentTimeMs);
 
-        List<RaftMessage> inboundMessages = channel.receive(pollTimeoutMs);
+        RaftMessage message = messageQueue.poll(pollTimeoutMs);
 
         currentTimeMs = time.milliseconds();
         kafkaRaftMetrics.updatePollEnd(currentTimeMs);
 
-        for (RaftMessage message : inboundMessages) {
+        if (message != null) {
             handleInboundMessage(message, currentTimeMs);
-            currentTimeMs = time.milliseconds();
         }
     }
 
@@ -1819,7 +1872,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         // the linger timeout so that it can schedule its own wakeup in case
         // there are no additional appends.
         if (isFirstAppend || accumulator.needsDrain(time.milliseconds())) {
-            channel.wakeup();
+            wakeup();
         }
         return offset;
     }
@@ -1829,7 +1882,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         logger.info("Beginning graceful shutdown");
         CompletableFuture<Void> shutdownComplete = new CompletableFuture<>();
         shutdown.set(new GracefulShutdown(timeoutMs, shutdownComplete));
-        channel.wakeup();
+        wakeup();
         return shutdownComplete;
     }
 
@@ -1991,7 +2044,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
             if (lastSent == reader) {
                 lastSent = null;
-                channel.wakeup();
+                wakeup();
             }
         }
 

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -159,14 +159,15 @@ public class LeaderState implements EpochState {
 
     public List<Integer> nonLeaderVotersByDescendingFetchOffset() {
         return followersByDescendingFetchOffset().stream()
-                   .filter(state -> state.nodeId != localId)
-                   .map(state -> state.nodeId)
-                   .collect(Collectors.toList());
+            .filter(state -> state.nodeId != localId)
+            .map(state -> state.nodeId)
+            .collect(Collectors.toList());
     }
 
     private List<VoterState> followersByDescendingFetchOffset() {
-        return new ArrayList<>(this.voterReplicaStates.values())
-            .stream().sorted().collect(Collectors.toList());
+        return new ArrayList<>(this.voterReplicaStates.values()).stream()
+            .sorted()
+            .collect(Collectors.toList());
     }
 
     private boolean updateEndOffset(ReplicaState state,

--- a/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
@@ -18,11 +18,10 @@ package org.apache.kafka.raft;
 
 import java.io.Closeable;
 import java.net.InetSocketAddress;
-import java.util.List;
 
 /**
  * A simple network interface with few assumptions. We do not assume ordering
- * of requests or even that every request will receive a response.
+ * of requests or even that every outbound request will receive a response.
  */
 public interface NetworkChannel extends Closeable {
 
@@ -37,21 +36,7 @@ public interface NetworkChannel extends Closeable {
      * or a response to a request that was received through {@link #receive(long)}
      * (i.e. an instance of {@link org.apache.kafka.raft.RaftResponse.Outbound}).
      */
-    void send(RaftMessage message);
-
-    /**
-     * Receive inbound messages. These could contain either inbound requests
-     * (i.e. instances of {@link org.apache.kafka.raft.RaftRequest.Inbound})
-     * or responses to outbound requests sent through {@link #send(RaftMessage)}
-     * (i.e. instances of {@link org.apache.kafka.raft.RaftResponse.Inbound}).
-     */
-    List<RaftMessage> receive(long timeoutMs);
-
-    /**
-     * Wakeup the channel if it is blocking in {@link #receive(long)}. This will cause
-     * the call to immediately return with whatever messages are available.
-     */
-    void wakeup();
+    void send(RaftRequest.Outbound request);
 
     /**
      * Update connection information for the given id.

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+/**
+ * This class is used to serialize inbound requests or responses to outbound requests.
+ * It basically just allows us to wrap a blocking queue so that we can have a mocked
+ * implementation which does not depend on system time.
+ *
+ * See {@link org.apache.kafka.raft.internals.BlockingMessageQueue}.
+ */
+public interface RaftMessageQueue {
+
+    /**
+     * Block for the arrival of a new message.
+     *
+     * @param timeoutMs timeout in milliseconds to wait for a new event
+     * @return the event or null if the timeout was reached
+     */
+    RaftMessage poll(long timeoutMs);
+
+    /**
+     * Offer a new message to the queue.
+     *
+     * @param message the message to deliver
+     * @throws IllegalStateException if the queue cannot accept the message
+     */
+    void offer(RaftMessage message);
+
+    /**
+     * Check whether there are pending messages awaiting delivery.
+     *
+     * @return if there are no pending messages to deliver
+     */
+    boolean isEmpty();
+
+    /**
+     * Wakeup the thread blocking in {@link #poll(long)}. This will cause
+     * {@link #poll(long)} to return null if no messages are available.
+     */
+    void wakeup();
+
+}

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
@@ -29,7 +29,8 @@ public interface RaftMessageQueue {
      * Block for the arrival of a new message.
      *
      * @param timeoutMs timeout in milliseconds to wait for a new event
-     * @return the event or null if the timeout was reached
+     * @return the event or null if either the timeout was reached or there was
+     *     a call to {@link #wakeup()} before any events became available
      */
     RaftMessage poll(long timeoutMs);
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftMessageQueue.java
@@ -35,12 +35,12 @@ public interface RaftMessageQueue {
     RaftMessage poll(long timeoutMs);
 
     /**
-     * Offer a new message to the queue.
+     * Add a new message to the queue.
      *
      * @param message the message to deliver
      * @throws IllegalStateException if the queue cannot accept the message
      */
-    void offer(RaftMessage message);
+    void add(RaftMessage message);
 
     /**
      * Check whether there are pending messages awaiting delivery.

--- a/raft/src/main/java/org/apache/kafka/raft/RaftRequest.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftRequest.java
@@ -18,6 +18,8 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.protocol.ApiMessage;
 
+import java.util.concurrent.CompletableFuture;
+
 public abstract class RaftRequest implements RaftMessage {
     protected final int correlationId;
     protected final ApiMessage data;
@@ -44,6 +46,8 @@ public abstract class RaftRequest implements RaftMessage {
     }
 
     public static class Inbound extends RaftRequest {
+        public final CompletableFuture<RaftResponse.Outbound> completion = new CompletableFuture<>();
+
         public Inbound(int correlationId, ApiMessage data, long createdTimeMs) {
             super(correlationId, data, createdTimeMs);
         }
@@ -60,6 +64,7 @@ public abstract class RaftRequest implements RaftMessage {
 
     public static class Outbound extends RaftRequest {
         private final int destinationId;
+        public final CompletableFuture<RaftResponse.Inbound> completion = new CompletableFuture<>();
 
         public Outbound(int correlationId, ApiMessage data, int destinationId, long createdTimeMs) {
             super(correlationId, data, createdTimeMs);

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.raft.RaftMessage;
+import org.apache.kafka.raft.RaftMessageQueue;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class BlockingMessageQueue implements RaftMessageQueue {
+    private final BlockingQueue<RaftEvent> queue = new LinkedBlockingQueue<>();
+    private final AtomicInteger size = new AtomicInteger(0);
+
+    @Override
+    public RaftMessage poll(long timeoutMs) {
+        try {
+            RaftEvent event = queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
+            if (event instanceof MessageReceived) {
+                size.decrementAndGet();
+                return ((MessageReceived) event).message;
+            } else {
+                return null;
+            }
+        } catch (InterruptedException e) {
+            throw new InterruptException(e);
+        }
+
+    }
+
+    @Override
+    public void offer(RaftMessage message) {
+        queue.add(new MessageReceived(message));
+        size.incrementAndGet();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size.get() == 0;
+    }
+
+    @Override
+    public void wakeup() {
+        queue.add(Wakeup.INSTANCE);
+    }
+
+    public interface RaftEvent {
+    }
+
+    static final class MessageReceived implements RaftEvent {
+        private final RaftMessage message;
+        private MessageReceived(RaftMessage message) {
+            this.message = message;
+        }
+    }
+
+    static final class Wakeup implements RaftEvent {
+        public static final Wakeup INSTANCE = new Wakeup();
+    }
+
+}

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BlockingMessageQueue.java
@@ -58,7 +58,7 @@ public class BlockingMessageQueue implements RaftMessageQueue {
     }
 
     @Override
-    public void offer(RaftMessage message) {
+    public void add(RaftMessage message) {
         queue.add(message);
         size.incrementAndGet();
     }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -109,7 +109,7 @@ public class KafkaRaftClientTest {
         // other voter in the same epoch, even if it has caught up to the same position.
         context.deliverRequest(context.voteRequest(epoch, remoteId,
             context.log.lastFetchedEpoch(), context.log.endOffset().offset));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.of(localId), false);
     }
 
@@ -134,7 +134,7 @@ public class KafkaRaftClientTest {
         // other voter in the same epoch, even if it has caught up to the same position.
         context.deliverRequest(context.voteRequest(epoch, remoteId,
             context.log.lastFetchedEpoch(), context.log.endOffset().offset));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.empty(), false);
     }
 
@@ -158,13 +158,13 @@ public class KafkaRaftClientTest {
         context.client.poll();
         assertEquals(Long.MAX_VALUE, context.client.scheduleAppend(epoch, Arrays.asList("a", "b")));
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         int correlationId = context.assertSentEndQuorumEpochRequest(epoch, 1);
         context.deliverResponse(correlationId, 1, context.endEpochResponse(epoch, OptionalInt.of(localId)));
         context.client.poll();
 
         context.time.sleep(context.electionTimeoutMs);
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(epoch + 1, localId);
         context.assertSentVoteRequest(epoch + 1, 0, 0L, 1);
     }
@@ -187,7 +187,7 @@ public class KafkaRaftClientTest {
             .withElectedLeader(epoch, localId)
             .build();
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         List<RaftRequest.Outbound> requests = context.collectEndQuorumRequests(epoch, Utils.mkSet(voter1, voter2));
         assertEquals(2, requests.size());
 
@@ -203,7 +203,7 @@ public class KafkaRaftClientTest {
         // retried request from the voter that hasn't responded yet.
         int nonRespondedId = requests.get(1).destinationId();
         context.time.sleep(6000);
-        context.pollUntilSend();
+        context.pollUntilRequest();
         List<RaftRequest.Outbound> retries = context.collectEndQuorumRequests(epoch, Utils.mkSet(nonRespondedId));
         assertEquals(1, retries.size());
     }
@@ -254,7 +254,7 @@ public class KafkaRaftClientTest {
         assertEquals(0L, context.log.endOffset().offset);
 
         // The candidate will resume the election after reinitialization
-        context.pollUntilSend();
+        context.pollUntilRequest();
         List<RaftRequest.Outbound> voteRequests = context.collectVoteRequests(2, 0, 0);
         assertEquals(2, voteRequests.size());
     }
@@ -269,7 +269,7 @@ public class KafkaRaftClientTest {
         context.assertUnknownLeader(0);
         context.time.sleep(2 * context.electionTimeoutMs);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(1, context.localId);
 
         int correlationId = context.assertSentVoteRequest(1, 0, 0L, 1);
@@ -309,7 +309,7 @@ public class KafkaRaftClientTest {
         context.assertUnknownLeader(0);
         context.time.sleep(2 * context.electionTimeoutMs);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(1, context.localId);
 
         int correlationId = context.assertSentVoteRequest(1, 0, 0L, 2);
@@ -350,8 +350,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.beginEpochRequest(votedCandidateEpoch, otherNodeId));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertElectedLeader(votedCandidateEpoch, otherNodeId);
 
@@ -370,8 +369,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.beginEpochRequest(leaderEpoch + 1, otherNodeId));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertElectedLeader(leaderEpoch + 1, otherNodeId);
     }
@@ -431,7 +429,7 @@ public class KafkaRaftClientTest {
         // One of the voters may have sent EndQuorumEpoch from an earlier epoch
         context.deliverRequest(context.endEpochRequest(epoch - 2, voter2, Arrays.asList(context.localId, voter3)));
 
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentEndQuorumEpochResponse(Errors.FENCED_LEADER_EPOCH, epoch, OptionalInt.of(context.localId));
 
         // We should still be leader as long as fetch timeout has not expired
@@ -455,7 +453,7 @@ public class KafkaRaftClientTest {
         context.deliverRequest(context.endEpochRequest(epoch, voter2,
             Arrays.asList(context.localId, voter3)));
 
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentEndQuorumEpochResponse(Errors.NONE, epoch, OptionalInt.of(voter2));
 
         // Should become a candidate immediately
@@ -486,7 +484,7 @@ public class KafkaRaftClientTest {
 
         assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
         context.deliverRequest(context.beginEpochRequest(epoch + 1, otherNodeId));
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertElectedLeader(epoch + 1, otherNodeId);
         Mockito.verify(memoryPool).release(buffer);
@@ -516,7 +514,7 @@ public class KafkaRaftClientTest {
         assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, epoch,
             context.log.endOffset().offset));
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertVotedCandidate(epoch + 1, otherNodeId);
         Mockito.verify(memoryPool).release(buffer);
@@ -545,7 +543,7 @@ public class KafkaRaftClientTest {
 
         assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, epoch, 0L));
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertUnknownLeader(epoch + 1);
         Mockito.verify(memoryPool).release(buffer);
@@ -571,14 +569,14 @@ public class KafkaRaftClientTest {
 
         int epoch = context.currentEpoch();
         assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
-        assertTrue(context.channel.wakeupRequested());
+        assertTrue(context.messageQueue.wakeupRequested());
 
         context.client.poll();
-        assertEquals(OptionalLong.of(lingerMs), context.channel.lastReceiveTimeout());
+        assertEquals(OptionalLong.of(lingerMs), context.messageQueue.lastPollTimeoutMs());
 
         context.time.sleep(20);
         context.client.poll();
-        assertEquals(OptionalLong.of(30), context.channel.lastReceiveTimeout());
+        assertEquals(OptionalLong.of(30), context.messageQueue.lastPollTimeoutMs());
 
         context.time.sleep(30);
         context.client.poll();
@@ -605,15 +603,15 @@ public class KafkaRaftClientTest {
 
         int epoch = context.currentEpoch();
         assertEquals(1L, context.client.scheduleAppend(epoch, singletonList("a")));
-        assertTrue(context.channel.wakeupRequested());
+        assertTrue(context.messageQueue.wakeupRequested());
 
         context.client.poll();
-        assertFalse(context.channel.wakeupRequested());
-        assertEquals(OptionalLong.of(lingerMs), context.channel.lastReceiveTimeout());
+        assertFalse(context.messageQueue.wakeupRequested());
+        assertEquals(OptionalLong.of(lingerMs), context.messageQueue.lastPollTimeoutMs());
 
         context.time.sleep(lingerMs);
         assertEquals(2L, context.client.scheduleAppend(epoch, singletonList("b")));
-        assertTrue(context.channel.wakeupRequested());
+        assertTrue(context.messageQueue.wakeupRequested());
 
         context.client.poll();
         assertEquals(3L, context.log.endOffset().offset);
@@ -633,7 +631,7 @@ public class KafkaRaftClientTest {
         context.deliverRequest(context.endEpochRequest(leaderEpoch, oldLeaderId,
             Collections.singletonList(context.localId)));
 
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentEndQuorumEpochResponse(Errors.NONE, leaderEpoch, OptionalInt.of(oldLeaderId));
 
         context.client.poll();
@@ -655,19 +653,19 @@ public class KafkaRaftClientTest {
         context.deliverRequest(context.endEpochRequest(leaderEpoch, oldLeaderId,
             Arrays.asList(preferredNextLeader, context.localId)));
 
-        context.pollUntilSend();
+        context.pollUntilResponse();
         context.assertSentEndQuorumEpochResponse(Errors.NONE, leaderEpoch, OptionalInt.of(oldLeaderId));
 
         // The election won't trigger by one round retry backoff
         context.time.sleep(1);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         context.assertSentFetchRequest(leaderEpoch, 0, 0);
 
         context.time.sleep(context.retryBackoffMs);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         List<RaftRequest.Outbound> voteRequests = context.collectVoteRequests(leaderEpoch + 1, 0, 0);
         assertEquals(2, voteRequests.size());
@@ -687,7 +685,7 @@ public class KafkaRaftClientTest {
         context.assertUnknownLeader(0);
 
         context.time.sleep(2 * context.electionTimeoutMs);
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(epoch, context.localId);
 
         int correlationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
@@ -696,13 +694,12 @@ public class KafkaRaftClientTest {
         context.client.poll();
         int retryCorrelationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
 
-        // Even though we have resent the request, we should still accept the response to
-        // the first request if it arrives late.
+        // We will ignore the timed out response if it arrives late
         context.deliverResponse(correlationId, otherNodeId, context.voteResponse(true, Optional.empty(), 1));
         context.client.poll();
-        context.assertElectedLeader(epoch, context.localId);
+        context.assertVotedCandidate(epoch, context.localId);
 
-        // If the second request arrives later, it should have no effect
+        // Become leader after receiving the retry response
         context.deliverResponse(retryCorrelationId, otherNodeId, context.voteResponse(true, Optional.empty(), 1));
         context.client.poll();
         context.assertElectedLeader(epoch, context.localId);
@@ -720,8 +717,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.voteRequest(epoch, otherNodeId, epoch - 1, 1));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.empty(), true);
 
@@ -741,8 +737,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.voteRequest(epoch, otherNodeId, epoch - 1, 1));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.of(electedLeaderId), false);
 
@@ -762,8 +757,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.voteRequest(epoch, otherNodeId, epoch - 1, 1));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertSentVoteResponse(Errors.NONE, epoch, OptionalInt.empty(), false);
         context.assertVotedCandidate(epoch, votedCandidateId);
@@ -781,8 +775,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.voteRequest(epoch - 1, otherNodeId, epoch - 2, 1));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertSentVoteResponse(Errors.FENCED_LEADER_EPOCH, epoch, OptionalInt.empty(), false);
         context.assertUnknownLeader(epoch);
@@ -801,8 +794,7 @@ public class KafkaRaftClientTest {
             .build();
 
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, epoch, 1));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertSentVoteResponse(Errors.INCONSISTENT_VOTER_SET, epoch, OptionalInt.empty(), false);
         context.assertUnknownLeader(epoch);
@@ -841,7 +833,8 @@ public class KafkaRaftClientTest {
         // Let follower send a fetch to initialize the high watermark,
         // note the offset 0 would be a control message for becoming the leader
         context.deliverRequest(context.fetchRequest(epoch, otherNodeId, 0L, epoch, 500));
-        context.pollUntilSend();
+        context.pollUntilResponse();
+        context.assertSentFetchResponse(Errors.NONE, epoch, OptionalInt.of(localId));
         assertEquals(OptionalLong.of(0L), context.client.highWatermark());
 
         List<String> records = Arrays.asList("a", "b", "c");
@@ -851,14 +844,14 @@ public class KafkaRaftClientTest {
 
         // Let the follower send a fetch, it should advance the high watermark
         context.deliverRequest(context.fetchRequest(epoch, otherNodeId, 1L, epoch, 500));
-        context.pollUntilSend();
+        context.pollUntilResponse();
+        context.assertSentFetchResponse(Errors.NONE, epoch, OptionalInt.of(localId));
         assertEquals(OptionalLong.of(1L), context.client.highWatermark());
         assertEquals(OptionalLong.empty(), context.listener.lastCommitOffset());
 
         // Let the follower send another fetch from offset 4
         context.deliverRequest(context.fetchRequest(epoch, otherNodeId, 4L, epoch, 500));
-        context.client.poll();
-        assertEquals(OptionalLong.of(4L), context.client.highWatermark());
+        context.pollUntil(() -> context.client.highWatermark().equals(OptionalLong.of(4L)));
         assertEquals(records, context.listener.commitWithLastOffset(offset));
     }
 
@@ -873,7 +866,7 @@ public class KafkaRaftClientTest {
             .withVotedCandidate(leaderEpoch, localId)
             .build();
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         context.deliverRequest(context.voteRequest(leaderEpoch, otherNodeId, leaderEpoch - 1, 1));
         context.client.poll();
@@ -898,7 +891,7 @@ public class KafkaRaftClientTest {
         context.assertUnknownLeader(0);
 
         context.time.sleep(2 * context.electionTimeoutMs);
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(epoch, context.localId);
 
         // Quorum size is two. If the other member rejects, then we need to schedule a revote.
@@ -919,7 +912,7 @@ public class KafkaRaftClientTest {
         // After jitter expires, we become a candidate again
         context.time.sleep(1);
         context.client.poll();
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(epoch + 1, context.localId);
         context.assertSentVoteRequest(epoch + 1, 0, 0L, 1);
     }
@@ -937,7 +930,7 @@ public class KafkaRaftClientTest {
 
         context.assertElectedLeader(epoch, otherNodeId);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         context.assertSentFetchRequest(epoch, 0L, 0);
     }
@@ -957,7 +950,7 @@ public class KafkaRaftClientTest {
 
         context.assertElectedLeader(epoch, otherNodeId);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertSentFetchRequest(epoch, 1L, lastEpoch);
     }
 
@@ -975,12 +968,12 @@ public class KafkaRaftClientTest {
             .build();
         context.assertElectedLeader(epoch, otherNodeId);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertSentFetchRequest(epoch, 1L, lastEpoch);
 
         context.time.sleep(context.fetchTimeoutMs);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         context.assertSentVoteRequest(epoch + 1, lastEpoch, 1L, 1);
         context.assertVotedCandidate(epoch + 1, context.localId);
@@ -996,7 +989,7 @@ public class KafkaRaftClientTest {
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters).build();
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
         context.assertFetchRequestData(fetchRequest, 0, 0L, 0);
@@ -1017,7 +1010,7 @@ public class KafkaRaftClientTest {
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters).build();
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
         context.assertFetchRequestData(fetchRequest, 0, 0L, 0);
@@ -1027,7 +1020,7 @@ public class KafkaRaftClientTest {
         context.client.poll();
 
         context.time.sleep(context.retryBackoffMs);
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
@@ -1050,7 +1043,7 @@ public class KafkaRaftClientTest {
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters).build();
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
         context.assertFetchRequestData(fetchRequest, 0, 0L, 0);
@@ -1062,7 +1055,7 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, leaderId);
         context.time.sleep(context.fetchTimeoutMs);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
@@ -1079,27 +1072,27 @@ public class KafkaRaftClientTest {
 
         context.deliverRequest(context.fetchRequest(
             epoch, otherNodeId, -5L, 0, 0));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentFetchResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(context.localId));
 
         context.deliverRequest(context.fetchRequest(
             epoch, otherNodeId, 0L, -1, 0));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentFetchResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(context.localId));
 
         context.deliverRequest(context.fetchRequest(
             epoch, otherNodeId, 0L, epoch + 1, 0));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentFetchResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(context.localId));
 
         context.deliverRequest(context.fetchRequest(
             epoch + 1, otherNodeId, 0L, 0, 0));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentFetchResponse(Errors.UNKNOWN_LEADER_EPOCH, epoch, OptionalInt.of(context.localId));
 
         context.deliverRequest(context.fetchRequest(
             epoch, otherNodeId, 0L, 0, -1));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentFetchResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(context.localId));
     }
 
@@ -1141,17 +1134,17 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, otherNodeId);
 
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, 0, -5L));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentVoteResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(otherNodeId), false);
         context.assertElectedLeader(epoch, otherNodeId);
 
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, -1, 0L));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentVoteResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(otherNodeId), false);
         context.assertElectedLeader(epoch, otherNodeId);
 
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, epoch + 1, 0L));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertSentVoteResponse(Errors.INVALID_REQUEST, epoch, OptionalInt.of(otherNodeId), false);
         context.assertElectedLeader(epoch, otherNodeId);
     }
@@ -1220,7 +1213,7 @@ public class KafkaRaftClientTest {
 
         // Now we get a BeginEpoch from the other voter and become a follower
         context.deliverRequest(context.beginEpochRequest(epoch + 1, voter3));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertElectedLeader(epoch + 1, voter3);
 
         // We expect the BeginQuorumEpoch response and a failed Fetch response
@@ -1246,7 +1239,7 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, otherNodeId);
 
         // Wait until we have a Fetch inflight to the leader
-        context.pollUntilSend();
+        context.pollUntilRequest();
         int fetchCorrelationId = context.assertSentFetchRequest(epoch, 0L, 0);
 
         // Now await the fetch timeout and become a candidate
@@ -1280,7 +1273,7 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, voter2);
 
         // Wait until we have a Fetch inflight to the leader
-        context.pollUntilSend();
+        context.pollUntilRequest();
         int fetchCorrelationId = context.assertSentFetchRequest(epoch, 0L, 0);
 
         // Now receive a BeginEpoch from `voter3`
@@ -1316,7 +1309,7 @@ public class KafkaRaftClientTest {
         context.time.sleep(context.electionTimeoutMs * 2);
 
         // Wait until the vote requests are inflight
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(epoch, context.localId);
         List<RaftRequest.Outbound> voteRequests = context.collectVoteRequests(epoch, 0, 0);
         assertEquals(2, voteRequests.size());
@@ -1349,14 +1342,14 @@ public class KafkaRaftClientTest {
 
         context.discoverLeaderAsObserver(leaderId, epoch);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest1 = context.assertSentFetchRequest();
         assertEquals(leaderId, fetchRequest1.destinationId());
         context.assertFetchRequestData(fetchRequest1, epoch, 0L, 0);
 
         context.deliverResponse(fetchRequest1.correlationId, fetchRequest1.destinationId(),
             context.fetchResponse(epoch, -1, MemoryRecords.EMPTY, -1, Errors.BROKER_NOT_AVAILABLE));
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         // We should retry the Fetch against the other voter since the original
         // voter connection will be backing off.
@@ -1386,13 +1379,13 @@ public class KafkaRaftClientTest {
 
         context.discoverLeaderAsObserver(leaderId, epoch);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest1 = context.assertSentFetchRequest();
         assertEquals(leaderId, fetchRequest1.destinationId());
         context.assertFetchRequestData(fetchRequest1, epoch, 0L, 0);
 
         context.time.sleep(context.requestTimeoutMs);
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         // We should retry the Fetch against the other voter since the original
         // voter connection will be backing off.
@@ -1427,7 +1420,7 @@ public class KafkaRaftClientTest {
         assertFalse(shutdownFuture.isDone());
 
         // Send EndQuorumEpoch request to the other voter
-        context.pollUntilSend();
+        context.pollUntilRequest();
         assertTrue(context.client.isShuttingDown());
         assertTrue(context.client.isRunning());
         context.assertSentEndQuorumEpochRequest(1, otherNodeId);
@@ -1469,7 +1462,7 @@ public class KafkaRaftClientTest {
         assertTrue(context.client.isRunning());
 
         // Send EndQuorumEpoch request to the close follower
-        context.pollUntilSend();
+        context.pollUntilRequest();
         assertTrue(context.client.isRunning());
 
         List<RaftRequest.Outbound> endQuorumRequests = context.collectEndQuorumRequests(
@@ -1494,14 +1487,14 @@ public class KafkaRaftClientTest {
         int observerId = 3;
         context.deliverRequest(context.fetchRequest(epoch, observerId, 0L, 0, 0));
 
-        context.client.poll();
+        context.pollUntilResponse();
 
         long highWatermark = 1L;
         context.assertSentFetchResponse(highWatermark, epoch);
 
         context.deliverRequest(DescribeQuorumRequest.singletonRequest(context.metadataPartition));
 
-        context.client.poll();
+        context.pollUntilResponse();
 
         context.assertSentDescribeQuorumResponse(context.localId, epoch, highWatermark,
             Arrays.asList(
@@ -1540,7 +1533,7 @@ public class KafkaRaftClientTest {
         assertFalse(shutdownFuture.isDone());
 
         // Send EndQuorumEpoch request to the other vote
-        context.pollUntilSend();
+        context.pollUntilRequest();
         assertTrue(context.client.isRunning());
 
         context.assertSentEndQuorumEpochRequest(epoch, otherNodeId);
@@ -1631,7 +1624,7 @@ public class KafkaRaftClientTest {
             .build();
         context.assertElectedLeader(epoch, otherNodeId);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         int fetchQuorumCorrelationId = context.assertSentFetchRequest(epoch, 0L, 0);
         Records records = context.buildBatch(0L, 3, Arrays.asList("a", "b"));
@@ -1656,7 +1649,7 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, otherNodeId);
 
         // Receive an empty fetch response
-        context.pollUntilSend();
+        context.pollUntilRequest();
         int fetchQuorumCorrelationId = context.assertSentFetchRequest(epoch, 0L, 0);
         FetchResponseData fetchResponse = context.fetchResponse(epoch, otherNodeId,
             MemoryRecords.EMPTY, 0L, Errors.NONE);
@@ -1666,7 +1659,7 @@ public class KafkaRaftClientTest {
         assertEquals(OptionalLong.of(0L), context.client.highWatermark());
 
         // Receive some records in the next poll, but do not advance high watermark
-        context.pollUntilSend();
+        context.pollUntilRequest();
         Records records = context.buildBatch(0L, epoch, Arrays.asList("a", "b"));
         fetchQuorumCorrelationId = context.assertSentFetchRequest(epoch, 0L, 0);
         fetchResponse = context.fetchResponse(epoch, otherNodeId,
@@ -1677,7 +1670,7 @@ public class KafkaRaftClientTest {
         assertEquals(OptionalLong.of(0L), context.client.highWatermark());
 
         // The next fetch response is empty, but should still advance the high watermark
-        context.pollUntilSend();
+        context.pollUntilRequest();
         fetchQuorumCorrelationId = context.assertSentFetchRequest(epoch, 2L, epoch);
         fetchResponse = context.fetchResponse(epoch, otherNodeId,
             MemoryRecords.EMPTY, 2L, Errors.NONE);
@@ -1704,7 +1697,7 @@ public class KafkaRaftClientTest {
         context.time.sleep(context.electionTimeoutMs);
         context.expectAndGrantVotes(epoch);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         // We send BeginEpoch, but it gets lost and the destination finds the leader through the Fetch API
         context.assertSentBeginQuorumEpochRequest(epoch, 1);
@@ -1720,12 +1713,12 @@ public class KafkaRaftClientTest {
 
         context.client.poll();
 
-        List<RaftMessage> sentMessages = context.channel.drainSendQueue();
+        List<RaftRequest.Outbound> sentMessages = context.channel.drainSendQueue();
         assertEquals(0, sentMessages.size());
     }
 
     @Test
-    public void testLeaderAppendSingleMemberQuorum() throws IOException {
+    public void testLeaderAppendSingleMemberQuorum() throws Exception {
         int localId = 0;
         Set<Integer> voters = Collections.singleton(localId);
 
@@ -1752,8 +1745,7 @@ public class KafkaRaftClientTest {
         // Now try reading it
         int otherNodeId = 1;
         context.deliverRequest(context.fetchRequest(1, otherNodeId, 0L, 0, 500));
-
-        context.client.poll();
+        context.pollUntilResponse();
 
         MemoryRecords fetchedRecords = context.assertSentFetchResponse(Errors.NONE, 1, OptionalInt.of(context.localId));
         List<MutableRecordBatch> batches = Utils.toList(fetchedRecords.batchIterator());
@@ -1796,7 +1788,7 @@ public class KafkaRaftClientTest {
         context.assertElectedLeader(epoch, otherNodeId);
         assertEquals(3L, context.log.endOffset().offset);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         int correlationId = context.assertSentFetchRequest(epoch, 3L, lastEpoch);
 
@@ -1873,7 +1865,7 @@ public class KafkaRaftClientTest {
 
         context.assertElectedLeader(epoch, otherNodeId);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         int correlationId = context.assertSentFetchRequest(epoch, 0, 0);
         FetchResponseData response = new FetchResponseData()
@@ -1899,7 +1891,7 @@ public class KafkaRaftClientTest {
         context.time.sleep(context.electionTimeoutMs);
         context.expectAndGrantVotes(epoch);
 
-        context.pollUntilSend();
+        context.pollUntilRequest();
         int correlationId = context.assertSentBeginQuorumEpochRequest(epoch, 1);
         BeginQuorumEpochResponseData response = new BeginQuorumEpochResponseData()
             .setErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code());
@@ -1921,7 +1913,7 @@ public class KafkaRaftClientTest {
 
         // Sleep a little to ensure that we become a candidate
         context.time.sleep(context.electionTimeoutMs * 2);
-        context.pollUntilSend();
+        context.pollUntilRequest();
         context.assertVotedCandidate(epoch, context.localId);
 
         int correlationId = context.assertSentVoteRequest(epoch, 0, 0L, 1);
@@ -1942,7 +1934,7 @@ public class KafkaRaftClientTest {
         RaftClientTestContext context = RaftClientTestContext.initializeAsLeader(localId, voters, epoch);
 
         context.client.shutdown(5000);
-        context.pollUntilSend();
+        context.pollUntilRequest();
 
         int correlationId = context.assertSentEndQuorumEpochRequest(epoch, otherNodeId);
         EndQuorumEpochResponseData response = new EndQuorumEpochResponseData()
@@ -2067,7 +2059,7 @@ public class KafkaRaftClientTest {
         assertEquals(OptionalLong.empty(), context.client.highWatermark());
 
         // Poll for our first fetch request
-        context.pollUntilSend();
+        context.pollUntilRequest();
         RaftRequest.Outbound fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
         context.assertFetchRequestData(fetchRequest, epoch, 0L, 0);
@@ -2085,7 +2077,7 @@ public class KafkaRaftClientTest {
         assertEquals(OptionalInt.empty(), context.listener.currentClaimedEpoch());
 
         // Now look for the next fetch request
-        context.pollUntilSend();
+        context.pollUntilRequest();
         fetchRequest = context.assertSentFetchRequest();
         assertTrue(voters.contains(fetchRequest.destinationId()));
         context.assertFetchRequestData(fetchRequest, epoch, 3L, 3);
@@ -2131,7 +2123,7 @@ public class KafkaRaftClientTest {
         // Now we receive a vote request which transitions us to the 'voted' state
         int candidateEpoch = epoch + 1;
         context.deliverRequest(context.voteRequest(candidateEpoch, otherNodeId, epoch, 10L));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertVotedCandidate(candidateEpoch, otherNodeId);
         assertEquals(OptionalLong.of(10L), context.client.highWatermark());
 
@@ -2166,12 +2158,13 @@ public class KafkaRaftClientTest {
         // Start off as the leader and receive a fetch to initialize the high watermark
         context.becomeLeader();
         context.deliverRequest(context.fetchRequest(epoch, otherNodeId, 9L, epoch, 500));
-        context.client.poll();
+        context.pollUntilResponse();
         assertEquals(OptionalLong.of(9L), context.client.highWatermark());
+        context.assertSentFetchResponse(Errors.NONE, epoch, OptionalInt.of(context.localId));
 
         // Now we receive a vote request which transitions us to the 'unattached' state
         context.deliverRequest(context.voteRequest(epoch + 1, otherNodeId, epoch, 9L));
-        context.client.poll();
+        context.pollUntilResponse();
         context.assertUnknownLeader(epoch + 1);
         assertEquals(OptionalLong.of(9L), context.client.highWatermark());
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -255,6 +255,13 @@ public class MockLog implements ReplicatedLog {
         long baseOffset = endOffset().offset;
         long lastOffset = baseOffset;
         for (RecordBatch batch : records.batches()) {
+            Optional<LogEntry> lastEntry = lastEntry();
+
+            if (lastEntry.isPresent() && batch.baseOffset() != lastEntry.get().offset + 1) {
+                throw new IllegalArgumentException("Illegal append at offset " + batch.baseOffset() +
+                    " with current end offset of " + endOffset().offset);
+            }
+
             List<LogEntry> entries = buildEntries(batch, Record::offset);
             appendBatch(new LogBatch(batch.partitionLeaderEpoch(), batch.isControlBatch(), entries));
             lastOffset = entries.get(entries.size() - 1).offset;

--- a/raft/src/test/java/org/apache/kafka/raft/MockMessageQueue.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockMessageQueue.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import java.util.ArrayDeque;
+import java.util.OptionalLong;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Mocked implementation which does not block in {@link #poll(long)}..
+ */
+public class MockMessageQueue implements RaftMessageQueue {
+    private final Queue<RaftMessage> messages = new ArrayDeque<>();
+    private final AtomicBoolean wakeupRequested = new AtomicBoolean(false);
+    private final AtomicLong lastPollTimeout = new AtomicLong(-1);
+
+    @Override
+    public RaftMessage poll(long timeoutMs) {
+        wakeupRequested.set(false);
+        lastPollTimeout.set(timeoutMs);
+        return messages.poll();
+    }
+
+    @Override
+    public void offer(RaftMessage message) {
+        messages.offer(message);
+    }
+
+    public OptionalLong lastPollTimeoutMs() {
+        long lastTimeoutMs = lastPollTimeout.get();
+        if (lastTimeoutMs < 0) {
+            return OptionalLong.empty();
+        } else {
+            return OptionalLong.of(lastTimeoutMs);
+        }
+    }
+
+    public boolean wakeupRequested() {
+        return wakeupRequested.get();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return messages.isEmpty();
+    }
+
+    @Override
+    public void wakeup() {
+        wakeupRequested.set(true);
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/MockMessageQueue.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockMessageQueue.java
@@ -38,7 +38,7 @@ public class MockMessageQueue implements RaftMessageQueue {
     }
 
     @Override
-    public void offer(RaftMessage message) {
+    public void add(RaftMessage message) {
         messages.offer(message);
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -19,8 +19,8 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.protocol.Writable;
 import org.apache.kafka.common.protocol.Readable;
+import org.apache.kafka.common.protocol.Writable;
 import org.apache.kafka.common.protocol.types.Type;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
@@ -62,9 +62,9 @@ public class RaftEventSimulationTest {
     private static final TopicPartition METADATA_PARTITION = new TopicPartition("__cluster_metadata", 0);
     private static final int ELECTION_TIMEOUT_MS = 1000;
     private static final int ELECTION_JITTER_MS = 100;
-    private static final int FETCH_TIMEOUT_MS = 5000;
+    private static final int FETCH_TIMEOUT_MS = 3000;
     private static final int RETRY_BACKOFF_MS = 50;
-    private static final int REQUEST_TIMEOUT_MS = 500;
+    private static final int REQUEST_TIMEOUT_MS = 3000;
     private static final int FETCH_MAX_WAIT_MS = 100;
     private static final int LINGER_MS = 0;
 
@@ -115,7 +115,7 @@ public class RaftEventSimulationTest {
 
     @Test
     public void testElectionAfterLeaderFailureQuorumSizeThreeAndTwoObservers() {
-        testElectionAfterLeaderFailure(new QuorumConfig(3, 2));
+        testElectionAfterLeaderFailure(new QuorumConfig(3, 1));
     }
 
     @Test
@@ -748,6 +748,7 @@ public class RaftEventSimulationTest {
             LogContext logContext = new LogContext("[Node " + nodeId + "] ");
             PersistentState persistentState = nodes.get(nodeId);
             MockNetworkChannel channel = new MockNetworkChannel(correlationIdCounter);
+            MockMessageQueue messageQueue = new MockMessageQueue();
             QuorumState quorum = new QuorumState(nodeId, voters(), ELECTION_TIMEOUT_MS,
                 FETCH_TIMEOUT_MS, persistentState.store, time, logContext, random);
             Metrics metrics = new Metrics(time);
@@ -766,6 +767,7 @@ public class RaftEventSimulationTest {
             KafkaRaftClient<Integer> client = new KafkaRaftClient<>(
                 serde,
                 channel,
+                messageQueue,
                 persistentState.log,
                 quorum,
                 memoryPool,
@@ -781,8 +783,16 @@ public class RaftEventSimulationTest {
                 logContext,
                 random
             );
-            RaftNode node = new RaftNode(nodeId, client, persistentState.log, channel,
-                    persistentState.store, quorum, logContext);
+            RaftNode node = new RaftNode(
+                nodeId,
+                client,
+                persistentState.log,
+                channel,
+                messageQueue,
+                persistentState.store,
+                quorum,
+                logContext
+            );
             node.initialize();
             running.put(nodeId, node);
         }
@@ -793,22 +803,27 @@ public class RaftEventSimulationTest {
         final KafkaRaftClient<Integer> client;
         final MockLog log;
         final MockNetworkChannel channel;
+        final MockMessageQueue messageQueue;
         final MockQuorumStateStore store;
         final QuorumState quorum;
         final LogContext logContext;
         final ReplicatedCounter counter;
 
-        private RaftNode(int nodeId,
-                         KafkaRaftClient<Integer> client,
-                         MockLog log,
-                         MockNetworkChannel channel,
-                         MockQuorumStateStore store,
-                         QuorumState quorum,
-                         LogContext logContext) {
+        private RaftNode(
+            int nodeId,
+            KafkaRaftClient<Integer> client,
+            MockLog log,
+            MockNetworkChannel channel,
+            MockMessageQueue messageQueue,
+            MockQuorumStateStore store,
+            QuorumState quorum,
+            LogContext logContext
+        ) {
             this.nodeId = nodeId;
             this.client = client;
             this.log = log;
             this.channel = channel;
+            this.messageQueue = messageQueue;
             this.store = store;
             this.quorum = quorum;
             this.logContext = logContext;
@@ -826,9 +841,11 @@ public class RaftEventSimulationTest {
 
         void poll() {
             try {
-                client.poll();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+                do {
+                    client.poll();
+                } while (client.isRunning() && !messageQueue.isEmpty());
+            } catch (Exception e) {
+                throw new RuntimeException("Uncaught exception during poll of node " + nodeId, e);
             }
         }
     }
@@ -1025,7 +1042,7 @@ public class RaftEventSimulationTest {
             return (int) Type.INT32.read(value);
         }
 
-        private void assertCommittedData(int nodeId, KafkaRaftClient manager, MockLog log) {
+        private void assertCommittedData(int nodeId, KafkaRaftClient<Integer> manager, MockLog log) {
             OptionalLong highWatermark = manager.highWatermark();
             if (!highWatermark.isPresent()) {
                 // We cannot do validation if the current high watermark is unknown
@@ -1070,6 +1087,9 @@ public class RaftEventSimulationTest {
         }
 
         void deliver(int senderId, RaftRequest.Outbound outbound) {
+            if (!filters.get(senderId).acceptOutbound(outbound))
+                return;
+
             int correlationId = outbound.correlationId();
             int destinationId = outbound.destinationId();
             RaftRequest.Inbound inbound = new RaftRequest.Inbound(correlationId, outbound.data(),
@@ -1079,9 +1099,15 @@ public class RaftEventSimulationTest {
                 return;
 
             cluster.nodeIfRunning(destinationId).ifPresent(node -> {
-                MockNetworkChannel destChannel = node.channel;
                 inflight.put(correlationId, new InflightRequest(correlationId, senderId, destinationId));
-                destChannel.mockReceive(inbound);
+
+                inbound.completion.whenComplete((response, exception) -> {
+                    if (response != null && filters.get(destinationId).acceptOutbound(response)) {
+                        deliver(destinationId, response);
+                    }
+                });
+
+                node.client.handle(inbound);
             });
         }
 
@@ -1089,6 +1115,7 @@ public class RaftEventSimulationTest {
             int correlationId = outbound.correlationId();
             RaftResponse.Inbound inbound = new RaftResponse.Inbound(correlationId, outbound.data(), senderId);
             InflightRequest inflightRequest = inflight.remove(correlationId);
+
             if (!filters.get(inflightRequest.sourceId).acceptInbound(inbound))
                 return;
 
@@ -1097,24 +1124,8 @@ public class RaftEventSimulationTest {
             });
         }
 
-        void deliver(int senderId, RaftMessage message) {
-            if (!filters.get(senderId).acceptOutbound(message)) {
-                return;
-            } else if (message instanceof RaftRequest.Outbound) {
-                deliver(senderId, (RaftRequest.Outbound) message);
-            } else if (message instanceof RaftResponse.Outbound) {
-                deliver(senderId, (RaftResponse.Outbound) message);
-            } else {
-                throw new AssertionError("Illegal message type sent by node " + message);
-            }
-        }
-
         void filter(int nodeId, NetworkFilter filter) {
             filters.put(nodeId, filter);
-        }
-
-        void deliverRandom() {
-            cluster.forRandomRunning(this::deliverTo);
         }
 
         void deliverTo(RaftNode node) {

--- a/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RequestManagerTest.java
@@ -92,7 +92,7 @@ public class RequestManagerTest {
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
         assertFalse(connectionState.isReady(time.milliseconds()));
-        connectionState.onResponseReceived(correlationId, time.milliseconds());
+        connectionState.onResponseReceived(correlationId);
         assertTrue(connectionState.isReady(time.milliseconds()));
     }
 
@@ -109,7 +109,7 @@ public class RequestManagerTest {
         long correlationId = 1;
         connectionState.onRequestSent(correlationId, time.milliseconds());
         assertFalse(connectionState.isReady(time.milliseconds()));
-        connectionState.onResponseReceived(correlationId + 1, time.milliseconds());
+        connectionState.onResponseReceived(correlationId + 1);
         assertFalse(connectionState.isReady(time.milliseconds()));
     }
 
@@ -120,7 +120,6 @@ public class RequestManagerTest {
             retryBackoffMs,
             requestTimeoutMs,
             random);
-
 
         RequestManager.ConnectionState connectionState = cache.getOrCreate(1);
 

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft.internals;
+
+import org.apache.kafka.raft.RaftMessage;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BlockingMessageQueueTest {
+
+    @Test
+    public void testOfferAndPoll() {
+        BlockingMessageQueue queue = new BlockingMessageQueue();
+        assertTrue(queue.isEmpty());
+        assertNull(queue.poll(0));
+
+        RaftMessage message1 = Mockito.mock(RaftMessage.class);
+        queue.offer(message1);
+        assertFalse(queue.isEmpty());
+        assertEquals(message1, queue.poll(0));
+        assertTrue(queue.isEmpty());
+
+        RaftMessage message2 = Mockito.mock(RaftMessage.class);
+        RaftMessage message3 = Mockito.mock(RaftMessage.class);
+        queue.offer(message2);
+        queue.offer(message3);
+        assertFalse(queue.isEmpty());
+        assertEquals(message2, queue.poll(0));
+        assertEquals(message3, queue.poll(0));
+
+    }
+
+    @Test
+    public void testWakeupFromPoll() {
+        BlockingMessageQueue queue = new BlockingMessageQueue();
+        queue.wakeup();
+        assertNull(queue.poll(Long.MAX_VALUE));
+    }
+
+}

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BlockingMessageQueueTest.java
@@ -34,15 +34,15 @@ class BlockingMessageQueueTest {
         assertNull(queue.poll(0));
 
         RaftMessage message1 = Mockito.mock(RaftMessage.class);
-        queue.offer(message1);
+        queue.add(message1);
         assertFalse(queue.isEmpty());
         assertEquals(message1, queue.poll(0));
         assertTrue(queue.isEmpty());
 
         RaftMessage message2 = Mockito.mock(RaftMessage.class);
         RaftMessage message3 = Mockito.mock(RaftMessage.class);
-        queue.offer(message2);
-        queue.offer(message3);
+        queue.add(message2);
+        queue.add(message3);
         assertFalse(queue.isEmpty());
         assertEquals(message2, queue.poll(0));
         assertEquals(message3, queue.poll(0));


### PR DESCRIPTION
This patch contains the following improvements:

- Separate inbound/outbound request flows so that we can open the door for concurrent inbound request handling
- Rewrite `KafkaNetworkChannel` to use `InterBrokerSendThread` which fixes a number of bugs/shortcomings
- Get rid of a lot of boilerplate conversions in `KafkaNetworkChannel` 
- Improve validation of inbound responses in `KafkaRaftClient` by checking correlationId. This fixes a bug which could cause an out of order Fetch to be applied incorrectly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
