### PR TITLE
KAFKA-10856: Convert sticky assignor userData schemas to use generated protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -25,11 +25,9 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.protocol.types.ArrayOf;
-import org.apache.kafka.common.protocol.types.Field;
-import org.apache.kafka.common.protocol.types.Schema;
-import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.message.StickyAssignorUserData;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.utils.CollectionUtils;
 
 /**
@@ -175,22 +173,6 @@ import org.apache.kafka.common.utils.CollectionUtils;
  */
 public class StickyAssignor extends AbstractStickyAssignor {
 
-    // these schemas are used for preserving consumer's previously assigned partitions
-    // list and sending it as user data to the leader during a rebalance
-    static final String TOPIC_PARTITIONS_KEY_NAME = "previous_assignment";
-    static final String TOPIC_KEY_NAME = "topic";
-    static final String PARTITIONS_KEY_NAME = "partitions";
-    private static final String GENERATION_KEY_NAME = "generation";
-
-    static final Schema TOPIC_ASSIGNMENT = new Schema(
-        new Field(TOPIC_KEY_NAME, Type.STRING),
-        new Field(PARTITIONS_KEY_NAME, new ArrayOf(Type.INT32)));
-    static final Schema STICKY_ASSIGNOR_USER_DATA_V0 = new Schema(
-        new Field(TOPIC_PARTITIONS_KEY_NAME, new ArrayOf(TOPIC_ASSIGNMENT)));
-    private static final Schema STICKY_ASSIGNOR_USER_DATA_V1 = new Schema(
-        new Field(TOPIC_PARTITIONS_KEY_NAME, new ArrayOf(TOPIC_ASSIGNMENT)),
-        new Field(GENERATION_KEY_NAME, Type.INT32));
-
     private List<TopicPartition> memberAssignment = null;
     private int generation = DEFAULT_GENERATION; // consumer group generation
 
@@ -224,49 +206,54 @@ public class StickyAssignor extends AbstractStickyAssignor {
 
     // visible for testing
     static ByteBuffer serializeTopicPartitionAssignment(MemberData memberData) {
-        Struct struct = new Struct(STICKY_ASSIGNOR_USER_DATA_V1);
-        List<Struct> topicAssignments = new ArrayList<>();
-        for (Map.Entry<String, List<Integer>> topicEntry : CollectionUtils.groupPartitionsByTopic(memberData.partitions).entrySet()) {
-            Struct topicAssignment = new Struct(TOPIC_ASSIGNMENT);
-            topicAssignment.set(TOPIC_KEY_NAME, topicEntry.getKey());
-            topicAssignment.set(PARTITIONS_KEY_NAME, topicEntry.getValue().toArray());
-            topicAssignments.add(topicAssignment);
-        }
-        struct.set(TOPIC_PARTITIONS_KEY_NAME, topicAssignments.toArray());
-        if (memberData.generation.isPresent())
-            struct.set(GENERATION_KEY_NAME, memberData.generation.get());
-        ByteBuffer buffer = ByteBuffer.allocate(STICKY_ASSIGNOR_USER_DATA_V1.sizeOf(struct));
-        STICKY_ASSIGNOR_USER_DATA_V1.write(buffer, struct);
-        buffer.flip();
-        return buffer;
+        return serializeTopicPartitionAssignment(memberData, StickyAssignorUserData.HIGHEST_SUPPORTED_VERSION);
     }
 
-    private static MemberData deserializeTopicPartitionAssignment(ByteBuffer buffer) {
-        Struct struct;
-        ByteBuffer copy = buffer.duplicate();
-        try {
-            struct = STICKY_ASSIGNOR_USER_DATA_V1.read(buffer);
-        } catch (Exception e1) {
-            try {
-                // fall back to older schema
-                struct = STICKY_ASSIGNOR_USER_DATA_V0.read(copy);
-            } catch (Exception e2) {
-                // ignore the consumer's previous assignment if it cannot be parsed
-                return new MemberData(Collections.emptyList(), Optional.of(DEFAULT_GENERATION));
-            }
+    // visible for testing
+    static ByteBuffer serializeTopicPartitionAssignment(MemberData memberData, short version) {
+
+        List<StickyAssignorUserData.TopicPartitions> topicAssignments = new ArrayList<>();
+        for (Map.Entry<String, List<Integer>> topicEntry : CollectionUtils.groupPartitionsByTopic(memberData.partitions).entrySet()) {
+            StickyAssignorUserData.TopicPartitions topicPartition = new StickyAssignorUserData.TopicPartitions()
+                    .setTopic(topicEntry.getKey())
+                    .setPartitions(topicEntry.getValue());
+            topicAssignments.add(topicPartition);
         }
+        StickyAssignorUserData data = new StickyAssignorUserData()
+                .setPreviousAssignment(topicAssignments);
+        memberData.generation.ifPresent(data::setGeneration);
+        return MessageUtil.toByteBuffer(data, version);
+    }
+
+    private static MemberData deserializeTopicPartitionAssignment(ByteBuffer buffer, short version) {
+        StickyAssignorUserData data = new StickyAssignorUserData(new ByteBufferAccessor(buffer), version);
 
         List<TopicPartition> partitions = new ArrayList<>();
-        for (Object structObj : struct.getArray(TOPIC_PARTITIONS_KEY_NAME)) {
-            Struct assignment = (Struct) structObj;
-            String topic = assignment.getString(TOPIC_KEY_NAME);
-            for (Object partitionObj : assignment.getArray(PARTITIONS_KEY_NAME)) {
-                Integer partition = (Integer) partitionObj;
+        for (StickyAssignorUserData.TopicPartitions topicPartition : data.previousAssignment()) {
+            String topic = topicPartition.topic();
+            for (Integer partition : topicPartition.partitions()) {
                 partitions.add(new TopicPartition(topic, partition));
             }
         }
         // make sure this is backward compatible
-        Optional<Integer> generation = struct.hasField(GENERATION_KEY_NAME) ? Optional.of(struct.getInt(GENERATION_KEY_NAME)) : Optional.empty();
+        Optional<Integer> generation = data.generation() > 0 ? Optional.of(data.generation()) : Optional.empty();
         return new MemberData(partitions, generation);
+    }
+
+    // visible for testing
+    static MemberData deserializeTopicPartitionAssignment(ByteBuffer buffer) {
+
+        for (short version = StickyAssignorUserData.HIGHEST_SUPPORTED_VERSION;
+             version >= StickyAssignorUserData.LOWEST_SUPPORTED_VERSION; version --) {
+            ByteBuffer copy = buffer.duplicate();
+            try {
+                return deserializeTopicPartitionAssignment(buffer, version);
+            } catch (Exception e) {
+                // fall back to older schema
+                buffer = copy;
+            }
+        }
+        // ignore the consumer's previous assignment if it cannot be parsed
+        return new MemberData(Collections.emptyList(), Optional.of(DEFAULT_GENERATION));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -244,7 +244,7 @@ public class StickyAssignor extends AbstractStickyAssignor {
     static MemberData deserializeTopicPartitionAssignment(ByteBuffer buffer) {
 
         for (short version = StickyAssignorUserData.HIGHEST_SUPPORTED_VERSION;
-             version >= StickyAssignorUserData.LOWEST_SUPPORTED_VERSION; version --) {
+             version >= StickyAssignorUserData.LOWEST_SUPPORTED_VERSION; version--) {
             ByteBuffer copy = buffer.duplicate();
             try {
                 return deserializeTopicPartitionAssignment(buffer, version);

--- a/clients/src/main/resources/common/message/StickyAssignorUserData.json
+++ b/clients/src/main/resources/common/message/StickyAssignorUserData.json
@@ -20,7 +20,7 @@
   "fields": [
     { "name": "PreviousAssignment", "type": "[]TopicPartitions", "versions": "0+",
       "fields": [
-        { "name": "Topic", "type": "string", "versions": "0+" },
+        { "name": "Topic", "type": "string", "mapKey": true, "versions": "0+" },
         { "name": "Partitions", "type": "[]int32", "versions": "0+" }
       ],
       "about": "Used for preserving consumer's previously assigned partitions to make the assignment more sticky during a rebalance"

--- a/clients/src/main/resources/common/message/StickyAssignorUserData.json
+++ b/clients/src/main/resources/common/message/StickyAssignorUserData.json
@@ -16,15 +16,14 @@
 {
   "type": "data",
   "name": "StickyAssignorUserData",
-  // Used for preserving consumer's previously assigned partitions,
-  // list and sending it as user data to the leader during a rebalance
   "validVersions": "0-1",
   "fields": [
     { "name": "PreviousAssignment", "type": "[]TopicPartitions", "versions": "0+",
       "fields": [
         { "name": "Topic", "type": "string", "versions": "0+" },
         { "name": "Partitions", "type": "[]int32", "versions": "0+" }
-      ]
+      ],
+      "about": "Used for preserving consumer's previously assigned partitions to make the assignment more sticky during a rebalance"
     },
     { "name": "generation", "type": "int32", "versions": "1+", "ignorable": true}
   ]

--- a/clients/src/main/resources/common/message/StickyAssignorUserData.json
+++ b/clients/src/main/resources/common/message/StickyAssignorUserData.json
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "StickyAssignorUserData",
+  // Used for preserving consumer's previously assigned partitions,
+  // list and sending it as user data to the leader during a rebalance
+  "validVersions": "0-1",
+  "fields": [
+    { "name": "PreviousAssignment", "type": "[]TopicPartitions", "versions": "0+",
+      "fields": [
+        { "name": "Topic", "type": "string", "versions": "0+" },
+        { "name": "Partitions", "type": "[]int32", "versions": "0+" }
+      ]
+    },
+    { "name": "generation", "type": "int32", "versions": "1+", "ignorable": true}
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -18,12 +18,13 @@ package org.apache.kafka.clients.consumer;
 
 import static org.apache.kafka.clients.consumer.StickyAssignor.serializeTopicPartitionAssignment;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
+import static org.apache.kafka.test.TestUtils.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +38,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.junit.jupiter.api.Test;
+import org.apache.kafka.common.message.StickyAssignorUserData;
 
 public class StickyAssignorTest extends AbstractStickyAssignorTest {
 
@@ -221,19 +223,30 @@ public class StickyAssignorTest extends AbstractStickyAssignorTest {
     }
 
     private static Subscription buildSubscriptionWithOldSchema(List<String> topics, List<TopicPartition> partitions) {
-        Struct struct = new Struct(StickyAssignor.STICKY_ASSIGNOR_USER_DATA_V0);
-        List<Struct> topicAssignments = new ArrayList<>();
-        for (Map.Entry<String, List<Integer>> topicEntry : CollectionUtils.groupPartitionsByTopic(partitions).entrySet()) {
-            Struct topicAssignment = new Struct(StickyAssignor.TOPIC_ASSIGNMENT);
-            topicAssignment.set(StickyAssignor.TOPIC_KEY_NAME, topicEntry.getKey());
-            topicAssignment.set(StickyAssignor.PARTITIONS_KEY_NAME, topicEntry.getValue().toArray());
-            topicAssignments.add(topicAssignment);
-        }
-        struct.set(StickyAssignor.TOPIC_PARTITIONS_KEY_NAME, topicAssignments.toArray());
-        ByteBuffer buffer = ByteBuffer.allocate(StickyAssignor.STICKY_ASSIGNOR_USER_DATA_V0.sizeOf(struct));
-        StickyAssignor.STICKY_ASSIGNOR_USER_DATA_V0.write(buffer, struct);
-        buffer.flip();
+        MemberData memberData = new MemberData(partitions, Optional.empty());
+        return new Subscription(topics, StickyAssignor.serializeTopicPartitionAssignment(memberData, StickyAssignorUserData.LOWEST_SUPPORTED_VERSION));
+    }
 
-        return new Subscription(topics, buffer);
+    @Test
+    public void serializeDeserializeStickyAssignorUserDataAllVersions() {
+        List<TopicPartition> ownedPartitions = Arrays.asList(
+                new TopicPartition("foo", 0),
+                new TopicPartition("bar", 0));
+        for (short version = StickyAssignorUserData.LOWEST_SUPPORTED_VERSION;
+             version <= StickyAssignorUserData.HIGHEST_SUPPORTED_VERSION; version++) {
+            for (Optional<Integer> generation: Arrays.asList(Optional.of(1), Optional.<Integer>empty())) {
+
+                MemberData memberData = new MemberData(ownedPartitions, generation);
+                ByteBuffer buffer = StickyAssignor.serializeTopicPartitionAssignment(memberData, version);
+                MemberData parsedMemberData = StickyAssignor.deserializeTopicPartitionAssignment(buffer);
+                assertEquals(toSet(memberData.partitions), toSet(parsedMemberData.partitions));
+
+                if (version >= 1 && generation.isPresent()) {
+                    assertTrue(parsedMemberData.generation.isPresent());
+                } else {
+                    assertFalse(parsedMemberData.generation.isPresent());
+                }
+            }
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.kafka.clients.consumer;
 
-import static org.apache.kafka.clients.consumer.StickyAssignor.serializeTopicPartitionAssignment;
-import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
-import static org.apache.kafka.test.TestUtils.toSet;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
+import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
+import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.MemberData;
+import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignorTest;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.StickyAssignorUserData;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -30,15 +31,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
-import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor;
-import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.MemberData;
-import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignorTest;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.protocol.types.Struct;
-import org.apache.kafka.common.utils.CollectionUtils;
-import org.junit.jupiter.api.Test;
-import org.apache.kafka.common.message.StickyAssignorUserData;
+
+import static org.apache.kafka.clients.consumer.StickyAssignor.serializeTopicPartitionAssignment;
+import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
+import static org.apache.kafka.test.TestUtils.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StickyAssignorTest extends AbstractStickyAssignorTest {
 


### PR DESCRIPTION
*More detailed description of your change*
Replace sticky assignor userData schemas to use generated protocol

*Summary of testing strategy (including rationale)*
Unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
