### PR TITLE
KAFKA-10874 Fix flaky ClientQuotasRequestTest.testAlterIpQuotasRequest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -29,6 +29,8 @@ import org.junit.Test
 import java.util
 import java.util.concurrent.{ExecutionException, TimeUnit}
 
+import kafka.utils.TestUtils
+
 import scala.jdk.CollectionConverters._
 
 class ClientQuotasRequestTest extends BaseRequestTest {
@@ -200,7 +202,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
     val defaultEntityFilter = ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.IP)
     val allIpEntityFilter = ClientQuotaFilterComponent.ofEntityType(ClientQuotaEntity.IP)
 
-    def verifyIpQuotas(entityFilter: ClientQuotaFilterComponent, expectedMatches: Map[ClientQuotaEntity, Double]): Unit = {
+    def verifyIpQuotas(entityFilter: ClientQuotaFilterComponent, expectedMatches: Map[ClientQuotaEntity, Double]): Unit = TestUtils.retry(10000L){
       val result = describeClientQuotas(ClientQuotaFilter.containsOnly(List(entityFilter).asJava))
       assertEquals(expectedMatches.keySet, result.asScala.keySet)
       result.asScala.foreach { case (entity, props) =>

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -215,6 +215,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
         else
           InetAddress.getByName(entityName)
         TestUtils.retry(10000L) {
+          //retry until Broker update prop from Zookeeper
           assertEquals(expectedMatches(entity), servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp), 0.01)
         }
       }

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -216,7 +216,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
           InetAddress.getByName(entityName)
         TestUtils.waitUntilTrue(
           () => expectedMatches(entity) - servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp) < 0.01
-          ,"Broker didn't update prop from Zookeeper")
+          ,"Broker didn't update quotas from Zookeeper")
       }
     }
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -202,7 +202,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
     val defaultEntityFilter = ClientQuotaFilterComponent.ofDefaultEntity(ClientQuotaEntity.IP)
     val allIpEntityFilter = ClientQuotaFilterComponent.ofEntityType(ClientQuotaEntity.IP)
 
-    def verifyIpQuotas(entityFilter: ClientQuotaFilterComponent, expectedMatches: Map[ClientQuotaEntity, Double]): Unit = TestUtils.retry(10000L){
+    def verifyIpQuotas(entityFilter: ClientQuotaFilterComponent, expectedMatches: Map[ClientQuotaEntity, Double]): Unit = {
       val result = describeClientQuotas(ClientQuotaFilter.containsOnly(List(entityFilter).asJava))
       assertEquals(expectedMatches.keySet, result.asScala.keySet)
       result.asScala.foreach { case (entity, props) =>
@@ -214,7 +214,9 @@ class ClientQuotasRequestTest extends BaseRequestTest {
           InetAddress.getByName(unknownHost)
         else
           InetAddress.getByName(entityName)
-        assertEquals(expectedMatches(entity), servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp), 0.01)
+        TestUtils.retry(10000L) {
+          assertEquals(expectedMatches(entity), servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp), 0.01)
+        }
       }
     }
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -214,9 +214,12 @@ class ClientQuotasRequestTest extends BaseRequestTest {
           InetAddress.getByName(unknownHost)
         else
           InetAddress.getByName(entityName)
+        var currentServerQuota = 0
         TestUtils.waitUntilTrue(
-          () => expectedMatches(entity) - servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp) < 0.01
-          ,"Broker didn't update quotas from Zookeeper")
+          () => {
+            currentServerQuota = servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp)
+            Math.abs(expectedMatches(entity) - currentServerQuota) < 0.01
+          }, s"Broker didn't update quotas from Zookeeper, expect: ${expectedMatches(entity)}, got: $currentServerQuota")
       }
     }
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -219,7 +219,7 @@ class ClientQuotasRequestTest extends BaseRequestTest {
           () => {
             currentServerQuota = servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp)
             Math.abs(expectedMatches(entity) - currentServerQuota) < 0.01
-          }, s"Broker didn't update quotas from Zookeeper, expect: ${expectedMatches(entity)}, got: $currentServerQuota")
+          }, s"Connection quota of $entity is not ${expectedMatches(entity)} but $currentServerQuota")
       }
     }
 

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -214,10 +214,9 @@ class ClientQuotasRequestTest extends BaseRequestTest {
           InetAddress.getByName(unknownHost)
         else
           InetAddress.getByName(entityName)
-        TestUtils.retry(10000L) {
-          //retry until Broker update prop from Zookeeper
-          assertEquals(expectedMatches(entity), servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp), 0.01)
-        }
+        TestUtils.waitUntilTrue(
+          () => expectedMatches(entity) - servers.head.socketServer.connectionQuotas.connectionRateForIp(entityIp) < 0.01
+          ,"Broker didn't update prop from Zookeeper")
       }
     }
 


### PR DESCRIPTION
The error  occcur when dynamic ip config  update after borker's config  get .  
solve this by waiting dynamic ip config update.