### PR TITLE
MINOR: Propagate version correctly in `FetchSnapshotRequest` constructor

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
@@ -32,7 +32,7 @@ final public class FetchSnapshotRequest extends AbstractRequest {
     public final FetchSnapshotRequestData data;
 
     public FetchSnapshotRequest(FetchSnapshotRequestData data, short version) {
-        super(ApiKeys.FETCH_SNAPSHOT, (short) (FetchSnapshotRequestData.SCHEMAS.length - 1));
+        super(ApiKeys.FETCH_SNAPSHOT, version);
         this.data = data;
     }
 


### PR DESCRIPTION
We missed this in the initial check-in of the `FetchSnapshot` API. We need to pass through the version to the super constructor.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
