### PR TITLE
KAFKA-10850: Use 'Int.box' to replace deprecated 'new Integer' from BrokerToControllerRequestThreadTest

### DIFF
--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -56,7 +56,7 @@ class BrokerToControllerRequestThreadTest {
     when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
     when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
 
-    val expectedResponse = RequestTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", Int.box(2)))
+    val expectedResponse = RequestTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", 2))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
     mockClient.prepareResponse(expectedResponse)
@@ -100,7 +100,7 @@ class BrokerToControllerRequestThreadTest {
     when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
     when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
 
-    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", Int.box(2)))
+    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", 2))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
       requestQueue, metadataCache, config, listenerName, time, "")
 
@@ -157,8 +157,8 @@ class BrokerToControllerRequestThreadTest {
 
     val responseWithNotControllerError = RequestTestUtils.metadataUpdateWith("cluster1", 2,
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
-      Collections.singletonMap("a", Int.box(2)))
-    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", Int.box(2)))
+      Collections.singletonMap("a", 2))
+    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", 2))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
 
@@ -207,7 +207,7 @@ class BrokerToControllerRequestThreadTest {
 
     val responseWithNotControllerError = RequestTestUtils.metadataUpdateWith("cluster1", 2,
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
-      Collections.singletonMap("a", Int.box(2)))
+      Collections.singletonMap("a", 2))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
 

--- a/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerToControllerRequestThreadTest.scala
@@ -56,7 +56,7 @@ class BrokerToControllerRequestThreadTest {
     when(metadataCache.getAliveBrokers).thenReturn(Seq(activeController))
     when(metadataCache.getAliveBroker(controllerId)).thenReturn(Some(activeController))
 
-    val expectedResponse = RequestTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", new Integer(2)))
+    val expectedResponse = RequestTestUtils.metadataUpdateWith(2, Collections.singletonMap("a", Int.box(2)))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
     mockClient.prepareResponse(expectedResponse)
@@ -100,7 +100,7 @@ class BrokerToControllerRequestThreadTest {
     when(metadataCache.getAliveBroker(newControllerId)).thenReturn(Some(newController))
     when(metadataCache.getAliveBrokers).thenReturn(Seq(oldController, newController))
 
-    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
+    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", Int.box(2)))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(),
       requestQueue, metadataCache, config, listenerName, time, "")
 
@@ -157,8 +157,8 @@ class BrokerToControllerRequestThreadTest {
 
     val responseWithNotControllerError = RequestTestUtils.metadataUpdateWith("cluster1", 2,
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
-      Collections.singletonMap("a", new Integer(2)))
-    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", new Integer(2)))
+      Collections.singletonMap("a", Int.box(2)))
+    val expectedResponse = RequestTestUtils.metadataUpdateWith(3, Collections.singletonMap("a", Int.box(2)))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
 
@@ -207,7 +207,7 @@ class BrokerToControllerRequestThreadTest {
 
     val responseWithNotControllerError = RequestTestUtils.metadataUpdateWith("cluster1", 2,
       Collections.singletonMap("a", Errors.NOT_CONTROLLER),
-      Collections.singletonMap("a", new Integer(2)))
+      Collections.singletonMap("a", Int.box(2)))
     val testRequestThread = new BrokerToControllerRequestThread(mockClient, new ManualMetadataUpdater(), requestQueue, metadataCache,
       config, listenerName, time, "")
 


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
