### PR TITLE
KAFKA-10898: Support snakeCaseName in JsonConverterGenerator

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/FieldNameStrategy.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldNameStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.message;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum FieldNameStrategy {
+
+    @JsonProperty("camel")
+    CAMEL {
+        @Override
+        public String getFieldName(FieldSpec field) {
+            return field.camelCaseName();
+        }
+    },
+
+    @JsonProperty("snack")
+    SNACK {
+        @Override
+        public String getFieldName(FieldSpec field) {
+            return field.snakeCaseName();
+        }
+    };
+
+    public abstract String getFieldName(FieldSpec field);
+
+}

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -60,6 +60,8 @@ public final class FieldSpec {
 
     private final boolean zeroCopy;
 
+    private final FieldNameStrategy jsonFieldNameStrategy;
+
     @JsonCreator
     public FieldSpec(@JsonProperty("name") String name,
                      @JsonProperty("versions") String versions,
@@ -74,7 +76,8 @@ public final class FieldSpec {
                      @JsonProperty("taggedVersions") String taggedVersions,
                      @JsonProperty("flexibleVersions") String flexibleVersions,
                      @JsonProperty("tag") Integer tag,
-                     @JsonProperty("zeroCopy") boolean zeroCopy) {
+                     @JsonProperty("zeroCopy") boolean zeroCopy,
+                     @JsonProperty("jsonFieldNameStrategy") FieldNameStrategy jsonFieldNameStrategy) {
         this.name = Objects.requireNonNull(name);
         if (!VALID_FIELD_NAMES.matcher(this.name).matches()) {
             throw new RuntimeException("Invalid field name " + this.name);
@@ -133,6 +136,8 @@ public final class FieldSpec {
             throw new RuntimeException("Invalid zeroCopy value for " + name +
                 ". Only fields of type bytes can use zeroCopy flag.");
         }
+
+        this.jsonFieldNameStrategy = jsonFieldNameStrategy == null ? FieldNameStrategy.CAMEL : jsonFieldNameStrategy;
     }
 
     private void checkTagInvariants() {
@@ -273,6 +278,11 @@ public final class FieldSpec {
     @JsonProperty("zeroCopy")
     public boolean zeroCopy() {
         return zeroCopy;
+    }
+
+    @JsonProperty("jsonFieldStrategy")
+    public FieldNameStrategy jsonFieldNameStrategy() {
+        return jsonFieldNameStrategy;
     }
 
     /**

--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -100,8 +100,7 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
         for (FieldSpec field : struct.fields()) {
             String sourceVariable = String.format("_%sNode", field.camelCaseName());
             buffer.printf("JsonNode %s = _node.get(\"%s\");%n",
-                sourceVariable,
-                field.camelCaseName());
+                sourceVariable, field.jsonFieldNameStrategy().getFieldName(field));
             buffer.printf("if (%s == null) {%n", sourceVariable);
             buffer.incrementIndent();
             Versions mandatoryVersions = field.versions().subtract(field.taggedVersions());
@@ -290,7 +289,7 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
             Target target = new Target(field,
                 String.format("_object.%s", field.camelCaseName()),
                 field.camelCaseName(),
-                input -> String.format("_node.set(\"%s\", %s)", field.camelCaseName(), input));
+                input -> String.format("_node.set(\"%s\", %s)", field.jsonFieldNameStrategy().getFieldName(field), input));
             VersionConditional cond = VersionConditional.forVersions(field.versions(), curVersions).
                 ifMember(presentVersions -> {
                     VersionConditional.forVersions(field.taggedVersions(), presentVersions).

--- a/generator/src/main/java/org/apache/kafka/message/MessageSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageSpec.java
@@ -44,7 +44,8 @@ public final class MessageSpec {
                        @JsonProperty("apiKey") Short apiKey,
                        @JsonProperty("type") MessageSpecType type,
                        @JsonProperty("commonStructs") List<StructSpec> commonStructs,
-                       @JsonProperty("flexibleVersions") String flexibleVersions) {
+                       @JsonProperty("flexibleVersions") String flexibleVersions,
+                       @JsonProperty("jsonFieldNameStrategy") FieldNameStrategy jsonFieldNameStrategy) {
         this.struct = new StructSpec(name, validVersions, fields);
         this.apiKey = apiKey == null ? Optional.empty() : Optional.of(apiKey);
         this.type = Objects.requireNonNull(type);

--- a/generator/src/main/java/org/apache/kafka/message/Target.java
+++ b/generator/src/main/java/org/apache/kafka/message/Target.java
@@ -40,19 +40,20 @@ public final class Target {
 
     public Target nonNullableCopy() {
         FieldSpec nonNullableField = new FieldSpec(field.name(),
-            field.versionsString(),
-            field.fields(),
-            field.typeString(),
-            field.mapKey(),
-            Versions.NONE.toString(),
-            field.defaultString(),
-            field.ignorable(),
-            field.entityType(),
-            field.about(),
-            field.taggedVersionsString(),
-            field.flexibleVersionsString(),
-            field.tagInteger(),
-            field.zeroCopy());
+                field.versionsString(),
+                field.fields(),
+                field.typeString(),
+                field.mapKey(),
+                Versions.NONE.toString(),
+                field.defaultString(),
+                field.ignorable(),
+                field.entityType(),
+                field.about(),
+                field.taggedVersionsString(),
+                field.flexibleVersionsString(),
+                field.tagInteger(),
+                field.zeroCopy(),
+                field.jsonFieldNameStrategy());
         return new Target(nonNullableField, sourceVariable, humanReadableName, assignmentStatementGenerator);
     }
 
@@ -74,7 +75,8 @@ public final class Target {
                 Versions.NONE.toString(),
                 field.flexibleVersionsString(),
                 null,
-                field.zeroCopy());
+                field.zeroCopy(),
+                field.jsonFieldNameStrategy());
         return new Target(elementField, "_element", humanReadableName + " element",
             assignmentStatementGenerator);
     }


### PR DESCRIPTION
*More detailed description of your change*
1. Add a field `jsonFieldNameStrategy` in `MessageSpec` to represent the naming strategy of JsonConverter
2. `jsonFieldNameStrategy` can be "camel" or "snack", "camel" is default value

*Summary of testing strategy (including rationale)*
Tried to parse ReassignPartitionsCommand args and it works normally:
1. define a PartitionReassignmentArgs to represent ReassignPartitionsCommand args
2.  Use `PartitionReassignmentArgsJsonConverter` to read and write ReassignPartitionsCommand json file

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
