### PR TITLE
KAFKA-10849: Remove useless ApiKeys#parseResponse and ApiKeys#parseRequest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -16,15 +16,7 @@
  */
 package org.apache.kafka.common.protocol;
 
-import org.apache.kafka.common.protocol.types.BoundField;
-import org.apache.kafka.common.protocol.types.Schema;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public class ApiKeysTest {
 
@@ -38,31 +30,4 @@ public class ApiKeysTest {
         ApiKeys.forId(10000);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void schemaVersionOutOfRange() {
-        ApiKeys.PRODUCE.requestSchema((short) ApiKeys.PRODUCE.requestSchemas.length);
-    }
-
-    /**
-     * All valid client responses which may be throttled should have a field named
-     * 'throttle_time_ms' to return the throttle time to the client. Exclusions are
-     * <ul>
-     *   <li> Cluster actions used only for inter-broker are throttled only if unauthorized
-     *   <li> SASL_HANDSHAKE and SASL_AUTHENTICATE are not throttled when used for authentication
-     *        when a connection is established or for re-authentication thereafter; these requests
-     *        return an error response that may be throttled if they are sent otherwise.
-     * </ul>
-     */
-    @Test
-    public void testResponseThrottleTime() {
-        List<ApiKeys> authenticationKeys = Arrays.asList(ApiKeys.SASL_HANDSHAKE, ApiKeys.SASL_AUTHENTICATE);
-        for (ApiKeys apiKey: ApiKeys.values()) {
-            Schema responseSchema = apiKey.responseSchema(apiKey.latestVersion());
-            BoundField throttleTimeField = responseSchema.get(CommonFields.THROTTLE_TIME_MS.name);
-            if (apiKey.clusterAction || authenticationKeys.contains(apiKey))
-                assertNull("Unexpected throttle time field: " + apiKey, throttleTimeField);
-            else
-                assertNotNull("Throttle time field missing: " + apiKey, throttleTimeField);
-        }
-    }
 }


### PR DESCRIPTION
*More detailed description of your change*
#7409 has removed the conversion to Struct when parsing resp, `ApiVersionsResponse.parse` will be used instead of `API_VERSIONS.parseResponse`, so the overwrite in `ApiKeys.API_VERSIONS` is useless. 

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
