### PR TITLE
MINOR: Remove assertDoesNotThrow at last line

### DIFF
--- a/log4j-appender/src/test/java/org/apache/kafka/log4jappender/KafkaLog4jAppenderTest.java
+++ b/log4j-appender/src/test/java/org/apache/kafka/log4jappender/KafkaLog4jAppenderTest.java
@@ -140,7 +140,7 @@ public class KafkaLog4jAppenderTest {
         MockKafkaLog4jAppender mockKafkaLog4jAppender = getMockKafkaLog4jAppender();
         replaceProducerWithMocked(mockKafkaLog4jAppender, true);
 
-        assertDoesNotThrow(() -> logger.error(getMessage(0)));
+        logger.error(getMessage(0));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class KafkaLog4jAppenderTest {
         Properties props = getLog4jConfigWithRealProducer(true);
         PropertyConfigurator.configure(props);
 
-        assertDoesNotThrow(() -> logger.error(getMessage(0)));
+        logger.error(getMessage(0));
     }
 
     @Test

--- a/log4j-appender/src/test/java/org/apache/kafka/log4jappender/KafkaLog4jAppenderTest.java
+++ b/log4j-appender/src/test/java/org/apache/kafka/log4jappender/KafkaLog4jAppenderTest.java
@@ -36,7 +36,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 


### PR DESCRIPTION
`assertDoesNotThrow(.....)` in the last line  
Above is unnecessary  noise in my commit .
Please let me revert it .

Discuss from 
https://github.com/apache/kafka/pull/9785/files#r554586805