### PR TITLE
MINOR: Bump Bouncy Castle Dependency

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -58,7 +58,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.66",
+  bcpkix: "1.68",
   checkstyle: "8.20",
   commonsCli: "1.4",
   gradle: "6.7.1",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-28052

It affects 1.65 and 1.66, which Kafka uses in 2.7+ test code