### PR TITLE
KAFKA-10652: Adding size based linger semnatics to Raft metadata

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -279,6 +279,7 @@ object Defaults {
   val QuorumFetchTimeoutMs = RaftConfig.DEFAULT_QUORUM_FETCH_TIMEOUT_MS
   val QuorumElectionBackoffMs = RaftConfig.DEFAULT_QUORUM_ELECTION_BACKOFF_MAX_MS
   val QuorumLingerMs = RaftConfig.DEFAULT_QUORUM_LINGER_MS
+  val QuorumMaxUnflushedBytes = RaftConfig.DEFAULT_QUORUM_APPEND_MAX_UNFLUSHED_BYTES
   val QuorumRequestTimeoutMs = RaftConfig.DEFAULT_QUORUM_REQUEST_TIMEOUT_MS
   val QuorumRetryBackoffMs = RaftConfig.DEFAULT_QUORUM_RETRY_BACKOFF_MS
 }
@@ -1314,6 +1315,7 @@ object KafkaConfig {
       .defineInternal(RaftConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG, INT, Defaults.QuorumFetchTimeoutMs, null, HIGH, RaftConfig.QUORUM_FETCH_TIMEOUT_MS_DOC)
       .defineInternal(RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG, INT, Defaults.QuorumElectionBackoffMs, null, HIGH, RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_DOC)
       .defineInternal(RaftConfig.QUORUM_LINGER_MS_CONFIG, INT, Defaults.QuorumLingerMs, null, MEDIUM, RaftConfig.QUORUM_LINGER_MS_DOC)
+      .defineInternal(RaftConfig.QUORUM_APPEND_MAX_UNFLUSHED_BYTES_CONFIG, INT, Defaults.QuorumMaxUnflushedBytes, null, MEDIUM, RaftConfig.QUORUM_APPEND_MAX_UNFLUSHED_BYTES_DOC)
       .defineInternal(RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG, INT, Defaults.QuorumRequestTimeoutMs, null, MEDIUM, RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_DOC)
       .defineInternal(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, INT, Defaults.QuorumRetryBackoffMs, null, LOW, RaftConfig.QUORUM_RETRY_BACKOFF_MS_DOC)
   }
@@ -1769,6 +1771,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val quorumFetchTimeoutMs = getInt(RaftConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG)
   val quorumElectionBackoffMs = getInt(RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG)
   val quorumLingerMs = getInt(RaftConfig.QUORUM_LINGER_MS_CONFIG)
+  val quorumMaxUnflushedBytes = getInt(RaftConfig.QUORUM_APPEND_MAX_UNFLUSHED_BYTES_CONFIG)
   val quorumRequestTimeoutMs = getInt(RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG)
   val quorumRetryBackoffMs = getInt(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG)
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -826,6 +826,7 @@ class KafkaConfigTest {
         case RaftConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case RaftConfig.QUORUM_LINGER_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")
+        case RaftConfig.QUORUM_APPEND_MAX_UNFLUSHED_BYTES_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG => assertPropertyInvalid(baseProperties, name, "not_a_number")
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -414,6 +414,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             quorum.epoch(),
             log.endOffset().offset,
             raftConfig.appendLingerMs(),
+            raftConfig.maxUnflushedBytes(),
             MAX_BATCH_SIZE_BYTES,
             memoryPool,
             time,
@@ -2247,6 +2248,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     public SnapshotWriter<T> createSnapshot(OffsetAndEpoch snapshotId) throws IOException {
         return new SnapshotWriter<>(
             log.createSnapshot(snapshotId),
+            raftConfig.maxUnflushedBytes(),
             MAX_BATCH_SIZE_BYTES,
             memoryPool,
             time,

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -81,6 +81,11 @@ public class RaftConfig {
         "wait for writes to accumulate before flushing them to disk.";
     public static final int DEFAULT_QUORUM_LINGER_MS = 25;
 
+    public static final String QUORUM_APPEND_MAX_UNFLUSHED_BYTES_CONFIG = QUORUM_PREFIX + "append.max.unflushed.bytes";
+    public static final String QUORUM_APPEND_MAX_UNFLUSHED_BYTES_DOC = "The maximum number of bytes that the leader " +
+        "will allow to be accumulated before appending to the topic partition.";
+    public static final int DEFAULT_QUORUM_APPEND_MAX_UNFLUSHED_BYTES = 1_024;
+
     public static final String QUORUM_REQUEST_TIMEOUT_MS_CONFIG = QUORUM_PREFIX +
         CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
     public static final String QUORUM_REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
@@ -98,6 +103,7 @@ public class RaftConfig {
     private final int fetchTimeoutMs;
     private final int appendLingerMs;
     private final Map<Integer, AddressSpec> voterConnections;
+    private final int maxUnflushedBytes;
 
     public interface AddressSpec {
     }
@@ -144,7 +150,8 @@ public class RaftConfig {
             abstractConfig.getInt(QUORUM_ELECTION_TIMEOUT_MS_CONFIG),
             abstractConfig.getInt(QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG),
             abstractConfig.getInt(QUORUM_FETCH_TIMEOUT_MS_CONFIG),
-            abstractConfig.getInt(QUORUM_LINGER_MS_CONFIG));
+            abstractConfig.getInt(QUORUM_LINGER_MS_CONFIG),
+            abstractConfig.getInt(QUORUM_APPEND_MAX_UNFLUSHED_BYTES_CONFIG));
     }
 
     public RaftConfig(
@@ -154,7 +161,8 @@ public class RaftConfig {
         int electionTimeoutMs,
         int electionBackoffMaxMs,
         int fetchTimeoutMs,
-        int appendLingerMs
+        int appendLingerMs,
+        int maxUnflushedBytes
     ) {
         this.voterConnections = voterConnections;
         this.requestTimeoutMs = requestTimeoutMs;
@@ -163,6 +171,7 @@ public class RaftConfig {
         this.electionBackoffMaxMs = electionBackoffMaxMs;
         this.fetchTimeoutMs = fetchTimeoutMs;
         this.appendLingerMs = appendLingerMs;
+        this.maxUnflushedBytes = maxUnflushedBytes;
     }
 
     public int requestTimeoutMs() {
@@ -187,6 +196,10 @@ public class RaftConfig {
 
     public int appendLingerMs() {
         return appendLingerMs;
+    }
+
+    public int maxUnflushedBytes() {
+        return maxUnflushedBytes;
     }
 
     public Set<Integer> quorumVoterIds() {

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * A type for writing a snapshot fora given end offset and epoch.
+ * A type for writing a snapshot for a given end offset and epoch.
  *
  * A snapshot writer can be used to append objects until freeze is called. When freeze is
  * called the snapshot is validated and marked as immutable. After freeze is called any
@@ -59,6 +59,7 @@ final public class SnapshotWriter<T> implements Closeable {
      */
     public SnapshotWriter(
         RawSnapshotWriter snapshot,
+        int maxUnflushedBytes,
         int maxBatchSize,
         MemoryPool memoryPool,
         Time time,
@@ -72,6 +73,7 @@ final public class SnapshotWriter<T> implements Closeable {
             snapshot.snapshotId().epoch,
             0,
             Integer.MAX_VALUE,
+            maxUnflushedBytes,
             maxBatchSize,
             memoryPool,
             time,

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -1360,7 +1360,8 @@ final public class KafkaRaftClientSnapshotTest {
     private static SnapshotWriter<String> snapshotWriter(RaftClientTestContext context, RawSnapshotWriter snapshot) {
         return new SnapshotWriter<>(
             snapshot,
-            4 * 1024,
+            1024,
+            1024,
             MemoryPool.NONE,
             context.time,
             CompressionType.NONE,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -120,6 +120,7 @@ public final class RaftClientTestContext {
         private static final int DEFAULT_REQUEST_TIMEOUT_MS = 5000;
         private static final int RETRY_BACKOFF_MS = 50;
         private static final int DEFAULT_APPEND_LINGER_MS = 0;
+        private static final int DEFAULT_MAX_UNFLUSHED_BYTES = 512;
 
         private final MockMessageQueue messageQueue = new MockMessageQueue();
         private final MockTime time = new MockTime();
@@ -133,6 +134,7 @@ public final class RaftClientTestContext {
         private int requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS;
         private int electionTimeoutMs = DEFAULT_ELECTION_TIMEOUT_MS;
         private int appendLingerMs = DEFAULT_APPEND_LINGER_MS;
+        private int maxUnflushedBytes = DEFAULT_MAX_UNFLUSHED_BYTES;
         private MemoryPool memoryPool = MemoryPool.NONE;
 
         public Builder(int localId, Set<Integer> voters) {
@@ -174,6 +176,11 @@ public final class RaftClientTestContext {
             return this;
         }
 
+        Builder withMaxUnflushedBytes(int maxUnflushedBytes) {
+            this.maxUnflushedBytes = maxUnflushedBytes;
+            return this;
+        }
+
         Builder appendToLog(int epoch, List<String> records) {
             MemoryRecords batch = buildBatch(
                 time.milliseconds(),
@@ -208,7 +215,7 @@ public final class RaftClientTestContext {
             Map<Integer, RaftConfig.AddressSpec> voterAddressMap = voters.stream()
                 .collect(Collectors.toMap(id -> id, RaftClientTestContext::mockAddress));
             RaftConfig raftConfig = new RaftConfig(voterAddressMap, requestTimeoutMs, RETRY_BACKOFF_MS, electionTimeoutMs,
-                    ELECTION_BACKOFF_MAX_MS, FETCH_TIMEOUT_MS, appendLingerMs);
+                    ELECTION_BACKOFF_MAX_MS, FETCH_TIMEOUT_MS, appendLingerMs, maxUnflushedBytes);
 
             KafkaRaftClient<String> client = new KafkaRaftClient<>(
                 STRING_SERDE,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -69,6 +69,7 @@ public class RaftEventSimulationTest {
     private static final int REQUEST_TIMEOUT_MS = 3000;
     private static final int FETCH_MAX_WAIT_MS = 100;
     private static final int LINGER_MS = 0;
+    private static final int MAX_UNFLUSHED_BYTES = 512;
 
     @Test
     public void testInitialLeaderElectionQuorumSizeOne() {
@@ -741,7 +742,7 @@ public class RaftEventSimulationTest {
             Map<Integer, RaftConfig.AddressSpec> voterAddressMap = voters.stream()
                 .collect(Collectors.toMap(id -> id, Cluster::nodeAddress));
             RaftConfig raftConfig = new RaftConfig(voterAddressMap, REQUEST_TIMEOUT_MS, RETRY_BACKOFF_MS, ELECTION_TIMEOUT_MS,
-                    ELECTION_JITTER_MS, FETCH_TIMEOUT_MS, LINGER_MS);
+                    ELECTION_JITTER_MS, FETCH_TIMEOUT_MS, LINGER_MS, MAX_UNFLUSHED_BYTES);
             Metrics metrics = new Metrics(time);
 
             persistentState.log.reopen();

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -51,12 +51,14 @@ class BatchAccumulatorTest {
         int leaderEpoch,
         long baseOffset,
         int lingerMs,
-        int maxBatchSize
+        int maxBatchSize,
+        int maxUnflushedBytes
     ) {
         return new BatchAccumulator<>(
             leaderEpoch,
             baseOffset,
             lingerMs,
+            maxUnflushedBytes,
             maxBatchSize,
             memoryPool,
             time,
@@ -71,12 +73,14 @@ class BatchAccumulatorTest {
         long baseOffset = 157;
         int lingerMs = 50;
         int maxBatchSize = 512;
+        int maxUnflushedBytes = 256;
 
         BatchAccumulator<String> acc = buildAccumulator(
             leaderEpoch,
             baseOffset,
             lingerMs,
-            maxBatchSize
+            maxBatchSize,
+            maxUnflushedBytes
         );
 
         assertTrue(acc.isEmpty());
@@ -90,6 +94,7 @@ class BatchAccumulatorTest {
         long baseOffset = 157;
         int lingerMs = 50;
         int maxBatchSize = 512;
+        int maxUnflushedBytes = 1024;
 
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
             .thenReturn(ByteBuffer.allocate(maxBatchSize));
@@ -98,7 +103,8 @@ class BatchAccumulatorTest {
             leaderEpoch,
             baseOffset,
             lingerMs,
-            maxBatchSize
+            maxBatchSize,
+            maxUnflushedBytes
         );
 
         time.sleep(15);
@@ -117,11 +123,40 @@ class BatchAccumulatorTest {
     }
 
     @Test
+    public void testShouldDrainRecordsWhenBatchSizeExceedsMaxUnflushedBytes() {
+        int leaderEpoch = 17;
+        long baseOffset = 157;
+        int lingerMs = 50;
+        int maxBatchSize = 512;
+        int maxUnflushedBytes = 512;
+
+        Mockito.when(memoryPool.tryAllocate(maxBatchSize))
+                .thenReturn(ByteBuffer.allocate(maxBatchSize));
+
+        BatchAccumulator<String> acc = buildAccumulator(
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize,
+            maxUnflushedBytes
+        );
+
+        assertEquals(baseOffset, acc.append(leaderEpoch, singletonList("a")));
+        assertEquals(lingerMs, acc.timeUntilDrain(time.milliseconds()));
+        assertFalse(acc.isEmpty());
+
+        assertEquals(lingerMs, acc.timeUntilDrain(time.milliseconds()));
+        assertFalse(acc.needsDrain(time.milliseconds()));
+        assertFalse(acc.isEmpty());
+    }
+
+    @Test
     public void testCompletedBatchReleaseBuffer() {
         int leaderEpoch = 17;
         long baseOffset = 157;
         int lingerMs = 50;
         int maxBatchSize = 512;
+        int maxUnflushedBytes = 1024;
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
@@ -131,11 +166,42 @@ class BatchAccumulatorTest {
             leaderEpoch,
             baseOffset,
             lingerMs,
-            maxBatchSize
+            maxBatchSize,
+            maxUnflushedBytes
         );
 
         assertEquals(baseOffset, acc.append(leaderEpoch, singletonList("a")));
         time.sleep(lingerMs);
+
+        List<BatchAccumulator.CompletedBatch<String>> batches = acc.drain();
+        assertEquals(1, batches.size());
+
+        BatchAccumulator.CompletedBatch<String> batch = batches.get(0);
+        batch.release();
+        Mockito.verify(memoryPool).release(buffer);
+    }
+
+    @Test
+    public void testCompletedBatchSizeBasedReleaseBuffer() {
+        int leaderEpoch = 17;
+        long baseOffset = 157;
+        int lingerMs = 50;
+        int maxBatchSize = 512;
+        int maxUnflushedBytes = 512;
+
+        ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
+        Mockito.when(memoryPool.tryAllocate(maxBatchSize))
+                .thenReturn(buffer);
+
+        BatchAccumulator<String> acc = buildAccumulator(
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize,
+            maxUnflushedBytes
+        );
+
+        assertEquals(baseOffset, acc.append(leaderEpoch, singletonList("a")));
 
         List<BatchAccumulator.CompletedBatch<String>> batches = acc.drain();
         assertEquals(1, batches.size());
@@ -151,6 +217,7 @@ class BatchAccumulatorTest {
         long baseOffset = 157;
         int lingerMs = 50;
         int maxBatchSize = 512;
+        int maxUnflushedBytes = 512;
 
         ByteBuffer buffer = ByteBuffer.allocate(maxBatchSize);
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
@@ -160,7 +227,8 @@ class BatchAccumulatorTest {
             leaderEpoch,
             baseOffset,
             lingerMs,
-            maxBatchSize
+            maxBatchSize,
+            maxUnflushedBytes
         );
 
         assertEquals(baseOffset, acc.append(leaderEpoch, singletonList("a")));
@@ -175,6 +243,7 @@ class BatchAccumulatorTest {
             long baseOffset = 157;
             int lingerMs = 50;
             int maxBatchSize = 512;
+            int maxUnflushedBytes = 512;
 
             Mockito.when(memoryPool.tryAllocate(maxBatchSize))
                 .thenReturn(ByteBuffer.allocate(maxBatchSize));
@@ -183,7 +252,8 @@ class BatchAccumulatorTest {
                 leaderEpoch,
                 baseOffset,
                 lingerMs,
-                maxBatchSize
+                maxBatchSize,
+                maxUnflushedBytes
             );
 
             List<String> records = asList("a", "b", "c", "d", "e", "f", "g", "h", "i");
@@ -206,6 +276,44 @@ class BatchAccumulatorTest {
             assertEquals(baseOffset, batch.baseOffset);
         });
     }
+    
+    @Test
+    public void testSingleBatchAccumulationSizeBased() {
+        int leaderEpoch = 17;
+        long baseOffset = 157;
+        int lingerMs = 50;
+        int maxBatchSize = 512;
+        int maxUnflushedBytes = 512;
+
+        Mockito.when(memoryPool.tryAllocate(maxBatchSize))
+                .thenReturn(ByteBuffer.allocate(maxBatchSize));
+
+        BatchAccumulator<String> acc = buildAccumulator(
+            leaderEpoch,
+            baseOffset,
+            lingerMs,
+            maxBatchSize,
+            maxUnflushedBytes
+        );
+
+        List<String> records = asList("a", "b", "c", "d", "e", "f", "g", "h", "i");
+        assertEquals(baseOffset, acc.append(leaderEpoch, records.subList(0, 1)));
+        assertEquals(baseOffset + 2, acc.append(leaderEpoch, records.subList(1, 3)));
+        assertEquals(baseOffset + 5, acc.append(leaderEpoch, records.subList(3, 6)));
+        assertEquals(baseOffset + 7, acc.append(leaderEpoch, records.subList(6, 8)));
+        assertEquals(baseOffset + 8, acc.append(leaderEpoch, records.subList(8, 9)));
+
+        assertFalse(acc.needsDrain(time.milliseconds()));
+
+        List<BatchAccumulator.CompletedBatch<String>> batches = acc.drain();
+        assertEquals(1, batches.size());
+        assertFalse(acc.needsDrain(time.milliseconds()));
+        assertEquals(Long.MAX_VALUE - time.milliseconds(), acc.timeUntilDrain(time.milliseconds()));
+
+        BatchAccumulator.CompletedBatch<String> batch = batches.get(0);
+        assertEquals(records, batch.records);
+        assertEquals(baseOffset, batch.baseOffset);
+    }
 
     @Test
     public void testMultipleBatchAccumulation() {
@@ -214,6 +322,7 @@ class BatchAccumulatorTest {
             long baseOffset = 157;
             int lingerMs = 50;
             int maxBatchSize = 256;
+            int maxUnflushedBytes = 256;
 
             Mockito.when(memoryPool.tryAllocate(maxBatchSize))
                 .thenReturn(ByteBuffer.allocate(maxBatchSize));
@@ -222,7 +331,8 @@ class BatchAccumulatorTest {
                 leaderEpoch,
                 baseOffset,
                 lingerMs,
-                maxBatchSize
+                maxBatchSize,
+                maxUnflushedBytes
             );
 
             // Append entries until we have 4 batches to drain (3 completed, 1 building)
@@ -249,6 +359,7 @@ class BatchAccumulatorTest {
             CompressionType.NONE
         );
         int maxBatchSize = batchHeaderSize + recordsPerBatch * recordSizeInBytes(record, recordsPerBatch);
+        int maxUnflushedBytes = 512;
 
         Mockito.when(memoryPool.tryAllocate(maxBatchSize))
             .thenReturn(ByteBuffer.allocate(maxBatchSize));
@@ -257,7 +368,8 @@ class BatchAccumulatorTest {
             leaderEpoch,
             baseOffset,
             lingerMs,
-            maxBatchSize
+            maxBatchSize,
+            maxUnflushedBytes
         );
 
         List<String> records = Stream
@@ -282,12 +394,14 @@ class BatchAccumulatorTest {
         long baseOffset = 157;
         int lingerMs = 50;
         int maxBatchSize = 256;
+        int maxUnflushedBytes = 256;
 
         BatchAccumulator<String> acc = buildAccumulator(
             leaderEpoch,
             baseOffset,
             lingerMs,
-            maxBatchSize
+            maxBatchSize,
+            maxUnflushedBytes
         );
 
         acc.close();
@@ -300,12 +414,14 @@ class BatchAccumulatorTest {
         long baseOffset = 157;
         int lingerMs = 50;
         int maxBatchSize = 256;
+        int maxUnflushedBytes = 256;
 
         StringSerde serde = Mockito.spy(new StringSerde());
         BatchAccumulator<String> acc = new BatchAccumulator<>(
             leaderEpoch,
             baseOffset,
             lingerMs,
+            maxUnflushedBytes,
             maxBatchSize,
             memoryPool,
             time,


### PR DESCRIPTION
This PR aims to add leader fsync occur with size based heuristic. Meaning, if we accumulate a configurable N bytes, then we should not wait for linger expiration and should just fsync immediately.
