### PR TITLE
KAFKA-10860: Fix NPE in JmxTool, add tests

### DIFF
--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -18,13 +18,14 @@
  */
 package kafka.tools
 
-import java.util.{Date, Objects}
+import java.{lang, util}
+import java.util.{Date}
 import java.text.SimpleDateFormat
+
 import javax.management._
 import javax.management.remote._
 import javax.rmi.ssl.SslRMIClientSocketFactory
-
-import joptsimple.OptionParser
+import joptsimple.{ArgumentAcceptingOptionSpec, OptionParser, OptionSpecBuilder}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
@@ -40,88 +41,94 @@ import kafka.utils.{CommandLineUtils, Exit, Logging}
   */
 object JmxTool extends Logging {
 
-  def main(args: Array[String]): Unit = {
-    // Parse command line
+  case class ToolOptions(args: Array[String]) {
     val parser = new OptionParser(false)
-    val objectNameOpt =
+    val objectNameOpt: ArgumentAcceptingOptionSpec[String] =
       parser.accepts("object-name", "A JMX object name to use as a query. This can contain wild cards, and this option " +
         "can be given multiple times to specify more than one query. If no objects are specified " +
         "all objects will be queried.")
         .withRequiredArg
         .describedAs("name")
         .ofType(classOf[String])
-    val attributesOpt =
+    val attributesOpt: ArgumentAcceptingOptionSpec[String] =
       parser.accepts("attributes", "The list of attributes to include in the query. This is a comma-separated list. If no " +
-        "attributes are specified all objects will be queried.")
+        "attributes are specified all attributes will be reported.")
         .withRequiredArg
         .describedAs("name")
         .ofType(classOf[String])
-    val reportingIntervalOpt = parser.accepts("reporting-interval", "Interval in MS with which to poll jmx stats; default value is 2 seconds. " +
-      "Value of -1 equivalent to setting one-time to true")
-      .withRequiredArg
-      .describedAs("ms")
-      .ofType(classOf[java.lang.Integer])
-      .defaultsTo(2000)
-    val oneTimeOpt = parser.accepts("one-time", "Flag to indicate run once only.")
-      .withRequiredArg
-      .describedAs("one-time")
-      .ofType(classOf[java.lang.Boolean])
-      .defaultsTo(false)
-    val dateFormatOpt = parser.accepts("date-format", "The date format to use for formatting the time field. " +
-      "See java.text.SimpleDateFormat for options.")
-      .withRequiredArg
-      .describedAs("format")
-      .ofType(classOf[String])
-    val jmxServiceUrlOpt =
+    val reportingIntervalOpt: ArgumentAcceptingOptionSpec[Integer] =
+      parser.accepts("reporting-interval", "Interval in MS with which to poll jmx stats; default value is 2 seconds. " +
+        "Value of -1 equivalent to setting one-time to true")
+        .withRequiredArg
+        .describedAs("ms")
+        .ofType(classOf[java.lang.Integer])
+        .defaultsTo(2000)
+    val oneTimeOpt: ArgumentAcceptingOptionSpec[lang.Boolean] =
+      parser.accepts("one-time", "Flag to indicate run once only.")
+        .withRequiredArg
+        .describedAs("one-time")
+        .ofType(classOf[java.lang.Boolean])
+        .defaultsTo(false)
+    val dateFormatOpt: ArgumentAcceptingOptionSpec[String] =
+      parser.accepts("date-format", "The date format to use for formatting the time field. " +
+        "See java.text.SimpleDateFormat for options.")
+        .withRequiredArg
+        .describedAs("format")
+        .ofType(classOf[String])
+    val jmxServiceUrlOpt: ArgumentAcceptingOptionSpec[String] =
       parser.accepts("jmx-url", "The url to connect to poll JMX data. See Oracle javadoc for JMXServiceURL for details.")
         .withRequiredArg
         .describedAs("service-url")
         .ofType(classOf[String])
         .defaultsTo("service:jmx:rmi:///jndi/rmi://:9999/jmxrmi")
-    val reportFormatOpt = parser.accepts("report-format", "output format name: either 'original', 'properties', 'csv', 'tsv' ")
-      .withRequiredArg
-      .describedAs("report-format")
-      .ofType(classOf[java.lang.String])
-      .defaultsTo("original")
-    val jmxAuthPropOpt = parser.accepts("jmx-auth-prop", "A mechanism to pass property in the form 'username=password' " +
-      "when enabling remote JMX with password authentication.")
-      .withRequiredArg
-      .describedAs("jmx-auth-prop")
-      .ofType(classOf[String])
-    val jmxSslEnableOpt = parser.accepts("jmx-ssl-enable", "Flag to enable remote JMX with SSL.")
-      .withRequiredArg
-      .describedAs("ssl-enable")
-      .ofType(classOf[java.lang.Boolean])
-      .defaultsTo(false)
-    val waitOpt = parser.accepts("wait", "Wait for requested JMX objects to become available before starting output. " +
+    val reportFormatOpt: ArgumentAcceptingOptionSpec[String] =
+      parser.accepts("report-format", "output format name: either 'original', 'properties', 'csv', 'tsv' ")
+        .withRequiredArg
+        .describedAs("report-format")
+        .ofType(classOf[java.lang.String])
+        .defaultsTo("original")
+    val jmxAuthPropOpt: ArgumentAcceptingOptionSpec[String] =
+      parser.accepts("jmx-auth-prop", "A mechanism to pass property in the form 'username=password' " +
+        "when enabling remote JMX with password authentication.")
+        .withRequiredArg
+        .describedAs("jmx-auth-prop")
+        .ofType(classOf[String])
+    val jmxSslEnableOpt: ArgumentAcceptingOptionSpec[lang.Boolean] =
+      parser.accepts("jmx-ssl-enable", "Flag to enable remote JMX with SSL.")
+        .withRequiredArg
+        .describedAs("ssl-enable")
+        .ofType(classOf[java.lang.Boolean])
+        .defaultsTo(false)
+    val waitOpt: OptionSpecBuilder = parser.accepts("wait",
+      "Wait for requested JMX objects to become available before starting output. " +
       "Only supported when the list of objects is non-empty and contains no object name patterns.")
-    val helpOpt = parser.accepts("help", "Print usage information.")
-
-
+    val helpOpt: OptionSpecBuilder = parser.accepts("help", "Print usage information.")
     if(args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, "Dump JMX values to standard output.")
 
     val options = parser.parse(args : _*)
 
-    if(options.has(helpOpt)) {
-      parser.printHelpOn(System.out)
-      Exit.exit(0)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val toolOptions = ToolOptions(args)
+    connectAndExecute(toolOptions) match {
+      case Some(false -> msg) => Exit.exit(1, Some(msg))
+      case Some(true -> msg) => CommandLineUtils.printUsageAndDie(toolOptions.parser, msg)
+      case None =>
     }
+  }
 
-    val url = new JMXServiceURL(options.valueOf(jmxServiceUrlOpt))
-    val interval = options.valueOf(reportingIntervalOpt).intValue
-    val oneTime = interval < 0 || options.has(oneTimeOpt)
-    val attributesIncludeExists = options.has(attributesOpt)
-    val attributesInclude = if(attributesIncludeExists) Some(options.valueOf(attributesOpt).split(",").filterNot(_.equals(""))) else None
-    val dateFormatExists = options.has(dateFormatOpt)
-    val dateFormat = if(dateFormatExists) Some(new SimpleDateFormat(options.valueOf(dateFormatOpt))) else None
-    val wait = options.has(waitOpt)
-
-    val reportFormat = parseFormat(options.valueOf(reportFormatOpt).toLowerCase)
-    val reportFormatOriginal = reportFormat.equals("original")
-
-    val enablePasswordAuth = options.has(jmxAuthPropOpt)
-    val enableSsl = options.has(jmxSslEnableOpt)
+  def connectAndExecute(toolOptions: ToolOptions): Option[(Boolean, String)] = {
+    if(toolOptions.options.has(toolOptions.helpOpt)) {
+      toolOptions.parser.printHelpOn(System.out)
+      return None
+    } else if (toolOptions.options.valueOf(toolOptions.oneTimeOpt) && toolOptions.options.valueOf(toolOptions.reportingIntervalOpt) != -1) {
+      return Some(true, s"--one-time=true is incompatible with --reporting-interval=${toolOptions.options.valueOf(toolOptions.reportingIntervalOpt)}")
+    }
+    val url = new JMXServiceURL(toolOptions.options.valueOf(toolOptions.jmxServiceUrlOpt))
+    val enablePasswordAuth = toolOptions.options.has(toolOptions.jmxAuthPropOpt)
+    val enableSsl = toolOptions.options.has(toolOptions.jmxSslEnableOpt)
 
     var jmxc: JMXConnector = null
     var mbsc: MBeanServerConnection = null
@@ -130,8 +137,8 @@ object JmxTool extends Logging {
     val connectTestStarted = System.currentTimeMillis
     do {
       try {
-        System.err.println(s"Trying to connect to JMX url: $url.")
-        val env = new java.util.HashMap[String, AnyRef]
+        Console.err.println(s"Trying to connect to JMX url: $url.")
+        val env = new util.HashMap[String, AnyRef]
         // ssl enable
         if (enableSsl) {
           val csf = new SslRMIClientSocketFactory
@@ -139,7 +146,7 @@ object JmxTool extends Logging {
         }
         // password authentication enable
         if (enablePasswordAuth) {
-          val credentials = options.valueOf(jmxAuthPropOpt).split("=", 2)
+          val credentials = toolOptions.options.valueOf(toolOptions.jmxAuthPropOpt).split("=", 2)
           env.put(JMXConnector.CREDENTIALS, credentials)
         }
         jmxc = JMXConnectorFactory.connect(url, env)
@@ -147,67 +154,74 @@ object JmxTool extends Logging {
         connected = true
       } catch {
         case e : Exception =>
-          System.err.println(s"Could not connect to JMX url: $url. Exception ${e.getMessage}.")
+          Console.err.println(s"Could not connect to JMX url: $url. Exception ${e.getMessage}.")
           e.printStackTrace()
           Thread.sleep(100)
       }
     } while (System.currentTimeMillis - connectTestStarted < connectTimeoutMs && !connected)
 
     if (!connected) {
-      System.err.println(s"Could not connect to JMX url $url after $connectTimeoutMs ms.")
-      System.err.println("Exiting.")
-      sys.exit(1)
+      Console.err.println(s"Could not connect to JMX url $url after $connectTimeoutMs ms.")
+      return Some(false -> "Exiting.")
     }
 
+    execute(toolOptions, mbsc)
+  }
+
+  def execute(toolOptions: ToolOptions, mbsc: MBeanServerConnection, waitTimeoutMs: Long = 10000): Option[(Boolean, String)] = {
+    val interval = toolOptions.options.valueOf(toolOptions.reportingIntervalOpt).intValue
+    val attributesIncludeExists = toolOptions.options.has(toolOptions.attributesOpt)
+    val dateFormatExists = toolOptions.options.has(toolOptions.dateFormatOpt)
+    val oneTime = interval < 0 || toolOptions.options.has(toolOptions.oneTimeOpt)
+    val attributesInclude = if (attributesIncludeExists) Some(toolOptions.options.valueOf(toolOptions.attributesOpt).split(",").filterNot(_.equals(""))) else None
+    val dateFormat = if (dateFormatExists) Some(new SimpleDateFormat(toolOptions.options.valueOf(toolOptions.dateFormatOpt))) else None
+    val wait = toolOptions.options.has(toolOptions.waitOpt)
+    val reportFormat = parseFormat(toolOptions.options.valueOf(toolOptions.reportFormatOpt).toLowerCase)
+    val reportFormatOriginal = reportFormat.equals("original")
     val queries: Iterable[ObjectName] =
-      if(options.has(objectNameOpt))
-        options.valuesOf(objectNameOpt).asScala.map(new ObjectName(_))
+      if (toolOptions.options.has(toolOptions.objectNameOpt))
+        toolOptions.options.valuesOf(toolOptions.objectNameOpt).asScala.map(new ObjectName(_))
       else
         List(null)
 
-    val hasPatternQueries = queries.filterNot(Objects.isNull).exists((name: ObjectName) => name.isPattern)
+    var selectedNames: Map[ObjectName, Set[ObjectName]] = null
+    var foundAllObjects = false
 
-    var names: Iterable[ObjectName] = null
-    def namesSet = Option(names).toSet.flatten
-    def foundAllObjects = queries.toSet == namesSet
-    val waitTimeoutMs = 10000
-    if (!hasPatternQueries) {
-      val start = System.currentTimeMillis
-      do {
-        if (names != null) {
-          System.err.println("Could not find all object names, retrying")
-          Thread.sleep(100)
-        }
-        names = queries.flatMap((name: ObjectName) => mbsc.queryNames(name, null).asScala)
-      } while (wait && System.currentTimeMillis - start < waitTimeoutMs && !foundAllObjects)
+    val start = System.currentTimeMillis
+    do {
+      if (selectedNames != null) {
+        Console.err.println(s"Could not find all object names, retrying")
+        Thread.sleep(100)
+      }
+      selectedNames = queries.map((name: ObjectName) => name -> mbsc.queryNames(name, null).asScala.toSet).toMap
+      foundAllObjects = selectedNames.forall{ case(_, ns) => ns.nonEmpty}
+    } while (wait && System.currentTimeMillis - start < waitTimeoutMs && !foundAllObjects)
+
+    if (!foundAllObjects) {
+      val missing = selectedNames.filter{ case _ -> ns => ns.isEmpty}.keys.mkString(", ")
+      val msg = s"Could not find any objects names matching $missing${if (wait) s" after $waitTimeoutMs ms" else ""}."
+      Console.err.println(msg)
+      return Some(false -> "Exiting.")
     }
 
-    if (wait && !foundAllObjects) {
-      val missing = (queries.toSet - namesSet).mkString(", ")
-      System.err.println(s"Could not find all requested object names after $waitTimeoutMs ms. Missing $missing")
-      System.err.println("Exiting.")
-      sys.exit(1)
-    }
-
+    val names = selectedNames.values.flatten
     val numExpectedAttributes: Map[ObjectName, Int] =
       if (!attributesIncludeExists)
-        names.map{name: ObjectName =>
+        names.map{ name: ObjectName =>
           val mbean = mbsc.getMBeanInfo(name)
           (name, mbsc.getAttributes(name, mbean.getAttributes.map(_.getName)).size)}.toMap
       else {
-        if (!hasPatternQueries)
-          names.map{name: ObjectName =>
-            val mbean = mbsc.getMBeanInfo(name)
-            val attributes = mbsc.getAttributes(name, mbean.getAttributes.map(_.getName))
-            val expectedAttributes = attributes.asScala.asInstanceOf[mutable.Buffer[Attribute]]
-              .filter(attr => attributesInclude.get.contains(attr.getName))
-            (name, expectedAttributes.size)}.toMap.filter(_._2 > 0)
-        else
-          queries.map((_, attributesInclude.get.length)).toMap
+        names.map { name: ObjectName =>
+          val mbean = mbsc.getMBeanInfo(name)
+          val attributes = mbsc.getAttributes(name, mbean.getAttributes.map(_.getName))
+          val expectedAttributes = attributes.asScala.asInstanceOf[mutable.Buffer[Attribute]]
+            .filter(attr => attributesInclude.get.contains(attr.getName))
+          (name, expectedAttributes.size)
+        }.toMap.filter(_._2 > 0)
       }
 
     if(numExpectedAttributes.isEmpty) {
-      CommandLineUtils.printUsageAndDie(parser, s"No matched attributes for the queried objects $queries.")
+      return Some(true -> s"No matched attributes for the queried objects ${queries.mkString(",")}.")
     }
 
     // print csv header
@@ -247,6 +261,7 @@ object JmxTool extends Logging {
         Thread.sleep(sleep)
       }
     }
+    None
   }
 
   def queryAttributes(mbsc: MBeanServerConnection, names: Iterable[ObjectName], attributesInclude: Option[Array[String]]): mutable.Map[String, Any] = {

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -101,7 +101,7 @@ object JmxTool extends Logging {
         .defaultsTo(false)
     val waitOpt: OptionSpecBuilder = parser.accepts("wait",
       "Wait for requested JMX objects to become available before starting output. " +
-      "Only supported when the list of objects is non-empty and contains no object name patterns.")
+      "Each of the given names or patterns must select at least one MBean before reporting starts.")
     val helpOpt: OptionSpecBuilder = parser.accepts("help", "Print usage information.")
     if(args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, "Dump JMX values to standard output.")

--- a/core/src/test/scala/unit/kafka/tools/JmxToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/JmxToolTest.scala
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.tools
+
+import java.lang.management.ManagementFactory
+import java.util.Locale
+
+import javax.management.{MBeanServer, ObjectName}
+import kafka.utils.TestUtils
+import org.apache.kafka.common.utils.KafkaThread
+import org.junit.{AfterClass, BeforeClass, Test}
+import org.junit.Assert._
+
+trait JmxToolTestColorMBean {
+  def getColor: String
+  def getUpperColor: String
+}
+
+class JmxToolTestColor(color: String) extends JmxToolTestColorMBean {
+  override def getColor: String = color
+  override def getUpperColor: String = color.toUpperCase(Locale.ROOT)
+}
+
+trait JmxToolTestNumMBean {
+  def getNum: Int
+}
+
+class JmxToolTestNum(num: Int) extends JmxToolTestNumMBean {
+  override def getNum: Int = num
+}
+
+object JmxToolTest {
+  private val server: MBeanServer = ManagementFactory.getPlatformMBeanServer
+  private val magenta = new ObjectName("kafka.test:type=Integration,color=M")
+  private val yellow = new ObjectName("kafka.test:type=Integration,color=Y")
+  private val zero = new ObjectName("kafka.test:type=Integration,num=zero")
+
+  @BeforeClass
+  def before(): Unit = {
+    server.registerMBean(new JmxToolTestColor("magenta"), magenta)
+    server.registerMBean(new JmxToolTestColor("yellow"), yellow)
+    server.registerMBean(new JmxToolTestNum(0), zero)
+  }
+
+  @AfterClass
+  def after(): Unit = {
+    server.unregisterMBean(magenta)
+    server.unregisterMBean(yellow)
+    server.unregisterMBean(zero)
+  }
+}
+
+class JmxToolTest {
+  import JmxToolTest._
+
+  private def assertToolError(args: Array[String], expectPrintUsage: Boolean, expectedMessage: String): (String, String) = {
+    TestUtils.grabConsoleOutputAndError {
+      val result = JmxTool.execute(JmxTool.ToolOptions(args), server, 200)
+      assertTrue(result.isDefined)
+      assertEquals(expectPrintUsage, result.get._1)
+      assertEquals(expectedMessage, result.get._2)
+    }
+  }
+
+  private def assertToolSuccess(args: Array[String]): (String, String) = {
+    TestUtils.grabConsoleOutputAndError {
+      val result = JmxTool.execute(JmxTool.ToolOptions(args), server)
+      assertTrue(result.isEmpty)
+    }
+  }
+
+  @Test
+  def testObjectName(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+      "--one-time", "true",
+      "--object-name", "kafka.test:type=Integration,color=M"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.contains("magenta"))
+    assertTrue(out.contains("MAGENTA"))
+  }
+
+  @Test
+  def testAttributes(): Unit = {
+    // That --attributes excludes non-selected attrs
+    var outErr = assertToolSuccess(Array(
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M",
+        "--attributes", "Color"))
+    assertTrue(outErr._2.isEmpty)
+    assertTrue(outErr._1.contains("magenta"))
+    assertFalse(outErr._1.contains("MAGENTA"))
+
+    // That --attributes narrows the matching mbeans to those with the attribute
+    outErr = assertToolSuccess(Array(
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,*",
+        "--attributes", "Color"))
+    assertTrue(outErr._2.isEmpty)
+    assertTrue(outErr._1.contains("magenta"))
+    assertFalse(outErr._1.contains("MAGENTA"))
+    assertFalse(outErr._1.contains("kafka.test:type=Integration,num=zero:Num"))
+    assertFalse(outErr._1.contains(",0"))
+
+    // That without --attributes we don't get the narrowing
+    outErr = assertToolSuccess(Array(
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,*"))
+    assertTrue(outErr._2.isEmpty)
+    assertTrue(outErr._1.contains("magenta"))
+    assertTrue(outErr._1.contains("MAGENTA"))
+    assertTrue(outErr._1.contains("kafka.test:type=Integration,num=zero:Num"))
+    assertTrue(outErr._1.contains(",0"))
+  }
+
+  @Test
+  def testNoMatchedAttributes(): Unit = {
+    val (out, err) = assertToolError(Array(
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M",
+        "--attributes", "Nonexistent"),
+      true, "No matched attributes for the queried objects kafka.test:type=Integration,color=M.")
+    assertTrue(err.isEmpty)
+    assertTrue(out.isEmpty)
+  }
+
+  @Test
+  def testPattern(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=*"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.contains("magenta"))
+    assertTrue(out.contains("MAGENTA"))
+    assertTrue(out.contains("yellow"))
+    assertTrue(out.contains("YELLOW"))
+  }
+
+  @Test
+  def testObjectNameNoWaitWithTimeout(): Unit = {
+    val (out, error) = assertToolError(Array(
+        "--one-time", "true",
+        "--object-name", "this.object:type=DoesNot,name=Exist",
+        "--object-name", "kafka.test:type=Integration,color=M"),
+      false,"Exiting.")
+    assertEquals("Could not find any objects names matching this.object:type=DoesNot,name=Exist.", error.trim)
+    assertTrue(out.isEmpty)
+  }
+
+  @Test
+  def testPatternNoWaitWithTimeout(): Unit = {
+    val (out, error) = assertToolError(Array(
+        "--one-time", "true",
+        "--object-name", "this.object:type=DoesNot,name=*",
+        "--object-name", "kafka.test:type=Integration,color=M"),
+      false, "Exiting.")
+    assertEquals("Could not find any objects names matching this.object:type=DoesNot,name=*.", error.trim)
+    assertTrue(out.isEmpty)
+  }
+
+  @Test
+  def testObjectNameWaitWithTimeout(): Unit = {
+    val (out, error) = assertToolError(Array(
+      "--wait",
+      "--one-time", "true",
+      "--object-name", "this.object:type=DoesNot,name=Exist",
+      "--object-name", "kafka.test:type=Integration,color=M"),
+      false, "Exiting.")
+    assertTrue(error.trim.endsWith("Could not find any objects names matching this.object:type=DoesNot,name=Exist after 200 ms."))
+    assertTrue(out.isEmpty)
+  }
+
+
+  @Test
+  def testPatternWaitWithTimeout(): Unit = {
+    val (out, error) = assertToolError(Array(
+        "--wait",
+        "--one-time", "true",
+        "--object-name", "this.object:type=DoesNot,name=*",
+        "--object-name", "kafka.test:type=Integration,color=M"),
+      false, "Exiting.")
+    assertTrue(error.trim.endsWith("Could not find any objects names matching this.object:type=DoesNot,name=* after 200 ms."))
+    assertTrue(out.isEmpty)
+  }
+
+  @Test
+  def testObjectNameWaitEventuallyFound(): Unit = {
+    val name = new ObjectName("kafka.test:type=Integration,color=C")
+    val thread = KafkaThread.daemon(classOf[JmxToolTest].getName, () => {
+      Thread.sleep(500)
+      server.registerMBean(new JmxToolTestColor("cyan"), name)
+    })
+    thread.start()
+    try {
+      val (out, _) = assertToolSuccess(Array(
+          "--wait",
+          "--one-time", "true",
+          "--object-name", "kafka.test:type=Integration,color=C",
+          "--object-name", "kafka.test:type=Integration,color=M"))
+      assertTrue(out.contains("cyan"))
+      assertTrue(out.contains("CYAN"))
+      assertTrue(out.contains("magenta"))
+      assertTrue(out.contains("MAGENTA"))
+
+    } finally {
+      thread.join()
+      server.unregisterMBean(name)
+    }
+  }
+
+  @Test
+  def testPatternWaitEventuallyFound(): Unit = {
+
+    val name = new ObjectName("kafka.test:type=Integration,color=C")
+    val thread = KafkaThread.daemon(classOf[JmxToolTest].getName, () => {
+      Thread.sleep(500)
+      server.registerMBean(new JmxToolTestColor("cyan"), name)
+    })
+    thread.start()
+    try {
+      val (out, _) = assertToolSuccess(Array(
+          "--wait",
+          "--one-time", "true",
+          "--object-name", "kafka.test:type=*,color=M",
+          "--object-name", "kafka.test:type=*,color=C"))
+      assertTrue(out.contains("cyan"))
+      assertTrue(out.contains("CYAN"))
+      assertTrue(out.contains("magenta"))
+      assertTrue(out.contains("MAGENTA"))
+    } finally {
+      thread.join()
+      server.unregisterMBean(name)
+    }
+  }
+
+  @Test
+  def testOriginalReportFormat(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+        "--report-format", "original",
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.trim.matches("\"time\",\"kafka.test:type=Integration,color=M:Color\",\"kafka.test:type=Integration,color=M:UpperColor\"" +
+      "[\n\r]+[0-9]+,magenta,MAGENTA"))
+  }
+
+  @Test
+  def testCsvReportFormat(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+        "--report-format", "csv",
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.trim.matches("time,\"[0-9]+\"[\n\r]+" +
+      "kafka.test:type=Integration,color=M:Color,\"magenta\"[\n\r]+" +
+      "kafka.test:type=Integration,color=M:UpperColor,\"MAGENTA\""))
+  }
+
+  @Test
+  def testTsvReportFormat(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+        "--report-format", "tsv",
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.trim.matches("time\t[0-9]+[\n\r]+" +
+      "kafka.test:type=Integration,color=M:Color\tmagenta[\n\r]+" +
+      "kafka.test:type=Integration,color=M:UpperColor\tMAGENTA"))
+  }
+
+  @Test
+  def testPropertiesReportFormat(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+        "--report-format", "properties",
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.trim.matches("time=[0-9]+[\n\r]+" +
+      "kafka.test:type=Integration,color=M:Color=magenta[\n\r]+" +
+      "kafka.test:type=Integration,color=M:UpperColor=MAGENTA"))
+  }
+
+  @Test
+  def testDateFormat(): Unit = {
+    val (out, error) = assertToolSuccess(Array(
+        "--date-format", "yyyy-MM-dd HH:mm:ss",
+        "--one-time", "true",
+        "--object-name", "kafka.test:type=Integration,color=M"))
+    assertTrue(error.isEmpty)
+    assertTrue(out.trim.matches("\"time\",\"kafka.test:type=Integration,color=M:Color\",\"kafka.test:type=Integration,color=M:UpperColor\"[\n\r]+" +
+      "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},magenta,MAGENTA"))
+  }
+
+}


### PR DESCRIPTION
Fixes [KAFKA-10860](https://issues.apache.org/jira/browse/KAFKA-10860) and adds a unit test.

The existing code was not easily testable, so refactored to allow the main logic to be executed without invoking `System.exit` or equivalent. The tests added here cover most of the non-connection options, but have to use `--one-time`. I just use the current JVM's MBean server for these tests. Testing the connection code would require spinning up a JVM to connect to, or using the Attach API (which is prevented by https://bugs.openjdk.java.net/browse/JDK-8180425).

Although `--wait` was described as not supported in the presence of a pattern but this wasn't validated previously. Supporting that actually makes the code simpler by avoiding the need to special-case the presence of a pattern. The semantics are that we wait until each of the given patterns selects at least one `ObjectName`, which is consistent with the behaviour for a non-patterned `--wait`.