### PR TITLE
KAFKA-8460: reduce the record size and increase the delay time

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -148,17 +148,16 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
 
   protected def consumeRecords[K, V](consumer: Consumer[K, V],
                                      numRecords: Int,
-                                     maxPollRecords: Int = Int.MaxValue,
-                                     waitTimeMs: Int = 60000): ArrayBuffer[ConsumerRecord[K, V]] = {
-    val records = new ArrayBuffer[ConsumerRecord[K, V]]
+                                     maxPollRecords: Int = Int.MaxValue): ArrayBuffer[ConsumerRecord[K, V]] = {
+    val records = new ArrayBuffer[ConsumerRecord[K, V]](numRecords)
     def pollAction(polledRecords: ConsumerRecords[K, V]): Boolean = {
       assertTrue(polledRecords.asScala.size <= maxPollRecords)
       records ++= polledRecords.asScala
       records.size >= numRecords
     }
-    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = waitTimeMs,
+    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = 60000,
       msg = s"Timed out before consuming expected $numRecords records. " +
-        s"The number consumed was ${records.size} after ${waitTimeMs} ms")
+        s"The number consumed was ${records.size}.")
     records
   }
 

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -148,16 +148,17 @@ abstract class AbstractConsumerTest extends BaseRequestTest {
 
   protected def consumeRecords[K, V](consumer: Consumer[K, V],
                                      numRecords: Int,
-                                     maxPollRecords: Int = Int.MaxValue): ArrayBuffer[ConsumerRecord[K, V]] = {
+                                     maxPollRecords: Int = Int.MaxValue,
+                                     waitTimeMs: Int = 60000): ArrayBuffer[ConsumerRecord[K, V]] = {
     val records = new ArrayBuffer[ConsumerRecord[K, V]]
     def pollAction(polledRecords: ConsumerRecords[K, V]): Boolean = {
       assertTrue(polledRecords.asScala.size <= maxPollRecords)
       records ++= polledRecords.asScala
       records.size >= numRecords
     }
-    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = 60000,
+    TestUtils.pollRecordsUntilTrue(consumer, pollAction, waitTimeMs = waitTimeMs,
       msg = s"Timed out before consuming expected $numRecords records. " +
-        s"The number consumed was ${records.size}.")
+        s"The number consumed was ${records.size} after ${waitTimeMs} ms")
     records
   }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -804,7 +804,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // we produce 10 records for each topic partition. There are 3 topics, and 30 partitions each topic,
     // so total producerRecords size should be 10 * 3 * 30 = 900
     val producerRecords = partitions.flatMap(sendRecords(producer, numRecords = 10, _))
-    val consumerRecords = consumeRecords(consumer, producerRecords.size, waitTimeMs = 90 * 1000)
+    val consumerRecords = consumeRecords(consumer, producerRecords.size)
 
     val expected = producerRecords.map { record =>
       (record.topic, record.partition, new String(record.key), new String(record.value), record.timestamp)

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -801,9 +801,9 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     awaitAssignment(consumer, partitions.toSet)
 
     val producer = createProducer()
-    // we produce 10 records for each topic partition. There are 3 topics, and 30 partitions each topic,
-    // so total producerRecords size should be 10 * 3 * 30 = 900
-    val producerRecords = partitions.flatMap(sendRecords(producer, numRecords = 10, _))
+    // we produce 5 records for each topic partition. There are 3 topics, and 30 partitions each topic,
+    // so total producerRecords size should be 5 * 3 * 30 = 450
+    val producerRecords = partitions.flatMap(sendRecords(producer, numRecords = 5, _))
     val consumerRecords = consumeRecords(consumer, producerRecords.size)
 
     val expected = producerRecords.map { record =>


### PR DESCRIPTION
Looking into this flaky test, the error messages are:
```
Timed out before consuming expected 1350 records. The number consumed was 1230.
```
https://ci-builds.apache.org/job/Kafka/job/kafka-trunk-jdk8/303/testReport/kafka.api/PlaintextConsumerTest/testLowMaxFetchSizeForRequestAndPartition/
```
Timed out before consuming expected 1350 records. The number consumed was 1200.
```
https://ci-builds.apache.org/job/Kafka/job/kafka-trunk-jdk8/305/testReport/kafka.api/PlaintextConsumerTest/testLowMaxFetchSizeForRequestAndPartition/
```
Timed out before consuming expected 1350 records. The number consumed was 1215.
```
https://ci-builds.apache.org/job/Kafka/job/kafka-trunk-jdk8/305/testReport/junit/kafka.api/PlaintextConsumerTest/testLowMaxFetchSizeForRequestAndPartition/

We can see, the number consumes are not fixed number and close to 1350. After checking the test, I found the test is expected to be slow because it tests `we can consume all partitions if fetch.max.bytes and max.partition.fetch.bytes are low`. So I think the test has no bug, just need more time. 

What I did are:
1. reduce the record size for each partition (from 15 -> 10), it should speed up the test, but also be able to test the original scenario
2. increase the timeout value (from 60 sec -> 90 sec)

Hope this can makes the test more reliable!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
