### PR TITLE
KAFKA-10047: Remove unnecessary widening of (int to long) scope in FloatSerializer.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/FloatSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/FloatSerializer.java
@@ -22,7 +22,7 @@ public class FloatSerializer implements Serializer<Float> {
         if (data == null)
             return null;
 
-        long bits = Float.floatToRawIntBits(data);
+        int bits = Float.floatToRawIntBits(data);
         return new byte[] {
             (byte) (bits >>> 24),
             (byte) (bits >>> 16),


### PR DESCRIPTION
@halorgium @astubbs @alexism @glasser @rhardouin 