### PR TITLE
KAFKA-10864: Convert end txn marker schema to use auto-generated protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.message.EndTxnMarker;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.MessageUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
@@ -96,7 +96,7 @@ public class EndTransactionMarker {
         if (version > EndTxnMarker.HIGHEST_SUPPORTED_VERSION)
             log.debug("Received end transaction marker value version {}. Parsing as version {}", version,
                     EndTxnMarker.HIGHEST_SUPPORTED_VERSION);
-        EndTxnMarker marker = new EndTxnMarker(new ByteBufferAccessor(value), version);
+        EndTxnMarker marker = new EndTxnMarker(new ByteBufferAccessor(value), EndTxnMarker.HIGHEST_SUPPORTED_VERSION);
         return new EndTransactionMarker(type, marker.coordinatorEpoch());
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/EndTransactionMarker.java
@@ -16,9 +16,12 @@
  */
 package org.apache.kafka.common.record;
 
+import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.message.EndTxnMarker;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.MessageUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 
@@ -28,6 +31,7 @@ import java.nio.ByteBuffer;
  * value embeds information useful for write validation (for now, just the coordinator epoch).
  */
 public class EndTransactionMarker {
+    private static final Logger log = LoggerFactory.getLogger(EndTransactionMarker.class);
 
     private final ControlRecordType type;
     private final int coordinatorEpoch;
@@ -84,6 +88,13 @@ public class EndTransactionMarker {
         ensureTransactionMarkerControlType(type);
 
         short version = value.getShort();
+        if (version < EndTxnMarker.LOWEST_SUPPORTED_VERSION)
+            throw new InvalidRecordException("Invalid version found for end transaction marker: " + version +
+                    ". May indicate data corruption");
+
+        if (version > EndTxnMarker.HIGHEST_SUPPORTED_VERSION)
+            log.debug("Received end transaction marker value version {}. Parsing as version {}", version,
+                    EndTxnMarker.HIGHEST_SUPPORTED_VERSION);
         EndTxnMarker marker = new EndTxnMarker(new ByteBufferAccessor(value), version);
         return new EndTransactionMarker(type, marker.coordinatorEpoch());
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -678,8 +678,7 @@ public class MemoryRecords extends AbstractRecords {
     public static MemoryRecords withEndTransactionMarker(long initialOffset, long timestamp, int partitionLeaderEpoch,
                                                          long producerId, short producerEpoch,
                                                          EndTransactionMarker marker) {
-        int endTxnMarkerBatchSize = DefaultRecordBatch.RECORD_BATCH_OVERHEAD +
-                EndTransactionMarker.CURRENT_END_TXN_SCHEMA_RECORD_SIZE;
+        int endTxnMarkerBatchSize = DefaultRecordBatch.RECORD_BATCH_OVERHEAD + marker.endTxnMarkerValueSize();
         ByteBuffer buffer = ByteBuffer.allocate(endTxnMarkerBatchSize);
         writeEndTransactionalMarker(buffer, initialOffset, timestamp, partitionLeaderEpoch, producerId,
                 producerEpoch, marker);

--- a/clients/src/main/resources/common/message/EndTxnMarker.json
+++ b/clients/src/main/resources/common/message/EndTxnMarker.json
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "type": "data",
+  "name": "EndTxnMarker",
+  "validVersions": "0",
+  "flexibleVersions": "none",
+  "fields": [
+    { "name": "CoordinatorEpoch", "type": "int32", "versions": "0+",
+      "about": "The coordinator epoch when appending the record"
+    }
+  ]
+}

--- a/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.utils.ByteUtils;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class EndTransactionMarkerTest {
 
     // Old hard-coded schema, used to validate old hard-coded schema format is exactly the same as new auto generated protocol format
-    private Schema v0Schema = new Schema(
+    private final Schema v0Schema = new Schema(
             new Field("version", Type.INT16),
             new Field("coordinator_epoch", Type.INT32));
 
@@ -93,6 +94,20 @@ public class EndTransactionMarkerTest {
                 EndTransactionMarker deserializedMarker = EndTransactionMarker.deserializeValue(type, buffer);
                 assertEquals(marker, deserializedMarker);
             }
+        }
+    }
+
+    @Test
+    public void testEndTxnMarkerValueSize() {
+        for (ControlRecordType type: VALID_CONTROLLER_RECORD_TYPE) {
+            EndTransactionMarker marker = new EndTransactionMarker(type, 1);
+            int offsetSize = ByteUtils.sizeOfVarint(0);
+            int timestampSize = ByteUtils.sizeOfVarlong(0);
+            int keySize = ControlRecordType.CURRENT_CONTROL_RECORD_KEY_SIZE;
+            int valueSize = marker.serializeValue().remaining();
+            int headerSize = ByteUtils.sizeOfVarint(Record.EMPTY_HEADERS.length);
+            int totalSize = 1 + offsetSize + timestampSize + ByteUtils.sizeOfVarint(keySize) + keySize + ByteUtils.sizeOfVarint(valueSize) + valueSize + headerSize;
+            assertEquals(ByteUtils.sizeOfVarint(totalSize) +  totalSize, marker.endTxnMarkerValueSize());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.record;
 
+import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.message.EndTxnMarker;
 import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
@@ -50,6 +51,14 @@ public class EndTransactionMarkerTest {
     public void testCannotDeserializeUnknownControlType() {
         assertThrows(IllegalArgumentException.class,
             () -> EndTransactionMarker.deserializeValue(ControlRecordType.UNKNOWN, ByteBuffer.wrap(new byte[0])));
+    }
+
+    @Test
+    public void testIllegalVersion() {
+        ByteBuffer buffer = ByteBuffer.allocate(2);
+        buffer.putShort((short) -1);
+        buffer.flip();
+        assertThrows(InvalidRecordException.class, () -> EndTransactionMarker.deserializeValue(ControlRecordType.ABORT, buffer));
     }
 
     @Test


### PR DESCRIPTION
*More detailed description of your change*
1. Convert end txn marker schema to use auto-generated protocol `EndTxnMarker`
2. substitute `CURRENT_END_TXN_MARKER_VALUE_SIZE` with an `endTnxMarkerValueSize` method since the size is accumulated from `EndTxnMarker`.
3. add buffer to `EndTransactionMarker` to avoid twice compute from `serializeValue` and `endTnxMarkerValueSize`.
4. flexibleVersions is set to none.

*Summary of testing strategy (including rationale)*
A unit test to verify serialize and deserialize

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
