### PR TITLE
MINOR: revise error message from TransactionalRequestResult#await

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
@@ -71,7 +71,7 @@ public final class TransactionalRequestResult {
                 throw error();
             }
             if (!success) {
-                throw new TimeoutException("Timeout expired after " + timeout + unit.name().toLowerCase(Locale.ROOT) + " while awaiting " + operation);
+                throw new TimeoutException("Timeout expired after " + timeout + " " + unit.name().toLowerCase(Locale.ROOT) + " while awaiting " + operation);
             }
         } catch (InterruptedException e) {
             throw new InterruptException("Received interrupt while awaiting " + operation, e);


### PR DESCRIPTION
**before**
```
Timeout expired after 1000milliseconds while awaiting InitProducerId
```

**after**
```
Timeout expired after 1000 milliseconds while awaiting InitProducerId
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
