### PR TITLE
KAFKA-12171 Migrate streams:test-utils module to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,7 @@ subprojects {
     }
   }
 
-  def shouldUseJUnit5 = ["tools", "raft", "log4j-appender", "examples"].contains(it.project.name)
+  def shouldUseJUnit5 = ["test-utils", "tools", "raft", "log4j-appender", "examples"].contains(it.project.name)
   def testLoggingEvents = ["passed", "skipped", "failed"]
   def testShowStandardStreams = false
   def testExceptionFormat = 'full'
@@ -1490,8 +1490,7 @@ project(':streams:test-utils') {
     compile project(':clients')
 
     testCompile project(':clients').sourceSets.test.output
-    testCompile libs.junitJupiterApi
-    testCompile libs.junitVintageEngine
+    testCompile libs.junitJupiter
     testCompile libs.easymock
     testCompile libs.hamcrest
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -30,18 +30,18 @@ import org.apache.kafka.streams.state.KeyValueStore;
 
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("deprecation") // this is a test of a deprecated API
 public class MockProcessorContextTest {

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockTimeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockTimeTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.streams;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MockTimeTest {
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TestTopicsTest.java
@@ -28,9 +28,9 @@ import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.test.TestRecord;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestTopicsTest {
     private static final Logger log = LoggerFactory.getLogger(TestTopicsTest.class);
@@ -66,7 +66,7 @@ public class TestTopicsTest {
 
     private final Instant testBaseTime = Instant.parse("2019-06-01T10:00:00Z");
 
-    @Before
+    @BeforeEach
     public void setup() {
         final StreamsBuilder builder = new StreamsBuilder();
         //Create Actual Stream Processing pipeline
@@ -77,7 +77,7 @@ public class TestTopicsTest {
         testDriver = new TopologyTestDriver(builder.build());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         try {
             testDriver.close();
@@ -326,14 +326,14 @@ public class TestTopicsTest {
     public void testNonExistingOutputTopic() {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic("no-exist", longSerde.deserializer(), stringSerde.deserializer());
-        assertThrows("Uninitialized topic", NoSuchElementException.class, outputTopic::readRecord);
+        assertThrows(NoSuchElementException.class, outputTopic::readRecord, "Uninitialized topic");
     }
 
     @Test
     public void testNonUsedOutputTopic() {
         final TestOutputTopic<Long, String> outputTopic =
             testDriver.createOutputTopic(OUTPUT_TOPIC, longSerde.deserializer(), stringSerde.deserializer());
-        assertThrows("Uninitialized topic", NoSuchElementException.class, outputTopic::readRecord);
+        assertThrows(NoSuchElementException.class, outputTopic::readRecord, "Uninitialized topic");
     }
 
     @Test
@@ -346,14 +346,14 @@ public class TestTopicsTest {
         inputTopic.pipeInput("Hello");
         assertThat(outputTopic.readValue(), equalTo("Hello"));
         //No more output in topic
-        assertThrows("Empty topic", NoSuchElementException.class, outputTopic::readRecord);
+        assertThrows(NoSuchElementException.class, outputTopic::readRecord, "Empty topic");
     }
 
     @Test
     public void testNonExistingInputTopic() {
         final TestInputTopic<Long, String> inputTopic =
             testDriver.createInputTopic("no-exist", longSerde.serializer(), stringSerde.serializer());
-        assertThrows("Unknown topic", IllegalArgumentException.class, () -> inputTopic.pipeInput(1L, "Hello"));
+        assertThrows(IllegalArgumentException.class, () -> inputTopic.pipeInput(1L, "Hello"), "Unknown topic");
     }
 
     @Test

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverAtLeastOnceTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverAtLeastOnceTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams;
+
+import java.util.Collections;
+
+public class TopologyTestDriverAtLeastOnceTest extends TopologyTestDriverTest {
+    TopologyTestDriverAtLeastOnceTest() {
+        super(Collections.singletonMap(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE));
+    }
+}

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverEosTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverEosTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams;
+
+import java.util.Collections;
+
+public class TopologyTestDriverEosTest extends TopologyTestDriverTest {
+    TopologyTestDriverEosTest() {
+        super(Collections.singletonMap(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE));
+    }
+}

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -96,7 +96,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TopologyTestDriverTest {
 
     private enum EosMode {
-        ENABLED, DISABLED
+        EOS_ENABLED, EOS_DISABLED
     }
 
     private final static String SOURCE_TOPIC_1 = "source-topic-1";
@@ -138,7 +138,7 @@ public class TopologyTestDriverTest {
             mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
             mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
         ));
-        if (mode == EosMode.ENABLED) {
+        if (mode == EosMode.EOS_ENABLED) {
             config.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
         }
     }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -135,8 +135,8 @@ public class TopologyTestDriverTest {
 
     private void setProperties(final EosMode mode) {
         config = mkProperties(mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
+            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
         ));
         if (mode == EosMode.ENABLED) {
             config.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -59,6 +59,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -76,6 +79,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
@@ -95,6 +99,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+/**
+ * the test case in TopologyTestDriverTest must obey following rules.
+ * 1) the method name must starts with "should"
+ * 2) the method modifier must be private
+ * 3) the method can't take any arguments
+ * 
+ * Junit 5 does not support to add "parameters" at class level. Hence, we call test method dynamically to avoid adding
+ * ParameterizedTest and MethodSource to each test method. We all hate duplicate code :)
+ * see {@link TopologyTestDriverTest#test} for more details
+ */
 public class TopologyTestDriverTest {
     private final static String SOURCE_TOPIC_1 = "source-topic-1";
     private final static String SOURCE_TOPIC_2 = "source-topic-2";
@@ -131,17 +145,15 @@ public class TopologyTestDriverTest {
     private final LongDeserializer longDeserializer = new LongDeserializer();
 
     public static Stream<Arguments> parameters() {
-        return Stream.of(true, false).map(Arguments::of);
-    }
-
-    private void setProperties(final boolean eosEnabled) {
-        config = mkProperties(mkMap(
-                mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
-                mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
-        ));
-        if (eosEnabled) {
-            config.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
-        }
+        final List<Arguments> params = new ArrayList<>();
+        Arrays.stream(TopologyTestDriverTest.class.getDeclaredMethods())
+                .filter(m -> m.getParameterCount() == 0
+                        && Modifier.isPrivate(m.getModifiers())
+                        && m.getName().startsWith("should"))
+                .map(Method::getName)
+                .collect(Collectors.toSet()).forEach(methodName -> Arrays.asList(true, false).forEach(enableEof ->
+                params.add(Arguments.of(enableEof, methodName))));
+        return params.stream();
     }
 
     private final static class TTDTestRecord {
@@ -442,25 +454,33 @@ public class TopologyTestDriverTest {
         return builder.build(config);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldNotRequireParameters(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    @ParameterizedTest(name = "eosEnabled = {0}, methodName = {1}")
+    @MethodSource(value = "parameters")
+    public void test(final boolean eosEnabled, final String methodName) throws InvocationTargetException, IllegalAccessException {
+        config = mkProperties(mkMap(
+            mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
+            mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
+        ));
+        if (eosEnabled) config.setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE);
+
+        // run specify test
+        Arrays.stream(TopologyTestDriverTest.class.getDeclaredMethods())
+                .filter(m -> m.getName().equals(methodName))
+                .findAny()
+                .get()
+                .invoke(this);
+    }
+
+    private void shouldNotRequireParameters() {
         new TopologyTestDriver(setupSingleProcessorTopology(), new Properties());
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldInitProcessor(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldInitProcessor() {
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
         assertTrue(mockProcessors.get(0).initialized);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldCloseProcessor(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldCloseProcessor() {
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
 
         testDriver.close();
@@ -469,10 +489,7 @@ public class TopologyTestDriverTest {
         testDriver = null;
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowForUnknownTopic(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowForUnknownTopic() {
         testDriver = new TopologyTestDriver(new Topology());
         assertThrows(
             IllegalArgumentException.class,
@@ -485,10 +502,7 @@ public class TopologyTestDriverTest {
         );
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowForMissingTime(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowForMissingTime() {
         testDriver = new TopologyTestDriver(new Topology());
         assertThrows(
             IllegalStateException.class,
@@ -501,10 +515,7 @@ public class TopologyTestDriverTest {
     }
 
     @Deprecated
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowForUnknownTopicDeprecated(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowForUnknownTopicDeprecated() {
         final String unknownTopic = "unknownTopic";
         final org.apache.kafka.streams.test.ConsumerRecordFactory<byte[], byte[]> consumerRecordFactory =
             new org.apache.kafka.streams.test.ConsumerRecordFactory<>(
@@ -521,10 +532,7 @@ public class TopologyTestDriverTest {
         }
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowNoSuchElementExceptionForUnusedOutputTopicWithDynamicRouting(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowNoSuchElementExceptionForUnusedOutputTopicWithDynamicRouting() {
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
         final TestOutputTopic<String, String> outputTopic = new TestOutputTopic<>(
             testDriver,
@@ -537,10 +545,7 @@ public class TopologyTestDriverTest {
         assertThrows(NoSuchElementException.class, outputTopic::readRecord);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldCaptureSinkTopicNamesIfWrittenInto(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldCaptureSinkTopicNamesIfWrittenInto() {
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
 
         assertThat(testDriver.producedTopicNames(), is(Collections.emptySet()));
@@ -549,10 +554,7 @@ public class TopologyTestDriverTest {
         assertThat(testDriver.producedTopicNames(), hasItem(SINK_TOPIC_1));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldCaptureInternalTopicNamesIfWrittenInto(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldCaptureInternalTopicNamesIfWrittenInto() {
         testDriver = new TopologyTestDriver(
             setupTopologyWithInternalTopic("table1", "table2", "join"),
             config
@@ -583,10 +585,7 @@ public class TopologyTestDriverTest {
         );
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldCaptureGlobalTopicNameIfWrittenInto(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldCaptureGlobalTopicNameIfWrittenInto() {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.globalTable(SOURCE_TOPIC_1, Materialized.as("globalTable"));
         builder.stream(SOURCE_TOPIC_2).to(SOURCE_TOPIC_1);
@@ -602,10 +601,7 @@ public class TopologyTestDriverTest {
         );
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldProcessRecordForTopic(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldProcessRecordForTopic() {
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
@@ -616,10 +612,7 @@ public class TopologyTestDriverTest {
         assertEquals(SINK_TOPIC_1, outputRecord.topic());
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldSetRecordMetadata(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldSetRecordMetadata() {
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology());
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
@@ -640,10 +633,7 @@ public class TopologyTestDriverTest {
 
     @Deprecated
     //Test not migrated to non-deprecated methods, topic handling not based on record any more
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldSendRecordViaCorrectSourceTopicDeprecated(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldSendRecordViaCorrectSourceTopicDeprecated() {
         testDriver = new TopologyTestDriver(setupMultipleSourceTopology(SOURCE_TOPIC_1, SOURCE_TOPIC_2));
 
         final List<TTDTestRecord> processedRecords1 = mockProcessors.get(0).processedRecords;
@@ -669,10 +659,7 @@ public class TopologyTestDriverTest {
     }
 
     @Deprecated
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldUseSourceSpecificDeserializersDeprecated(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldUseSourceSpecificDeserializersDeprecated() {
         final Topology topology = new Topology();
 
         final String sourceName1 = "source-1";
@@ -733,10 +720,7 @@ public class TopologyTestDriverTest {
         assertThat(record2.value(), equalTo(source2Value));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldUseSourceSpecificDeserializers(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldUseSourceSpecificDeserializers() {
         final Topology topology = new Topology();
 
         final String sourceName1 = "source-1";
@@ -794,10 +778,7 @@ public class TopologyTestDriverTest {
         assertThat(result2.getValue(), equalTo(source2Value));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPassRecordHeadersIntoSerializersAndDeserializers(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPassRecordHeadersIntoSerializersAndDeserializers() {
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
 
         final AtomicBoolean passedHeadersToKeySerializer = new AtomicBoolean(false);
@@ -846,10 +827,7 @@ public class TopologyTestDriverTest {
         assertThat(passedHeadersToValueDeserializer.get(), equalTo(true));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldUseSinkSpecificSerializers(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldUseSinkSpecificSerializers() {
         final Topology topology = new Topology();
 
         final String sourceName1 = "source-1";
@@ -893,10 +871,7 @@ public class TopologyTestDriverTest {
 
     @Deprecated
     //Test not migrated to non-deprecated methods, List processing now in TestInputTopic
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldProcessConsumerRecordList(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldProcessConsumerRecordList() {
         testDriver = new TopologyTestDriver(setupMultipleSourceTopology(SOURCE_TOPIC_1, SOURCE_TOPIC_2));
 
         final List<TTDTestRecord> processedRecords1 = mockProcessors.get(0).processedRecords;
@@ -920,10 +895,7 @@ public class TopologyTestDriverTest {
         assertThat(record, equalTo(expectedResult));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldForwardRecordsFromSubtopologyToSubtopology(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldForwardRecordsFromSubtopologyToSubtopology() {
         testDriver = new TopologyTestDriver(setupTopologyWithTwoSubtopologies());
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
@@ -939,10 +911,7 @@ public class TopologyTestDriverTest {
         assertEquals(SINK_TOPIC_2, outputRecord.topic());
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPopulateGlobalStore(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPopulateGlobalStore() {
         testDriver = new TopologyTestDriver(setupGlobalStoreTopology(SOURCE_TOPIC_1));
 
         final KeyValueStore<byte[], byte[]> globalStore = testDriver.getKeyValueStore(SOURCE_TOPIC_1 + "-globalStore");
@@ -954,10 +923,7 @@ public class TopologyTestDriverTest {
         assertThat(globalStore.get(testRecord1.key()), is(testRecord1.value()));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPunctuateOnStreamsTime(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPunctuateOnStreamsTime() {
         final MockPunctuator mockPunctuator = new MockPunctuator();
         testDriver = new TopologyTestDriver(
             setupSingleProcessorTopology(10L, PunctuationType.STREAM_TIME, mockPunctuator)
@@ -1007,10 +973,7 @@ public class TopologyTestDriverTest {
 
     @SuppressWarnings("deprecation")
     //Testing already deprecatd methods until methods removed
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPunctuateOnWallClockTimeDeprecated(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPunctuateOnWallClockTimeDeprecated() {
         final MockPunctuator mockPunctuator = new MockPunctuator();
         testDriver = new TopologyTestDriver(
             setupSingleProcessorTopology(10L, PunctuationType.WALL_CLOCK_TIME, mockPunctuator),
@@ -1038,10 +1001,7 @@ public class TopologyTestDriverTest {
         assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPunctuateOnWallClockTime(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPunctuateOnWallClockTime() {
         final MockPunctuator mockPunctuator = new MockPunctuator();
         testDriver = new TopologyTestDriver(
             setupSingleProcessorTopology(10L, PunctuationType.WALL_CLOCK_TIME, mockPunctuator),
@@ -1068,10 +1028,7 @@ public class TopologyTestDriverTest {
         assertThat(mockPunctuator.punctuatedAt, equalTo(expectedPunctuations));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldReturnAllStores(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldReturnAllStores() {
         final Topology topology = setupSourceSinkTopology();
         topology.addProcessor("processor", new MockProcessorSupplier(), "source");
         topology.addStateStore(
@@ -1106,17 +1063,11 @@ public class TopologyTestDriverTest {
         }
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldReturnCorrectPersistentStoreTypeOnly(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldReturnCorrectPersistentStoreTypeOnly() {
         shouldReturnCorrectStoreTypeOnly(true);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldReturnCorrectInMemoryStoreTypeOnly(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldReturnCorrectInMemoryStoreTypeOnly() {
         shouldReturnCorrectStoreTypeOnly(false);
     }
 
@@ -1189,17 +1140,11 @@ public class TopologyTestDriverTest {
         assertNull(testDriver.getSessionStore(globalTimestampedKeyValueStoreName));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowIfInMemoryBuiltInStoreIsAccessedWithUntypedMethod(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowIfInMemoryBuiltInStoreIsAccessedWithUntypedMethod() {
         shouldThrowIfBuiltInStoreIsAccessedWithUntypedMethod(false);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowIfPersistentBuiltInStoreIsAccessedWithUntypedMethod(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowIfPersistentBuiltInStoreIsAccessedWithUntypedMethod() {
         shouldThrowIfBuiltInStoreIsAccessedWithUntypedMethod(true);
     }
 
@@ -1395,10 +1340,7 @@ public class TopologyTestDriverTest {
             voidProcessorSupplier);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldReturnAllStoresNames(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldReturnAllStoresNames() {
         final Topology topology = setupSourceSinkTopology();
         topology.addStateStore(
             new KeyValueStoreBuilder<>(
@@ -1460,20 +1402,14 @@ public class TopologyTestDriverTest {
         assertThat(record.getValue(), equalTo(value));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldFlushStoreForFirstInput(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldFlushStoreForFirstInput() {
         setup();
         pipeInput("input-topic", "a", 1L, 9999L);
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "a", 21L);
         assertTrue(testDriver.isEmpty("result-topic"));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldNotUpdateStoreForSmallerValue(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldNotUpdateStoreForSmallerValue() {
         setup();
         pipeInput("input-topic", "a", 1L, 9999L);
         assertThat(store.get("a"), equalTo(21L));
@@ -1481,10 +1417,7 @@ public class TopologyTestDriverTest {
         assertTrue(testDriver.isEmpty("result-topic"));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldNotUpdateStoreForLargerValue(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldNotUpdateStoreForLargerValue() {
         setup();
         pipeInput("input-topic", "a", 42L, 9999L);
         assertThat(store.get("a"), equalTo(42L));
@@ -1492,10 +1425,7 @@ public class TopologyTestDriverTest {
         assertTrue(testDriver.isEmpty("result-topic"));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldUpdateStoreForNewKey(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldUpdateStoreForNewKey() {
         setup();
         pipeInput("input-topic", "b", 21L, 9999L);
         assertThat(store.get("b"), equalTo(21L));
@@ -1504,10 +1434,7 @@ public class TopologyTestDriverTest {
         assertTrue(testDriver.isEmpty("result-topic"));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPunctuateIfEvenTimeAdvances(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPunctuateIfEvenTimeAdvances() {
         setup();
         pipeInput("input-topic", "a", 1L, 9999L);
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "a", 21L);
@@ -1520,10 +1447,7 @@ public class TopologyTestDriverTest {
         assertTrue(testDriver.isEmpty("result-topic"));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldPunctuateIfWallClockTimeAdvances(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldPunctuateIfWallClockTimeAdvances() {
         setup();
         testDriver.advanceWallClockTime(Duration.ofMillis(60000));
         compareKeyValue(testDriver.readRecord("result-topic", stringDeserializer, longDeserializer), "a", 21L);
@@ -1568,10 +1492,7 @@ public class TopologyTestDriverTest {
         }
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldAllowPrePopulatingStatesStoresWithCachingEnabled(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldAllowPrePopulatingStatesStoresWithCachingEnabled() {
         final Topology topology = new Topology();
         topology.addSource("sourceProcessor", "input-topic");
         topology.addProcessor("aggregator", new CustomMaxAggregatorSupplier(), "sourceProcessor");
@@ -1587,10 +1508,7 @@ public class TopologyTestDriverTest {
         store.put("a", 21L);
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldCleanUpPersistentStateStoresOnClose(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldCleanUpPersistentStateStoresOnClose() {
         final Topology topology = new Topology();
         topology.addSource("sourceProcessor", "input-topic");
         topology.addProcessor(
@@ -1643,10 +1561,7 @@ public class TopologyTestDriverTest {
 
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldFeedStoreFromGlobalKTable(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldFeedStoreFromGlobalKTable() {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.globalTable("topic",
             Consumed.with(Serdes.String(), Serdes.String()),
@@ -1682,11 +1597,7 @@ public class TopologyTestDriverTest {
         return topology;
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldProcessFromSourcesThatMatchMultiplePattern(final boolean eosEnabled) {
-        setProperties(eosEnabled);
-
+    private void shouldProcessFromSourcesThatMatchMultiplePattern() {
         final  Pattern pattern2Source1 = Pattern.compile("source-topic-\\d");
         final  Pattern pattern2Source2 = Pattern.compile("source-topic-[A-Z]");
         final  String consumerTopic2 = "source-topic-Z";
@@ -1717,10 +1628,7 @@ public class TopologyTestDriverTest {
         assertThat(record2, equalTo(expectedResult2));
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldProcessFromSourceThatMatchPattern(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldProcessFromSourceThatMatchPattern() {
         final String sourceName = "source";
         final Pattern pattern2Source1 = Pattern.compile("source-topic-\\d");
 
@@ -1738,10 +1646,7 @@ public class TopologyTestDriverTest {
         assertEquals(SINK_TOPIC_1, outputRecord.topic());
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldThrowPatternNotValidForTopicNameException(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldThrowPatternNotValidForTopicNameException() {
         final String sourceName = "source";
         final String pattern2Source1 = "source-topic-\\d";
 
@@ -1764,20 +1669,14 @@ public class TopologyTestDriverTest {
         }
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldNotCreateStateDirectoryForStatelessTopology(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldNotCreateStateDirectoryForStatelessTopology() {
         setup();
         final String stateDir = config.getProperty(StreamsConfig.STATE_DIR_CONFIG);
         final File appDir = new File(stateDir, config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG));
         assertFalse(appDir.exists());
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldCreateStateDirectoryForStatefulTopology(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldCreateStateDirectoryForStatefulTopology() {
         setup(Stores.persistentKeyValueStore("aggStore"));
         final String stateDir = config.getProperty(StreamsConfig.STATE_DIR_CONFIG);
         final File appDir = new File(stateDir, config.getProperty(StreamsConfig.APPLICATION_ID_CONFIG));
@@ -1789,10 +1688,7 @@ public class TopologyTestDriverTest {
         assertTrue(new File(appDir, taskId.toString()).exists());
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldEnqueueLaterOutputsAfterEarlierOnes(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldEnqueueLaterOutputsAfterEarlierOnes() {
         final Topology topology = new Topology();
         topology.addSource("source", new StringDeserializer(), new StringDeserializer(), "input");
         topology.addProcessor(
@@ -1839,10 +1735,7 @@ public class TopologyTestDriverTest {
         }
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldApplyGlobalUpdatesCorrectlyInRecursiveTopologies(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldApplyGlobalUpdatesCorrectlyInRecursiveTopologies() {
         final Topology topology = new Topology();
         topology.addSource("source", new StringDeserializer(), new StringDeserializer(), "input");
         topology.addGlobalStore(
@@ -1916,10 +1809,7 @@ public class TopologyTestDriverTest {
         }
     }
 
-    @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
-    public void shouldRespectTaskIdling(final boolean eosEnabled) {
-        setProperties(eosEnabled);
+    private void shouldRespectTaskIdling() {
         final Properties properties = new Properties();
         // This is the key to this test. Wall-clock time doesn't advance automatically in TopologyTestDriver,
         // so with an idle time specified, TTD can't just expect all enqueued records to be processable.

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -875,10 +875,8 @@ public abstract class TopologyTestDriverTest {
         assertThat(record, equalTo(expectedResult));
     }
 
-    
     @Test
     public void shouldForwardRecordsFromSubtopologyToSubtopology() {
-        
         testDriver = new TopologyTestDriver(setupTopologyWithTwoSubtopologies());
 
         pipeRecord(SOURCE_TOPIC_1, testRecord1);
@@ -1554,10 +1552,8 @@ public abstract class TopologyTestDriverTest {
 
 
         try (final TopologyTestDriver testDriver = new TopologyTestDriver(topology, config)) {
-            assertNull(
-                testDriver.getKeyValueStore("storeProcessorStore").get("a"),
-                "Closing the prior test driver should have cleaned up this store and value."
-            );
+            assertNull(testDriver.getKeyValueStore("storeProcessorStore").get("a"),
+                    "Closing the prior test driver should have cleaned up this store and value.");
         }
 
     }
@@ -1601,6 +1597,7 @@ public abstract class TopologyTestDriverTest {
 
     @Test
     public void shouldProcessFromSourcesThatMatchMultiplePattern() {
+
         final  Pattern pattern2Source1 = Pattern.compile("source-topic-\\d");
         final  Pattern pattern2Source2 = Pattern.compile("source-topic-[A-Z]");
         final  String consumerTopic2 = "source-topic-Z";

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -55,8 +55,7 @@ import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.time.Duration;
@@ -76,7 +75,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -129,10 +127,6 @@ public class TopologyTestDriverTest {
 
     private final StringDeserializer stringDeserializer = new StringDeserializer();
     private final LongDeserializer longDeserializer = new LongDeserializer();
-
-    public static Stream<Arguments> parameters() {
-        return Stream.of(true, false).map(Arguments::of);
-    }
 
     private void setProperties(final boolean eosEnabled) {
         config = mkProperties(mkMap(
@@ -443,14 +437,14 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldNotRequireParameters(final boolean eosEnabled) {
         setProperties(eosEnabled);
         new TopologyTestDriver(setupSingleProcessorTopology(), new Properties());
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldInitProcessor(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
@@ -458,7 +452,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldCloseProcessor(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
@@ -470,7 +464,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowForUnknownTopic(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(new Topology());
@@ -486,7 +480,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowForMissingTime(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(new Topology());
@@ -502,7 +496,7 @@ public class TopologyTestDriverTest {
 
     @Deprecated
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowForUnknownTopicDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final String unknownTopic = "unknownTopic";
@@ -522,7 +516,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowNoSuchElementExceptionForUnusedOutputTopicWithDynamicRouting(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -538,7 +532,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldCaptureSinkTopicNamesIfWrittenInto(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -550,7 +544,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldCaptureInternalTopicNamesIfWrittenInto(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(
@@ -584,7 +578,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldCaptureGlobalTopicNameIfWrittenInto(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -603,7 +597,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldProcessRecordForTopic(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -617,7 +611,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldSetRecordMetadata(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology());
@@ -641,7 +635,7 @@ public class TopologyTestDriverTest {
     @Deprecated
     //Test not migrated to non-deprecated methods, topic handling not based on record any more
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldSendRecordViaCorrectSourceTopicDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupMultipleSourceTopology(SOURCE_TOPIC_1, SOURCE_TOPIC_2));
@@ -670,7 +664,7 @@ public class TopologyTestDriverTest {
 
     @Deprecated
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldUseSourceSpecificDeserializersDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -734,7 +728,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldUseSourceSpecificDeserializers(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -795,7 +789,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPassRecordHeadersIntoSerializersAndDeserializers(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -847,7 +841,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldUseSinkSpecificSerializers(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -894,7 +888,7 @@ public class TopologyTestDriverTest {
     @Deprecated
     //Test not migrated to non-deprecated methods, List processing now in TestInputTopic
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldProcessConsumerRecordList(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupMultipleSourceTopology(SOURCE_TOPIC_1, SOURCE_TOPIC_2));
@@ -921,7 +915,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldForwardRecordsFromSubtopologyToSubtopology(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupTopologyWithTwoSubtopologies());
@@ -940,7 +934,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPopulateGlobalStore(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupGlobalStoreTopology(SOURCE_TOPIC_1));
@@ -955,7 +949,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPunctuateOnStreamsTime(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final MockPunctuator mockPunctuator = new MockPunctuator();
@@ -1008,7 +1002,7 @@ public class TopologyTestDriverTest {
     @SuppressWarnings("deprecation")
     //Testing already deprecatd methods until methods removed
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPunctuateOnWallClockTimeDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final MockPunctuator mockPunctuator = new MockPunctuator();
@@ -1039,7 +1033,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPunctuateOnWallClockTime(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final MockPunctuator mockPunctuator = new MockPunctuator();
@@ -1069,7 +1063,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldReturnAllStores(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = setupSourceSinkTopology();
@@ -1107,14 +1101,14 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldReturnCorrectPersistentStoreTypeOnly(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldReturnCorrectStoreTypeOnly(true);
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldReturnCorrectInMemoryStoreTypeOnly(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldReturnCorrectStoreTypeOnly(false);
@@ -1190,14 +1184,14 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowIfInMemoryBuiltInStoreIsAccessedWithUntypedMethod(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldThrowIfBuiltInStoreIsAccessedWithUntypedMethod(false);
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowIfPersistentBuiltInStoreIsAccessedWithUntypedMethod(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldThrowIfBuiltInStoreIsAccessedWithUntypedMethod(true);
@@ -1396,7 +1390,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldReturnAllStoresNames(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = setupSourceSinkTopology();
@@ -1461,7 +1455,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldFlushStoreForFirstInput(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1471,7 +1465,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldNotUpdateStoreForSmallerValue(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1482,7 +1476,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldNotUpdateStoreForLargerValue(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1493,7 +1487,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldUpdateStoreForNewKey(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1505,7 +1499,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPunctuateIfEvenTimeAdvances(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1521,7 +1515,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldPunctuateIfWallClockTimeAdvances(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1569,7 +1563,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldAllowPrePopulatingStatesStoresWithCachingEnabled(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1588,7 +1582,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldCleanUpPersistentStateStoresOnClose(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1644,7 +1638,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldFeedStoreFromGlobalKTable(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1683,7 +1677,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldProcessFromSourcesThatMatchMultiplePattern(final boolean eosEnabled) {
         setProperties(eosEnabled);
 
@@ -1718,7 +1712,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldProcessFromSourceThatMatchPattern(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final String sourceName = "source";
@@ -1739,7 +1733,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldThrowPatternNotValidForTopicNameException(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final String sourceName = "source";
@@ -1765,7 +1759,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldNotCreateStateDirectoryForStatelessTopology(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1775,7 +1769,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldCreateStateDirectoryForStatefulTopology(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup(Stores.persistentKeyValueStore("aggStore"));
@@ -1790,7 +1784,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldEnqueueLaterOutputsAfterEarlierOnes(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1840,7 +1834,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldApplyGlobalUpdatesCorrectlyInRecursiveTopologies(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1917,7 +1911,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @MethodSource("parameters")
+    @ValueSource(booleans = {true, false})
     public void shouldRespectTaskIdling(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Properties properties = new Properties();

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -55,7 +55,8 @@ import org.apache.kafka.streams.test.TestRecord;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.time.Duration;
@@ -75,6 +76,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
@@ -127,6 +129,10 @@ public class TopologyTestDriverTest {
 
     private final StringDeserializer stringDeserializer = new StringDeserializer();
     private final LongDeserializer longDeserializer = new LongDeserializer();
+
+    public static Stream<Arguments> parameters() {
+        return Stream.of(true, false).map(Arguments::of);
+    }
 
     private void setProperties(final boolean eosEnabled) {
         config = mkProperties(mkMap(
@@ -437,14 +443,14 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldNotRequireParameters(final boolean eosEnabled) {
         setProperties(eosEnabled);
         new TopologyTestDriver(setupSingleProcessorTopology(), new Properties());
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldInitProcessor(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
@@ -452,7 +458,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldCloseProcessor(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology(), config);
@@ -464,7 +470,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowForUnknownTopic(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(new Topology());
@@ -480,7 +486,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowForMissingTime(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(new Topology());
@@ -496,7 +502,7 @@ public class TopologyTestDriverTest {
 
     @Deprecated
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowForUnknownTopicDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final String unknownTopic = "unknownTopic";
@@ -516,7 +522,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowNoSuchElementExceptionForUnusedOutputTopicWithDynamicRouting(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -532,7 +538,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldCaptureSinkTopicNamesIfWrittenInto(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -544,7 +550,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldCaptureInternalTopicNamesIfWrittenInto(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(
@@ -578,7 +584,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldCaptureGlobalTopicNameIfWrittenInto(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -597,7 +603,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldProcessRecordForTopic(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -611,7 +617,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldSetRecordMetadata(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSingleProcessorTopology());
@@ -635,7 +641,7 @@ public class TopologyTestDriverTest {
     @Deprecated
     //Test not migrated to non-deprecated methods, topic handling not based on record any more
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldSendRecordViaCorrectSourceTopicDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupMultipleSourceTopology(SOURCE_TOPIC_1, SOURCE_TOPIC_2));
@@ -664,7 +670,7 @@ public class TopologyTestDriverTest {
 
     @Deprecated
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldUseSourceSpecificDeserializersDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -728,7 +734,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldUseSourceSpecificDeserializers(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -789,7 +795,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPassRecordHeadersIntoSerializersAndDeserializers(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupSourceSinkTopology());
@@ -841,7 +847,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldUseSinkSpecificSerializers(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -888,7 +894,7 @@ public class TopologyTestDriverTest {
     @Deprecated
     //Test not migrated to non-deprecated methods, List processing now in TestInputTopic
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldProcessConsumerRecordList(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupMultipleSourceTopology(SOURCE_TOPIC_1, SOURCE_TOPIC_2));
@@ -915,7 +921,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldForwardRecordsFromSubtopologyToSubtopology(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupTopologyWithTwoSubtopologies());
@@ -934,7 +940,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPopulateGlobalStore(final boolean eosEnabled) {
         setProperties(eosEnabled);
         testDriver = new TopologyTestDriver(setupGlobalStoreTopology(SOURCE_TOPIC_1));
@@ -949,7 +955,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPunctuateOnStreamsTime(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final MockPunctuator mockPunctuator = new MockPunctuator();
@@ -1002,7 +1008,7 @@ public class TopologyTestDriverTest {
     @SuppressWarnings("deprecation")
     //Testing already deprecatd methods until methods removed
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPunctuateOnWallClockTimeDeprecated(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final MockPunctuator mockPunctuator = new MockPunctuator();
@@ -1033,7 +1039,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPunctuateOnWallClockTime(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final MockPunctuator mockPunctuator = new MockPunctuator();
@@ -1063,7 +1069,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldReturnAllStores(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = setupSourceSinkTopology();
@@ -1101,14 +1107,14 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldReturnCorrectPersistentStoreTypeOnly(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldReturnCorrectStoreTypeOnly(true);
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldReturnCorrectInMemoryStoreTypeOnly(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldReturnCorrectStoreTypeOnly(false);
@@ -1184,14 +1190,14 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowIfInMemoryBuiltInStoreIsAccessedWithUntypedMethod(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldThrowIfBuiltInStoreIsAccessedWithUntypedMethod(false);
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowIfPersistentBuiltInStoreIsAccessedWithUntypedMethod(final boolean eosEnabled) {
         setProperties(eosEnabled);
         shouldThrowIfBuiltInStoreIsAccessedWithUntypedMethod(true);
@@ -1390,7 +1396,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldReturnAllStoresNames(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = setupSourceSinkTopology();
@@ -1455,7 +1461,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldFlushStoreForFirstInput(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1465,7 +1471,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldNotUpdateStoreForSmallerValue(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1476,7 +1482,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldNotUpdateStoreForLargerValue(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1487,7 +1493,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldUpdateStoreForNewKey(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1499,7 +1505,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPunctuateIfEvenTimeAdvances(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1515,7 +1521,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldPunctuateIfWallClockTimeAdvances(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1563,7 +1569,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldAllowPrePopulatingStatesStoresWithCachingEnabled(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1582,7 +1588,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldCleanUpPersistentStateStoresOnClose(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1638,7 +1644,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldFeedStoreFromGlobalKTable(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final StreamsBuilder builder = new StreamsBuilder();
@@ -1677,7 +1683,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldProcessFromSourcesThatMatchMultiplePattern(final boolean eosEnabled) {
         setProperties(eosEnabled);
 
@@ -1712,7 +1718,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldProcessFromSourceThatMatchPattern(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final String sourceName = "source";
@@ -1733,7 +1739,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldThrowPatternNotValidForTopicNameException(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final String sourceName = "source";
@@ -1759,7 +1765,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldNotCreateStateDirectoryForStatelessTopology(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup();
@@ -1769,7 +1775,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldCreateStateDirectoryForStatefulTopology(final boolean eosEnabled) {
         setProperties(eosEnabled);
         setup(Stores.persistentKeyValueStore("aggStore"));
@@ -1784,7 +1790,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldEnqueueLaterOutputsAfterEarlierOnes(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1834,7 +1840,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldApplyGlobalUpdatesCorrectlyInRecursiveTopologies(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Topology topology = new Topology();
@@ -1911,7 +1917,7 @@ public class TopologyTestDriverTest {
     }
 
     @ParameterizedTest(name = "Eos enabled = {0}")
-    @ValueSource(booleans = {true, false})
+    @MethodSource("parameters")
     public void shouldRespectTaskIdling(final boolean eosEnabled) {
         setProperties(eosEnabled);
         final Properties properties = new Properties();

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/internals/KeyValueStoreFacadeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/internals/KeyValueStoreFacadeTest.java
@@ -21,14 +21,11 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
 import static org.easymock.EasyMock.expect;
@@ -38,18 +35,14 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-@RunWith(EasyMockRunner.class)
 public class KeyValueStoreFacadeTest {
-    @Mock
-    private TimestampedKeyValueStore<String, String> mockedKeyValueTimestampStore;
-    @Mock
-    private KeyValueIterator<String, ValueAndTimestamp<String>> mockedKeyValueTimestampIterator;
+    private final TimestampedKeyValueStore<String, String> mockedKeyValueTimestampStore = EasyMock.mock(TimestampedKeyValueStore.class);
 
     private KeyValueStoreFacade<String, String> keyValueStoreFacade;
 
-    @Before
+    @BeforeEach
     public void setup() {
         keyValueStoreFacade = new KeyValueStoreFacade<>(mockedKeyValueTimestampStore);
     }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/internals/WindowStoreFacadeTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/internals/WindowStoreFacadeTest.java
@@ -22,11 +22,9 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
-import org.easymock.EasyMockRunner;
-import org.easymock.Mock;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
@@ -36,14 +34,12 @@ import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@RunWith(EasyMockRunner.class)
 public class WindowStoreFacadeTest {
-    @Mock
-    private TimestampedWindowStore<String, String> mockedWindowTimestampStore;
+    private final TimestampedWindowStore<String, String> mockedWindowTimestampStore = EasyMock.mock(TimestampedWindowStore.class);
 
     private WindowStoreFacade<String, String> windowStoreFacade;
 
-    @Before
+    @BeforeEach
     public void setup() {
         windowStoreFacade = new WindowStoreFacade<>(mockedWindowTimestampStore);
     }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java
@@ -21,15 +21,15 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Deprecated
 public class ConsumerRecordFactoryTest {

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextAPITest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextAPITest.java
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.processor.api.RecordMetadata;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.time.Duration;

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/MockProcessorContextStateStoreTest.java
@@ -31,36 +31,30 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(value = Parameterized.class)
 public class MockProcessorContextStateStoreTest {
-    private final StoreBuilder<StateStore> builder;
-    private final boolean timestamped;
-    private final boolean caching;
-    private final boolean logging;
 
-    @Parameterized.Parameters(name = "builder = {0}, timestamped = {1}, caching = {2}, logging = {3}")
-    public static Collection<Object[]> data() {
+    public static Stream<Arguments> parameters() {
         final List<Boolean> booleans = asList(true, false);
 
-        final List<Object[]> values = new ArrayList<>();
+        final List<Arguments> values = new ArrayList<>();
 
         for (final Boolean timestamped : booleans) {
             for (final Boolean caching : booleans) {
@@ -88,7 +82,7 @@ public class MockProcessorContextStateStoreTest {
                             builder.withLoggingDisabled();
                         }
 
-                        values.add(new Object[] {builder, timestamped, caching, logging});
+                        values.add(Arguments.of(builder, timestamped, caching, logging));
                     }
                 }
             }
@@ -121,7 +115,7 @@ public class MockProcessorContextStateStoreTest {
                             builder.withLoggingDisabled();
                         }
 
-                        values.add(new Object[] {builder, timestamped, caching, logging});
+                        values.add(Arguments.of(builder, timestamped, caching, logging));
                     }
                 }
             }
@@ -148,27 +142,20 @@ public class MockProcessorContextStateStoreTest {
                         builder.withLoggingDisabled();
                     }
 
-                    values.add(new Object[] {builder, false, caching, logging});
+                    values.add(Arguments.of(builder, false, caching, logging));
                 }
             }
         }
 
-        return values;
+        return values.stream();
     }
 
-    public MockProcessorContextStateStoreTest(final StoreBuilder<StateStore> builder,
-                                              final boolean timestamped,
-                                              final boolean caching,
-                                              final boolean logging) {
-
-        this.builder = builder;
-        this.timestamped = timestamped;
-        this.caching = caching;
-        this.logging = logging;
-    }
-
-    @Test
-    public void shouldEitherInitOrThrow() {
+    @ParameterizedTest(name = "builder = {0}, timestamped = {1}, caching = {2}, logging = {3}")
+    @MethodSource(value = "parameters")
+    public void shouldEitherInitOrThrow(final StoreBuilder<StateStore> builder,
+                                        final boolean timestamped,
+                                        final boolean caching,
+                                        final boolean logging) {
         final File stateDir = TestUtils.tempDirectory();
         try {
             final MockProcessorContext<Void, Void> context = new MockProcessorContext<>(

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/OutputVerifierTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.streams.test;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Deprecated
 public class OutputVerifierTest {

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
@@ -31,9 +31,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestRecordTest {
     private final String key = "testKey";

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/KAFKA-12171

1. replace ```org.junit.Assert``` by ```org.junit.jupiter.api.Assertions``` 
1. replace ```org.junit``` by ```org.junit.jupiter.api``` 
1. replace ```org.junit.runners.Parameterized``` by ```org.junit.jupiter.params.ParameterizedTest```
1. replace ```org.junit.runners.Parameterized.Parameters``` by ```org.junit.jupiter.params.provider.{Arguments, MethodSource}```
1. replace ```Before``` by ```BeforeEach```
1. replace ```After``` by ```AfterEach``` 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
