### PR TITLE
MINOR: Fix error message in SnapshotWriter.java

### DIFF
--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -107,8 +107,8 @@ final public class SnapshotWriter<T> implements Closeable {
     public void append(List<T> records) throws IOException {
         if (snapshot.isFrozen()) {
             String message = String.format(
-                "Append not supported. Snapshot is already frozen: id = {%s}.",
-                snapshot.snapshotId().toString()
+                "Append not supported. Snapshot is already frozen: id = '%s'.",
+                snapshot.snapshotId()
             );
 
             throw new IllegalStateException(message);

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -107,7 +107,7 @@ final public class SnapshotWriter<T> implements Closeable {
     public void append(List<T> records) throws IOException {
         if (snapshot.isFrozen()) {
             String message = String.format(
-                "Append not supported. Snapshot is already frozen: id = {}.",
+                "Append not supported. Snapshot is already frozen: id = {%s}.",
                 snapshot.snapshotId()
             );
 

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -108,7 +108,7 @@ final public class SnapshotWriter<T> implements Closeable {
         if (snapshot.isFrozen()) {
             String message = String.format(
                 "Append not supported. Snapshot is already frozen: id = {%s}.",
-                snapshot.snapshotId()
+                snapshot.snapshotId().toString()
             );
 
             throw new IllegalStateException(message);


### PR DESCRIPTION
before
```
            String message = String.format(
                "Append not supported. Snapshot is already frozen: id = {}.",
                snapshot.snapshotId()
            );
```

after
```
            String message = String.format(
                "Append not supported. Snapshot is already frozen: id = '%s'.",
                snapshot.snapshotId()
            );
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
