### PR TITLE
KAFKA-12152; Idempotent Producer does not reset the sequence number of partitions without in-flight batches

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -508,15 +508,11 @@ public final class RecordAccumulator {
                 return true;
 
             if (!first.hasSequence()) {
-                if (transactionManager.hasInflightBatches(tp)) {
+                if (transactionManager.hasInflightBatches(tp) && transactionManager.hasStaleProducerIdAndEpoch(tp)) {
                     // Don't drain any new batches while the partition has in-flight batches with a different epoch
                     // and/or producer ID. Otherwise, a batch with a new epoch and sequence number
                     // 0 could be written before earlier batches complete, which would cause out of sequence errors
-                    ProducerBatch firstInFlightBatch = transactionManager.nextBatchBySequence(tp);
-
-                    if (firstInFlightBatch != null && transactionManager.producerIdOrEpochNotMatch(firstInFlightBatch)) {
-                        return true;
-                    }
+                    return true;
                 }
 
                 if (transactionManager.hasUnresolvedSequence(first.topicPartition))
@@ -582,6 +578,12 @@ public final class RecordAccumulator {
                         transactionManager != null ? transactionManager.producerIdAndEpoch() : null;
                     ProducerBatch batch = deque.pollFirst();
                     if (producerIdAndEpoch != null && !batch.hasSequence()) {
+                        // The the producer id/epoch of the partition do not match the latest one
+                        // of the producer, we update it and reset the sequence. This should be
+                        // only done when all its in-flight batches have completed. This is guarantee
+                        // in `shouldStopDrainBatchesForPartition`.
+                        transactionManager.maybeUpdateProducerIdAndEpoch(batch.topicPartition);
+
                         // If the batch already has an assigned sequence, then we should not change the producer id and
                         // sequence number, since this may introduce duplicates. In particular, the previous attempt
                         // may actually have been accepted, and if we change the producer id and sequence here, this

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -578,7 +578,7 @@ public final class RecordAccumulator {
                         transactionManager != null ? transactionManager.producerIdAndEpoch() : null;
                     ProducerBatch batch = deque.pollFirst();
                     if (producerIdAndEpoch != null && !batch.hasSequence()) {
-                        // The the producer id/epoch of the partition do not match the latest one
+                        // If the the producer id/epoch of the partition do not match the latest one
                         // of the producer, we update it and reset the sequence. This should be
                         // only done when all its in-flight batches have completed. This is guarantee
                         // in `shouldStopDrainBatchesForPartition`.

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1005,7 +1005,7 @@ public class SenderTest {
         appendToAccumulator(tp1);
         sender.runOnce();
 
-        // Partition 1 - Epoch is bump, sequence is reset and incremented
+        // Partition 1 - Epoch is bumped, sequence is reset and incremented
         assertPartitionState(transactionManager, tp1, producerId, (short) 1, 1, OptionalInt.empty());
 
         // Partition 1 - Successful Response

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -1146,10 +1146,10 @@ public class SenderTest {
         long expectedSequenceValue,
         OptionalInt expectedLastAckedSequence
     ) {
-        assertEquals("Producer Id:", expectedProducerId, transactionManager.producerIdAndEpoch(tp).producerId);
-        assertEquals("Producer Epoch:", expectedProducerEpoch, transactionManager.producerIdAndEpoch(tp).epoch);
-        assertEquals("Seq Number:", expectedSequenceValue, transactionManager.sequenceNumber(tp).longValue());
-        assertEquals("Last Acked Seq Number:", expectedLastAckedSequence, transactionManager.lastAckedSequence(tp));
+        assertEquals(expectedProducerId, transactionManager.producerIdAndEpoch(tp).producerId, "Producer Id:");
+        assertEquals(expectedProducerEpoch, transactionManager.producerIdAndEpoch(tp).epoch, "Producer Epoch:");
+        assertEquals(expectedSequenceValue, transactionManager.sequenceNumber(tp).longValue(), "Seq Number:");
+        assertEquals(expectedLastAckedSequence, transactionManager.lastAckedSequence(tp), "Last Acked Seq Number:");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -685,6 +685,7 @@ public class TransactionManagerTest {
                 Errors.NONE, 500L, time.milliseconds(), 0L);
         transactionManager.handleCompletedBatch(b2, b2Response);
 
+        transactionManager.maybeUpdateProducerIdAndEpoch(tp0);
         assertEquals(0, transactionManager.sequenceNumber(tp0).intValue());
         assertFalse(transactionManager.lastAckedSequence(tp0).isPresent());
         assertNull(transactionManager.nextBatchBySequence(tp0));
@@ -693,6 +694,7 @@ public class TransactionManagerTest {
     private ProducerBatch writeIdempotentBatchWithValue(TransactionManager manager,
                                                         TopicPartition tp,
                                                         String value) {
+        manager.maybeUpdateProducerIdAndEpoch(tp);
         int seq = manager.sequenceNumber(tp);
         manager.incrementSequenceNumber(tp, 1);
         ProducerBatch batch = batchWithValue(tp, value);
@@ -3135,6 +3137,7 @@ public class TransactionManagerTest {
         tp1b2.done(500L, b1AppendTime, null);
         transactionManager.handleCompletedBatch(tp1b2, t1b2Response);
 
+        transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
         assertFalse(transactionManager.hasInflightBatches(tp1));
         assertEquals(0, transactionManager.sequenceNumber(tp1).intValue());
 
@@ -3149,6 +3152,7 @@ public class TransactionManagerTest {
         tp1b3.done(500L, b1AppendTime, null);
         transactionManager.handleCompletedBatch(tp1b3, t1b3Response);
 
+        transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
         assertFalse(transactionManager.hasInflightBatches(tp1));
         assertEquals(1, transactionManager.sequenceNumber(tp1).intValue());
     }
@@ -3257,6 +3261,7 @@ public class TransactionManagerTest {
         tp1b2.done(500L, b1AppendTime, null);
         transactionManager.handleCompletedBatch(tp1b2, t1b2Response);
 
+        transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
         assertFalse(transactionManager.hasInflightBatches(tp1));
         assertEquals(0, transactionManager.sequenceNumber(tp1).intValue());
 


### PR DESCRIPTION
When a `OutOfOrderSequenceException` error is received by an idempotent producer for a partition, the producer bumps its epoch, adjusts the sequence number and the epoch of the in-flight batches of the partitions affected by the `OutOfOrderSequenceException` error. This happens in `TransactionManager#bumpIdempotentProducerEpoch`.

The remaining partitions are treated separately. When the last in-flight batch of a given partition is completed, the sequence number is reset. This happens in `TransactionManager#handleCompletedBatch`.

However, when a given partition does not have in-flight batches when the producer epoch is bumped, its sequence number is not reset. It results in having subsequent producer request to use the new producer epoch with the old sequence number and to be rejected by the broker.

This PR adds logic to reset the sequences of those partitions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
