### PR TITLE
KAFKA-10768 Make ByteBufferInputStream.read(byte[], int, int) to follow the contract

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ByteBufferInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ByteBufferInputStream.java
@@ -37,6 +37,9 @@ public final class ByteBufferInputStream extends InputStream {
     }
 
     public int read(byte[] bytes, int off, int len) {
+        if (len == 0) {
+            return 0;
+        }
         if (!buffer.hasRemaining()) {
             return -1;
         }

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -119,4 +119,5 @@ public class ByteBufferLogInputStreamTest {
         assertNotNull(logInputStream.nextBatch());
         logInputStream.nextBatch();
     }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.errors.CorruptRecordException;
+import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -120,4 +121,26 @@ public class ByteBufferLogInputStreamTest {
         logInputStream.nextBatch();
     }
 
+    @Test
+    public void testReadUnsignedIntFromInputStream() {
+        ByteBuffer buffer = ByteBuffer.allocate(5);
+        buffer.put((byte) 10);
+        buffer.put((byte) 20);
+        buffer.put((byte) 30);
+        buffer.rewind();
+
+        byte[] b = new byte[1];
+
+        ByteBufferInputStream inputStream = new ByteBufferInputStream(buffer);
+        assertEquals(10, inputStream.read());
+
+        inputStream.read(b, 0, 0);
+        assertEquals(20, inputStream.read());
+
+        inputStream.read(b, 0, b.length);
+        assertEquals(0, inputStream.read());
+
+        inputStream.read(b, 0, b.length);
+        assertEquals(-1, inputStream.read());
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.errors.CorruptRecordException;
-import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -119,28 +118,5 @@ public class ByteBufferLogInputStreamTest {
         ByteBufferLogInputStream logInputStream = new ByteBufferLogInputStream(buffer, 25);
         assertNotNull(logInputStream.nextBatch());
         logInputStream.nextBatch();
-    }
-
-    @Test
-    public void testReadUnsignedIntFromInputStream() {
-        ByteBuffer buffer = ByteBuffer.allocate(5);
-        buffer.put((byte) 10);
-        buffer.put((byte) 20);
-        buffer.put((byte) 30);
-        buffer.rewind();
-
-        byte[] b = new byte[1];
-
-        ByteBufferInputStream inputStream = new ByteBufferInputStream(buffer);
-        assertEquals(10, inputStream.read());
-
-        inputStream.read(b, 0, 0);
-        assertEquals(20, inputStream.read());
-
-        inputStream.read(b, 0, b.length);
-        assertEquals(0, inputStream.read());
-
-        inputStream.read(b, 0, b.length);
-        assertEquals(-1, inputStream.read());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.utils;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 
 import java.nio.ByteBuffer;
-
-import org.junit.Test;
 
 public class ByteBufferInputStreamTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class ByteBufferInputStreamTest {
 
     @Test
-    public void testReadUnsignedIntFromInputStream() throws Exception {
+    public void testReadUnsignedIntFromInputStream() {
         ByteBuffer buffer = ByteBuffer.allocate(8);
         buffer.put((byte) 10);
         buffer.put((byte) 20);

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+public class ByteBufferInputStreamTest {
+
+    @Test
+    public void testReadUnsignedIntFromInputStream() throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        buffer.put((byte) 10);
+        buffer.put((byte) 20);
+        buffer.put((byte) 30);
+        buffer.rewind();
+
+        byte[] b = new byte[6];
+
+        ByteBufferInputStream inputStream = new ByteBufferInputStream(buffer);
+        assertEquals(10, inputStream.read());
+        assertEquals(20, inputStream.read());
+
+        assertEquals(3, inputStream.read(b, 3, b.length - 3));
+        assertEquals(0, inputStream.read());
+
+        assertEquals(2, inputStream.read(b, 0, b.length));
+        assertEquals(-1, inputStream.read(b, 0, b.length));
+        assertEquals(0, inputStream.read(b, 0, 0));
+        assertEquals(-1, inputStream.read());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.common.utils;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
 
 public class ByteBufferInputStreamTest {
 


### PR DESCRIPTION
I made a test for ByteBufferInputStream in the ByteBufferLogInputStreamTest.
First, I add a ByteBuffer that it's not empty to the ByteBufferInputStream, in order to verify it.
After that, I try to use ByteBufferInputStream's read function and check return value whether it's correct.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
