### PR TITLE
MINOR: Eliminate KafkaScheduler#scheduleOnce in favor of KafkaScheduler#schedule

### DIFF
--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -99,10 +99,6 @@ class KafkaScheduler(val threads: Int,
     }
   }
 
-  def scheduleOnce(name: String, fun: () => Unit, delay: Long = 0L, unit: TimeUnit = TimeUnit.MILLISECONDS): Unit = {
-    schedule(name, fun, delay = delay, period = -1L, unit = unit)
-  }
-
   def schedule(name: String, fun: () => Unit, delay: Long, period: Long, unit: TimeUnit): ScheduledFuture[_] = {
     debug("Scheduling task %s with initial delay %d ms and period %d ms."
         .format(name, TimeUnit.MILLISECONDS.convert(delay, unit), TimeUnit.MILLISECONDS.convert(period, unit)))

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -99,8 +99,8 @@ class KafkaScheduler(val threads: Int,
     }
   }
 
-  def scheduleOnce(name: String, fun: () => Unit): Unit = {
-    schedule(name, fun, delay = 0L, period = -1L, unit = TimeUnit.MILLISECONDS)
+  def scheduleOnce(name: String, fun: () => Unit, delay: Long = 0L, unit: TimeUnit = TimeUnit.MILLISECONDS): Unit = {
+    schedule(name, fun, delay = delay, period = -1L, unit = unit)
   }
 
   def schedule(name: String, fun: () => Unit, delay: Long, period: Long, unit: TimeUnit): ScheduledFuture[_] = {

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -430,10 +430,10 @@ class ZooKeeperClient(connectString: String,
 
   // Visibility for testing
   private[zookeeper] def scheduleReinitialize(name: String, message: String, delayMs: Long): Unit = {
-    reinitializeScheduler.schedule(name, () => {
+    reinitializeScheduler.scheduleOnce(name, () => {
       info(message)
       reinitialize()
-    }, delayMs, period = -1L, unit = TimeUnit.MILLISECONDS)
+    }, delayMs)
   }
 
   private def threadPrefix: String = name.map(n => n.replaceAll("\\s", "") + "-").getOrElse("")

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -430,7 +430,7 @@ class ZooKeeperClient(connectString: String,
 
   // Visibility for testing
   private[zookeeper] def scheduleReinitialize(name: String, message: String, delayMs: Long): Unit = {
-    reinitializeScheduler.scheduleOnce(name, () => {
+    reinitializeScheduler.schedule(name, () => {
       info(message)
       reinitialize()
     }, delayMs)

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -633,7 +633,7 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
     val semaphore = new Semaphore(0)
     val closeExecutor = Executors.newSingleThreadExecutor
     try {
-      zooKeeperClient.reinitializeScheduler.scheduleOnce("test", () => semaphore.acquireUninterruptibly())
+      zooKeeperClient.reinitializeScheduler.schedule("test", () => semaphore.acquireUninterruptibly())
       zooKeeperClient.scheduleReinitialize("session-expired", "Session expired.", delayMs = 0L)
       val closeFuture = closeExecutor.submit(new Runnable {
         override def run(): Unit = {

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -633,8 +633,7 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
     val semaphore = new Semaphore(0)
     val closeExecutor = Executors.newSingleThreadExecutor
     try {
-      zooKeeperClient.reinitializeScheduler.schedule("test", () => semaphore.acquireUninterruptibly(),
-        delay = 0, period = -1, TimeUnit.SECONDS)
+      zooKeeperClient.reinitializeScheduler.scheduleOnce("test", () => semaphore.acquireUninterruptibly())
       zooKeeperClient.scheduleReinitialize("session-expired", "Session expired.", delayMs = 0L)
       val closeFuture = closeExecutor.submit(new Runnable {
         override def run(): Unit = {


### PR DESCRIPTION
In this PR, I've eliminated `KafkaScheduler#scheduleOnce` API. It had only 1 call site, and instead we can just use `KafkaScheduler#schedule`.

**Test plan:**
Rely on existing tests.