### PR TITLE
MINOR: Fixed two properties in EOS example plus some thread cleanup

### DIFF
--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -16,7 +16,6 @@
  */
 package kafka.examples;
 
-import kafka.utils.ShutdownableThread;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -26,7 +25,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 
 public class Consumer implements Runnable {
     private final KafkaConsumer<Integer, String> consumer;

--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -39,17 +39,22 @@ public class Consumer implements Runnable {
                     final String groupId,
                     final Optional<String> instanceId,
                     final boolean readCommitted,
-                    final int numMessageToConsume) {
+                    final int numMessageToConsume,
+                    final boolean transactional) {
         this.groupId = groupId;
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaProperties.KAFKA_SERVER_URL + ":" + KafkaProperties.KAFKA_SERVER_PORT);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         instanceId.ifPresent(id -> props.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, id));
-        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
         props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "30000");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.IntegerDeserializer");
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
+        // if consuming as part of exactly-once processor, committing will be done by the producer
+        if (transactional) {
+            props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        } else {
+            props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "1000");
+        }
         if (readCommitted) {
             props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
         }

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * A demo class for how to write a customized EOS app. It takes a consume-process-produce loop.
  * Important configurations and APIs are commented.
  */
-public class ExactlyOnceMessageProcessor extends Thread {
+public class ExactlyOnceMessageProcessor implements Runnable {
 
     private static final boolean READ_COMMITTED = true;
 
@@ -54,25 +54,22 @@ public class ExactlyOnceMessageProcessor extends Thread {
     private final KafkaProducer<Integer, String> producer;
     private final KafkaConsumer<Integer, String> consumer;
 
-    private final CountDownLatch latch;
-
     public ExactlyOnceMessageProcessor(final String inputTopic,
                                        final String outputTopic,
-                                       final int instanceIdx,
-                                       final CountDownLatch latch) {
+                                       final int instanceIdx) {
         this.inputTopic = inputTopic;
         this.outputTopic = outputTopic;
+        // A unique transactional.id must be provided in order to properly use EOS.
         this.transactionalId = "Processor-" + instanceIdx;
         // It is recommended to have a relatively short txn timeout in order to clear pending offsets faster.
         final int transactionTimeoutMs = 10000;
-        // A unique transactional.id must be provided in order to properly use EOS.
-        producer = new Producer(outputTopic, true, transactionalId, true, -1, transactionTimeoutMs, null).get();
-        // Consumer must be in read_committed mode, which means it won't be able to read uncommitted data.
+        producer = new Producer(outputTopic, true, transactionalId, true, -1, transactionTimeoutMs).get();
+        // Consumer can be in read_committed mode, which means it won't be able to read uncommitted data
+        // if the producer that populated the input topic was transactional.
         // Consumer could optionally configure groupInstanceId to avoid unnecessary rebalances.
         this.groupInstanceId = "Txn-consumer-" + instanceIdx;
         consumer = new Consumer(inputTopic, "Eos-consumer",
-            Optional.of(groupInstanceId), READ_COMMITTED, -1, null).get();
-        this.latch = latch;
+            Optional.of(groupInstanceId), READ_COMMITTED, -1).get();
     }
 
     @Override
@@ -137,7 +134,6 @@ public class ExactlyOnceMessageProcessor extends Thread {
         }
 
         printWithTxnId("Finished processing " + messageProcessed + " records");
-        latch.countDown();
     }
 
     private Map<TopicPartition, OffsetAndMetadata> consumerOffsets() {

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**

--- a/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
+++ b/examples/src/main/java/kafka/examples/ExactlyOnceMessageProcessor.java
@@ -65,11 +65,12 @@ public class ExactlyOnceMessageProcessor implements Runnable {
         final int transactionTimeoutMs = 10000;
         producer = new Producer(outputTopic, true, transactionalId, true, -1, transactionTimeoutMs).get();
         // Consumer can be in read_committed mode, which means it won't be able to read uncommitted data
+        // Consumer is part of the transaction, so it does not commit its own offsets and auto-commit will be disabled
         // if the producer that populated the input topic was transactional.
         // Consumer could optionally configure groupInstanceId to avoid unnecessary rebalances.
         this.groupInstanceId = "Txn-consumer-" + instanceIdx;
         consumer = new Consumer(inputTopic, "Eos-consumer",
-            Optional.of(groupInstanceId), READ_COMMITTED, -1).get();
+            Optional.of(groupInstanceId), READ_COMMITTED, -1, KafkaProperties.TRANSACTIONAL).get();
     }
 
     @Override

--- a/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
@@ -16,27 +16,35 @@
  */
 package kafka.examples;
 
-import org.apache.kafka.common.errors.TimeoutException;
-
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class KafkaConsumerProducerDemo {
     public static void main(String[] args) throws InterruptedException {
         boolean isAsync = args.length == 0 || !args[0].trim().equalsIgnoreCase("sync");
-        CountDownLatch latch = new CountDownLatch(2);
-        Producer producerThread = new Producer(KafkaProperties.TOPIC, isAsync, null, false, 10000, -1, latch);
-        producerThread.start();
+        ExecutorService threads = Executors.newFixedThreadPool(2);
 
-        Consumer consumerThread = new Consumer(KafkaProperties.TOPIC, "DemoConsumer", Optional.empty(), false, 10000, latch);
-        consumerThread.start();
+        Producer producerTask = new Producer(KafkaProperties.TOPIC, isAsync, null, false, 10000, -1);
+        Consumer consumerTask = new Consumer(KafkaProperties.TOPIC, "DemoConsumer", Optional.empty(), false, 10000);
 
-        if (!latch.await(5, TimeUnit.MINUTES)) {
-            throw new TimeoutException("Timeout after 5 minutes waiting for demo producer and consumer to finish");
+        try {
+            CompletableFuture.allOf(
+                    CompletableFuture.runAsync(producerTask, threads),
+                    CompletableFuture.runAsync(consumerTask, threads)
+            ).get(5, TimeUnit.MINUTES);
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (java.util.concurrent.TimeoutException e) {
+            System.out.println("Timeout after 5 minutes waiting for demo producer and consumer to finish");
+            System.exit(1);
         }
 
-        consumerThread.shutdown();
+        threads.shutdownNow();
         System.out.println("All finished!");
     }
 }

--- a/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
@@ -16,6 +16,8 @@
  */
 package kafka.examples;
 
+import org.apache.kafka.common.utils.Exit;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -40,7 +42,7 @@ public class KafkaConsumerProducerDemo {
             e.printStackTrace();
         } catch (java.util.concurrent.TimeoutException e) {
             System.out.println("Timeout after 5 minutes waiting for demo producer and consumer to finish");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         threads.shutdownNow();

--- a/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaConsumerProducerDemo.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class KafkaConsumerProducerDemo {
     public static void main(String[] args) throws InterruptedException {
@@ -30,7 +29,7 @@ public class KafkaConsumerProducerDemo {
         ExecutorService threads = Executors.newFixedThreadPool(2);
 
         Producer producerTask = new Producer(KafkaProperties.TOPIC, isAsync, null, false, 10000, -1);
-        Consumer consumerTask = new Consumer(KafkaProperties.TOPIC, "DemoConsumer", Optional.empty(), false, 10000);
+        Consumer consumerTask = new Consumer(KafkaProperties.TOPIC, "DemoConsumer", Optional.empty(), false, 10000, KafkaProperties.NON_TRANSACTIONAL);
 
         try {
             CompletableFuture.allOf(

--- a/examples/src/main/java/kafka/examples/KafkaExactlyOnceDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaExactlyOnceDemo.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -120,8 +119,11 @@ public class KafkaExactlyOnceDemo {
             System.exit(1);
         }
 
-        /* Stage 4: consume all processed messages to verify exactly once */
-        Consumer consumerTask = new Consumer(OUTPUT_TOPIC, "Verify-consumer", Optional.empty(), true, numRecords);
+        /* Stage 4: consume all processed messages to verify exactly once.
+        Consumer uses read committed to guarantee that uncommitted events will not be included in verification
+        but the consumer is not part of the transaction itself
+        */
+        Consumer consumerTask = new Consumer(OUTPUT_TOPIC, "Verify-consumer", Optional.empty(), true, numRecords, KafkaProperties.NON_TRANSACTIONAL);
 
         try {
             CompletableFuture.runAsync(consumerTask, driver).get(5, TimeUnit.MINUTES);

--- a/examples/src/main/java/kafka/examples/KafkaExactlyOnceDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaExactlyOnceDemo.java
@@ -19,7 +19,6 @@ package kafka.examples;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 
@@ -28,9 +27,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * This exactly once demo driver takes 3 arguments:
@@ -88,40 +91,47 @@ public class KafkaExactlyOnceDemo {
         /* Stage 1: topic cleanup and recreation */
         recreateTopics(numPartitions);
 
-        CountDownLatch prePopulateLatch = new CountDownLatch(1);
 
         /* Stage 2: pre-populate records */
-        Producer producerThread = new Producer(INPUT_TOPIC, false, null, true, numRecords, -1, prePopulateLatch);
-        producerThread.start();
-
-        if (!prePopulateLatch.await(5, TimeUnit.MINUTES)) {
-            throw new TimeoutException("Timeout after 5 minutes waiting for data pre-population");
+        ExecutorService driver = Executors.newFixedThreadPool(2); // populating producer and validating consumer will run here
+        Producer producerTask = new Producer(INPUT_TOPIC, false, null, true, numRecords, -1);
+        try {
+            CompletableFuture.runAsync(producerTask, driver).get(5, TimeUnit.MINUTES);
+        } catch (TimeoutException e) {
+            System.out.println("Timeout after 5 minutes waiting for data pre-population");
+            System.exit(1);
         }
 
-        CountDownLatch transactionalCopyLatch = new CountDownLatch(numInstances);
+
 
         /* Stage 3: transactionally process all messages */
+        ExecutorService processorThreads = Executors.newFixedThreadPool(numInstances);
+        CompletableFuture[] messageProcessors = new CompletableFuture[numInstances];
         for (int instanceIdx = 0; instanceIdx < numInstances; instanceIdx++) {
-            ExactlyOnceMessageProcessor messageProcessor = new ExactlyOnceMessageProcessor(
-                INPUT_TOPIC, OUTPUT_TOPIC, instanceIdx, transactionalCopyLatch);
-            messageProcessor.start();
-        }
+            messageProcessors[instanceIdx] = CompletableFuture.runAsync(
+                    new ExactlyOnceMessageProcessor(INPUT_TOPIC, OUTPUT_TOPIC, instanceIdx),
+                    processorThreads);
+        };
 
-        if (!transactionalCopyLatch.await(5, TimeUnit.MINUTES)) {
-            throw new TimeoutException("Timeout after 5 minutes waiting for transactionally message copy");
+        try {
+            CompletableFuture.allOf(messageProcessors).get(5, TimeUnit.MINUTES);
+        } catch (TimeoutException e) {
+            System.out.println("Timeout after 5 minutes waiting for transactional message copy");
+            System.exit(1);
         }
-
-        CountDownLatch consumeLatch = new CountDownLatch(1);
 
         /* Stage 4: consume all processed messages to verify exactly once */
-        Consumer consumerThread = new Consumer(OUTPUT_TOPIC, "Verify-consumer", Optional.empty(), true, numRecords, consumeLatch);
-        consumerThread.start();
+        Consumer consumerTask = new Consumer(OUTPUT_TOPIC, "Verify-consumer", Optional.empty(), true, numRecords);
 
-        if (!consumeLatch.await(5, TimeUnit.MINUTES)) {
-            throw new TimeoutException("Timeout after 5 minutes waiting for output data consumption");
+        try {
+            CompletableFuture.runAsync(consumerTask, driver).get(5, TimeUnit.MINUTES);
+        } catch (TimeoutException e) {
+            System.out.println("Timeout after 5 minutes waiting for output data consumption");
+            System.exit(1);
         }
 
-        consumerThread.shutdown();
+        processorThreads.shutdownNow();
+        driver.shutdownNow();
         System.out.println("All finished!");
     }
 

--- a/examples/src/main/java/kafka/examples/KafkaExactlyOnceDemo.java
+++ b/examples/src/main/java/kafka/examples/KafkaExactlyOnceDemo.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.utils.Exit;
 
 import java.util.Arrays;
 import java.util.List;
@@ -98,7 +99,7 @@ public class KafkaExactlyOnceDemo {
             CompletableFuture.runAsync(producerTask, driver).get(5, TimeUnit.MINUTES);
         } catch (TimeoutException e) {
             System.out.println("Timeout after 5 minutes waiting for data pre-population");
-            System.exit(1);
+            Exit.exit(1);
         }
 
 
@@ -110,13 +111,13 @@ public class KafkaExactlyOnceDemo {
             messageProcessors[instanceIdx] = CompletableFuture.runAsync(
                     new ExactlyOnceMessageProcessor(INPUT_TOPIC, OUTPUT_TOPIC, instanceIdx),
                     processorThreads);
-        };
+        }
 
         try {
             CompletableFuture.allOf(messageProcessors).get(5, TimeUnit.MINUTES);
         } catch (TimeoutException e) {
             System.out.println("Timeout after 5 minutes waiting for transactional message copy");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         /* Stage 4: consume all processed messages to verify exactly once.
@@ -129,7 +130,7 @@ public class KafkaExactlyOnceDemo {
             CompletableFuture.runAsync(consumerTask, driver).get(5, TimeUnit.MINUTES);
         } catch (TimeoutException e) {
             System.out.println("Timeout after 5 minutes waiting for output data consumption");
-            System.exit(1);
+            Exit.exit(1);
         }
 
         processorThreads.shutdownNow();

--- a/examples/src/main/java/kafka/examples/KafkaProperties.java
+++ b/examples/src/main/java/kafka/examples/KafkaProperties.java
@@ -20,6 +20,8 @@ public class KafkaProperties {
     public static final String TOPIC = "topic1";
     public static final String KAFKA_SERVER_URL = "localhost";
     public static final int KAFKA_SERVER_PORT = 9092;
+    public static final boolean TRANSACTIONAL = true;
+    public static final boolean NON_TRANSACTIONAL = false;
 
     private KafkaProperties() {}
 }

--- a/examples/src/main/java/kafka/examples/Producer.java
+++ b/examples/src/main/java/kafka/examples/Producer.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
 public class Producer implements Runnable {

--- a/examples/src/main/java/kafka/examples/Producer.java
+++ b/examples/src/main/java/kafka/examples/Producer.java
@@ -28,20 +28,18 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 
-public class Producer extends Thread {
+public class Producer implements Runnable {
     private final KafkaProducer<Integer, String> producer;
     private final String topic;
     private final Boolean isAsync;
     private int numRecords;
-    private final CountDownLatch latch;
 
     public Producer(final String topic,
                     final Boolean isAsync,
                     final String transactionalId,
                     final boolean enableIdempotency,
                     final int numRecords,
-                    final int transactionTimeoutMs,
-                    final CountDownLatch latch) {
+                    final int transactionTimeoutMs) {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaProperties.KAFKA_SERVER_URL + ":" + KafkaProperties.KAFKA_SERVER_PORT);
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "DemoProducer");
@@ -59,7 +57,6 @@ public class Producer extends Thread {
         this.topic = topic;
         this.isAsync = isAsync;
         this.numRecords = numRecords;
-        this.latch = latch;
     }
 
     KafkaProducer<Integer, String> get() {
@@ -70,7 +67,7 @@ public class Producer extends Thread {
     public void run() {
         int messageKey = 0;
         int recordsSent = 0;
-        while (recordsSent < numRecords) {
+        while (!Thread.currentThread().isInterrupted() && recordsSent < numRecords) {
             String messageStr = "Message_" + messageKey;
             long startTime = System.currentTimeMillis();
             if (isAsync) { // Send asynchronously
@@ -83,15 +80,16 @@ public class Producer extends Thread {
                         messageKey,
                         messageStr)).get();
                     System.out.println("Sent message: (" + messageKey + ", " + messageStr + ")");
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (ExecutionException e) {
                     e.printStackTrace();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 }
             }
             messageKey += 2;
             recordsSent += 1;
         }
         System.out.println("Producer sent " + numRecords + " records successfully");
-        latch.countDown();
     }
 }
 

--- a/examples/src/main/java/kafka/examples/Producer.java
+++ b/examples/src/main/java/kafka/examples/Producer.java
@@ -50,8 +50,10 @@ public class Producer implements Runnable {
         }
         if (transactionalId != null) {
             props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+        } else {
+            // Transactions are always idempotent, but in other cases we need to explicitly set idempotence
+            props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, enableIdempotency);
         }
-        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, enableIdempotency);
 
         producer = new KafkaProducer<>(props);
         this.topic = topic;


### PR DESCRIPTION
Changes:
* Passing the latches into the consumer/producer wrappers seemed a bit unclean. I removed the latches and used futures to wait on producer/consumer execution.
* Consumer that is part of the transaction should not auto-commit
* Transactional producers don't need to set idempotency explicitly. 
