### PR TITLE
MINOR: gradle wrapper should handle directories with spaces

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -83,7 +83,7 @@ esac
 
 # Loop in case we encounter an error.
 for attempt in 1 2 3; do
-  if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
+  if [ ! -e "$APP_HOME"/gradle/wrapper/gradle-wrapper.jar ]; then
     if ! curl -s -S --retry 3 -L -o "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" "https://raw.githubusercontent.com/gradle/gradle/v6.7.1/gradle/wrapper/gradle-wrapper.jar"; then
       rm -f "$APP_HOME/gradle/wrapper/gradle-wrapper.jar"
       # Pause for a bit before looping in case the server throttled us.


### PR DESCRIPTION
If attempting to build the project from a directory with spaces in its name and gradle-wrapper.jar is missing, the script will fail to download a new one because the "if" condition will break because $APP_HOME will resolve to multiple strings. Protecting $APP_HOME with quotes fixes the issue. Tested by deleting gradle.wrapper and trying to build.
