### PR TITLE
KAFKA-10779; Reassignment tool sets throttles incorrectly when overriding a reassignment

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -1271,7 +1271,8 @@ object ReassignPartitionsCommand extends Logging {
       case (part, replicas) =>
         val partMoves = moveMap.getOrElseUpdate(part.topic(), new mutable.HashMap[Int, PartitionMove])
 
-        // If there is a reassignment in progress,
+        // If there is a reassignment in progress, use the sources from moveMap, otherwise
+        // use the sources from currentParts
         val sources = mutable.Set[Int]() ++ (partMoves.get(part.partition()) match {
           case Some(move) => move.sources.toSeq
           case None => currentParts.getOrElse(part,

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
@@ -28,7 +28,6 @@ import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{InvalidReplicationFactorException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.{Node, TopicPartition, TopicPartitionInfo, TopicPartitionReplica}
 import org.junit.Assert.{assertEquals, assertFalse, assertThrows, assertTrue}
-import org.junit.function.ThrowingRunnable
 import org.junit.rules.Timeout
 import org.junit.{After, Assert, Before, Rule, Test}
 
@@ -75,11 +74,11 @@ class ReassignPartitionsUnitTest {
         mkString(System.lineSeparator()),
       partitionReassignmentStatesToString(Map(
         new TopicPartition("foo", 0) ->
-          new PartitionReassignmentState(Seq(1, 2, 3), Seq(1, 2, 3), true),
+          PartitionReassignmentState(Seq(1, 2, 3), Seq(1, 2, 3), true),
         new TopicPartition("foo", 1) ->
-          new PartitionReassignmentState(Seq(1, 2, 3), Seq(1, 2, 4), false),
+          PartitionReassignmentState(Seq(1, 2, 3), Seq(1, 2, 4), false),
         new TopicPartition("bar", 0) ->
-          new PartitionReassignmentState(Seq(1, 2, 3), Seq(1, 2, 4), false),
+          PartitionReassignmentState(Seq(1, 2, 3), Seq(1, 2, 4), false),
       )))
   }
 
@@ -192,15 +191,15 @@ class ReassignPartitionsUnitTest {
       "Partition quux-2 is not found in any live log dir on broker 1. " +
           "There is likely an offline log directory on the broker.").mkString(System.lineSeparator()),
         replicaMoveStatesToString(Map(
-          new TopicPartitionReplica("bar", 0, 0) -> new CompletedMoveState("/tmp/kafka-logs0"),
-          new TopicPartitionReplica("foo", 0, 0) -> new ActiveMoveState("/tmp/kafka-logs0",
+          new TopicPartitionReplica("bar", 0, 0) -> CompletedMoveState("/tmp/kafka-logs0"),
+          new TopicPartitionReplica("foo", 0, 0) -> ActiveMoveState("/tmp/kafka-logs0",
             "/tmp/kafka-logs1", "/tmp/kafka-logs1"),
-          new TopicPartitionReplica("foo", 1, 0) -> new CancelledMoveState("/tmp/kafka-logs0",
+          new TopicPartitionReplica("foo", 1, 0) -> CancelledMoveState("/tmp/kafka-logs0",
             "/tmp/kafka-logs1"),
-          new TopicPartitionReplica("quux", 0, 0) -> new MissingReplicaMoveState("/tmp/kafka-logs1"),
-          new TopicPartitionReplica("quux", 1, 1) -> new ActiveMoveState("/tmp/kafka-logs0",
+          new TopicPartitionReplica("quux", 0, 0) -> MissingReplicaMoveState("/tmp/kafka-logs1"),
+          new TopicPartitionReplica("quux", 1, 1) -> ActiveMoveState("/tmp/kafka-logs0",
             "/tmp/kafka-logs1", "/tmp/kafka-logs2"),
-          new TopicPartitionReplica("quux", 2, 1) -> new MissingLogDirMoveState("/tmp/kafka-logs1")
+          new TopicPartitionReplica("quux", 2, 1) -> MissingLogDirMoveState("/tmp/kafka-logs1")
         )))
   }
 
@@ -234,20 +233,19 @@ class ReassignPartitionsUnitTest {
       build()
     try {
       assertEquals(Seq(
-        new BrokerMetadata(0, Some("rack0")),
-        new BrokerMetadata(1, Some("rack1"))
+        BrokerMetadata(0, Some("rack0")),
+        BrokerMetadata(1, Some("rack1"))
       ), getBrokerMetadata(adminClient, Seq(0, 1), true))
       assertEquals(Seq(
-        new BrokerMetadata(0, None),
-        new BrokerMetadata(1, None)
+        BrokerMetadata(0, None),
+        BrokerMetadata(1, None)
       ), getBrokerMetadata(adminClient, Seq(0, 1), false))
       assertStartsWith("Not all brokers have rack information",
-        assertThrows(classOf[AdminOperationException], new ThrowingRunnable {
-          override def run(): Unit = getBrokerMetadata(adminClient, Seq(1, 2), true)
-        }).getMessage)
+        assertThrows(classOf[AdminOperationException],
+          () => getBrokerMetadata(adminClient, Seq(1, 2), true)).getMessage)
       assertEquals(Seq(
-        new BrokerMetadata(1, None),
-        new BrokerMetadata(2, None)
+        BrokerMetadata(1, None),
+        BrokerMetadata(2, None)
       ), getBrokerMetadata(adminClient, Seq(1, 2), false))
     } finally {
       adminClient.close()
@@ -258,25 +256,19 @@ class ReassignPartitionsUnitTest {
   def testParseGenerateAssignmentArgs(): Unit = {
     assertStartsWith("Broker list contains duplicate entries",
       assertThrows("Expected to detect duplicate broker list entries",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit = parseGenerateAssignmentArgs(
-            """{"topics": [{"topic": "foo"}], "version":1}""", "1,1,2")
-        }).getMessage)
+        classOf[AdminCommandFailedException], () => parseGenerateAssignmentArgs(
+          """{"topics": [{"topic": "foo"}], "version":1}""", "1,1,2")).getMessage)
     assertStartsWith("Broker list contains duplicate entries",
       assertThrows("Expected to detect duplicate broker list entries",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit = parseGenerateAssignmentArgs(
-            """{"topics": [{"topic": "foo"}], "version":1}""", "5,2,3,4,5")
-        }).getMessage)
+        classOf[AdminCommandFailedException], () => parseGenerateAssignmentArgs(
+          """{"topics": [{"topic": "foo"}], "version":1}""", "5,2,3,4,5")).getMessage)
     assertEquals((Seq(5,2,3,4),Seq("foo")),
       parseGenerateAssignmentArgs("""{"topics": [{"topic": "foo"}], "version":1}""",
         "5,2,3,4"))
     assertStartsWith("List of topics to reassign contains duplicate entries",
       assertThrows("Expected to detect duplicate topic entries",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit = parseGenerateAssignmentArgs(
-            """{"topics": [{"topic": "foo"},{"topic": "foo"}], "version":1}""", "5,2,3,4")
-        }).getMessage)
+        classOf[AdminCommandFailedException], () => parseGenerateAssignmentArgs(
+          """{"topics": [{"topic": "foo"},{"topic": "foo"}], "version":1}""", "5,2,3,4")).getMessage)
     assertEquals((Seq(5,3,4),Seq("foo","bar")),
       parseGenerateAssignmentArgs(
         """{"topics": [{"topic": "foo"},{"topic": "bar"}], "version":1}""",
@@ -290,11 +282,9 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Replication factor: 3 larger than available brokers: 2",
         assertThrows("Expected generateAssignment to fail",
-          classOf[InvalidReplicationFactorException], new ThrowingRunnable {
-            override def run():Unit = {
-              generateAssignment(adminClient,
-                """{"topics":[{"topic":"foo"},{"topic":"bar"}]}""", "0,1", false)
-            }
+          classOf[InvalidReplicationFactorException], () => {
+            generateAssignment(adminClient,
+              """{"topics":[{"topic":"foo"},{"topic":"bar"}]}""", "0,1", false)
           }).getMessage)
     } finally {
       adminClient.close()
@@ -316,11 +306,9 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Not all brokers have rack information.",
         assertThrows("Expected generateAssignment to fail",
-          classOf[AdminOperationException], new ThrowingRunnable {
-            override def run():Unit = {
-              generateAssignment(adminClient,
-                """{"topics":[{"topic":"foo"}]}""", "0,1,2,3", true)
-            }
+          classOf[AdminOperationException], () => {
+            generateAssignment(adminClient,
+              """{"topics":[{"topic":"foo"}]}""", "0,1,2,3", true)
           }).getMessage)
       // It should succeed when --disable-rack-aware is used.
       val (_, current) = generateAssignment(adminClient,
@@ -351,7 +339,7 @@ class ReassignPartitionsUnitTest {
 
       // The proposed assignment should only span the provided brokers
       proposed.values.foreach {
-        case replicas => {
+        replicas => {
           if (!replicas.forall(goalBrokers.contains(_))) {
             Assert.fail(s"Proposed assignment ${proposed} puts replicas on brokers " +
               s"other than ${goalBrokers}")
@@ -392,25 +380,25 @@ class ReassignPartitionsUnitTest {
   def testMoveMap(): Unit = {
     val moveMap = calculateProposedMoveMap(Map(
       new TopicPartition("foo", 0) -> new PartitionReassignment(
-        Arrays.asList(1,2,3),Arrays.asList(4),Arrays.asList(3)),
+        Arrays.asList(1,2,3,4), Arrays.asList(4), Arrays.asList(3)),
       new TopicPartition("foo", 1) -> new PartitionReassignment(
-        Arrays.asList(4,5,6),Arrays.asList(7, 8),Arrays.asList(4, 5))
+        Arrays.asList(4,5,6,7,8), Arrays.asList(7, 8), Arrays.asList(4, 5))
     ), Map(
       new TopicPartition("foo", 0) -> Seq(1,2,5),
       new TopicPartition("bar", 0) -> Seq(1,2,3)
     ), Map(
-      new TopicPartition("foo", 0) -> Seq(1,2,3),
-      new TopicPartition("foo", 1) -> Seq(4,5,6),
+      new TopicPartition("foo", 0) -> Seq(1,2,3,4),
+      new TopicPartition("foo", 1) -> Seq(4,5,6,7,8),
       new TopicPartition("bar", 0) -> Seq(2,3,4),
       new TopicPartition("baz", 0) -> Seq(1,2,3)
     ))
     assertEquals(
       mutable.Map("foo" -> mutable.Map(
-          0 -> new PartitionMove(mutable.Set(1,2,3), mutable.Set(5)),
-          1 -> new PartitionMove(mutable.Set(4,5,6), mutable.Set(7, 8))
+          0 -> PartitionMove(mutable.Set(1,2,3), mutable.Set(5)),
+          1 -> PartitionMove(mutable.Set(4,5,6), mutable.Set(7, 8))
         ),
         "bar" -> mutable.Map(
-          0 -> new PartitionMove(mutable.Set(2,3,4), mutable.Set(1)),
+          0 -> PartitionMove(mutable.Set(2,3,4), mutable.Set(1)),
         )
       ), moveMap)
     assertEquals(Map(
@@ -431,40 +419,29 @@ class ReassignPartitionsUnitTest {
   def testParseExecuteAssignmentArgs(): Unit = {
     assertStartsWith("Partition reassignment list cannot be empty",
       assertThrows("Expected to detect empty partition reassignment list",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit =
-            parseExecuteAssignmentArgs("""{"version":1,"partitions":[]}""")
-        }).getMessage)
+        classOf[AdminCommandFailedException],
+        () => parseExecuteAssignmentArgs("""{"version":1,"partitions":[]}""")).getMessage)
     assertStartsWith("Partition reassignment contains duplicate topic partitions",
       assertThrows("Expected to detect a partition list with duplicate entries",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit =
-            parseExecuteAssignmentArgs(
-              """{"version":1,"partitions":""" +
-                """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
-                """{"topic":"foo","partition":0,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
-                """]}""")
-        }).getMessage)
+        classOf[AdminCommandFailedException], () => parseExecuteAssignmentArgs(
+          """{"version":1,"partitions":""" +
+            """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
+            """{"topic":"foo","partition":0,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
+            """]}""")).getMessage)
     assertStartsWith("Partition reassignment contains duplicate topic partitions",
       assertThrows("Expected to detect a partition replica list with duplicate entries",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit =
-            parseExecuteAssignmentArgs(
-              """{"version":1,"partitions":""" +
-                """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["/abc","/def"]},""" +
-                """{"topic":"foo","partition":0,"replicas":[2,3],"log_dirs":["/abc","/def"]}""" +
-                """]}""")
-        }).getMessage)
+        classOf[AdminCommandFailedException], () => parseExecuteAssignmentArgs(
+          """{"version":1,"partitions":""" +
+            """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["/abc","/def"]},""" +
+            """{"topic":"foo","partition":0,"replicas":[2,3],"log_dirs":["/abc","/def"]}""" +
+            """]}""")).getMessage)
     assertStartsWith("Partition replica lists may not contain duplicate entries",
       assertThrows("Expected to detect a partition replica list with duplicate entries",
-        classOf[AdminCommandFailedException], new ThrowingRunnable {
-          override def run():Unit =
-            parseExecuteAssignmentArgs(
-              """{"version":1,"partitions":""" +
-                """[{"topic":"foo","partition":0,"replicas":[0,0],"log_dirs":["/abc","/def"]},""" +
-                """{"topic":"foo","partition":1,"replicas":[2,3],"log_dirs":["/abc","/def"]}""" +
-                """]}""")
-        }).getMessage)
+        classOf[AdminCommandFailedException], () => parseExecuteAssignmentArgs(
+          """{"version":1,"partitions":""" +
+            """[{"topic":"foo","partition":0,"replicas":[0,0],"log_dirs":["/abc","/def"]},""" +
+            """{"topic":"foo","partition":1,"replicas":[2,3],"log_dirs":["/abc","/def"]}""" +
+            """]}""")).getMessage)
     assertEquals((Map(
         new TopicPartition("foo", 0) -> Seq(1, 2, 3),
         new TopicPartition("foo", 1) -> Seq(3, 4, 5),
@@ -495,14 +472,11 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Topic quux not found",
         assertThrows("Expected reassignment with non-existent topic to fail",
-          classOf[ExecutionException], new ThrowingRunnable {
-            override def run():Unit =
-              executeAssignment(adminClient, false,
-                """{"version":1,"partitions":""" +
-                """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
-                """{"topic":"quux","partition":0,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
-                """]}""")
-          }).getCause.getMessage)
+          classOf[ExecutionException], () => executeAssignment(adminClient, false,
+            """{"version":1,"partitions":""" +
+              """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
+              """{"topic":"quux","partition":0,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
+              """]}""")).getCause.getMessage)
     } finally {
       adminClient.close()
     }
@@ -515,14 +489,11 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Unknown broker id 4",
         assertThrows("Expected reassignment with non-existent broker id to fail",
-          classOf[AdminCommandFailedException], new ThrowingRunnable {
-            override def run():Unit =
-              executeAssignment(adminClient, false,
-                """{"version":1,"partitions":""" +
-                  """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
-                  """{"topic":"foo","partition":1,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
-                  """]}""")
-          }).getMessage)
+          classOf[AdminCommandFailedException], () => executeAssignment(adminClient, false,
+            """{"version":1,"partitions":""" +
+              """[{"topic":"foo","partition":0,"replicas":[0,1],"log_dirs":["any","any"]},""" +
+              """{"topic":"foo","partition":1,"replicas":[2,3,4],"log_dirs":["any","any","any"]}""" +
+              """]}""")).getMessage)
     } finally {
       adminClient.close()
     }
@@ -614,7 +585,7 @@ class ReassignPartitionsUnitTest {
         Map("foo" -> "leaderFoo", "bar" -> "leaderBar"),
         Map("bar" -> "followerBar"))
       val topics = Seq("bar", "foo").map(
-        id => new ConfigResource(ConfigResource.Type.TOPIC, id.toString))
+        id => new ConfigResource(ConfigResource.Type.TOPIC, id))
       val results = adminClient.describeConfigs(topics.asJava).all().get()
       verifyTopicThrottleResults(results.get(topics(0)), "leaderBar", "followerBar")
       verifyTopicThrottleResults(results.get(topics(1)), "leaderFoo", "")
@@ -628,9 +599,9 @@ class ReassignPartitionsUnitTest {
                                          expectedFollowerThrottle: String): Unit = {
     val configs = new mutable.HashMap[String, String]
     config.entries.forEach(entry => configs.put(entry.name, entry.value))
-    assertEquals(expectedLeaderThrottle.toString,
+    assertEquals(expectedLeaderThrottle,
       configs.getOrElse(topicLevelLeaderThrottle, ""))
-    assertEquals(expectedFollowerThrottle.toString,
+    assertEquals(expectedFollowerThrottle,
       configs.getOrElse(topicLevelFollowerThrottle, ""))
   }
 


### PR DESCRIPTION
*More detailed description of your change*
1. The addingReplicas is included in the AR during reassignment, so remove addingReplicas from AR  in `calculateCurrentMoveMap`
2.  The addingReplicas is also included in MetadataResponse, so only use MetadataResponse data when there is no existing reassignment of this partition
3. Alter test code data
4. Improve some code style

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
