### PR TITLE
KAFKA-10891:The control plane needs to force the validation of requests from the controller

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -260,7 +260,7 @@ class SocketServer(val config: KafkaConfig,
       connectionQuotas.addListener(config, endpoint.listenerName)
       val controlPlaneAcceptor = createAcceptor(endpoint, ControlPlaneMetricPrefix)
       val controlPlaneProcessor = newProcessor(nextProcessorId, controlPlaneRequestChannelOpt.get,
-        connectionQuotas, endpoint.listenerName, endpoint.securityProtocol, memoryPool, isPrivilegedListener = true)
+        connectionQuotas, endpoint.listenerName, endpoint.securityProtocol, memoryPool, isPrivilegedListener = true, isControlPlane = true)
       controlPlaneAcceptorOpt = Some(controlPlaneAcceptor)
       controlPlaneProcessorOpt = Some(controlPlaneProcessor)
       val listenerProcessors = new ArrayBuffer[Processor]()
@@ -287,7 +287,7 @@ class SocketServer(val config: KafkaConfig,
 
     for (_ <- 0 until newProcessorsPerListener) {
       val processor = newProcessor(nextProcessorId, dataPlaneRequestChannel, connectionQuotas,
-        listenerName, securityProtocol, memoryPool, isPrivilegedListener)
+        listenerName, securityProtocol, memoryPool, isPrivilegedListener, false)
       listenerProcessors += processor
       dataPlaneRequestChannel.addProcessor(processor)
       nextProcessorId += 1
@@ -413,7 +413,7 @@ class SocketServer(val config: KafkaConfig,
 
   // `protected` for test usage
   protected[network] def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                      securityProtocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean): Processor = {
+                                      securityProtocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean, isControlPlane: Boolean): Processor = {
     new Processor(id,
       time,
       config.socketRequestMaxBytes,
@@ -429,7 +429,8 @@ class SocketServer(val config: KafkaConfig,
       memoryPool,
       logContext,
       isPrivilegedListener = isPrivilegedListener,
-      allowDisabledApis = allowDisabledApis
+      allowDisabledApis = allowDisabledApis,
+      isControlPlane = isControlPlane
     )
   }
 
@@ -790,7 +791,8 @@ private[kafka] class Processor(val id: Int,
                                logContext: LogContext,
                                connectionQueueSize: Int = ConnectionQueueSize,
                                isPrivilegedListener: Boolean = false,
-                               allowDisabledApis: Boolean = false) extends AbstractServerThread(connectionQuotas) with KafkaMetricsGroup {
+                               allowDisabledApis: Boolean = false,
+                               isControlPlane: Boolean = false) extends AbstractServerThread(connectionQuotas) with KafkaMetricsGroup {
 
   private object ConnectionId {
     def fromString(s: String): Option[ConnectionId] = s.split("-") match {
@@ -988,60 +990,79 @@ private[kafka] class Processor(val id: Int,
     }
   }
 
+  protected def isControlRequest(header: RequestHeader): Boolean = {
+    if (isControlPlane) {
+      header.apiKey() match {
+        case ApiKeys.LEADER_AND_ISR => true
+        case ApiKeys.STOP_REPLICA => true
+        case ApiKeys.UPDATE_METADATA => true
+        case ApiKeys.CONTROLLED_SHUTDOWN => true
+        case _ => false
+      }
+    }else {
+      true
+    }
+  }
+
   private def processCompletedReceives(): Unit = {
     selector.completedReceives.forEach { receive =>
       try {
         openOrClosingChannel(receive.source) match {
           case Some(channel) =>
             val header = parseRequestHeader(receive.payload)
-            if (header.apiKey == ApiKeys.SASL_HANDSHAKE && channel.maybeBeginServerReauthentication(receive,
-              () => time.nanoseconds()))
-              trace(s"Begin re-authentication: $channel")
-            else {
-              val nowNanos = time.nanoseconds()
-              if (channel.serverAuthenticationSessionExpired(nowNanos)) {
-                // be sure to decrease connection count and drop any in-flight responses
-                debug(s"Disconnecting expired channel: $channel : $header")
-                close(channel.id)
-                expiredConnectionsKilledCount.record(null, 1, 0)
-              } else {
-                val connectionId = receive.source
-                val context = new RequestContext(header, connectionId, channel.socketAddress,
-                  channel.principal, listenerName, securityProtocol,
-                  channel.channelMetadataRegistry.clientInformation, isPrivilegedListener, channel.principalSerde)
+            if (!isControlRequest(header)) {
+              info(s"Current plane is control-plan, disconnecting non controller channel: $channel : $header")
+              close(channel.id)
+            }else{
+              if (header.apiKey == ApiKeys.SASL_HANDSHAKE && channel.maybeBeginServerReauthentication(receive,
+                () => time.nanoseconds()))
+                trace(s"Begin re-authentication: $channel")
+              else {
+                val nowNanos = time.nanoseconds()
+                if (channel.serverAuthenticationSessionExpired(nowNanos)) {
+                  // be sure to decrease connection count and drop any in-flight responses
+                  debug(s"Disconnecting expired channel: $channel : $header")
+                  close(channel.id)
+                  expiredConnectionsKilledCount.record(null, 1, 0)
+                } else {
+                  val connectionId = receive.source
+                  val context = new RequestContext(header, connectionId, channel.socketAddress,
+                    channel.principal, listenerName, securityProtocol,
+                    channel.channelMetadataRegistry.clientInformation, isPrivilegedListener, channel.principalSerde)
 
-                var req = new RequestChannel.Request(processor = id, context = context,
-                  startTimeNanos = nowNanos, memoryPool, receive.payload, requestChannel.metrics, None)
+                  var req = new RequestChannel.Request(processor = id, context = context,
+                    startTimeNanos = nowNanos, memoryPool, receive.payload, requestChannel.metrics, None)
 
-                if (req.header.apiKey == ApiKeys.ENVELOPE) {
-                  // Override the request context with the forwarded request context.
-                  // The envelope's context will be preserved in the forwarded context
+                  if (req.header.apiKey == ApiKeys.ENVELOPE) {
+                    // Override the request context with the forwarded request context.
+                    // The envelope's context will be preserved in the forwarded context
 
-                  req = parseForwardedPrincipal(req, channel.principalSerde.asScala) match {
-                    case Some(forwardedPrincipal) =>
-                      buildForwardedRequestContext(req, forwardedPrincipal)
+                    req = parseForwardedPrincipal(req, channel.principalSerde.asScala) match {
+                      case Some(forwardedPrincipal) =>
+                        buildForwardedRequestContext(req, forwardedPrincipal)
 
-                    case None =>
-                      val envelopeResponse = new EnvelopeResponse(Errors.PRINCIPAL_DESERIALIZATION_FAILURE)
-                      sendEnvelopeResponse(req, envelopeResponse)
-                      null
-                  }
-                }
-
-                if (req != null) {
-                  // KIP-511: ApiVersionsRequest is intercepted here to catch the client software name
-                  // and version. It is done here to avoid wiring things up to the api layer.
-                  if (header.apiKey == ApiKeys.API_VERSIONS) {
-                    val apiVersionsRequest = req.body[ApiVersionsRequest]
-                    if (apiVersionsRequest.isValid) {
-                      channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
-                        apiVersionsRequest.data.clientSoftwareName,
-                        apiVersionsRequest.data.clientSoftwareVersion))
+                      case None =>
+                        val envelopeResponse = new EnvelopeResponse(Errors.PRINCIPAL_DESERIALIZATION_FAILURE)
+                        sendEnvelopeResponse(req, envelopeResponse)
+                        null
                     }
                   }
-                  requestChannel.sendRequest(req)
-                  selector.mute(connectionId)
-                  handleChannelMuteEvent(connectionId, ChannelMuteEvent.REQUEST_RECEIVED)
+
+                  if (req != null) {
+                    // KIP-511: ApiVersionsRequest is intercepted here to catch the client software name
+                    // and version. It is done here to avoid wiring things up to the api layer.
+                    if (header.apiKey == ApiKeys.API_VERSIONS) {
+                      val apiVersionsRequest = req.body[ApiVersionsRequest]
+                      if (apiVersionsRequest.isValid) {
+                        channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
+                          apiVersionsRequest.data.clientSoftwareName,
+                          apiVersionsRequest.data.clientSoftwareVersion))
+                      }
+                    }
+                    requestChannel.sendRequest(req)
+                    selector.mute(connectionId)
+                    handleChannelMuteEvent(connectionId, ChannelMuteEvent.REQUEST_RECEIVED)
+                  }
                 }
               }
             }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -534,7 +534,10 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
    */
   private def controlledShutdown(): Unit = {
 
-    def node(broker: Broker): Node = broker.node(config.interBrokerListenerName)
+    val brokerToControllerListenerName = config.controlPlaneListenerName.getOrElse(config.interBrokerListenerName)
+    val brokerToControllerSecurityProtocol = config.controlPlaneSecurityProtocol.getOrElse(config.interBrokerSecurityProtocol)
+
+    def node(broker: Broker): Node = broker.node(brokerToControllerListenerName)
 
     val socketTimeoutMs = config.controllerSocketTimeoutMs
 
@@ -542,10 +545,10 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
       val metadataUpdater = new ManualMetadataUpdater()
       val networkClient = {
         val channelBuilder = ChannelBuilders.clientChannelBuilder(
-          config.interBrokerSecurityProtocol,
+          brokerToControllerSecurityProtocol,
           JaasContext.Type.SERVER,
           config,
-          config.interBrokerListenerName,
+          brokerToControllerListenerName,
           config.saslMechanismInterBrokerProtocol,
           time,
           config.saslInterBrokerHandshakeRequestEnable,

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -1758,6 +1758,7 @@ class SocketServerTest {
     testProps.put("listeners", "PLAINTEXT://localhost:0,CONTROLLER://localhost:0")
     testProps.put("listener.security.protocol.map", "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT")
     testProps.put("control.plane.listener.name", "CONTROLLER")
+    testProps.put("control.plane.force.controller.requests.enable", "true")
     val config = KafkaConfig.fromProps(testProps)
     withTestableServer(config, { testableServer =>
       val controlPlaneSocket = connect(testableServer, config.controlPlaneListenerName.get,

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -507,10 +507,10 @@ class SocketServerTest {
     val overrideConnectionId = "127.0.0.1:1-127.0.0.1:2-0"
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics, time, credentialProvider) {
       override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false): Processor = {
+                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false, isControlPlane:Boolean = false): Processor = {
         new Processor(id, time, config.socketRequestMaxBytes, dataPlaneRequestChannel, connectionQuotas,
           config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics,
-          credentialProvider, memoryPool, new LogContext(), isPrivilegedListener = isPrivilegedListener) {
+          credentialProvider, memoryPool, new LogContext(), isPrivilegedListener = isPrivilegedListener, isControlPlane = isControlPlane) {
           override protected[network] def connectionId(socket: Socket): String = overrideConnectionId
           override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
             val testableSelector = new TestableSelector(config, channelBuilder, time, metrics)
@@ -1086,10 +1086,10 @@ class SocketServerTest {
     var conn: Socket = null
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics, Time.SYSTEM, credentialProvider) {
       override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false): Processor = {
+                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false, isControlPlane: Boolean = false): Processor = {
         new Processor(id, time, config.socketRequestMaxBytes, dataPlaneRequestChannel, connectionQuotas,
           config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics,
-          credentialProvider, MemoryPool.NONE, new LogContext(), isPrivilegedListener = isPrivilegedListener) {
+          credentialProvider, MemoryPool.NONE, new LogContext(), isPrivilegedListener = isPrivilegedListener, isControlPlane = isControlPlane) {
           override protected[network] def sendResponse(response: RequestChannel.Response, responseSend: Send): Unit = {
             conn.close()
             super.sendResponse(response, responseSend)
@@ -1128,10 +1128,10 @@ class SocketServerTest {
     @volatile var selector: TestableSelector = null
     val overrideServer = new SocketServer(KafkaConfig.fromProps(props), serverMetrics, Time.SYSTEM, credentialProvider) {
       override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false): Processor = {
+                                protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false, isControlPlane:Boolean = false): Processor = {
         new Processor(id, time, config.socketRequestMaxBytes, dataPlaneRequestChannel, connectionQuotas,
           config.connectionsMaxIdleMs, config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics,
-          credentialProvider, memoryPool, new LogContext(), isPrivilegedListener = isPrivilegedListener) {
+          credentialProvider, memoryPool, new LogContext(), isPrivilegedListener = isPrivilegedListener, isControlPlane = isControlPlane) {
           override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
             val testableSelector = new TestableSelector(config, channelBuilder, time, metrics)
             selector = testableSelector
@@ -1887,10 +1887,10 @@ class SocketServerTest {
     @volatile var uncaughtExceptions = 0
 
     override def newProcessor(id: Int, requestChannel: RequestChannel, connectionQuotas: ConnectionQuotas, listenerName: ListenerName,
-                              protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false): Processor = {
+                              protocol: SecurityProtocol, memoryPool: MemoryPool, isPrivilegedListener: Boolean = false, isControlPlane: Boolean = false): Processor = {
       new Processor(id, time, config.socketRequestMaxBytes, requestChannel, connectionQuotas, config.connectionsMaxIdleMs,
         config.failedAuthenticationDelayMs, listenerName, protocol, config, metrics, credentialProvider,
-        memoryPool, new LogContext(), connectionQueueSize, isPrivilegedListener) {
+        memoryPool, new LogContext(), connectionQueueSize, isPrivilegedListener, isControlPlane) {
 
         override protected[network] def createSelector(channelBuilder: ChannelBuilder): Selector = {
           val testableSelector = new TestableSelector(config, channelBuilder, time, metrics, metricTags.asScala)


### PR DESCRIPTION
…ect the control plane to be safe and stable.

At present,data requests and control requests use different endpoints,these endpoints are all registered with ZooKeeper.This results in the client business still having access to the metadata that controls the endpoint,this returns the control endpoint back to the data endpoint.One option is to turn on the firewall to disable client access to the control port.But does Kafka need to do something on its own to handle data request access control endpoints to deny those requests.I modified part of the code to deny access control endpoints for data requests.This is the first time I've submitted code to the community,I hope to get some advice, if possible, I will continue to work on this.