### PR TITLE
KAFKA-10017: fix 2 issues in EosBetaUpgradeIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosBetaUpgradeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosBetaUpgradeIntegrationTest.java
@@ -82,7 +82,7 @@ import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.test.TestUtils.waitForCondition;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 @Category({IntegrationTest.class})
@@ -123,13 +123,8 @@ public class EosBetaUpgradeIntegrationTest {
                 KeyValue.pair(KafkaStreams.State.PENDING_SHUTDOWN, KafkaStreams.State.NOT_RUNNING)
             )
         );
-    private static final List<KeyValue<KafkaStreams.State, KafkaStreams.State>> REBALANCED_RUNNING =
-        Collections.unmodifiableList(
-            Arrays.asList(
-                KeyValue.pair(State.RUNNING, State.REBALANCING),
-                KeyValue.pair(State.REBALANCING, State.RUNNING)
-            )
-        );
+    private static final KeyValue<KafkaStreams.State, KafkaStreams.State> REBALANCED_RUNNING =
+        KeyValue.pair(State.REBALANCING, State.RUNNING);
 
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
@@ -142,7 +137,12 @@ public class EosBetaUpgradeIntegrationTest {
     private final static String CONSUMER_GROUP_ID = "readCommitted";
     private final static String MULTI_PARTITION_INPUT_TOPIC = "multiPartitionInputTopic";
     private final static String MULTI_PARTITION_OUTPUT_TOPIC = "multiPartitionOutputTopic";
+    private final static String APP_DIR_1 = "appDir1";
+    private final static String APP_DIR_2 = "appDir2";
+    private final static String UNEXPECTED_EXCEPTION_MSG = "Fail the test since we got an unexpected exception or" +
+        "there are too many exceptions thrown, please check standard error log for more info.";
     private final String storeName = "store";
+
 
     private final StableAssignmentListener assignmentListener = new StableAssignmentListener();
 
@@ -155,6 +155,15 @@ public class EosBetaUpgradeIntegrationTest {
     private final AtomicInteger commitRequested = new AtomicInteger(0);
 
     private int testNumber = 0;
+    private boolean hasUnexpectedError = false;
+    private Map<String, Integer> exceptionCounts = new HashMap<String, Integer>() {
+        {
+            put(APP_DIR_1, 0);
+            put(APP_DIR_2, 0);
+        }
+    };
+    private int prevNumAssignments = 0;
+    private int expectedNumAssignments = 0;
 
     @Before
     public void createTopics() throws Exception {
@@ -240,7 +249,7 @@ public class EosBetaUpgradeIntegrationTest {
 
         try {
             // phase 1: start both clients
-            streams1Alpha = getKafkaStreams("appDir1", StreamsConfig.EXACTLY_ONCE);
+            streams1Alpha = getKafkaStreams(APP_DIR_1, StreamsConfig.EXACTLY_ONCE);
             streams1Alpha.setStateListener(
                 (newState, oldState) -> stateTransitions1.add(KeyValue.pair(oldState, newState))
             );
@@ -251,18 +260,19 @@ public class EosBetaUpgradeIntegrationTest {
             assignmentListener.waitForNextStableAssignment(MAX_WAIT_TIME_MS);
             waitForRunning(stateTransitions1);
 
-            streams2Alpha = getKafkaStreams("appDir2", StreamsConfig.EXACTLY_ONCE);
+            streams2Alpha = getKafkaStreams(APP_DIR_2, StreamsConfig.EXACTLY_ONCE);
             streams2Alpha.setStateListener(
                 (newState, oldState) -> stateTransitions2.add(KeyValue.pair(oldState, newState))
             );
             stateTransitions1.clear();
 
-            assignmentListener.prepareForRebalance();
+            prevNumAssignments = assignmentListener.prepareForRebalance();
             streams2Alpha.cleanUp();
             streams2Alpha.start();
             assignmentListener.waitForNextStableAssignment(MAX_WAIT_TIME_MS);
-            waitForRebalancingRunning(stateTransitions1);
-            waitForRebalancingRunning(stateTransitions2);
+            expectedNumAssignments = assignmentListener.numTotalAssignments() - prevNumAssignments;
+            waitForNumRebalancingToRunning(stateTransitions2, expectedNumAssignments);
+            waitForRunning(stateTransitions1);
 
             // in all phases, we write comments that assume that p-0/p-1 are assigned to the first client
             // and p-2/p-3 are assigned to the second client (in reality the assignment might be different though)
@@ -394,6 +404,7 @@ public class EosBetaUpgradeIntegrationTest {
                 stateTransitions1.clear();
                 streams1Alpha.close();
                 waitForStateTransition(stateTransitions1, CLOSE_CRASHED);
+                assertFalse(UNEXPECTED_EXCEPTION_MSG, hasUnexpectedError);
             }
 
             // phase 5: (restart first client)
@@ -416,13 +427,14 @@ public class EosBetaUpgradeIntegrationTest {
             commitRequested.set(0);
             stateTransitions1.clear();
             stateTransitions2.clear();
-            streams1Beta = getKafkaStreams("appDir1", StreamsConfig.EXACTLY_ONCE_BETA);
+            streams1Beta = getKafkaStreams(APP_DIR_1, StreamsConfig.EXACTLY_ONCE_BETA);
             streams1Beta.setStateListener((newState, oldState) -> stateTransitions1.add(KeyValue.pair(oldState, newState)));
-            assignmentListener.prepareForRebalance();
+            prevNumAssignments = assignmentListener.prepareForRebalance();
             streams1Beta.start();
             assignmentListener.waitForNextStableAssignment(MAX_WAIT_TIME_MS);
-            waitForRebalancingRunning(stateTransitions1);
-            waitForRebalancingRunning(stateTransitions2);
+            expectedNumAssignments = assignmentListener.numTotalAssignments() - prevNumAssignments;
+            waitForNumRebalancingToRunning(stateTransitions1, expectedNumAssignments);
+            waitForRunning(stateTransitions2);
 
             final Set<Long> newlyCommittedKeys;
             if (!injectError) {
@@ -532,6 +544,7 @@ public class EosBetaUpgradeIntegrationTest {
                 stateTransitions2.clear();
                 streams2Alpha.close();
                 waitForStateTransition(stateTransitions2, CLOSE_CRASHED);
+                assertFalse(UNEXPECTED_EXCEPTION_MSG, hasUnexpectedError);
 
                 final List<KeyValue<Long, Long>> expectedCommittedResultAfterFailure =
                     computeExpectedResult(uncommittedInputDataAfterFirstUpgrade, committedState);
@@ -560,15 +573,16 @@ public class EosBetaUpgradeIntegrationTest {
                 commitCounterClient2.set(-1);
                 stateTransitions1.clear();
                 stateTransitions2.clear();
-                streams2AlphaTwo = getKafkaStreams("appDir2", StreamsConfig.EXACTLY_ONCE);
+                streams2AlphaTwo = getKafkaStreams(APP_DIR_2, StreamsConfig.EXACTLY_ONCE);
                 streams2AlphaTwo.setStateListener(
                     (newState, oldState) -> stateTransitions2.add(KeyValue.pair(oldState, newState))
                 );
-                assignmentListener.prepareForRebalance();
+                prevNumAssignments = assignmentListener.prepareForRebalance();
                 streams2AlphaTwo.start();
                 assignmentListener.waitForNextStableAssignment(MAX_WAIT_TIME_MS);
-                waitForRebalancingRunning(stateTransitions1);
-                waitForRebalancingRunning(stateTransitions2);
+                expectedNumAssignments = assignmentListener.numTotalAssignments() - prevNumAssignments;
+                waitForNumRebalancingToRunning(stateTransitions2, expectedNumAssignments);
+                waitForRunning(stateTransitions1);
 
                 // 7b. write third batch of input data
                 final Set<Long> keysFirstClientBeta = keysFromInstance(streams1Beta);
@@ -622,6 +636,7 @@ public class EosBetaUpgradeIntegrationTest {
                 stateTransitions1.clear();
                 streams1Beta.close();
                 waitForStateTransition(stateTransitions1, CLOSE_CRASHED);
+                assertFalse(UNEXPECTED_EXCEPTION_MSG, hasUnexpectedError);
 
                 final List<KeyValue<Long, Long>> expectedCommittedResultAfterFailure =
                     computeExpectedResult(uncommittedInputDataBetweenUpgrade, committedState);
@@ -631,13 +646,14 @@ public class EosBetaUpgradeIntegrationTest {
                 // 7c. restart the first client in eos-beta mode and wait until rebalance stabilizes
                 stateTransitions1.clear();
                 stateTransitions2.clear();
-                streams1BetaTwo = getKafkaStreams("appDir1", StreamsConfig.EXACTLY_ONCE_BETA);
+                streams1BetaTwo = getKafkaStreams(APP_DIR_1, StreamsConfig.EXACTLY_ONCE_BETA);
                 streams1BetaTwo.setStateListener((newState, oldState) -> stateTransitions1.add(KeyValue.pair(oldState, newState)));
-                assignmentListener.prepareForRebalance();
+                prevNumAssignments = assignmentListener.prepareForRebalance();
                 streams1BetaTwo.start();
                 assignmentListener.waitForNextStableAssignment(MAX_WAIT_TIME_MS);
-                waitForRebalancingRunning(stateTransitions1);
-                waitForRebalancingRunning(stateTransitions2);
+                expectedNumAssignments = assignmentListener.numTotalAssignments() - prevNumAssignments;
+                waitForNumRebalancingToRunning(stateTransitions1, expectedNumAssignments);
+                waitForRunning(stateTransitions2);
             }
 
             // phase 8: (write partial last batch of data)
@@ -743,6 +759,7 @@ public class EosBetaUpgradeIntegrationTest {
                 stateTransitions2.clear();
                 streams2AlphaTwo.close();
                 waitForStateTransition(stateTransitions2, CLOSE_CRASHED);
+                assertFalse(UNEXPECTED_EXCEPTION_MSG, hasUnexpectedError);
             }
 
             // phase 10: (restart second client)
@@ -764,15 +781,16 @@ public class EosBetaUpgradeIntegrationTest {
             commitRequested.set(0);
             stateTransitions1.clear();
             stateTransitions2.clear();
-            streams2Beta = getKafkaStreams("appDir1", StreamsConfig.EXACTLY_ONCE_BETA);
+            streams2Beta = getKafkaStreams(APP_DIR_1, StreamsConfig.EXACTLY_ONCE_BETA);
             streams2Beta.setStateListener(
                 (newState, oldState) -> stateTransitions2.add(KeyValue.pair(oldState, newState))
             );
-            assignmentListener.prepareForRebalance();
+            prevNumAssignments = assignmentListener.prepareForRebalance();
             streams2Beta.start();
             assignmentListener.waitForNextStableAssignment(MAX_WAIT_TIME_MS);
-            waitForRebalancingRunning(stateTransitions1);
-            waitForRebalancingRunning(stateTransitions2);
+            expectedNumAssignments = assignmentListener.numTotalAssignments() - prevNumAssignments;
+            waitForNumRebalancingToRunning(stateTransitions2, expectedNumAssignments);
+            waitForRunning(stateTransitions1);
 
             newlyCommittedKeys.clear();
             if (!injectError) {
@@ -874,7 +892,7 @@ public class EosBetaUpgradeIntegrationTest {
                         this.context = context;
                         state = (KeyValueStore<Long, Long>) context.getStateStore(storeName);
                         final String clientId = context.appConfigs().get(StreamsConfig.CLIENT_ID_CONFIG).toString();
-                        if ("appDir1".equals(clientId)) {
+                        if (APP_DIR_1.equals(clientId)) {
                             crash = errorInjectedClient1;
                             sharedCommit = commitCounterClient1;
                         } else {
@@ -943,12 +961,21 @@ public class EosBetaUpgradeIntegrationTest {
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), config, new TestKafkaClientSupplier());
         streams.setUncaughtExceptionHandler((t, e) -> {
-            // should only have our injected exception or commit exception
-            if (!(e instanceof RuntimeException) && !(e.getMessage().contains("test exception"))) {
-                // The exception won't cause the test fail since we actually "expected" exception thrown and failed the stream.
-                // So, log to stderr for debugging when the exception is not what we expected
+            if (!injectError) {
+                // we don't expect any exception thrown in stop case
                 e.printStackTrace(System.err);
-                fail("Should only get one uncaught exception from Streams.");
+                hasUnexpectedError = true;
+            } else {
+                int exceptionCount = (int) exceptionCounts.get(appDir);
+                // should only have our injected exception or commit exception, and 2 exceptions for each stream
+                if (++exceptionCount > 2 || !(e instanceof RuntimeException) ||
+                    !(e.getMessage().contains("test exception"))) {
+                    // The exception won't cause the test fail since we actually "expected" exception thrown and failed the stream.
+                    // So, log to stderr for debugging when the exception is not what we expected, and fail in the main thread
+                    e.printStackTrace(System.err);
+                    hasUnexpectedError = true;
+                }
+                exceptionCounts.put(appDir, exceptionCount);
             }
         });
 
@@ -963,17 +990,14 @@ public class EosBetaUpgradeIntegrationTest {
         );
     }
 
-    // Wait state from RUNNING -> REBALANCING -> RUNNING because when new stream joined, we'll do 2 rebalancing: 1 for
-    // new member join, 1 for leader re-join group during Stable. So, if we only wait for Running, it might enter rebalancing soon
-    private void waitForRebalancingRunning(final List<KeyValue<KafkaStreams.State, KafkaStreams.State>> observed) throws Exception {
-        waitForCondition(
-            () -> !observed.isEmpty() && observed.size() >= 2 &&
-                Arrays.asList(
-                    observed.get(observed.size() - 2),
-                    observed.get(observed.size() - 1)
-                ).equals(REBALANCED_RUNNING),
+    // Wait for the numRebalancing of <REBALANCING -> RUNNING> state transition because when new stream joined,
+    // we'll do multiple rebalancing. So, if we only wait for Running, it might enter rebalancing soon
+    private void waitForNumRebalancingToRunning(final List<KeyValue<KafkaStreams.State, KafkaStreams.State>> observed,
+                                                final int numRebalancing) throws Exception {
+        waitForCondition(() -> !observed.isEmpty() &&
+                    observed.stream().filter(kv -> kv.equals(REBALANCED_RUNNING)).count() == numRebalancing,
             MAX_WAIT_TIME_MS,
-            () -> "Client did not run from Rebalancing to Running on time. Observers transitions: " + observed
+            () -> "Client did not run " + numRebalancing + " of Rebalancing to Running on time. Observers transitions: " + observed
         );
     }
 
@@ -1164,7 +1188,7 @@ public class EosBetaUpgradeIntegrationTest {
         public ErrorInjector(final Map<String, Object> configs) {
             super(configs, new ByteArraySerializer(), new ByteArraySerializer());
             final String clientId = configs.get(ProducerConfig.CLIENT_ID_CONFIG).toString();
-            if (clientId.contains("appDir1")) {
+            if (clientId.contains(APP_DIR_1)) {
                 crash = commitErrorInjectedClient1;
             } else {
                 crash = commitErrorInjectedClient2;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosBetaUpgradeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosBetaUpgradeIntegrationTest.java
@@ -139,7 +139,7 @@ public class EosBetaUpgradeIntegrationTest {
     private final static String MULTI_PARTITION_OUTPUT_TOPIC = "multiPartitionOutputTopic";
     private final static String APP_DIR_1 = "appDir1";
     private final static String APP_DIR_2 = "appDir2";
-    private final static String UNEXPECTED_EXCEPTION_MSG = "Fail the test since we got an unexpected exception or" +
+    private final static String UNEXPECTED_EXCEPTION_MSG = "Fail the test since we got an unexpected exception or " +
         "there are too many exceptions thrown, please check standard error log for more info.";
     private final String storeName = "store";
 
@@ -155,7 +155,6 @@ public class EosBetaUpgradeIntegrationTest {
     private final AtomicInteger commitRequested = new AtomicInteger(0);
 
     private int testNumber = 0;
-    private boolean hasUnexpectedError = false;
     private Map<String, Integer> exceptionCounts = new HashMap<String, Integer>() {
         {
             put(APP_DIR_1, 0);
@@ -164,6 +163,8 @@ public class EosBetaUpgradeIntegrationTest {
     };
     private int prevNumAssignments = 0;
     private int expectedNumAssignments = 0;
+
+    private volatile boolean hasUnexpectedError = false;
 
     @Before
     public void createTopics() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosBetaUpgradeIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosBetaUpgradeIntegrationTest.java
@@ -137,7 +137,7 @@ public class EosBetaUpgradeIntegrationTest {
     private final static String MULTI_PARTITION_OUTPUT_TOPIC = "multiPartitionOutputTopic";
     private final static String APP_DIR_1 = "appDir1";
     private final static String APP_DIR_2 = "appDir2";
-    private final static String UNEXPECTED_EXCEPTION_MSG = "Fail the test since we got an unexpected exception or " +
+    private final static String UNEXPECTED_EXCEPTION_MSG = "Fail the test since we got an unexpected exception, or " +
         "there are too many exceptions thrown, please check standard error log for more info.";
     private final String storeName = "store";
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1270,22 +1270,13 @@ public class IntegrationTestUtils {
 
     public static class StableAssignmentListener implements AssignmentListener {
         final AtomicInteger numStableAssignments = new AtomicInteger(0);
-        final AtomicInteger totalAssignments = new AtomicInteger(0);
         int nextExpectedNumStableAssignments;
 
         @Override
         public void onAssignmentComplete(final boolean stable) {
-            totalAssignments.incrementAndGet();
             if (stable) {
                 numStableAssignments.incrementAndGet();
             }
-        }
-
-        /**
-         * get the total number of assignments (unstable + stable)
-         */
-        public int numTotalAssignments() {
-            return totalAssignments.get();
         }
 
         public int numStableAssignments() {
@@ -1296,12 +1287,9 @@ public class IntegrationTestUtils {
          * Saves the current number of stable rebalances so that we can tell when the next stable assignment has been
          * reached. This should be called once for every invocation of {@link #waitForNextStableAssignment(long)},
          * before the rebalance-triggering event.
-         *
-         * @return the total number of assignments so far
          */
-        public int prepareForRebalance() {
+        public void prepareForRebalance() {
             nextExpectedNumStableAssignments = numStableAssignments.get() + 1;
-            return totalAssignments.get();
         }
 
         /**

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -1270,13 +1270,22 @@ public class IntegrationTestUtils {
 
     public static class StableAssignmentListener implements AssignmentListener {
         final AtomicInteger numStableAssignments = new AtomicInteger(0);
+        final AtomicInteger totalAssignments = new AtomicInteger(0);
         int nextExpectedNumStableAssignments;
 
         @Override
         public void onAssignmentComplete(final boolean stable) {
+            totalAssignments.incrementAndGet();
             if (stable) {
                 numStableAssignments.incrementAndGet();
             }
+        }
+
+        /**
+         * get the total number of assignments (unstable + stable)
+         */
+        public int numTotalAssignments() {
+            return totalAssignments.get();
         }
 
         public int numStableAssignments() {
@@ -1287,9 +1296,12 @@ public class IntegrationTestUtils {
          * Saves the current number of stable rebalances so that we can tell when the next stable assignment has been
          * reached. This should be called once for every invocation of {@link #waitForNextStableAssignment(long)},
          * before the rebalance-triggering event.
+         *
+         * @return the total number of assignments so far
          */
-        public void prepareForRebalance() {
+        public int prepareForRebalance() {
             nextExpectedNumStableAssignments = numStableAssignments.get() + 1;
+            return totalAssignments.get();
         }
 
         /**


### PR DESCRIPTION
The PR follows #9688, to make the EosBetaUpgradeIntegrationTest more stable. Fixed some issues:
1. Test failed with the error message:
```
org.apache.kafka.streams.errors.InvalidStateStoreException: Cannot get state store store because the stream thread is PARTITIONS_ASSIGNED, not RUNNING
```
https://ci-builds.apache.org/job/Kafka/job/kafka-trunk-jdk8/274/testReport/org.apache.kafka.streams.integration/EosBetaUpgradeIntegrationTest/shouldUpgradeFromEosAlphaToEosBeta_true_/
After investigation, I found it's because we actually do rebalancing twice after new stream started: 1 for Adding new member, 1 for leader re-joining group during Stable. So, if we only wait for the state to be `RUNNING`, it might enter `REBALANCING` state later, and cause that we can't get store successfully 

2. We setUncaughtExceptionHandler, but didn't handle it well. Before, we expected the uncaught exception only got 1, but actually, we'll get 4 here (2 injected exception, 2 injected commit exception). So, we saw many messages in stderr output, which is not good for debugging. After fix, we only output to stderr when the exception is not what we expected for debugging use.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
