### PR TITLE
MINOR: Tweak IBM i platform support in "stop" scripts

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -22,7 +22,7 @@ if [[ "$OSNAME" == "OS/390" ]]; then
     fi
     PIDS=$(ps -A -o pid,jobname,comm | grep -i $JOBNAME | grep java | grep -v grep | awk '{print $1}')
 elif [[ "$OSNAME" == "OS400" ]]; then
-    PIDS=$(ps -af | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $2}')
+    PIDS=$(ps -Af | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $2}')
 else
     PIDS=$(ps ax | grep ' kafka\.Kafka ' | grep java | grep -v grep | awk '{print $1}')
 fi

--- a/bin/zookeeper-server-stop.sh
+++ b/bin/zookeeper-server-stop.sh
@@ -22,7 +22,7 @@ if [[ "$OSNAME" == "OS/390" ]]; then
     fi
     PIDS=$(ps -A -o pid,jobname,comm | grep -i $JOBNAME | grep java | grep -v grep | awk '{print $1}')
 elif [[ "$OSNAME" == "OS400" ]]; then
-    PIDS=$(ps -af | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $2}')
+    PIDS=$(ps -Af | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $2}')
 else
     PIDS=$(ps ax | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $1}')
 fi


### PR DESCRIPTION
IBM i support to the "stop" scripts was added in a previous PR (https://github.com/apache/kafka/pull/9023), but it misses cases where certain service managers dispatch the zookeeper/kafka jobs with "nohup" or system batch job capabilities. We need a tweak to the `ps` invocation for this to work properly in those scenarios. 

Due to the minor nature of the problem and the trivial nature of the fix, I did not create a JIRA issue, but I will happily do so if that's the recommended best route. 


### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] ~~Verify test coverage and CI build status~~ (self tested)
- [x] ~~Verify documentation (including upgrade notes)~~ n/a
