### PR TITLE
KAFKA-12165: Include org.apache.kafka.common.quota in javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1157,6 +1157,7 @@ project(':clients') {
     include "**/org/apache/kafka/common/header/*"
     include "**/org/apache/kafka/common/metrics/*"
     include "**/org/apache/kafka/common/metrics/stats/*"
+    include "**/org/apache/kafka/common/quota/*"
     include "**/org/apache/kafka/common/resource/*"
     include "**/org/apache/kafka/common/serialization/*"
     include "**/org/apache/kafka/common/config/*"


### PR DESCRIPTION
The public API classes in `org.apache.kafka.common.quota` should be included in the javadoc. 
(they're not currently, see for example https://kafka.apache.org/27/javadoc/org/apache/kafka/clients/admin/Admin.html#alterClientQuotas-java.util.Collection-)