### PR TITLE
KAFKA-10894; Ensure PartitionInfo replicas are not null in client quota callback

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -232,9 +232,9 @@ public final class Cluster {
     }
 
     /**
-     * Get the node by the node id (or null if no such node exists)
+     * Get the node by the node id (or null if the node is not online or does not exist)
      * @param id The id of the node
-     * @return The node, or null if no such node exists
+     * @return The node, or null if the node is not online or does not exist
      */
     public Node nodeById(int id) {
         return this.nodesById.get(id);

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -20,7 +20,7 @@ import java.util
 import java.util.Collections
 import util.Arrays.asList
 
-import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.{Node, TopicPartition, Uuid}
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
@@ -417,7 +417,7 @@ class MetadataCacheTest {
     val controllerEpoch = 1
     val leader = 0
     val leaderEpoch = 0
-    val replicas = asList[Integer](0)
+    val replicas = asList[Integer](0, 1)
     val isr = asList[Integer](0, 1)
     val partitionStates = Seq(new UpdateMetadataPartitionState()
       .setTopicName(topic)
@@ -459,7 +459,7 @@ class MetadataCacheTest {
       val controllerEpoch = 1
       val leader = 0
       val leaderEpoch = 0
-      val replicas = asList[Integer](0)
+      val replicas = asList[Integer](0, 1)
       val isr = asList[Integer](0, 1)
       val partitionStates = Seq(new UpdateMetadataPartitionState()
         .setTopicName(topic)
@@ -482,6 +482,63 @@ class MetadataCacheTest {
     // This should not change `aliveBrokersFromCache`
     updateCache((0 to 3))
     assertEquals(initialBrokerIds.toSet, aliveBrokersFromCache.map(_.id).toSet)
+  }
+
+  @Test
+  def testGetClusterMetadataWithOfflineReplicas(): Unit = {
+    val cache = new MetadataCache(1)
+    val topic = "topic"
+    val topicPartition = new TopicPartition(topic, 0)
+    val securityProtocol = SecurityProtocol.PLAINTEXT
+    val listenerName = ListenerName.forSecurityProtocol(securityProtocol)
+
+    val brokers = Seq(
+      new UpdateMetadataBroker()
+        .setId(0)
+        .setRack("")
+        .setEndpoints(Seq(new UpdateMetadataEndpoint()
+          .setHost("foo")
+          .setPort(9092)
+          .setSecurityProtocol(securityProtocol.id)
+          .setListener(listenerName.value)).asJava),
+      new UpdateMetadataBroker()
+        .setId(1)
+        .setEndpoints(Seq.empty.asJava)
+    )
+    val controllerEpoch = 1
+    val leader = 1
+    val leaderEpoch = 0
+    val replicas = asList[Integer](0, 1)
+    val isr = asList[Integer](0, 1)
+    val offline = asList[Integer](1)
+    val partitionStates = Seq(new UpdateMetadataPartitionState()
+      .setTopicName(topic)
+      .setPartitionIndex(topicPartition.partition)
+      .setControllerEpoch(controllerEpoch)
+      .setLeader(leader)
+      .setLeaderEpoch(leaderEpoch)
+      .setIsr(isr)
+      .setZkVersion(3)
+      .setReplicas(replicas)
+      .setOfflineReplicas(offline))
+    val version = ApiKeys.UPDATE_METADATA.latestVersion
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, brokerEpoch, partitionStates.asJava,
+      brokers.asJava, Collections.emptyMap()).build()
+    cache.updateMetadata(15, updateMetadataRequest)
+
+    val expectedNode0 = new Node(0, "foo", 9092)
+    val expectedNode1 = new Node(1, "", -1)
+
+    val cluster = cache.getClusterMetadata("clusterId", listenerName)
+    assertEquals(expectedNode0, cluster.nodeById(0))
+    assertNull(cluster.nodeById(1))
+    assertEquals(expectedNode1, cluster.leaderFor(topicPartition))
+
+    val partitionInfo = cluster.partition(topicPartition)
+    assertEquals(expectedNode1, partitionInfo.leader)
+    assertEquals(Seq(expectedNode0, expectedNode1), partitionInfo.replicas.toSeq)
+    assertEquals(Seq(expectedNode0, expectedNode1), partitionInfo.inSyncReplicas.toSeq)
+    assertEquals(Seq(expectedNode1), partitionInfo.offlineReplicas.toSeq)
   }
 
 }


### PR DESCRIPTION
Previously offline replicas were included as `null` in the array of replicas in `PartitionInfo` when populated by the `MetadataCache` for the purpose of the client quota callback. This patch instead initializes empty non-null nodes, which is consistent with how `PartitionInfo` is constructed by the clients in `MetadataResponse`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
