### PR TITLE
KAFKA-8744: Update Scala API to give names to processors

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -38,7 +38,7 @@ class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
    * @return a [[CogroupedKStream]]
    */
   def cogroup[VIn](groupedStream: KGroupedStream[KIn, VIn],
-                   aggregator: (KIn, VIn, VOut) => VOut) =
+                   aggregator: (KIn, VIn, VOut) => VOut): CogroupedKStream[KIn, VOut] =
     new CogroupedKStream(inner.cogroup(groupedStream.inner, aggregator.asAggregator))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -23,16 +23,22 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFrom
 /**
  * Wraps the Java class CogroupedKStream and delegates method calls to the underlying Java object.
  *
- * @tparam KIn Type of keys
+ * @tparam KIn  Type of keys
  * @tparam VOut Type of values
  * @param inner The underlying Java abstraction for CogroupedKStream
- *
  * @see `org.apache.kafka.streams.kstream.CogroupedKStream`
  */
 class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
 
+  /**
+   * Add an already [[KGroupedStream]] to this [[CogroupedKStream]].
+   *
+   * @param groupedStream a group stream
+   * @param aggregator    a function that computes a new aggregate result
+   * @return a [[CogroupedKStream]]
+   */
   def cogroup[VIn](groupedStream: KGroupedStream[KIn, VIn],
-                   aggregator: (KIn, VIn, VOut) => VOut): CogroupedKStream[KIn, VOut] =
+                   aggregator: (KIn, VIn, VOut) => VOut) =
     new CogroupedKStream(inner.cogroup(groupedStream.inner, aggregator.asAggregator))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -38,10 +38,10 @@ class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
   /**
    * Aggregate the values of records in these streams by the grouped key and defined window.
    *
-   * @param initializer   an `Initializer` that computes an initial intermediate aggregation result.
-   *                      Cannot be { @code null}.
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
-   *                      Cannot be { @code null}.
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result.
+   *                     Cannot be { @code null}.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   *                     Cannot be { @code null}.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
    *         (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.CogroupedKStream#aggregate`
@@ -49,6 +49,22 @@ class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
   def aggregate(initializer: => VOut)(
     implicit materialized: Materialized[KIn, VOut, ByteArrayKeyValueStore]
   ): KTable[KIn, VOut] = new KTable(inner.aggregate((() => initializer).asInitializer, materialized))
+
+  /**
+   * Aggregate the values of records in these streams by the grouped key and defined window.
+   *
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result.
+   *                     Cannot be { @code null}.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
+   *                     Cannot be { @code null}.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
+   *         (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.CogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => VOut, named: Named)(
+    implicit materialized: Materialized[KIn, VOut, ByteArrayKeyValueStore]
+  ): KTable[KIn, VOut] = new KTable(inner.aggregate((() => initializer).asInitializer, named, materialized))
 
   /**
    * Create a new [[TimeWindowedCogroupedKStream]] instance that can be used to perform windowed aggregations.

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
@@ -113,7 +113,8 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
    *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#reduce`
    */
-  def reduce(reducer: (V, V) => V, named: Named)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+  def reduce(reducer: (V, V) => V,
+             named: Named)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.reduce(reducer.asReducer, materialized))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
@@ -42,7 +42,6 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
  * @tparam K Type of keys
  * @tparam V Type of values
  * @param inner The underlying Java abstraction for KGroupedStream
- *
  * @see `org.apache.kafka.streams.kstream.KGroupedStream`
  */
 class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
@@ -52,9 +51,9 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
    * The result is written into a local `KeyValueStore` (which is basically an ever-updating materialized view)
    * provided by the given `materialized`.
    *
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
-   * represent the latest (rolling) count (i.e., number of records) for each key
+   *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#count`
    */
   def count()(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
@@ -74,10 +73,10 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
    * The result is written into a local `KeyValueStore` (which is basically an ever-updating materialized view)
    * provided by the given `materialized`.
    *
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
-   * represent the latest (rolling) count (i.e., number of records) for each key
+   *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#count`
    */
   def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
@@ -95,10 +94,10 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
   /**
    * Combine the values of records in this stream by the grouped key.
    *
-   * @param reducer   a function `(V, V) => V` that computes a new aggregate result.
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param reducer      a function `(V, V) => V` that computes a new aggregate result.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#reduce`
    */
   def reduce(reducer: (V, V) => V)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
@@ -107,11 +106,11 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
   /**
    * Combine the values of records in this stream by the grouped key.
    *
-   * @param reducer   a function `(V, V) => V` that computes a new aggregate result.
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param reducer      a function `(V, V) => V` that computes a new aggregate result.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#reduce`
    */
   def reduce(reducer: (V, V) => V, named: Named)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
@@ -120,11 +119,11 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
   /**
    * Aggregate the values of records in this stream by the grouped key.
    *
-   * @param initializer   an `Initializer` that computes an initial intermediate aggregation result
-   * @param aggregator    an `Aggregator` that computes a new aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result
+   * @param aggregator   an `Aggregator` that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#aggregate`
    */
   def aggregate[VR](initializer: => VR)(aggregator: (K, V, VR) => VR)(
@@ -135,12 +134,12 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
   /**
    * Aggregate the values of records in this stream by the grouped key.
    *
-   * @param initializer   an `Initializer` that computes an initial intermediate aggregation result
-   * @param aggregator    an `Aggregator` that computes a new aggregate result
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  an `Initializer` that computes an initial intermediate aggregation result
+   * @param aggregator   an `Aggregator` that computes a new aggregate result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#aggregate`
    */
   def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR)(

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
@@ -95,9 +95,9 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#reduce`
    */
-  def reduce(adder: (V, V) => V,
-             subtractor: (V, V) => V,
-             named: Named)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+  def reduce(adder: (V, V) => V, subtractor: (V, V) => V, named: Named)(
+    implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]
+  ): KTable[K, V] =
     new KTable(inner.reduce(adder.asReducer, subtractor.asReducer, named, materialized))
 
   /**
@@ -136,6 +136,10 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
     implicit materialized: Materialized[K, VR, ByteArrayKeyValueStore]
   ): KTable[K, VR] =
     new KTable(
-      inner.aggregate((() => initializer).asInitializer, adder.asAggregator, subtractor.asAggregator, named, materialized)
+      inner.aggregate((() => initializer).asInitializer,
+                      adder.asAggregator,
+                      subtractor.asAggregator,
+                      named,
+                      materialized)
     )
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
@@ -33,7 +33,6 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
  * @tparam K Type of keys
  * @tparam V Type of values
  * @param inner The underlying Java abstraction for KGroupedTable
- *
  * @see `org.apache.kafka.streams.kstream.KGroupedTable`
  */
 class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
@@ -42,9 +41,9 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    * Count number of records of the original [[KTable]] that got [[KTable#groupBy]] to
    * the same key into a new instance of [[KTable]].
    *
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
-   * represent the latest (rolling) count (i.e., number of records) for each key
+   *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#count`
    */
   def count()(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
@@ -57,10 +56,10 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    * Count number of records of the original [[KTable]] that got [[KTable#groupBy]] to
    * the same key into a new instance of [[KTable]].
    *
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
-   * represent the latest (rolling) count (i.e., number of records) for each key
+   *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#count`
    */
   def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
@@ -73,11 +72,11 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    * Combine the value of records of the original [[KTable]] that got [[KTable#groupBy]]
    * to the same key into a new instance of [[KTable]].
    *
-   * @param adder      a function that adds a new value to the aggregate result
-   * @param subtractor a function that removed an old value from the aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param adder        a function that adds a new value to the aggregate result
+   * @param subtractor   a function that removed an old value from the aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#reduce`
    */
   def reduce(adder: (V, V) => V,
@@ -88,12 +87,12 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    * Combine the value of records of the original [[KTable]] that got [[KTable#groupBy]]
    * to the same key into a new instance of [[KTable]].
    *
-   * @param adder      a function that adds a new value to the aggregate result
-   * @param subtractor a function that removed an old value from the aggregate result
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param adder        a function that adds a new value to the aggregate result
+   * @param subtractor   a function that removed an old value from the aggregate result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#reduce`
    */
   def reduce(adder: (V, V) => V,
@@ -105,12 +104,12 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    * Aggregate the value of records of the original [[KTable]] that got [[KTable#groupBy]]
    * to the same key into a new instance of [[KTable]] using default serializers and deserializers.
    *
-   * @param initializer a function that provides an initial aggregate result value
-   * @param adder       a function that adds a new record to the aggregate result
-   * @param subtractor  an aggregator function that removed an old record from the aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  a function that provides an initial aggregate result value
+   * @param adder        a function that adds a new record to the aggregate result
+   * @param subtractor   an aggregator function that removed an old record from the aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#aggregate`
    */
   def aggregate[VR](initializer: => VR)(adder: (K, V, VR) => VR, subtractor: (K, V, VR) => VR)(
@@ -124,13 +123,13 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
    * Aggregate the value of records of the original [[KTable]] that got [[KTable#groupBy]]
    * to the same key into a new instance of [[KTable]] using default serializers and deserializers.
    *
-   * @param initializer a function that provides an initial aggregate result value
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param adder       a function that adds a new record to the aggregate result
-   * @param subtractor  an aggregator function that removed an old record from the aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  a function that provides an initial aggregate result value
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param adder        a function that adds a new record to the aggregate result
+   * @param subtractor   an aggregator function that removed an old record from the aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.KGroupedTable#aggregate`
    */
   def aggregate[VR](initializer: => VR, named: Named)(adder: (K, V, VR) => VR, subtractor: (K, V, VR) => VR)(

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedTable.scala
@@ -54,6 +54,22 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
   }
 
   /**
+   * Count number of records of the original [[KTable]] that got [[KTable#groupBy]] to
+   * the same key into a new instance of [[KTable]].
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   * represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#count`
+   */
+  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayKeyValueStore]): KTable[K, Long] = {
+    val c: KTable[K, java.lang.Long] =
+      new KTable(inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayKeyValueStore]]))
+    c.mapValues[Long](Long2long _)
+  }
+
+  /**
    * Combine the value of records of the original [[KTable]] that got [[KTable#groupBy]]
    * to the same key into a new instance of [[KTable]].
    *
@@ -67,6 +83,23 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
   def reduce(adder: (V, V) => V,
              subtractor: (V, V) => V)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.reduce(adder.asReducer, subtractor.asReducer, materialized))
+
+  /**
+   * Combine the value of records of the original [[KTable]] that got [[KTable#groupBy]]
+   * to the same key into a new instance of [[KTable]].
+   *
+   * @param adder      a function that adds a new value to the aggregate result
+   * @param subtractor a function that removed an old value from the aggregate result
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   * latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#reduce`
+   */
+  def reduce(adder: (V, V) => V,
+             subtractor: (V, V) => V,
+             named: Named)(implicit materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.reduce(adder.asReducer, subtractor.asReducer, named, materialized))
 
   /**
    * Aggregate the value of records of the original [[KTable]] that got [[KTable#groupBy]]
@@ -85,5 +118,25 @@ class KGroupedTable[K, V](inner: KGroupedTableJ[K, V]) {
   ): KTable[K, VR] =
     new KTable(
       inner.aggregate((() => initializer).asInitializer, adder.asAggregator, subtractor.asAggregator, materialized)
+    )
+
+  /**
+   * Aggregate the value of records of the original [[KTable]] that got [[KTable#groupBy]]
+   * to the same key into a new instance of [[KTable]] using default serializers and deserializers.
+   *
+   * @param initializer a function that provides an initial aggregate result value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param adder       a function that adds a new record to the aggregate result
+   * @param subtractor  an aggregator function that removed an old record from the aggregate result
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   * latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.KGroupedTable#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(adder: (K, V, VR) => VR, subtractor: (K, V, VR) => VR)(
+    implicit materialized: Materialized[K, VR, ByteArrayKeyValueStore]
+  ): KTable[K, VR] =
+    new KTable(
+      inner.aggregate((() => initializer).asInitializer, adder.asAggregator, subtractor.asAggregator, named, materialized)
     )
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -999,18 +999,17 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Join records of this stream with `GlobalKTable`'s records using non-windowed inner equi join.
    *
    * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param named          a [[Named]] config used to name the processor in the topology
    * @param keyValueMapper a function used to map from the (key, value) of this stream
    *                       to the key of the `GlobalKTable`
    * @param joiner         a function that computes the join result for a pair of matching records
-   * @param named          a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
    *         one output for each input [[KStream]] record
    * @see `org.apache.kafka.streams.kstream.KStream#join`
    */
-  def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
+  def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV], named: Named)(
     keyValueMapper: (K, V) => GK,
-    joiner: (V, GV) => RV,
-    named: Named
+    joiner: (V, GV) => RV
   ): KStream[K, RV] =
     new KStream(
       inner.join[GK, GV, RV](
@@ -1042,18 +1041,17 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Join records of this stream with `GlobalKTable`'s records using non-windowed left equi join.
    *
    * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param named          a [[Named]] config used to name the processor in the topology
    * @param keyValueMapper a function used to map from the (key, value) of this stream
    *                       to the key of the `GlobalKTable`
    * @param joiner         a function that computes the join result for a pair of matching records
-   * @param named          a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
    *         one output for each input [[KStream]] record
    * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
    */
-  def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
+  def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV], named: Named)(
     keyValueMapper: (K, V) => GK,
-    joiner: (V, GV) => RV,
-    named: Named
+    joiner: (V, GV) => RV
   ): KStream[K, RV] =
     new KStream(inner.leftJoin[GK, GV, RV](globalKTable, keyValueMapper.asKeyValueMapper, joiner.asValueJoiner, named))
 

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -54,7 +54,6 @@ import scala.jdk.CollectionConverters._
  * @tparam K Type of keys
  * @tparam V Type of values
  * @param inner The underlying Java abstraction for KStream
- *
  * @see `org.apache.kafka.streams.kstream.KStream`
  */
 class KStream[K, V](val inner: KStreamJ[K, V]) {
@@ -73,7 +72,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Create a new [[KStream]] that consists all records of this stream which satisfies the given predicate.
    *
    * @param predicate a filter that is applied to each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named     a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains only those records that satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KStream#filter`
    */
@@ -96,7 +95,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * predicate.
    *
    * @param predicate a filter that is applied to each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named     a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains only those records that do <em>not</em> satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KStream#filterNot`
    */
@@ -123,7 +122,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * key `KR`. The function outputs a new [[KStream]] where each record has this new key.
    *
    * @param mapper a function `(K, V) => KR` that computes a new key for each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains records with new key (possibly of different type) and unmodified value
    * @see `org.apache.kafka.streams.kstream.KStream#selectKey`
    */
@@ -150,7 +149,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * The provided `mapper`, a function `(K, V) => (KR, VR)` is applied to each input record and computes a new output record.
    *
    * @param mapper a function `(K, V) => (KR, VR)` that computes a new output record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains records with new key and value (possibly both of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#map`
    */
@@ -162,7 +161,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `V => VR` that computes a new output value
+   * @param mapper , a function `V => VR` that computes a new output value
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
    */
@@ -174,8 +173,8 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `V => VR` that computes a new output value
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param mapper , a function `V => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
    */
@@ -187,7 +186,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `(K, V) => VR` that computes a new output value
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
    */
@@ -199,8 +198,8 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `(K, V) => VR` that computes a new output value
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
    */
@@ -229,7 +228,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * The provided `mapper`, function `(K, V) => Iterable[(KR, VR)]` is applied to each input record and computes zero or more output records.
    *
    * @param mapper function `(K, V) => Iterable[(KR, VR)]` that computes the new output records
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#flatMap`
    */
@@ -262,7 +261,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * The provided `mapper`, a function `V => Iterable[VR]` is applied to each input record and computes zero or more output values.
    *
    * @param mapper a function `V => Iterable[VR]` that computes the new output values
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
    * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
    */
@@ -293,7 +292,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * The provided `mapper`, a function `(K, V) => Iterable[VR]` is applied to each input record and computes zero or more output values.
    *
    * @param mapper a function `(K, V) => Iterable[VR]` that computes the new output values
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
    * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
    */
@@ -321,7 +320,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Perform an action on each record of `KStream`
    *
    * @param action an action to perform on each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @see `org.apache.kafka.streams.kstream.KStream#foreach`
    */
   def foreach(action: (K, V) => Unit, named: Named): Unit =
@@ -343,7 +342,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Creates an array of `KStream` from this stream by branching the records in the original stream based on
    * the supplied predicates.
    *
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named      a [[Named]] config used to name the processor in the topology
    * @param predicates the ordered list of functions that return a Boolean
    * @return multiple distinct substreams of this [[KStream]]
    * @see `org.apache.kafka.streams.kstream.KStream#branch`
@@ -376,7 +375,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * // to the through call
    * }}}
    *
-   * @param topic the topic name
+   * @param topic    the topic name
    * @param produced the instance of Produced that gives the serdes and `StreamPartitioner`
    * @return a [[KStream]] that contains the exact same (and potentially repartitioned) records as this [[KStream]]
    * @see `org.apache.kafka.streams.kstream.KStream#through`
@@ -394,7 +393,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * The created topic is considered as an internal topic and is meant to be used only by the current Kafka Streams instance.
    * Similar to auto-repartitioning, the topic will be created with infinite retention time and data will be automatically purged by Kafka Streams.
    * The topic will be named as "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is user-specified in
-   * `StreamsConfig` via parameter APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG`,
+   * `StreamsConfig` via parameter `APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG`,
    * "&lt;name&gt;" is either provided via `Repartitioned#as(String)` or an internally
    * generated name, and "-repartition" is a fixed suffix.
    * <p>
@@ -418,7 +417,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * // to the repartition call
    * }}}
    *
-   * @param repartitioned the `Repartitioned` instance used to specify `Serdes`, `StreamPartitioner`` which determines
+   * @param repartitioned the `Repartitioned` instance used to specify `Serdes`, `StreamPartitioner` which determines
    *                      how records are distributed among partitions of the topic,
    *                      part of the topic name, and number of partitions for a repartition topic.
    * @return a [[KStream]] that contains the exact same repartitioned records as this [[KStream]]
@@ -451,7 +450,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * // to the through call
    * }}}
    *
-   * @param topic the topic name
+   * @param topic    the topic name
    * @param produced the instance of Produced that gives the serdes and `StreamPartitioner`
    * @see `org.apache.kafka.streams.kstream.KStream#to`
    */
@@ -484,7 +483,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * }}}
    *
    * @param extractor the extractor to determine the name of the Kafka topic to write to for reach record
-   * @param produced the instance of Produced that gives the serdes and `StreamPartitioner`
+   * @param produced  the instance of Produced that gives the serdes and `StreamPartitioner`
    * @see `org.apache.kafka.streams.kstream.KStream#to`
    */
   def to(extractor: TopicNameExtractor[K, V])(implicit produced: Produced[K, V]): Unit =
@@ -512,8 +511,8 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   /**
    * Convert this stream to a [[KTable]].
    *
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains the same records as this [[KStream]]
    * @see `org.apache.kafka.streams.kstream.KStream#toTable`
    */
@@ -523,9 +522,9 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   /**
    * Convert this stream to a [[KTable]].
    *
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains the same records as this [[KStream]]
    * @see `org.apache.kafka.streams.kstream.KStream#toTable`
    */
@@ -562,7 +561,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param transformerSupplier the `TransformerSuplier` that generates `Transformer`
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named               a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames     the names of the state stores used by the processor
    * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transform`
@@ -602,7 +601,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param transformerSupplier the `TransformerSuplier` that generates `Transformer`
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named               a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames     the names of the state stores used by the processor
    * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transform`
@@ -642,7 +641,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param valueTransformerSupplier a instance of `ValueTransformerSupplier` that generates a `ValueTransformer`
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named                    a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames          the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
@@ -682,7 +681,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param valueTransformerSupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named                    a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames          the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
@@ -720,7 +719,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param valueTransformerSupplier a instance of `ValueTransformerSupplier` that generates a `ValueTransformer`
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named                    a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames          the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
@@ -758,7 +757,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param valueTransformerSupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named                    a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames          the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
@@ -794,7 +793,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param processorSupplier a function that generates a [[org.apache.kafka.streams.processor.Processor]]
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named             a [[Named]] config used to name the processor in the topology
    * @param stateStoreNames   the names of the state store used by the processor
    * @see `org.apache.kafka.streams.kstream.KStream#process`
    */
@@ -884,7 +883,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    *                    also name the repartition topic (if required), the state stores for the join, and the join
    *                    processor node.
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   * one for each matched record-pair with the same key and within the joining window intervals
+   *         one for each matched record-pair with the same key and within the joining window intervals
    * @see `org.apache.kafka.streams.kstream.KStream#join`
    */
   def join[VO, VR](otherStream: KStream[K, VO])(
@@ -907,7 +906,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    *                    also name the repartition topic (if required), the state stores for the join, and the join
    *                    processor node.
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   *                    one for each matched record-pair with the same key and within the joining window intervals
+   *         one for each matched record-pair with the same key and within the joining window intervals
    * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
    */
   def leftJoin[VO, VR](otherStream: KStream[K, VO])(
@@ -930,7 +929,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    *                    also name the repartition topic (if required), the state stores for the join, and the join
    *                    processor node.
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   * one for each matched record-pair with the same key and within the joining window intervals
+   *         one for each matched record-pair with the same key and within the joining window intervals
    * @see `org.apache.kafka.streams.kstream.KStream#outerJoin`
    */
   def outerJoin[VO, VR](otherStream: KStream[K, VO])(
@@ -943,14 +942,14 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Join records of this stream with another [[KTable]]'s records using inner equi join with
    * serializers and deserializers supplied by the implicit `Joined` instance.
    *
-   * @param table    the [[KTable]] to be joined with this stream
-   * @param joiner   a function that computes the join result for a pair of matching records
-   * @param joined   an implicit `Joined` instance that defines the serdes to be used to serialize/deserialize
-   *                 inputs and outputs of the joined streams. Instead of `Joined`, the user can also supply
-   *                 key serde, value serde and other value serde in implicit scope and they will be
-   *                 converted to the instance of `Joined` through implicit conversion
+   * @param table  the [[KTable]] to be joined with this stream
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param joined an implicit `Joined` instance that defines the serdes to be used to serialize/deserialize
+   *               inputs and outputs of the joined streams. Instead of `Joined`, the user can also supply
+   *               key serde, value serde and other value serde in implicit scope and they will be
+   *               converted to the instance of `Joined` through implicit conversion
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KStream#join`
    */
   def join[VT, VR](table: KTable[K, VT])(joiner: (V, VT) => VR)(implicit joined: Joined[K, V, VT]): KStream[K, VR] =
@@ -960,14 +959,14 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * Join records of this stream with another [[KTable]]'s records using left equi join with
    * serializers and deserializers supplied by the implicit `Joined` instance.
    *
-   * @param table    the [[KTable]] to be joined with this stream
-   * @param joiner   a function that computes the join result for a pair of matching records
-   * @param joined   an implicit `Joined` instance that defines the serdes to be used to serialize/deserialize
-   *                 inputs and outputs of the joined streams. Instead of `Joined`, the user can also supply
-   *                 key serde, value serde and other value serde in implicit scope and they will be
-   *                 converted to the instance of `Joined` through implicit conversion
+   * @param table  the [[KTable]] to be joined with this stream
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param joined an implicit `Joined` instance that defines the serdes to be used to serialize/deserialize
+   *               inputs and outputs of the joined streams. Instead of `Joined`, the user can also supply
+   *               key serde, value serde and other value serde in implicit scope and they will be
+   *               converted to the instance of `Joined` through implicit conversion
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   *                 one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
    */
   def leftJoin[VT, VR](table: KTable[K, VT])(joiner: (V, VT) => VR)(implicit joined: Joined[K, V, VT]): KStream[K, VR] =
@@ -981,7 +980,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    *                       to the key of the `GlobalKTable`
    * @param joiner         a function that computes the join result for a pair of matching records
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   *                       one output for each input [[KStream]] record
+   *         one output for each input [[KStream]] record
    * @see `org.apache.kafka.streams.kstream.KStream#join`
    */
   def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
@@ -1003,9 +1002,9 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * @param keyValueMapper a function used to map from the (key, value) of this stream
    *                       to the key of the `GlobalKTable`
    * @param joiner         a function that computes the join result for a pair of matching records
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named          a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   *                       one output for each input [[KStream]] record
+   *         one output for each input [[KStream]] record
    * @see `org.apache.kafka.streams.kstream.KStream#join`
    */
   def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
@@ -1030,7 +1029,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    *                       to the key of the `GlobalKTable`
    * @param joiner         a function that computes the join result for a pair of matching records
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   *                       one output for each input [[KStream]] record
+   *         one output for each input [[KStream]] record
    * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
    */
   def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
@@ -1046,9 +1045,9 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * @param keyValueMapper a function used to map from the (key, value) of this stream
    *                       to the key of the `GlobalKTable`
    * @param joiner         a function that computes the join result for a pair of matching records
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named          a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
-   *                       one output for each input [[KStream]] record
+   *         one output for each input [[KStream]] record
    * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
    */
   def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
@@ -1079,7 +1078,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * in the merged stream. Relative order is preserved within each input stream though (ie, records within
    * one input stream are processed in order).
    *
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @param stream a stream which is to be merged into this stream
    * @return a merged stream containing all records from this and the provided [[KStream]]
    * @see `org.apache.kafka.streams.kstream.KStream#merge`
@@ -1106,7 +1105,7 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * and returns an unchanged stream.
    *
    * @param action an action to perform on each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @see `org.apache.kafka.streams.kstream.KStream#peek`
    */
   def peek(action: (K, V) => Unit, named: Named): KStream[K, V] =

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -70,6 +70,17 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
     new KStream(inner.filter(predicate.asPredicate))
 
   /**
+   * Create a new [[KStream]] that consists all records of this stream which satisfies the given predicate.
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KStream#filter`
+   */
+  def filter(predicate: (K, V) => Boolean, named: Named): KStream[K, V] =
+    new KStream(inner.filter(predicate.asPredicate, named))
+
+  /**
    * Create a new [[KStream]] that consists all records of this stream which do <em>not</em> satisfy the given
    * predicate.
    *
@@ -79,6 +90,18 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def filterNot(predicate: (K, V) => Boolean): KStream[K, V] =
     new KStream(inner.filterNot(predicate.asPredicate))
+
+  /**
+   * Create a new [[KStream]] that consists all records of this stream which do <em>not</em> satisfy the given
+   * predicate.
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KStream#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean, named: Named): KStream[K, V] =
+    new KStream(inner.filterNot(predicate.asPredicate, named))
 
   /**
    * Set a new key (with possibly new type) for each input record.
@@ -94,6 +117,20 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
     new KStream(inner.selectKey[KR](mapper.asKeyValueMapper))
 
   /**
+   * Set a new key (with possibly new type) for each input record.
+   * <p>
+   * The function `mapper` passed is applied to every record and results in the generation of a new
+   * key `KR`. The function outputs a new [[KStream]] where each record has this new key.
+   *
+   * @param mapper a function `(K, V) => KR` that computes a new key for each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with new key (possibly of different type) and unmodified value
+   * @see `org.apache.kafka.streams.kstream.KStream#selectKey`
+   */
+  def selectKey[KR](mapper: (K, V) => KR, named: Named): KStream[KR, V] =
+    new KStream(inner.selectKey[KR](mapper.asKeyValueMapper, named))
+
+  /**
    * Transform each record of the input stream into a new record in the output stream (both key and value type can be
    * altered arbitrarily).
    * <p>
@@ -105,6 +142,20 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def map[KR, VR](mapper: (K, V) => (KR, VR)): KStream[KR, VR] =
     new KStream(inner.map[KR, VR](mapper.asKeyValueMapper))
+
+  /**
+   * Transform each record of the input stream into a new record in the output stream (both key and value type can be
+   * altered arbitrarily).
+   * <p>
+   * The provided `mapper`, a function `(K, V) => (KR, VR)` is applied to each input record and computes a new output record.
+   *
+   * @param mapper a function `(K, V) => (KR, VR)` that computes a new output record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with new key and value (possibly both of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#map`
+   */
+  def map[KR, VR](mapper: (K, V) => (KR, VR), named: Named): KStream[KR, VR] =
+    new KStream(inner.map[KR, VR](mapper.asKeyValueMapper, named))
 
   /**
    * Transform the value of each input record into a new value (with possible new type) of the output record.
@@ -121,6 +172,19 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   /**
    * Transform the value of each input record into a new value (with possible new type) of the output record.
    * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper, a function `V => VR` that computes a new output value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR, named: Named): KStream[K, VR] =
+    new KStream(inner.mapValues[VR](mapper.asValueMapper, named))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
    * @param mapper, a function `(K, V) => VR` that computes a new output value
@@ -129,6 +193,19 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def mapValues[VR](mapper: (K, V) => VR): KStream[K, VR] =
     new KStream(inner.mapValues[VR](mapper.asValueMapperWithKey))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper, a function `(K, V) => VR` that computes a new output value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR, named: Named): KStream[K, VR] =
+    new KStream(inner.mapValues[VR](mapper.asValueMapperWithKey, named))
 
   /**
    * Transform each record of the input stream into zero or more records in the output stream (both key and value type
@@ -143,6 +220,22 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   def flatMap[KR, VR](mapper: (K, V) => Iterable[(KR, VR)]): KStream[KR, VR] = {
     val kvMapper = mapper.tupled.andThen(_.map(ImplicitConversions.tuple2ToKeyValue).asJava)
     new KStream(inner.flatMap[KR, VR](((k: K, v: V) => kvMapper(k, v)).asKeyValueMapper))
+  }
+
+  /**
+   * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+   * can be altered arbitrarily).
+   * <p>
+   * The provided `mapper`, function `(K, V) => Iterable[(KR, VR)]` is applied to each input record and computes zero or more output records.
+   *
+   * @param mapper function `(K, V) => Iterable[(KR, VR)]` that computes the new output records
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMap`
+   */
+  def flatMap[KR, VR](mapper: (K, V) => Iterable[(KR, VR)], named: Named): KStream[KR, VR] = {
+    val kvMapper = mapper.tupled.andThen(_.map(ImplicitConversions.tuple2ToKeyValue).asJava)
+    new KStream(inner.flatMap[KR, VR](((k: K, v: V) => kvMapper(k, v)).asKeyValueMapper, named))
   }
 
   /**
@@ -166,6 +259,22 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * <p>
    * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
    * stream (value type can be altered arbitrarily).
+   * The provided `mapper`, a function `V => Iterable[VR]` is applied to each input record and computes zero or more output values.
+   *
+   * @param mapper a function `V => Iterable[VR]` that computes the new output values
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
+   */
+  def flatMapValues[VR](mapper: V => Iterable[VR], named: Named): KStream[K, VR] =
+    new KStream(inner.flatMapValues[VR](mapper.asValueMapper, named))
+
+  /**
+   * Create a new [[KStream]] by transforming the value of each record in this stream into zero or more values
+   * with the same key in the new stream.
+   * <p>
+   * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
+   * stream (value type can be altered arbitrarily).
    * The provided `mapper`, a function `(K, V) => Iterable[VR]` is applied to each input record and computes zero or more output values.
    *
    * @param mapper a function `(K, V) => Iterable[VR]` that computes the new output values
@@ -174,6 +283,22 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def flatMapValues[VR](mapper: (K, V) => Iterable[VR]): KStream[K, VR] =
     new KStream(inner.flatMapValues[VR](mapper.asValueMapperWithKey))
+
+  /**
+   * Create a new [[KStream]] by transforming the value of each record in this stream into zero or more values
+   * with the same key in the new stream.
+   * <p>
+   * Transform the value of each input record into zero or more records with the same (unmodified) key in the output
+   * stream (value type can be altered arbitrarily).
+   * The provided `mapper`, a function `(K, V) => Iterable[VR]` is applied to each input record and computes zero or more output values.
+   *
+   * @param mapper a function `(K, V) => Iterable[VR]` that computes the new output values
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains more or less records with unmodified keys and new values of different type
+   * @see `org.apache.kafka.streams.kstream.KStream#flatMapValues`
+   */
+  def flatMapValues[VR](mapper: (K, V) => Iterable[VR], named: Named): KStream[K, VR] =
+    new KStream(inner.flatMapValues[VR](mapper.asValueMapperWithKey, named))
 
   /**
    * Print the records of this KStream using the options provided by `Printed`
@@ -193,6 +318,16 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
     inner.foreach(action.asForeachAction)
 
   /**
+   * Perform an action on each record of `KStream`
+   *
+   * @param action an action to perform on each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @see `org.apache.kafka.streams.kstream.KStream#foreach`
+   */
+  def foreach(action: (K, V) => Unit, named: Named): Unit =
+    inner.foreach(action.asForeachAction, named)
+
+  /**
    * Creates an array of `KStream` from this stream by branching the records in the original stream based on
    * the supplied predicates.
    *
@@ -203,6 +338,19 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   //noinspection ScalaUnnecessaryParentheses
   def branch(predicates: ((K, V) => Boolean)*): Array[KStream[K, V]] =
     inner.branch(predicates.map(_.asPredicate): _*).map(kstream => new KStream(kstream))
+
+  /**
+   * Creates an array of `KStream` from this stream by branching the records in the original stream based on
+   * the supplied predicates.
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param predicates the ordered list of functions that return a Boolean
+   * @return multiple distinct substreams of this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#branch`
+   */
+  //noinspection ScalaUnnecessaryParentheses
+  def branch(named: Named, predicates: ((K, V) => Boolean)*): Array[KStream[K, V]] =
+    inner.branch(named, predicates.map(_.asPredicate): _*).map(kstream => new KStream(kstream))
 
   /**
    * Materialize this stream to a topic and creates a new [[KStream]] from the topic using the `Produced` instance for
@@ -354,6 +502,16 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   /**
    * Convert this stream to a [[KTable]].
    *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains the same records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#toTable`
+   */
+  def toTable(named: Named): KTable[K, V] =
+    new KTable(inner.toTable(named))
+
+  /**
+   * Convert this stream to a [[KTable]].
+   *
    * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
    *                      should be materialized.
    * @return a [[KTable]] that contains the same records as this [[KStream]]
@@ -361,6 +519,18 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def toTable(materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.toTable(materialized))
+
+  /**
+   * Convert this stream to a [[KTable]].
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains the same records as this [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#toTable`
+   */
+  def toTable(named: Named, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.toTable(named, materialized))
 
   /**
    * Transform each record of the input stream into zero or more records in the output stream (both key and value type
@@ -392,6 +562,27 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * read-only access to global state stores is available by default.
    *
    * @param transformerSupplier the `TransformerSuplier` that generates `Transformer`
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames     the names of the state stores used by the processor
+   * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transform`
+   */
+  def transform[K1, V1](transformerSupplier: TransformerSupplier[K, V, KeyValue[K1, V1]],
+                        named: Named,
+                        stateStoreNames: String*): KStream[K1, V1] =
+    new KStream(inner.transform(transformerSupplier, named, stateStoreNames: _*))
+
+  /**
+   * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+   * can be altered arbitrarily).
+   * A `Transformer` (provided by the given `TransformerSupplier`) is applied to each input record
+   * and computes zero or more output records.
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `Transformer`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * @param transformerSupplier the `TransformerSuplier` that generates `Transformer`
    * @param stateStoreNames     the names of the state stores used by the processor
    * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transform`
@@ -399,6 +590,27 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   def flatTransform[K1, V1](transformerSupplier: TransformerSupplier[K, V, Iterable[KeyValue[K1, V1]]],
                             stateStoreNames: String*): KStream[K1, V1] =
     new KStream(inner.flatTransform(transformerSupplier.asJava, stateStoreNames: _*))
+
+  /**
+   * Transform each record of the input stream into zero or more records in the output stream (both key and value type
+   * can be altered arbitrarily).
+   * A `Transformer` (provided by the given `TransformerSupplier`) is applied to each input record
+   * and computes zero or more output records.
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `Transformer`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * @param transformerSupplier the `TransformerSuplier` that generates `Transformer`
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames     the names of the state stores used by the processor
+   * @return a [[KStream]] that contains more or less records with new key and value (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transform`
+   */
+  def flatTransform[K1, V1](transformerSupplier: TransformerSupplier[K, V, Iterable[KeyValue[K1, V1]]],
+                            named: Named,
+                            stateStoreNames: String*): KStream[K1, V1] =
+    new KStream(inner.flatTransform(transformerSupplier.asJava, named, stateStoreNames: _*))
 
   /**
    * Transform the value of each input record into zero or more records (with possible new type) in the
@@ -429,6 +641,27 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * It's not required to connect global state stores that are added via `addGlobalStore`;
    * read-only access to global state stores is available by default.
    *
+   * @param valueTransformerSupplier a instance of `ValueTransformerSupplier` that generates a `ValueTransformer`
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames          the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def flatTransformValues[VR](valueTransformerSupplier: ValueTransformerSupplier[V, Iterable[VR]],
+                              named: Named,
+                              stateStoreNames: String*): KStream[K, VR] =
+    new KStream(inner.flatTransformValues[VR](valueTransformerSupplier.asJava, named, stateStoreNames: _*))
+
+  /**
+   * Transform the value of each input record into zero or more records (with possible new type) in the
+   * output stream.
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `ValueTransformer`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
    * @param valueTransformerSupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
    * @param stateStoreNames          the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
@@ -437,6 +670,27 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   def flatTransformValues[VR](valueTransformerSupplier: ValueTransformerWithKeySupplier[K, V, Iterable[VR]],
                               stateStoreNames: String*): KStream[K, VR] =
     new KStream(inner.flatTransformValues[VR](valueTransformerSupplier.asJava, stateStoreNames: _*))
+
+  /**
+   * Transform the value of each input record into zero or more records (with possible new type) in the
+   * output stream.
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `ValueTransformer`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * @param valueTransformerSupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames          the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def flatTransformValues[VR](valueTransformerSupplier: ValueTransformerWithKeySupplier[K, V, Iterable[VR]],
+                              named: Named,
+                              stateStoreNames: String*): KStream[K, VR] =
+    new KStream(inner.flatTransformValues[VR](valueTransformerSupplier.asJava, named, stateStoreNames: _*))
 
   /**
    * Transform the value of each input record into a new value (with possible new type) of the output record.
@@ -465,6 +719,26 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * It's not required to connect global state stores that are added via `addGlobalStore`;
    * read-only access to global state stores is available by default.
    *
+   * @param valueTransformerSupplier a instance of `ValueTransformerSupplier` that generates a `ValueTransformer`
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames          the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](valueTransformerSupplier: ValueTransformerSupplier[V, VR],
+                          named: Named,
+                          stateStoreNames: String*): KStream[K, VR] =
+    new KStream(inner.transformValues[VR](valueTransformerSupplier, named, stateStoreNames: _*))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `ValueTransformer`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
    * @param valueTransformerSupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
    * @param stateStoreNames          the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
@@ -473,6 +747,26 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   def transformValues[VR](valueTransformerSupplier: ValueTransformerWithKeySupplier[K, V, VR],
                           stateStoreNames: String*): KStream[K, VR] =
     new KStream(inner.transformValues[VR](valueTransformerSupplier, stateStoreNames: _*))
+
+  /**
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `ValueTransformer`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * @param valueTransformerSupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames          the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](valueTransformerSupplier: ValueTransformerWithKeySupplier[K, V, VR],
+                          named: Named,
+                          stateStoreNames: String*): KStream[K, VR] =
+    new KStream(inner.transformValues[VR](valueTransformerSupplier, named, stateStoreNames: _*))
 
   /**
    * Process all records in this stream, one record at a time, by applying a `Processor` (provided by the given
@@ -489,6 +783,24 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
   def process(processorSupplier: () => Processor[K, V], stateStoreNames: String*): Unit = {
     val processorSupplierJ: ProcessorSupplier[K, V] = () => processorSupplier()
     inner.process(processorSupplierJ, stateStoreNames: _*)
+  }
+
+  /**
+   * Process all records in this stream, one record at a time, by applying a `Processor` (provided by the given
+   * `processorSupplier`).
+   * In order to assign a state, the state must be created and added via `addStateStore` before they can be connected
+   * to the `Processor`.
+   * It's not required to connect global state stores that are added via `addGlobalStore`;
+   * read-only access to global state stores is available by default.
+   *
+   * @param processorSupplier a function that generates a [[org.apache.kafka.streams.processor.Processor]]
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames   the names of the state store used by the processor
+   * @see `org.apache.kafka.streams.kstream.KStream#process`
+   */
+  def process(processorSupplier: () => Processor[K, V], named: Named, stateStoreNames: String*): Unit = {
+    val processorSupplierJ: ProcessorSupplier[K, V] = () => processorSupplier()
+    inner.process(processorSupplierJ, named, stateStoreNames: _*)
   }
 
   /**
@@ -674,13 +986,39 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
     keyValueMapper: (K, V) => GK,
-    joiner: (V, GV) => RV
+    joiner: (V, GV) => RV,
   ): KStream[K, RV] =
     new KStream(
       inner.join[GK, GV, RV](
         globalKTable,
         ((k: K, v: V) => keyValueMapper(k, v)).asKeyValueMapper,
         ((v: V, gv: GV) => joiner(v, gv)).asValueJoiner
+      )
+    )
+
+  /**
+   * Join records of this stream with `GlobalKTable`'s records using non-windowed inner equi join.
+   *
+   * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param keyValueMapper a function used to map from the (key, value) of this stream
+   *                       to the key of the `GlobalKTable`
+   * @param joiner         a function that computes the join result for a pair of matching records
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *                       one output for each input [[KStream]] record
+   * @see `org.apache.kafka.streams.kstream.KStream#join`
+   */
+  def join[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
+    keyValueMapper: (K, V) => GK,
+    joiner: (V, GV) => RV,
+    named: Named
+  ): KStream[K, RV] =
+    new KStream(
+      inner.join[GK, GV, RV](
+        globalKTable,
+        ((k: K, v: V) => keyValueMapper(k, v)).asKeyValueMapper,
+        ((v: V, gv: GV) => joiner(v, gv)).asValueJoiner,
+        named
       )
     )
 
@@ -702,6 +1040,25 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
     new KStream(inner.leftJoin[GK, GV, RV](globalKTable, keyValueMapper.asKeyValueMapper, joiner.asValueJoiner))
 
   /**
+   * Join records of this stream with `GlobalKTable`'s records using non-windowed left equi join.
+   *
+   * @param globalKTable   the `GlobalKTable` to be joined with this stream
+   * @param keyValueMapper a function used to map from the (key, value) of this stream
+   *                       to the key of the `GlobalKTable`
+   * @param joiner         a function that computes the join result for a pair of matching records
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains join-records for each key and values computed by the given `joiner`,
+   *                       one output for each input [[KStream]] record
+   * @see `org.apache.kafka.streams.kstream.KStream#leftJoin`
+   */
+  def leftJoin[GK, GV, RV](globalKTable: GlobalKTable[GK, GV])(
+    keyValueMapper: (K, V) => GK,
+    joiner: (V, GV) => RV,
+    named: Named
+  ): KStream[K, RV] =
+    new KStream(inner.leftJoin[GK, GV, RV](globalKTable, keyValueMapper.asKeyValueMapper, joiner.asValueJoiner, named))
+
+  /**
    * Merge this stream and the given stream into one larger stream.
    * <p>
    * There is no ordering guarantee between records from this `KStream` and records from the provided `KStream`
@@ -716,6 +1073,21 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
     new KStream(inner.merge(stream.inner))
 
   /**
+   * Merge this stream and the given stream into one larger stream.
+   * <p>
+   * There is no ordering guarantee between records from this `KStream` and records from the provided `KStream`
+   * in the merged stream. Relative order is preserved within each input stream though (ie, records within
+   * one input stream are processed in order).
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stream a stream which is to be merged into this stream
+   * @return a merged stream containing all records from this and the provided [[KStream]]
+   * @see `org.apache.kafka.streams.kstream.KStream#merge`
+   */
+  def merge(stream: KStream[K, V], named: Named): KStream[K, V] =
+    new KStream(inner.merge(stream.inner, named))
+
+  /**
    * Perform an action on each record of `KStream`.
    * <p>
    * Peek is a non-terminal operation that triggers a side effect (such as logging or statistics collection)
@@ -726,4 +1098,17 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    */
   def peek(action: (K, V) => Unit): KStream[K, V] =
     new KStream(inner.peek(action.asForeachAction))
+
+  /**
+   * Perform an action on each record of `KStream`.
+   * <p>
+   * Peek is a non-terminal operation that triggers a side effect (such as logging or statistics collection)
+   * and returns an unchanged stream.
+   *
+   * @param action an action to perform on each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @see `org.apache.kafka.streams.kstream.KStream#peek`
+   */
+  def peek(action: (K, V) => Unit, named: Named): KStream[K, V] =
+    new KStream(inner.peek(action.asForeachAction, named))
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
@@ -38,7 +38,6 @@ import org.apache.kafka.streams.state.KeyValueStore
  * @tparam K Type of keys
  * @tparam V Type of values
  * @param inner The underlying Java abstraction for KTable
- *
  * @see `org.apache.kafka.streams.kstream.KTable`
  */
 class KTable[K, V](val inner: KTableJ[K, V]) {
@@ -59,7 +58,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * predicate
    *
    * @param predicate a filter that is applied to each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named     a [[Named]] config used to name the processor in the topology
    * @return a [[KTable]] that contains only those records that satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filter`
    */
@@ -70,9 +69,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
    * predicate
    *
-   * @param predicate a filter that is applied to each record
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param predicate    a filter that is applied to each record
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains only those records that satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filter`
    */
@@ -83,10 +82,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
    * predicate
    *
-   * @param predicate a filter that is applied to each record
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param predicate    a filter that is applied to each record
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains only those records that satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filter`
    */
@@ -109,7 +108,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * predicate
    *
    * @param predicate a filter that is applied to each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named     a [[Named]] config used to name the processor in the topology
    * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
    */
@@ -120,9 +119,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
    * predicate
    *
-   * @param predicate a filter that is applied to each record
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param predicate    a filter that is applied to each record
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
    */
@@ -133,10 +132,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
    * predicate
    *
-   * @param predicate a filter that is applied to each record
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param predicate    a filter that is applied to each record
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
    */
@@ -149,7 +148,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `V => VR` that computes a new output value
+   * @param mapper , a function `V => VR` that computes a new output value
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -162,8 +161,8 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `V => VR` that computes a new output value
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param mapper , a function `V => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -176,9 +175,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `V => VR` that computes a new output value
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param mapper       , a function `V => VR` that computes a new output value
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -191,10 +190,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `V => VR` that computes a new output value
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param mapper       , a function `V => VR` that computes a new output value
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -207,7 +206,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `(K, V) => VR` that computes a new output value
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -220,8 +219,8 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `(K, V) => VR` that computes a new output value
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param mapper , a function `(K, V) => VR` that computes a new output value
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -234,9 +233,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `(K, V) => VR` that computes a new output value
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param mapper       , a function `(K, V) => VR` that computes a new output value
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -250,10 +249,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * <p>
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
-   * @param mapper, a function `(K, V) => VR` that computes a new output value
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param mapper       , a function `(K, V) => VR` that computes a new output value
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
@@ -293,7 +292,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Convert this changelog stream to a [[KStream]] using the given key/value mapper to select the new key
    *
    * @param mapper a function that computes a new key for each record
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @return a [[KStream]] that contains the same records as this [[KTable]]
    * @see `org.apache.kafka.streams.kstream.KTable#toStream`
    */
@@ -328,9 +327,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
    *
    * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`.
-   *                                 At least one transformer instance will be created per streaming task.
-   *                                 Transformer implementations doe not need to be thread-safe.
-   * @param stateStoreNames          the names of the state stores used by the processor
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param stateStoreNames                 the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
    */
@@ -354,10 +353,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
    *
    * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`.
-   *                                 At least one transformer instance will be created per streaming task.
-   *                                 Transformer implementations doe not need to be thread-safe.
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param stateStoreNames          the names of the state stores used by the processor
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param named                           a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames                 the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
    */
@@ -378,11 +377,11 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * as specified by the user via `Materialized` parameter, and is queryable through its given name.
    *
    * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
-   *                                 At least one transformer instance will be created per streaming task.
-   *                                 Transformer implementations doe not need to be thread-safe.
-   * @param materialized             an instance of `Materialized` used to describe how the state store of the
-   *                                 resulting table should be materialized.
-   * @param stateStoreNames          the names of the state stores used by the processor
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param materialized                    an instance of `Materialized` used to describe how the state store of the
+   *                                        resulting table should be materialized.
+   * @param stateStoreNames                 the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
    */
@@ -403,12 +402,12 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * as specified by the user via `Materialized` parameter, and is queryable through its given name.
    *
    * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
-   *                                 At least one transformer instance will be created per streaming task.
-   *                                 Transformer implementations doe not need to be thread-safe.
-   * @param materialized             an instance of `Materialized` used to describe how the state store of the
-   *                                 resulting table should be materialized.
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param stateStoreNames          the names of the state stores used by the processor
+   *                                        At least one transformer instance will be created per streaming task.
+   *                                        Transformer implementations doe not need to be thread-safe.
+   * @param materialized                    an instance of `Materialized` used to describe how the state store of the
+   *                                        resulting table should be materialized.
+   * @param named                           a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames                 the names of the state stores used by the processor
    * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
    */
@@ -422,8 +421,8 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Re-groups the records of this [[KTable]] using the provided key/value mapper
    * and `Serde`s as specified by `Grouped`.
    *
-   * @param selector      a function that computes a new grouping key and value to be aggregated
-   * @param grouped       the `Grouped` instance used to specify `Serdes`
+   * @param selector a function that computes a new grouping key and value to be aggregated
+   * @param grouped  the `Grouped` instance used to specify `Serdes`
    * @return a [[KGroupedTable]] that contains the re-grouped records of the original [[KTable]]
    * @see `org.apache.kafka.streams.kstream.KTable#groupBy`
    */
@@ -436,7 +435,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
    * @param joiner a function that computes the join result for a pair of matching records
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#join`
    */
   def join[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
@@ -446,10 +445,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
    *
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @param joiner a function that computes the join result for a pair of matching records
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#join`
    */
   def join[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
@@ -458,12 +457,12 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
    *
-   * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param joiner a function that computes the join result for a pair of matching records
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#join`
    */
   def join[VO, VR](other: KTable[K, VO], materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
@@ -474,13 +473,13 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
    *
-   * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param joiner a function that computes the join result for a pair of matching records
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#join`
    */
   def join[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
@@ -494,7 +493,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
    * @param joiner a function that computes the join result for a pair of matching records
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def leftJoin[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
@@ -504,10 +503,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
    *
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @param joiner a function that computes the join result for a pair of matching records
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def leftJoin[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
@@ -516,12 +515,12 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
    *
-   * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param joiner a function that computes the join result for a pair of matching records
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def leftJoin[VO, VR](other: KTable[K, VO], materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
@@ -532,13 +531,13 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
    *
-   * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param joiner a function that computes the join result for a pair of matching records
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def leftJoin[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
@@ -552,7 +551,7 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
    * @param joiner a function that computes the join result for a pair of matching records
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def outerJoin[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
@@ -562,10 +561,10 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
    *
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named  a [[Named]] config used to name the processor in the topology
    * @param joiner a function that computes the join result for a pair of matching records
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def outerJoin[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
@@ -574,12 +573,12 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
    *
-   * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param joiner a function that computes the join result for a pair of matching records
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def outerJoin[VO, VR](other: KTable[K, VO], materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
@@ -590,13 +589,13 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
    *
-   * @param other  the other [[KTable]] to be joined with this [[KTable]]
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param joiner a function that computes the join result for a pair of matching records
-   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   *                      should be materialized.
+   * @param other        the other [[KTable]] to be joined with this [[KTable]]
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
    */
   def outerJoin[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
@@ -608,13 +607,13 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
    * table are joined according to the result of keyExtractor on the other KTable.
    *
-   * @param other the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
    * @param keyExtractor a function that extracts the foreign key from this table's value
    * @param joiner       a function that computes the join result for a pair of matching records
    * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   * should be materialized.
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    */
   def join[VR, KO, VO](other: KTable[KO, VO],
                        keyExtractor: Function[V, KO],
@@ -626,14 +625,14 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
    * table are joined according to the result of keyExtractor on the other KTable.
    *
-   * @param other the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
    * @param keyExtractor a function that extracts the foreign key from this table's value
    * @param joiner       a function that computes the join result for a pair of matching records
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named        a [[Named]] config used to name the processor in the topology
    * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   * should be materialized.
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    */
   def join[VR, KO, VO](other: KTable[KO, VO],
                        keyExtractor: Function[V, KO],
@@ -646,13 +645,13 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
    * table are joined according to the result of keyExtractor on the other KTable.
    *
-   * @param other the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
    * @param keyExtractor a function that extracts the foreign key from this table's value
    * @param joiner       a function that computes the join result for a pair of matching records
    * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   * should be materialized.
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    */
   def leftJoin[VR, KO, VO](other: KTable[KO, VO],
                            keyExtractor: Function[V, KO],
@@ -664,14 +663,14 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
    * table are joined according to the result of keyExtractor on the other KTable.
    *
-   * @param other the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param other        the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
    * @param keyExtractor a function that extracts the foreign key from this table's value
    * @param joiner       a function that computes the join result for a pair of matching records
-   * @param named a [[Named]] config used to name the processor in the topology
+   * @param named        a [[Named]] config used to name the processor in the topology
    * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
-   * should be materialized.
+   *                     should be materialized.
    * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
-   * one for each matched record-pair with the same key
+   *         one for each matched record-pair with the same key
    */
   def leftJoin[VR, KO, VO](other: KTable[KO, VO],
                            keyExtractor: Function[V, KO],

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
@@ -89,7 +89,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @return a [[KTable]] that contains only those records that satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filter`
    */
-  def filter(predicate: (K, V) => Boolean, named: Named, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+  def filter(predicate: (K, V) => Boolean,
+             named: Named,
+             materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.filter(predicate.asPredicate, named, materialized))
 
   /**
@@ -139,7 +141,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
    * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
    */
-  def filterNot(predicate: (K, V) => Boolean, named: Named, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+  def filterNot(predicate: (K, V) => Boolean,
+                named: Named,
+                materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.filterNot(predicate.asPredicate, named, materialized))
 
   /**
@@ -197,7 +201,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
-  def mapValues[VR](mapper: V => VR, named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
+  def mapValues[VR](mapper: V => VR,
+                    named: Named,
+                    materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
     new KTable(inner.mapValues[VR](mapper.asValueMapper, named, materialized))
 
   /**
@@ -242,7 +248,6 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
   def mapValues[VR](mapper: (K, V) => VR, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
     new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey))
 
-
   /**
    * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
    * (with possible new type) in the new [[KTable]].
@@ -256,7 +261,9 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
    * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
    */
-  def mapValues[VR](mapper: (K, V) => VR, named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
+  def mapValues[VR](mapper: (K, V) => VR,
+                    named: Named,
+                    materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
     new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, named, materialized))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KTable.scala
@@ -59,6 +59,18 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * predicate
    *
    * @param predicate a filter that is applied to each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filter`
+   */
+  def filter(predicate: (K, V) => Boolean, named: Named): KTable[K, V] =
+    new KTable(inner.filter(predicate.asPredicate, named))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
    * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
    *                      should be materialized.
    * @return a [[KTable]] that contains only those records that satisfy the given predicate
@@ -66,6 +78,20 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def filter(predicate: (K, V) => Boolean, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.filter(predicate.asPredicate, materialized))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which satisfies the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains only those records that satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filter`
+   */
+  def filter(predicate: (K, V) => Boolean, named: Named, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.filter(predicate.asPredicate, named, materialized))
 
   /**
    * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
@@ -83,6 +109,18 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * predicate
    *
    * @param predicate a filter that is applied to each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean, named: Named): KTable[K, V] =
+    new KTable(inner.filterNot(predicate.asPredicate, named))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
    * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
    *                      should be materialized.
    * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
@@ -90,6 +128,20 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def filterNot(predicate: (K, V) => Boolean, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
     new KTable(inner.filterNot(predicate.asPredicate, materialized))
+
+  /**
+   * Create a new [[KTable]] that consists all records of this [[KTable]] which do <em>not</em> satisfy the given
+   * predicate
+   *
+   * @param predicate a filter that is applied to each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains only those records that do <em>not</em> satisfy the given predicate
+   * @see `org.apache.kafka.streams.kstream.KTable#filterNot`
+   */
+  def filterNot(predicate: (K, V) => Boolean, named: Named, materialized: Materialized[K, V, ByteArrayKeyValueStore]): KTable[K, V] =
+    new KTable(inner.filterNot(predicate.asPredicate, named, materialized))
 
   /**
    * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
@@ -111,6 +163,20 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
    *
    * @param mapper, a function `V => VR` that computes a new output value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR, named: Named): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapper, named))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper, a function `V => VR` that computes a new output value
    * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
    *                      should be materialized.
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
@@ -118,6 +184,22 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def mapValues[VR](mapper: V => VR, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
     new KTable(inner.mapValues[VR](mapper.asValueMapper, materialized))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `V => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper, a function `V => VR` that computes a new output value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: V => VR, named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapper, named, materialized))
 
   /**
    * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
@@ -139,6 +221,20 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
    *
    * @param mapper, a function `(K, V) => VR` that computes a new output value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR, named: Named): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, named))
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper, a function `(K, V) => VR` that computes a new output value
    * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
    *                      should be materialized.
    * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
@@ -146,6 +242,23 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def mapValues[VR](mapper: (K, V) => VR, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
     new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey))
+
+
+  /**
+   * Create a new [[KTable]] by transforming the value of each record in this [[KTable]] into a new value
+   * (with possible new type) in the new [[KTable]].
+   * <p>
+   * The provided `mapper`, a function `(K, V) => VR` is applied to each input record value and computes a new value for it
+   *
+   * @param mapper, a function `(K, V) => VR` that computes a new output value
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KTable#mapValues`
+   */
+  def mapValues[VR](mapper: (K, V) => VR, named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore]): KTable[K, VR] =
+    new KTable(inner.mapValues[VR](mapper.asValueMapperWithKey, named, materialized))
 
   /**
    * Convert this changelog stream to a [[KStream]].
@@ -157,6 +270,16 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
     new KStream(inner.toStream)
 
   /**
+   * Convert this changelog stream to a [[KStream]].
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains the same records as this [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#toStream`
+   */
+  def toStream(named: Named): KStream[K, V] =
+    new KStream(inner.toStream(named))
+
+  /**
    * Convert this changelog stream to a [[KStream]] using the given key/value mapper to select the new key
    *
    * @param mapper a function that computes a new key for each record
@@ -165,6 +288,17 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def toStream[KR](mapper: (K, V) => KR): KStream[KR, V] =
     new KStream(inner.toStream[KR](mapper.asKeyValueMapper))
+
+  /**
+   * Convert this changelog stream to a [[KStream]] using the given key/value mapper to select the new key
+   *
+   * @param mapper a function that computes a new key for each record
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @return a [[KStream]] that contains the same records as this [[KTable]]
+   * @see `org.apache.kafka.streams.kstream.KTable#toStream`
+   */
+  def toStream[KR](mapper: (K, V) => KR, named: Named): KStream[KR, V] =
+    new KStream(inner.toStream[KR](mapper.asKeyValueMapper, named))
 
   /**
    * Suppress some updates from this changelog stream, determined by the supplied [[Suppressed]] configuration.
@@ -206,6 +340,34 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
 
   /**
    * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
+   * Transform the value of each input record into a new value (with possible new type) of the output record.
+   * A `ValueTransformerWithKey` (provided by the given `ValueTransformerWithKeySupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing access to additional state-stores,
+   * and to the `ProcessorContext`.
+   * If the downstream topology uses aggregation functions, (e.g. `KGroupedTable#reduce`, `KGroupedTable#aggregate`, etc),
+   * care must be taken when dealing with state, (either held in state-stores or transformer instances), to ensure correct
+   * aggregate results.
+   * In contrast, if the resulting KTable is materialized, (cf. `#transformValues(ValueTransformerWithKeySupplier, Materialized, String...)`),
+   * such concerns are handled for you.
+   * In order to assign a state, the state must be created and registered
+   * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
+   *
+   * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`.
+   *                                 At least one transformer instance will be created per streaming task.
+   *                                 Transformer implementations doe not need to be thread-safe.
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames          the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](valueTransformerWithKeySupplier: ValueTransformerWithKeySupplier[K, V, VR],
+                          named: Named,
+                          stateStoreNames: String*): KTable[K, VR] =
+    new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, named, stateStoreNames: _*))
+
+  /**
+   * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
    * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
    * record value and computes a new value for it.
    * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing stateful, rather than stateless,
@@ -228,6 +390,33 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
                           materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]],
                           stateStoreNames: String*): KTable[K, VR] =
     new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, materialized, stateStoreNames: _*))
+
+  /**
+   * Create a new `KTable` by transforming the value of each record in this `KTable` into a new value, (with possibly new type).
+   * A `ValueTransformer` (provided by the given `ValueTransformerSupplier`) is applied to each input
+   * record value and computes a new value for it.
+   * This is similar to `#mapValues(ValueMapperWithKey)`, but more flexible, allowing stateful, rather than stateless,
+   * record-by-record operation, access to additional state-stores, and access to the `ProcessorContext`.
+   * In order to assign a state, the state must be created and registered
+   * beforehand via stores added via `addStateStore` or `addGlobalStore` before they can be connected to the `Transformer`
+   * The resulting `KTable` is materialized into another state store (additional to the provided state store names)
+   * as specified by the user via `Materialized` parameter, and is queryable through its given name.
+   *
+   * @param valueTransformerWithKeySupplier a instance of `ValueTransformerWithKeySupplier` that generates a `ValueTransformerWithKey`
+   *                                 At least one transformer instance will be created per streaming task.
+   *                                 Transformer implementations doe not need to be thread-safe.
+   * @param materialized             an instance of `Materialized` used to describe how the state store of the
+   *                                 resulting table should be materialized.
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param stateStoreNames          the names of the state stores used by the processor
+   * @return a [[KStream]] that contains records with unmodified key and new values (possibly of different type)
+   * @see `org.apache.kafka.streams.kstream.KStream#transformValues`
+   */
+  def transformValues[VR](valueTransformerWithKeySupplier: ValueTransformerWithKeySupplier[K, V, VR],
+                          materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]],
+                          named: Named,
+                          stateStoreNames: String*): KTable[K, VR] =
+    new KTable(inner.transformValues[VR](valueTransformerWithKeySupplier, materialized, named, stateStoreNames: _*))
 
   /**
    * Re-groups the records of this [[KTable]] using the provided key/value mapper
@@ -257,6 +446,19 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
    *
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#join`
+   */
+  def join[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner, named))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
    * @param joiner a function that computes the join result for a pair of matching records
    * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
    *                      should be materialized.
@@ -270,6 +472,23 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
     new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner, materialized))
 
   /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#join`
+   */
+  def join[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.join[VO, VR](other.inner, joiner.asValueJoiner, named, materialized))
+
+  /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
    *
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
@@ -280,6 +499,19 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def leftJoin[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
     new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def leftJoin[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner, named))
 
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
@@ -298,6 +530,23 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
     new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner, materialized))
 
   /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def leftJoin[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.leftJoin[VO, VR](other.inner, joiner.asValueJoiner, named, materialized))
+
+  /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
    *
    * @param other  the other [[KTable]] to be joined with this [[KTable]]
@@ -308,6 +557,19 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
    */
   def outerJoin[VO, VR](other: KTable[K, VO])(joiner: (V, VO) => VR): KTable[K, VR] =
     new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def outerJoin[VO, VR](other: KTable[K, VO], named: Named)(joiner: (V, VO) => VR): KTable[K, VR] =
+    new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner, named))
 
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
@@ -324,6 +586,23 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
     joiner: (V, VO) => VR
   ): KTable[K, VR] =
     new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed outer equi join.
+   *
+   * @param other  the other [[KTable]] to be joined with this [[KTable]]
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param joiner a function that computes the join result for a pair of matching records
+   * @param materialized  a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   *                      should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   * @see `org.apache.kafka.streams.kstream.KTable#leftJoin`
+   */
+  def outerJoin[VO, VR](other: KTable[K, VO], named: Named, materialized: Materialized[K, VR, ByteArrayKeyValueStore])(
+    joiner: (V, VO) => VR
+  ): KTable[K, VR] =
+    new KTable(inner.outerJoin[VO, VR](other.inner, joiner.asValueJoiner, named, materialized))
 
   /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
@@ -344,6 +623,26 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
     new KTable(inner.join(other.inner, keyExtractor.asJavaFunction, joiner, materialized))
 
   /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed inner join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   * should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   */
+  def join[VR, KO, VO](other: KTable[KO, VO],
+                       keyExtractor: Function[V, KO],
+                       joiner: ValueJoiner[V, VO, VR],
+                       named: Named,
+                       materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTable[K, VR] =
+    new KTable(inner.join(other.inner, keyExtractor.asJavaFunction, joiner, named, materialized))
+
+  /**
    * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
    * table are joined according to the result of keyExtractor on the other KTable.
    *
@@ -360,6 +659,26 @@ class KTable[K, V](val inner: KTableJ[K, V]) {
                            joiner: ValueJoiner[V, VO, VR],
                            materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTable[K, VR] =
     new KTable(inner.leftJoin(other.inner, keyExtractor.asJavaFunction, joiner, materialized))
+
+  /**
+   * Join records of this [[KTable]] with another [[KTable]]'s records using non-windowed left join. Records from this
+   * table are joined according to the result of keyExtractor on the other KTable.
+   *
+   * @param other the other [[KTable]] to be joined with this [[KTable]], keyed on the value obtained from keyExtractor
+   * @param keyExtractor a function that extracts the foreign key from this table's value
+   * @param joiner       a function that computes the join result for a pair of matching records
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized a `Materialized` that describes how the `StateStore` for the resulting [[KTable]]
+   * should be materialized.
+   * @return a [[KTable]] that contains join-records for each key and values computed by the given joiner,
+   * one for each matched record-pair with the same key
+   */
+  def leftJoin[VR, KO, VO](other: KTable[KO, VO],
+                           keyExtractor: Function[V, KO],
+                           joiner: ValueJoiner[V, VO, VR],
+                           named: Named,
+                           materialized: Materialized[K, VR, KeyValueStore[Bytes, Array[Byte]]]): KTable[K, VR] =
+    new KTable(inner.leftJoin(other.inner, keyExtractor.asJavaFunction, joiner, named, materialized))
 
   /**
    * Get the name of the local state store used that can be used to query this [[KTable]].

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedCogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedCogroupedKStream.scala
@@ -35,6 +35,7 @@ class SessionWindowedCogroupedKStream[K, V](val inner: SessionWindowedCogroupedK
    * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
    *
    * @param initializer    the initializer function
+   * @param merger  a function that combines two aggregation results.
    * @param materialized  an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
    * the latest (rolling) aggregate for each key within a window
@@ -44,5 +45,21 @@ class SessionWindowedCogroupedKStream[K, V](val inner: SessionWindowedCogroupedK
     implicit materialized: Materialized[K, V, ByteArraySessionStore]
   ): KTable[Windowed[K], V] =
     new KTable(inner.aggregate((() => initializer).asInitializer, merger.asMerger, materialized))
+
+  /**
+   * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
+   *
+   * @param initializer    the initializer function
+   * @param merger  a function that combines two aggregation results.
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   * the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => V, merger: (K, V, V) => V, named: Named)(
+    implicit materialized: Materialized[K, V, ByteArraySessionStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, merger.asMerger, named,  materialized))
 
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedCogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedCogroupedKStream.scala
@@ -26,7 +26,6 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.{InitializerFro
  * @tparam K Type of keys
  * @tparam V Type of values
  * @param inner The underlying Java abstraction for SessionWindowedCogroupedKStream
- *
  * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream`
  */
 class SessionWindowedCogroupedKStream[K, V](val inner: SessionWindowedCogroupedKStreamJ[K, V]) {
@@ -34,11 +33,11 @@ class SessionWindowedCogroupedKStream[K, V](val inner: SessionWindowedCogroupedK
   /**
    * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
    *
-   * @param initializer    the initializer function
-   * @param merger  a function that combines two aggregation results.
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  the initializer function
+   * @param merger       a function that combines two aggregation results.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
-   * the latest (rolling) aggregate for each key within a window
+   *         the latest (rolling) aggregate for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream#aggregate`
    */
   def aggregate(initializer: => V, merger: (K, V, V) => V)(
@@ -49,17 +48,17 @@ class SessionWindowedCogroupedKStream[K, V](val inner: SessionWindowedCogroupedK
   /**
    * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
    *
-   * @param initializer    the initializer function
-   * @param merger  a function that combines two aggregation results.
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  the initializer function
+   * @param merger       a function that combines two aggregation results.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
-   * the latest (rolling) aggregate for each key within a window
+   *         the latest (rolling) aggregate for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedCogroupedKStream#aggregate`
    */
   def aggregate(initializer: => V, merger: (K, V, V) => V, named: Named)(
     implicit materialized: Materialized[K, V, ByteArraySessionStore]
   ): KTable[Windowed[K], V] =
-    new KTable(inner.aggregate((() => initializer).asInitializer, merger.asMerger, named,  materialized))
+    new KTable(inner.aggregate((() => initializer).asInitializer, merger.asMerger, named, materialized))
 
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
@@ -37,7 +37,6 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
  * @tparam K Type of keys
  * @tparam V Type of values
  * @param inner The underlying Java abstraction for SessionWindowedKStream
- *
  * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream`
  */
 class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
@@ -45,12 +44,12 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   /**
    * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
    *
-   * @param initializer    the initializer function
-   * @param aggregator     the aggregator function
-   * @param merger         the merger function
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  the initializer function
+   * @param aggregator   the aggregator function
+   * @param merger       the merger function
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
-   * the latest (rolling) aggregate for each key within a window
+   *         the latest (rolling) aggregate for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#aggregate`
    */
   def aggregate[VR](initializer: => VR)(aggregator: (K, V, VR) => VR, merger: (K, VR, VR) => VR)(
@@ -63,13 +62,13 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   /**
    * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
    *
-   * @param initializer    the initializer function
-   * @param aggregator     the aggregator function
-   * @param merger         the merger function
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  the initializer function
+   * @param aggregator   the aggregator function
+   * @param merger       the merger function
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
-   * the latest (rolling) aggregate for each key within a window
+   *         the latest (rolling) aggregate for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#aggregate`
    */
   def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR, merger: (K, VR, VR) => VR)(
@@ -82,9 +81,9 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   /**
    * Count the number of records in this stream by the grouped key into `SessionWindows`.
    *
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys and `Long` values
-   * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+   *         that represent the latest (rolling) count (i.e., number of records) for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#count`
    */
   def count()(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
@@ -102,10 +101,10 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   /**
    * Count the number of records in this stream by the grouped key into `SessionWindows`.
    *
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys and `Long` values
-   * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+   *         that represent the latest (rolling) count (i.e., number of records) for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#count`
    */
   def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
@@ -123,10 +122,10 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   /**
    * Combine values of this stream by the grouped key into `SessionWindows`.
    *
-   * @param reducer           a reducer function that computes a new aggregate result.
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param reducer      a reducer function that computes a new aggregate result.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
-   * the latest (rolling) aggregate for each key within a window
+   *         the latest (rolling) aggregate for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#reduce`
    */
   def reduce(reducer: (V, V) => V)(
@@ -137,10 +136,10 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   /**
    * Combine values of this stream by the grouped key into `SessionWindows`.
    *
-   * @param reducer           a reducer function that computes a new aggregate result.
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param reducer      a reducer function that computes a new aggregate result.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
-   * the latest (rolling) aggregate for each key within a window
+   *         the latest (rolling) aggregate for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#reduce`
    */
   def reduce(reducer: (V, V) => V, named: Named)(

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
@@ -61,6 +61,25 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
     )
 
   /**
+   * Aggregate the values of records in this stream by the grouped key and defined `SessionWindows`.
+   *
+   * @param initializer    the initializer function
+   * @param aggregator     the aggregator function
+   * @param merger         the merger function
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   * the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR, merger: (K, VR, VR) => VR)(
+    implicit materialized: Materialized[K, VR, ByteArraySessionStore]
+  ): KTable[Windowed[K], VR] =
+    new KTable(
+      inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, merger.asMerger, named, materialized)
+    )
+
+  /**
    * Count the number of records in this stream by the grouped key into `SessionWindows`.
    *
    * @param materialized  an instance of `Materialized` used to materialize a state store.
@@ -71,6 +90,27 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
   def count()(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
     val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
       inner.count(materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArraySessionStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArraySessionStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[Windowed[K], Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
+   * Count the number of records in this stream by the grouped key into `SessionWindows`.
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys and `Long` values
+   * that represent the latest (rolling) count (i.e., number of records) for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#count`
+   */
+  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
+    val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
+      inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArraySessionStore]])
     val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArraySessionStore, java.lang.Long]]
     new KTable(
       javaCountTable.mapValues[Long](
@@ -93,4 +133,18 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
     implicit materialized: Materialized[K, V, ByteArraySessionStore]
   ): KTable[Windowed[K], V] =
     new KTable(inner.reduce(reducer.asReducer, materialized))
+
+  /**
+   * Combine values of this stream by the grouped key into `SessionWindows`.
+   *
+   * @param reducer           a reducer function that computes a new aggregate result.
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a windowed [[KTable]] that contains "update" records with unmodified keys, and values that represent
+   * the latest (rolling) aggregate for each key within a window
+   * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V, named: Named)(
+    implicit materialized: Materialized[K, V, ByteArraySessionStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.reduce(reducer.asReducer, named, materialized))
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/SessionWindowedKStream.scala
@@ -107,7 +107,9 @@ class SessionWindowedKStream[K, V](val inner: SessionWindowedKStreamJ[K, V]) {
    *         that represent the latest (rolling) count (i.e., number of records) for each key within a window
    * @see `org.apache.kafka.streams.kstream.SessionWindowedKStream#count`
    */
-  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
+  def count(
+    named: Named
+  )(implicit materialized: Materialized[K, Long, ByteArraySessionStore]): KTable[Windowed[K], Long] = {
     val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
       inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArraySessionStore]])
     val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArraySessionStore, java.lang.Long]]

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedCogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedCogroupedKStream.scala
@@ -45,4 +45,19 @@ class TimeWindowedCogroupedKStream[K, V](val inner: TimeWindowedCogroupedKStream
   ): KTable[Windowed[K], V] =
     new KTable(inner.aggregate((() => initializer).asInitializer, materialized))
 
+  /**
+   * Aggregate the values of records in these streams by the grouped key and defined window.
+   *
+   * @param initializer   an initializer function that computes an initial intermediate aggregation result
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
+   *         (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream#aggregate`
+   */
+  def aggregate(initializer: => V, named: Named)(
+    implicit materialized: Materialized[K, V, ByteArrayWindowStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, named, materialized))
+
 }

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedCogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedCogroupedKStream.scala
@@ -23,10 +23,9 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.InitializerFrom
 /**
  * Wraps the Java class TimeWindowedCogroupedKStream and delegates method calls to the underlying Java object.
  *
- * @tparam K    Type of keys
- * @tparam V    Type of values
+ * @tparam K Type of keys
+ * @tparam V Type of values
  * @param inner The underlying Java abstraction for TimeWindowedCogroupedKStream
- *
  * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream`
  */
 class TimeWindowedCogroupedKStream[K, V](val inner: TimeWindowedCogroupedKStreamJ[K, V]) {
@@ -34,8 +33,8 @@ class TimeWindowedCogroupedKStream[K, V](val inner: TimeWindowedCogroupedKStream
   /**
    * Aggregate the values of records in these streams by the grouped key and defined window.
    *
-   * @param initializer   an initializer function that computes an initial intermediate aggregation result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
    *         (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream#aggregate`
@@ -48,9 +47,9 @@ class TimeWindowedCogroupedKStream[K, V](val inner: TimeWindowedCogroupedKStream
   /**
    * Aggregate the values of records in these streams by the grouped key and defined window.
    *
-   * @param initializer   an initializer function that computes an initial intermediate aggregation result
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the latest
    *         (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedCogroupedKStream#aggregate`

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
@@ -33,10 +33,9 @@ import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
 /**
  * Wraps the Java class TimeWindowedKStream and delegates method calls to the underlying Java object.
  *
- * @tparam K    Type of keys
- * @tparam V    Type of values
+ * @tparam K Type of keys
+ * @tparam V Type of values
  * @param inner The underlying Java abstraction for TimeWindowedKStream
- *
  * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream`
  */
 class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
@@ -44,11 +43,11 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   /**
    * Aggregate the values of records in this stream by the grouped key.
    *
-   * @param initializer   an initializer function that computes an initial intermediate aggregation result
-   * @param aggregator    an aggregator function that computes a new aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param aggregator   an aggregator function that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#aggregate`
    */
   def aggregate[VR](initializer: => VR)(aggregator: (K, V, VR) => VR)(
@@ -59,12 +58,12 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   /**
    * Aggregate the values of records in this stream by the grouped key.
    *
-   * @param initializer   an initializer function that computes an initial intermediate aggregation result
-   * @param named   a [[Named]] config used to name the processor in the topology
-   * @param aggregator    an aggregator function that computes a new aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param initializer  an initializer function that computes an initial intermediate aggregation result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param aggregator   an aggregator function that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#aggregate`
    */
   def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR)(
@@ -75,9 +74,9 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   /**
    * Count the number of records in this stream by the grouped key and the defined windows.
    *
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
-   * represent the latest (rolling) count (i.e., number of records) for each key
+   *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#count`
    */
   def count()(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
@@ -95,10 +94,10 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   /**
    * Count the number of records in this stream by the grouped key and the defined windows.
    *
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
-   * represent the latest (rolling) count (i.e., number of records) for each key
+   *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#count`
    */
   def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
@@ -116,10 +115,10 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   /**
    * Combine the values of records in this stream by the grouped key.
    *
-   * @param reducer   a function that computes a new aggregate result
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param reducer      a function that computes a new aggregate result
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#reduce`
    */
   def reduce(reducer: (V, V) => V)(
@@ -130,11 +129,11 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   /**
    * Combine the values of records in this stream by the grouped key.
    *
-   * @param reducer   a function that computes a new aggregate result
-   * @param named a [[Named]] config used to name the processor in the topology
-   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @param reducer      a function that computes a new aggregate result
+   * @param named        a [[Named]] config used to name the processor in the topology
+   * @param materialized an instance of `Materialized` used to materialize a state store.
    * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
-   * latest (rolling) aggregate for each key
+   *         latest (rolling) aggregate for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#reduce`
    */
   def reduce(reducer: (V, V) => V, named: Named)(

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
@@ -57,6 +57,22 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
     new KTable(inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, materialized))
 
   /**
+   * Aggregate the values of records in this stream by the grouped key.
+   *
+   * @param initializer   an initializer function that computes an initial intermediate aggregation result
+   * @param named   a [[Named]] config used to name the processor in the topology
+   * @param aggregator    an aggregator function that computes a new aggregate result
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   * latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#aggregate`
+   */
+  def aggregate[VR](initializer: => VR, named: Named)(aggregator: (K, V, VR) => VR)(
+    implicit materialized: Materialized[K, VR, ByteArrayWindowStore]
+  ): KTable[Windowed[K], VR] =
+    new KTable(inner.aggregate((() => initializer).asInitializer, aggregator.asAggregator, named, materialized))
+
+  /**
    * Count the number of records in this stream by the grouped key and the defined windows.
    *
    * @param materialized  an instance of `Materialized` used to materialize a state store.
@@ -77,6 +93,27 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
   }
 
   /**
+   * Count the number of records in this stream by the grouped key and the defined windows.
+   *
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys and `Long` values that
+   * represent the latest (rolling) count (i.e., number of records) for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#count`
+   */
+  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
+    val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
+      inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayWindowStore]])
+    val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArrayWindowStore, java.lang.Long]]
+    new KTable(
+      javaCountTable.mapValues[Long](
+        ((l: java.lang.Long) => Long2long(l)).asValueMapper,
+        Materialized.`with`[Windowed[K], Long, ByteArrayKeyValueStore](tableImpl.keySerde(), Serdes.longSerde)
+      )
+    )
+  }
+
+  /**
    * Combine the values of records in this stream by the grouped key.
    *
    * @param reducer   a function that computes a new aggregate result
@@ -86,6 +123,21 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#reduce`
    */
   def reduce(reducer: (V, V) => V)(
+    implicit materialized: Materialized[K, V, ByteArrayWindowStore]
+  ): KTable[Windowed[K], V] =
+    new KTable(inner.reduce(reducer.asReducer, materialized))
+
+  /**
+   * Combine the values of records in this stream by the grouped key.
+   *
+   * @param reducer   a function that computes a new aggregate result
+   * @param named a [[Named]] config used to name the processor in the topology
+   * @param materialized  an instance of `Materialized` used to materialize a state store.
+   * @return a [[KTable]] that contains "update" records with unmodified keys, and values that represent the
+   * latest (rolling) aggregate for each key
+   * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#reduce`
+   */
+  def reduce(reducer: (V, V) => V, named: Named)(
     implicit materialized: Materialized[K, V, ByteArrayWindowStore]
   ): KTable[Windowed[K], V] =
     new KTable(inner.reduce(reducer.asReducer, materialized))

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/TimeWindowedKStream.scala
@@ -100,7 +100,9 @@ class TimeWindowedKStream[K, V](val inner: TimeWindowedKStreamJ[K, V]) {
    *         represent the latest (rolling) count (i.e., number of records) for each key
    * @see `org.apache.kafka.streams.kstream.TimeWindowedKStream#count`
    */
-  def count(named: Named)(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
+  def count(
+    named: Named
+  )(implicit materialized: Materialized[K, Long, ByteArrayWindowStore]): KTable[Windowed[K], Long] = {
     val javaCountTable: KTableJ[Windowed[K], java.lang.Long] =
       inner.count(named, materialized.asInstanceOf[Materialized[K, java.lang.Long, ByteArrayWindowStore]])
     val tableImpl = javaCountTable.asInstanceOf[KTableImpl[Windowed[K], ByteArrayWindowStore, java.lang.Long]]

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/package.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/package.scala
@@ -26,4 +26,5 @@ package object kstream {
   type Repartitioned[K, V] = org.apache.kafka.streams.kstream.Repartitioned[K, V]
   type Joined[K, V, VO] = org.apache.kafka.streams.kstream.Joined[K, V, VO]
   type StreamJoined[K, V, VO] = org.apache.kafka.streams.kstream.StreamJoined[K, V, VO]
+  type Named = org.apache.kafka.streams.kstream.Named
 }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -22,7 +22,15 @@ import java.time.Duration.ofSeconds
 import java.time.Instant
 
 import org.apache.kafka.streams.KeyValue
-import org.apache.kafka.streams.kstream.{JoinWindows, Named, Transformer, ValueTransformer, ValueTransformerSupplier, ValueTransformerWithKey, ValueTransformerWithKeySupplier}
+import org.apache.kafka.streams.kstream.{
+  JoinWindows,
+  Named,
+  Transformer,
+  ValueTransformer,
+  ValueTransformerSupplier,
+  ValueTransformerWithKey,
+  ValueTransformerWithKeySupplier
+}
 import org.apache.kafka.streams.processor.ProcessorContext
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.serialization.Serdes._

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -381,11 +381,15 @@ class KStreamTest extends FlatSpec with Matchers with TestDriver {
       .filter((_, value) => value != "value2", Named.as("my-name"))
       .to(sinkTopic)
 
-    val filterNode =    builder
+    val filterNode = builder
       .build()
       .describe()
-      .subtopologies().asScala.head
-      .nodes().asScala.toList(1)
+      .subtopologies()
+      .asScala
+      .head
+      .nodes()
+      .asScala
+      .toList(1)
 
     filterNode.name() shouldBe "my-name"
   }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -21,7 +21,7 @@ package org.apache.kafka.streams.scala.kstream
 import java.time.Duration.ofSeconds
 import java.time.Instant
 
-import org.apache.kafka.streams.{KeyValue, TopologyDescription}
+import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams.kstream.{
   JoinWindows,
   Named,

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -19,8 +19,7 @@
 package org.apache.kafka.streams.scala.kstream
 
 import java.time.Duration
-
-import org.apache.kafka.streams.kstream.{SessionWindows, Suppressed => JSuppressed, TimeWindows, Windowed}
+import org.apache.kafka.streams.kstream.{Named, SessionWindows, TimeWindows, Windowed, Suppressed => JSuppressed}
 import org.apache.kafka.streams.kstream.Suppressed.BufferConfig
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.serialization.Serdes._
@@ -391,4 +390,57 @@ class KTableTest extends FlatSpec with Matchers with TestDriver {
 
     testDriver.close()
   }
+
+  "setting a name on a filter processor" should "pass the name to the topology" in {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val table = builder.stream[String, String](sourceTopic).groupBy((key, _) => key).count()
+    table
+      .filter((key, value) => key.equals("a") && value == 1, Named.as("my-name"))
+      .toStream
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val filterNode = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(3)
+    filterNode.name() shouldBe "my-name"
+  }
+
+  "setting a name on a count processor" should "pass the name to the topology" in {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+
+    val table = builder.stream[String, String](sourceTopic).groupBy((key, _) => key).count(Named.as("my-name"))
+    table.toStream.to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val filterNode = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(1)
+    filterNode.name() shouldBe "my-name"
+  }
+
+  "setting a name on a join processor" should "pass the name to the topology" in {
+    val builder = new StreamsBuilder()
+    val sourceTopic1 = "source1"
+    val sourceTopic2 = "source2"
+    val sinkTopic = "sink"
+
+    val table1 = builder.stream[String, String](sourceTopic1).groupBy((key, _) => key).count()
+    val table2 = builder.stream[String, String](sourceTopic2).groupBy((key, _) => key).count()
+    table1
+      .join(table2, Named.as("my-name"))((a, b) => a + b)
+      .toStream
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val joinNodeLeft = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(6)
+    val joinNodeRight = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(7)
+    joinNodeLeft.name() should include("my-name")
+    joinNodeRight.name() should include("my-name")
+  }
+
 }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -418,8 +418,8 @@ class KTableTest extends FlatSpec with Matchers with TestDriver {
 
     import scala.jdk.CollectionConverters._
 
-    val filterNode = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(1)
-    filterNode.name() shouldBe "my-name"
+    val countNode = builder.build().describe().subtopologies().asScala.toList(1).nodes().asScala.toList(1)
+    countNode.name() shouldBe "my-name"
   }
 
   "setting a name on a join processor" should "pass the name to the topology" in {


### PR DESCRIPTION

* As it's only API extension to match the java API with Named object with lots of duplication, I only tested the logic once.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
