### PR TITLE
MINOR: Factor `RaftManager` out of `TestRaftServer`

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -263,8 +263,11 @@ public class MockClient implements KafkaClient {
             if (remainingBlockingWakeups <= 0)
                 return;
 
-            while (numBlockingWakeups == remainingBlockingWakeups)
-                wait();
+            TestUtils.waitForCondition(() -> {
+                if (numBlockingWakeups == remainingBlockingWakeups)
+                    MockClient.this.wait(500);
+                return numBlockingWakeups < remainingBlockingWakeups;
+            }, 5000, "Failed to receive expected wakeup");
         } catch (InterruptedException e) {
             throw new InterruptException(e);
         }

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -87,6 +87,7 @@ private[raft] class RaftSendThread(
 
   def sendRequest(request: RequestAndCompletionHandler): Unit = {
     queue.add(request)
+    wakeup()
   }
 
 }

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.raft
+
+import java.io.File
+import java.nio.file.Files
+import java.util.Random
+import java.util.concurrent.CompletableFuture
+
+import kafka.log.{Log, LogConfig, LogManager}
+import kafka.raft.KafkaRaftManager.RaftIoThread
+import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaServer, LogDirFailureChannel}
+import kafka.utils.timer.SystemTimer
+import kafka.utils.{KafkaScheduler, Logging, ShutdownableThread}
+import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.{ChannelBuilders, NetworkReceive, Selectable, Selector}
+import org.apache.kafka.common.protocol.ApiMessage
+import org.apache.kafka.common.requests.RequestHeader
+import org.apache.kafka.common.security.JaasContext
+import org.apache.kafka.common.utils.{LogContext, Time}
+import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, QuorumState, RaftClient, RaftConfig, RaftRequest, RecordSerde}
+
+import scala.jdk.CollectionConverters._
+
+object KafkaRaftManager {
+  class RaftIoThread(
+    client: KafkaRaftClient[_]
+  ) extends ShutdownableThread(
+    name = "raft-io-thread",
+    isInterruptible = false
+  ) {
+    override def doWork(): Unit = {
+      client.poll()
+    }
+
+    override def initiateShutdown(): Boolean = {
+      if (super.initiateShutdown()) {
+        client.shutdown(5000).whenComplete { (_, exception) =>
+          if (exception != null) {
+            error("Graceful shutdown of RaftClient failed", exception)
+          } else {
+            info("Completed graceful shutdown of RaftClient")
+          }
+        }
+        true
+      } else {
+        false
+      }
+    }
+
+    override def isRunning: Boolean = {
+      client.isRunning
+    }
+  }
+
+  private def createLogDirectory(logDir: File, logDirName: String): File = {
+    val logDirPath = logDir.getAbsolutePath
+    val dir = new File(logDirPath, logDirName)
+    Files.createDirectories(dir.toPath)
+    dir
+  }
+}
+
+trait RaftManager[T] {
+  def handleRequest(
+    header: RequestHeader,
+    request: ApiMessage,
+    createdTimeMs: Long
+  ): CompletableFuture[ApiMessage]
+
+  def register(
+    listener: RaftClient.Listener[T]
+  ): Unit
+
+  def scheduleAppend(
+    epoch: Int,
+    records: Seq[T]
+  ): Option[Long]
+}
+
+class KafkaRaftManager[T](
+  nodeId: Int,
+  baseLogDir: String,
+  recordSerde: RecordSerde[T],
+  topicPartition: TopicPartition,
+  config: KafkaConfig,
+  time: Time,
+  metrics: Metrics
+) extends RaftManager[T] with Logging {
+
+  private val raftConfig = new RaftConfig(config.originals)
+  private val logContext = new LogContext(s"[RaftManager $nodeId] ")
+  this.logIdent = logContext.logPrefix()
+
+  private val scheduler = new KafkaScheduler(threads = 1)
+  scheduler.startup()
+
+  private val dataDir = createDataDir()
+  private val metadataLog = buildMetadataLog()
+  private val netChannel = buildNetworkChannel()
+  private val raftClient = buildRaftClient()
+  private val raftIoThread = new RaftIoThread(raftClient)
+
+  def startup(): Unit = {
+    netChannel.start()
+    raftClient.initialize()
+    raftIoThread.start()
+  }
+
+  def shutdown(): Unit = {
+    raftIoThread.shutdown()
+    scheduler.shutdown()
+    netChannel.close()
+    metadataLog.close()
+  }
+
+  override def register(
+    listener: RaftClient.Listener[T]
+  ): Unit = {
+    raftClient.register(listener)
+  }
+
+  override def scheduleAppend(
+    epoch: Int,
+    records: Seq[T]
+  ): Option[Long] = {
+    val offset: java.lang.Long = raftClient.scheduleAppend(epoch, records.asJava)
+    if (offset == null) {
+      None
+    } else {
+      Some(Long.unbox(offset))
+    }
+  }
+
+  override def handleRequest(
+    header: RequestHeader,
+    request: ApiMessage,
+    createdTimeMs: Long
+  ): CompletableFuture[ApiMessage] = {
+    val inboundRequest = new RaftRequest.Inbound(
+      header.correlationId,
+      request,
+      createdTimeMs
+    )
+
+    raftClient.handle(inboundRequest)
+
+    inboundRequest.completion.thenApply { response =>
+      response.data
+    }
+  }
+
+  private def buildRaftClient(): KafkaRaftClient[T] = {
+    val quorumState = new QuorumState(
+      nodeId,
+      raftConfig.quorumVoterIds,
+      raftConfig.electionTimeoutMs,
+      raftConfig.fetchTimeoutMs,
+      new FileBasedStateStore(new File(dataDir, "quorum-state")),
+      time,
+      logContext,
+      new Random()
+    )
+
+    val expirationTimer = new SystemTimer("raft-expiration-executor")
+    val expirationService = new TimingWheelExpirationService(expirationTimer)
+
+    new KafkaRaftClient(
+      raftConfig,
+      recordSerde,
+      netChannel,
+      metadataLog,
+      quorumState,
+      time,
+      metrics,
+      expirationService,
+      logContext
+    )
+  }
+
+  private def buildNetworkChannel(): KafkaNetworkChannel = {
+    val netClient = buildNetworkClient()
+    new KafkaNetworkChannel(time, netClient, raftConfig.requestTimeoutMs)
+  }
+
+  private def createDataDir(): File = {
+    val logDirName = Log.logDirName(topicPartition)
+    KafkaRaftManager.createLogDirectory(new File(baseLogDir), logDirName)
+  }
+
+  private def buildMetadataLog(): KafkaMetadataLog = {
+    val defaultProps = KafkaServer.copyKafkaConfigToLog(config)
+    LogConfig.validateValues(defaultProps)
+    val defaultLogConfig = LogConfig(defaultProps)
+
+    val log = Log(
+      dir = dataDir,
+      config = defaultLogConfig,
+      logStartOffset = 0L,
+      recoveryPoint = 0L,
+      scheduler = scheduler,
+      brokerTopicStats = new BrokerTopicStats,
+      time = time,
+      maxProducerIdExpirationMs = config.transactionalIdExpirationMs,
+      producerIdExpirationCheckIntervalMs = LogManager.ProducerIdExpirationCheckIntervalMs,
+      logDirFailureChannel = new LogDirFailureChannel(5)
+    )
+    new KafkaMetadataLog(log, topicPartition)
+  }
+
+  private def buildNetworkClient(): NetworkClient = {
+    val channelBuilder = ChannelBuilders.clientChannelBuilder(
+      config.interBrokerSecurityProtocol,
+      JaasContext.Type.SERVER,
+      config,
+      config.interBrokerListenerName,
+      config.saslMechanismInterBrokerProtocol,
+      time,
+      config.saslInterBrokerHandshakeRequestEnable,
+      logContext
+    )
+
+    val metricGroupPrefix = "raft-channel"
+    val collectPerConnectionMetrics = false
+
+    val selector = new Selector(
+      NetworkReceive.UNLIMITED,
+      config.connectionsMaxIdleMs,
+      metrics,
+      time,
+      metricGroupPrefix,
+      Map.empty[String, String].asJava,
+      collectPerConnectionMetrics,
+      channelBuilder,
+      logContext
+    )
+
+    val clientId = s"raft-client-$nodeId"
+    val maxInflightRequestsPerConnection = 1
+    val reconnectBackoffMs = 50
+    val reconnectBackoffMsMs = 500
+    val discoverBrokerVersions = false
+
+    new NetworkClient(
+      selector,
+      new ManualMetadataUpdater(),
+      clientId,
+      maxInflightRequestsPerConnection,
+      reconnectBackoffMs,
+      reconnectBackoffMsMs,
+      Selectable.USE_DEFAULT_BUFFER_SIZE,
+      config.socketReceiveBufferBytes,
+      raftConfig.requestTimeoutMs,
+      config.connectionSetupTimeoutMs,
+      config.connectionSetupTimeoutMaxMs,
+      ClientDnsLookup.USE_ALL_DNS_IPS,
+      time,
+      discoverBrokerVersions,
+      new ApiVersions,
+      logContext
+    )
+  }
+}

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -125,6 +125,7 @@ class KafkaRaftManager[T](
 
   def shutdown(): Unit = {
     raftIoThread.shutdown()
+    raftClient.close()
     scheduler.shutdown()
     netChannel.close()
     metadataLog.close()

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -65,7 +65,7 @@ object KafkaRaftManager {
     }
 
     override def isRunning: Boolean = {
-      client.isRunning
+      client.isRunning && !isThreadFailed
     }
   }
 

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -108,6 +108,8 @@ class TestRaftServer(
   }
 
   def shutdown(): Unit = {
+    if (raftManager != null)
+      CoreUtils.swallow(raftManager.shutdown(), this)
     if (workloadGenerator != null)
       CoreUtils.swallow(workloadGenerator.shutdown(), this)
     if (dataPlaneRequestHandlerPool != null)

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -17,34 +17,25 @@
 
 package kafka.tools
 
-import java.io.File
-import java.nio.file.Files
 import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.concurrent.{CountDownLatch, LinkedBlockingDeque, TimeUnit}
-import java.util.{Collections, Random}
 
 import joptsimple.OptionException
-import kafka.log.{Log, LogConfig, LogManager}
 import kafka.network.SocketServer
-import kafka.raft.{KafkaMetadataLog, KafkaNetworkChannel, TimingWheelExpirationService}
+import kafka.raft.{KafkaRaftManager, RaftManager}
 import kafka.security.CredentialProvider
-import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaRequestHandlerPool, KafkaServer, LogDirFailureChannel}
-import kafka.utils.timer.SystemTimer
-import kafka.utils.{CommandDefaultOptions, CommandLineUtils, CoreUtils, Exit, KafkaScheduler, Logging, ShutdownableThread}
-import org.apache.kafka.clients.{ApiVersions, ClientDnsLookup, ManualMetadataUpdater, NetworkClient}
-import org.apache.kafka.common.config.ConfigException
+import kafka.server.{KafkaConfig, KafkaRequestHandlerPool}
+import kafka.utils.{CommandDefaultOptions, CommandLineUtils, CoreUtils, Exit, Logging, ShutdownableThread}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.stats.Percentiles.BucketSizing
 import org.apache.kafka.common.metrics.stats.{Meter, Percentile, Percentiles}
-import org.apache.kafka.common.network.{ChannelBuilders, NetworkReceive, Selectable, Selector}
 import org.apache.kafka.common.protocol.Writable
-import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
-import org.apache.kafka.common.utils.{LogContext, Time, Utils}
+import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{TopicPartition, protocol}
 import org.apache.kafka.raft.BatchReader.Batch
-import org.apache.kafka.raft.{BatchReader, FileBasedStateStore, KafkaRaftClient, QuorumState, RaftClient, RaftConfig, RecordSerde}
+import org.apache.kafka.raft.{BatchReader, RaftClient, RecordSerde}
 
 import scala.jdk.CollectionConverters._
 
@@ -61,62 +52,42 @@ class TestRaftServer(
 
   private val partition = new TopicPartition("__cluster_metadata", 0)
   private val time = Time.SYSTEM
+  private val metrics = new Metrics(time)
   private val shutdownLatch = new CountDownLatch(1)
 
   var socketServer: SocketServer = _
   var credentialProvider: CredentialProvider = _
   var tokenCache: DelegationTokenCache = _
   var dataPlaneRequestHandlerPool: KafkaRequestHandlerPool = _
-  var scheduler: KafkaScheduler = _
-  var metrics: Metrics = _
-  var ioThread: RaftIoThread = _
-  var networkChannel: KafkaNetworkChannel = _
-  var metadataLog: KafkaMetadataLog = _
   var workloadGenerator: RaftWorkloadGenerator = _
+  var raftManager: KafkaRaftManager[Array[Byte]] = _
 
   def startup(): Unit = {
-    val logContext = new LogContext(s"[Raft id=${config.brokerId}] ")
-
-    metrics = new Metrics()
-    scheduler = new KafkaScheduler(threads = 1)
-
-    scheduler.startup()
-
     tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
     credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
 
     socketServer = new SocketServer(config, metrics, time, credentialProvider, allowDisabledApis = true)
     socketServer.startup(startProcessingRequests = false)
 
-    val logDirName = Log.logDirName(partition)
-    val logDir = createLogDirectory(new File(config.logDirs.head), logDirName)
-
-    val raftConfig = new RaftConfig(config.originals)
-    val metadataLog = buildMetadataLog(logDir)
-    val networkChannel = buildNetworkChannel(raftConfig, logContext)
-
-    networkChannel.start()
-
-    val raftClient = buildRaftClient(
-      raftConfig,
-      metadataLog,
-      networkChannel,
-      logContext,
-      logDir
+    raftManager = new KafkaRaftManager[Array[Byte]](
+      config.brokerId,
+      config.logDirs.head,
+      new ByteArraySerde,
+      partition,
+      config,
+      time,
+      metrics
     )
 
     workloadGenerator = new RaftWorkloadGenerator(
-      raftClient,
+      raftManager,
       time,
       recordsPerSec = 20000,
       recordSize = 256
     )
 
-    raftClient.register(workloadGenerator)
-    raftClient.initialize()
-
     val requestHandler = new TestRaftRequestHandler(
-      raftClient,
+      raftManager,
       socketServer.dataPlaneRequestChannel,
       time
     )
@@ -131,30 +102,20 @@ class TestRaftServer(
       SocketServer.DataPlaneThreadPrefix
     )
 
-    socketServer.startProcessingRequests(Map.empty)
-    ioThread = new RaftIoThread(raftClient)
-    ioThread.start()
     workloadGenerator.start()
+    raftManager.startup()
+    socketServer.startProcessingRequests(Map.empty)
   }
 
   def shutdown(): Unit = {
     if (workloadGenerator != null)
       CoreUtils.swallow(workloadGenerator.shutdown(), this)
-    if (ioThread != null)
-      CoreUtils.swallow(ioThread.shutdown(), this)
     if (dataPlaneRequestHandlerPool != null)
       CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), this)
     if (socketServer != null)
       CoreUtils.swallow(socketServer.shutdown(), this)
-    if (networkChannel != null)
-      CoreUtils.swallow(networkChannel.close(), this)
-    if (scheduler != null)
-      CoreUtils.swallow(scheduler.shutdown(), this)
     if (metrics != null)
       CoreUtils.swallow(metrics.close(), this)
-    if (metadataLog != null)
-      CoreUtils.swallow(metadataLog.close(), this)
-
     shutdownLatch.countDown()
   }
 
@@ -162,131 +123,8 @@ class TestRaftServer(
     shutdownLatch.await()
   }
 
-  private def buildNetworkChannel(raftConfig: RaftConfig,
-                                  logContext: LogContext): KafkaNetworkChannel = {
-    val netClient = buildNetworkClient(raftConfig, logContext)
-    new KafkaNetworkChannel(time, netClient, raftConfig.requestTimeoutMs)
-  }
-
-  private def buildMetadataLog(logDir: File): KafkaMetadataLog = {
-    if (config.logDirs.size != 1) {
-      throw new ConfigException("There must be exactly one configured log dir")
-    }
-
-    val defaultProps = KafkaServer.copyKafkaConfigToLog(config)
-    LogConfig.validateValues(defaultProps)
-    val defaultLogConfig = LogConfig(defaultProps)
-
-    val log = Log(
-      dir = logDir,
-      config = defaultLogConfig,
-      logStartOffset = 0L,
-      recoveryPoint = 0L,
-      scheduler = scheduler,
-      brokerTopicStats = new BrokerTopicStats,
-      time = time,
-      maxProducerIdExpirationMs = config.transactionalIdExpirationMs,
-      producerIdExpirationCheckIntervalMs = LogManager.ProducerIdExpirationCheckIntervalMs,
-      logDirFailureChannel = new LogDirFailureChannel(5)
-    )
-    new KafkaMetadataLog(log, partition)
-  }
-
-  private def createLogDirectory(logDir: File, logDirName: String): File = {
-    val logDirPath = logDir.getAbsolutePath
-    val dir = new File(logDirPath, logDirName)
-    Files.createDirectories(dir.toPath)
-    dir
-  }
-
-  private def buildRaftClient(raftConfig: RaftConfig,
-                              metadataLog: KafkaMetadataLog,
-                              networkChannel: KafkaNetworkChannel,
-                              logContext: LogContext,
-                              logDir: File): KafkaRaftClient[Array[Byte]] = {
-    val quorumState = new QuorumState(
-      config.brokerId,
-      raftConfig.quorumVoterIds,
-      raftConfig.electionTimeoutMs,
-      raftConfig.fetchTimeoutMs,
-      new FileBasedStateStore(new File(logDir, "quorum-state")),
-      time,
-      logContext,
-      new Random()
-    )
-
-    val expirationTimer = new SystemTimer("raft-expiration-executor")
-    val expirationService = new TimingWheelExpirationService(expirationTimer)
-    val serde = new ByteArraySerde
-
-    new KafkaRaftClient(
-      raftConfig,
-      serde,
-      networkChannel,
-      metadataLog,
-      quorumState,
-      time,
-      expirationService,
-      logContext
-    )
-  }
-
-  private def buildNetworkClient(raftConfig: RaftConfig,
-                                 logContext: LogContext): NetworkClient = {
-    val channelBuilder = ChannelBuilders.clientChannelBuilder(
-      config.interBrokerSecurityProtocol,
-      JaasContext.Type.SERVER,
-      config,
-      config.interBrokerListenerName,
-      config.saslMechanismInterBrokerProtocol,
-      time,
-      config.saslInterBrokerHandshakeRequestEnable,
-      logContext
-    )
-
-    val metricGroupPrefix = "raft-channel"
-    val collectPerConnectionMetrics = false
-
-    val selector = new Selector(
-      NetworkReceive.UNLIMITED,
-      config.connectionsMaxIdleMs,
-      metrics,
-      time,
-      metricGroupPrefix,
-      Map.empty[String, String].asJava,
-      collectPerConnectionMetrics,
-      channelBuilder,
-      logContext
-    )
-
-    val clientId = s"broker-${config.brokerId}-raft-client"
-    val maxInflightRequestsPerConnection = 1
-    val reconnectBackoffMs = 50
-    val reconnectBackoffMsMs = 500
-    val discoverBrokerVersions = false
-
-    new NetworkClient(
-      selector,
-      new ManualMetadataUpdater(),
-      clientId,
-      maxInflightRequestsPerConnection,
-      reconnectBackoffMs,
-      reconnectBackoffMsMs,
-      Selectable.USE_DEFAULT_BUFFER_SIZE,
-      config.socketReceiveBufferBytes,
-      raftConfig.requestTimeoutMs,
-      config.connectionSetupTimeoutMs,
-      config.connectionSetupTimeoutMaxMs,
-      ClientDnsLookup.USE_ALL_DNS_IPS,
-      time,
-      discoverBrokerVersions,
-      new ApiVersions,
-      logContext
-    )
-  }
-
   class RaftWorkloadGenerator(
-    client: KafkaRaftClient[Array[Byte]],
+    raftManager: RaftManager[Array[Byte]],
     time: Time,
     recordsPerSec: Int,
     recordSize: Int
@@ -307,6 +145,8 @@ class TestRaftServer(
     private val throttler = new ThroughputThrottler(time, recordsPerSec)
 
     private var claimedEpoch: Option[Int] = None
+
+    raftManager.register(this)
 
     override def handleClaim(epoch: Int): Unit = {
       eventQueue.offer(HandleClaim(epoch))
@@ -332,11 +172,9 @@ class TestRaftServer(
     ): Unit = {
       recordCount.incrementAndGet()
 
-      val offset = client.scheduleAppend(leaderEpoch, Collections.singletonList(payload))
-      if (offset == null) {
-        time.sleep(10)
-      } else {
-        pendingAppends.offer(PendingAppend(offset, currentTimeMs))
+      raftManager.scheduleAppend(leaderEpoch, Seq(payload)) match {
+        case Some(offset) => pendingAppends.offer(PendingAppend(offset, currentTimeMs))
+        case None => time.sleep(10)
       }
     }
 
@@ -406,36 +244,6 @@ class TestRaftServer(
       }
     }
 
-  }
-
-  class RaftIoThread(
-    client: KafkaRaftClient[Array[Byte]]
-  ) extends ShutdownableThread(
-    name = "raft-io-thread",
-    isInterruptible = false
-  ) {
-    override def doWork(): Unit = {
-      client.poll()
-    }
-
-    override def initiateShutdown(): Boolean = {
-      if (super.initiateShutdown()) {
-        client.shutdown(5000).whenComplete { (_, exception) =>
-          if (exception != null) {
-            error("Graceful shutdown of RaftClient failed", exception)
-          } else {
-            info("Completed graceful shutdown of RaftClient")
-          }
-        }
-        true
-      } else {
-        false
-      }
-    }
-
-    override def isRunning: Boolean = {
-      client.isRunning
-    }
   }
 
 }

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -72,8 +72,12 @@ class KafkaNetworkChannelTest {
 
     client.enableBlockingUntilWakeup(1)
 
-    val ioThread: Thread = new Thread() {
+    val ioThread = new Thread() {
       override def run(): Unit = {
+        // Block in poll until we get the expected wakeup
+        channel.pollOnce()
+
+        // Poll a second time to send request and receive response
         channel.pollOnce()
       }
     }

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -49,4 +49,20 @@ class RaftManagerTest {
     assertTrue(ioThread.isShutdownComplete)
   }
 
+  @Test
+  def testUncaughtExceptionInIoThread(): Unit = {
+    val raftClient = mock(classOf[KafkaRaftClient[String]])
+    val ioThread = new RaftIoThread(raftClient)
+
+    when(raftClient.isRunning).thenReturn(true)
+    assertTrue(ioThread.isRunning)
+
+    when(raftClient.poll()).thenThrow(new RuntimeException)
+    ioThread.run()
+
+    assertTrue(ioThread.isShutdownComplete)
+    assertTrue(ioThread.isThreadFailed)
+    assertFalse(ioThread.isRunning)
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.raft
+
+import java.util.concurrent.CompletableFuture
+
+import kafka.raft.KafkaRaftManager.RaftIoThread
+import org.apache.kafka.raft.KafkaRaftClient
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions._
+import org.mockito.Mockito._
+
+class RaftManagerTest {
+
+  @Test
+  def testShutdownIoThread(): Unit = {
+    val raftClient = mock(classOf[KafkaRaftClient[String]])
+    val ioThread = new RaftIoThread(raftClient)
+
+    when(raftClient.isRunning).thenReturn(true)
+    assertTrue(ioThread.isRunning)
+
+    val shutdownFuture = new CompletableFuture[Void]
+    when(raftClient.shutdown(5000)).thenReturn(shutdownFuture)
+
+    ioThread.initiateShutdown()
+    assertTrue(ioThread.isRunning)
+    assertTrue(ioThread.isShutdownInitiated)
+    verify(raftClient).shutdown(5000)
+
+    shutdownFuture.complete(null)
+    when(raftClient.isRunning).thenReturn(false)
+    ioThread.run()
+    assertFalse(ioThread.isRunning)
+    assertTrue(ioThread.isShutdownComplete)
+  }
+
+}

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -165,6 +165,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         ReplicatedLog log,
         QuorumState quorum,
         Time time,
+        Metrics metrics,
         ExpirationService expirationService,
         LogContext logContext
     ) {
@@ -175,7 +176,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             quorum,
             new BatchMemoryPool(5, MAX_BATCH_SIZE),
             time,
-            new Metrics(time),
+            metrics,
             expirationService,
             raftConfig.quorumVoterConnections(),
             raftConfig.electionBackoffMaxMs(),

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2161,7 +2161,8 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private void close() {
+    @Override
+    public void close() {
         kafkaRaftMetrics.close();
     }
 
@@ -2196,14 +2197,12 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         }
 
         public void failWithTimeout() {
-            close();
             logger.warn("Graceful shutdown timed out after {}ms", finishTimer.timeoutMs());
             completeFuture.completeExceptionally(
                 new TimeoutException("Timeout expired before graceful shutdown completed"));
         }
 
         public void complete() {
-            close();
             logger.info("Graceful shutdown completed");
             completeFuture.complete(null);
         }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -1843,10 +1843,7 @@ public class KafkaRaftClientTest {
         assertEquals((double) 4L, getMetric(context.metrics, "log-end-offset").metricValue());
         assertEquals((double) epoch, getMetric(context.metrics, "log-end-epoch").metricValue());
 
-        CompletableFuture<Void> shutdownFuture = context.client.shutdown(100);
-        context.client.poll();
-        assertTrue(shutdownFuture.isDone());
-        assertNull(shutdownFuture.get());
+        context.client.close();
 
         // should only have total-metrics-count left
         assertEquals(1, context.metrics.metrics().size());


### PR DESCRIPTION
This patch factors out a `RaftManager` class from `TestRaftServer` which will be needed when we integrate this layer into the server. This class encapsulates the logic to build `KafkaRaftClient` as well as its IO thread.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
