### PR TITLE
MINOR: Don't include stack trace for StateChangeFailedException

### DIFF
--- a/core/src/main/scala/kafka/common/StateChangeFailedException.scala
+++ b/core/src/main/scala/kafka/common/StateChangeFailedException.scala
@@ -17,7 +17,6 @@
 
 package kafka.common
 
-class StateChangeFailedException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
-  def this(message: String) = this(message, null)
-  def this() = this(null, null)
+class StateChangeFailedException(message: String) extends RuntimeException(message) {
+  override def fillInStackTrace: Throwable = this
 }


### PR DESCRIPTION
The stack trace for `StateChangeFailedException` is useless since the exception is just used to propagate an error message to the state change logger. This patch eliminates the stack trace which should help to clean up logging a little bit. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
