### PR TITLE
MINOR: Make data in FetchSnapshotReq and FetchSnapshotResp private

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
@@ -16,17 +16,17 @@
  */
 package org.apache.kafka.common.requests;
 
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.function.UnaryOperator;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.FetchSnapshotRequestData;
 import org.apache.kafka.common.message.FetchSnapshotResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 final public class FetchSnapshotRequest extends AbstractRequest {
     private final FetchSnapshotRequestData data;

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 final public class FetchSnapshotRequest extends AbstractRequest {
-    public final FetchSnapshotRequestData data;
+    private final FetchSnapshotRequestData data;
 
     public FetchSnapshotRequest(FetchSnapshotRequestData data, short version) {
         super(ApiKeys.FETCH_SNAPSHOT, version);
@@ -46,7 +46,7 @@ final public class FetchSnapshotRequest extends AbstractRequest {
     }
 
     @Override
-    public ApiMessage data() {
+    public FetchSnapshotRequestData data() {
         return data;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
@@ -16,18 +16,18 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.FetchSnapshotResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.UnaryOperator;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.message.FetchSnapshotResponseData;
-import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.protocol.ByteBufferAccessor;
-import org.apache.kafka.common.protocol.Errors;
 
 final public class FetchSnapshotResponse extends AbstractResponse {
     private final FetchSnapshotResponseData data;

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotResponse.java
@@ -30,11 +30,10 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 final public class FetchSnapshotResponse extends AbstractResponse {
-    public final FetchSnapshotResponseData data;
+    private final FetchSnapshotResponseData data;
 
     public FetchSnapshotResponse(FetchSnapshotResponseData data) {
         super(ApiKeys.FETCH_SNAPSHOT);
-
         this.data = data;
     }
 
@@ -63,7 +62,7 @@ final public class FetchSnapshotResponse extends AbstractResponse {
     }
 
     @Override
-    public ApiMessage data() {
+    public FetchSnapshotResponseData data() {
         return data;
     }
 


### PR DESCRIPTION
*More detailed description of your change*
We keep all data in request and response private, use public method `AbstractRequestResponse.data()` to access them.

Following work: maybe we could try to parameterize `AbstractRequestResponse` to `AbstractRequestResponse<DATA extends ApiMessage>` to simplify the data field.

*Summary of testing strategy (including rationale)*
just trivial changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
