### PR TITLE
KAFKA-12153; Update producer state before updating start/end offsets after truncation

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2106,8 +2106,8 @@ class Log(@volatile private var _dir: File,
             // in case the first unstable offset is invalidated by the truncation.
             loadProducerState(targetOffset, reloadFromCleanShutdown = false)
 
-            updateLogStartOffset(math.min(targetOffset, this.logStartOffset))
             updateLogEndOffset(targetOffset)
+            updateLogStartOffset(math.min(targetOffset, this.logStartOffset))
           }
           true
         }
@@ -2139,8 +2139,8 @@ class Log(@volatile private var _dir: File,
         producerStateManager.truncateFullyAndStartAt(newOffset)
         maybeIncrementFirstUnstableOffset()
 
-        updateLogStartOffset(newOffset)
         updateLogEndOffset(newOffset)
+        updateLogStartOffset(newOffset)
       }
     }
   }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2143,7 +2143,7 @@ class Log(@volatile private var _dir: File,
 
   private def completeTruncation(
     startOffset: Long,
-    endOffset: Long,
+    endOffset: Long
   ): Unit = {
     logStartOffset = startOffset
     nextOffsetMetadata = LogOffsetMetadata(endOffset, activeSegment.baseOffset, activeSegment.size)

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -770,7 +770,7 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   /**
    * Truncate the producer id mapping and remove all snapshots. This resets the state of the mapping.
    */
-  def truncate(): Unit = {
+  def truncateFullyAndStartAt(offset: Long): Unit = {
     producers.clear()
     ongoingTxns.clear()
     unreplicatedTxns.clear()
@@ -778,7 +778,7 @@ class ProducerStateManager(val topicPartition: TopicPartition,
       removeAndDeleteSnapshot(snapshot.offset)
     }
     lastSnapOffset = 0L
-    lastMapOffset = 0L
+    lastMapOffset = offset
   }
 
   /**

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -119,7 +119,7 @@ class KafkaMetadataLog(
 
   override def updateHighWatermark(offsetMetadata: LogOffsetMetadata): Unit = {
     offsetMetadata.metadata.asScala match {
-      case Some(segmentPosition: SegmentPosition) => log.updateHighWatermarkOffsetMetadata(
+      case Some(segmentPosition: SegmentPosition) => log.updateHighWatermark(
         new kafka.server.LogOffsetMetadata(
           offsetMetadata.offset,
           segmentPosition.baseOffset,

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -1054,8 +1054,9 @@ class LogTest {
     // Truncation causes the map end offset to reset to 0
     EasyMock.expect(stateManager.mapEndOffset).andReturn(0L)
     // We skip directly to updating the map end offset
-    stateManager.updateMapEndOffset(1L)
-    EasyMock.expectLastCall()
+    EasyMock.expect(stateManager.updateMapEndOffset(1L))
+    EasyMock.expect(stateManager.onHighWatermarkUpdated(0L))
+
     // Finally, we take a snapshot
     stateManager.takeSnapshot()
     EasyMock.expectLastCall().once()

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -200,7 +200,7 @@ class LogTest {
     testTruncateBelowFirstUnstableOffset(_.truncateFullyAndStartAt)
   }
 
-  def testTruncateBelowFirstUnstableOffset(
+  private def testTruncateBelowFirstUnstableOffset(
     truncateFunc: Log => (Long => Unit)
   ): Unit = {
     // Verify that truncation below the first unstable offset correctly

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -635,7 +635,7 @@ class ProducerStateManagerTest {
   }
 
   @Test
-  def testTruncate(): Unit = {
+  def testTruncateFullyAndStartAt(): Unit = {
     val epoch = 0.toShort
 
     append(stateManager, producerId, epoch, 0, 0L)
@@ -649,7 +649,7 @@ class ProducerStateManagerTest {
     assertEquals(2, logDir.listFiles().length)
     assertEquals(Set(2, 3), currentSnapshotOffsets)
 
-    stateManager.truncate()
+    stateManager.truncateFullyAndStartAt(0L)
 
     assertEquals(0, logDir.listFiles().length)
     assertEquals(Set(), currentSnapshotOffsets)


### PR DESCRIPTION
When we truncate the log, the first unstable offset might become valid. On the other hand, the logic in `updateHighWatermarkMetadata` assumes that the first stable offset remains at a valid position. Since this method can be reached through either `updateLogStartOffset` or `updateLogEndOffset` in the truncation paths, we need to ensure that the first unstable offset first reflects the truncated state.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
