### PR TITLE
MINOR: Missing entity type tags

### DIFF
--- a/clients/src/main/resources/common/message/OffsetDeleteRequest.json
+++ b/clients/src/main/resources/common/message/OffsetDeleteRequest.json
@@ -19,11 +19,11 @@
   "name": "OffsetDeleteRequest",
   "validVersions": "0",
   "fields": [
-    { "name": "GroupId", "type": "string", "versions": "0+",
+    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
       "about": "The unique group identifier." },
     { "name": "Topics", "type": "[]OffsetDeleteRequestTopic", "versions": "0+",
       "about": "The topics to delete offsets for", "fields": [
-        { "name": "Name",  "type": "string",  "versions": "0+", "mapKey": true,
+        { "name": "Name",  "type": "string",  "versions": "0+", "mapKey": true, "entityType": "topicName",
           "about": "The topic name." },
         { "name": "Partitions", "type": "[]OffsetDeleteRequestPartition", "versions": "0+",
           "about": "Each partition to delete offsets for.", "fields": [

--- a/clients/src/main/resources/common/message/OffsetDeleteResponse.json
+++ b/clients/src/main/resources/common/message/OffsetDeleteResponse.json
@@ -25,7 +25,7 @@
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
     { "name": "Topics", "type": "[]OffsetDeleteResponseTopic", "versions": "0+",
       "about": "The responses for each topic.", "fields": [
-        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true,
+        { "name": "Name", "type": "string", "versions": "0+", "mapKey": true, "entityType": "topicName",
           "about": "The topic name." },
         { "name": "Partitions", "type": "[]OffsetDeleteResponsePartition", "versions": "0+",
           "about": "The responses for each partition in the topic.", "fields": [

--- a/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+++ b/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
@@ -25,7 +25,7 @@
   "validVersions": "0-3",
   "flexibleVersions": "3+",
   "fields": [
-    { "name": "TransactionalId", "type": "string", "versions": "0+",
+    { "name": "TransactionalId", "type": "string", "versions": "0+", "entityType": "transactionalId",
       "about": "The ID of the transaction." },
     { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
       "about": "The ID of the group." },


### PR DESCRIPTION
This patch adds a few missing "entity type" tags to the schema definitions. These aren't really used for anything at the moment, but it's useful to keep them up to date. We had planned to use them perhaps for generating documentation for example.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
