### PR TITLE
KAFKA-10703: Better handling and doc for config defaults of topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -59,13 +59,19 @@ public final class ConfigResource {
 
     /**
      * Create an instance of this class with the provided parameters.
+     * An empty name is used to refer to the default resource of a resource type.
+     * Default configs are not supported for topic resources.
      *
      * @param type a non-null resource type
      * @param name a non-null resource name
+     * @throws IllegalArgumentException if an empty name is passed for a topic resource.
      */
     public ConfigResource(Type type, String name) {
         Objects.requireNonNull(type, "type should not be null");
         Objects.requireNonNull(name, "name should not be null");
+        if (type == Type.TOPIC && name.isEmpty()) {
+            throw new IllegalArgumentException("Default configs are not supported for topic resources");
+        }
         this.type = type;
         this.name = name;
     }

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -60,18 +60,13 @@ public final class ConfigResource {
     /**
      * Create an instance of this class with the provided parameters.
      * An empty name is used to refer to the default resource of a resource type.
-     * Default configs are not supported for topic resources.
      *
      * @param type a non-null resource type
      * @param name a non-null resource name
-     * @throws IllegalArgumentException if an empty name is passed for a topic resource.
      */
     public ConfigResource(Type type, String name) {
         Objects.requireNonNull(type, "type should not be null");
         Objects.requireNonNull(name, "name should not be null");
-        if (type == Type.TOPIC && name.isEmpty()) {
-            throw new IllegalArgumentException("Default configs are not supported for topic resources");
-        }
         this.type = type;
         this.name = name;
     }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -755,7 +755,8 @@ object ConfigCommand extends Config {
     val entityName = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id/ip)")
             .withRequiredArg
             .ofType(classOf[String])
-    val entityDefault = parser.accepts("entity-default", "Default entity name for clients/users/brokers/ips (applies to corresponding entity type in command line)")
+    val entityDefault = parser.accepts("entity-default", "Default entity name for clients/users/brokers/ips (applies to corresponding entity type in command line). " +
+      "Default configs are not supported for topic entities.")
 
     val nl = System.getProperty("line.separator")
     val addConfig = parser.accepts("add-config", "Key Value pairs of configs to add. Square brackets can be used to group values which contain commas: 'k1=v1,k2=[v1,v2,v2],k3=v3'. The following is a list of valid configurations: " +
@@ -894,6 +895,9 @@ object ConfigCommand extends Config {
 
       if (options.has(describeOpt) && entityTypeVals.contains(BrokerLoggerConfigType) && !hasEntityName)
         throw new IllegalArgumentException(s"an entity name must be specified with --describe of ${entityTypeVals.mkString(",")}")
+
+      if (entityTypeVals.contains(ConfigType.Topic) && options.has(entityDefault) )
+        throw new IllegalArgumentException(s"Default configs are not supported for topic entities.")
 
       if (options.has(alterOpt)) {
         if (entityTypeVals.contains(ConfigType.User) ||

--- a/core/src/main/scala/kafka/server/ConfigHelper.scala
+++ b/core/src/main/scala/kafka/server/ConfigHelper.scala
@@ -23,7 +23,7 @@ import kafka.log.LogConfig
 import kafka.server.metadata.ConfigRepository
 import kafka.utils.{Log4jController, Logging}
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigResource}
-import org.apache.kafka.common.errors.{ApiException, InvalidRequestException}
+import org.apache.kafka.common.errors.{ApiException, InvalidRequestException, InvalidTopicException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.message.DescribeConfigsRequestData.DescribeConfigsResource
 import org.apache.kafka.common.message.DescribeConfigsResponseData
@@ -63,6 +63,9 @@ class ConfigHelper(metadataCache: MetadataCache, config: KafkaConfig, configRepo
         val configResult = ConfigResource.Type.forId(resource.resourceType) match {
           case ConfigResource.Type.TOPIC =>
             val topic = resource.resourceName
+            if (topic.isEmpty) {
+              throw new InvalidTopicException("Default configs are not supported for topic entities.")
+            }
             Topic.validate(topic)
             if (metadataCache.contains(topic)) {
               val topicProps = configRepository.topicConfig(topic)

--- a/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ZkAdminManagerTest.scala
@@ -17,22 +17,25 @@
 
 package kafka.server
 
-import kafka.zk.{AdminZkClient, KafkaZkClient}
-import org.apache.kafka.common.metrics.Metrics
-import org.easymock.EasyMock
+import kafka.zk.{AdminZkClient}
 import kafka.utils.TestUtils
+import kafka.zk.KafkaZkClient
+import org.apache.kafka.clients.admin.AlterConfigOp.OpType
+import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.common.config.ConfigResource
-import org.apache.kafka.common.message.DescribeConfigsRequestData
-import org.apache.kafka.common.message.DescribeConfigsResponseData
+import org.apache.kafka.common.message.DescribeConfigsRequestData.DescribeConfigsResource
+import org.apache.kafka.common.message.{DescribeConfigsRequestData, DescribeConfigsResponseData}
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.junit.jupiter.api.{AfterEach, Test}
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertNotNull, fail}
 import java.util.Properties
 
 import kafka.server.metadata.ZkConfigRepository
+import org.apache.kafka.common.requests.AlterConfigsRequest
+import org.easymock.EasyMock
+
+import scala.jdk.CollectionConverters._
 
 class ZkAdminManagerTest {
 
@@ -52,6 +55,11 @@ class ZkAdminManagerTest {
     new ConfigHelper(metadataCache, KafkaConfig.fromProps(props), new ZkConfigRepository(new AdminZkClient(zkClient)))
   }
 
+  def createAdminManager(): ZkAdminManager = {
+    val props = TestUtils.createBrokerConfig(brokerId, "zk")
+    new ZkAdminManager(KafkaConfig.fromProps(props), metrics, metadataCache, zkClient)
+  }
+
   @Test
   def testDescribeConfigsWithNullConfigurationKeys(): Unit = {
     EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(TestUtils.createBrokerConfig(brokerId, "zk"))
@@ -67,6 +75,7 @@ class ZkAdminManagerTest {
     val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = configHelper.describeConfigs(resources, true, true)
     assertEquals(Errors.NONE.code, results.head.errorCode())
     assertFalse(results.head.configs().isEmpty, "Should return configs")
+    EasyMock.verify(zkClient, metadataCache)
   }
 
   @Test
@@ -83,12 +92,12 @@ class ZkAdminManagerTest {
     val results: List[DescribeConfigsResponseData.DescribeConfigsResult] = configHelper.describeConfigs(resources, true, true)
     assertEquals(Errors.NONE.code, results.head.errorCode())
     assertFalse(results.head.configs().isEmpty, "Should return configs")
+    EasyMock.verify(zkClient, metadataCache)
   }
 
   @Test
   def testDescribeConfigsWithDocumentation(): Unit = {
     EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Topic, topic)).andReturn(new Properties)
-    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Broker, brokerId.toString)).andReturn(new Properties)
     EasyMock.expect(metadataCache.contains(topic)).andReturn(true)
     EasyMock.replay(zkClient, metadataCache)
 
@@ -112,5 +121,106 @@ class ZkAdminManagerTest {
         assertNotEquals(s"Config ${c.name} should have non blank documentation", "", c.documentation.trim)
       })
     })
+
+    EasyMock.verify(zkClient, metadataCache)
+  }
+
+  @Test
+  def testDescribeConfigsWithDefaultEntityNames(): Unit = {
+    val defaultEntityName = ""
+
+    EasyMock.replay(zkClient, metadataCache)
+
+    val resources = ConfigResource.Type.values.filterNot(t => t == ConfigResource.Type.UNKNOWN).map(resourceType => {
+      new DescribeConfigsResource().setResourceType(resourceType.id).setResourceName(defaultEntityName)
+    }).toList
+    val configHelper = createConfigHelper(metadataCache, zkClient)
+    val results = configHelper.describeConfigs(resources, false, false)
+    results.foreach { result =>
+      assertEquals(defaultEntityName, result.resourceName)
+      val resourceType = ConfigResource.Type.forId(result.resourceType)
+      resourceType match {
+        case ConfigResource.Type.BROKER =>
+          assertEquals(Errors.NONE, Errors.forCode(result.errorCode))
+          assertEquals("", result.errorMessage)
+        case ConfigResource.Type.BROKER_LOGGER =>
+          assertEquals(Errors.INVALID_REQUEST, Errors.forCode(result.errorCode))
+          assertEquals("Broker id must not be empty", result.errorMessage)
+        case ConfigResource.Type.TOPIC =>
+          assertEquals(Errors.INVALID_TOPIC_EXCEPTION, Errors.forCode(result.errorCode))
+          assertEquals("Default configs are not supported for topic entities.", result.errorMessage)
+        case _ => fail(s"Unhandled resource type $resourceType in test")
+      }
+    }
+    EasyMock.verify(zkClient, metadataCache)
+  }
+
+  @Test
+  def testIncrementalAlterConfigsWithDefaultEntityNames(): Unit = {
+    val defaultEntityName = ""
+    EasyMock.expect(zkClient.getEntityConfigs(ConfigType.Broker, ConfigEntityName.Default)).andReturn(new Properties)
+    EasyMock.replay(zkClient, metadataCache)
+
+    val resources = ConfigResource.Type.values.filterNot(t => t == ConfigResource.Type.UNKNOWN).map(resourceType => {
+      new ConfigResource(resourceType, defaultEntityName) -> Seq(resourceType match {
+        case ConfigResource.Type.BROKER => new AlterConfigOp(new ConfigEntry("log.segment.bytes", "1024"), OpType.SET)
+        case ConfigResource.Type.BROKER_LOGGER => new AlterConfigOp(new ConfigEntry("kafka", "INFO"), OpType.SET)
+        case ConfigResource.Type.TOPIC => new AlterConfigOp(new ConfigEntry("segment.bytes", "1024"), OpType.SET)
+        case _ => throw new AssertionError(s"Unhandled resource type $resourceType in test")
+      })
+    }).toMap
+    val adminManager = createAdminManager()
+    val results = adminManager.incrementalAlterConfigs(resources, validateOnly = true)
+    results.foreach { case (configResource, apiError) => {
+      assertEquals(defaultEntityName, configResource.name)
+      val resourceType = configResource.`type`
+      resourceType match {
+        case ConfigResource.Type.BROKER =>
+          assertEquals(Errors.NONE, apiError.error)
+          assertEquals(null, apiError.message)
+        case ConfigResource.Type.BROKER_LOGGER =>
+          assertEquals(Errors.NONE, apiError.error)
+          assertEquals(null, apiError.message)
+        case ConfigResource.Type.TOPIC =>
+          assertEquals(Errors.INVALID_REQUEST, apiError.error())
+          assertEquals("Default configs are not supported for topic entities.", apiError.message)
+        case _ => fail(s"Unhandled resource type $resourceType in test")
+      }
+    }}
+    EasyMock.verify(zkClient, metadataCache)
+  }
+
+  @Test
+  def testAlterConfigsWithDefaultEntityNames(): Unit = {
+    val defaultEntityName = ""
+    EasyMock.replay(zkClient, metadataCache)
+
+    val resources = ConfigResource.Type.values.filterNot(t => t == ConfigResource.Type.UNKNOWN).map(resourceType => {
+      new ConfigResource(resourceType, defaultEntityName) -> new AlterConfigsRequest.Config(List(resourceType match {
+        case ConfigResource.Type.BROKER => new AlterConfigsRequest.ConfigEntry("log.segment.bytes", "1024")
+        case ConfigResource.Type.BROKER_LOGGER => new AlterConfigsRequest.ConfigEntry("kafka", "INFO")
+        case ConfigResource.Type.TOPIC => new AlterConfigsRequest.ConfigEntry("segment.bytes", "1024")
+        case _ => throw new AssertionError(s"Unhandled resource type $resourceType in test")
+      }).asJava)
+    }).toMap
+    val adminManager = createAdminManager()
+    val results = adminManager.alterConfigs(resources, validateOnly = true)
+    results.foreach { case (configResource, err) => {
+      assertEquals(defaultEntityName, configResource.name)
+      val resourceType = configResource.`type`
+      resourceType match {
+        case ConfigResource.Type.BROKER =>
+          assertEquals(Errors.NONE, err.error)
+          assertEquals(null, err.message)
+        case ConfigResource.Type.BROKER_LOGGER =>
+          assertEquals(Errors.INVALID_REQUEST, err.error)
+          assertEquals("AlterConfigs is only supported for topics and brokers, but resource type is BROKER_LOGGER", err.message)
+        case ConfigResource.Type.TOPIC =>
+          assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, err.error)
+          assertEquals("Default configs are not supported for topic entities.", err.message)
+        case _ => fail(s"Unhandled resource type $resourceType in test")
+      }
+    }}
+    EasyMock.verify(zkClient, metadataCache)
   }
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -259,6 +259,9 @@ public class ConfigurationControlManager {
                 }
                 return ApiError.NONE;
             case TOPIC:
+                if (configResource.name().isEmpty()) {
+                    return new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, "Default configs are not supported for topic entities.");
+                }
                 try {
                     Topic.validate(configResource.name());
                 } catch (Exception e) {

--- a/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
@@ -114,7 +114,7 @@ public class ConfigurationControlManagerTest {
         assertEquals(new ApiError(Errors.INVALID_REQUEST, "Illegal topic name.").toString(),
             ConfigurationControlManager.checkConfigResource(
                 new ConfigResource(TOPIC, "* @ invalid$")).toString());
-        assertEquals(new ApiError(Errors.INVALID_REQUEST, "Illegal topic name.").toString(),
+        assertEquals(new ApiError(Errors.INVALID_REQUEST, "Default configs are not supported for topic entities.").toString(),
             ConfigurationControlManager.checkConfigResource(
                 new ConfigResource(TOPIC, "")).toString());
         assertEquals(new ApiError(Errors.INVALID_REQUEST, "Illegal non-integral " +


### PR DESCRIPTION
Default configs are not supported for topic resources, so document this
and prevent the creation of such ConfigResources.

