### PR TITLE
KAFKA-10846: Grow buffer in FileSourceStreamTask only when needed

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
@@ -137,16 +137,12 @@ public class FileStreamSourceTask extends SourceTask {
 
                 if (nread > 0) {
                     offset += nread;
-                    if (offset == buffer.length) {
-                        char[] newbuf = new char[buffer.length * 2];
-                        System.arraycopy(buffer, 0, newbuf, 0, buffer.length);
-                        buffer = newbuf;
-                    }
-
                     String line;
+                    boolean foundOneLine = false;
                     do {
                         line = extractLine();
                         if (line != null) {
+                            foundOneLine = true;
                             log.trace("Read a line from {}", logFilename());
                             if (records == null)
                                 records = new ArrayList<>();
@@ -158,6 +154,13 @@ public class FileStreamSourceTask extends SourceTask {
                             }
                         }
                     } while (line != null);
+
+                    if (!foundOneLine && offset == buffer.length) {
+                        char[] newbuf = new char[buffer.length * 2];
+                        System.arraycopy(buffer, 0, newbuf, 0, buffer.length);
+                        log.info("Increased buffer from {} to {}", buffer.length, newbuf.length);
+                        buffer = newbuf;
+                    }
                 }
             }
 

--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
@@ -48,12 +48,21 @@ public class FileStreamSourceTask extends SourceTask {
     private String filename;
     private InputStream stream;
     private BufferedReader reader = null;
-    private char[] buffer = new char[1024];
+    private char[] buffer;
     private int offset = 0;
     private String topic = null;
     private int batchSize = FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE;
 
     private Long streamOffset;
+
+    public FileStreamSourceTask() {
+        this(1024);
+    }
+
+    /* visible for testing */
+    FileStreamSourceTask(int initialBufferSize) {
+        buffer = new char[initialBufferSize];
+    }
 
     @Override
     public String version() {
@@ -233,5 +242,10 @@ public class FileStreamSourceTask extends SourceTask {
 
     private String logFilename() {
         return filename == null ? "stdin" : filename;
+    }
+
+    /* visible for testing */
+    int bufferSize() {
+        return buffer.length;
     }
 }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -77,6 +78,17 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
 
     @Test
     public void testNormalLifecycle() throws InterruptedException, IOException {
+        normalLifecycle();
+    }
+
+    @Test
+    public void testNormalLifecycleWithResize() throws InterruptedException, IOException {
+        task = new FileStreamSourceTask(2);
+        task.initialize(context);
+        normalLifecycle();
+    }
+
+    private void normalLifecycle() throws InterruptedException, IOException {
         expectOffsetLookupReturnNone();
         replay();
 
@@ -137,19 +149,69 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
         task.start(config);
 
         OutputStream os = Files.newOutputStream(tempFile.toPath());
-        for (int i = 0; i < 10_000; i++) {
-            os.write("Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...\n".getBytes());
-        }
-        os.flush();
+        writeTimesAndFlush(os, 10_000,
+                "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...\n".getBytes()
+        );
 
+        assertEquals(1024, task.bufferSize());
         List<SourceRecord> records = task.poll();
         assertEquals(5000, records.size());
+        assertEquals(1024, task.bufferSize());
 
         records = task.poll();
         assertEquals(5000, records.size());
+        assertEquals(1024, task.bufferSize());
 
         os.close();
         task.stop();
+    }
+
+    @Test
+    public void testBufferResize() throws IOException, InterruptedException {
+        int batchSize = 1000;
+        task = new FileStreamSourceTask(2);
+        task.initialize(context);
+        expectOffsetLookupReturnNone();
+        replay();
+
+        config.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG, Integer.toString(batchSize));
+        task.start(config);
+
+        OutputStream os = Files.newOutputStream(tempFile.toPath());
+
+        assertEquals(2, task.bufferSize());
+        writeAndAssertBufferSize(batchSize, os, "1\n".getBytes(), 2);
+        writeAndAssertBufferSize(batchSize, os, "3 \n".getBytes(), 4);
+        writeAndAssertBufferSize(batchSize, os, "7     \n".getBytes(), 8);
+        writeAndAssertBufferSize(batchSize, os, "8      \n".getBytes(), 8);
+        writeAndAssertBufferSize(batchSize, os, "9       \n".getBytes(), 16);
+
+        byte[] bytes = new byte[1025];
+        Arrays.fill(bytes, (byte) '*');
+        bytes[bytes.length - 1] = '\n';
+        writeAndAssertBufferSize(batchSize, os, bytes, 2048);
+        writeAndAssertBufferSize(batchSize, os, "9       \n".getBytes(), 2048);
+        os.close();
+        task.stop();
+    }
+
+    private void writeAndAssertBufferSize(int batchSize, OutputStream os, byte[] bytes, int expectBufferSize)
+            throws IOException, InterruptedException {
+        writeTimesAndFlush(os, batchSize, bytes);
+        List<SourceRecord> records = task.poll();
+        assertEquals(batchSize, records.size());
+        String expectedLine = new String(bytes, 0, bytes.length - 1); // remove \n
+        for (SourceRecord record : records) {
+            assertEquals(expectedLine, record.value());
+        }
+        assertEquals(expectBufferSize, task.bufferSize());
+    }
+
+    private void writeTimesAndFlush(OutputStream os, int times, byte[] line) throws IOException {
+        for (int i = 0; i < times; i++) {
+            os.write(line);
+        }
+        os.flush();
     }
 
     @Test

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -78,10 +78,6 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
 
     @Test
     public void testNormalLifecycle() throws InterruptedException, IOException {
-        normalLifecycle();
-    }
-
-    private void normalLifecycle() throws InterruptedException, IOException {
         expectOffsetLookupReturnNone();
         replay();
 

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -57,7 +57,7 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
         config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsolutePath());
         config.put(FileStreamSourceConnector.TOPIC_CONFIG, TOPIC);
         config.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG, String.valueOf(FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE));
-        task = new FileStreamSourceTask();
+        task = new FileStreamSourceTask(2);
         offsetStorageReader = createMock(OffsetStorageReader.class);
         context = createMock(SourceTaskContext.class);
         task.initialize(context);
@@ -78,13 +78,6 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
 
     @Test
     public void testNormalLifecycle() throws InterruptedException, IOException {
-        normalLifecycle();
-    }
-
-    @Test
-    public void testNormalLifecycleWithResize() throws InterruptedException, IOException {
-        task = new FileStreamSourceTask(2);
-        task.initialize(context);
         normalLifecycle();
     }
 
@@ -153,14 +146,14 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
                 "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...\n".getBytes()
         );
 
-        assertEquals(1024, task.bufferSize());
+        assertEquals(2, task.bufferSize());
         List<SourceRecord> records = task.poll();
         assertEquals(5000, records.size());
-        assertEquals(1024, task.bufferSize());
+        assertEquals(128, task.bufferSize());
 
         records = task.poll();
         assertEquals(5000, records.size());
-        assertEquals(1024, task.bufferSize());
+        assertEquals(128, task.bufferSize());
 
         os.close();
         task.stop();
@@ -169,8 +162,6 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
     @Test
     public void testBufferResize() throws IOException, InterruptedException {
         int batchSize = 1000;
-        task = new FileStreamSourceTask(2);
-        task.initialize(context);
         expectOffsetLookupReturnNone();
         replay();
 


### PR DESCRIPTION
See [KAFKA-10846](https://issues.apache.org/jira/browse/KAFKA-10846)