### PR TITLE
KAFKA-10904: There is a misleading log when the replica fetcher thread handles offsets that are out of range

### DIFF
--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -675,12 +675,18 @@ abstract class AbstractFetcherThread(name: String,
        * and the current leader's log start offset.
        */
       val leaderStartOffset = fetchEarliestOffsetFromLeader(topicPartition, currentLeaderEpoch)
-      warn(s"Reset fetch offset for partition $topicPartition from $replicaEndOffset to current " +
-        s"leader's start offset $leaderStartOffset")
+
       val offsetToFetch = Math.max(leaderStartOffset, replicaEndOffset)
       // Only truncate log when current leader's log start offset is greater than follower's log end offset.
-      if (leaderStartOffset > replicaEndOffset)
+      if (leaderStartOffset > replicaEndOffset) {
+        warn(s"Reset fetch offset for partition $topicPartition from $replicaEndOffset to current " +
+          s"leader's start offset $leaderStartOffset")
         truncateFullyAndStartAt(topicPartition, leaderStartOffset)
+      } else {
+        warn(s"Keep fetch offset for partition $topicPartition from $replicaEndOffset to $replicaEndOffset " +
+          s"because it's still between leader's start offset $leaderStartOffset and leader's end offset $leaderEndOffset")
+      }
+
 
       val initialLag = leaderEndOffset - offsetToFetch
       fetcherLagStats.getAndMaybePut(topicPartition).lag = initialLag


### PR DESCRIPTION
There is ambiguity in the replica fetcher thread's log. When the fetcher thread is handling with offset out of range, it needs to try to truncate the log. When the end offset of the follower replica is greater than the log start offset of the leader replica and smaller than the end offset of the leader replica, the follower replica will maintain its own fetch offset.However, such cases are processed together with cases where the follower replica's end offset is smaller than the leader replica's start offset, resulting in ambiguities in the log, where the follower replica's fetch offset is reported to reset to the leader replica's start offset.In fact, it still maintains its own fetch offset, so this WARN log is misleading to the user.It is more accurate to print this WARN log only when follower replica really need to truncate the fetch offset to the leader replica's log start offset.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
