### PR TITLE
KAFKA-10893 Increase target_messages_per_sec of ReplicaScaleTest to r…

### DIFF
--- a/tests/kafkatest/tests/core/replica_scale_test.py
+++ b/tests/kafkatest/tests/core/replica_scale_test.py
@@ -72,7 +72,7 @@ class ReplicaScaleTest(Test):
         produce_spec = ProduceBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
                                                 producer_workload_service.producer_node,
                                                 producer_workload_service.bootstrap_servers,
-                                                target_messages_per_sec=10000,
+                                                target_messages_per_sec=150000,
                                                 max_messages=3400000,
                                                 producer_conf={},
                                                 admin_client_conf={},
@@ -83,12 +83,12 @@ class ReplicaScaleTest(Test):
                                                 }})
         produce_workload = trogdor.create_task("replicas-produce-workload", produce_spec)
         produce_workload.wait_for_done(timeout_sec=600)
-        self.logger.info("Completed produce bench")
+        print("Completed produce bench", flush=True)  # Force some stdout for Travis
 
         consume_spec = ConsumeBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
                                                 consumer_workload_service.consumer_node,
                                                 consumer_workload_service.bootstrap_servers,
-                                                target_messages_per_sec=10000,
+                                                target_messages_per_sec=150000,
                                                 max_messages=3400000,
                                                 consumer_conf={},
                                                 admin_client_conf={},


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-10893

The expected size is 3400000 and the throttle is 10000 msg/sec so the expected minimal run time of one consumer/producer is about 6 mins. Hence, the test case is always timeout on travis (6 + 6 > 10 mins)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
