### PR TITLE
Add a job to build on ARM64 at Amazon Graviton2 nodes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,13 @@ services:
 jdk:
   - openjdk8
 
+jobs:
+  include:
+    - name: arm64
+      arch: arm64-graviton2
+      group: edge
+      virt: vm
+
 env:
   - _DUCKTAPE_OPTIONS="--subset 0  --subsets 15"
   - _DUCKTAPE_OPTIONS="--subset 1  --subsets 15"

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG jdk_version=openjdk:8
+ARG jdk_version=openjdk:11
 FROM $jdk_version
 
 MAINTAINER Apache Kafka dev@kafka.apache.org
@@ -33,9 +33,15 @@ LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
 # we have to install git since it is included in openjdk:8 but not openjdk:11
-RUN apt update && apt install -y sudo git netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
-RUN python3 -m pip install -U pip==20.2.2;
-RUN pip3 install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip3 install --upgrade ducktape==0.8.0
+RUN apt update && apt install -y \
+  sudo \
+  # iproute2 is required by DegradedNetworkFaultWorker (round_trip_fault_test.py) and it is not in openjdk:11
+  iproute2 \
+  # we have to install git since it is included in openjdk:8 but not openjdk:11
+  git \
+  netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python3-pip python3-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev iperf traceroute && apt-get -y clean
+RUN pip3 install -U pip==20.3.3;
+RUN pip3 install --upgrade pynacl cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip3 install --upgrade ducktape==0.8.0
 
 # Set up ssh
 COPY ./ssh-config /root/.ssh/config

--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -42,7 +42,7 @@ docker_run_memory_limit="2000m"
 default_num_nodes=14
 
 # The default OpenJDK base image.
-default_jdk="openjdk:8"
+default_jdk="openjdk:11"
 
 # The default ducker-ak image name.
 default_image_name="ducker-ak"


### PR DESCRIPTION
More and more software development is being done on ARM64 CPU architecture.
It would be good if Apache Kafka is being regularly tested on ARM64.

Changes:

* apply the changes from https://github.com/apache/kafka/pull/8489 - `ducker` needs multi-arch Docker image, like `openjdk:11`

* upgrade Pip to 20.3.3 (latest available at the moment).

* explicitly install pynacl to workaround https://github.com/apache/kafka/pull/8489#issuecomment-751998685
