### PR TITLE
KAFKA-7340: Migrate clients module to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,8 @@ subprojects {
     }
   }
 
-  def shouldUseJUnit5 = ["tools", "raft", "log4j-appender", "examples"].contains(it.project.name)
+  def shouldUseJUnit5 = ["clients", "examples", "log4j-appender", "raft", "tools"].contains(it.project.name)
+
   def testLoggingEvents = ["passed", "skipped", "failed"]
   def testShowStandardStreams = false
   def testExceptionFormat = 'full'
@@ -1067,8 +1068,7 @@ project(':clients') {
     jacksonDatabindConfig libs.jacksonDatabind // to publish as provided scope dependency.
 
     testCompile libs.bcpkix
-    testCompile libs.junitJupiterApi
-    testCompile libs.junitVintageEngine
+    testCompile libs.junitJupiter
     testCompile libs.mockitoCore
 
     testRuntime libs.slf4jlog4j

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -27,6 +27,7 @@
   <allow pkg="javax.management" />
   <allow pkg="org.slf4j" />
   <allow pkg="org.junit" />
+  <allow pkg="org.opentest4j" />
   <allow pkg="org.hamcrest" />
   <allow pkg="org.mockito" />
   <allow pkg="org.easymock" />

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.utils;
 
 import java.nio.BufferUnderflowException;
+import java.util.AbstractMap;
 import java.util.EnumSet;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -753,22 +754,7 @@ public final class Utils {
      * @return An entry
      */
     public static <K, V> Map.Entry<K, V> mkEntry(final K k, final V v) {
-        return new Map.Entry<K, V>() {
-            @Override
-            public K getKey() {
-                return k;
-            }
-
-            @Override
-            public V getValue() {
-                return v;
-            }
-
-            @Override
-            public V setValue(final V value) {
-                throw new UnsupportedOperationException();
-            }
-        };
+        return new AbstractMap.SimpleEntry<>(k, v);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/ApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ApiVersionsTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.clients;
 
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.record.RecordBatch;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ApiVersionsTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -63,7 +63,7 @@ public class ClientUtilsTest {
                 .collect(Collectors.toList());
         List<String> expectedHostNames = Arrays.asList("93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946");
         assertTrue(expectedHostNames.containsAll(validatedHostNames), "Unexpected addresses " + validatedHostNames);
-        validatedAddresses.forEach(address -> Assertions.assertEquals(10000, address.getPort()));
+        validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -24,11 +24,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientUtilsTest {
 
@@ -56,12 +58,12 @@ public class ClientUtilsTest {
         // With lookup of example.com, either one or two addresses are expected depending on
         // whether ipv4 and ipv6 are enabled
         List<InetSocketAddress> validatedAddresses = checkWithLookup(Arrays.asList("example.com:10000"));
-        assertTrue("Unexpected addresses " + validatedAddresses, validatedAddresses.size() >= 1);
+        assertTrue(validatedAddresses.size() >= 1, "Unexpected addresses " + validatedAddresses);
         List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)
                 .collect(Collectors.toList());
         List<String> expectedHostNames = Arrays.asList("93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946");
-        assertTrue("Unexpected addresses " + validatedHostNames, expectedHostNames.containsAll(validatedHostNames));
-        validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
+        assertTrue(expectedHostNames.containsAll(validatedHostNames), "Unexpected addresses " + validatedHostNames);
+        validatedAddresses.forEach(address -> Assertions.assertEquals(10000, address.getPort()));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.kafka.clients;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -33,8 +33,8 @@ import java.util.List;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ClusterConnectionStatesTest {
 
@@ -54,7 +54,7 @@ public class ClusterConnectionStatesTest {
 
     private ClusterConnectionStates connectionStates;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.connectionStates = new ClusterConnectionStates(
                 reconnectBackoffMs, reconnectBackoffMax,

--- a/clients/src/test/java/org/apache/kafka/clients/CommonClientConfigsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/CommonClientConfigsTest.java
@@ -19,14 +19,14 @@ package org.apache.kafka.clients;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommonClientConfigsTest {
     private static class TestConfig extends AbstractConfig {

--- a/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/FetchSessionHandlerTest.java
@@ -22,9 +22,8 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.LogContext;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,18 +38,16 @@ import java.util.TreeSet;
 
 import static org.apache.kafka.common.requests.FetchMetadata.INITIAL_EPOCH;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A unit test for FetchSessionHandler.
  */
+@Timeout(120)
 public class FetchSessionHandlerTest {
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
-
     private static final LogContext LOG_CONTEXT = new LogContext("[FetchSessionHandler]=");
 
     /**
@@ -119,10 +116,10 @@ public class FetchSessionHandlerTest {
                 fail("Element " + i + " not found.");
             }
             Map.Entry<TopicPartition, FetchRequest.PartitionData> actuaLEntry = actualIter.next();
-            assertEquals("Element " + i + " had a different TopicPartition than expected.",
-                expectedEntry.getKey(), actuaLEntry.getKey());
-            assertEquals("Element " + i + " had different PartitionData than expected.",
-                expectedEntry.getValue(), actuaLEntry.getValue());
+            assertEquals(expectedEntry.getKey(), actuaLEntry.getKey(), "Element " + i +
+                " had a different TopicPartition than expected.");
+            assertEquals(expectedEntry.getValue(), actuaLEntry.getValue(), "Element " + i +
+                " had different PartitionData than expected.");
             i++;
         }
         if (expectedIter.hasNext()) {

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -22,15 +22,15 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InFlightRequestsTest {
 
@@ -38,7 +38,7 @@ public class InFlightRequestsTest {
     private int correlationId;
     private String dest = "dest";
 
-    @Before
+    @BeforeEach
     public void setup() {
         inFlightRequests = new InFlightRequests(12);
         correlationId = 0;

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataCacheTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataCacheTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.MetadataResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,9 +32,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetadataCacheTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -38,7 +38,8 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.MockClusterResourceListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -54,12 +55,12 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.kafka.test.TestUtils.assertOptional;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetadataTest {
 
@@ -291,8 +292,8 @@ public class MetadataTest {
 
         String hostName = "www.example.com";
         metadata.bootstrap(Collections.singletonList(new InetSocketAddress(hostName, 9002)));
-        assertFalse("ClusterResourceListener should not called when metadata is updated with bootstrap Cluster",
-                MockClusterResourceListener.IS_ON_UPDATE_CALLED.get());
+        assertFalse(
+                MockClusterResourceListener.IS_ON_UPDATE_CALLED.get(), "ClusterResourceListener should not called when metadata is updated with bootstrap Cluster");
 
         Map<String, Integer> partitionCounts = new HashMap<>();
         partitionCounts.put("topic", 1);
@@ -300,10 +301,10 @@ public class MetadataTest {
         MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, partitionCounts);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 100);
 
-        assertEquals("MockClusterResourceListener did not get cluster metadata correctly",
-                "dummy", mockClusterListener.clusterResource().clusterId());
-        assertTrue("MockClusterResourceListener should be called when metadata is updated with non-bootstrap Cluster",
-                MockClusterResourceListener.IS_ON_UPDATE_CALLED.get());
+        assertEquals(
+                "dummy", mockClusterListener.clusterResource().clusterId(), "MockClusterResourceListener did not get cluster metadata correctly");
+        assertTrue(
+                MockClusterResourceListener.IS_ON_UPDATE_CALLED.get(), "MockClusterResourceListener should be called when metadata is updated with non-bootstrap Cluster");
     }
 
 
@@ -322,9 +323,9 @@ public class MetadataTest {
         for (int i = 0; i < epochs.length; i++) {
             metadata.updateLastSeenEpochIfNewer(tp, epochs[i]);
             if (updateResult[i]) {
-                assertTrue("Expected metadata update to be requested [" + i + "]", metadata.updateRequested());
+                assertTrue(metadata.updateRequested(), "Expected metadata update to be requested [" + i + "]");
             } else {
-                assertFalse("Did not expect metadata update to be requested [" + i + "]", metadata.updateRequested());
+                assertFalse(metadata.updateRequested(), "Did not expect metadata update to be requested [" + i + "]");
             }
             metadata.updateWithCurrentRequestVersion(emptyMetadataResponse(), false, 0L);
             assertFalse(metadata.updateRequested());
@@ -347,28 +348,28 @@ public class MetadataTest {
         // Metadata with newer epoch is handled
         metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 10));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 10));
 
         // Don't update to an older one
         assertFalse(metadata.updateLastSeenEpochIfNewer(tp, 1));
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 10));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 10));
 
         // Don't cause update if it's the same one
         assertFalse(metadata.updateLastSeenEpochIfNewer(tp, 10));
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 10));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 10));
 
         // Update if we see newer epoch
         assertTrue(metadata.updateLastSeenEpochIfNewer(tp, 12));
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 12));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 12));
 
         metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 12);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 2L);
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 12));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 12));
 
         // Don't overwrite metadata with older epoch
         metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 11);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 3L);
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 12));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 12));
     }
 
     @Test
@@ -718,7 +719,7 @@ public class MetadataTest {
 
         TopicPartition tp = new TopicPartition("topic-1", 0);
 
-        assertOptional(metadata.fetch().nodeIfOnline(tp, 0), node -> assertEquals(node.id(), 0));
+        assertOptional(metadata.fetch().nodeIfOnline(tp, 0), node -> Assertions.assertEquals(node.id(), 0));
         assertFalse(metadata.fetch().nodeIfOnline(tp, 1).isPresent());
         assertEquals(metadata.fetch().nodeById(0).id(), 0);
         assertEquals(metadata.fetch().nodeById(1).id(), 1);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -348,28 +348,28 @@ public class MetadataTest {
         // Metadata with newer epoch is handled
         metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 10);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 1L);
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 10));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 10));
 
         // Don't update to an older one
         assertFalse(metadata.updateLastSeenEpochIfNewer(tp, 1));
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 10));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 10));
 
         // Don't cause update if it's the same one
         assertFalse(metadata.updateLastSeenEpochIfNewer(tp, 10));
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 10));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 10));
 
         // Update if we see newer epoch
         assertTrue(metadata.updateLastSeenEpochIfNewer(tp, 12));
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 12));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 12));
 
         metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 12);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 2L);
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 12));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 12));
 
         // Don't overwrite metadata with older epoch
         metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, Collections.emptyMap(), Collections.singletonMap("topic-1", 1), _tp -> 11);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 3L);
-        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> Assertions.assertEquals(leaderAndEpoch.intValue(), 12));
+        assertOptional(metadata.lastSeenLeaderEpoch(tp), leaderAndEpoch -> assertEquals(leaderAndEpoch.intValue(), 12));
     }
 
     @Test
@@ -719,7 +719,7 @@ public class MetadataTest {
 
         TopicPartition tp = new TopicPartition("topic-1", 0);
 
-        assertOptional(metadata.fetch().nodeIfOnline(tp, 0), node -> Assertions.assertEquals(node.id(), 0));
+        assertOptional(metadata.fetch().nodeIfOnline(tp, 0), node -> assertEquals(node.id(), 0));
         assertFalse(metadata.fetch().nodeIfOnline(tp, 1).isPresent());
         assertEquals(metadata.fetch().nodeById(0).id(), 0);
         assertEquals(metadata.fetch().nodeById(1).id(), 1);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -38,7 +38,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.MockClusterResourceListener;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -292,8 +292,8 @@ public class MetadataTest {
 
         String hostName = "www.example.com";
         metadata.bootstrap(Collections.singletonList(new InetSocketAddress(hostName, 9002)));
-        assertFalse(
-                MockClusterResourceListener.IS_ON_UPDATE_CALLED.get(), "ClusterResourceListener should not called when metadata is updated with bootstrap Cluster");
+        assertFalse(MockClusterResourceListener.IS_ON_UPDATE_CALLED.get(),
+            "ClusterResourceListener should not called when metadata is updated with bootstrap Cluster");
 
         Map<String, Integer> partitionCounts = new HashMap<>();
         partitionCounts.put("topic", 1);
@@ -301,10 +301,10 @@ public class MetadataTest {
         MetadataResponse metadataResponse = RequestTestUtils.metadataUpdateWith("dummy", 1, partitionCounts);
         metadata.updateWithCurrentRequestVersion(metadataResponse, false, 100);
 
-        assertEquals(
-                "dummy", mockClusterListener.clusterResource().clusterId(), "MockClusterResourceListener did not get cluster metadata correctly");
-        assertTrue(
-                MockClusterResourceListener.IS_ON_UPDATE_CALLED.get(), "MockClusterResourceListener should be called when metadata is updated with non-bootstrap Cluster");
+        assertEquals("dummy", mockClusterListener.clusterResource().clusterId(),
+            "MockClusterResourceListener did not get cluster metadata correctly");
+        assertTrue(MockClusterResourceListener.IS_ON_UPDATE_CALLED.get(),
+            "MockClusterResourceListener should be called when metadata is updated with non-bootstrap Cluster");
     }
 
 

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -163,8 +163,8 @@ public class NetworkClientTest {
                 .setTimeoutMs(1000));
         ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
         client.send(request, time.milliseconds());
-        assertEquals(1,
-                client.inFlightRequestCount(node.idString()), "There should be 1 in-flight request after send");
+        assertEquals(1, client.inFlightRequestCount(node.idString()),
+            "There should be 1 in-flight request after send");
         assertTrue(client.hasInFlightRequests(node.idString()));
         assertTrue(client.hasInFlightRequests());
 
@@ -207,8 +207,8 @@ public class NetworkClientTest {
         assertEquals(1, responses.size());
         assertTrue(handler.executed, "The handler should have executed.");
         assertTrue(handler.response.hasResponse(), "Should have a response body.");
-        assertEquals(
-                request.correlationId(), handler.response.requestHeader().correlationId(), "Should be correlated to the original request");
+        assertEquals(request.correlationId(), handler.response.requestHeader().correlationId(),
+            "Should be correlated to the original request");
     }
 
     private void delayedApiVersionsResponse(int correlationId, short version, ApiVersionsResponse response) {
@@ -478,15 +478,13 @@ public class NetworkClientTest {
         selector.serverConnectionBlocked(node1.idString());
 
         client.poll(0, time.milliseconds());
-        assertFalse(
-                client.connectionFailed(node),
-                "The connections should not fail before the socket connection setup timeout elapsed");
+        assertFalse(client.connectionFailed(node),
+            "The connections should not fail before the socket connection setup timeout elapsed");
 
         time.sleep((long) (connectionSetupTimeoutMsTest * 1.2) + 1);
         client.poll(0, time.milliseconds());
-        assertTrue(
-                client.connectionFailed(node),
-                "Expected the connections to fail due to the socket connection setup timeout");
+        assertTrue(client.connectionFailed(node),
+            "Expected the connections to fail due to the socket connection setup timeout");
     }
 
     @Test
@@ -839,8 +837,8 @@ public class NetworkClientTest {
     public void testDisconnectWithMultipleInFlights() {
         NetworkClient client = this.clientWithNoVersionDiscovery;
         awaitReady(client, node);
-        assertTrue(
-                client.isReady(node, time.milliseconds()), "Expected NetworkClient to be ready to send to node " + node.idString());
+        assertTrue(client.isReady(node, time.milliseconds()),
+            "Expected NetworkClient to be ready to send to node " + node.idString());
 
         MetadataRequest.Builder builder = new MetadataRequest.Builder(Collections.emptyList(), true);
         long now = time.milliseconds();
@@ -882,15 +880,15 @@ public class NetworkClientTest {
     @Test
     public void testCallDisconnect() throws Exception {
         awaitReady(client, node);
-        assertTrue(
-                client.isReady(node, time.milliseconds()), "Expected NetworkClient to be ready to send to node " + node.idString());
-        assertFalse(
-                client.connectionFailed(node), "Did not expect connection to node " + node.idString() + " to be failed");
+        assertTrue(client.isReady(node, time.milliseconds()),
+            "Expected NetworkClient to be ready to send to node " + node.idString());
+        assertFalse(client.connectionFailed(node),
+            "Did not expect connection to node " + node.idString() + " to be failed");
         client.disconnect(node.idString());
-        assertFalse(
-                client.isReady(node, time.milliseconds()), "Expected node " + node.idString() + " to be disconnected.");
-        assertTrue(
-                client.connectionFailed(node), "Expected connection to node " + node.idString() + " to be failed after disconnect");
+        assertFalse(client.isReady(node, time.milliseconds()),
+            "Expected node " + node.idString() + " to be disconnected.");
+        assertTrue(client.connectionFailed(node),
+            "Expected connection to node " + node.idString() + " to be failed after disconnect");
         assertFalse(client.canConnect(node, time.milliseconds()));
 
         // ensure disconnect does not reset backoff period if already disconnected

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -44,8 +44,9 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.DelayedReceive;
 import org.apache.kafka.test.MockSelector;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -58,13 +59,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetworkClientTest {
 
@@ -115,7 +116,7 @@ public class NetworkClientTest {
                 connectionSetupTimeoutMsTest, connectionSetupTimeoutMaxMsTest, ClientDnsLookup.DEFAULT, time, false, new ApiVersions(), new LogContext());
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         selector.reset();
     }
@@ -154,7 +155,7 @@ public class NetworkClientTest {
         client.ready(node, time.milliseconds());
         awaitReady(client, node);
         client.poll(1, time.milliseconds());
-        assertTrue("The client should be ready", client.isReady(node, time.milliseconds()));
+        assertTrue(client.isReady(node, time.milliseconds()), "The client should be ready");
 
         ProduceRequest.Builder builder = ProduceRequest.forCurrentMagic(new ProduceRequestData()
                 .setTopicData(new ProduceRequestData.TopicProduceDataCollection())
@@ -162,16 +163,16 @@ public class NetworkClientTest {
                 .setTimeoutMs(1000));
         ClientRequest request = client.newClientRequest(node.idString(), builder, time.milliseconds(), true);
         client.send(request, time.milliseconds());
-        assertEquals("There should be 1 in-flight request after send", 1,
-                client.inFlightRequestCount(node.idString()));
+        assertEquals(1,
+                client.inFlightRequestCount(node.idString()), "There should be 1 in-flight request after send");
         assertTrue(client.hasInFlightRequests(node.idString()));
         assertTrue(client.hasInFlightRequests());
 
         client.close(node.idString());
-        assertEquals("There should be no in-flight request after close", 0, client.inFlightRequestCount(node.idString()));
+        assertEquals(0, client.inFlightRequestCount(node.idString()), "There should be no in-flight request after close");
         assertFalse(client.hasInFlightRequests(node.idString()));
         assertFalse(client.hasInFlightRequests());
-        assertFalse("Connection should not be ready after close", client.isReady(node, 0));
+        assertFalse(client.isReady(node, 0), "Connection should not be ready after close");
     }
 
     @Test
@@ -204,10 +205,10 @@ public class NetworkClientTest {
         selector.completeReceive(new NetworkReceive(node.idString(), buffer));
         List<ClientResponse> responses = networkClient.poll(1, time.milliseconds());
         assertEquals(1, responses.size());
-        assertTrue("The handler should have executed.", handler.executed);
-        assertTrue("Should have a response body.", handler.response.hasResponse());
-        assertEquals("Should be correlated to the original request",
-                request.correlationId(), handler.response.requestHeader().correlationId());
+        assertTrue(handler.executed, "The handler should have executed.");
+        assertTrue(handler.response.hasResponse(), "Should have a response body.");
+        assertEquals(
+                request.correlationId(), handler.response.requestHeader().correlationId(), "Should be correlated to the original request");
     }
 
     private void delayedApiVersionsResponse(int correlationId, short version, ApiVersionsResponse response) {
@@ -459,7 +460,7 @@ public class NetworkClientTest {
         assertEquals(1, responses.size());
         ClientResponse clientResponse = responses.get(0);
         assertEquals(node.idString(), clientResponse.destination());
-        assertTrue("Expected response to fail due to disconnection", clientResponse.wasDisconnected());
+        assertTrue(clientResponse.wasDisconnected(), "Expected response to fail due to disconnection");
     }
 
     @Test
@@ -478,16 +479,14 @@ public class NetworkClientTest {
 
         client.poll(0, time.milliseconds());
         assertFalse(
-                "The connections should not fail before the socket connection setup timeout elapsed",
-                client.connectionFailed(node)
-        );
+                client.connectionFailed(node),
+                "The connections should not fail before the socket connection setup timeout elapsed");
 
         time.sleep((long) (connectionSetupTimeoutMsTest * 1.2) + 1);
         client.poll(0, time.milliseconds());
         assertTrue(
-                "Expected the connections to fail due to the socket connection setup timeout",
-                client.connectionFailed(node)
-        );
+                client.connectionFailed(node),
+                "Expected the connections to fail due to the socket connection setup timeout");
     }
 
     @Test
@@ -605,11 +604,11 @@ public class NetworkClientTest {
 
         awaitReady(client, node);
         client.poll(1, time.milliseconds());
-        assertTrue("The client should be ready", client.isReady(node, time.milliseconds()));
+        assertTrue(client.isReady(node, time.milliseconds()), "The client should be ready");
 
         // leastloadednode should be our single node
         Node leastNode = client.leastLoadedNode(time.milliseconds());
-        assertEquals("There should be one leastloadednode", leastNode.id(), node.id());
+        assertEquals(leastNode.id(), node.id(), "There should be one leastloadednode");
 
         // sleep for longer than reconnect backoff
         time.sleep(reconnectBackoffMsTest);
@@ -618,9 +617,9 @@ public class NetworkClientTest {
         selector.serverDisconnect(node.idString());
 
         client.poll(1, time.milliseconds());
-        assertFalse("After we forced the disconnection the client is no longer ready.", client.ready(node, time.milliseconds()));
+        assertFalse(client.ready(node, time.milliseconds()), "After we forced the disconnection the client is no longer ready.");
         leastNode = client.leastLoadedNode(time.milliseconds());
-        assertNull("There should be NO leastloadednode", leastNode);
+        assertNull(leastNode, "There should be NO leastloadednode");
     }
 
     @Test
@@ -631,7 +630,7 @@ public class NetworkClientTest {
         Set<Node> providedNodeIds = new HashSet<>();
         for (int i = 0; i < nodeNumber * 10; i++) {
             Node node = client.leastLoadedNode(time.milliseconds());
-            assertNotNull("Should provide a node", node);
+            assertNotNull(node, "Should provide a node");
             providedNodeIds.add(node);
             client.ready(node, time.milliseconds());
             client.disconnect(node.idString());
@@ -640,7 +639,7 @@ public class NetworkClientTest {
             // Define a round as nodeNumber of nodes have been provided
             // In each round every node should be provided exactly once
             if ((i + 1) % nodeNumber == 0) {
-                assertEquals("All the nodes should be provided", nodeNumber, providedNodeIds.size());
+                assertEquals(nodeNumber, providedNodeIds.size(), "All the nodes should be provided");
                 providedNodeIds.clear();
             }
         }
@@ -694,7 +693,7 @@ public class NetworkClientTest {
         client.ready(node, time.milliseconds());
         awaitReady(client, node);
         client.poll(1, time.milliseconds());
-        assertTrue("The client should be ready", client.isReady(node, time.milliseconds()));
+        assertTrue(client.isReady(node, time.milliseconds()), "The client should be ready");
 
         int correlationId = sendEmptyProduceRequest();
         client.poll(1, time.milliseconds());
@@ -840,14 +839,14 @@ public class NetworkClientTest {
     public void testDisconnectWithMultipleInFlights() {
         NetworkClient client = this.clientWithNoVersionDiscovery;
         awaitReady(client, node);
-        assertTrue("Expected NetworkClient to be ready to send to node " + node.idString(),
-                client.isReady(node, time.milliseconds()));
+        assertTrue(
+                client.isReady(node, time.milliseconds()), "Expected NetworkClient to be ready to send to node " + node.idString());
 
         MetadataRequest.Builder builder = new MetadataRequest.Builder(Collections.emptyList(), true);
         long now = time.milliseconds();
 
         final List<ClientResponse> callbackResponses = new ArrayList<>();
-        RequestCompletionHandler callback = response -> callbackResponses.add(response);
+        RequestCompletionHandler callback = callbackResponses::add;
 
         ClientRequest request1 = client.newClientRequest(node.idString(), builder, now, true, defaultRequestTimeoutMs, callback);
         client.send(request1, now);
@@ -883,15 +882,15 @@ public class NetworkClientTest {
     @Test
     public void testCallDisconnect() throws Exception {
         awaitReady(client, node);
-        assertTrue("Expected NetworkClient to be ready to send to node " + node.idString(),
-            client.isReady(node, time.milliseconds()));
-        assertFalse("Did not expect connection to node " + node.idString() + " to be failed",
-            client.connectionFailed(node));
+        assertTrue(
+                client.isReady(node, time.milliseconds()), "Expected NetworkClient to be ready to send to node " + node.idString());
+        assertFalse(
+                client.connectionFailed(node), "Did not expect connection to node " + node.idString() + " to be failed");
         client.disconnect(node.idString());
-        assertFalse("Expected node " + node.idString() + " to be disconnected.",
-            client.isReady(node, time.milliseconds()));
-        assertTrue("Expected connection to node " + node.idString() + " to be failed after disconnect",
-            client.connectionFailed(node));
+        assertFalse(
+                client.isReady(node, time.milliseconds()), "Expected node " + node.idString() + " to be disconnected.");
+        assertTrue(
+                client.connectionFailed(node), "Expected connection to node " + node.idString() + " to be failed after disconnect");
         assertFalse(client.canConnect(node, time.milliseconds()));
 
         // ensure disconnect does not reset backoff period if already disconnected
@@ -908,7 +907,7 @@ public class NetworkClientTest {
             .mapToObj(i -> client.nextCorrelationId())
             .collect(Collectors.toSet());
         assertEquals(count, ids.size());
-        ids.forEach(id -> assertTrue(id < SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID));
+        ids.forEach(id -> Assertions.assertTrue(id < SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID));
     }
 
     private RequestHeader parseHeader(ByteBuffer buffer) {

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -44,7 +44,6 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.DelayedReceive;
 import org.apache.kafka.test.MockSelector;
 import org.apache.kafka.test.TestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -907,7 +907,7 @@ public class NetworkClientTest {
             .mapToObj(i -> client.nextCorrelationId())
             .collect(Collectors.toSet());
         assertEquals(count, ids.size());
-        ids.forEach(id -> Assertions.assertTrue(id < SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID));
+        ids.forEach(id -> assertTrue(id < SaslClientAuthenticator.MIN_RESERVED_CORRELATION_ID));
     }
 
     private RequestHeader parseHeader(ByteBuffer buffer) {

--- a/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NodeApiVersionsTest.java
@@ -24,12 +24,12 @@ import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsRespon
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKeyCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NodeApiVersionsTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -18,77 +18,64 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.clients.admin.ConfigEntry.ConfigType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConfigTest {
     private static final ConfigEntry E1 = new ConfigEntry("a", "b");
     private static final ConfigEntry E2 = new ConfigEntry("c", "d");
     private Config config;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        final Collection<ConfigEntry> entries = new ArrayList<>();
-        entries.add(E1);
-        entries.add(E2);
-
-        config = new Config(entries);
+        config = new Config(asList(E1, E2));
     }
 
     @Test
     public void shouldGetEntry() {
-        assertThat(config.get("a"), is(E1));
-        assertThat(config.get("c"), is(E2));
+        assertEquals(E1, config.get("a"));
+        assertEquals(E2, config.get("c"));
     }
 
     @Test
     public void shouldReturnNullOnGetUnknownEntry() {
-        assertThat(config.get("unknown"), is(nullValue()));
+        assertNull(config.get("unknown"));
     }
 
     @Test
     public void shouldGetAllEntries() {
-        assertThat(config.entries().size(), is(2));
-        assertThat(config.entries(), hasItems(E1, E2));
+        assertEquals(2, config.entries().size());
+        assertTrue(config.entries().contains(E1));
+        assertTrue(config.entries().contains(E2));
     }
 
     @Test
     public void shouldImplementEqualsProperly() {
-        final Collection<ConfigEntry> entries = new ArrayList<>();
-        entries.add(E1);
-
-        assertThat(config, is(equalTo(config)));
-        assertThat(config, is(equalTo(new Config(config.entries()))));
-        assertThat(config, is(not(equalTo(new Config(entries)))));
-        assertThat(config, is(not(equalTo((Object) "this"))));
+        assertEquals(config, config);
+        assertEquals(config, new Config(config.entries()));
+        assertNotEquals(new Config(asList(E1)), config);
+        assertNotEquals("this", config);
     }
 
     @Test
     public void shouldImplementHashCodeProperly() {
-        final Collection<ConfigEntry> entries = new ArrayList<>();
-        entries.add(E1);
-
-        assertThat(config.hashCode(), is(config.hashCode()));
-        assertThat(config.hashCode(), is(new Config(config.entries()).hashCode()));
-        assertThat(config.hashCode(), is(not(new Config(entries).hashCode())));
+        assertEquals(config.hashCode(), config.hashCode());
+        assertEquals(config.hashCode(), new Config(config.entries()).hashCode());
+        assertNotEquals(new Config(asList(E1)).hashCode(), config.hashCode());
     }
 
     @Test
     public void shouldImplementToStringProperly() {
-        assertThat(config.toString(), containsString(E1.toString()));
-        assertThat(config.toString(), containsString(E2.toString()));
+        assertTrue(config.toString().contains(E1.toString()));
+        assertTrue(config.toString().contains(E2.toString()));
     }
 
     public static ConfigEntry newConfigEntry(String name, String value, ConfigEntry.ConfigSource source, boolean isSensitive,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -62,7 +62,7 @@ public class ConfigTest {
         assertEquals(config, config);
         assertEquals(config, new Config(config.entries()));
         assertNotEquals(new Config(asList(E1)), config);
-        assertNotEquals("this", config);
+        assertNotEquals(config, "this");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/DeleteConsumerGroupOffsetsResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/DeleteConsumerGroupOffsetsResultTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,9 +32,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DeleteConsumerGroupOffsetsResultTest {
 
@@ -46,7 +46,7 @@ public class DeleteConsumerGroupOffsetsResultTest {
 
     private KafkaFutureImpl<Map<TopicPartition, Errors>> partitionFutures;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         partitionFutures = new KafkaFutureImpl<>();
         partitions = new HashSet<>();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/DescribeUserScramCredentialsResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/DescribeUserScramCredentialsResultTest.java
@@ -20,13 +20,13 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DescribeUserScramCredentialsResultTest {
     @Test
@@ -74,7 +74,7 @@ public class DescribeUserScramCredentialsResultTest {
         } catch (Exception expected) {
             // ignore, expected
         }
-        assertEquals("Expected 2 users with credentials", Arrays.asList(goodUser, failedUser), results.users().get());
+        assertEquals(Arrays.asList(goodUser, failedUser), results.users().get(), "Expected 2 users with credentials");
         UserScramCredentialsDescription goodUserDescription = results.description(goodUser).get();
         assertEquals(new UserScramCredentialsDescription(goodUser, Arrays.asList(new ScramCredentialInfo(scramSha256, iterations))), goodUserDescription);
         try {
@@ -102,12 +102,12 @@ public class DescribeUserScramCredentialsResultTest {
                 new DescribeUserScramCredentialsResponseData.DescribeUserScramCredentialsResult().setUser(goodUser).setCredentialInfos(
                         Arrays.asList(new DescribeUserScramCredentialsResponseData.CredentialInfo().setMechanism(scramSha256.type()).setIterations(iterations))))));
         DescribeUserScramCredentialsResult results = new DescribeUserScramCredentialsResult(dataFuture);
-        assertEquals("Expected 1 user with credentials", Arrays.asList(goodUser), results.users().get());
+        assertEquals(Arrays.asList(goodUser), results.users().get(), "Expected 1 user with credentials");
         Map<String, UserScramCredentialsDescription> allResults = results.all().get();
         assertEquals(1, allResults.size());
         UserScramCredentialsDescription goodUserDescriptionViaAll = allResults.get(goodUser);
         assertEquals(new UserScramCredentialsDescription(goodUser, Arrays.asList(new ScramCredentialInfo(scramSha256, iterations))), goodUserDescriptionViaAll);
-        assertEquals("Expected same thing via all() and description()", goodUserDescriptionViaAll, results.description(goodUser).get());
+        assertEquals(goodUserDescriptionViaAll, results.description(goodUser).get(), "Expected same thing via all() and description()");
         try {
             results.description(unknownUser).get();
             fail("expected description(unknownUser) to fail when there is no such user even when all() succeeds");

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -171,9 +171,8 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -201,30 +200,29 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignablePartitionResponse;
 import static org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignableTopicResponse;
 import static org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingPartitionReassignment;
 import static org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingTopicReassignment;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A unit test for KafkaAdminClient.
  *
  * See AdminClientIntegrationTest for an integration test.
  */
+@Timeout(120)
 public class KafkaAdminClientTest {
     private static final Logger log = LoggerFactory.getLogger(KafkaAdminClientTest.class);
-
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testDefaultApiTimeoutAndRequestTimeoutConflicts() {
@@ -288,7 +286,7 @@ public class KafkaAdminClientTest {
         Set<String> ids = new HashSet<>();
         for (int i = 0; i < 10; i++) {
             String id = KafkaAdminClient.generateClientId(newConfMap(AdminClientConfig.CLIENT_ID_CONFIG, ""));
-            assertTrue("Got duplicate id " + id, !ids.contains(id));
+            assertTrue(!ids.contains(id), "Got duplicate id " + id);
             ids.add(id);
         }
         assertEquals("myCustomId",
@@ -327,7 +325,7 @@ public class KafkaAdminClientTest {
      * Test if admin client can be closed in the callback invoked when
      * an api call completes. If calling {@link Admin#close()} in callback, AdminClient thread hangs
      */
-    @Test(timeout = 10_000)
+    @Test @Timeout(10)
     public void testCloseAdminClientInCallback() throws InterruptedException {
         MockTime time = new MockTime();
         AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, mockCluster(3, 0));
@@ -546,7 +544,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareResponse(prepareCreateTopicsResponse("myTopic", Errors.NONE));
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                    singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                     new CreateTopicsOptions().timeoutMs(1000)).all();
             TestUtils.assertFutureError(future, TimeoutException.class);
         }
@@ -569,7 +567,7 @@ public class KafkaAdminClientTest {
                     prepareCreateTopicsResponse("myTopic", Errors.NONE));
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                    singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                     new CreateTopicsOptions().timeoutMs(10000)).all();
 
             future.get();
@@ -594,7 +592,7 @@ public class KafkaAdminClientTest {
                 prepareCreateTopicsResponse("myTopic", Errors.NONE));
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                    singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                     new CreateTopicsOptions().timeoutMs(10000)).all();
 
             future.get();
@@ -615,7 +613,7 @@ public class KafkaAdminClientTest {
                     TimeUnit.DAYS.toMillis(1));
             env.kafkaClient().prepareResponse(prepareCreateTopicsResponse("myTopic", Errors.NONE));
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                 new CreateTopicsOptions().timeoutMs(1000)).all();
             TestUtils.assertFutureError(future, SaslAuthenticationException.class);
         }
@@ -629,7 +627,7 @@ public class KafkaAdminClientTest {
                 expectCreateTopicsRequestWithTopics("myTopic"),
                 prepareCreateTopicsResponse("myTopic", Errors.NONE));
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                    singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                     new CreateTopicsOptions().timeoutMs(10000)).all();
             future.get();
         }
@@ -677,7 +675,7 @@ public class KafkaAdminClientTest {
             }, prepareCreateTopicsResponse("myTopic", Errors.NONE));
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                 new CreateTopicsOptions().timeoutMs(10000)).all();
 
             // Wait until the first attempt has failed, then advance the time
@@ -693,8 +691,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("CreateTopics retry did not await expected backoff",
-                    retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "CreateTopics retry did not await expected backoff");
         }
     }
 
@@ -713,7 +710,7 @@ public class KafkaAdminClientTest {
                 prepareCreateTopicsResponse("myTopic", Errors.NONE),
                 env.cluster().nodeById(1));
             KafkaFuture<Void> future = env.adminClient().createTopics(
-                Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                 new CreateTopicsOptions().timeoutMs(10000)).all();
             future.get();
         }
@@ -1064,7 +1061,7 @@ public class KafkaAdminClientTest {
                     singletonList(new MetadataResponse.TopicMetadata(Errors.NONE, topic, Uuid.ZERO_UUID, false,
                             singletonList(partitionMetadata), MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED))));
 
-            DescribeTopicsResult result = env.adminClient().describeTopics(Collections.singleton(topic));
+            DescribeTopicsResult result = env.adminClient().describeTopics(singleton(topic));
             Map<String, TopicDescription> topicDescriptions = result.all().get();
             assertEquals(leader, topicDescriptions.get(topic).partitions().get(0).leader());
             assertNull(topicDescriptions.get(topic).authorizedOperations());
@@ -1085,78 +1082,50 @@ public class KafkaAdminClientTest {
     }
 
     private void callAdminClientApisAndExpectAnAuthenticationError(AdminClientUnitTestEnv env) throws InterruptedException {
-        try {
-            env.adminClient().createTopics(
-                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        ExecutionException e = assertThrows(ExecutionException.class, () -> env.adminClient().createTopics(
+            singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+            new CreateTopicsOptions().timeoutMs(10000)).all().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
 
-        try {
-            Map<String, NewPartitions> counts = new HashMap<>();
-            counts.put("my_topic", NewPartitions.increaseTo(3));
-            counts.put("other_topic", NewPartitions.increaseTo(3, asList(asList(2), asList(3))));
-            env.adminClient().createPartitions(counts).all().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        Map<String, NewPartitions> counts = new HashMap<>();
+        counts.put("my_topic", NewPartitions.increaseTo(3));
+        counts.put("other_topic", NewPartitions.increaseTo(3, asList(asList(2), asList(3))));
+        e = assertThrows(ExecutionException.class, () -> env.adminClient().createPartitions(counts).all().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
 
-        try {
-            env.adminClient().createAcls(asList(ACL1, ACL2)).all().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        e = assertThrows(ExecutionException.class, () -> env.adminClient().createAcls(asList(ACL1, ACL2)).all().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
 
-        try {
-            env.adminClient().describeAcls(FILTER1).values().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        e = assertThrows(ExecutionException.class, () -> env.adminClient().describeAcls(FILTER1).values().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
 
-        try {
-            env.adminClient().deleteAcls(asList(FILTER1, FILTER2)).all().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        e = assertThrows(ExecutionException.class, () -> env.adminClient().deleteAcls(asList(FILTER1, FILTER2)).all().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
 
-        try {
-            env.adminClient().describeConfigs(Collections.singleton(new ConfigResource(ConfigResource.Type.BROKER, "0"))).all().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        e = assertThrows(ExecutionException.class, () -> env.adminClient().describeConfigs(
+            singleton(new ConfigResource(ConfigResource.Type.BROKER, "0"))).all().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
     }
 
     private void callClientQuotasApisAndExpectAnAuthenticationError(AdminClientUnitTestEnv env) throws InterruptedException {
-        try {
-            env.adminClient().describeClientQuotas(ClientQuotaFilter.all()).entities().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        ExecutionException e = assertThrows(ExecutionException.class,
+            () -> env.adminClient().describeClientQuotas(ClientQuotaFilter.all()).entities().get());
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
 
-        try {
-            ClientQuotaEntity entity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, "user"));
-            ClientQuotaAlteration alteration = new ClientQuotaAlteration(entity, asList(new ClientQuotaAlteration.Op("consumer_byte_rate", 1000.0)));
-            env.adminClient().alterClientQuotas(asList(alteration)).all().get();
-            fail("Expected an authentication error.");
-        } catch (ExecutionException e) {
-            assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
-                e.getCause() instanceof AuthenticationException);
-        }
+        ClientQuotaEntity entity = new ClientQuotaEntity(Collections.singletonMap(ClientQuotaEntity.USER, "user"));
+        ClientQuotaAlteration alteration = new ClientQuotaAlteration(entity, asList(new ClientQuotaAlteration.Op("consumer_byte_rate", 1000.0)));
+        e = assertThrows(ExecutionException.class,
+            () -> env.adminClient().alterClientQuotas(asList(alteration)).all().get());
+
+        assertTrue(e.getCause() instanceof AuthenticationException,
+            "Expected an authentication error, but got " + Utils.stackTrace(e));
     }
 
     private static final AclBinding ACL1 = new AclBinding(new ResourcePattern(ResourceType.TOPIC, "mytopic3", PatternType.LITERAL),
@@ -1461,7 +1430,7 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testDescribeLogDirs() throws ExecutionException, InterruptedException {
-        Set<Integer> brokers = Collections.singleton(0);
+        Set<Integer> brokers = singleton(0);
         String logDir = "/var/data/kafka";
         TopicPartition tp = new TopicPartition("topic", 12);
         long partitionSize = 1234567890;
@@ -1489,10 +1458,10 @@ public class KafkaAdminClientTest {
     private static void assertDescriptionContains(Map<String, LogDirDescription> descriptionsMap, String logDir,
                                            TopicPartition tp, long partitionSize, long offsetLag) {
         assertNotNull(descriptionsMap);
-        assertEquals(Collections.singleton(logDir), descriptionsMap.keySet());
+        assertEquals(singleton(logDir), descriptionsMap.keySet());
         assertNull(descriptionsMap.get(logDir).error());
         Map<TopicPartition, ReplicaInfo> descriptionsReplicaInfos = descriptionsMap.get(logDir).replicaInfos();
-        assertEquals(Collections.singleton(tp), descriptionsReplicaInfos.keySet());
+        assertEquals(singleton(tp), descriptionsReplicaInfos.keySet());
         assertEquals(partitionSize, descriptionsReplicaInfos.get(tp).size());
         assertEquals(offsetLag, descriptionsReplicaInfos.get(tp).offsetLag());
         assertFalse(descriptionsReplicaInfos.get(tp).isFuture());
@@ -1501,7 +1470,7 @@ public class KafkaAdminClientTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testDescribeLogDirsDeprecated() throws ExecutionException, InterruptedException {
-        Set<Integer> brokers = Collections.singleton(0);
+        Set<Integer> brokers = singleton(0);
         TopicPartition tp = new TopicPartition("topic", 12);
         String logDir = "/var/data/kafka";
         Errors error = Errors.NONE;
@@ -1532,11 +1501,11 @@ public class KafkaAdminClientTest {
                                            String logDir, TopicPartition tp, Errors error,
                                            int offsetLag, long partitionSize) {
         assertNotNull(descriptionsMap);
-        assertEquals(Collections.singleton(logDir), descriptionsMap.keySet());
+        assertEquals(singleton(logDir), descriptionsMap.keySet());
         assertEquals(error, descriptionsMap.get(logDir).error);
         Map<TopicPartition, DescribeLogDirsResponse.ReplicaInfo> allReplicaInfos =
                 descriptionsMap.get(logDir).replicaInfos;
-        assertEquals(Collections.singleton(tp), allReplicaInfos.keySet());
+        assertEquals(singleton(tp), allReplicaInfos.keySet());
         assertEquals(partitionSize, allReplicaInfos.get(tp).size);
         assertEquals(offsetLag, allReplicaInfos.get(tp).offsetLag);
         assertFalse(allReplicaInfos.get(tp).isFuture);
@@ -1544,7 +1513,7 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testDescribeLogDirsOfflineDir() throws ExecutionException, InterruptedException {
-        Set<Integer> brokers = Collections.singleton(0);
+        Set<Integer> brokers = singleton(0);
         String logDir = "/var/data/kafka";
         Errors error = Errors.KAFKA_STORAGE_ERROR;
 
@@ -1560,7 +1529,7 @@ public class KafkaAdminClientTest {
             assertEquals(brokers, descriptions.keySet());
             assertNotNull(descriptions.get(0));
             Map<String, LogDirDescription> descriptionsMap = descriptions.get(0).get();
-            assertEquals(Collections.singleton(logDir), descriptionsMap.keySet());
+            assertEquals(singleton(logDir), descriptionsMap.keySet());
             assertEquals(error.exception().getClass(), descriptionsMap.get(logDir).error().getClass());
             assertEquals(emptySet(), descriptionsMap.get(logDir).replicaInfos().keySet());
 
@@ -1568,7 +1537,7 @@ public class KafkaAdminClientTest {
             assertEquals(brokers, allDescriptions.keySet());
             Map<String, LogDirDescription> allMap = allDescriptions.get(0);
             assertNotNull(allMap);
-            assertEquals(Collections.singleton(logDir), allMap.keySet());
+            assertEquals(singleton(logDir), allMap.keySet());
             assertEquals(error.exception().getClass(), allMap.get(logDir).error().getClass());
             assertEquals(emptySet(), allMap.get(logDir).replicaInfos().keySet());
         }
@@ -1577,7 +1546,7 @@ public class KafkaAdminClientTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testDescribeLogDirsOfflineDirDeprecated() throws ExecutionException, InterruptedException {
-        Set<Integer> brokers = Collections.singleton(0);
+        Set<Integer> brokers = singleton(0);
         String logDir = "/var/data/kafka";
         Errors error = Errors.KAFKA_STORAGE_ERROR;
 
@@ -1593,7 +1562,7 @@ public class KafkaAdminClientTest {
             assertEquals(brokers, deprecatedValues.keySet());
             assertNotNull(deprecatedValues.get(0));
             Map<String, DescribeLogDirsResponse.LogDirInfo> valuesMap = deprecatedValues.get(0).get();
-            assertEquals(Collections.singleton(logDir), valuesMap.keySet());
+            assertEquals(singleton(logDir), valuesMap.keySet());
             assertEquals(error, valuesMap.get(logDir).error);
             assertEquals(emptySet(), valuesMap.get(logDir).replicaInfos.keySet());
 
@@ -1601,7 +1570,7 @@ public class KafkaAdminClientTest {
             assertEquals(brokers, deprecatedAll.keySet());
             Map<String, DescribeLogDirsResponse.LogDirInfo> allMap = deprecatedAll.get(0);
             assertNotNull(allMap);
-            assertEquals(Collections.singleton(logDir), allMap.keySet());
+            assertEquals(singleton(logDir), allMap.keySet());
             assertEquals(error, allMap.get(logDir).error);
             assertEquals(emptySet(), allMap.get(logDir).replicaInfos.keySet());
         }
@@ -2273,7 +2242,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareUnsupportedVersionResponse(
                 body -> body instanceof ListGroupsRequest);
 
-            options = new ListConsumerGroupsOptions().inStates(Collections.singleton(ConsumerGroupState.STABLE));
+            options = new ListConsumerGroupsOptions().inStates(singleton(ConsumerGroupState.STABLE));
             result = env.adminClient().listConsumerGroups(options);
             TestUtils.assertFutureThrows(result.all(), UnsupportedVersionException.class);
         }
@@ -2346,7 +2315,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("CommitOffsets retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "CommitOffsets retry did not await expected backoff");
         }
     }
 
@@ -2439,7 +2408,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("DescribeConsumerGroup retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "DescribeConsumerGroup retry did not await expected backoff!");
         }
     }
 
@@ -2707,7 +2676,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("ListConsumerGroupOffsets retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "ListConsumerGroupOffsets retry did not await expected backoff!");
         }
     }
 
@@ -2838,7 +2807,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("DeleteConsumerGroups retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "DeleteConsumerGroups retry did not await expected backoff!");
         }
     }
 
@@ -2986,7 +2955,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("DeleteConsumerGroupOffsets retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "DeleteConsumerGroupOffsets retry did not await expected backoff!");
         }
     }
 
@@ -3278,7 +3247,7 @@ public class KafkaAdminClientTest {
             future.get();
 
             long actualRetryBackoff = secondAttemptTime.get() - firstAttemptTime.get();
-            assertEquals("RemoveMembersFromGroup retry did not await expected backoff!", retryBackoff, actualRetryBackoff);
+            assertEquals(retryBackoff, actualRetryBackoff, "RemoveMembersFromGroup retry did not await expected backoff!");
         }
     }
 
@@ -3991,13 +3960,11 @@ public class KafkaAdminClientTest {
                     if (error.error() == Errors.NONE) {
                         future.get();
                     } else {
-                        final ExecutionException e = assertThrows(ExecutionException.class,
-                            () -> future.get());
+                        final ExecutionException e = assertThrows(ExecutionException.class, future::get);
                         assertEquals(e.getCause().getClass(), error.exception().getClass());
                     }
                 } else {
-                    final ExecutionException e = assertThrows(ExecutionException.class,
-                        () -> future.get());
+                    final ExecutionException e = assertThrows(ExecutionException.class, future::get);
                     assertEquals(e.getCause().getClass(), topLevelError.exception().getClass());
                 }
             }
@@ -4119,7 +4086,7 @@ public class KafkaAdminClientTest {
             final DescribeFeaturesOptions options = new DescribeFeaturesOptions();
             options.timeoutMs(10000);
             final KafkaFuture<FeatureMetadata> future = env.adminClient().describeFeatures(options).featureMetadata();
-            final ExecutionException e = assertThrows(ExecutionException.class, () -> future.get());
+            final ExecutionException e = assertThrows(ExecutionException.class, future::get);
             assertEquals(e.getCause().getClass(), Errors.INVALID_REQUEST.exception().getClass());
         }
     }
@@ -4455,8 +4422,8 @@ public class KafkaAdminClientTest {
 
         final int retryBackoffMs = 100;
         final int effectiveTimeoutMs = overrideApiTimeoutMs.orElse(defaultApiTimeoutMs);
-        assertEquals("This test expects the effective timeout to be twice the request timeout",
-                2 * requestTimeoutMs, effectiveTimeoutMs);
+        assertEquals(2 * requestTimeoutMs, effectiveTimeoutMs,
+            "This test expects the effective timeout to be twice the request timeout");
 
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, cluster,
                 AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, String.valueOf(retryBackoffMs),
@@ -4611,9 +4578,9 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(AlterClientQuotasResponse.fromQuotaEntities(responseData, 0));
 
             List<ClientQuotaAlteration> entries = new ArrayList<>(3);
-            entries.add(new ClientQuotaAlteration(goodEntity, Collections.singleton(new ClientQuotaAlteration.Op("consumer_byte_rate", 10000.0))));
-            entries.add(new ClientQuotaAlteration(unauthorizedEntity, Collections.singleton(new ClientQuotaAlteration.Op("producer_byte_rate", 10000.0))));
-            entries.add(new ClientQuotaAlteration(invalidEntity, Collections.singleton(new ClientQuotaAlteration.Op("producer_byte_rate", 100.0))));
+            entries.add(new ClientQuotaAlteration(goodEntity, singleton(new ClientQuotaAlteration.Op("consumer_byte_rate", 10000.0))));
+            entries.add(new ClientQuotaAlteration(unauthorizedEntity, singleton(new ClientQuotaAlteration.Op("producer_byte_rate", 10000.0))));
+            entries.add(new ClientQuotaAlteration(invalidEntity, singleton(new ClientQuotaAlteration.Op("producer_byte_rate", 100.0))));
 
             AlterClientQuotasResult result = env.adminClient().alterClientQuotas(entries);
             result.values().get(goodEntity);
@@ -4987,10 +4954,9 @@ public class KafkaAdminClientTest {
     @SafeVarargs
     private static <T> void assertCollectionIs(Collection<T> collection, T... elements) {
         for (T element : elements) {
-            assertTrue("Did not find " + element, collection.contains(element));
+            assertTrue(collection.contains(element), "Did not find " + element);
         }
-        assertEquals("There are unexpected extra elements in the collection.",
-            elements.length, collection.size());
+        assertEquals(elements.length, collection.size(), "There are unexpected extra elements in the collection.");
     }
 
     public static KafkaAdminClient createInternal(AdminClientConfig config, KafkaAdminClient.TimeoutProcessorFactory timeoutProcessorFactory) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MemberDescriptionTest.java
@@ -17,13 +17,13 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class MemberDescriptionTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupOptionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupOptionsTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.clients.admin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RemoveMembersFromConsumerGroupOptionsTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/RemoveMembersFromConsumerGroupResultTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,9 +32,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RemoveMembersFromConsumerGroupResultTest {
 
@@ -45,7 +45,7 @@ public class RemoveMembersFromConsumerGroupResultTest {
 
     private KafkaFutureImpl<Map<MemberIdentity, Errors>> memberFutures;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         memberFutures = new KafkaFutureImpl<>();
         membersToRemove = new HashSet<>();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminMetadataManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminMetadataManagerTest.java
@@ -23,16 +23,16 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AdminMetadataManagerTest {
     private final MockTime time = new MockTime();
@@ -83,13 +83,7 @@ public class AdminMetadataManagerTest {
         mgr.transitionToUpdatePending(time.milliseconds());
         mgr.updateFailed(new AuthenticationException("Authentication failed"));
         assertEquals(refreshBackoffMs, mgr.metadataFetchDelayMs(time.milliseconds()));
-        try {
-            mgr.isReady();
-            fail("Expected AuthenticationException to be thrown");
-        } catch (AuthenticationException e) {
-            // Expected
-        }
-
+        assertThrows(AuthenticationException.class, mgr::isReady);
         mgr.update(mockCluster(), time.milliseconds());
         assertTrue(mgr.isReady());
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -20,15 +20,15 @@ import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConsumerConfigTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerGroupMetadataTest.java
@@ -17,14 +17,14 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.common.requests.JoinGroupRequest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumerGroupMetadataTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordTest.java
@@ -19,11 +19,11 @@ package org.apache.kafka.clients.consumer;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.DefaultRecord;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConsumerRecordTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerRecordsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.consumer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConsumerRecordsTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.clients.consumer;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -95,10 +95,10 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
         Set<TopicPartition> intersection = new HashSet<>(allAddedPartitions);
         intersection.retainAll(allRevokedPartitions);
-        assertTrue("Error: Some partitions were assigned to a new consumer during the same rebalance they are being "
-            + "revoked from their previous owner."
-            + "Partitions: " + intersection.toString(),
-            intersection.isEmpty());
+        assertTrue(
+                intersection.isEmpty(), "Error: Some partitions were assigned to a new consumer during the same rebalance they are being "
+                    + "revoked from their previous owner."
+                    + "Partitions: " + intersection.toString());
 
         return !allRevokedPartitions.isEmpty();
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/CooperativeStickyAssignorTest.java
@@ -95,10 +95,9 @@ public class CooperativeStickyAssignorTest extends AbstractStickyAssignorTest {
 
         Set<TopicPartition> intersection = new HashSet<>(allAddedPartitions);
         intersection.retainAll(allRevokedPartitions);
-        assertTrue(
-                intersection.isEmpty(), "Error: Some partitions were assigned to a new consumer during the same rebalance they are being "
-                    + "revoked from their previous owner."
-                    + "Partitions: " + intersection.toString());
+        assertTrue(intersection.isEmpty(),
+            "Error: Some partitions were assigned to a new consumer during the same rebalance they are being " +
+            "revoked from their previous owner. Partitions: " + intersection);
 
         return !allRevokedPartitions.isEmpty();
     }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -93,8 +93,8 @@ import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.common.metrics.stats.Avg;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -133,15 +133,15 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -187,7 +187,7 @@ public class KafkaConsumerTest {
 
         MockMetricsReporter mockMetricsReporter = (MockMetricsReporter) consumer.metrics.reporters().get(0);
 
-        Assert.assertEquals(consumer.getClientId(), mockMetricsReporter.clientId);
+        assertEquals(consumer.getClientId(), mockMetricsReporter.clientId);
         consumer.close();
     }
 
@@ -202,7 +202,7 @@ public class KafkaConsumerTest {
         final int oldCloseCount = MockMetricsReporter.CLOSE_COUNT.get();
         try {
             new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
-            Assert.fail("should have caught an exception and returned");
+            fail("should have caught an exception and returned");
         } catch (KafkaException e) {
             assertEquals(oldInitCount + 1, MockMetricsReporter.INIT_COUNT.get());
             assertEquals(oldCloseCount + 1, MockMetricsReporter.CLOSE_COUNT.get());
@@ -378,7 +378,7 @@ public class KafkaConsumerTest {
             assertEquals(1, MockConsumerInterceptor.INIT_COUNT.get());
             assertEquals(1, MockConsumerInterceptor.CLOSE_COUNT.get());
             // Cluster metadata will only be updated on calling poll.
-            Assert.assertNull(MockConsumerInterceptor.CLUSTER_META.get());
+            assertNull(MockConsumerInterceptor.CLUSTER_META.get());
 
         } finally {
             // cleanup since we are using mutable static variables in MockConsumerInterceptor
@@ -419,7 +419,7 @@ public class KafkaConsumerTest {
         MetricName testMetricName = consumer.metrics.metricName("test-metric",
                 "grp1", "test metric");
         consumer.metrics.addMetric(testMetricName, new Avg());
-        Assert.assertNotNull(server.getObjectInstance(new ObjectName("kafka.consumer:type=grp1,client-id=client-1")));
+        assertNotNull(server.getObjectInstance(new ObjectName("kafka.consumer:type=grp1,client-id=client-1")));
         consumer.close();
     }
 
@@ -536,7 +536,7 @@ public class KafkaConsumerTest {
         consumer.poll(Duration.ZERO);
 
         final Queue<ClientRequest> requests = client.requests();
-        Assert.assertEquals(0, requests.stream().filter(request -> request.apiKey().equals(ApiKeys.FETCH)).count());
+        assertEquals(0, requests.stream().filter(request -> request.apiKey().equals(ApiKeys.FETCH)).count());
     }
 
     @SuppressWarnings("deprecation")
@@ -560,9 +560,9 @@ public class KafkaConsumerTest {
 
         // The underlying client SHOULD get a fetch request
         final Queue<ClientRequest> requests = client.requests();
-        Assert.assertEquals(1, requests.size());
+        assertEquals(1, requests.size());
         final Class<? extends AbstractRequest.Builder> aClass = requests.peek().requestBuilder().getClass();
-        Assert.assertEquals(FetchRequest.Builder.class, aClass);
+        assertEquals(FetchRequest.Builder.class, aClass);
     }
 
     @Test
@@ -1747,15 +1747,15 @@ public class KafkaConsumerTest {
             if (waitMs > 0)
                 time.sleep(waitMs);
             if (interrupt) {
-                assertTrue("Close terminated prematurely", future.cancel(true));
+                assertTrue(future.cancel(true), "Close terminated prematurely");
 
                 TestUtils.waitForCondition(
                     () -> closeException.get() != null, "InterruptException did not occur within timeout.");
 
-                assertTrue("Expected exception not thrown " + closeException, closeException.get() instanceof InterruptException);
+                assertTrue(closeException.get() instanceof InterruptException, "Expected exception not thrown " + closeException);
             } else {
                 future.get(500, TimeUnit.MILLISECONDS); // Should succeed without TimeoutException or ExecutionException
-                assertNull("Unexpected exception during close", closeException.get());
+                assertNull(closeException.get(), "Unexpected exception during close");
             }
         } finally {
             executor.shutdownNow();
@@ -2596,7 +2596,7 @@ public class KafkaConsumerTest {
         assertNotNull(consumer.getClientId());
         assertNotEquals(0, consumer.getClientId().length());
         assertEquals(3, CLIENT_IDS.size());
-        CLIENT_IDS.forEach(id -> assertEquals(id, consumer.getClientId()));
+        CLIENT_IDS.forEach(id -> Assertions.assertEquals(id, consumer.getClientId()));
         consumer.close();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -93,7 +93,6 @@ import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.common.metrics.stats.Avg;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2596,7 +2596,7 @@ public class KafkaConsumerTest {
         assertNotNull(consumer.getClientId());
         assertNotEquals(0, consumer.getClientId().length());
         assertEquals(3, CLIENT_IDS.size());
-        CLIENT_IDS.forEach(id -> Assertions.assertEquals(id, consumer.getClientId()));
+        CLIENT_IDS.forEach(id -> assertEquals(id, consumer.getClientId()));
         consumer.close();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/MockConsumerTest.java
@@ -18,8 +18,7 @@ package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -29,15 +28,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MockConsumerTest {
     
-    private MockConsumer<String, String> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    private final MockConsumer<String, String> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
 
     @Test
     public void testSimpleMock() {
@@ -90,7 +87,8 @@ public class MockConsumerTest {
         assertEquals(2L, consumer.position(tp));
         consumer.commitSync();
         assertEquals(2L, consumer.committed(Collections.singleton(tp)).get(tp).offset());
-        assertThat(consumer.groupMetadata(), equalTo(new ConsumerGroupMetadata("dummy.group.id", 1, "1", Optional.empty())));
+        assertEquals(new ConsumerGroupMetadata("dummy.group.id", 1, "1", Optional.empty()),
+            consumer.groupMetadata());
     }
 
     @Test
@@ -101,8 +99,8 @@ public class MockConsumerTest {
         consumer.updateEndOffsets(Collections.singletonMap(partition, 1L));
         consumer.seekToEnd(Collections.singleton(partition));
         ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1));
-        assertThat(records.count(), is(0));
-        assertThat(records.isEmpty(), is(true));
+        assertEquals(0, records.count());
+        assertTrue(records.isEmpty());
     }
 
     @Test
@@ -118,7 +116,7 @@ public class MockConsumerTest {
         consumer.poll(Duration.ofMillis(1));
         consumer.resume(testPartitionList);
         ConsumerRecords<String, String> recordsSecondPoll = consumer.poll(Duration.ofMillis(1));
-        assertThat(recordsSecondPoll.count(), is(1));
+        assertEquals(1, recordsSecondPoll.count());
     }
 
     @Test
@@ -126,14 +124,14 @@ public class MockConsumerTest {
         TopicPartition partition = new TopicPartition("test", 0);
         consumer.updateEndOffsets(Collections.singletonMap(partition, 10L));
         // consumer.endOffsets should NOT change the value of end offsets
-        Assert.assertEquals(10L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
-        Assert.assertEquals(10L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
-        Assert.assertEquals(10L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
+        assertEquals(10L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
+        assertEquals(10L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
+        assertEquals(10L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
         consumer.updateEndOffsets(Collections.singletonMap(partition, 11L));
         // consumer.endOffsets should NOT change the value of end offsets
-        Assert.assertEquals(11L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
-        Assert.assertEquals(11L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
-        Assert.assertEquals(11L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
+        assertEquals(11L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
+        assertEquals(11L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
+        assertEquals(11L, (long) consumer.endOffsets(Collections.singleton(partition)).get(partition));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/OffsetAndMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/OffsetAndMetadataTest.java
@@ -17,13 +17,13 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.common.utils.Serializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This test case ensures OffsetAndMetadata class is serializable and is serialization compatible.

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -20,8 +20,8 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,8 +32,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RangeAssignorTest {
 
@@ -51,7 +51,7 @@ public class RangeAssignorTest {
 
     private List<MemberInfo> staticMemberInfos;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         staticMemberInfos = new ArrayList<>();
         staticMemberInfos.add(new MemberInfo(consumer1, Optional.of(instance1)));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,8 +31,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.clients.consumer.RangeAssignorTest.checkStaticAssignment;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RoundRobinAssignorTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.clients.consumer;
 
 import static org.apache.kafka.clients.consumer.StickyAssignor.serializeTopicPartitionAssignment;
 import static org.apache.kafka.clients.consumer.internals.AbstractStickyAssignor.DEFAULT_GENERATION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -36,7 +36,7 @@ import org.apache.kafka.clients.consumer.internals.AbstractStickyAssignorTest;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.CollectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StickyAssignorTest extends AbstractStickyAssignorTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -52,7 +52,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -69,14 +69,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractCoordinatorTest {
     private static final ByteBuffer EMPTY_DATA = ByteBuffer.wrap(new byte[0]);
@@ -1008,16 +1008,16 @@ public class AbstractCoordinatorTest {
 
         mockClient.backoff(node, 50);
         RequestFuture<Void> noBrokersAvailableFuture = coordinator.lookupCoordinator();
-        assertTrue("Failed future expected", noBrokersAvailableFuture.failed());
+        assertTrue(noBrokersAvailableFuture.failed(), "Failed future expected");
         mockTime.sleep(50);
 
         RequestFuture<Void> future = coordinator.lookupCoordinator();
-        assertFalse("Request not sent", future.isDone());
-        assertSame("New request sent while one is in progress", future, coordinator.lookupCoordinator());
+        assertFalse(future.isDone(), "Request not sent");
+        assertSame(future, coordinator.lookupCoordinator(), "New request sent while one is in progress");
 
         mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
         coordinator.ensureCoordinatorReady(mockTime.timer(Long.MAX_VALUE));
-        assertNotSame("New request not sent after previous completed", future, coordinator.lookupCoordinator());
+        assertNotSame(future, coordinator.lookupCoordinator(), "New request not sent after previous completed");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignorTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor.MemberInfo;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractPartitionAssignorTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -30,14 +30,15 @@ import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractStickyAssignorTest {
     protected AbstractStickyAssignor assignor;
@@ -49,7 +50,7 @@ public abstract class AbstractStickyAssignorTest {
 
     protected abstract Subscription buildSubscription(List<String> topics, List<TopicPartition> partitions);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         assignor = createAssignor();
 
@@ -422,7 +423,8 @@ public abstract class AbstractStickyAssignorTest {
         verifyValidityAndBalance(subscriptions, assignment, partitionsPerTopic);
     }
 
-    @Test(timeout = 30 * 1000)
+    @Timeout(30)
+    @Test
     public void testLargeAssignmentAndGroupWithUniformSubscription() {
         // 1 million partitions!
         int topicCount = 500;
@@ -552,7 +554,7 @@ public abstract class AbstractStickyAssignorTest {
             String consumer = entry.getKey();
             List<TopicPartition> topicPartitions = entry.getValue();
             int size = topicPartitions.size();
-            assertTrue("Consumer " + consumer + " is assigned more topic partitions than expected.", size <= 1);
+            assertTrue(size <= 1, "Consumer " + consumer + " is assigned more topic partitions than expected.");
             if (size == 1)
                 partitionsAssigned.put(consumer, topicPartitions.get(0));
         }
@@ -574,9 +576,9 @@ public abstract class AbstractStickyAssignorTest {
         for (Map.Entry<String, List<TopicPartition>> entry: assignments) {
             String consumer = entry.getKey();
             List<TopicPartition> topicPartitions = entry.getValue();
-            assertEquals("Consumer " + consumer + " is assigned more topic partitions than expected.", 1, topicPartitions.size());
-            assertTrue("Stickiness was not honored for consumer " + consumer,
-                (!partitionsAssigned.containsKey(consumer)) || (assignment.get(consumer).contains(partitionsAssigned.get(consumer))));
+            assertEquals(1, topicPartitions.size(), "Consumer " + consumer + " is assigned more topic partitions than expected.");
+            assertTrue((!partitionsAssigned.containsKey(consumer)) || (assignment.get(consumer).contains(partitionsAssigned.get(consumer))),
+                "Stickiness was not honored for consumer " + consumer);
         }
     }
 
@@ -588,7 +590,7 @@ public abstract class AbstractStickyAssignorTest {
         subscriptions = Collections.singletonMap(consumerId, new Subscription(topics("topic01", "topic02", "topic03")));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
-        assertEquals(assignment.values().stream().mapToInt(topicPartitions -> topicPartitions.size()).sum(), 1 + 100);
+        assertEquals(assignment.values().stream().mapToInt(List::size).sum(), 1 + 100);
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
         assertTrue(isFullyBalanced(assignment));
     }
@@ -734,9 +736,9 @@ public abstract class AbstractStickyAssignorTest {
             String consumer = consumers.get(i);
             List<TopicPartition> partitions = assignments.get(consumer);
             for (TopicPartition partition: partitions)
-                assertTrue("Error: Partition " + partition + "is assigned to c" + i + ", but it is not subscribed to Topic t" + partition.topic()
-                        + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString(),
-                    subscriptions.get(consumer).topics().contains(partition.topic()));
+                assertTrue(subscriptions.get(consumer).topics().contains(partition.topic()),
+                    "Error: Partition " + partition + "is assigned to c" + i + ", but it is not subscribed to Topic t" + partition.topic()
+                                + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString());
 
             if (i == size - 1)
                 continue;
@@ -747,9 +749,9 @@ public abstract class AbstractStickyAssignorTest {
 
                 Set<TopicPartition> intersection = new HashSet<>(partitions);
                 intersection.retainAll(otherPartitions);
-                assertTrue("Error: Consumers c" + i + " and c" + j + " have common partitions assigned to them: " + intersection.toString()
-                        + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString(),
-                    intersection.isEmpty());
+                assertTrue(intersection.isEmpty(),
+                    "Error: Consumers c" + i + " and c" + j + " have common partitions assigned to them: " + intersection.toString()
+                                + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString());
 
                 int len = partitions.size();
                 int otherLen = otherPartitions.size();
@@ -765,13 +767,12 @@ public abstract class AbstractStickyAssignorTest {
 
                 // If there's any overlap in the subscribed topics, we should have been able to balance partitions
                 for (String topic: map.keySet()) {
-                    assertFalse("Error: Some partitions can be moved from c" + moreLoaded + " to c" + lessLoaded
-                            + " to achieve a better balance"
-                            + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen
-                            + " partitions."
-                            + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments
-                            .toString(),
-                        otherMap.containsKey(topic));
+                    assertFalse(otherMap.containsKey(topic),
+                        "Error: Some partitions can be moved from c" + moreLoaded + " to c" + lessLoaded
+                                        + " to achieve a better balance"
+                                        + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen
+                                        + " partitions."
+                                        + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments);
                 }
             }
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractStickyAssignorTest.java
@@ -737,8 +737,8 @@ public abstract class AbstractStickyAssignorTest {
             List<TopicPartition> partitions = assignments.get(consumer);
             for (TopicPartition partition: partitions)
                 assertTrue(subscriptions.get(consumer).topics().contains(partition.topic()),
-                    "Error: Partition " + partition + "is assigned to c" + i + ", but it is not subscribed to Topic t" + partition.topic()
-                                + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString());
+                    "Error: Partition " + partition + "is assigned to c" + i + ", but it is not subscribed to Topic t" +
+                    partition.topic() + "\nSubscriptions: " + subscriptions + "\nAssignments: " + assignments);
 
             if (i == size - 1)
                 continue;
@@ -750,8 +750,8 @@ public abstract class AbstractStickyAssignorTest {
                 Set<TopicPartition> intersection = new HashSet<>(partitions);
                 intersection.retainAll(otherPartitions);
                 assertTrue(intersection.isEmpty(),
-                    "Error: Consumers c" + i + " and c" + j + " have common partitions assigned to them: " + intersection.toString()
-                                + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments.toString());
+                    "Error: Consumers c" + i + " and c" + j + " have common partitions assigned to them: " + intersection +
+                    "\nSubscriptions: " + subscriptions + "\nAssignments: " + assignments);
 
                 int len = partitions.size();
                 int otherLen = otherPartitions.size();
@@ -768,11 +768,10 @@ public abstract class AbstractStickyAssignorTest {
                 // If there's any overlap in the subscribed topics, we should have been able to balance partitions
                 for (String topic: map.keySet()) {
                     assertFalse(otherMap.containsKey(topic),
-                        "Error: Some partitions can be moved from c" + moreLoaded + " to c" + lessLoaded
-                                        + " to achieve a better balance"
-                                        + "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen
-                                        + " partitions."
-                                        + "\nSubscriptions: " + subscriptions.toString() + "\nAssignments: " + assignments);
+                        "Error: Some partitions can be moved from c" + moreLoaded + " to c" + lessLoaded + " to achieve a better balance" +
+                        "\nc" + i + " has " + len + " partitions, and c" + j + " has " + otherLen + " partitions." +
+                        "\nSubscriptions: " + subscriptions +
+                        "\nAssignments: " + assignments);
                 }
             }
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptorsTest.java
@@ -24,16 +24,16 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumerInterceptorsTest {
     private final int filterPartition1 = 5;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,9 +43,9 @@ import java.util.regex.Pattern;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumerMetadataTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -40,18 +40,18 @@ import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -94,7 +94,7 @@ public class ConsumerNetworkClientTest {
         final RequestFuture<ClientResponse> future = consumerClient.send(node, heartbeat());
         consumerClient.poll(future);
         assertTrue(future.failed());
-        assertTrue("Expected only an authentication error.", future.exception() instanceof AuthenticationException);
+        assertTrue(future.exception() instanceof AuthenticationException, "Expected only an authentication error.");
 
         time.sleep(30); // wait less than the backoff period
         assertTrue(client.connectionFailed(node));
@@ -102,7 +102,7 @@ public class ConsumerNetworkClientTest {
         final RequestFuture<ClientResponse> future2 = consumerClient.send(node, heartbeat());
         consumerClient.poll(future2);
         assertTrue(future2.failed());
-        assertTrue("Expected only an authentication error.", future2.exception() instanceof AuthenticationException);
+        assertTrue(future2.exception() instanceof AuthenticationException, "Expected only an authentication error.");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.protocol.types.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -35,10 +35,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.kafka.test.TestUtils.toSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConsumerProtocolTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CooperativeConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CooperativeConsumerCoordinatorTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+
+public class CooperativeConsumerCoordinatorTest extends ConsumerCoordinatorTest {
+    public CooperativeConsumerCoordinatorTest() {
+        super(ConsumerPartitionAssignor.RebalanceProtocol.COOPERATIVE);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/EagerConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/EagerConsumerCoordinatorTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor;
+
+public class EagerConsumerCoordinatorTest extends ConsumerCoordinatorTest {
+    public EagerConsumerCoordinatorTest() {
+        super(ConsumerPartitionAssignor.RebalanceProtocol.EAGER);
+    }
+}
+

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -99,10 +99,10 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.DelayedReceive;
 import org.apache.kafka.test.MockSelector;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.DataOutputStream;
 import java.lang.reflect.Field;
@@ -139,15 +139,15 @@ import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UND
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
 import static org.apache.kafka.test.TestUtils.assertOptional;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
 
@@ -188,7 +188,7 @@ public class FetcherTest {
     private MemoryRecords partialRecords;
     private ExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         records = buildRecords(1L, 3, 1);
         nextRecords = buildRecords(4L, 2, 4);
@@ -207,7 +207,7 @@ public class FetcherTest {
             tp -> validLeaderEpoch), false, 0L);
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         if (metrics != null)
             this.metrics.close();
@@ -958,26 +958,26 @@ public class FetcherTest {
         consumerClient.poll(time.timer(0));
 
         Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
-        assertEquals("Should not return any records when partition is paused", 0, fetchedRecords.size());
-        assertTrue("Should still contain completed fetches", fetcher.hasCompletedFetches());
-        assertFalse("Should not have any available (non-paused) completed fetches", fetcher.hasAvailableFetches());
+        assertEquals(0, fetchedRecords.size(), "Should not return any records when partition is paused");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
+        assertFalse(fetcher.hasAvailableFetches(), "Should not have any available (non-paused) completed fetches");
         assertNull(fetchedRecords.get(tp0));
         assertEquals(0, fetcher.sendFetches());
 
         subscriptions.resume(tp0);
 
-        assertTrue("Should have available (non-paused) completed fetches", fetcher.hasAvailableFetches());
+        assertTrue(fetcher.hasAvailableFetches(), "Should have available (non-paused) completed fetches");
 
         consumerClient.poll(time.timer(0));
         fetchedRecords = fetchedRecords();
-        assertEquals("Should return records when partition is resumed", 1, fetchedRecords.size());
+        assertEquals(1, fetchedRecords.size(), "Should return records when partition is resumed");
         assertNotNull(fetchedRecords.get(tp0));
         assertEquals(3, fetchedRecords.get(tp0).size());
 
         consumerClient.poll(time.timer(0));
         fetchedRecords = fetchedRecords();
-        assertEquals("Should not return records after previously paused partitions are fetched", 0, fetchedRecords.size());
-        assertFalse("Should no longer contain completed fetches", fetcher.hasCompletedFetches());
+        assertEquals(0, fetchedRecords.size(), "Should not return records after previously paused partitions are fetched");
+        assertFalse(fetcher.hasCompletedFetches(), "Should no longer contain completed fetches");
     }
 
     @Test
@@ -1005,14 +1005,14 @@ public class FetcherTest {
         consumerClient.poll(time.timer(0));
 
         fetchedRecords = fetchedRecords();
-        assertEquals("Should return completed fetch for unpaused partitions", 1, fetchedRecords.size());
-        assertTrue("Should still contain completed fetches", fetcher.hasCompletedFetches());
+        assertEquals(1, fetchedRecords.size(), "Should return completed fetch for unpaused partitions");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
         assertNotNull(fetchedRecords.get(tp1));
         assertNull(fetchedRecords.get(tp0));
 
         fetchedRecords = fetchedRecords();
-        assertEquals("Should return no records for remaining paused partition", 0, fetchedRecords.size());
-        assertTrue("Should still contain completed fetches", fetcher.hasCompletedFetches());
+        assertEquals(0, fetchedRecords.size(), "Should return no records for remaining paused partition");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
     }
 
     @Test
@@ -1042,9 +1042,9 @@ public class FetcherTest {
         consumerClient.poll(time.timer(0));
 
         fetchedRecords = fetchedRecords();
-        assertEquals("Should return no records for all paused partitions", 0, fetchedRecords.size());
-        assertTrue("Should still contain completed fetches", fetcher.hasCompletedFetches());
-        assertFalse("Should not have any available (non-paused) completed fetches", fetcher.hasAvailableFetches());
+        assertEquals(0, fetchedRecords.size(), "Should return no records for all paused partitions");
+        assertTrue(fetcher.hasCompletedFetches(), "Should still contain completed fetches");
+        assertFalse(fetcher.hasAvailableFetches(), "Should not have any available (non-paused) completed fetches");
     }
 
     @Test
@@ -1065,17 +1065,17 @@ public class FetcherTest {
 
         fetchedRecords = fetchedRecords();
 
-        assertEquals("Should return 2 records from fetch with 3 records", 2, fetchedRecords.get(tp0).size());
-        assertFalse("Should have no completed fetches", fetcher.hasCompletedFetches());
+        assertEquals(2, fetchedRecords.get(tp0).size(), "Should return 2 records from fetch with 3 records");
+        assertFalse(fetcher.hasCompletedFetches(), "Should have no completed fetches");
 
         subscriptions.pause(tp0);
         consumerClient.poll(time.timer(0));
 
         fetchedRecords = fetchedRecords();
 
-        assertEquals("Should return no records for paused partitions", 0, fetchedRecords.size());
-        assertTrue("Should have 1 entry in completed fetches", fetcher.hasCompletedFetches());
-        assertFalse("Should not have any available (non-paused) completed fetches", fetcher.hasAvailableFetches());
+        assertEquals(0, fetchedRecords.size(), "Should return no records for paused partitions");
+        assertTrue(fetcher.hasCompletedFetches(), "Should have 1 entry in completed fetches");
+        assertFalse(fetcher.hasAvailableFetches(), "Should not have any available (non-paused) completed fetches");
 
         subscriptions.resume(tp0);
 
@@ -1083,8 +1083,8 @@ public class FetcherTest {
 
         fetchedRecords = fetchedRecords();
 
-        assertEquals("Should return last remaining record", 1, fetchedRecords.get(tp0).size());
-        assertFalse("Should have no completed fetches", fetcher.hasCompletedFetches());
+        assertEquals(1, fetchedRecords.get(tp0).size(), "Should return last remaining record");
+        assertFalse(fetcher.hasCompletedFetches(), "Should have no completed fetches");
     }
 
     @Test
@@ -1101,11 +1101,11 @@ public class FetcherTest {
         subscriptions.resume(tp0);
         consumerClient.poll(time.timer(0));
 
-        assertTrue("Should have 1 entry in completed fetches", fetcher.hasCompletedFetches());
+        assertTrue(fetcher.hasCompletedFetches(), "Should have 1 entry in completed fetches");
         Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchedRecords = fetchedRecords();
-        assertEquals("Should not return any records because we seeked to a new offset", 0, fetchedRecords.size());
+        assertEquals(0, fetchedRecords.size(), "Should not return any records because we seeked to a new offset");
         assertNull(fetchedRecords.get(tp0));
-        assertFalse("Should have no completed fetches", fetcher.hasCompletedFetches());
+        assertFalse(fetcher.hasCompletedFetches(), "Should have no completed fetches");
     }
 
     @Test
@@ -1144,8 +1144,8 @@ public class FetcherTest {
         client.prepareResponse(fullFetchResponse(tp0, this.records, Errors.FENCED_LEADER_EPOCH, 100L, 0));
         consumerClient.poll(time.timer(0));
 
-        assertEquals("Should not return any records", 0, fetcher.fetchedRecords().size());
-        assertEquals("Should have requested metadata update", 0L, metadata.timeToNextUpdate(time.milliseconds()));
+        assertEquals(0, fetcher.fetchedRecords().size(), "Should not return any records");
+        assertEquals(0L, metadata.timeToNextUpdate(time.milliseconds()), "Should have requested metadata update");
     }
 
     @Test
@@ -1158,8 +1158,8 @@ public class FetcherTest {
         client.prepareResponse(fullFetchResponse(tp0, this.records, Errors.UNKNOWN_LEADER_EPOCH, 100L, 0));
         consumerClient.poll(time.timer(0));
 
-        assertEquals("Should not return any records", 0, fetcher.fetchedRecords().size());
-        assertNotEquals("Should not have requested metadata update", 0L, metadata.timeToNextUpdate(time.milliseconds()));
+        assertEquals(0, fetcher.fetchedRecords().size(), "Should not return any records");
+        assertNotEquals(0L, metadata.timeToNextUpdate(time.milliseconds()), "Should not have requested metadata update");
     }
 
     @Test
@@ -1178,8 +1178,8 @@ public class FetcherTest {
             if (body instanceof FetchRequest) {
                 FetchRequest fetchRequest = (FetchRequest) body;
                 fetchRequest.fetchData().values().forEach(partitionData -> {
-                    assertTrue("Expected Fetcher to set leader epoch in request", partitionData.currentLeaderEpoch.isPresent());
-                    assertEquals("Expected leader epoch to match epoch from metadata update", 99, partitionData.currentLeaderEpoch.get().longValue());
+                    assertTrue(partitionData.currentLeaderEpoch.isPresent(), "Expected Fetcher to set leader epoch in request");
+                    assertEquals(99, partitionData.currentLeaderEpoch.get().longValue(), "Expected leader epoch to match epoch from metadata update");
                 });
                 return true;
             } else {
@@ -1745,7 +1745,7 @@ public class FetcherTest {
         assertEquals(237L, subscriptions.position(tp0).offset);
     }
 
-    @Test(timeout = 10000)
+    @Test @Timeout(10)
     public void testEarlierOffsetResetArrivesLate() throws InterruptedException {
         LogContext lc = new LogContext();
         buildFetcher(spy(new SubscriptionState(lc, OffsetResetStrategy.EARLIEST)), lc);
@@ -2044,10 +2044,10 @@ public class FetcherTest {
             fetcher.getTopicMetadata(new MetadataRequest.Builder(Collections.singletonList(topicName), false),
                     time.timer(5000L));
 
-        Assert.assertNotNull(topicMetadata);
-        Assert.assertNotNull(topicMetadata.get(topicName));
+        assertNotNull(topicMetadata);
+        assertNotNull(topicMetadata.get(topicName));
         //noinspection ConstantConditions
-        Assert.assertEquals(metadata.fetch().partitionCountForTopic(topicName).longValue(), topicMetadata.get(topicName).size());
+        assertEquals(metadata.fetch().partitionCountForTopic(topicName).longValue(), topicMetadata.get(topicName).size());
     }
 
     /*
@@ -2635,8 +2635,8 @@ public class FetcherTest {
             if (body instanceof ListOffsetsRequest) {
                 ListOffsetsRequest offsetRequest = (ListOffsetsRequest) body;
                 int epoch = offsetRequest.topics().get(0).partitions().get(0).currentLeaderEpoch();
-                assertTrue("Expected Fetcher to set leader epoch in request", epoch != ListOffsetsResponse.UNKNOWN_EPOCH);
-                assertEquals("Expected leader epoch to match epoch from metadata update", epoch, 99);
+                assertTrue(epoch != ListOffsetsResponse.UNKNOWN_EPOCH, "Expected Fetcher to set leader epoch in request");
+                assertEquals(epoch, 99, "Expected leader epoch to match epoch from metadata update");
                 return true;
             } else {
                 fail("Should have seen ListOffsetRequest");
@@ -2685,12 +2685,9 @@ public class FetcherTest {
         Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestampMap =
             fetcher.offsetsForTimes(timestampToSearch, time.timer(Long.MAX_VALUE));
 
-        assertNotNull("Expect Fetcher.offsetsForTimes() to return non-null result for " + tp0,
-                      offsetAndTimestampMap.get(tp0));
-        assertNotNull("Expect Fetcher.offsetsForTimes() to return non-null result for " + tp1,
-                      offsetAndTimestampMap.get(tp1));
-        assertNotNull("Expect Fetcher.offsetsForTimes() to return non-null result for " + t2p0,
-                      offsetAndTimestampMap.get(t2p0));
+        assertNotNull(offsetAndTimestampMap.get(tp0), "Expect Fetcher.offsetsForTimes() to return non-null result for " + tp0);
+        assertNotNull(offsetAndTimestampMap.get(tp1), "Expect Fetcher.offsetsForTimes() to return non-null result for " + tp1);
+        assertNotNull(offsetAndTimestampMap.get(t2p0), "Expect Fetcher.offsetsForTimes() to return non-null result for " + t2p0);
         assertEquals(11L, offsetAndTimestampMap.get(tp0).offset());
         assertEquals(32L, offsetAndTimestampMap.get(tp1).offset());
         assertEquals(54L, offsetAndTimestampMap.get(t2p0).offset());
@@ -2722,10 +2719,9 @@ public class FetcherTest {
         timestampToSearch.put(tp0, ListOffsetsRequest.LATEST_TIMESTAMP);
         Map<TopicPartition, OffsetAndTimestamp> offsetAndTimestampMap = fetcher.offsetsForTimes(timestampToSearch, time.timer(Long.MAX_VALUE));
 
-        assertNotNull("Expect Fetcher.offsetsForTimes() to return non-null result for " + tp0,
-                     offsetAndTimestampMap.get(tp0));
+        assertNotNull(offsetAndTimestampMap.get(tp0), "Expect Fetcher.offsetsForTimes() to return non-null result for " + tp0);
         assertEquals(11L, offsetAndTimestampMap.get(tp0).offset());
-        Assert.assertNotNull(metadata.fetch().partitionCountForTopic(anotherTopic));
+        assertNotNull(metadata.fetch().partitionCountForTopic(anotherTopic));
     }
 
     @Test
@@ -3419,7 +3415,8 @@ public class FetcherTest {
                         ClientRequest request = client.requests().peek();
                         FetchRequest fetchRequest = (FetchRequest) request.requestBuilder().build();
                         int epoch = fetchRequest.metadata().epoch();
-                        assertTrue(String.format("Unexpected epoch expected %d got %d", nextEpoch, epoch), epoch == 0 || epoch == nextEpoch);
+                        assertTrue(epoch == 0 || epoch == nextEpoch,
+                            String.format("Unexpected epoch expected %d got %d", nextEpoch, epoch));
                         nextEpoch++;
                         LinkedHashMap<TopicPartition, FetchResponse.PartitionData<MemoryRecords>> responseMap = new LinkedHashMap<>();
                         responseMap.put(tp0, new FetchResponse.PartitionData<>(Errors.NONE, nextOffset + 2L, nextOffset + 2,
@@ -4054,13 +4051,13 @@ public class FetcherTest {
         // Prepare offset list response from async validation with epoch=2
         client.prepareResponse(prepareOffsetsForLeaderEpochResponse(tp0, Errors.NONE, epochTwo, 10L));
         consumerClient.pollNoWakeup();
-        assertTrue("Expected validation to fail since leader epoch changed", subscriptions.awaitingValidation(tp0));
+        assertTrue(subscriptions.awaitingValidation(tp0), "Expected validation to fail since leader epoch changed");
 
         // Next round of validation, should succeed in validating the position
         fetcher.validateOffsetsIfNeeded();
         client.prepareResponse(prepareOffsetsForLeaderEpochResponse(tp0, Errors.NONE, epochThree, 10L));
         consumerClient.pollNoWakeup();
-        assertFalse("Expected validation to succeed with latest epoch", subscriptions.awaitingValidation(tp0));
+        assertFalse(subscriptions.awaitingValidation(tp0), "Expected validation to succeed with latest epoch");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1745,7 +1745,8 @@ public class FetcherTest {
         assertEquals(237L, subscriptions.position(tp0).offset);
     }
 
-    @Test @Timeout(10)
+    @Timeout(10)
+    @Test
     public void testEarlierOffsetResetArrivesLate() throws InterruptedException {
         LogContext lc = new LogContext();
         buildFetcher(spy(new SubscriptionState(lc, OffsetResetStrategy.EARLIEST)), lc);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/HeartbeatTest.java
@@ -19,14 +19,14 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.GroupRebalanceConfig;
 import org.apache.kafka.common.utils.MockTime;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HeartbeatTest {
     private int sessionTimeoutMs = 300;
@@ -37,7 +37,7 @@ public class HeartbeatTest {
 
     private Heartbeat heartbeat;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         GroupRebalanceConfig rebalanceConfig = new GroupRebalanceConfig(sessionTimeoutMs,
                                                                         maxPollIntervalMs,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/OffsetForLeaderEpochClientTest.java
@@ -31,16 +31,16 @@ import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OffsetForLeaderEpochClientTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/PartitionAssignorAdapterTest.java
@@ -17,9 +17,9 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import static org.apache.kafka.clients.consumer.internals.PartitionAssignorAdapter.getAssignorInstances;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,7 +41,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PartitionAssignorAdapterTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/RequestFutureTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RequestFutureTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -30,7 +30,8 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,11 +44,11 @@ import java.util.regex.Pattern;
 import static java.util.Collections.singleton;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SubscriptionStateTest {
 
@@ -312,7 +313,7 @@ public class SubscriptionStateTest {
     public void patternSubscription() {
         state.subscribe(Pattern.compile(".*"), rebalanceListener);
         state.subscribeFromPattern(new HashSet<>(Arrays.asList(topic, topic1)));
-        assertEquals("Expected subscribed topics count is incorrect", 2, state.subscription().size());
+        assertEquals(2, state.subscription().size(), "Expected subscribed topics count is incorrect");
     }
 
     @Test
@@ -366,8 +367,8 @@ public class SubscriptionStateTest {
 
         // Set the preferred replica with lease
         state.updatePreferredReadReplica(tp0, 42, () -> 10L);
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 9L),  value -> assertEquals(value.intValue(), 42));
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 10L),  value -> assertEquals(value.intValue(), 42));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 9L),  value -> Assertions.assertEquals(value.intValue(), 42));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 10L),  value -> Assertions.assertEquals(value.intValue(), 42));
         assertFalse(state.preferredReadReplica(tp0, 11L).isPresent());
 
         // Unset the preferred replica
@@ -377,13 +378,13 @@ public class SubscriptionStateTest {
 
         // Set to new preferred replica with lease
         state.updatePreferredReadReplica(tp0, 43, () -> 20L);
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 11L),  value -> assertEquals(value.intValue(), 43));
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 20L),  value -> assertEquals(value.intValue(), 43));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 11L),  value -> Assertions.assertEquals(value.intValue(), 43));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 20L),  value -> Assertions.assertEquals(value.intValue(), 43));
         assertFalse(state.preferredReadReplica(tp0, 21L).isPresent());
 
         // Set to new preferred replica without clearing first
         state.updatePreferredReadReplica(tp0, 44, () -> 30L);
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 30L),  value -> assertEquals(value.intValue(), 44));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 30L),  value -> Assertions.assertEquals(value.intValue(), 44));
         assertFalse(state.preferredReadReplica(tp0, 31L).isPresent());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -367,8 +367,8 @@ public class SubscriptionStateTest {
 
         // Set the preferred replica with lease
         state.updatePreferredReadReplica(tp0, 42, () -> 10L);
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 9L),  value -> Assertions.assertEquals(value.intValue(), 42));
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 10L),  value -> Assertions.assertEquals(value.intValue(), 42));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 9L),  value -> assertEquals(value.intValue(), 42));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 10L),  value -> assertEquals(value.intValue(), 42));
         assertFalse(state.preferredReadReplica(tp0, 11L).isPresent());
 
         // Unset the preferred replica
@@ -378,13 +378,13 @@ public class SubscriptionStateTest {
 
         // Set to new preferred replica with lease
         state.updatePreferredReadReplica(tp0, 43, () -> 20L);
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 11L),  value -> Assertions.assertEquals(value.intValue(), 43));
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 20L),  value -> Assertions.assertEquals(value.intValue(), 43));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 11L),  value -> assertEquals(value.intValue(), 43));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 20L),  value -> assertEquals(value.intValue(), 43));
         assertFalse(state.preferredReadReplica(tp0, 21L).isPresent());
 
         // Set to new preferred replica without clearing first
         state.updatePreferredReadReplica(tp0, 44, () -> 30L);
-        TestUtils.assertOptional(state.preferredReadReplica(tp0, 30L),  value -> Assertions.assertEquals(value.intValue(), 44));
+        TestUtils.assertOptional(state.preferredReadReplica(tp0, 30L),  value -> assertEquals(value.intValue(), 44));
         assertFalse(state.preferredReadReplica(tp0, 31L).isPresent());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -341,8 +341,7 @@ public class KafkaProducerTest {
             TestUtils.waitForCondition(() -> closeException.get() != null,
                     "InterruptException did not occur within timeout.");
 
-            assertTrue(
-                    closeException.get() instanceof InterruptException, "Expected exception not thrown " + closeException);
+            assertTrue(closeException.get() instanceof InterruptException, "Expected exception not thrown " + closeException);
         } finally {
             executor.shutdownNow();
         }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -68,8 +68,8 @@ import org.apache.kafka.test.MockPartitioner;
 import org.apache.kafka.test.MockProducerInterceptor;
 import org.apache.kafka.test.MockSerializer;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -98,14 +98,14 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -181,7 +181,7 @@ public class KafkaProducerTest {
 
         MockMetricsReporter mockMetricsReporter = (MockMetricsReporter) producer.metrics.reporters().get(0);
 
-        Assert.assertEquals(producer.getClientId(), mockMetricsReporter.clientId);
+        assertEquals(producer.getClientId(), mockMetricsReporter.clientId);
         producer.close();
     }
 
@@ -225,7 +225,7 @@ public class KafkaProducerTest {
         try (KafkaProducer<?, ?> ff = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer())) {
             fail("Constructor should throw exception");
         } catch (ConfigException e) {
-            assertTrue("Unexpected exception message: " + e.getMessage(), e.getMessage().contains("not string key"));
+            assertTrue(e.getMessage().contains("not string key"), "Unexpected exception message: " + e.getMessage());
         }
     }
 
@@ -264,7 +264,7 @@ public class KafkaProducerTest {
             assertEquals(0, MockProducerInterceptor.CLOSE_COUNT.get());
 
             // Cluster metadata will only be updated on calling onSend.
-            Assert.assertNull(MockProducerInterceptor.CLUSTER_META.get());
+            assertNull(MockProducerInterceptor.CLUSTER_META.get());
 
             producer.close();
             assertEquals(1, MockProducerInterceptor.INIT_COUNT.get());
@@ -335,13 +335,13 @@ public class KafkaProducerTest {
             // Ensure send has started
             client.waitForRequests(1, 1000);
 
-            assertTrue("Close terminated prematurely", future.cancel(true));
+            assertTrue(future.cancel(true), "Close terminated prematurely");
 
             TestUtils.waitForCondition(() -> closeException.get() != null,
                     "InterruptException did not occur within timeout.");
 
-            assertTrue("Expected exception not thrown " + closeException,
-                    closeException.get() instanceof InterruptException);
+            assertTrue(
+                    closeException.get() instanceof InterruptException, "Expected exception not thrown " + closeException);
         } finally {
             executor.shutdownNow();
         }
@@ -731,9 +731,9 @@ public class KafkaProducerTest {
                 Future<RecordMetadata> response = producer.send(new ProducerRecord<>("topic", "value" + i));
                 futureResponses.add(response);
             }
-            futureResponses.forEach(res -> assertFalse(res.isDone()));
+            futureResponses.forEach(res -> Assertions.assertFalse(res.isDone()));
             producer.flush();
-            futureResponses.forEach(res -> assertTrue(res.isDone()));
+            futureResponses.forEach(res -> Assertions.assertTrue(res.isDone()));
         }
     }
 
@@ -1096,8 +1096,8 @@ public class KafkaProducerTest {
 
         Future<RecordMetadata> future = producer.send(record);
 
-        assertEquals("Cluster has incorrect invalid topic list.", Collections.singleton(invalidTopicName),
-                metadata.fetch().invalidTopics());
+        assertEquals(Collections.singleton(invalidTopicName),
+                metadata.fetch().invalidTopics(), "Cluster has incorrect invalid topic list.");
         TestUtils.assertFutureError(future, InvalidTopicException.class);
 
         producer.close(Duration.ofMillis(0));
@@ -1267,7 +1267,7 @@ public class KafkaProducerTest {
         MetricName testMetricName = producer.metrics.metricName("test-metric",
                 "grp1", "test metric");
         producer.metrics.addMetric(testMetricName, new Avg());
-        Assert.assertNotNull(server.getObjectInstance(new ObjectName("kafka.producer:type=grp1,client-id=client-1")));
+        assertNotNull(server.getObjectInstance(new ObjectName("kafka.producer:type=grp1,client-id=client-1")));
         producer.close();
     }
 
@@ -1289,7 +1289,7 @@ public class KafkaProducerTest {
         assertNotNull(producer.getClientId());
         assertNotEquals(0, producer.getClientId().length());
         assertEquals(4, CLIENT_IDS.size());
-        CLIENT_IDS.forEach(id -> assertEquals(id, producer.getClientId()));
+        CLIENT_IDS.forEach(id -> Assertions.assertEquals(id, producer.getClientId()));
         producer.close();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -68,7 +68,6 @@ import org.apache.kafka.test.MockPartitioner;
 import org.apache.kafka.test.MockProducerInterceptor;
 import org.apache.kafka.test.MockSerializer;
 import org.apache.kafka.test.TestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -100,6 +100,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -731,9 +732,9 @@ public class KafkaProducerTest {
                 Future<RecordMetadata> response = producer.send(new ProducerRecord<>("topic", "value" + i));
                 futureResponses.add(response);
             }
-            futureResponses.forEach(res -> Assertions.assertFalse(res.isDone()));
+            futureResponses.forEach(res -> assertFalse(res.isDone()));
             producer.flush();
-            futureResponses.forEach(res -> Assertions.assertTrue(res.isDone()));
+            futureResponses.forEach(res -> assertTrue(res.isDone()));
         }
     }
 
@@ -1289,7 +1290,7 @@ public class KafkaProducerTest {
         assertNotNull(producer.getClientId());
         assertNotEquals(0, producer.getClientId().length());
         assertEquals(4, CLIENT_IDS.size());
-        CLIENT_IDS.forEach(id -> Assertions.assertEquals(id, producer.getClientId()));
+        CLIENT_IDS.forEach(id -> assertEquals(id, producer.getClientId()));
         producer.close();
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/ProducerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/ProducerConfigTest.java
@@ -19,13 +19,13 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProducerConfigTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/ProducerRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/ProducerRecordTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.clients.producer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProducerRecordTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordMetadataTest.java
@@ -18,10 +18,10 @@ package org.apache.kafka.clients.producer;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.DefaultRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RecordMetadataTest {
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.clients.producer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +33,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RecordSendTest {
 
@@ -49,7 +49,7 @@ public class RecordSendTest {
         ProduceRequestResult request = new ProduceRequestResult(topicPartition);
         FutureRecordMetadata future = new FutureRecordMetadata(request, relOffset,
                 RecordBatch.NO_TIMESTAMP, 0L, 0, 0, Time.SYSTEM);
-        assertFalse("Request is not completed", future.isDone());
+        assertFalse(future.isDone(), "Request is not completed");
         try {
             future.get(5, TimeUnit.MILLISECONDS);
             fail("Should have thrown exception.");

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RoundRobinPartitionerTest.java
@@ -19,15 +19,15 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RoundRobinPartitionerTest {
     private final static Node[] NODES = new Node[] {
@@ -54,13 +54,13 @@ public class RoundRobinPartitionerTest {
             Collections.<String>emptySet(), Collections.<String>emptySet());
         for (int i = 1; i <= 100; i++) {
             int part = partitioner.partition("test", null, null, null, null, cluster);
-            assertTrue("We should never choose a leader-less node in round robin", part == 0 || part == 2);
+            assertTrue(part == 0 || part == 2, "We should never choose a leader-less node in round robin");
             if (part == 0)
                 countForPart0++;
             else
                 countForPart2++;
         }
-        assertEquals("The distribution between two available partitions should be even", countForPart0, countForPart2);
+        assertEquals(countForPart0, countForPart2, "The distribution between two available partitions should be even");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/UniformStickyPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/UniformStickyPartitionerTest.java
@@ -19,15 +19,15 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UniformStickyPartitionerTest {
     private final static Node[] NODES = new Node[] {
@@ -58,7 +58,7 @@ public class UniformStickyPartitionerTest {
             Collections.<String>emptySet(), Collections.<String>emptySet());
         for (int i = 0; i < 50; i++) {
             part = partitioner.partition("test", null, null, null, null, cluster);
-            assertTrue("We should never choose a leader-less node in round robin", part == 0 || part == 2);
+            assertTrue(part == 0 || part == 2, "We should never choose a leader-less node in round robin");
             if (part == 0)
                 countForPart0++;
             else
@@ -68,13 +68,13 @@ public class UniformStickyPartitionerTest {
         partitioner.onNewBatch("test", cluster, part);       
         for (int i = 1; i <= 50; i++) {
             part = partitioner.partition("test", null, null, null, null, cluster);
-            assertTrue("We should never choose a leader-less node in round robin", part == 0 || part == 2);
+            assertTrue(part == 0 || part == 2, "We should never choose a leader-less node in round robin");
             if (part == 0)
                 countForPart0++;
             else
                 countForPart2++;
         }
-        assertEquals("The distribution between two available partitions should be even", countForPart0, countForPart2);
+        assertEquals(countForPart0, countForPart2, "The distribution between two available partitions should be even");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -22,8 +22,8 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -38,11 +38,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
@@ -54,7 +54,7 @@ public class BufferPoolTest {
     private final long maxBlockTimeMs = 10;
     private final String metricGroup = "TestMetrics";
 
-    @After
+    @AfterEach
     public void teardown() {
         this.metrics.close();
     }
@@ -68,24 +68,24 @@ public class BufferPoolTest {
         int size = 1024;
         BufferPool pool = new BufferPool(totalMemory, size, metrics, time, metricGroup);
         ByteBuffer buffer = pool.allocate(size, maxBlockTimeMs);
-        assertEquals("Buffer size should equal requested size.", size, buffer.limit());
-        assertEquals("Unallocated memory should have shrunk", totalMemory - size, pool.unallocatedMemory());
-        assertEquals("Available memory should have shrunk", totalMemory - size, pool.availableMemory());
+        assertEquals(size, buffer.limit(), "Buffer size should equal requested size.");
+        assertEquals(totalMemory - size, pool.unallocatedMemory(), "Unallocated memory should have shrunk");
+        assertEquals(totalMemory - size, pool.availableMemory(), "Available memory should have shrunk");
         buffer.putInt(1);
         buffer.flip();
         pool.deallocate(buffer);
-        assertEquals("All memory should be available", totalMemory, pool.availableMemory());
-        assertEquals("But now some is on the free list", totalMemory - size, pool.unallocatedMemory());
+        assertEquals(totalMemory, pool.availableMemory(), "All memory should be available");
+        assertEquals(totalMemory - size, pool.unallocatedMemory(), "But now some is on the free list");
         buffer = pool.allocate(size, maxBlockTimeMs);
-        assertEquals("Recycled buffer should be cleared.", 0, buffer.position());
-        assertEquals("Recycled buffer should be cleared.", buffer.capacity(), buffer.limit());
+        assertEquals(0, buffer.position(), "Recycled buffer should be cleared.");
+        assertEquals(buffer.capacity(), buffer.limit(), "Recycled buffer should be cleared.");
         pool.deallocate(buffer);
-        assertEquals("All memory should be available", totalMemory, pool.availableMemory());
-        assertEquals("Still a single buffer on the free list", totalMemory - size, pool.unallocatedMemory());
+        assertEquals(totalMemory, pool.availableMemory(), "All memory should be available");
+        assertEquals(totalMemory - size, pool.unallocatedMemory(), "Still a single buffer on the free list");
         buffer = pool.allocate(2 * size, maxBlockTimeMs);
         pool.deallocate(buffer);
-        assertEquals("All memory should be available", totalMemory, pool.availableMemory());
-        assertEquals("Non-standard size didn't go to the free list.", totalMemory - size, pool.unallocatedMemory());
+        assertEquals(totalMemory, pool.availableMemory(), "All memory should be available");
+        assertEquals(totalMemory - size, pool.unallocatedMemory(), "Non-standard size didn't go to the free list.");
     }
 
     /**
@@ -109,9 +109,9 @@ public class BufferPoolTest {
         ByteBuffer buffer = pool.allocate(1024, maxBlockTimeMs);
         CountDownLatch doDealloc = asyncDeallocate(pool, buffer);
         CountDownLatch allocation = asyncAllocate(pool, 5 * 1024);
-        assertEquals("Allocation shouldn't have happened yet, waiting on memory.", 1L, allocation.getCount());
+        assertEquals(1L, allocation.getCount(), "Allocation shouldn't have happened yet, waiting on memory.");
         doDealloc.countDown(); // return the memory
-        assertTrue("Allocation should succeed soon after de-allocation", allocation.await(1, TimeUnit.SECONDS));
+        assertTrue(allocation.await(1, TimeUnit.SECONDS), "Allocation should succeed soon after de-allocation");
     }
 
     private CountDownLatch asyncDeallocate(final BufferPool pool, final ByteBuffer buffer) {
@@ -185,10 +185,10 @@ public class BufferPoolTest {
             // this is good
         }
         // Thread scheduling sometimes means that deallocation varies by this point
-        assertTrue("available memory " + pool.availableMemory(), pool.availableMemory() >= 7 && pool.availableMemory() <= 10);
+        assertTrue(pool.availableMemory() >= 7 && pool.availableMemory() <= 10, "available memory " + pool.availableMemory());
         long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
-        assertTrue("BufferExhaustedException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);
-        assertTrue("BufferExhaustedException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 1000);
+        assertTrue(durationMs >= maxBlockTimeMs, "BufferExhaustedException should not throw before maxBlockTimeMs");
+        assertTrue(durationMs < maxBlockTimeMs + 1000, "BufferExhaustedException should throw soon after maxBlockTimeMs");
     }
 
     /**
@@ -302,7 +302,7 @@ public class BufferPoolTest {
         for (StressTestThread thread : threads)
             thread.join();
         for (StressTestThread thread : threads)
-            assertTrue("Thread should have completed all iterations successfully.", thread.success.get());
+            assertTrue(thread.success.get(), "Thread should have completed all iterations successfully.");
         assertEquals(totalMemory, pool.availableMemory());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/DefaultPartitionerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/DefaultPartitionerTest.java
@@ -20,12 +20,12 @@ import org.apache.kafka.clients.producer.Partitioner;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DefaultPartitionerTest {
     private final static byte[] KEY_BYTES = "key".getBytes();
@@ -46,6 +46,6 @@ public class DefaultPartitionerTest {
         final Cluster cluster = new Cluster("clusterId", asList(NODES), PARTITIONS,
             Collections.<String>emptySet(), Collections.<String>emptySet());
         int partition = partitioner.partition("test",  null, KEY_BYTES, null, null, cluster);
-        assertEquals("Same key should yield same partition", partition, partitioner.partition("test", null, KEY_BYTES, null, null, cluster));
+        assertEquals(partition, partitioner.partition("test", null, KEY_BYTES, null, null, cluster), "Same key should yield same partition");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/FutureRecordMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/FutureRecordMetadataTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.clients.producer.internals;
 
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.MockTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerBatchTest.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -39,12 +39,12 @@ import java.util.concurrent.ExecutionException;
 import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V0;
 import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V1;
 import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProducerBatchTest {
 
@@ -176,14 +176,14 @@ public class ProducerBatchTest {
                 }
             }
             Deque<ProducerBatch> batches = batch.split(200);
-            assertTrue("This batch should be split to multiple small batches.", batches.size() >= 2);
+            assertTrue(batches.size() >= 2, "This batch should be split to multiple small batches.");
 
             for (ProducerBatch splitProducerBatch : batches) {
                 for (RecordBatch splitBatch : splitProducerBatch.records().batches()) {
                     for (Record record : splitBatch) {
-                        assertTrue("Header size should be 1.", record.headers().length == 1);
-                        assertTrue("Header key should be 'header-key'.", record.headers()[0].key().equals("header-key"));
-                        assertTrue("Header value should be 'header-value'.", new String(record.headers()[0].value()).equals("header-value"));
+                        assertTrue(record.headers().length == 1, "Header size should be 1.");
+                        assertTrue(record.headers()[0].key().equals("header-key"), "Header key should be 'header-key'.");
+                        assertTrue(new String(record.headers()[0].value()).equals("header-value"), "Header value should be 'header-value'.");
                     }
                 }
             }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerInterceptorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerInterceptorsTest.java
@@ -22,13 +22,13 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProducerInterceptorsTest {
     private final TopicPartition tp = new TopicPartition("test", 0);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerMetadataTest.java
@@ -24,8 +24,8 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,12 +35,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProducerMetadataTest {
     private static final long METADATA_IDLE_MS = 60 * 1000;
@@ -50,9 +50,9 @@ public class ProducerMetadataTest {
             new LogContext(), new ClusterResourceListeners(), Time.SYSTEM);
     private AtomicReference<Exception> backgroundError = new AtomicReference<>();
 
-    @After
+    @AfterEach
     public void tearDown() {
-        assertNull("Exception in background thread : " + backgroundError.get(), backgroundError.get());
+        assertNull(backgroundError.get(), "Exception in background thread : " + backgroundError.get());
     }
 
     @Test
@@ -62,15 +62,15 @@ public class ProducerMetadataTest {
         metadata.add(topic, time);
 
         metadata.updateWithCurrentRequestVersion(responseWithTopics(Collections.emptySet()), false, time);
-        assertTrue("No update needed.", metadata.timeToNextUpdate(time) > 0);
+        assertTrue(metadata.timeToNextUpdate(time) > 0, "No update needed.");
         metadata.requestUpdate();
-        assertTrue("Still no updated needed due to backoff", metadata.timeToNextUpdate(time) > 0);
+        assertTrue(metadata.timeToNextUpdate(time) > 0, "Still no updated needed due to backoff");
         time += refreshBackoffMs;
-        assertEquals("Update needed now that backoff time expired", 0, metadata.timeToNextUpdate(time));
+        assertEquals(0, metadata.timeToNextUpdate(time), "Update needed now that backoff time expired");
         Thread t1 = asyncFetch(topic, 500);
         Thread t2 = asyncFetch(topic, 500);
-        assertTrue("Awaiting update", t1.isAlive());
-        assertTrue("Awaiting update", t2.isAlive());
+        assertTrue(t1.isAlive(), "Awaiting update");
+        assertTrue(t2.isAlive(), "Awaiting update");
         // Perform metadata update when an update is requested on the async fetch thread
         // This simulates the metadata update sequence in KafkaProducer
         while (t1.isAlive() || t2.isAlive()) {
@@ -82,20 +82,20 @@ public class ProducerMetadataTest {
         }
         t1.join();
         t2.join();
-        assertTrue("No update needed.", metadata.timeToNextUpdate(time) > 0);
+        assertTrue(metadata.timeToNextUpdate(time) > 0, "No update needed.");
         time += metadataExpireMs;
-        assertEquals("Update needed due to stale metadata.", 0, metadata.timeToNextUpdate(time));
+        assertEquals(0, metadata.timeToNextUpdate(time), "Update needed due to stale metadata.");
     }
 
     @Test
     public void testMetadataAwaitAfterClose() throws InterruptedException {
         long time = 0;
         metadata.updateWithCurrentRequestVersion(responseWithCurrentTopics(), false, time);
-        assertTrue("No update needed.", metadata.timeToNextUpdate(time) > 0);
+        assertTrue(metadata.timeToNextUpdate(time) > 0, "No update needed.");
         metadata.requestUpdate();
-        assertTrue("Still no updated needed due to backoff", metadata.timeToNextUpdate(time) > 0);
+        assertTrue(metadata.timeToNextUpdate(time) > 0, "Still no updated needed due to backoff");
         time += refreshBackoffMs;
-        assertEquals("Update needed now that backoff time expired", 0, metadata.timeToNextUpdate(time));
+        assertEquals(0, metadata.timeToNextUpdate(time), "Update needed now that backoff time expired");
         String topic = "my-topic";
         metadata.close();
         Thread t1 = asyncFetch(topic, 500);
@@ -116,7 +116,7 @@ public class ProducerMetadataTest {
     public void testMetadataUpdateWaitTime() throws Exception {
         long time = 0;
         metadata.updateWithCurrentRequestVersion(responseWithCurrentTopics(), false, time);
-        assertTrue("No update needed.", metadata.timeToNextUpdate(time) > 0);
+        assertTrue(metadata.timeToNextUpdate(time) > 0, "No update needed.");
         // first try with a max wait time of 0 and ensure that this returns back without waiting forever
         try {
             metadata.awaitUpdate(metadata.requestUpdate(), 0);
@@ -165,7 +165,7 @@ public class ProducerMetadataTest {
 
         time += METADATA_IDLE_MS;
         metadata.updateWithCurrentRequestVersion(responseWithCurrentTopics(), false, time);
-        assertFalse("Unused topic not expired", metadata.containsTopic(topic1));
+        assertFalse(metadata.containsTopic(topic1), "Unused topic not expired");
 
         // Test that topic is not expired if used within the expiry interval
         final String topic2 = "topic2";
@@ -174,7 +174,7 @@ public class ProducerMetadataTest {
         for (int i = 0; i < 3; i++) {
             time += METADATA_IDLE_MS / 2;
             metadata.updateWithCurrentRequestVersion(responseWithCurrentTopics(), false, time);
-            assertTrue("Topic expired even though in use", metadata.containsTopic(topic2));
+            assertTrue(metadata.containsTopic(topic2), "Topic expired even though in use");
             metadata.add(topic2, time);
         }
 
@@ -184,7 +184,7 @@ public class ProducerMetadataTest {
         metadata.add(topic3, time);
         time += METADATA_IDLE_MS * 2;
         metadata.updateWithCurrentRequestVersion(responseWithCurrentTopics(), false, time);
-        assertTrue("Topic expired while awaiting metadata", metadata.containsTopic(topic3));
+        assertTrue(metadata.containsTopic(topic3), "Topic expired while awaiting metadata");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -42,8 +42,8 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -60,12 +60,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RecordAccumulatorTest {
 
@@ -91,7 +91,7 @@ public class RecordAccumulatorTest {
     private final long maxBlockTimeMs = 1000;
     private final LogContext logContext = new LogContext();
 
-    @After
+    @AfterEach
     public void teardown() {
         this.metrics.close();
     }
@@ -114,7 +114,7 @@ public class RecordAccumulatorTest {
 
             ProducerBatch batch = partitionBatches.peekFirst();
             assertTrue(batch.isWritable());
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
+            assertEquals(0, accum.ready(cluster, now).readyNodes.size(), "No partitions should be ready.");
         }
 
         // this append doesn't fit in the first batch, so a new batch is created and the first batch is closed
@@ -124,7 +124,7 @@ public class RecordAccumulatorTest {
         assertEquals(2, partitionBatches.size());
         Iterator<ProducerBatch> partitionBatchesIterator = partitionBatches.iterator();
         assertTrue(partitionBatchesIterator.next().isWritable());
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        assertEquals(Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes, "Our partition's leader should be ready");
 
         List<ProducerBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, 0).get(node1.id());
         assertEquals(1, batches.size());
@@ -133,10 +133,10 @@ public class RecordAccumulatorTest {
         Iterator<Record> iter = batch.records().records().iterator();
         for (int i = 0; i < appends; i++) {
             Record record = iter.next();
-            assertEquals("Keys should match", ByteBuffer.wrap(key), record.key());
-            assertEquals("Values should match", ByteBuffer.wrap(value), record.value());
+            assertEquals(ByteBuffer.wrap(key), record.key(), "Keys should match");
+            assertEquals(ByteBuffer.wrap(value), record.value(), "Values should match");
         }
-        assertFalse("No more records", iter.hasNext());
+        assertFalse(iter.hasNext(), "No more records");
     }
 
     @Test
@@ -155,7 +155,7 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = createTestRecordAccumulator(
                 batchSize + DefaultRecordBatch.RECORD_BATCH_OVERHEAD, 10 * 1024, compressionType, 0);
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        assertEquals(Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes, "Our partition's leader should be ready");
 
         Deque<ProducerBatch> batches = accum.batches().get(tp1);
         assertEquals(1, batches.size());
@@ -193,7 +193,7 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = createTestRecordAccumulator(
                 batchSize + DefaultRecordBatch.RECORD_BATCH_OVERHEAD, 10 * 1024, compressionType, 0);
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        assertEquals(Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes, "Our partition's leader should be ready");
 
         Deque<ProducerBatch> batches = accum.batches().get(tp1);
         assertEquals(1, batches.size());
@@ -217,18 +217,18 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = createTestRecordAccumulator(
                 1024 + DefaultRecordBatch.RECORD_BATCH_OVERHEAD, 10 * 1024, CompressionType.NONE, lingerMs);
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
-        assertEquals("No partitions should be ready", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+        assertEquals(0, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partitions should be ready");
         time.sleep(10);
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        assertEquals(Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes, "Our partition's leader should be ready");
         List<ProducerBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, 0).get(node1.id());
         assertEquals(1, batches.size());
         ProducerBatch batch = batches.get(0);
 
         Iterator<Record> iter = batch.records().records().iterator();
         Record record = iter.next();
-        assertEquals("Keys should match", ByteBuffer.wrap(key), record.key());
-        assertEquals("Values should match", ByteBuffer.wrap(value), record.value());
-        assertFalse("No more records", iter.hasNext());
+        assertEquals(ByteBuffer.wrap(key), record.key(), "Keys should match");
+        assertEquals(ByteBuffer.wrap(value), record.value(), "Values should match");
+        assertFalse(iter.hasNext(), "No more records");
     }
 
     @Test
@@ -241,10 +241,10 @@ public class RecordAccumulatorTest {
             for (int i = 0; i < appends; i++)
                 accum.append(tp, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
         }
-        assertEquals("Partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        assertEquals(Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes, "Partition's leader should be ready");
 
         List<ProducerBatch> batches = accum.drain(cluster, Collections.singleton(node1), 1024, 0).get(node1.id());
-        assertEquals("But due to size bound only one partition should have been retrieved", 1, batches.size());
+        assertEquals(1, batches.size(), "But due to size bound only one partition should have been retrieved");
     }
 
     @SuppressWarnings("unused")
@@ -307,8 +307,8 @@ public class RecordAccumulatorTest {
         for (int i = 0; i < appends; i++)
             accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
-        assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
-        assertEquals("Next check time should be the linger time", lingerMs, result.nextReadyCheckDelayMs);
+        assertEquals(0, result.readyNodes.size(), "No nodes should be ready.");
+        assertEquals(lingerMs, result.nextReadyCheckDelayMs, "Next check time should be the linger time");
 
         time.sleep(lingerMs / 2);
 
@@ -316,17 +316,17 @@ public class RecordAccumulatorTest {
         for (int i = 0; i < appends; i++)
             accum.append(tp3, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
         result = accum.ready(cluster, time.milliseconds());
-        assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
-        assertEquals("Next check time should be defined by node1, half remaining linger time", lingerMs / 2, result.nextReadyCheckDelayMs);
+        assertEquals(0, result.readyNodes.size(), "No nodes should be ready.");
+        assertEquals(lingerMs / 2, result.nextReadyCheckDelayMs, "Next check time should be defined by node1, half remaining linger time");
 
         // Add data for another partition on node1, enough to make data sendable immediately
         for (int i = 0; i < appends + 1; i++)
             accum.append(tp2, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
         result = accum.ready(cluster, time.milliseconds());
-        assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
+        assertEquals(Collections.singleton(node1), result.readyNodes, "Node1 should be ready");
         // Note this can actually be < linger time because it may use delays from partitions that aren't sendable
         // but have leaders with other sendable data.
-        assertTrue("Next check time should be defined by node2, at most linger time", result.nextReadyCheckDelayMs <= lingerMs);
+        assertTrue(result.nextReadyCheckDelayMs <= lingerMs, "Next check time should be defined by node2, at most linger time");
     }
 
     @Test
@@ -345,10 +345,10 @@ public class RecordAccumulatorTest {
         long now = time.milliseconds();
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, now + lingerMs + 1);
-        assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
+        assertEquals(Collections.singleton(node1), result.readyNodes, "Node1 should be ready");
         Map<Integer, List<ProducerBatch>> batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + lingerMs + 1);
-        assertEquals("Node1 should be the only ready node.", 1, batches.size());
-        assertEquals("Partition 0 should only have one batch drained.", 1, batches.get(0).size());
+        assertEquals(1, batches.size(), "Node1 should be the only ready node.");
+        assertEquals(1, batches.get(0).size(), "Partition 0 should only have one batch drained.");
 
         // Reenqueue the batch
         now = time.milliseconds();
@@ -357,21 +357,21 @@ public class RecordAccumulatorTest {
         // Put message for partition 1 into accumulator
         accum.append(tp2, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
         result = accum.ready(cluster, now + lingerMs + 1);
-        assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
+        assertEquals(Collections.singleton(node1), result.readyNodes, "Node1 should be ready");
 
         // tp1 should backoff while tp2 should not
         batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + lingerMs + 1);
-        assertEquals("Node1 should be the only ready node.", 1, batches.size());
-        assertEquals("Node1 should only have one batch drained.", 1, batches.get(0).size());
-        assertEquals("Node1 should only have one batch for partition 1.", tp2, batches.get(0).get(0).topicPartition);
+        assertEquals(1, batches.size(), "Node1 should be the only ready node.");
+        assertEquals(1, batches.get(0).size(), "Node1 should only have one batch drained.");
+        assertEquals(tp2, batches.get(0).get(0).topicPartition, "Node1 should only have one batch for partition 1.");
 
         // Partition 0 can be drained after retry backoff
         result = accum.ready(cluster, now + retryBackoffMs + 1);
-        assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
+        assertEquals(Collections.singleton(node1), result.readyNodes, "Node1 should be ready");
         batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + retryBackoffMs + 1);
-        assertEquals("Node1 should be the only ready node.", 1, batches.size());
-        assertEquals("Node1 should only have one batch drained.", 1, batches.get(0).size());
-        assertEquals("Node1 should only have one batch for partition 0.", tp1, batches.get(0).get(0).topicPartition);
+        assertEquals(1, batches.size(), "Node1 should be the only ready node.");
+        assertEquals(1, batches.get(0).size(), "Node1 should only have one batch drained.");
+        assertEquals(tp1, batches.get(0).get(0).topicPartition, "Node1 should only have one batch for partition 0.");
     }
 
     @Test
@@ -385,7 +385,7 @@ public class RecordAccumulatorTest {
             assertTrue(accum.hasIncomplete());
         }
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
-        assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
+        assertEquals(0, result.readyNodes.size(), "No nodes should be ready.");
 
         accum.beginFlush();
         result = accum.ready(cluster, time.milliseconds());
@@ -428,7 +428,7 @@ public class RecordAccumulatorTest {
             accum.awaitFlushCompletion();
             fail("awaitFlushCompletion should throw InterruptException");
         } catch (InterruptedException e) {
-            assertFalse("flushInProgress count should be decremented even if thread is interrupted", accum.flushInProgress());
+            assertFalse(accum.flushInProgress(), "flushInProgress count should be decremented even if thread is interrupted");
         }
     }
 
@@ -529,14 +529,14 @@ public class RecordAccumulatorTest {
             if (time.milliseconds() < System.currentTimeMillis())
                 time.setCurrentTimeMs(System.currentTimeMillis());
             accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
-            assertEquals("No partition should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+            assertEquals(0, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partition should be ready.");
 
             time.sleep(lingerMs);
             readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
-            assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
+            assertEquals(Collections.singleton(node1), readyNodes, "Our partition's leader should be ready");
 
             expiredBatches = accum.expiredBatches(time.milliseconds());
-            assertEquals("The batch should not expire when just linger has passed", 0, expiredBatches.size());
+            assertEquals(0, expiredBatches.size(), "The batch should not expire when just linger has passed");
 
             if (mute)
                 accum.mutePartition(tp1);
@@ -546,8 +546,8 @@ public class RecordAccumulatorTest {
             // Advance the clock to expire the batch.
             time.sleep(deliveryTimeoutMs - lingerMs);
             expiredBatches = accum.expiredBatches(time.milliseconds());
-            assertEquals("The batch may expire when the partition is muted", 1, expiredBatches.size());
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+            assertEquals(1, expiredBatches.size(), "The batch may expire when the partition is muted");
+            assertEquals(0, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partitions should be ready.");
         }
     }
 
@@ -578,84 +578,84 @@ public class RecordAccumulatorTest {
         // Test batches not in retry
         for (int i = 0; i < appends; i++) {
             accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+            assertEquals(0, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partitions should be ready.");
         }
         // Make the batches ready due to batch full
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0, false, time.milliseconds());
         Set<Node> readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
+        assertEquals(Collections.singleton(node1), readyNodes, "Our partition's leader should be ready");
         // Advance the clock to expire the batch.
         time.sleep(deliveryTimeoutMs + 1);
         accum.mutePartition(tp1);
         List<ProducerBatch> expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("The batches will be muted no matter if the partition is muted or not", 2, expiredBatches.size());
+        assertEquals(2, expiredBatches.size(), "The batches will be muted no matter if the partition is muted or not");
 
         accum.unmutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("All batches should have been expired earlier", 0, expiredBatches.size());
-        assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+        assertEquals(0, expiredBatches.size(), "All batches should have been expired earlier");
+        assertEquals(0, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partitions should be ready.");
 
         // Advance the clock to make the next batch ready due to linger.ms
         time.sleep(lingerMs);
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
+        assertEquals(Collections.singleton(node1), readyNodes, "Our partition's leader should be ready");
         time.sleep(requestTimeout + 1);
 
         accum.mutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("The batch should not be expired when metadata is still available and partition is muted", 0, expiredBatches.size());
+        assertEquals(0, expiredBatches.size(), "The batch should not be expired when metadata is still available and partition is muted");
 
         accum.unmutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("All batches should have been expired", 0, expiredBatches.size());
-        assertEquals("No partitions should be ready.", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+        assertEquals(0, expiredBatches.size(), "All batches should have been expired");
+        assertEquals(0, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partitions should be ready.");
 
         // Test batches in retry.
         // Create a retried batch
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0, false, time.milliseconds());
         time.sleep(lingerMs);
         readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
+        assertEquals(Collections.singleton(node1), readyNodes, "Our partition's leader should be ready");
         Map<Integer, List<ProducerBatch>> drained = accum.drain(cluster, readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertEquals("There should be only one batch.", drained.get(node1.id()).size(), 1);
+        assertEquals(drained.get(node1.id()).size(), 1, "There should be only one batch.");
         time.sleep(1000L);
         accum.reenqueue(drained.get(node1.id()).get(0), time.milliseconds());
 
         // test expiration.
         time.sleep(requestTimeout + retryBackoffMs);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("The batch should not be expired.", 0, expiredBatches.size());
+        assertEquals(0, expiredBatches.size(), "The batch should not be expired.");
         time.sleep(1L);
 
         accum.mutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
+        assertEquals(0, expiredBatches.size(), "The batch should not be expired when the partition is muted");
 
         accum.unmutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("All batches should have been expired.", 0, expiredBatches.size());
+        assertEquals(0, expiredBatches.size(), "All batches should have been expired.");
 
         // Test that when being throttled muted batches are expired before the throttle time is over.
         accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0, false, time.milliseconds());
         time.sleep(lingerMs);
         readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
+        assertEquals(Collections.singleton(node1), readyNodes, "Our partition's leader should be ready");
         // Advance the clock to expire the batch.
         time.sleep(requestTimeout + 1);
         accum.mutePartition(tp1);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
+        assertEquals(0, expiredBatches.size(), "The batch should not be expired when the partition is muted");
 
         long throttleTimeMs = 100L;
         accum.unmutePartition(tp1);
         // The batch shouldn't be expired yet.
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("The batch should not be expired when the partition is muted", 0, expiredBatches.size());
+        assertEquals(0, expiredBatches.size(), "The batch should not be expired when the partition is muted");
 
         // Once the throttle time is over, the batch can be expired.
         time.sleep(throttleTimeMs);
         expiredBatches = accum.expiredBatches(time.milliseconds());
-        assertEquals("All batches should have been expired earlier", 0, expiredBatches.size());
-        assertEquals("No partitions should be ready.", 1, accum.ready(cluster, time.milliseconds()).readyNodes.size());
+        assertEquals(0, expiredBatches.size(), "All batches should have been expired earlier");
+        assertEquals(1, accum.ready(cluster, time.milliseconds()).readyNodes.size(), "No partitions should be ready.");
     }
 
     @Test
@@ -669,29 +669,29 @@ public class RecordAccumulatorTest {
         int appends = expectedNumAppends(batchSize);
         for (int i = 0; i < appends; i++) {
             accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, maxBlockTimeMs, false, time.milliseconds());
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
+            assertEquals(0, accum.ready(cluster, now).readyNodes.size(), "No partitions should be ready.");
         }
         time.sleep(2000);
 
         // Test ready with muted partition
         accum.mutePartition(tp1);
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
-        assertEquals("No node should be ready", 0, result.readyNodes.size());
+        assertEquals(0, result.readyNodes.size(), "No node should be ready");
 
         // Test ready without muted partition
         accum.unmutePartition(tp1);
         result = accum.ready(cluster, time.milliseconds());
-        assertTrue("The batch should be ready", result.readyNodes.size() > 0);
+        assertTrue(result.readyNodes.size() > 0, "The batch should be ready");
 
         // Test drain with muted partition
         accum.mutePartition(tp1);
         Map<Integer, List<ProducerBatch>> drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertEquals("No batch should have been drained", 0, drained.get(node1.id()).size());
+        assertEquals(0, drained.get(node1.id()).size(), "No batch should have been drained");
 
         // Test drain without muted partition.
         accum.unmutePartition(tp1);
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertTrue("The batch should have been drained.", drained.get(node1.id()).size() > 0);
+        assertTrue(drained.get(node1.id()).size() > 0, "The batch should have been drained.");
     }
 
     @Test
@@ -743,10 +743,10 @@ public class RecordAccumulatorTest {
         time.sleep(101L);
         // Drain the batch.
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
-        assertTrue("The batch should be ready", result.readyNodes.size() > 0);
+        assertTrue(result.readyNodes.size() > 0, "The batch should be ready");
         Map<Integer, List<ProducerBatch>> drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertEquals("Only node1 should be drained", 1, drained.size());
-        assertEquals("Only one batch should be drained", 1, drained.get(node1.id()).size());
+        assertEquals(1, drained.size(), "Only node1 should be drained");
+        assertEquals(1, drained.get(node1.id()).size(), "Only one batch should be drained");
         // Split and reenqueue the batch.
         accum.splitAndReenqueue(drained.get(node1.id()).get(0));
         time.sleep(101L);
@@ -755,7 +755,7 @@ public class RecordAccumulatorTest {
         assertFalse(drained.isEmpty());
         assertFalse(drained.get(node1.id()).isEmpty());
         drained.get(node1.id()).get(0).done(acked.get(), 100L, null);
-        assertEquals("The first message should have been acked.", 1, acked.get());
+        assertEquals(1, acked.get(), "The first message should have been acked.");
         assertTrue(future1.isDone());
         assertEquals(0, future1.get().offset());
 
@@ -763,7 +763,7 @@ public class RecordAccumulatorTest {
         assertFalse(drained.isEmpty());
         assertFalse(drained.get(node1.id()).isEmpty());
         drained.get(node1.id()).get(0).done(acked.get(), 100L, null);
-        assertEquals("Both message should have been acked.", 2, acked.get());
+        assertEquals(2, acked.get(), "Both message should have been acked.");
         assertTrue(future2.isDone());
         assertEquals(1, future2.get().offset());
     }
@@ -778,7 +778,7 @@ public class RecordAccumulatorTest {
         CompressionRatioEstimator.setEstimation(tp1.topic(), CompressionType.GZIP, 0.1f);
         RecordAccumulator accum = createTestRecordAccumulator(batchSize, bufferCapacity, CompressionType.GZIP, 0);
         int numSplitBatches = prepareSplitBatches(accum, seed, 100, 20);
-        assertTrue("There should be some split batches", numSplitBatches > 0);
+        assertTrue(numSplitBatches > 0, "There should be some split batches");
         // Drain all the split batches.
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         for (int i = 0; i < numSplitBatches; i++) {
@@ -787,10 +787,10 @@ public class RecordAccumulatorTest {
             assertFalse(drained.isEmpty());
             assertFalse(drained.get(node1.id()).isEmpty());
         }
-        assertTrue("All the batches should have been drained.",
-                accum.ready(cluster, time.milliseconds()).readyNodes.isEmpty());
-        assertEquals("The split batches should be allocated off the accumulator",
-                bufferCapacity, accum.bufferPoolAvailableMemory());
+        assertTrue(
+                accum.ready(cluster, time.milliseconds()).readyNodes.isEmpty(), "All the batches should have been drained.");
+        assertEquals(
+                bufferCapacity, accum.bufferPoolAvailableMemory(), "The split batches should be allocated off the accumulator");
     }
 
     @Test
@@ -820,9 +820,9 @@ public class RecordAccumulatorTest {
             BatchDrainedResult result = completeOrSplitBatches(accum, batchSize);
             numSplit += result.numSplit;
             numBatches += result.numBatches;
-            assertTrue(String.format("Total num batches = %d, split batches = %d, more than 10%% of the batch splits. "
+            assertTrue((double) numSplit / numBatches < 0.1f, String.format("Total num batches = %d, split batches = %d, more than 10%% of the batch splits. "
                     + "Random seed is " + seed,
-                numBatches, numSplit), (double) numSplit / numBatches < 0.1f);
+                numBatches, numSplit));
         }
     }
 
@@ -845,7 +845,7 @@ public class RecordAccumulatorTest {
         time.sleep(lingerMs + 1);
         readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
         drained = accum.drain(cluster, readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertEquals("A batch did not drain after linger", 1, drained.size());
+        assertEquals(1, drained.size(), "A batch did not drain after linger");
         //assertTrue(accum.soonToExpireInFlightBatches().isEmpty());
 
         // Queue another batch and advance clock such that batch expiry time is earlier than request timeout.
@@ -855,7 +855,7 @@ public class RecordAccumulatorTest {
         // Now drain and check that accumulator picked up the drained batch because its expiry is soon.
         readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
         drained = accum.drain(cluster, readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertEquals("A batch did not drain after linger", 1, drained.size());
+        assertEquals(1, drained.size(), "A batch did not drain after linger");
     }
 
     @Test
@@ -877,9 +877,9 @@ public class RecordAccumulatorTest {
             accum.append(tp1, 0L, key, value, Record.EMPTY_HEADERS, null, 0, false, time.milliseconds());
             time.sleep(lingerMs);
             readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
-            assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
+            assertEquals(Collections.singleton(node1), readyNodes, "Our partition's leader should be ready");
             Map<Integer, List<ProducerBatch>> drained = accum.drain(cluster, readyNodes, Integer.MAX_VALUE, time.milliseconds());
-            assertEquals("There should be only one batch.", 1, drained.get(node1.id()).size());
+            assertEquals(1, drained.get(node1.id()).size(), "There should be only one batch.");
             time.sleep(rtt);
             accum.reenqueue(drained.get(node1.id()).get(0), time.milliseconds());
 
@@ -892,7 +892,7 @@ public class RecordAccumulatorTest {
             time.sleep(deliveryTimeoutMs - rtt);
             accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, time.milliseconds());
             expiredBatches = accum.expiredBatches(time.milliseconds());
-            assertEquals("RecordAccumulator has expired batches if the partition is not muted", mute ? 1 : 0, expiredBatches.size());
+            assertEquals(mute ? 1 : 0, expiredBatches.size(), "RecordAccumulator has expired batches if the partition is not muted");
         }
     }
 
@@ -931,7 +931,7 @@ public class RecordAccumulatorTest {
             // We only appended if we do not retry.
             if (!switchPartition) {
                 appends++;
-                assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
+                assertEquals(0, accum.ready(cluster, now).readyNodes.size(), "No partitions should be ready.");
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -787,10 +787,9 @@ public class RecordAccumulatorTest {
             assertFalse(drained.isEmpty());
             assertFalse(drained.get(node1.id()).isEmpty());
         }
-        assertTrue(
-                accum.ready(cluster, time.milliseconds()).readyNodes.isEmpty(), "All the batches should have been drained.");
-        assertEquals(
-                bufferCapacity, accum.bufferPoolAvailableMemory(), "The split batches should be allocated off the accumulator");
+        assertTrue(accum.ready(cluster, time.milliseconds()).readyNodes.isEmpty(), "All the batches should have been drained.");
+        assertEquals(bufferCapacity, accum.bufferPoolAvailableMemory(),
+            "The split batches should be allocated off the accumulator");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -80,9 +80,10 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.DelayedReceive;
 import org.apache.kafka.test.MockSelector;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.InOrder;
 
 import java.nio.ByteBuffer;
@@ -104,14 +105,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -149,12 +150,12 @@ public class SenderTest {
     private SenderMetricsRegistry senderMetricsRegistry = null;
     private final LogContext logContext = new LogContext();
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupWithTransactionState(null);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         this.metrics.close();
     }
@@ -174,16 +175,16 @@ public class SenderTest {
         Future<RecordMetadata> future = appendToAccumulator(tp0, 0L, "key", "value");
         sender.runOnce(); // connect
         sender.runOnce(); // send produce request
-        assertEquals("We should have a single produce request in flight.", 1, client.inFlightRequestCount());
+        assertEquals(1, client.inFlightRequestCount(), "We should have a single produce request in flight.");
         assertEquals(1, sender.inFlightBatches(tp0).size());
         assertTrue(client.hasInFlightRequests());
         client.respond(produceResponse(tp0, offset, Errors.NONE, 0));
         sender.runOnce();
-        assertEquals("All requests completed.", 0, client.inFlightRequestCount());
+        assertEquals(0, client.inFlightRequestCount(), "All requests completed.");
         assertEquals(0, sender.inFlightBatches(tp0).size());
         assertFalse(client.hasInFlightRequests());
         sender.runOnce();
-        assertTrue("Request should be completed", future.isDone());
+        assertTrue(future.isDone(), "Request should be completed");
         assertEquals(offset, future.get().offset());
     }
 
@@ -216,7 +217,7 @@ public class SenderTest {
         sender.runOnce(); // connect
         sender.runOnce(); // send produce request
 
-        assertTrue("Request should be completed", future.isDone());
+        assertTrue(future.isDone(), "Request should be completed");
         assertEquals(offset, future.get().offset());
     }
 
@@ -268,8 +269,8 @@ public class SenderTest {
         sender.runOnce(); // connect
         sender.runOnce(); // send produce request
 
-        assertTrue("Request should be completed", future1.isDone());
-        assertTrue("Request should be completed", future2.isDone());
+        assertTrue(future1.isDone(), "Request should be completed");
+        assertTrue(future2.isDone(), "Request should be completed");
     }
 
     /*
@@ -369,11 +370,11 @@ public class SenderTest {
             assertEquals(1, client.inFlightRequestCount());
             assertTrue(client.hasInFlightRequests());
             assertEquals(1, sender.inFlightBatches(tp0).size());
-            assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+            assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
             client.disconnect(id);
             assertEquals(0, client.inFlightRequestCount());
             assertFalse(client.hasInFlightRequests());
-            assertFalse("Client ready status should be false", client.isReady(node, time.milliseconds()));
+            assertFalse(client.isReady(node, time.milliseconds()), "Client ready status should be false");
             // the batch is in accumulator.inFlightBatches until it expires
             assertEquals(1, sender.inFlightBatches(tp0).size());
             sender.runOnce(); // receive error
@@ -385,7 +386,7 @@ public class SenderTest {
             long offset = 0;
             client.respond(produceResponse(tp0, offset, Errors.NONE, 0));
             sender.runOnce();
-            assertTrue("Request should have retried and completed", future.isDone());
+            assertTrue(future.isDone(), "Request should have retried and completed");
             assertEquals(offset, future.get().offset());
             assertEquals(0, sender.inFlightBatches(tp0).size());
 
@@ -432,7 +433,7 @@ public class SenderTest {
             Node node = new Node(Integer.parseInt(id), "localhost", 0);
             assertEquals(1, client.inFlightRequestCount());
             assertTrue(client.hasInFlightRequests());
-            assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+            assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
             assertEquals(1, sender.inFlightBatches(tp2).size());
 
             time.sleep(900);
@@ -492,8 +493,8 @@ public class SenderTest {
         client.backoff(clusterNode, 100);
 
         sender.runOnce();  // We should try to flush the batch, but we expire it instead without sending anything.
-        assertEquals("Callbacks not invoked for expiry", messagesPerBatch, expiryCallbackCount.get());
-        assertNull("Unexpected exception", unexpectedException.get());
+        assertEquals(messagesPerBatch, expiryCallbackCount.get(), "Callbacks not invoked for expiry");
+        assertNull(unexpectedException.get(), "Unexpected exception");
         // Make sure that the reconds were appended back to the batch.
         assertTrue(accumulator.batches().containsKey(tp1));
         assertEquals(1, accumulator.batches().get(tp1).size());
@@ -511,33 +512,33 @@ public class SenderTest {
 
         Future<RecordMetadata> future = appendToAccumulator(tp0);
         sender.runOnce();
-        assertTrue("Topic not added to metadata", metadata.containsTopic(tp0.topic()));
+        assertTrue(metadata.containsTopic(tp0.topic()), "Topic not added to metadata");
         client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
         sender.runOnce();  // send produce request
         client.respond(produceResponse(tp0, offset, Errors.NONE, 0));
         sender.runOnce();
-        assertEquals("Request completed.", 0, client.inFlightRequestCount());
+        assertEquals(0, client.inFlightRequestCount(), "Request completed.");
         assertFalse(client.hasInFlightRequests());
         assertEquals(0, sender.inFlightBatches(tp0).size());
         sender.runOnce();
-        assertTrue("Request should be completed", future.isDone());
+        assertTrue(future.isDone(), "Request should be completed");
 
-        assertTrue("Topic not retained in metadata list", metadata.containsTopic(tp0.topic()));
+        assertTrue(metadata.containsTopic(tp0.topic()), "Topic not retained in metadata list");
         time.sleep(TOPIC_IDLE_MS);
         client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
-        assertFalse("Unused topic has not been expired", metadata.containsTopic(tp0.topic()));
+        assertFalse(metadata.containsTopic(tp0.topic()), "Unused topic has not been expired");
         future = appendToAccumulator(tp0);
         sender.runOnce();
-        assertTrue("Topic not added to metadata", metadata.containsTopic(tp0.topic()));
+        assertTrue(metadata.containsTopic(tp0.topic()), "Topic not added to metadata");
         client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, Collections.singletonMap("test", 2)));
         sender.runOnce();  // send produce request
         client.respond(produceResponse(tp0, offset + 1, Errors.NONE, 0));
         sender.runOnce();
-        assertEquals("Request completed.", 0, client.inFlightRequestCount());
+        assertEquals(0, client.inFlightRequestCount(), "Request completed.");
         assertFalse(client.hasInFlightRequests());
         assertEquals(0, sender.inFlightBatches(tp0).size());
         sender.runOnce();
-        assertTrue("Request should be completed", future.isDone());
+        assertTrue(future.isDone(), "Request should be completed");
     }
 
     @Test
@@ -627,7 +628,7 @@ public class SenderTest {
         prepareFindCoordinatorResponse(Errors.NONE);
         sender.runOnce();
         sender.runOnce();
-        assertNotNull("Coordinator not found", transactionManager.coordinator(CoordinatorType.TRANSACTION));
+        assertNotNull(transactionManager.coordinator(CoordinatorType.TRANSACTION), "Coordinator not found");
 
         client.throttle(node, REQUEST_TIMEOUT + 20);
         prepareFindCoordinatorResponse(Errors.NONE);
@@ -660,7 +661,7 @@ public class SenderTest {
         assertEquals(1, client.inFlightRequestCount());
         assertTrue(client.hasInFlightRequests());
         assertEquals(1, sender.inFlightBatches(tp0).size());
-        assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+        assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
         assertFalse(future.isDone());
 
         client.respond(body -> {
@@ -1406,7 +1407,7 @@ public class SenderTest {
         sender.forceClose(); // initiate force close
         sender.runOnce(); // this should not block
         sender.run(); // run main loop to test forceClose flag
-        assertFalse("Pending batches are not aborted.", accumulator.hasUndrained());
+        assertFalse(accumulator.hasUndrained(), "Pending batches are not aborted.");
         assertTrue(successfulResponse.isDone());
     }
 
@@ -1994,16 +1995,16 @@ public class SenderTest {
         String id = client.requests().peek().destination();
         Node node = new Node(Integer.valueOf(id), "localhost", 0);
         assertEquals(1, client.inFlightRequestCount());
-        assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+        assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
         client.disconnect(id);
         assertEquals(0, client.inFlightRequestCount());
-        assertFalse("Client ready status should be false", client.isReady(node, time.milliseconds()));
+        assertFalse(client.isReady(node, time.milliseconds()), "Client ready status should be false");
         sender.runOnce(); // receive error
         sender.runOnce(); // reset producer ID because epoch is maxed out
 
         prepareAndReceiveInitProducerId(producerId + 1, Errors.NONE);
         sender.runOnce(); // nothing to do, since the pid has changed. We should check the metrics for errors.
-        assertEquals("Expected requests to be retried after pid change", 1, client.inFlightRequestCount());
+        assertEquals(1, client.inFlightRequestCount(), "Expected requests to be retried after pid change");
 
         assertFalse(responseFuture.isDone());
         assertEquals(1, (long) transactionManager.sequenceNumber(tp0));
@@ -2099,59 +2100,59 @@ public class SenderTest {
             sender.runOnce(); // connect
             sender.runOnce(); // send produce request
 
-            assertEquals("The next sequence should be 2", 2, txnManager.sequenceNumber(tp).longValue());
+            assertEquals(2, txnManager.sequenceNumber(tp).longValue(), "The next sequence should be 2");
             String id = client.requests().peek().destination();
             assertEquals(ApiKeys.PRODUCE, client.requests().peek().requestBuilder().apiKey());
             Node node = new Node(Integer.valueOf(id), "localhost", 0);
             assertEquals(1, client.inFlightRequestCount());
-            assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+            assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
 
             Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new HashMap<>();
             responseMap.put(tp, new ProduceResponse.PartitionResponse(Errors.MESSAGE_TOO_LARGE));
             client.respond(new ProduceResponse(responseMap));
             sender.runOnce(); // split and reenqueue
-            assertEquals("The next sequence should be 2", 2, txnManager.sequenceNumber(tp).longValue());
+            assertEquals(2, txnManager.sequenceNumber(tp).longValue(), "The next sequence should be 2");
             // The compression ratio should have been improved once.
             assertEquals(CompressionType.GZIP.rate - CompressionRatioEstimator.COMPRESSION_RATIO_IMPROVING_STEP,
                     CompressionRatioEstimator.estimation(topic, CompressionType.GZIP), 0.01);
             sender.runOnce(); // send the first produce request
-            assertEquals("The next sequence number should be 2", 2, txnManager.sequenceNumber(tp).longValue());
-            assertFalse("The future shouldn't have been done.", f1.isDone());
-            assertFalse("The future shouldn't have been done.", f2.isDone());
+            assertEquals(2, txnManager.sequenceNumber(tp).longValue(), "The next sequence number should be 2");
+            assertFalse(f1.isDone(), "The future shouldn't have been done.");
+            assertFalse(f2.isDone(), "The future shouldn't have been done.");
             id = client.requests().peek().destination();
             assertEquals(ApiKeys.PRODUCE, client.requests().peek().requestBuilder().apiKey());
             node = new Node(Integer.valueOf(id), "localhost", 0);
             assertEquals(1, client.inFlightRequestCount());
-            assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+            assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
 
             responseMap.put(tp, new ProduceResponse.PartitionResponse(Errors.NONE, 0L, 0L, 0L));
             client.respond(produceRequestMatcher(tp, producerIdAndEpoch, 0, txnManager.isTransactional()),
                     new ProduceResponse(responseMap));
 
             sender.runOnce(); // receive
-            assertTrue("The future should have been done.", f1.isDone());
-            assertEquals("The next sequence number should still be 2", 2, txnManager.sequenceNumber(tp).longValue());
-            assertEquals("The last ack'd sequence number should be 0", OptionalInt.of(0), txnManager.lastAckedSequence(tp));
-            assertFalse("The future shouldn't have been done.", f2.isDone());
-            assertEquals("Offset of the first message should be 0", 0L, f1.get().offset());
+            assertTrue(f1.isDone(), "The future should have been done.");
+            assertEquals(2, txnManager.sequenceNumber(tp).longValue(), "The next sequence number should still be 2");
+            assertEquals(OptionalInt.of(0), txnManager.lastAckedSequence(tp), "The last ack'd sequence number should be 0");
+            assertFalse(f2.isDone(), "The future shouldn't have been done.");
+            assertEquals(0L, f1.get().offset(), "Offset of the first message should be 0");
             sender.runOnce(); // send the seconcd produce request
             id = client.requests().peek().destination();
             assertEquals(ApiKeys.PRODUCE, client.requests().peek().requestBuilder().apiKey());
             node = new Node(Integer.valueOf(id), "localhost", 0);
             assertEquals(1, client.inFlightRequestCount());
-            assertTrue("Client ready status should be true", client.isReady(node, time.milliseconds()));
+            assertTrue(client.isReady(node, time.milliseconds()), "Client ready status should be true");
 
             responseMap.put(tp, new ProduceResponse.PartitionResponse(Errors.NONE, 1L, 0L, 0L));
             client.respond(produceRequestMatcher(tp, producerIdAndEpoch, 1, txnManager.isTransactional()),
                     new ProduceResponse(responseMap));
 
             sender.runOnce(); // receive
-            assertTrue("The future should have been done.", f2.isDone());
-            assertEquals("The next sequence number should be 2", 2, txnManager.sequenceNumber(tp).longValue());
-            assertEquals("The last ack'd sequence number should be 1", OptionalInt.of(1), txnManager.lastAckedSequence(tp));
-            assertEquals("Offset of the first message should be 1", 1L, f2.get().offset());
-            assertTrue("There should be no batch in the accumulator", accumulator.batches().get(tp).isEmpty());
-            assertTrue("There should be a split", (Double) (m.metrics().get(senderMetrics.batchSplitRate).metricValue()) > 0);
+            assertTrue(f2.isDone(), "The future should have been done.");
+            assertEquals(2, txnManager.sequenceNumber(tp).longValue(), "The next sequence number should be 2");
+            assertEquals(OptionalInt.of(1), txnManager.lastAckedSequence(tp), "The last ack'd sequence number should be 1");
+            assertEquals(1L, f2.get().offset(), "Offset of the first message should be 1");
+            assertTrue(accumulator.batches().get(tp).isEmpty(), "There should be no batch in the accumulator");
+            assertTrue((Double) (m.metrics().get(senderMetrics.batchSplitRate).metricValue()) > 0, "There should be a split");
         }
     }
 
@@ -2174,11 +2175,11 @@ public class SenderTest {
 
         sender.runOnce();  // expire the batch
         assertTrue(request1.isDone());
-        assertTrue("The batch should have been de-allocated", pool.allMatch());
+        assertTrue(pool.allMatch(), "The batch should have been de-allocated");
         assertTrue(pool.allMatch());
 
         sender.runOnce();
-        assertTrue("The batch should have been de-allocated", pool.allMatch());
+        assertTrue(pool.allMatch(), "The batch should have been de-allocated");
         assertEquals(0, client.inFlightRequestCount());
         assertEquals(0, sender.inFlightBatches(tp0).size());
     }
@@ -2193,7 +2194,7 @@ public class SenderTest {
         Future<RecordMetadata> request = appendToAccumulator(tp0);
         sender.runOnce();  // send request
         assertEquals(1, client.inFlightRequestCount());
-        assertEquals("Expect one in-flight batch in accumulator", 1, sender.inFlightBatches(tp0).size());
+        assertEquals(1, sender.inFlightBatches(tp0).size(), "Expect one in-flight batch in accumulator");
 
         Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new HashMap<>();
         responseMap.put(tp0, new ProduceResponse.PartitionResponse(Errors.NONE, 0L, 0L, 0L));
@@ -2201,7 +2202,7 @@ public class SenderTest {
 
         time.sleep(deliveryTimeoutMs);
         sender.runOnce();  // receive first response
-        assertEquals("Expect zero in-flight batch in accumulator", 0, sender.inFlightBatches(tp0).size());
+        assertEquals(0, sender.inFlightBatches(tp0).size(), "Expect zero in-flight batch in accumulator");
         try {
             request.get();
             fail("The expired batch should throw a TimeoutException");
@@ -2331,7 +2332,7 @@ public class SenderTest {
         // Send request.
         sender.runOnce();
         assertEquals(1, client.inFlightRequestCount());
-        assertEquals("Expect one in-flight batch in accumulator", 1, sender.inFlightBatches(tp0).size());
+        assertEquals(1, sender.inFlightBatches(tp0).size(), "Expect one in-flight batch in accumulator");
 
         Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new HashMap<>();
         responseMap.put(tp0, new ProduceResponse.PartitionResponse(Errors.NONE, 0L, 0L, 0L));
@@ -2340,21 +2341,13 @@ public class SenderTest {
         // Successfully expire both batches.
         time.sleep(deliveryTimeoutMs);
         sender.runOnce();
-        assertEquals("Expect zero in-flight batch in accumulator", 0, sender.inFlightBatches(tp0).size());
+        assertEquals(0, sender.inFlightBatches(tp0).size(), "Expect zero in-flight batch in accumulator");
 
-        try {
-            request1.get();
-            fail("The expired batch should throw a TimeoutException");
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof TimeoutException);
-        }
+        ExecutionException e = assertThrows(ExecutionException.class, request1::get);
+        assertTrue(e.getCause() instanceof TimeoutException);
 
-        try {
-            request2.get();
-            fail("The expired batch should throw a TimeoutException");
-        } catch (ExecutionException e) {
-            assertTrue(e.getCause() instanceof TimeoutException);
-        }
+        e = assertThrows(ExecutionException.class, request2::get);
+        assertTrue(e.getCause() instanceof TimeoutException);
     }
 
     @Test
@@ -2386,7 +2379,7 @@ public class SenderTest {
                                                                          .setErrorCode(Errors.NONE.code())
                                                                          .setThrottleTimeMs(0)));
             sender.run();
-            assertTrue("Response didn't match in test", endTxnMatcher.matched);
+            assertTrue(endTxnMatcher.matched, "Response didn't match in test");
         } finally {
             m.close();
         }
@@ -2420,13 +2413,13 @@ public class SenderTest {
                                                                          .setErrorCode(Errors.NONE.code())
                                                                          .setThrottleTimeMs(0)));
             sender.run();
-            assertTrue("Response didn't match in test", endTxnMatcher.matched);
+            assertTrue(endTxnMatcher.matched, "Response didn't match in test");
         } finally {
             m.close();
         }
     }
 
-    @Test(timeout = 10000L)
+    @Test @Timeout(10L)
     public void testForceShutdownWithIncompleteTransaction() {
         // create a sender with retries = 1
         int maxRetries = 1;
@@ -2454,8 +2447,8 @@ public class SenderTest {
 
             sender.forceClose();
             sender.run();
-            assertThrows("The test expected to throw a KafkaException for forcefully closing the sender",
-                    KafkaException.class, commitResult::await);
+            assertThrows(KafkaException.class, commitResult::await,
+                "The test expected to throw a KafkaException for forcefully closing the sender");
         } finally {
             m.close();
         }
@@ -2770,7 +2763,7 @@ public class SenderTest {
             fail("Future should have raised " + expectedExceptionType.getName());
         } catch (ExecutionException e) {
             Class<? extends Throwable> causeType = e.getCause().getClass();
-            assertTrue("Unexpected cause " + causeType.getName(), expectedExceptionType.isAssignableFrom(causeType));
+            assertTrue(expectedExceptionType.isAssignableFrom(causeType), "Unexpected cause " + causeType.getName());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -2419,7 +2419,8 @@ public class SenderTest {
         }
     }
 
-    @Test @Timeout(10L)
+    @Timeout(10L)
+    @Test
     public void testForceShutdownWithIncompleteTransaction() {
         // create a sender with retries = 1
         int maxRetries = 1;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/StickyPartitionCacheTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/StickyPartitionCacheTest.java
@@ -19,14 +19,14 @@ package org.apache.kafka.clients.producer.internals;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class StickyPartitionCacheTest {
     private final static Node[] NODES = new Node[] {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -75,8 +75,8 @@ import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -98,17 +98,14 @@ import java.util.function.Supplier;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TransactionManagerTest {
     private static final int MAX_REQUEST_SIZE = 1024 * 1024;
@@ -143,7 +140,7 @@ public class TransactionManagerTest {
     private TransactionManager transactionManager = null;
     private Node brokerNode = null;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.metadata.add("test", time.milliseconds());
         this.client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, singletonMap("test", 2)));
@@ -2092,7 +2089,7 @@ public class TransactionManagerTest {
             offsets, new ConsumerGroupMetadata(consumerGroupId));
         prepareAddOffsetsToTxnResponse(Errors.NONE, consumerGroupId, producerId, epoch);
         runUntil(() -> !client.hasPendingResponses());
-        assertThat(addOffsetsResult.isCompleted(), is(false));  // The request should complete only after the TxnOffsetCommit completes.
+        assertFalse(addOffsetsResult.isCompleted());  // The request should complete only after the TxnOffsetCommit completes.
 
         Map<TopicPartition, Errors> txnOffsetCommitResponse = new HashMap<>();
         txnOffsetCommitResponse.put(tp0, Errors.NONE);
@@ -2102,8 +2099,8 @@ public class TransactionManagerTest {
         prepareTxnOffsetCommitResponse(consumerGroupId, producerId, epoch, txnOffsetCommitResponse);
 
         runUntil(addOffsetsResult::isCompleted);
-        assertThat(addOffsetsResult.isSuccessful(), is(false));
-        assertThat(addOffsetsResult.error(), instanceOf(error.exception().getClass()));
+        assertFalse(addOffsetsResult.isSuccessful());
+        assertEquals(error.exception().getClass(), addOffsetsResult.error().getClass());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/ClusterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/ClusterTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common;
 
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ClusterTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -17,10 +17,8 @@
 package org.apache.kafka.common;
 
 import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,19 +26,17 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A unit test for KafkaFuture.
  */
+@Timeout(120)
 public class KafkaFutureTest {
-
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testCompleteFutures() throws Exception {
@@ -57,13 +53,9 @@ public class KafkaFutureTest {
 
         KafkaFutureImpl<Integer> futureFail = new KafkaFutureImpl<>();
         futureFail.completeExceptionally(new RuntimeException("We require more vespene gas"));
-        try {
-            futureFail.get();
-            Assert.fail("Expected an exception");
-        } catch (ExecutionException e) {
-            assertEquals(RuntimeException.class, e.getCause().getClass());
-            Assert.assertEquals("We require more vespene gas", e.getCause().getMessage());
-        }
+        ExecutionException e = assertThrows(ExecutionException.class, futureFail::get);
+        assertEquals(RuntimeException.class, e.getCause().getClass());
+        assertEquals("We require more vespene gas", e.getCause().getMessage());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/PartitionInfoTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/PartitionInfoTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.kafka.common;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionInfoTest {
 
@@ -35,7 +36,7 @@ public class PartitionInfoTest {
 
         String expected = String.format("Partition(topic = %s, partition = %d, leader = %s, replicas = %s, isr = %s, offlineReplicas = %s)",
                 topic, partition, leader.idString(), "[0,1,2]", "[0,1]", "[2]");
-        Assert.assertEquals(expected, partitionInfo.toString());
+        assertEquals(expected, partitionInfo.toString());
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/TopicPartitionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/TopicPartitionTest.java
@@ -17,12 +17,12 @@
 package org.apache.kafka.common;
 
 import org.apache.kafka.common.utils.Serializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This test ensures TopicPartition class is serializable and is serialization compatible.
@@ -36,8 +36,8 @@ public class TopicPartitionTest {
 
     private void checkValues(TopicPartition deSerTP) {
         //assert deserialized values are same as original
-        assertEquals("partition number should be " + partNum + " but got " + deSerTP.partition(), partNum, deSerTP.partition());
-        assertEquals("topic should be " + topicName + " but got " + deSerTP.topic(), topicName, deSerTP.topic());
+        assertEquals(partNum, deSerTP.partition(), "partition number should be " + partNum + " but got " + deSerTP.partition());
+        assertEquals(topicName, deSerTP.topic(), "topic should be " + topicName + " but got " + deSerTP.topic());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/UuidTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/UuidTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class UuidTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclBindingTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclBindingTest.java
@@ -20,14 +20,14 @@ import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AclBindingTest {
     private static final AclBinding ACL1 = new AclBinding(

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclOperationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclOperationTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.common.acl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AclOperationTest {
     private static class AclOperationTestInfo {
@@ -54,8 +54,8 @@ public class AclOperationTest {
     @Test
     public void testIsUnknown() throws Exception {
         for (AclOperationTestInfo info : INFOS) {
-            assertEquals(info.operation + " was supposed to have unknown == " + info.unknown,
-                info.unknown, info.operation.isUnknown());
+            assertEquals(
+                    info.unknown, info.operation.isUnknown(), info.operation + " was supposed to have unknown == " + info.unknown);
         }
     }
 
@@ -63,10 +63,10 @@ public class AclOperationTest {
     public void testCode() throws Exception {
         assertEquals(AclOperation.values().length, INFOS.length);
         for (AclOperationTestInfo info : INFOS) {
-            assertEquals(info.operation + " was supposed to have code == " + info.code,
-                info.code, info.operation.code());
-            assertEquals("AclOperation.fromCode(" + info.code + ") was supposed to be " +  info.operation,
-                info.operation, AclOperation.fromCode((byte) info.code));
+            assertEquals(
+                    info.code, info.operation.code(), info.operation + " was supposed to have code == " + info.code);
+            assertEquals(
+                    info.operation, AclOperation.fromCode((byte) info.code), "AclOperation.fromCode(" + info.code + ") was supposed to be " +  info.operation);
         }
         assertEquals(AclOperation.UNKNOWN, AclOperation.fromCode((byte) 120));
     }
@@ -74,8 +74,8 @@ public class AclOperationTest {
     @Test
     public void testName() throws Exception {
         for (AclOperationTestInfo info : INFOS) {
-            assertEquals("AclOperation.fromString(" + info.name + ") was supposed to be " +  info.operation,
-                info.operation, AclOperation.fromString(info.name));
+            assertEquals(
+                    info.operation, AclOperation.fromString(info.name), "AclOperation.fromString(" + info.name + ") was supposed to be " +  info.operation);
         }
         assertEquals(AclOperation.UNKNOWN, AclOperation.fromString("something"));
     }

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclOperationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclOperationTest.java
@@ -54,8 +54,8 @@ public class AclOperationTest {
     @Test
     public void testIsUnknown() throws Exception {
         for (AclOperationTestInfo info : INFOS) {
-            assertEquals(
-                    info.unknown, info.operation.isUnknown(), info.operation + " was supposed to have unknown == " + info.unknown);
+            assertEquals(info.unknown, info.operation.isUnknown(),
+                info.operation + " was supposed to have unknown == " + info.unknown);
         }
     }
 
@@ -63,10 +63,9 @@ public class AclOperationTest {
     public void testCode() throws Exception {
         assertEquals(AclOperation.values().length, INFOS.length);
         for (AclOperationTestInfo info : INFOS) {
-            assertEquals(
-                    info.code, info.operation.code(), info.operation + " was supposed to have code == " + info.code);
-            assertEquals(
-                    info.operation, AclOperation.fromCode((byte) info.code), "AclOperation.fromCode(" + info.code + ") was supposed to be " +  info.operation);
+            assertEquals(info.code, info.operation.code(), info.operation + " was supposed to have code == " + info.code);
+            assertEquals(info.operation, AclOperation.fromCode((byte) info.code),
+                "AclOperation.fromCode(" + info.code + ") was supposed to be " +  info.operation);
         }
         assertEquals(AclOperation.UNKNOWN, AclOperation.fromCode((byte) 120));
     }
@@ -74,14 +73,14 @@ public class AclOperationTest {
     @Test
     public void testName() throws Exception {
         for (AclOperationTestInfo info : INFOS) {
-            assertEquals(
-                    info.operation, AclOperation.fromString(info.name), "AclOperation.fromString(" + info.name + ") was supposed to be " +  info.operation);
+            assertEquals(info.operation, AclOperation.fromString(info.name),
+                "AclOperation.fromString(" + info.name + ") was supposed to be " +  info.operation);
         }
         assertEquals(AclOperation.UNKNOWN, AclOperation.fromString("something"));
     }
 
     @Test
-    public void testExhaustive() throws Exception {
+    public void testExhaustive() {
         assertEquals(INFOS.length, AclOperation.values().length);
         for (int i = 0; i < INFOS.length; i++) {
             assertEquals(INFOS[i].operation, AclOperation.values()[i]);

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclPermissionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclPermissionTypeTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.kafka.common.acl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AclPermissionTypeTest {
     private static class AclPermissionTypeTestInfo {
@@ -46,8 +46,8 @@ public class AclPermissionTypeTest {
     @Test
     public void testIsUnknown() throws Exception {
         for (AclPermissionTypeTestInfo info : INFOS) {
-            assertEquals(info.ty + " was supposed to have unknown == " + info.unknown,
-                info.unknown, info.ty.isUnknown());
+            assertEquals(
+                    info.unknown, info.ty.isUnknown(), info.ty + " was supposed to have unknown == " + info.unknown);
         }
     }
 
@@ -55,10 +55,10 @@ public class AclPermissionTypeTest {
     public void testCode() throws Exception {
         assertEquals(AclPermissionType.values().length, INFOS.length);
         for (AclPermissionTypeTestInfo info : INFOS) {
-            assertEquals(info.ty + " was supposed to have code == " + info.code,
-                info.code, info.ty.code());
-            assertEquals("AclPermissionType.fromCode(" + info.code + ") was supposed to be " +  info.ty,
-                info.ty, AclPermissionType.fromCode((byte) info.code));
+            assertEquals(
+                    info.code, info.ty.code(), info.ty + " was supposed to have code == " + info.code);
+            assertEquals(
+                    info.ty, AclPermissionType.fromCode((byte) info.code), "AclPermissionType.fromCode(" + info.code + ") was supposed to be " +  info.ty);
         }
         assertEquals(AclPermissionType.UNKNOWN, AclPermissionType.fromCode((byte) 120));
     }
@@ -66,8 +66,8 @@ public class AclPermissionTypeTest {
     @Test
     public void testName() throws Exception {
         for (AclPermissionTypeTestInfo info : INFOS) {
-            assertEquals("AclPermissionType.fromString(" + info.name + ") was supposed to be " +  info.ty,
-                info.ty, AclPermissionType.fromString(info.name));
+            assertEquals(
+                    info.ty, AclPermissionType.fromString(info.name), "AclPermissionType.fromString(" + info.name + ") was supposed to be " +  info.ty);
         }
         assertEquals(AclPermissionType.UNKNOWN, AclPermissionType.fromString("something"));
     }

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclPermissionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclPermissionTypeTest.java
@@ -46,8 +46,7 @@ public class AclPermissionTypeTest {
     @Test
     public void testIsUnknown() throws Exception {
         for (AclPermissionTypeTestInfo info : INFOS) {
-            assertEquals(
-                    info.unknown, info.ty.isUnknown(), info.ty + " was supposed to have unknown == " + info.unknown);
+            assertEquals(info.unknown, info.ty.isUnknown(), info.ty + " was supposed to have unknown == " + info.unknown);
         }
     }
 
@@ -55,10 +54,9 @@ public class AclPermissionTypeTest {
     public void testCode() throws Exception {
         assertEquals(AclPermissionType.values().length, INFOS.length);
         for (AclPermissionTypeTestInfo info : INFOS) {
-            assertEquals(
-                    info.code, info.ty.code(), info.ty + " was supposed to have code == " + info.code);
-            assertEquals(
-                    info.ty, AclPermissionType.fromCode((byte) info.code), "AclPermissionType.fromCode(" + info.code + ") was supposed to be " +  info.ty);
+            assertEquals(info.code, info.ty.code(), info.ty + " was supposed to have code == " + info.code);
+            assertEquals(info.ty, AclPermissionType.fromCode((byte) info.code),
+                "AclPermissionType.fromCode(" + info.code + ") was supposed to be " +  info.ty);
         }
         assertEquals(AclPermissionType.UNKNOWN, AclPermissionType.fromCode((byte) 120));
     }
@@ -66,8 +64,8 @@ public class AclPermissionTypeTest {
     @Test
     public void testName() throws Exception {
         for (AclPermissionTypeTestInfo info : INFOS) {
-            assertEquals(
-                    info.ty, AclPermissionType.fromString(info.name), "AclPermissionType.fromString(" + info.name + ") was supposed to be " +  info.ty);
+            assertEquals(info.ty, AclPermissionType.fromString(info.name),
+                "AclPermissionType.fromString(" + info.name + ") was supposed to be " +  info.ty);
         }
         assertEquals(AclPermissionType.UNKNOWN, AclPermissionType.fromString("something"));
     }

--- a/clients/src/test/java/org/apache/kafka/common/acl/ResourcePatternFilterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/ResourcePatternFilterTest.java
@@ -20,7 +20,7 @@ package org.apache.kafka.common.acl;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.resource.PatternType.LITERAL;
 import static org.apache.kafka.common.resource.PatternType.PREFIXED;
@@ -28,8 +28,8 @@ import static org.apache.kafka.common.resource.ResourceType.ANY;
 import static org.apache.kafka.common.resource.ResourceType.GROUP;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
 import static org.apache.kafka.common.resource.ResourceType.UNKNOWN;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourcePatternFilterTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/acl/ResourcePatternTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/ResourcePatternTest.java
@@ -20,9 +20,9 @@ package org.apache.kafka.common.acl;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ResourcePatternTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/cache/LRUCacheTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/cache/LRUCacheTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common.cache;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LRUCacheTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.security.TestSecurityConfig;
 import org.apache.kafka.common.config.provider.MockVaultConfigProvider;
 import org.apache.kafka.common.config.provider.MockFileConfigProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,11 +36,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AbstractConfigTest {
 
@@ -227,12 +227,12 @@ public class AbstractConfigTest {
         props.put(ConfiguredFakeMetricsReporter.EXTRA_CONFIG, "my_value");
         TestConfig config = new TestConfig(props);
 
-        assertTrue(ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked unused before getConfiguredInstances is called",
-            config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG));
+        assertTrue(
+                config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG), ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked unused before getConfiguredInstances is called");
 
         config.getConfiguredInstances(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, MetricsReporter.class);
-        assertFalse(ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked as used",
-            config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG));
+        assertFalse(
+                config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG), ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked as used");
     }
 
     private void testValidInputs(String configValue) {

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -227,12 +227,12 @@ public class AbstractConfigTest {
         props.put(ConfiguredFakeMetricsReporter.EXTRA_CONFIG, "my_value");
         TestConfig config = new TestConfig(props);
 
-        assertTrue(
-                config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG), ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked unused before getConfiguredInstances is called");
+        assertTrue(config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG),
+            ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked unused before getConfiguredInstances is called");
 
         config.getConfiguredInstances(TestConfig.METRIC_REPORTER_CLASSES_CONFIG, MetricsReporter.class);
-        assertFalse(
-                config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG), ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked as used");
+        assertFalse(config.unused().contains(ConfiguredFakeMetricsReporter.EXTRA_CONFIG),
+            ConfiguredFakeMetricsReporter.EXTRA_CONFIG + " should be marked as used");
     }
 
     private void testValidInputs(String configValue) {

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.config.ConfigDef.ValidString;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.types.Password;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -38,12 +38,12 @@ import java.util.Properties;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConfigDefTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigResourceTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigResourceTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.kafka.common.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ConfigResourceTest {
     @Test
@@ -40,6 +40,6 @@ public class ConfigResourceTest {
     @Test
     public void shouldRoundTripEveryType() {
         Arrays.stream(ConfigResource.Type.values()).forEach(type ->
-            assertEquals(type.toString(), type, ConfigResource.Type.forId(type.id())));
+            assertEquals(type, ConfigResource.Type.forId(type.id()), type.toString()));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
@@ -17,17 +17,17 @@
 package org.apache.kafka.common.config;
 
 import org.apache.kafka.common.config.provider.ConfigProvider;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConfigTransformerTest {
 
@@ -42,7 +42,7 @@ public class ConfigTransformerTest {
 
     private ConfigTransformer configTransformer;
 
-    @Before
+    @BeforeEach
     public void setup() {
         configTransformer = new ConfigTransformer(Collections.singletonMap("test", new TestConfigProvider()));
     }

--- a/clients/src/test/java/org/apache/kafka/common/config/SaslConfigsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/SaslConfigsTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.kafka.common.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SaslConfigsTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/DirectoryConfigProviderTest.java
@@ -19,9 +19,9 @@ package org.apache.kafka.common.config.provider;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,9 +33,9 @@ import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.test.TestUtils.toSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DirectoryConfigProviderTest {
 
@@ -55,7 +55,7 @@ public class DirectoryConfigProviderTest {
         return file;
     }
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         provider = new DirectoryConfigProvider();
         provider.configure(Collections.emptyMap());
@@ -73,7 +73,7 @@ public class DirectoryConfigProviderTest {
         siblingFile = writeFile(new File(parent, "siblingFile"));
     }
 
-    @After
+    @AfterEach
     public void close() throws IOException {
         provider.close();
         Utils.delete(parent);

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/FileConfigProviderTest.java
@@ -17,8 +17,8 @@
 package org.apache.kafka.common.config.provider;
 
 import org.apache.kafka.common.config.ConfigData;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -27,15 +27,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileConfigProviderTest {
 
     private FileConfigProvider configProvider;
 
-    @Before
+    @BeforeEach
     public void setup() {
         configProvider = new TestFileConfigProvider();
     }

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/MockFileConfigProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/MockFileConfigProvider.java
@@ -23,8 +23,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MockFileConfigProvider extends FileConfigProvider {
 

--- a/clients/src/test/java/org/apache/kafka/common/feature/FeaturesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/FeaturesTest.java
@@ -20,15 +20,15 @@ package org.apache.kafka.common.feature;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FeaturesTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/feature/FinalizedVersionRangeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/FinalizedVersionRangeTest.java
@@ -19,13 +19,13 @@ package org.apache.kafka.common.feature;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the FinalizedVersionRange class.

--- a/clients/src/test/java/org/apache/kafka/common/feature/SupportedVersionRangeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/feature/SupportedVersionRangeTest.java
@@ -19,14 +19,14 @@ package org.apache.kafka.common.feature;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for the SupportedVersionRange class.

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeadersTest.java
@@ -18,18 +18,18 @@ package org.apache.kafka.common.header.internals;
 
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RecordHeadersTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/internals/PartitionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/internals/PartitionStatesTest.java
@@ -17,13 +17,13 @@
 package org.apache.kafka.common.internals;
 
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionStatesTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/internals/TopicTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/internals/TopicTest.java
@@ -18,15 +18,15 @@ package org.apache.kafka.common.internals;
 
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TopicTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/message/ApiMessageTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/ApiMessageTypeTest.java
@@ -19,23 +19,20 @@ package org.apache.kafka.common.message;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.types.Schema;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Timeout(120)
 public class ApiMessageTypeTest {
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testFromApiKey() {
@@ -61,16 +58,16 @@ public class ApiMessageTypeTest {
         Set<String> requestNames = new HashSet<>();
         Set<String> responseNames = new HashSet<>();
         for (ApiMessageType type : ApiMessageType.values()) {
-            assertFalse("found two ApiMessageType objects with id " + type.apiKey(),
-                ids.contains(type.apiKey()));
+            assertFalse(ids.contains(type.apiKey()),
+                "found two ApiMessageType objects with id " + type.apiKey());
             ids.add(type.apiKey());
             String requestName = type.newRequest().getClass().getSimpleName();
-            assertFalse("found two ApiMessageType objects with requestName " + requestName,
-                requestNames.contains(requestName));
+            assertFalse(requestNames.contains(requestName),
+                "found two ApiMessageType objects with requestName " + requestName);
             requestNames.add(requestName);
             String responseName = type.newResponse().getClass().getSimpleName();
-            assertFalse("found two ApiMessageType objects with responseName " + responseName,
-                responseNames.contains(responseName));
+            assertFalse(responseNames.contains(responseName),
+                "found two ApiMessageType objects with responseName " + responseName);
             responseNames.add(responseName);
         }
         assertEquals(ApiMessageType.values().length, ids.size());
@@ -106,7 +103,7 @@ public class ApiMessageTypeTest {
     @Test
     public void testAllVersionsHaveSchemas() {
         for (ApiMessageType type : ApiMessageType.values()) {
-            Assertions.assertEquals(0, type.lowestSupportedVersion());
+            assertEquals(0, type.lowestSupportedVersion());
 
             assertEquals(type.requestSchemas().length, type.responseSchemas().length);
             for (Schema schema : type.requestSchemas())

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -52,9 +52,8 @@ import org.apache.kafka.common.protocol.types.RawTaggedField;
 import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.protocol.types.Type;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -65,19 +64,17 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@Timeout(120)
 public final class MessageTest {
 
     private final String memberId = "memberId";
     private final String instanceId = "instanceId";
-
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testAddOffsetsToTxnVersions() throws Exception {
@@ -803,15 +800,15 @@ public final class MessageTest {
         ByteBuffer buf = ByteBuffer.allocate(size);
         ByteBufferAccessor byteBufferAccessor = new ByteBufferAccessor(buf);
         message.write(byteBufferAccessor, cache, version);
-        assertEquals("The result of the size function does not match the number of bytes " +
-            "written for version " + version, size, buf.position());
+        assertEquals(size, buf.position(), "The result of the size function does not match the number of bytes " +
+            "written for version " + version);
         Message message2 = message.getClass().getConstructor().newInstance();
         buf.flip();
         message2.read(byteBufferAccessor, version);
-        assertEquals("The result of the size function does not match the number of bytes " +
-            "read back in for version " + version, size, buf.position());
-        assertEquals("The message object created after a round trip did not match for " +
-            "version " + version, expected, message2);
+        assertEquals(size, buf.position(), "The result of the size function does not match the number of bytes " +
+            "read back in for version " + version);
+        assertEquals(expected, message2, "The message object created after a round trip did not match for " +
+            "version " + version);
         assertEquals(expected.hashCode(), message2.hashCode());
         assertEquals(expected.toString(), message2.toString());
     }
@@ -861,17 +858,17 @@ public final class MessageTest {
             } catch (UnsupportedVersionException e) {
                 fail("No request message spec found for API " + apiKey);
             }
-            assertTrue("Request message spec for " + apiKey + " only " +
-                    "supports versions up to " + message.highestSupportedVersion(),
-                apiKey.latestVersion() <= message.highestSupportedVersion());
+            assertTrue(apiKey.latestVersion() <= message.highestSupportedVersion(),
+                "Request message spec for " + apiKey + " only " + "supports versions up to " +
+                message.highestSupportedVersion());
             try {
                 message = ApiMessageType.fromApiKey(apiKey.id).newResponse();
             } catch (UnsupportedVersionException e) {
                 fail("No response message spec found for API " + apiKey);
             }
-            assertTrue("Response message spec for " + apiKey + " only " +
-                    "supports versions up to " + message.highestSupportedVersion(),
-                apiKey.latestVersion() <= message.highestSupportedVersion());
+            assertTrue(apiKey.latestVersion() <= message.highestSupportedVersion(),
+                "Response message spec for " + apiKey + " only " + "supports versions up to " +
+                message.highestSupportedVersion());
         }
     }
 
@@ -975,9 +972,8 @@ public final class MessageTest {
                 ByteBufferAccessor byteBufferAccessor = new ByteBufferAccessor(buf);
                 message.write(byteBufferAccessor, cache, version);
             });
-        assertTrue("Expected to get an error message about " + problemText +
-                ", but got: " + e.getMessage(),
-                e.getMessage().contains(problemText));
+        assertTrue(e.getMessage().contains(problemText), "Expected to get an error message about " + problemText +
+            ", but got: " + e.getMessage());
     }
 
     private void verifyWriteSucceeds(short version, Message message) {
@@ -992,8 +988,7 @@ public final class MessageTest {
         while (alt.hasRemaining()) {
             bld.append(String.format(" %02x", alt.get()));
         }
-        assertEquals("Expected the serialized size to be " + size +
-            ", but it was " + buf.position(), size, buf.position());
+        assertEquals(size, buf.position(), "Expected the serialized size to be " + size + ", but it was " + buf.position());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
@@ -23,13 +23,13 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class RecordsSerdeTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -24,18 +24,17 @@ import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SimpleExampleMessageTest {
 
@@ -201,33 +200,33 @@ public class SimpleExampleMessageTest {
     public void testMyTaggedIntArray() {
         // Verify that the tagged int array reads as empty when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertEquals(Collections.emptyList(), message.myTaggedIntArray()));
+            message -> Assertions.assertEquals(Collections.emptyList(), message.myTaggedIntArray()));
 
         // Verify that we can set a tagged array of ints.
         testRoundTrip(new SimpleExampleMessageData().
                 setMyTaggedIntArray(Arrays.asList(1, 2, 3)),
-            message -> assertEquals(Arrays.asList(1, 2, 3), message.myTaggedIntArray()));
+            message -> Assertions.assertEquals(Arrays.asList(1, 2, 3), message.myTaggedIntArray()));
     }
 
     @Test
     public void testMyNullableString() {
         // Verify that the tagged field reads as null when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertTrue(message.myNullableString() == null));
+            message -> Assertions.assertTrue(message.myNullableString() == null));
 
         // Verify that we can set and retrieve a string for the tagged field.
         testRoundTrip(new SimpleExampleMessageData().setMyNullableString("foobar"),
-            message -> assertEquals("foobar", message.myNullableString()));
+            message -> Assertions.assertEquals("foobar", message.myNullableString()));
     }
 
     @Test
     public void testMyInt16() {
         // Verify that the tagged field reads as 123 when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertEquals((short) 123, message.myInt16()));
+            message -> Assertions.assertEquals((short) 123, message.myInt16()));
 
         testRoundTrip(new SimpleExampleMessageData().setMyInt16((short) 456),
-            message -> assertEquals((short) 456, message.myInt16()));
+            message -> Assertions.assertEquals((short) 456, message.myInt16()));
     }
 
     @Test
@@ -246,10 +245,10 @@ public class SimpleExampleMessageTest {
     public void testMyString() {
         // Verify that the tagged field reads as empty when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertEquals("", message.myString()));
+            message -> Assertions.assertEquals("", message.myString()));
 
         testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
-            message -> assertEquals("abc", message.myString()));
+            message -> Assertions.assertEquals("abc", message.myString()));
     }
 
     @Test
@@ -261,27 +260,27 @@ public class SimpleExampleMessageTest {
 
         // Verify that the tagged field reads as empty when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertArrayEquals(new byte[0], message.myBytes()));
+            message -> Assertions.assertArrayEquals(new byte[0], message.myBytes()));
 
         testRoundTrip(new SimpleExampleMessageData().
                 setMyBytes(new byte[] {0x43, 0x66}),
-            message -> assertArrayEquals(new byte[] {0x43, 0x66},
+            message -> Assertions.assertArrayEquals(new byte[] {0x43, 0x66},
                 message.myBytes()));
 
         testRoundTrip(new SimpleExampleMessageData().setMyBytes(null),
-            message -> assertTrue(message.myBytes() == null));
+            message -> Assertions.assertTrue(message.myBytes() == null));
     }
 
     @Test
     public void testTaggedUuid() {
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertEquals(
+            message -> Assertions.assertEquals(
                 Uuid.fromString("212d54944a8b4fdf94b388b470beb367"),
                 message.taggedUuid()));
 
         testRoundTrip(new SimpleExampleMessageData().
                 setTaggedUuid(Uuid.fromString("0123456789abcdef0123456789abcdef")),
-            message -> assertEquals(
+            message -> Assertions.assertEquals(
                 Uuid.fromString("0123456789abcdef0123456789abcdef"),
                 message.taggedUuid()));
     }
@@ -289,14 +288,14 @@ public class SimpleExampleMessageTest {
     @Test
     public void testTaggedLong() {
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertEquals(0xcafcacafcacafcaL,
+            message -> Assertions.assertEquals(0xcafcacafcacafcaL,
                 message.taggedLong()));
 
         testRoundTrip(new SimpleExampleMessageData().
                 setMyString("blah").
                 setMyTaggedIntArray(Arrays.asList(4)).
                 setTaggedLong(0x123443211234432L),
-            message -> assertEquals(0x123443211234432L,
+            message -> Assertions.assertEquals(0x123443211234432L,
                 message.taggedLong()));
     }
 
@@ -308,7 +307,7 @@ public class SimpleExampleMessageTest {
                 Collections.singletonList(new SimpleExampleMessageData.StructArray().setArrayFieldId(20))
             );
         testRoundTrip(new SimpleExampleMessageData().setMyStruct(myStruct),
-            message -> assertEquals(myStruct, message.myStruct()), (short) 2);
+            message -> Assertions.assertEquals(myStruct, message.myStruct()), (short) 2);
     }
 
     @Test
@@ -331,13 +330,13 @@ public class SimpleExampleMessageTest {
         SimpleExampleMessageData.TaggedStruct myStruct =
             new SimpleExampleMessageData.TaggedStruct().setStructId("abc");
         testRoundTrip(new SimpleExampleMessageData().setMyTaggedStruct(myStruct),
-            message -> assertEquals(myStruct, message.myTaggedStruct()), (short) 2);
+            message -> Assertions.assertEquals(myStruct, message.myTaggedStruct()), (short) 2);
 
         // Not setting field works for both version 1 and version 2 protocol
         testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
-            message -> assertEquals("abc", message.myString()), (short) 1);
+            message -> Assertions.assertEquals("abc", message.myString()), (short) 1);
         testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
-            message -> assertEquals("abc", message.myString()), (short) 2);
+            message -> Assertions.assertEquals("abc", message.myString()), (short) 2);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -32,9 +32,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Consumer;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleExampleMessageTest {
 
@@ -200,33 +202,33 @@ public class SimpleExampleMessageTest {
     public void testMyTaggedIntArray() {
         // Verify that the tagged int array reads as empty when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertEquals(Collections.emptyList(), message.myTaggedIntArray()));
+            message -> assertEquals(Collections.emptyList(), message.myTaggedIntArray()));
 
         // Verify that we can set a tagged array of ints.
         testRoundTrip(new SimpleExampleMessageData().
                 setMyTaggedIntArray(Arrays.asList(1, 2, 3)),
-            message -> Assertions.assertEquals(Arrays.asList(1, 2, 3), message.myTaggedIntArray()));
+            message -> assertEquals(Arrays.asList(1, 2, 3), message.myTaggedIntArray()));
     }
 
     @Test
     public void testMyNullableString() {
         // Verify that the tagged field reads as null when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertTrue(message.myNullableString() == null));
+            message -> assertTrue(message.myNullableString() == null));
 
         // Verify that we can set and retrieve a string for the tagged field.
         testRoundTrip(new SimpleExampleMessageData().setMyNullableString("foobar"),
-            message -> Assertions.assertEquals("foobar", message.myNullableString()));
+            message -> assertEquals("foobar", message.myNullableString()));
     }
 
     @Test
     public void testMyInt16() {
         // Verify that the tagged field reads as 123 when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertEquals((short) 123, message.myInt16()));
+            message -> assertEquals((short) 123, message.myInt16()));
 
         testRoundTrip(new SimpleExampleMessageData().setMyInt16((short) 456),
-            message -> Assertions.assertEquals((short) 456, message.myInt16()));
+            message -> assertEquals((short) 456, message.myInt16()));
     }
 
     @Test
@@ -245,10 +247,10 @@ public class SimpleExampleMessageTest {
     public void testMyString() {
         // Verify that the tagged field reads as empty when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertEquals("", message.myString()));
+            message -> assertEquals("", message.myString()));
 
         testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
-            message -> Assertions.assertEquals("abc", message.myString()));
+            message -> assertEquals("abc", message.myString()));
     }
 
     @Test
@@ -260,27 +262,27 @@ public class SimpleExampleMessageTest {
 
         // Verify that the tagged field reads as empty when not set.
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertArrayEquals(new byte[0], message.myBytes()));
+            message -> assertArrayEquals(new byte[0], message.myBytes()));
 
         testRoundTrip(new SimpleExampleMessageData().
                 setMyBytes(new byte[] {0x43, 0x66}),
-            message -> Assertions.assertArrayEquals(new byte[] {0x43, 0x66},
+            message -> assertArrayEquals(new byte[] {0x43, 0x66},
                 message.myBytes()));
 
         testRoundTrip(new SimpleExampleMessageData().setMyBytes(null),
-            message -> Assertions.assertTrue(message.myBytes() == null));
+            message -> assertTrue(message.myBytes() == null));
     }
 
     @Test
     public void testTaggedUuid() {
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertEquals(
+            message -> assertEquals(
                 Uuid.fromString("212d54944a8b4fdf94b388b470beb367"),
                 message.taggedUuid()));
 
         testRoundTrip(new SimpleExampleMessageData().
                 setTaggedUuid(Uuid.fromString("0123456789abcdef0123456789abcdef")),
-            message -> Assertions.assertEquals(
+            message -> assertEquals(
                 Uuid.fromString("0123456789abcdef0123456789abcdef"),
                 message.taggedUuid()));
     }
@@ -288,14 +290,14 @@ public class SimpleExampleMessageTest {
     @Test
     public void testTaggedLong() {
         testRoundTrip(new SimpleExampleMessageData(),
-            message -> Assertions.assertEquals(0xcafcacafcacafcaL,
+            message -> assertEquals(0xcafcacafcacafcaL,
                 message.taggedLong()));
 
         testRoundTrip(new SimpleExampleMessageData().
                 setMyString("blah").
                 setMyTaggedIntArray(Arrays.asList(4)).
                 setTaggedLong(0x123443211234432L),
-            message -> Assertions.assertEquals(0x123443211234432L,
+            message -> assertEquals(0x123443211234432L,
                 message.taggedLong()));
     }
 
@@ -307,7 +309,7 @@ public class SimpleExampleMessageTest {
                 Collections.singletonList(new SimpleExampleMessageData.StructArray().setArrayFieldId(20))
             );
         testRoundTrip(new SimpleExampleMessageData().setMyStruct(myStruct),
-            message -> Assertions.assertEquals(myStruct, message.myStruct()), (short) 2);
+            message -> assertEquals(myStruct, message.myStruct()), (short) 2);
     }
 
     @Test
@@ -330,13 +332,13 @@ public class SimpleExampleMessageTest {
         SimpleExampleMessageData.TaggedStruct myStruct =
             new SimpleExampleMessageData.TaggedStruct().setStructId("abc");
         testRoundTrip(new SimpleExampleMessageData().setMyTaggedStruct(myStruct),
-            message -> Assertions.assertEquals(myStruct, message.myTaggedStruct()), (short) 2);
+            message -> assertEquals(myStruct, message.myTaggedStruct()), (short) 2);
 
         // Not setting field works for both version 1 and version 2 protocol
         testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
-            message -> Assertions.assertEquals("abc", message.myString()), (short) 1);
+            message -> assertEquals("abc", message.myString()), (short) 1);
         testRoundTrip(new SimpleExampleMessageData().setMyString("abc"),
-            message -> Assertions.assertEquals("abc", message.myString()), (short) 2);
+            message -> assertEquals("abc", message.myString()), (short) 2);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -30,9 +30,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JmxReporterTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMbeanTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMbeanTest.java
@@ -19,9 +19,9 @@ package org.apache.kafka.common.metrics;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.metrics.stats.WindowedSum;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -32,10 +32,9 @@ import javax.management.RuntimeMBeanException;
 import java.lang.management.ManagementFactory;
 import java.util.List;
 
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class KafkaMbeanTest {
 
@@ -45,7 +44,7 @@ public class KafkaMbeanTest {
     private MetricName sumMetricName;
     private Metrics metrics;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         metrics = new Metrics();
         metrics.addReporter(new JmxReporter());
@@ -56,7 +55,7 @@ public class KafkaMbeanTest {
         sensor.add(sumMetricName, new WindowedSum());
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         metrics.close();
     }
@@ -118,32 +117,23 @@ public class KafkaMbeanTest {
 
     @Test
     public void testInvoke() throws Exception {
-        try {
-            mBeanServer.invoke(objectName(countMetricName), "something", null, null);
-            fail("invoke should have failed");
-        } catch (RuntimeMBeanException e) {
-            assertThat(e.getCause(), instanceOf(UnsupportedOperationException.class));
-        }
+        RuntimeMBeanException e = assertThrows(RuntimeMBeanException.class,
+            () -> mBeanServer.invoke(objectName(countMetricName), "something", null, null));
+        assertEquals(UnsupportedOperationException.class, e.getCause().getClass());
     }
 
     @Test
     public void testSetAttribute() throws Exception {
-        try {
-            mBeanServer.setAttribute(objectName(countMetricName), new Attribute("anything", 1));
-            fail("setAttribute should have failed");
-        } catch (RuntimeMBeanException e) {
-            assertThat(e.getCause(), instanceOf(UnsupportedOperationException.class));
-        }
+        RuntimeMBeanException e = assertThrows(RuntimeMBeanException.class,
+            () -> mBeanServer.setAttribute(objectName(countMetricName), new Attribute("anything", 1)));
+        assertEquals(UnsupportedOperationException.class, e.getCause().getClass());
     }
 
     @Test
     public void testSetAttributes() throws Exception {
-        try {
-            mBeanServer.setAttributes(objectName(countMetricName), new AttributeList(1));
-            fail("setAttributes should have failed");
-        } catch (Exception e) {
-            assertThat(e.getCause(), instanceOf(UnsupportedOperationException.class));
-        }
+        RuntimeMBeanException e = assertThrows(RuntimeMBeanException.class,
+            () -> mBeanServer.setAttributes(objectName(countMetricName), new AttributeList(1)));
+        assertEquals(UnsupportedOperationException.class, e.getCause().getClass());
     }
 
     private ObjectName objectName(MetricName metricName) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMetricsContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/KafkaMetricsContextTest.java
@@ -19,12 +19,12 @@ package org.apache.kafka.common.metrics;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaMetricsContextTest {
 
@@ -37,7 +37,7 @@ public class KafkaMetricsContextTest {
     private Map<String, String> labels;
     private KafkaMetricsContext context;
 
-    @Before
+    @BeforeEach
     public void beforeEach() {
         namespace = SAMPLE_NAMESPACE;
         labels = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -139,25 +139,28 @@ public class MetricsTest {
         }
         // prior to any time passing
         double elapsedSecs = (config.timeWindowMs() * (config.samples() - 1)) / 1000.0;
-        assertEquals(count / elapsedSecs,
-                     metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS, String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
+        assertEquals(count / elapsedSecs, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS,
+            String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
 
         // pretend 2 seconds passed...
         long sleepTimeMs = 2;
         time.sleep(sleepTimeMs * 1000);
         elapsedSecs += sleepTimeMs;
 
-        assertEquals(5.0, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("s2.total", "grp1"))), EPS, "s2 reflects the constant value");
-        assertEquals(4.5, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.avg", "grp1"))), EPS, "Avg(0...9) = 4.5");
-        assertEquals(count - 1,  metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.max", "grp1"))), EPS, "Max(0...9) = 9");
-        assertEquals(0.0, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.min", "grp1"))), EPS, "Min(0...9) = 0");
-        assertEquals(
-                sum / elapsedSecs, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.rate", "grp1"))), EPS, "Rate(0...9) = 1.40625");
-        assertEquals(
-                count / elapsedSecs,
-                     metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS, String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
-        assertEquals(
-                (double) count, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.count", "grp1"))), EPS, "Count(0...9) = 10");
+        assertEquals(5.0, metricValueFunc.apply(metrics.metric(metrics.metricName("s2.total", "grp1"))), EPS,
+            "s2 reflects the constant value");
+        assertEquals(4.5, metricValueFunc.apply(metrics.metric(metrics.metricName("test.avg", "grp1"))), EPS,
+            "Avg(0...9) = 4.5");
+        assertEquals(count - 1,  metricValueFunc.apply(metrics.metric(metrics.metricName("test.max", "grp1"))), EPS,
+            "Max(0...9) = 9");
+        assertEquals(0.0, metricValueFunc.apply(metrics.metric(metrics.metricName("test.min", "grp1"))), EPS,
+            "Min(0...9) = 0");
+        assertEquals(sum / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.rate", "grp1"))), EPS,
+            "Rate(0...9) = 1.40625");
+        assertEquals(count / elapsedSecs, metricValueFunc.apply(metrics.metric(metrics.metricName("test.occurences", "grp1"))), EPS,
+            String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
+        assertEquals(count, metricValueFunc.apply(metrics.metric(metrics.metricName("test.count", "grp1"))), EPS,
+            "Count(0...9) = 10");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -18,13 +18,13 @@ package org.apache.kafka.common.metrics;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,9 +59,9 @@ import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.common.metrics.stats.SimpleRate;
 import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.utils.MockTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,12 +74,12 @@ public class MetricsTest {
     private Metrics metrics;
     private ExecutorService executorService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.metrics = new Metrics(config, Arrays.asList(new JmxReporter()), time, true);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         if (executorService != null) {
             executorService.shutdownNow();
@@ -95,7 +95,7 @@ public class MetricsTest {
         tags.put("key1", "value1");
         tags.put("key2", "value2");
         MetricName n2 = metrics.metricName("name", "group", "description", tags);
-        assertEquals("metric names created in two different ways should be equal", n1, n2);
+        assertEquals(n1, n2, "metric names created in two different ways should be equal");
 
         try {
             metrics.metricName("name", "group", "description", "key1");
@@ -139,25 +139,25 @@ public class MetricsTest {
         }
         // prior to any time passing
         double elapsedSecs = (config.timeWindowMs() * (config.samples() - 1)) / 1000.0;
-        assertEquals(String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs), count / elapsedSecs,
-                     metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS);
+        assertEquals(count / elapsedSecs,
+                     metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS, String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
 
         // pretend 2 seconds passed...
         long sleepTimeMs = 2;
         time.sleep(sleepTimeMs * 1000);
         elapsedSecs += sleepTimeMs;
 
-        assertEquals("s2 reflects the constant value", 5.0, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("s2.total", "grp1"))), EPS);
-        assertEquals("Avg(0...9) = 4.5", 4.5, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.avg", "grp1"))), EPS);
-        assertEquals("Max(0...9) = 9", count - 1,  metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.max", "grp1"))), EPS);
-        assertEquals("Min(0...9) = 0", 0.0, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.min", "grp1"))), EPS);
-        assertEquals("Rate(0...9) = 1.40625",
-                     sum / elapsedSecs, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.rate", "grp1"))), EPS);
-        assertEquals(String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs),
-                     count / elapsedSecs,
-                     metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS);
-        assertEquals("Count(0...9) = 10",
-                     (double) count, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.count", "grp1"))), EPS);
+        assertEquals(5.0, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("s2.total", "grp1"))), EPS, "s2 reflects the constant value");
+        assertEquals(4.5, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.avg", "grp1"))), EPS, "Avg(0...9) = 4.5");
+        assertEquals(count - 1,  metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.max", "grp1"))), EPS, "Max(0...9) = 9");
+        assertEquals(0.0, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.min", "grp1"))), EPS, "Min(0...9) = 0");
+        assertEquals(
+                sum / elapsedSecs, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.rate", "grp1"))), EPS, "Rate(0...9) = 1.40625");
+        assertEquals(
+                count / elapsedSecs,
+                     metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.occurences", "grp1"))), EPS, String.format("Occurrences(0...%d) = %f", count, count / elapsedSecs));
+        assertEquals(
+                (double) count, metricValueFunc.apply(metrics.metrics().get(metrics.metricName("test.count", "grp1"))), EPS, "Count(0...9) = 10");
     }
 
     @Test
@@ -276,44 +276,44 @@ public class MetricsTest {
 
         Metrics.ExpireSensorTask purger = metrics.new ExpireSensorTask();
         purger.run();
-        assertNotNull("Sensor test.s1 must be present", metrics.getSensor("test.s1"));
-        assertNotNull("MetricName test.s1.count must be present",
-                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")));
-        assertNotNull("Sensor test.s2 must be present", metrics.getSensor("test.s2"));
-        assertNotNull("MetricName test.s2.count must be present",
-                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")));
+        assertNotNull(metrics.getSensor("test.s1"), "Sensor test.s1 must be present");
+        assertNotNull(
+                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")), "MetricName test.s1.count must be present");
+        assertNotNull(metrics.getSensor("test.s2"), "Sensor test.s2 must be present");
+        assertNotNull(
+                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")), "MetricName test.s2.count must be present");
 
         time.sleep(1001);
         purger.run();
-        assertNull("Sensor test.s1 should have been purged", metrics.getSensor("test.s1"));
-        assertNull("MetricName test.s1.count should have been purged",
-                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")));
-        assertNotNull("Sensor test.s2 must be present", metrics.getSensor("test.s2"));
-        assertNotNull("MetricName test.s2.count must be present",
-                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")));
+        assertNull(metrics.getSensor("test.s1"), "Sensor test.s1 should have been purged");
+        assertNull(
+                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")), "MetricName test.s1.count should have been purged");
+        assertNotNull(metrics.getSensor("test.s2"), "Sensor test.s2 must be present");
+        assertNotNull(
+                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")), "MetricName test.s2.count must be present");
 
         // record a value in sensor s2. This should reset the clock for that sensor.
         // It should not get purged at the 3 second mark after creation
         s2.record();
         time.sleep(2000);
         purger.run();
-        assertNotNull("Sensor test.s2 must be present", metrics.getSensor("test.s2"));
-        assertNotNull("MetricName test.s2.count must be present",
-                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")));
+        assertNotNull(metrics.getSensor("test.s2"), "Sensor test.s2 must be present");
+        assertNotNull(
+                metrics.metrics().get(metrics.metricName("test.s2.count", "grp1")), "MetricName test.s2.count must be present");
 
         // After another 1 second sleep, the metric should be purged
         time.sleep(1000);
         purger.run();
-        assertNull("Sensor test.s2 should have been purged", metrics.getSensor("test.s1"));
-        assertNull("MetricName test.s2.count should have been purged",
-                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")));
+        assertNull(metrics.getSensor("test.s1"), "Sensor test.s2 should have been purged");
+        assertNull(
+                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")), "MetricName test.s2.count should have been purged");
 
         // After purging, it should be possible to recreate a metric
         s1 = metrics.sensor("test.s1", null, 1);
         s1.add(metrics.metricName("test.s1.count", "grp1"), new WindowedCount());
-        assertNotNull("Sensor test.s1 must be present", metrics.getSensor("test.s1"));
-        assertNotNull("MetricName test.s1.count must be present",
-                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")));
+        assertNotNull(metrics.getSensor("test.s1"), "Sensor test.s1 must be present");
+        assertNotNull(
+                metrics.metrics().get(metrics.metricName("test.s1.count", "grp1")), "MetricName test.s1.count must be present");
     }
 
     @Test
@@ -447,11 +447,11 @@ public class MetricsTest {
         final Quota quota1 = Quota.upperBound(10.5);
         final Quota quota2 = Quota.lowerBound(10.5);
 
-        assertFalse("Quota with different upper values shouldn't be equal", quota1.equals(quota2));
+        assertFalse(quota1.equals(quota2), "Quota with different upper values shouldn't be equal");
 
         final Quota quota3 = Quota.lowerBound(10.5);
 
-        assertTrue("Quota with same upper and bound values should be equal", quota2.equals(quota3));
+        assertTrue(quota2.equals(quota3), "Quota with same upper and bound values should be equal");
     }
 
     @Test
@@ -609,10 +609,10 @@ public class MetricsTest {
 
         KafkaMetric rateMetric = metrics.metrics().get(rateMetricName);
         KafkaMetric countRateMetric = metrics.metrics().get(countRateMetricName);
-        assertEquals("Rate(0...2) = 2.666", sum / elapsedSecs, (Double) rateMetric.metricValue(), EPS);
-        assertEquals("Count rate(0...2) = 0.02666", count / elapsedSecs, (Double) countRateMetric.metricValue(), EPS);
-        assertEquals("Elapsed Time = 75 seconds", elapsedSecs,
-                ((Rate) rateMetric.measurable()).windowSize(cfg, time.milliseconds()) / 1000, EPS);
+        assertEquals(sum / elapsedSecs, (Double) rateMetric.metricValue(), EPS, "Rate(0...2) = 2.666");
+        assertEquals(count / elapsedSecs, (Double) countRateMetric.metricValue(), EPS, "Count rate(0...2) = 0.02666");
+        assertEquals(elapsedSecs,
+                ((Rate) rateMetric.measurable()).windowSize(cfg, time.milliseconds()) / 1000, EPS, "Elapsed Time = 75 seconds");
         assertEquals(sum, (Double) totalMetric.metricValue(), EPS);
         assertEquals(count, (Double) countTotalMetric.metricValue(), EPS);
 
@@ -700,7 +700,7 @@ public class MetricsTest {
         tags.put("key1", "value1");
         tags.put("key2", "value2");
         MetricName n2 = metrics.metricInstance(SampleMetrics.METRIC2, tags);
-        assertEquals("metric names created in two different ways should be equal", n1, n2);
+        assertEquals(n1, n2, "metric names created in two different ways should be equal");
 
         try {
             metrics.metricInstance(SampleMetrics.METRIC1, "key1");
@@ -719,8 +719,8 @@ public class MetricsTest {
             MetricName inheritedMetric = inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, childTagsWithValues);
 
             Map<String, String> filledOutTags = inheritedMetric.tags();
-            assertEquals("parent-tag should be set properly", filledOutTags.get("parent-tag"), "parent-tag-value");
-            assertEquals("child-tag should be set properly", filledOutTags.get("child-tag"), "child-tag-value");
+            assertEquals(filledOutTags.get("parent-tag"), "parent-tag-value", "parent-tag should be set properly");
+            assertEquals(filledOutTags.get("child-tag"), "child-tag-value", "child-tag should be set properly");
 
             try {
                 inherited.metricInstance(SampleMetrics.METRIC_WITH_INHERITED_TAGS, parentTagsWithValues);
@@ -768,7 +768,7 @@ public class MetricsTest {
             sensors.add(sensorCreator.createSensor(statType, i));
             for (Sensor sensor : sensors) {
                 for (KafkaMetric metric : sensor.metrics()) {
-                    assertNotNull("Invalid metric value", metric.metricValue());
+                    assertNotNull(metric.metricValue(), "Invalid metric value");
                 }
             }
         }
@@ -808,7 +808,7 @@ public class MetricsTest {
 
             synchronized void processMetrics() {
                 for (KafkaMetric metric : activeMetrics.values()) {
-                    assertNotNull("Invalid metric value", metric.metricValue());
+                    assertNotNull(metric.metricValue(), "Invalid metric value");
                 }
             }
         }
@@ -827,9 +827,9 @@ public class MetricsTest {
             () -> sensors.forEach(sensor -> sensor.record(random.nextInt(10000)))));
         Future<?> readFuture = executorService.submit(new ConcurrentMetricOperation(alive, "read",
             () -> sensors.forEach(sensor -> sensor.metrics().forEach(metric ->
-                assertNotNull("Invalid metric value", metric.metricValue())))));
+                assertNotNull(metric.metricValue(), "Invalid metric value")))));
         Future<?> reportFuture = executorService.submit(new ConcurrentMetricOperation(alive, "report",
-            () -> reporter.processMetrics()));
+                reporter::processMetrics));
 
         for (int i = 0; i < 10000; i++) {
             if (sensors.size() > 10) {
@@ -839,9 +839,9 @@ public class MetricsTest {
             StatType statType = StatType.forId(random.nextInt(StatType.values().length));
             sensors.add(sensorCreator.createSensor(statType, i));
         }
-        assertFalse("Read failed", readFuture.isDone());
-        assertFalse("Write failed", writeFuture.isDone());
-        assertFalse("Report failed", reportFuture.isDone());
+        assertFalse(readFuture.isDone(), "Read failed");
+        assertFalse(writeFuture.isDone(), "Write failed");
+        assertFalse(reportFuture.isDone(), "Report failed");
 
         alive.set(false);
     }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/SensorTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,14 +42,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.mockito.Mockito;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SensorTest {
 
@@ -220,8 +218,8 @@ public class SensorTest {
             assertTrue(service.awaitTermination(10, TimeUnit.SECONDS));
             needShutdown = false;
             for (Future<Throwable> callable : workers) {
-                assertTrue("If this failure happen frequently, we can try to increase the wait time", callable.isDone());
-                assertNull("Sensor#checkQuotas SHOULD be thread-safe!", callable.get());
+                assertTrue(callable.isDone(), "If this failure happen frequently, we can try to increase the wait time");
+                assertNull(callable.get(), "Sensor#checkQuotas SHOULD be thread-safe!");
             }
         } finally {
             if (needShutdown) {
@@ -235,21 +233,21 @@ public class SensorTest {
         final Metrics metrics = new Metrics();
         final Sensor sensor = metrics.sensor("sensor");
 
-        assertThat(sensor.hasMetrics(), is(false));
+        assertFalse(sensor.hasMetrics());
 
         sensor.add(
             new MetricName("name1", "group1", "description1", Collections.emptyMap()),
             new WindowedSum()
         );
 
-        assertThat(sensor.hasMetrics(), is(true));
+        assertTrue(sensor.hasMetrics());
 
         sensor.add(
             new MetricName("name2", "group2", "description2", Collections.emptyMap()),
             new CumulativeCount()
         );
 
-        assertThat(sensor.hasMetrics(), is(true));
+        assertTrue(sensor.hasMetrics());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/TokenBucketTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/TokenBucketTest.java
@@ -16,19 +16,19 @@
  */
 package org.apache.kafka.common.metrics;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.metrics.stats.TokenBucket;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TokenBucketTest {
     Time time;
 
-    @Before
+    @BeforeEach
     public void setup() {
         time = new MockTime(0, System.currentTimeMillis(), System.nanoTime());
     }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/internals/IntGaugeSuiteTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/internals/IntGaugeSuiteTest.java
@@ -20,15 +20,15 @@ package org.apache.kafka.common.metrics.internals;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class IntGaugeSuiteTest {
     private static final Logger log = LoggerFactory.getLogger(IntGaugeSuiteTest.class);

--- a/clients/src/test/java/org/apache/kafka/common/metrics/internals/MetricsUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/internals/MetricsUtilsTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.common.metrics.internals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MetricsUtilsTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/FrequenciesTest.java
@@ -25,15 +25,15 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FrequenciesTest {
 
@@ -42,14 +42,14 @@ public class FrequenciesTest {
     private Time time;
     private Metrics metrics;
 
-    @Before
+    @BeforeEach
     public void setup() {
         config = new MetricConfig().eventWindow(50).samples(2);
         time = new MockTime();
         metrics = new Metrics(config, Arrays.asList(new JmxReporter()), time, true);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         metrics.close();
     }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/HistogramTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/HistogramTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.metrics.stats;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Random;
@@ -25,7 +25,7 @@ import java.util.Random;
 import org.apache.kafka.common.metrics.stats.Histogram.BinScheme;
 import org.apache.kafka.common.metrics.stats.Histogram.ConstantBinScheme;
 import org.apache.kafka.common.metrics.stats.Histogram.LinearBinScheme;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HistogramTest {
 
@@ -44,22 +44,22 @@ public class HistogramTest {
     @Test
     public void testConstantBinScheme() {
         ConstantBinScheme scheme = new ConstantBinScheme(5, -5, 5);
-        assertEquals("A value below the lower bound should map to the first bin", 0, scheme.toBin(-5.01));
-        assertEquals("A value above the upper bound should map to the last bin", 4, scheme.toBin(5.01));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(-5.0001));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(-5.0000));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(-4.99999));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(-3.00001));
-        assertEquals("Check boundary of bucket 1", 1, scheme.toBin(-3));
-        assertEquals("Check boundary of bucket 1", 1, scheme.toBin(-1.00001));
-        assertEquals("Check boundary of bucket 2", 2, scheme.toBin(-1));
-        assertEquals("Check boundary of bucket 2", 2, scheme.toBin(0.99999));
-        assertEquals("Check boundary of bucket 3", 3, scheme.toBin(1));
-        assertEquals("Check boundary of bucket 3", 3, scheme.toBin(2.99999));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(3));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(4.9999));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(5.000));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(5.001));
+        assertEquals(0, scheme.toBin(-5.01), "A value below the lower bound should map to the first bin");
+        assertEquals(4, scheme.toBin(5.01), "A value above the upper bound should map to the last bin");
+        assertEquals(0, scheme.toBin(-5.0001), "Check boundary of bucket 0");
+        assertEquals(0, scheme.toBin(-5.0000), "Check boundary of bucket 0");
+        assertEquals(0, scheme.toBin(-4.99999), "Check boundary of bucket 0");
+        assertEquals(0, scheme.toBin(-3.00001), "Check boundary of bucket 0");
+        assertEquals(1, scheme.toBin(-3), "Check boundary of bucket 1");
+        assertEquals(1, scheme.toBin(-1.00001), "Check boundary of bucket 1");
+        assertEquals(2, scheme.toBin(-1), "Check boundary of bucket 2");
+        assertEquals(2, scheme.toBin(0.99999), "Check boundary of bucket 2");
+        assertEquals(3, scheme.toBin(1), "Check boundary of bucket 3");
+        assertEquals(3, scheme.toBin(2.99999), "Check boundary of bucket 3");
+        assertEquals(4, scheme.toBin(3), "Check boundary of bucket 4");
+        assertEquals(4, scheme.toBin(4.9999), "Check boundary of bucket 4");
+        assertEquals(4, scheme.toBin(5.000), "Check boundary of bucket 4");
+        assertEquals(4, scheme.toBin(5.001), "Check boundary of bucket 4");
         assertEquals(Float.NEGATIVE_INFINITY, scheme.fromBin(-1), 0.001d);
         assertEquals(Float.POSITIVE_INFINITY, scheme.fromBin(5), 0.001d);
         assertEquals(-5.0, scheme.fromBin(0), 0.001d);
@@ -73,25 +73,25 @@ public class HistogramTest {
     @Test
     public void testConstantBinSchemeWithPositiveRange() {
         ConstantBinScheme scheme = new ConstantBinScheme(5, 0, 5);
-        assertEquals("A value below the lower bound should map to the first bin", 0, scheme.toBin(-1.0));
-        assertEquals("A value above the upper bound should map to the last bin", 4, scheme.toBin(5.01));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(-0.0001));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(0.0000));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(0.0001));
-        assertEquals("Check boundary of bucket 0", 0, scheme.toBin(0.9999));
-        assertEquals("Check boundary of bucket 1", 1, scheme.toBin(1.0000));
-        assertEquals("Check boundary of bucket 1", 1, scheme.toBin(1.0001));
-        assertEquals("Check boundary of bucket 1", 1, scheme.toBin(1.9999));
-        assertEquals("Check boundary of bucket 2", 2, scheme.toBin(2.0000));
-        assertEquals("Check boundary of bucket 2", 2, scheme.toBin(2.0001));
-        assertEquals("Check boundary of bucket 2", 2, scheme.toBin(2.9999));
-        assertEquals("Check boundary of bucket 3", 3, scheme.toBin(3.0000));
-        assertEquals("Check boundary of bucket 3", 3, scheme.toBin(3.0001));
-        assertEquals("Check boundary of bucket 3", 3, scheme.toBin(3.9999));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(4.0000));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(4.9999));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(5.0000));
-        assertEquals("Check boundary of bucket 4", 4, scheme.toBin(5.0001));
+        assertEquals(0, scheme.toBin(-1.0), "A value below the lower bound should map to the first bin");
+        assertEquals(4, scheme.toBin(5.01), "A value above the upper bound should map to the last bin");
+        assertEquals(0, scheme.toBin(-0.0001), "Check boundary of bucket 0");
+        assertEquals(0, scheme.toBin(0.0000), "Check boundary of bucket 0");
+        assertEquals(0, scheme.toBin(0.0001), "Check boundary of bucket 0");
+        assertEquals(0, scheme.toBin(0.9999), "Check boundary of bucket 0");
+        assertEquals(1, scheme.toBin(1.0000), "Check boundary of bucket 1");
+        assertEquals(1, scheme.toBin(1.0001), "Check boundary of bucket 1");
+        assertEquals(1, scheme.toBin(1.9999), "Check boundary of bucket 1");
+        assertEquals(2, scheme.toBin(2.0000), "Check boundary of bucket 2");
+        assertEquals(2, scheme.toBin(2.0001), "Check boundary of bucket 2");
+        assertEquals(2, scheme.toBin(2.9999), "Check boundary of bucket 2");
+        assertEquals(3, scheme.toBin(3.0000), "Check boundary of bucket 3");
+        assertEquals(3, scheme.toBin(3.0001), "Check boundary of bucket 3");
+        assertEquals(3, scheme.toBin(3.9999), "Check boundary of bucket 3");
+        assertEquals(4, scheme.toBin(4.0000), "Check boundary of bucket 4");
+        assertEquals(4, scheme.toBin(4.9999), "Check boundary of bucket 4");
+        assertEquals(4, scheme.toBin(5.0000), "Check boundary of bucket 4");
+        assertEquals(4, scheme.toBin(5.0001), "Check boundary of bucket 4");
         assertEquals(Float.NEGATIVE_INFINITY, scheme.fromBin(-1), 0.001d);
         assertEquals(Float.POSITIVE_INFINITY, scheme.fromBin(5), 0.001d);
         assertEquals(0.0, scheme.fromBin(0), 0.001d);
@@ -137,12 +137,12 @@ public class HistogramTest {
         for (int bin = 0; bin < scheme.bins(); bin++) {
             double fromBin = scheme.fromBin(bin);
             int binAgain = scheme.toBin(fromBin + EPS);
-            assertEquals("unbinning and rebinning the bin " + bin
+            assertEquals(bin, binAgain, "unbinning and rebinning the bin " + bin
                          + " gave a different result ("
                          + fromBin
                          + " was placed in bin "
                          + binAgain
-                         + " )", bin, binAgain);
+                         + " )");
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/metrics/stats/MeterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/stats/MeterTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.metrics.stats;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.CompoundStat.NamedMeasurable;
 import org.apache.kafka.common.metrics.MetricConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MeterTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ChannelBuildersTest.java
@@ -25,7 +25,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
 import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.security.Principal;
@@ -33,10 +33,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class ChannelBuildersTest {

--- a/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/KafkaChannelTest.java
@@ -18,18 +18,18 @@ package org.apache.kafka.common.network;
 
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KafkaChannelTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkReceiveTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common.network;
 
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -25,9 +25,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ScatteringByteChannel;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NetworkReceiveTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -21,8 +21,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -74,7 +74,7 @@ public class NetworkTestUtils {
         requests++;
         while (responses < messageCount) {
             selector.poll(0L);
-            assertEquals("No disconnects should have occurred ." + selector.disconnected(),  0, selector.disconnected().size());
+            assertEquals(0, selector.disconnected().size(), "No disconnects should have occurred ." + selector.disconnected());
 
             for (NetworkReceive receive : selector.completedReceives()) {
                 assertEquals(prefix + "-" + responses, new String(Utils.toArray(receive.payload()), StandardCharsets.UTF_8));
@@ -106,7 +106,7 @@ public class NetworkTestUtils {
                 break;
             }
         }
-        assertTrue("Channel was not closed by timeout", closed);
+        assertTrue(closed, "Channel was not closed by timeout");
         ChannelState finalState = selector.disconnected().get(node);
         assertEquals(channelState, finalState.state());
         return finalState;

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -49,7 +49,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Non-blocking EchoServer implementation that uses ChannelBuilder to create channels
@@ -187,8 +187,8 @@ public class NioEchoServer extends Thread {
                 if (metricType == MetricType.MAX || metricType == MetricType.AVG)
                     expected = Double.NaN;
 
-                assertEquals("Metric not updated " + metricName + " expected:<" + expectedValue + "> but was:<"
-                    + metricValue(metricName) + ">", expected, metricValue(metricName), EPS);
+                assertEquals(expected, metricValue(metricName), EPS, "Metric not updated " + metricName +
+                    " expected:<" + expectedValue + "> but was:<" + metricValue(metricName) + ">");
             } else if (metricType == MetricType.TOTAL)
                 TestUtils.waitForCondition(() -> Math.abs(metricValue(metricName) - expectedValue) <= EPS,
                         thisMaxWaitMs, () -> "Metric not updated " + metricName + " expected:<" + expectedValue
@@ -251,7 +251,7 @@ public class NioEchoServer extends Thread {
     private static boolean maybeBeginServerReauthentication(KafkaChannel channel, NetworkReceive networkReceive, Time time) {
         try {
             if (TestUtils.apiKeyFrom(networkReceive) == ApiKeys.SASL_HANDSHAKE) {
-                return channel.maybeBeginServerReauthentication(networkReceive, () -> time.nanoseconds());
+                return channel.maybeBeginServerReauthentication(networkReceive, time::nanoseconds);
             }
         } catch (Exception e) {
             // ignore

--- a/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SaslChannelBuilderTest.java
@@ -36,8 +36,8 @@ import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.security.auth.Subject;
@@ -49,16 +49,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class SaslChannelBuilderTest {
 
-    @After
+    @AfterEach
     public void tearDown() {
         System.clearProperty(SaslChannelBuilder.GSS_NATIVE_PROP);
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -33,9 +33,9 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,10 +53,10 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A set of tests for the selector. These use a test harness that runs a simple socket server that echos back responses.
@@ -65,7 +65,7 @@ public class SslSelectorTest extends SelectorTest {
 
     private Map<String, Object> sslClientConfigs;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
 
@@ -81,7 +81,7 @@ public class SslSelectorTest extends SelectorTest {
         this.selector = new Selector(5000, metrics, time, "MetricGroup", channelBuilder, logContext);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         this.selector.close();
         this.server.close();
@@ -274,7 +274,7 @@ public class SslSelectorTest extends SelectorTest {
             selector.poll(10);
             disconnected.addAll(selector.disconnected().keySet());
         }
-        assertTrue("Renegotiation should cause disconnection", disconnected.contains(node));
+        assertTrue(disconnected.contains(node), "Renegotiation should cause disconnection");
 
     }
 
@@ -324,13 +324,13 @@ public class SslSelectorTest extends SelectorTest {
                 Collection<NetworkReceive> completed = selector.completedReceives();
                 if (firstReceive == null) {
                     if (!completed.isEmpty()) {
-                        assertEquals("expecting a single request", 1, completed.size());
+                        assertEquals(1, completed.size(), "expecting a single request");
                         firstReceive = completed.iterator().next();
                         assertTrue(selector.isMadeReadProgressLastPoll());
                         assertEquals(0, pool.availableMemory());
                     }
                 } else {
-                    assertTrue("only expecting single request", completed.isEmpty());
+                    assertTrue(completed.isEmpty(), "only expecting single request");
                 }
 
                 handshaked = sender1.waitForHandshake(1) && sender2.waitForHandshake(1);
@@ -338,13 +338,13 @@ public class SslSelectorTest extends SelectorTest {
                 if (handshaked && firstReceive != null && selector.isOutOfMemory())
                     break;
             }
-            assertTrue("could not initiate connections within timeout", handshaked);
+            assertTrue(handshaked, "could not initiate connections within timeout");
 
             selector.poll(10);
             assertTrue(selector.completedReceives().isEmpty());
             assertEquals(0, pool.availableMemory());
-            assertNotNull("First receive not complete", firstReceive);
-            assertTrue("Selector not out of memory", selector.isOutOfMemory());
+            assertNotNull(firstReceive, "First receive not complete");
+            assertTrue(selector.isOutOfMemory(), "Selector not out of memory");
 
             firstReceive.close();
             assertEquals(900, pool.availableMemory()); //memory has been released back to pool
@@ -355,7 +355,7 @@ public class SslSelectorTest extends SelectorTest {
                 selector.poll(1000);
                 completed = selector.completedReceives();
             }
-            assertEquals("could not read remaining request within timeout", 1, completed.size());
+            assertEquals(1, completed.size(), "could not read remaining request within timeout");
             assertEquals(0, pool.availableMemory());
             assertFalse(selector.isOutOfMemory());
         }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -279,6 +279,7 @@ public class SslSelectorTest extends SelectorTest {
     }
 
     @Override
+    @Test
     public void testMuteOnOOM() throws Exception {
         //clean up default selector, replace it with one that uses a finite mem pool
         selector.close();

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -33,11 +33,12 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -57,78 +58,85 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests for the SSL transport layer. These use a test harness that runs a simple socket server that echos back responses.
  */
-@RunWith(value = Parameterized.class)
 public class SslTransportLayerTest {
 
     private static final int BUFFER_SIZE = 4 * 1024;
     private static Time time = Time.SYSTEM;
 
-    private final String tlsProtocol;
-    private final boolean useInlinePem;
+    private static class Args {
+        private final String tlsProtocol;
+        private final boolean useInlinePem;
+        private CertStores serverCertStores;
+        private CertStores clientCertStores;
+        private Map<String, Object> sslClientConfigs;
+        private Map<String, Object> sslServerConfigs;
+        private Map<String, Object> sslConfigOverrides;
+
+        public Args(String tlsProtocol, boolean useInlinePem) throws Exception {
+            this.tlsProtocol = tlsProtocol;
+            this.useInlinePem = useInlinePem;
+            sslConfigOverrides = new HashMap<>();
+            sslConfigOverrides.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol);
+            sslConfigOverrides.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList(tlsProtocol));
+            init();
+        }
+
+        Map<String, Object> getTrustingConfig(CertStores certStores, CertStores peerCertStores) {
+            Map<String, Object> configs = certStores.getTrustingConfig(peerCertStores);
+            configs.putAll(sslConfigOverrides);
+            return configs;
+        }
+
+        private void init() throws Exception {
+            // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
+            serverCertStores = certBuilder(true, "server", useInlinePem).addHostName("localhost").build();
+            clientCertStores = certBuilder(false, "client", useInlinePem).addHostName("localhost").build();
+            sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
+            sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
+            sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, DefaultSslEngineFactory.class);
+            sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, DefaultSslEngineFactory.class);
+        }
+
+        @Override
+        public String toString() {
+            return "tlsProtocol=" + tlsProtocol +
+                    ", useInlinePem=" + useInlinePem;
+        }
+    }
+
+    private static class SslTransportLayerArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+            List<Arguments> parameters = new ArrayList<>();
+            parameters.add(Arguments.of(new Args("TLSv1.2", false)));
+            parameters.add(Arguments.of(new Args("TLSv1.2", true)));
+            if (Java.IS_JAVA11_COMPATIBLE) {
+                parameters.add(Arguments.of(new Args("TLSv1.3", false)));
+            }
+            return parameters.stream();
+        }
+    }
+
     private NioEchoServer server;
     private Selector selector;
-    private CertStores serverCertStores;
-    private CertStores clientCertStores;
-    private Map<String, Object> sslClientConfigs;
-    private Map<String, Object> sslServerConfigs;
-    private Map<String, Object> sslConfigOverrides;
 
-    @Parameterized.Parameters(name = "tlsProtocol={0}, useInlinePem={1}")
-    public static Collection<Object[]> data() {
-        List<Object[]> values = new ArrayList<>();
-        values.add(new Object[] {"TLSv1.2", false});
-        values.add(new Object[] {"TLSv1.2", true});
-        if (Java.IS_JAVA11_COMPATIBLE) {
-            values.add(new Object[] {"TLSv1.3", false});
-        }
-        return values;
-    }
-
-    public SslTransportLayerTest(String tlsProtocol, boolean useInlinePem) {
-        this.tlsProtocol = tlsProtocol;
-        this.useInlinePem = useInlinePem;
-        sslConfigOverrides = new HashMap<>();
-        sslConfigOverrides.put(SslConfigs.SSL_PROTOCOL_CONFIG, tlsProtocol);
-        sslConfigOverrides.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Collections.singletonList(tlsProtocol));
-    }
-    private CertStores.Builder certBuilder(boolean isServer, String cn) {
-        return new CertStores.Builder(isServer)
-            .cn(cn)
-            .usePem(useInlinePem);
-    }
-
-    @Before
-    public void setup() throws Exception {
-        // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
-        serverCertStores = certBuilder(true, "server").addHostName("localhost").build();
-        clientCertStores = certBuilder(false, "client").addHostName("localhost").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
-        sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, DefaultSslEngineFactory.class);
-        sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, DefaultSslEngineFactory.class);
-
-        LogContext logContext = new LogContext();
-        ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
-        channelBuilder.configure(sslClientConfigs);
-        this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, logContext);
-    }
-
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         if (selector != null)
             this.selector.close();
@@ -140,12 +148,14 @@ public class SslTransportLayerTest {
      * Tests that server certificate with SubjectAltName containing the valid hostname
      * is accepted by a client that connects using the hostname and validates server endpoint.
      */
-    @Test
-    public void testValidEndpointIdentificationSanDns() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testValidEndpointIdentificationSanDns(Args args) throws Exception {
+        createSelector(args);
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        createSelector(sslClientConfigs);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -157,16 +167,17 @@ public class SslTransportLayerTest {
      * Tests that server certificate with SubjectAltName containing valid IP address
      * is accepted by a client that connects using IP address and validates server endpoint.
      */
-    @Test
-    public void testValidEndpointIdentificationSanIp() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testValidEndpointIdentificationSanIp(Args args) throws Exception {
         String node = "0";
-        serverCertStores = certBuilder(true, "server").hostAddress(InetAddress.getByName("127.0.0.1")).build();
-        clientCertStores = certBuilder(false, "client").hostAddress(InetAddress.getByName("127.0.0.1")).build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
-        server = createEchoServer(SecurityProtocol.SSL);
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        createSelector(sslClientConfigs);
+        args.serverCertStores = certBuilder(true, "server", args.useInlinePem).hostAddress(InetAddress.getByName("127.0.0.1")).build();
+        args.clientCertStores = certBuilder(false, "client", args.useInlinePem).hostAddress(InetAddress.getByName("127.0.0.1")).build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -177,14 +188,15 @@ public class SslTransportLayerTest {
      * Tests that server certificate with CN containing valid hostname
      * is accepted by a client that connects using hostname and validates server endpoint.
      */
-    @Test
-    public void testValidEndpointIdentificationCN() throws Exception {
-        serverCertStores = certBuilder(true, "localhost").build();
-        clientCertStores = certBuilder(false, "localhost").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testValidEndpointIdentificationCN(Args args) throws Exception {
+        args.serverCertStores = certBuilder(true, "localhost", args.useInlinePem).build();
+        args.clientCertStores = certBuilder(false, "localhost", args.useInlinePem).build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        verifySslConfigs(args);
     }
 
     /**
@@ -193,12 +205,13 @@ public class SslTransportLayerTest {
      * created with hostname, client connection uses IP address. Endpoint validation
      * must fail.
      */
-    @Test
-    public void testEndpointIdentificationNoReverseLookup() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testEndpointIdentificationNoReverseLookup(Args args) throws Exception {
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        createSelector(sslClientConfigs);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -219,15 +232,16 @@ public class SslTransportLayerTest {
      * This test is to ensure that if client endpoint validation is added to Java in future, we can detect
      * and update Kafka SSL code to enable validation on the server-side and provide hostname if required.
      */
-    @Test
-    public void testClientEndpointNotValidated() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientEndpointNotValidated(Args args) throws Exception {
         String node = "0";
 
         // Create client certificate with an invalid hostname
-        clientCertStores = certBuilder(false, "non-existent.com").build();
-        serverCertStores = certBuilder(true, "localhost").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
+        args.clientCertStores = certBuilder(false, "non-existent.com", args.useInlinePem).build();
+        args.serverCertStores = certBuilder(true, "localhost", args.useInlinePem).build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
 
         // Create a server with endpoint validation enabled on the server SSL engine
         SslChannelBuilder serverChannelBuilder = new TestSslChannelBuilder(Mode.SERVER) {
@@ -239,12 +253,12 @@ public class SslTransportLayerTest {
                 return super.newTransportLayer(id, key, sslEngine);
             }
         };
-        serverChannelBuilder.configure(sslServerConfigs);
+        serverChannelBuilder.configure(args.sslServerConfigs);
         server = new NioEchoServer(ListenerName.forSecurityProtocol(SecurityProtocol.SSL), SecurityProtocol.SSL,
-                new TestSecurityConfig(sslServerConfigs), "localhost", serverChannelBuilder, null, time);
+                new TestSecurityConfig(args.sslServerConfigs), "localhost", serverChannelBuilder, null, time);
         server.start();
 
-        createSelector(sslClientConfigs);
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -256,48 +270,50 @@ public class SslTransportLayerTest {
      * a client that validates server endpoint. Server certificate uses
      * wrong hostname as common name to trigger endpoint validation failure.
      */
-    @Test
-    public void testInvalidEndpointIdentification() throws Exception {
-        serverCertStores = certBuilder(true, "server").addHostName("notahost").build();
-        clientCertStores = certBuilder(false, "client").addHostName("localhost").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        verifySslConfigsWithHandshakeFailure();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInvalidEndpointIdentification(Args args) throws Exception {
+        args.serverCertStores = certBuilder(true, "server", args.useInlinePem).addHostName("notahost").build();
+        args.clientCertStores = certBuilder(false, "client", args.useInlinePem).addHostName("localhost").build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        verifySslConfigsWithHandshakeFailure(args);
     }
 
     /**
      * Tests that server certificate with invalid host name is accepted by
      * a client that has disabled endpoint validation
      */
-    @Test
-    public void testEndpointIdentificationDisabled() throws Exception {
-        serverCertStores = certBuilder(true, "server").addHostName("notahost").build();
-        clientCertStores = certBuilder(false, "client").addHostName("localhost").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testEndpointIdentificationDisabled(Args args) throws Exception {
+        args.serverCertStores = certBuilder(true, "server", args.useInlinePem).addHostName("notahost").build();
+        args.clientCertStores = certBuilder(false, "client", args.useInlinePem).addHostName("localhost").build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
 
-        server = createEchoServer(SecurityProtocol.SSL);
+        server = createEchoServer(args, SecurityProtocol.SSL);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
 
         // Disable endpoint validation, connection should succeed
         String node = "1";
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
-        createSelector(sslClientConfigs);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
+        createSelector(args.sslClientConfigs);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
 
         // Disable endpoint validation using null value, connection should succeed
         String node2 = "2";
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, null);
-        createSelector(sslClientConfigs);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, null);
+        createSelector(args.sslClientConfigs);
         selector.connect(node2, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node2, 100, 10);
 
         // Connection should fail with endpoint validation enabled
         String node3 = "3";
-        sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        createSelector(sslClientConfigs);
+        args.sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        createSelector(args.sslClientConfigs);
         selector.connect(node3, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.waitForChannelClose(selector, node3, ChannelState.State.AUTHENTICATION_FAILED);
         selector.close();
@@ -307,46 +323,48 @@ public class SslTransportLayerTest {
      * Tests that server accepts connections from clients with a trusted certificate
      * when client authentication is required.
      */
-    @Test
-    public void testClientAuthenticationRequiredValidProvided() throws Exception {
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationRequiredValidProvided(Args args) throws Exception {
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        verifySslConfigs(args);
     }
 
     /**
      * Tests that disabling client authentication as a listener override has the desired effect.
      */
-    @Test
-    public void testListenerConfigOverride() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testListenerConfigOverride(Args args) throws Exception {
         String node = "0";
         ListenerName clientListenerName = new ListenerName("client");
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        sslServerConfigs.put(clientListenerName.configPrefix() + BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        args.sslServerConfigs.put(clientListenerName.configPrefix() + BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
 
         // `client` listener is not configured at this point, so client auth should be required
-        server = createEchoServer(SecurityProtocol.SSL);
+        server = createEchoServer(args, SecurityProtocol.SSL);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
 
         // Connect with client auth should work fine
-        createSelector(sslClientConfigs);
+        createSelector(args.sslClientConfigs);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
         selector.close();
 
         // Remove client auth, so connection should fail
-        CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
-        createSelector(sslClientConfigs);
+        CertStores.KEYSTORE_PROPS.forEach(args.sslClientConfigs::remove);
+        createSelector(args.sslClientConfigs);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.waitForChannelClose(selector, node, ChannelState.State.AUTHENTICATION_FAILED);
         selector.close();
         server.close();
 
         // Listener-specific config should be used and client auth should be disabled
-        server = createEchoServer(clientListenerName, SecurityProtocol.SSL);
+        server = createEchoServer(args, clientListenerName, SecurityProtocol.SSL);
         addr = new InetSocketAddress("localhost", server.port());
 
         // Connect without client auth should work fine now
-        createSelector(sslClientConfigs);
+        createSelector(args.sslClientConfigs);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
@@ -355,108 +373,117 @@ public class SslTransportLayerTest {
      * Tests that server does not accept connections from clients with an untrusted certificate
      * when client authentication is required.
      */
-    @Test
-    public void testClientAuthenticationRequiredUntrustedProvided() throws Exception {
-        sslServerConfigs = serverCertStores.getUntrustingConfig();
-        sslServerConfigs.putAll(sslConfigOverrides);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        verifySslConfigsWithHandshakeFailure();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationRequiredUntrustedProvided(Args args) throws Exception {
+        args.sslServerConfigs = args.serverCertStores.getUntrustingConfig();
+        args.sslServerConfigs.putAll(args.sslConfigOverrides);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        verifySslConfigsWithHandshakeFailure(args);
     }
 
     /**
      * Tests that server does not accept connections from clients which don't
      * provide a certificate when client authentication is required.
      */
-    @Test
-    public void testClientAuthenticationRequiredNotProvided() throws Exception {
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
-        verifySslConfigsWithHandshakeFailure();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationRequiredNotProvided(Args args) throws Exception {
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        CertStores.KEYSTORE_PROPS.forEach(args.sslClientConfigs::remove);
+        verifySslConfigsWithHandshakeFailure(args);
     }
 
     /**
      * Tests that server accepts connections from a client configured
      * with an untrusted certificate if client authentication is disabled
      */
-    @Test
-    public void testClientAuthenticationDisabledUntrustedProvided() throws Exception {
-        sslServerConfigs = serverCertStores.getUntrustingConfig();
-        sslServerConfigs.putAll(sslConfigOverrides);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationDisabledUntrustedProvided(Args args) throws Exception {
+        args.sslServerConfigs = args.serverCertStores.getUntrustingConfig();
+        args.sslServerConfigs.putAll(args.sslConfigOverrides);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
+        verifySslConfigs(args);
     }
 
     /**
      * Tests that server accepts connections from a client that does not provide
      * a certificate if client authentication is disabled
      */
-    @Test
-    public void testClientAuthenticationDisabledNotProvided() throws Exception {
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationDisabledNotProvided(Args args) throws Exception {
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
 
-        CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
-        verifySslConfigs();
+        CertStores.KEYSTORE_PROPS.forEach(args.sslClientConfigs::remove);
+        verifySslConfigs(args);
     }
 
     /**
      * Tests that server accepts connections from a client configured
      * with a valid certificate if client authentication is requested
      */
-    @Test
-    public void testClientAuthenticationRequestedValidProvided() throws Exception {
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationRequestedValidProvided(Args args) throws Exception {
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
+        verifySslConfigs(args);
     }
 
     /**
      * Tests that server accepts connections from a client that does not provide
      * a certificate if client authentication is requested but not required
      */
-    @Test
-    public void testClientAuthenticationRequestedNotProvided() throws Exception {
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClientAuthenticationRequestedNotProvided(Args args) throws Exception {
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
 
-        CertStores.KEYSTORE_PROPS.forEach(sslClientConfigs::remove);
-        verifySslConfigs();
+        CertStores.KEYSTORE_PROPS.forEach(args.sslClientConfigs::remove);
+        verifySslConfigs(args);
     }
 
     /**
      * Tests key-pair created using DSA.
      */
-    @Test
-    public void testDsaKeyPair() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testDsaKeyPair(Args args) throws Exception {
         // DSA algorithms are not supported for TLSv1.3.
-        assumeTrue(tlsProtocol.equals("TLSv1.2"));
-        serverCertStores = certBuilder(true, "server").keyAlgorithm("DSA").build();
-        clientCertStores = certBuilder(false, "client").keyAlgorithm("DSA").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        verifySslConfigs();
+        assumeTrue(args.tlsProtocol.equals("TLSv1.2"));
+        args.serverCertStores = certBuilder(true, "server", args.useInlinePem).keyAlgorithm("DSA").build();
+        args.clientCertStores = certBuilder(false, "client", args.useInlinePem).keyAlgorithm("DSA").build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        verifySslConfigs(args);
     }
 
     /**
      * Tests key-pair created using EC.
      */
-    @Test
-    public void testECKeyPair() throws Exception {
-        serverCertStores = certBuilder(true, "server").keyAlgorithm("EC").build();
-        clientCertStores = certBuilder(false, "client").keyAlgorithm("EC").build();
-        sslServerConfigs = getTrustingConfig(serverCertStores, clientCertStores);
-        sslClientConfigs = getTrustingConfig(clientCertStores, serverCertStores);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testECKeyPair(Args args) throws Exception {
+        args.serverCertStores = certBuilder(true, "server", args.useInlinePem).keyAlgorithm("EC").build();
+        args.clientCertStores = certBuilder(false, "client", args.useInlinePem).keyAlgorithm("EC").build();
+        args.sslServerConfigs = args.getTrustingConfig(args.serverCertStores, args.clientCertStores);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, args.serverCertStores);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        verifySslConfigs(args);
     }
 
     /**
      * Tests PEM key store and trust store files which don't have store passwords.
      */
-    @Test
-    public void testPemFiles() throws Exception {
-        TestSslUtils.convertToPem(sslServerConfigs, true, true);
-        TestSslUtils.convertToPem(sslClientConfigs, true, true);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testPemFiles(Args args) throws Exception {
+        TestSslUtils.convertToPem(args.sslServerConfigs, true, true);
+        TestSslUtils.convertToPem(args.sslClientConfigs, true, true);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        verifySslConfigs(args);
     }
 
     /**
@@ -464,16 +491,18 @@ public class SslTransportLayerTest {
      * with PEM files since unprotected private key on disk is not safe. We do allow with inline
      * PEM config since key config can be encrypted or externalized similar to other password configs.
      */
-    @Test
-    public void testPemFilesWithoutClientKeyPassword() throws Exception {
-        TestSslUtils.convertToPem(sslServerConfigs, !useInlinePem, true);
-        TestSslUtils.convertToPem(sslClientConfigs, !useInlinePem, false);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        server = createEchoServer(SecurityProtocol.SSL);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testPemFilesWithoutClientKeyPassword(Args args) throws Exception {
+        boolean useInlinePem = args.useInlinePem;
+        TestSslUtils.convertToPem(args.sslServerConfigs, !useInlinePem, true);
+        TestSslUtils.convertToPem(args.sslClientConfigs, !useInlinePem, false);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        server = createEchoServer(args, SecurityProtocol.SSL);
         if (useInlinePem)
-            verifySslConfigs();
+            verifySslConfigs(args);
         else
-            assertThrows(KafkaException.class, () -> createSelector(sslClientConfigs));
+            assertThrows(KafkaException.class, () -> createSelector(args.sslClientConfigs));
     }
 
     /**
@@ -481,56 +510,51 @@ public class SslTransportLayerTest {
      * with PEM files since unprotected private key on disk is not safe. We do allow with inline
      * PEM config since key config can be encrypted or externalized similar to other password configs.
      */
-    @Test
-    public void testPemFilesWithoutServerKeyPassword() throws Exception {
-        TestSslUtils.convertToPem(sslServerConfigs, !useInlinePem, false);
-        TestSslUtils.convertToPem(sslClientConfigs, !useInlinePem, true);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testPemFilesWithoutServerKeyPassword(Args args) throws Exception {
+        TestSslUtils.convertToPem(args.sslServerConfigs, !args.useInlinePem, false);
+        TestSslUtils.convertToPem(args.sslClientConfigs, !args.useInlinePem, true);
 
-        if (useInlinePem)
-            verifySslConfigs();
+        if (args.useInlinePem)
+            verifySslConfigs(args);
         else
-            assertThrows(KafkaException.class, () -> createEchoServer(SecurityProtocol.SSL));
+            assertThrows(KafkaException.class, () -> createEchoServer(args, SecurityProtocol.SSL));
     }
 
     /**
      * Tests that an invalid SecureRandom implementation cannot be configured
      */
-    @Test
-    public void testInvalidSecureRandomImplementation() {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInvalidSecureRandomImplementation(Args args) {
         try (SslChannelBuilder channelBuilder = newClientChannelBuilder()) {
-            sslClientConfigs.put(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, "invalid");
-            channelBuilder.configure(sslClientConfigs);
-            fail("SSL channel configured with invalid SecureRandom implementation");
-        } catch (KafkaException e) {
-            // Expected exception
+            args.sslClientConfigs.put(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG, "invalid");
+            assertThrows(KafkaException.class, () -> channelBuilder.configure(args.sslClientConfigs));
         }
     }
 
     /**
      * Tests that channels cannot be created if truststore cannot be loaded
      */
-    @Test
-    public void testInvalidTruststorePassword() {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInvalidTruststorePassword(Args args) {
         try (SslChannelBuilder channelBuilder = newClientChannelBuilder()) {
-            sslClientConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "invalid");
-            channelBuilder.configure(sslClientConfigs);
-            fail("SSL channel configured with invalid truststore password");
-        } catch (KafkaException e) {
-            // Expected exception
+            args.sslClientConfigs.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, "invalid");
+            assertThrows(KafkaException.class, () -> channelBuilder.configure(args.sslClientConfigs));
         }
     }
 
     /**
      * Tests that channels cannot be created if keystore cannot be loaded
      */
-    @Test
-    public void testInvalidKeystorePassword() {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInvalidKeystorePassword(Args args) {
         try (SslChannelBuilder channelBuilder = newClientChannelBuilder()) {
-            sslClientConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "invalid");
-            channelBuilder.configure(sslClientConfigs);
-            fail("SSL channel configured with invalid keystore password");
-        } catch (KafkaException e) {
-            // Expected exception
+            args.sslClientConfigs.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "invalid");
+            assertThrows(KafkaException.class, () -> channelBuilder.configure(args.sslClientConfigs));
         }
     }
 
@@ -538,42 +562,45 @@ public class SslTransportLayerTest {
      * Tests that client connections can be created to a server
      * if null truststore password is used
      */
-    @Test
-    public void testNullTruststorePassword() throws Exception {
-        sslClientConfigs.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
-        sslServerConfigs.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testNullTruststorePassword(Args args) throws Exception {
+        args.sslClientConfigs.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
+        args.sslServerConfigs.remove(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
 
-        verifySslConfigs();
+        verifySslConfigs(args);
     }
 
     /**
      * Tests that client connections cannot be created to a server
      * if key password is invalid
      */
-    @Test
-    public void testInvalidKeyPassword() throws Exception {
-        sslServerConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, new Password("invalid"));
-        if (useInlinePem) {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInvalidKeyPassword(Args args) throws Exception {
+        args.sslServerConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, new Password("invalid"));
+        if (args.useInlinePem) {
             // We fail fast for PEM
-            assertThrows(InvalidConfigurationException.class, () -> createEchoServer(SecurityProtocol.SSL));
+            assertThrows(InvalidConfigurationException.class, () -> createEchoServer(args, SecurityProtocol.SSL));
             return;
         }
-        verifySslConfigsWithHandshakeFailure();
+        verifySslConfigsWithHandshakeFailure(args);
     }
 
     /**
      * Tests that connection success with the default TLS version.
      */
-    @Test
-    public void testTlsDefaults() throws Exception {
-        sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
-        sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testTlsDefaults(Args args) throws Exception {
+        args.sslServerConfigs = args.serverCertStores.getTrustingConfig(args.clientCertStores);
+        args.sslClientConfigs = args.clientCertStores.getTrustingConfig(args.serverCertStores);
 
-        assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslServerConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
-        assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, sslClientConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
+        assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, args.sslServerConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
+        assertEquals(SslConfigs.DEFAULT_SSL_PROTOCOL, args.sslClientConfigs.get(SslConfigs.SSL_PROTOCOL_CONFIG));
 
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs);
 
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect("0", addr, BUFFER_SIZE, BUFFER_SIZE);
@@ -582,17 +609,17 @@ public class SslTransportLayerTest {
         server.verifyAuthenticationMetrics(1, 0);
         selector.close();
 
-        checkAuthenticationFailed("1", "TLSv1.1");
+        checkAuthenticationFailed(args, "1", "TLSv1.1");
         server.verifyAuthenticationMetrics(1, 1);
 
-        checkAuthenticationFailed("2", "TLSv1");
+        checkAuthenticationFailed(args, "2", "TLSv1");
         server.verifyAuthenticationMetrics(1, 2);
     }
 
     /** Checks connection failed using the specified {@code tlsVersion}. */
-    private void checkAuthenticationFailed(String node, String tlsVersion) throws IOException {
-        sslClientConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList(tlsVersion));
-        createSelector(sslClientConfigs);
+    private void checkAuthenticationFailed(Args args, String node, String tlsVersion) throws IOException {
+        args.sslClientConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList(tlsVersion));
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -604,38 +631,41 @@ public class SslTransportLayerTest {
     /**
      * Tests that connections cannot be made with unsupported TLS versions
      */
-    @Test
-    public void testUnsupportedTLSVersion() throws Exception {
-        sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
-        server = createEchoServer(SecurityProtocol.SSL);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testUnsupportedTLSVersion(Args args) throws Exception {
+        args.sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
+        server = createEchoServer(args, SecurityProtocol.SSL);
 
-        checkAuthenticationFailed("0", "TLSv1.1");
+        checkAuthenticationFailed(args, "0", "TLSv1.1");
         server.verifyAuthenticationMetrics(0, 1);
     }
 
     /**
      * Tests that connections cannot be made with unsupported TLS cipher suites
      */
-    @Test
-    public void testUnsupportedCiphers() throws Exception {
-        SSLContext context = SSLContext.getInstance(tlsProtocol);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testUnsupportedCiphers(Args args) throws Exception {
+        SSLContext context = SSLContext.getInstance(args.tlsProtocol);
         context.init(null, null, null);
         String[] cipherSuites = context.getDefaultSSLParameters().getCipherSuites();
-        sslServerConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[0]));
-        server = createEchoServer(SecurityProtocol.SSL);
+        args.sslServerConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[0]));
+        server = createEchoServer(args, SecurityProtocol.SSL);
 
-        sslClientConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[1]));
-        createSelector(sslClientConfigs);
+        args.sslClientConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[1]));
+        createSelector(args.sslClientConfigs);
 
-        checkAuthenticationFailed("1", tlsProtocol);
+        checkAuthenticationFailed(args, "1", args.tlsProtocol);
         server.verifyAuthenticationMetrics(0, 1);
     }
 
-    @Test
-    public void testServerRequestMetrics() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testServerRequestMetrics(Args args) throws Exception {
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs, 16384, 16384, 16384);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs, 16384, 16384, 16384);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, 102400, 102400);
         NetworkTestUtils.waitForChannelReady(selector, node);
@@ -655,11 +685,12 @@ public class SslTransportLayerTest {
     /**
      * selector.poll() should be able to fetch more data than netReadBuffer from the socket.
      */
-    @Test
-    public void testSelectorPollReadSize() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testSelectorPollReadSize(Args args) throws Exception {
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs, 16384, 16384, 16384);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs, 16384, 16384, 16384);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, 102400, 102400);
         NetworkTestUtils.checkClientConnection(selector, node, 81920, 1);
@@ -694,11 +725,12 @@ public class SslTransportLayerTest {
     /**
      * Tests handling of BUFFER_UNDERFLOW during unwrap when network read buffer is smaller than SSL session packet buffer size.
      */
-    @Test
-    public void testNetReadBufferResize() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testNetReadBufferResize(Args args) throws Exception {
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs, 10, null, null);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs, 10, null, null);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -708,11 +740,12 @@ public class SslTransportLayerTest {
     /**
      * Tests handling of BUFFER_OVERFLOW during wrap when network write buffer is smaller than SSL session packet buffer size.
      */
-    @Test
-    public void testNetWriteBufferResize() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testNetWriteBufferResize(Args args) throws Exception {
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs, null, 10, null);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs, null, 10, null);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -722,11 +755,12 @@ public class SslTransportLayerTest {
     /**
      * Tests handling of BUFFER_OVERFLOW during unwrap when application read buffer is smaller than SSL session application buffer size.
      */
-    @Test
-    public void testApplicationBufferResize() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testApplicationBufferResize(Args args) throws Exception {
         String node = "0";
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs, null, null, 10);
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs, null, null, 10);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -736,24 +770,25 @@ public class SslTransportLayerTest {
     /**
      * Tests that time spent on the network thread is accumulated on each channel
      */
-    @Test
-    public void testNetworkThreadTimeRecorded() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testNetworkThreadTimeRecorded(Args args) throws Exception {
         LogContext logContext = new LogContext();
         ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
-        channelBuilder.configure(sslClientConfigs);
+        channelBuilder.configure(args.sslClientConfigs);
         try (Selector selector = new Selector(NetworkReceive.UNLIMITED, Selector.NO_IDLE_TIMEOUT_MS, new Metrics(), Time.SYSTEM,
                 "MetricGroup", new HashMap<>(), false, true, channelBuilder, MemoryPool.NONE, logContext)) {
 
             String node = "0";
-            server = createEchoServer(SecurityProtocol.SSL);
+            server = createEchoServer(args, SecurityProtocol.SSL);
             InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
             selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
             String message = TestUtils.randomString(1024 * 1024);
             NetworkTestUtils.waitForChannelReady(selector, node);
             final KafkaChannel channel = selector.channel(node);
-            assertTrue("SSL handshake time not recorded", channel.getAndResetNetworkThreadTimeNanos() > 0);
-            assertEquals("Time not reset", 0, channel.getAndResetNetworkThreadTimeNanos());
+            assertTrue(channel.getAndResetNetworkThreadTimeNanos() > 0, "SSL handshake time not recorded");
+            assertEquals(0, channel.getAndResetNetworkThreadTimeNanos(), "Time not reset");
 
             selector.mute(node);
             selector.send(new NetworkSend(node, ByteBufferSend.sizePrefixed(ByteBuffer.wrap(message.getBytes()))));
@@ -761,9 +796,9 @@ public class SslTransportLayerTest {
                 selector.poll(100L);
             }
             long sendTimeNanos = channel.getAndResetNetworkThreadTimeNanos();
-            assertTrue("Send time not recorded: " + sendTimeNanos, sendTimeNanos > 0);
-            assertEquals("Time not reset", 0, channel.getAndResetNetworkThreadTimeNanos());
-            assertFalse("Unexpected bytes buffered", channel.hasBytesBuffered());
+            assertTrue(sendTimeNanos > 0, "Send time not recorded: " + sendTimeNanos);
+            assertEquals(0, channel.getAndResetNetworkThreadTimeNanos(), "Time not reset");
+            assertFalse(channel.hasBytesBuffered(), "Unexpected bytes buffered");
             assertEquals(0, selector.completedReceives().size());
 
             selector.unmute(node);
@@ -778,69 +813,76 @@ public class SslTransportLayerTest {
             }, "Timed out waiting for a message to receive from echo server");
 
             long receiveTimeNanos = channel.getAndResetNetworkThreadTimeNanos();
-            assertTrue("Receive time not recorded: " + receiveTimeNanos, receiveTimeNanos > 0);
+            assertTrue(receiveTimeNanos > 0, "Receive time not recorded: " + receiveTimeNanos);
         }
     }
 
     /**
      * Tests that IOExceptions from read during SSL handshake are not treated as authentication failures.
      */
-    @Test
-    public void testIOExceptionsDuringHandshakeRead() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        testIOExceptionsDuringHandshake(FailureAction.THROW_IO_EXCEPTION, FailureAction.NO_OP);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testIOExceptionsDuringHandshakeRead(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        testIOExceptionsDuringHandshake(args, FailureAction.THROW_IO_EXCEPTION, FailureAction.NO_OP);
     }
 
     /**
      * Tests that IOExceptions from write during SSL handshake are not treated as authentication failures.
      */
-    @Test
-    public void testIOExceptionsDuringHandshakeWrite() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        testIOExceptionsDuringHandshake(FailureAction.NO_OP, FailureAction.THROW_IO_EXCEPTION);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testIOExceptionsDuringHandshakeWrite(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        testIOExceptionsDuringHandshake(args, FailureAction.NO_OP, FailureAction.THROW_IO_EXCEPTION);
     }
 
     /**
      * Tests that if the remote end closes connection ungracefully  during SSL handshake while reading data,
      * the disconnection is not treated as an authentication failure.
      */
-    @Test
-    public void testUngracefulRemoteCloseDuringHandshakeRead() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        testIOExceptionsDuringHandshake(server::closeSocketChannels, FailureAction.NO_OP);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testUngracefulRemoteCloseDuringHandshakeRead(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        testIOExceptionsDuringHandshake(args, server::closeSocketChannels, FailureAction.NO_OP);
     }
 
     /**
      * Tests that if the remote end closes connection ungracefully during SSL handshake while writing data,
      * the disconnection is not treated as an authentication failure.
      */
-    @Test
-    public void testUngracefulRemoteCloseDuringHandshakeWrite() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        testIOExceptionsDuringHandshake(FailureAction.NO_OP, server::closeSocketChannels);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testUngracefulRemoteCloseDuringHandshakeWrite(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        testIOExceptionsDuringHandshake(args, FailureAction.NO_OP, server::closeSocketChannels);
     }
 
     /**
      * Tests that if the remote end closes the connection during SSL handshake while reading data,
      * the disconnection is not treated as an authentication failure.
      */
-    @Test
-    public void testGracefulRemoteCloseDuringHandshakeRead() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        testIOExceptionsDuringHandshake(FailureAction.NO_OP, server::closeKafkaChannels);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testGracefulRemoteCloseDuringHandshakeRead(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        testIOExceptionsDuringHandshake(args, FailureAction.NO_OP, server::closeKafkaChannels);
     }
 
     /**
      * Tests that if the remote end closes the connection during SSL handshake while writing data,
      * the disconnection is not treated as an authentication failure.
      */
-    @Test
-    public void testGracefulRemoteCloseDuringHandshakeWrite() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        testIOExceptionsDuringHandshake(server::closeKafkaChannels, FailureAction.NO_OP);
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testGracefulRemoteCloseDuringHandshakeWrite(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        testIOExceptionsDuringHandshake(args, server::closeKafkaChannels, FailureAction.NO_OP);
     }
 
-    private void testIOExceptionsDuringHandshake(FailureAction readFailureAction,
+    private void testIOExceptionsDuringHandshake(Args args,
+                                                 FailureAction readFailureAction,
                                                  FailureAction flushFailureAction) throws Exception {
         TestSslChannelBuilder channelBuilder = new TestSslChannelBuilder(Mode.CLIENT);
         boolean done = false;
@@ -850,7 +892,7 @@ public class SslTransportLayerTest {
             channelBuilder.readFailureAction = readFailureAction;
             channelBuilder.flushFailureAction = flushFailureAction;
             channelBuilder.failureIndex = i;
-            channelBuilder.configure(sslClientConfigs);
+            channelBuilder.configure(args.sslClientConfigs);
             this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
 
             InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
@@ -864,17 +906,17 @@ public class SslTransportLayerTest {
                 }
                 if (selector.disconnected().containsKey(node)) {
                     ChannelState.State state = selector.disconnected().get(node).state();
-                    assertTrue("Unexpected channel state " + state,
-                            state == ChannelState.State.AUTHENTICATE || state == ChannelState.State.READY);
+                    assertTrue(state == ChannelState.State.AUTHENTICATE || state == ChannelState.State.READY,
+                        "Unexpected channel state " + state);
                     break;
                 }
             }
             KafkaChannel channel = selector.channel(node);
             if (channel != null)
-                assertTrue("Channel not ready or disconnected:" + channel.state().state(), channel.ready());
+                assertTrue(channel.ready(), "Channel not ready or disconnected:" + channel.state().state());
             selector.close();
         }
-        assertTrue("Too many invocations of read/write during SslTransportLayer.handshake()", done);
+        assertTrue(done, "Too many invocations of read/write during SslTransportLayer.handshake()");
     }
 
     /**
@@ -882,23 +924,24 @@ public class SslTransportLayerTest {
      * there are delays in writes to ensure that clients see an authentication exception
      * rather than a connection failure.
      */
-    @Test
-    public void testPeerNotifiedOfHandshakeFailure() throws Exception {
-        sslServerConfigs = serverCertStores.getUntrustingConfig();
-        sslServerConfigs.putAll(sslConfigOverrides);
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testPeerNotifiedOfHandshakeFailure(Args args) throws Exception {
+        args.sslServerConfigs = args.serverCertStores.getUntrustingConfig();
+        args.sslServerConfigs.putAll(args.sslConfigOverrides);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
 
         // Test without delay and a couple of delay counts to ensure delay applies to handshake failure
         for (int i = 0; i < 3; i++) {
             String node = "0";
             TestSslChannelBuilder serverChannelBuilder = new TestSslChannelBuilder(Mode.SERVER);
-            serverChannelBuilder.configure(sslServerConfigs);
+            serverChannelBuilder.configure(args.sslServerConfigs);
             serverChannelBuilder.flushDelayCount = i;
             server = new NioEchoServer(ListenerName.forSecurityProtocol(SecurityProtocol.SSL),
-                    SecurityProtocol.SSL, new TestSecurityConfig(sslServerConfigs),
+                    SecurityProtocol.SSL, new TestSecurityConfig(args.sslServerConfigs),
                     "localhost", serverChannelBuilder, null, time);
             server.start();
-            createSelector(sslClientConfigs);
+            createSelector(args.sslClientConfigs);
             InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
             selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -909,24 +952,26 @@ public class SslTransportLayerTest {
         }
     }
 
-    @Test
-    public void testCloseSsl() throws Exception {
-        testClose(SecurityProtocol.SSL, newClientChannelBuilder());
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testCloseSsl(Args args) throws Exception {
+        testClose(args, SecurityProtocol.SSL, newClientChannelBuilder());
     }
 
-    @Test
-    public void testClosePlaintext() throws Exception {
-        testClose(SecurityProtocol.PLAINTEXT, new PlaintextChannelBuilder(null));
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testClosePlaintext(Args args) throws Exception {
+        testClose(args, SecurityProtocol.PLAINTEXT, new PlaintextChannelBuilder(null));
     }
 
     private SslChannelBuilder newClientChannelBuilder() {
         return new SslChannelBuilder(Mode.CLIENT, null, false, new LogContext());
     }
 
-    private void testClose(SecurityProtocol securityProtocol, ChannelBuilder clientChannelBuilder) throws Exception {
+    private void testClose(Args args, SecurityProtocol securityProtocol, ChannelBuilder clientChannelBuilder) throws Exception {
         String node = "0";
-        server = createEchoServer(securityProtocol);
-        clientChannelBuilder.configure(sslClientConfigs);
+        server = createEchoServer(args, securityProtocol);
+        clientChannelBuilder.configure(args.sslClientConfigs);
         this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", clientChannelBuilder, new LogContext());
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
@@ -960,16 +1005,17 @@ public class SslTransportLayerTest {
      * Verifies that inter-broker listener with validation of truststore against keystore works
      * with configs including mutual authentication and hostname verification.
      */
-    @Test
-    public void testInterBrokerSslConfigValidation() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInterBrokerSslConfigValidation(Args args) throws Exception {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        sslServerConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
-        sslServerConfigs.putAll(serverCertStores.keyStoreProps());
-        sslServerConfigs.putAll(serverCertStores.trustStoreProps());
-        sslClientConfigs.putAll(serverCertStores.keyStoreProps());
-        sslClientConfigs.putAll(serverCertStores.trustStoreProps());
-        TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        args.sslServerConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
+        args.sslServerConfigs.putAll(args.serverCertStores.keyStoreProps());
+        args.sslServerConfigs.putAll(args.serverCertStores.trustStoreProps());
+        args.sslClientConfigs.putAll(args.serverCertStores.keyStoreProps());
+        args.sslClientConfigs.putAll(args.serverCertStores.trustStoreProps());
+        TestSecurityConfig config = new TestSecurityConfig(args.sslServerConfigs);
         ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
         ChannelBuilder serverChannelBuilder = ChannelBuilders.serverChannelBuilder(listenerName,
                 true, securityProtocol, config, null, null, time, new LogContext());
@@ -977,7 +1023,7 @@ public class SslTransportLayerTest {
                 "localhost", serverChannelBuilder, null, time);
         server.start();
 
-        this.selector = createSelector(sslClientConfigs, null, null, null);
+        this.selector = createSelector(args.sslClientConfigs, null, null, null);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect("0", addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, "0", 100, 10);
@@ -987,11 +1033,12 @@ public class SslTransportLayerTest {
      * Verifies that inter-broker listener with validation of truststore against keystore
      * fails if certs from keystore are not trusted.
      */
-    @Test
-    public void testInterBrokerSslConfigValidationFailure() {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInterBrokerSslConfigValidationFailure(Args args) {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        TestSecurityConfig config = new TestSecurityConfig(args.sslServerConfigs);
         ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
         assertThrows(KafkaException.class, () -> ChannelBuilders.serverChannelBuilder(listenerName, true, securityProtocol, config,
                 null, null, time, new LogContext()));
@@ -1001,10 +1048,11 @@ public class SslTransportLayerTest {
      * Tests reconfiguration of server keystore. Verifies that existing connections continue
      * to work with old keystore and new connections work with new keystore.
      */
-    @Test
-    public void testServerKeystoreDynamicUpdate() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testServerKeystoreDynamicUpdate(Args args) throws Exception {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
-        TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
+        TestSecurityConfig config = new TestSecurityConfig(args.sslServerConfigs);
         ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
         ChannelBuilder serverChannelBuilder = ChannelBuilders.serverChannelBuilder(listenerName,
                 false, securityProtocol, config, null, null, time, new LogContext());
@@ -1015,13 +1063,13 @@ public class SslTransportLayerTest {
 
         // Verify that client with matching truststore can authenticate, send and receive
         String oldNode = "0";
-        Selector oldClientSelector = createSelector(sslClientConfigs);
+        Selector oldClientSelector = createSelector(args.sslClientConfigs);
         oldClientSelector.connect(oldNode, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, oldNode, 100, 10);
 
-        CertStores newServerCertStores = certBuilder(true, "server").addHostName("localhost").build();
+        CertStores newServerCertStores = certBuilder(true, "server", args.useInlinePem).addHostName("localhost").build();
         Map<String, Object> newKeystoreConfigs = newServerCertStores.keyStoreProps();
-        assertTrue("SslChannelBuilder not reconfigurable", serverChannelBuilder instanceof ListenerReconfigurable);
+        assertTrue(serverChannelBuilder instanceof ListenerReconfigurable, "SslChannelBuilder not reconfigurable");
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
         assertEquals(listenerName, reconfigurableBuilder.listenerName());
         reconfigurableBuilder.validateReconfiguration(newKeystoreConfigs);
@@ -1032,16 +1080,16 @@ public class SslTransportLayerTest {
         NetworkTestUtils.waitForChannelClose(oldClientSelector, "1", ChannelState.State.AUTHENTICATION_FAILED);
 
         // Verify that new client with new truststore can authenticate, send and receive
-        sslClientConfigs = getTrustingConfig(clientCertStores, newServerCertStores);
-        Selector newClientSelector = createSelector(sslClientConfigs);
+        args.sslClientConfigs = args.getTrustingConfig(args.clientCertStores, newServerCertStores);
+        Selector newClientSelector = createSelector(args.sslClientConfigs);
         newClientSelector.connect("2", addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(newClientSelector, "2", 100, 10);
 
         // Verify that old client continues to work
         NetworkTestUtils.checkClientConnection(oldClientSelector, oldNode, 100, 10);
 
-        CertStores invalidCertStores = certBuilder(true, "server").addHostName("127.0.0.1").build();
-        Map<String, Object>  invalidConfigs = getTrustingConfig(invalidCertStores, clientCertStores);
+        CertStores invalidCertStores = certBuilder(true, "server", args.useInlinePem).addHostName("127.0.0.1").build();
+        Map<String, Object>  invalidConfigs = args.getTrustingConfig(invalidCertStores, args.clientCertStores);
         verifyInvalidReconfigure(reconfigurableBuilder, invalidConfigs, "keystore with different SubjectAltName");
 
         Map<String, Object>  missingStoreConfigs = new HashMap<>();
@@ -1056,10 +1104,11 @@ public class SslTransportLayerTest {
         NetworkTestUtils.checkClientConnection(newClientSelector, "3", 100, 10);
     }
 
-    @Test
-    public void testServerKeystoreDynamicUpdateWithNewSubjectAltName() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testServerKeystoreDynamicUpdateWithNewSubjectAltName(Args args) throws Exception {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
-        TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
+        TestSecurityConfig config = new TestSecurityConfig(args.sslServerConfigs);
         ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
         ChannelBuilder serverChannelBuilder = ChannelBuilders.serverChannelBuilder(listenerName,
             false, securityProtocol, config, null, null, time, new LogContext());
@@ -1068,14 +1117,14 @@ public class SslTransportLayerTest {
         server.start();
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
 
-        Selector selector = createSelector(sslClientConfigs);
+        Selector selector = createSelector(args.sslClientConfigs);
         String node1 = "1";
         selector.connect(node1, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node1, 100, 10);
         selector.close();
 
         TestSslUtils.CertificateBuilder certBuilder = new TestSslUtils.CertificateBuilder().sanDnsNames("localhost", "*.example.com");
-        String truststorePath = (String) sslClientConfigs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
+        String truststorePath = (String) args.sslClientConfigs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
         File truststoreFile = truststorePath != null ? new File(truststorePath) : null;
         TestSslUtils.SslConfigsBuilder builder = new TestSslUtils.SslConfigsBuilder(Mode.SERVER)
                 .useClientCert(false)
@@ -1083,7 +1132,7 @@ public class SslTransportLayerTest {
                 .cn("server")
                 .certBuilder(certBuilder)
                 .createNewTrustStore(truststoreFile)
-                .usePem(useInlinePem);
+                .usePem(args.useInlinePem);
         Map<String, Object> newConfigs = builder.build();
         Map<String, Object> newKeystoreConfigs = new HashMap<>();
         for (String propName : CertStores.KEYSTORE_PROPS) {
@@ -1094,15 +1143,15 @@ public class SslTransportLayerTest {
         reconfigurableBuilder.reconfigure(newKeystoreConfigs);
 
         for (String propName : CertStores.TRUSTSTORE_PROPS) {
-            sslClientConfigs.put(propName, newConfigs.get(propName));
+            args.sslClientConfigs.put(propName, newConfigs.get(propName));
         }
-        selector = createSelector(sslClientConfigs);
+        selector = createSelector(args.sslClientConfigs);
         String node2 = "2";
         selector.connect(node2, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node2, 100, 10);
 
         TestSslUtils.CertificateBuilder invalidBuilder = new TestSslUtils.CertificateBuilder().sanDnsNames("localhost");
-        if (!useInlinePem)
+        if (!args.useInlinePem)
             builder.useExistingTrustStore(truststoreFile);
         Map<String, Object> invalidConfig = builder.certBuilder(invalidBuilder).build();
         Map<String, Object> invalidKeystoreConfigs = new HashMap<>();
@@ -1119,11 +1168,12 @@ public class SslTransportLayerTest {
      * Tests reconfiguration of server truststore. Verifies that existing connections continue
      * to work with old truststore and new connections work with new truststore.
      */
-    @Test
-    public void testServerTruststoreDynamicUpdate() throws Exception {
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testServerTruststoreDynamicUpdate(Args args) throws Exception {
         SecurityProtocol securityProtocol = SecurityProtocol.SSL;
-        sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        TestSecurityConfig config = new TestSecurityConfig(sslServerConfigs);
+        args.sslServerConfigs.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+        TestSecurityConfig config = new TestSecurityConfig(args.sslServerConfigs);
         ListenerName listenerName = ListenerName.forSecurityProtocol(securityProtocol);
         ChannelBuilder serverChannelBuilder = ChannelBuilders.serverChannelBuilder(listenerName,
                 false, securityProtocol, config, null, null, time, new LogContext());
@@ -1134,14 +1184,14 @@ public class SslTransportLayerTest {
 
         // Verify that client with matching keystore can authenticate, send and receive
         String oldNode = "0";
-        Selector oldClientSelector = createSelector(sslClientConfigs);
+        Selector oldClientSelector = createSelector(args.sslClientConfigs);
         oldClientSelector.connect(oldNode, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, oldNode, 100, 10);
 
-        CertStores newClientCertStores = certBuilder(true, "client").addHostName("localhost").build();
-        sslClientConfigs = getTrustingConfig(newClientCertStores, serverCertStores);
+        CertStores newClientCertStores = certBuilder(true, "client", args.useInlinePem).addHostName("localhost").build();
+        args.sslClientConfigs = args.getTrustingConfig(newClientCertStores, args.serverCertStores);
         Map<String, Object> newTruststoreConfigs = newClientCertStores.trustStoreProps();
-        assertTrue("SslChannelBuilder not reconfigurable", serverChannelBuilder instanceof ListenerReconfigurable);
+        assertTrue(serverChannelBuilder instanceof ListenerReconfigurable, "SslChannelBuilder not reconfigurable");
         ListenerReconfigurable reconfigurableBuilder = (ListenerReconfigurable) serverChannelBuilder;
         assertEquals(listenerName, reconfigurableBuilder.listenerName());
         reconfigurableBuilder.validateReconfiguration(newTruststoreConfigs);
@@ -1152,7 +1202,7 @@ public class SslTransportLayerTest {
         NetworkTestUtils.waitForChannelClose(oldClientSelector, "1", ChannelState.State.AUTHENTICATION_FAILED);
 
         // Verify that new client with new truststore can authenticate, send and receive
-        Selector newClientSelector = createSelector(sslClientConfigs);
+        Selector newClientSelector = createSelector(args.sslClientConfigs);
         newClientSelector.connect("2", addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(newClientSelector, "2", 100, 10);
 
@@ -1177,54 +1227,48 @@ public class SslTransportLayerTest {
     /**
      * Tests if client can plugin customize ssl.engine.factory
      */
-    @Test
-    public void testCustomClientSslEngineFactory() throws Exception {
-        sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testCustomClientSslEngineFactory(Args args) throws Exception {
+        args.sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
+        verifySslConfigs(args);
     }
 
     /**
      * Tests if server can plugin customize ssl.engine.factory
      */
-    @Test
-    public void testCustomServerSslEngineFactory() throws Exception {
-        sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testCustomServerSslEngineFactory(Args args) throws Exception {
+        args.sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
+        verifySslConfigs(args);
     }
 
     /**
      * Tests if client and server both can plugin customize ssl.engine.factory and talk to each other!
      */
-    @Test
-    public void testCustomClientAndServerSslEngineFactory() throws Exception {
-        sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
-        sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
-        verifySslConfigs();
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testCustomClientAndServerSslEngineFactory(Args args) throws Exception {
+        args.sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
+        args.sslServerConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
+        verifySslConfigs(args);
     }
 
     /**
      * Tests invalid ssl.engine.factory plugin class
      */
-    @Test
-    public void testInvalidSslEngineFactory() {
-        sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, String.class);
-        assertThrows(KafkaException.class, () -> createSelector(sslClientConfigs));
+    @ParameterizedTest
+    @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
+    public void testInvalidSslEngineFactory(Args args) {
+        args.sslClientConfigs.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, String.class);
+        assertThrows(KafkaException.class, () -> createSelector(args.sslClientConfigs));
     }
 
     private void verifyInvalidReconfigure(ListenerReconfigurable reconfigurable,
                                           Map<String, Object>  invalidConfigs, String errorMessage) {
-        try {
-            reconfigurable.validateReconfiguration(invalidConfigs);
-            fail("Should have failed validation with an exception: " + errorMessage);
-        } catch (KafkaException e) {
-            // expected exception
-        }
-        try {
-            reconfigurable.reconfigure(invalidConfigs);
-            fail("Should have failed to reconfigure: " + errorMessage);
-        } catch (KafkaException e) {
-            // expected exception
-        }
+        assertThrows(KafkaException.class, () -> reconfigurable.validateReconfiguration(invalidConfigs));
+        assertThrows(KafkaException.class, () -> reconfigurable.reconfigure(invalidConfigs));
     }
 
     private Selector createSelector(Map<String, Object> sslClientConfigs) {
@@ -1240,37 +1284,45 @@ public class SslTransportLayerTest {
         return selector;
     }
 
-    private NioEchoServer createEchoServer(ListenerName listenerName, SecurityProtocol securityProtocol) throws Exception {
-        return NetworkTestUtils.createEchoServer(listenerName, securityProtocol, new TestSecurityConfig(sslServerConfigs), null, time);
+    private NioEchoServer createEchoServer(Args args, ListenerName listenerName, SecurityProtocol securityProtocol) throws Exception {
+        return NetworkTestUtils.createEchoServer(listenerName, securityProtocol, new TestSecurityConfig(args.sslServerConfigs), null, time);
     }
 
-    private NioEchoServer createEchoServer(SecurityProtocol securityProtocol) throws Exception {
-        return createEchoServer(ListenerName.forSecurityProtocol(securityProtocol), securityProtocol);
+    private NioEchoServer createEchoServer(Args args, SecurityProtocol securityProtocol) throws Exception {
+        return createEchoServer(args, ListenerName.forSecurityProtocol(securityProtocol), securityProtocol);
     }
 
-    private Map<String, Object> getTrustingConfig(CertStores certStores, CertStores peerCertStores) {
-        Map<String, Object> configs = certStores.getTrustingConfig(peerCertStores);
-        configs.putAll(sslConfigOverrides);
-        return configs;
+    private Selector createSelector(Args args) {
+        LogContext logContext = new LogContext();
+        ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
+        channelBuilder.configure(args.sslClientConfigs);
+        selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, logContext);
+        return selector;
     }
 
-    private void verifySslConfigs() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs);
+    private void verifySslConfigs(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         String node = "0";
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
 
-    public void verifySslConfigsWithHandshakeFailure() throws Exception {
-        server = createEchoServer(SecurityProtocol.SSL);
-        createSelector(sslClientConfigs);
+    public void verifySslConfigsWithHandshakeFailure(Args args) throws Exception {
+        server = createEchoServer(args, SecurityProtocol.SSL);
+        createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         String node = "0";
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
         NetworkTestUtils.waitForChannelClose(selector, node, ChannelState.State.AUTHENTICATION_FAILED);
         server.verifyAuthenticationMetrics(0, 1);
+    }
+
+    private static CertStores.Builder certBuilder(boolean isServer, String cn, boolean useInlinePem) {
+        return new CertStores.Builder(isServer)
+                .cn(cn)
+                .usePem(useInlinePem);
     }
 
     @FunctionalInterface
@@ -1383,7 +1435,7 @@ public class SslTransportLayerTest {
 
             @Override
             protected void startHandshake() throws IOException {
-                assertTrue("SSL handshake initialized too early", socketChannel().isConnected());
+                assertTrue(socketChannel().isConnected(), "SSL handshake initialized too early");
                 super.startHandshake();
             }
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -1309,7 +1309,7 @@ public class SslTransportLayerTest {
         NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
 
-    public void verifySslConfigsWithHandshakeFailure(Args args) throws Exception {
+    private void verifySslConfigsWithHandshakeFailure(Args args) throws Exception {
         server = createEchoServer(args, SecurityProtocol.SSL);
         createSelector(args.sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
@@ -28,11 +28,11 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SslTransportTls12Tls13Test {
     private static final int BUFFER_SIZE = 4 * 1024;
@@ -43,7 +43,7 @@ public class SslTransportTls12Tls13Test {
     private Map<String, Object> sslClientConfigs;
     private Map<String, Object> sslServerConfigs;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
         CertStores serverCertStores = new CertStores(true, "server", "localhost");
@@ -57,7 +57,7 @@ public class SslTransportTls12Tls13Test {
         this.selector = new Selector(5000, new Metrics(), TIME, "MetricGroup", channelBuilder, logContext);
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         if (selector != null)
             this.selector.close();

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -18,14 +18,14 @@ package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.protocol.types.BoundField;
 import org.apache.kafka.common.protocol.types.Schema;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.EnumSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApiKeysTest {
@@ -65,9 +65,9 @@ public class ApiKeysTest {
             BoundField throttleTimeField = responseSchema.get("throttle_time_ms");
             if ((apiKey.clusterAction && !clusterActionsWithThrottleTimeMs.contains(apiKey))
                 || authenticationKeys.contains(apiKey))
-                assertNull("Unexpected throttle time field: " + apiKey, throttleTimeField);
+                assertNull(throttleTimeField, "Unexpected throttle time field: " + apiKey);
             else
-                assertNotNull("Throttle time field missing: " + apiKey, throttleTimeField);
+                assertNotNull(throttleTimeField, "Throttle time field missing: " + apiKey);
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.kafka.common.protocol;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ErrorsTest {
 
@@ -35,7 +35,7 @@ public class ErrorsTest {
         for (Errors error : Errors.values()) {
             codeSet.add(error.code());
         }
-        assertEquals("Error codes must be unique", codeSet.size(), Errors.values().length);
+        assertEquals(codeSet.size(), Errors.values().length, "Error codes must be unique");
     }
 
     @Test
@@ -45,20 +45,20 @@ public class ErrorsTest {
             if (error != Errors.NONE)
                 exceptionSet.add(error.exception().getClass());
         }
-        assertEquals("Exceptions must be unique", exceptionSet.size(), Errors.values().length - 1); // Ignore NONE
+        assertEquals(exceptionSet.size(), Errors.values().length - 1, "Exceptions must be unique"); // Ignore NONE
     }
 
     @Test
     public void testExceptionsAreNotGeneric() {
         for (Errors error : Errors.values()) {
             if (error != Errors.NONE)
-                assertNotEquals("Generic ApiException should not be used", error.exception().getClass(), ApiException.class);
+                assertNotEquals(error.exception().getClass(), ApiException.class, "Generic ApiException should not be used");
         }
     }
 
     @Test
     public void testNoneException() {
-        assertNull("The NONE error should not have an exception", Errors.NONE.exception());
+        assertNull(Errors.NONE.exception(), "The NONE error should not have an exception");
     }
 
     @Test
@@ -68,13 +68,13 @@ public class ErrorsTest {
         Errors expectedError = Errors.forException(new TimeoutException());
         Errors actualError = Errors.forException(new ExtendedTimeoutException());
 
-        assertEquals("forException should match super classes", expectedError, actualError);
+        assertEquals(expectedError, actualError, "forException should match super classes");
     }
 
     @Test
     public void testForExceptionDefault() {
         Errors error = Errors.forException(new ApiException());
-        assertEquals("forException should default to unknown", Errors.UNKNOWN_SERVER_ERROR, error);
+        assertEquals(Errors.UNKNOWN_SERVER_ERROR, error, "forException should default to unknown");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/protocol/MessageUtilTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/MessageUtilTest.java
@@ -18,23 +18,21 @@
 package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.protocol.types.RawTaggedField;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Timeout(120)
 public final class MessageUtilTest {
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testDeepToString() {

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common.protocol;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtoUtilsTest {
     @Test
@@ -35,15 +35,15 @@ public class ProtoUtilsTest {
                 case RENEW_DELEGATION_TOKEN:
                 case ALTER_USER_SCRAM_CREDENTIALS:
                 case ENVELOPE:
-                    assertTrue(key + " should require delayed allocation", key.requiresDelayedAllocation);
+                    assertTrue(key.requiresDelayedAllocation, key + " should require delayed allocation");
                     break;
                 default:
                     if (key.forwardable) {
-                        assertTrue(key + " should require delayed allocation since it is forwardable",
-                            key.requiresDelayedAllocation);
+                        assertTrue(
+                                key.requiresDelayedAllocation, key + " should require delayed allocation since it is forwardable");
                     } else {
-                        assertFalse(key + " should not require delayed allocation",
-                            key.requiresDelayedAllocation);
+                        assertFalse(
+                                key.requiresDelayedAllocation, key + " should not require delayed allocation");
                     }
                     break;
             }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
@@ -38,13 +38,11 @@ public class ProtoUtilsTest {
                     assertTrue(key.requiresDelayedAllocation, key + " should require delayed allocation");
                     break;
                 default:
-                    if (key.forwardable) {
-                        assertTrue(
-                                key.requiresDelayedAllocation, key + " should require delayed allocation since it is forwardable");
-                    } else {
-                        assertFalse(
-                                key.requiresDelayedAllocation, key + " should not require delayed allocation");
-                    }
+                    if (key.forwardable)
+                        assertTrue(key.requiresDelayedAllocation,
+                            key + " should require delayed allocation since it is forwardable");
+                    else
+                        assertFalse(key.requiresDelayedAllocation, key + " should not require delayed allocation");
                     break;
             }
         }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/SendBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/SendBuilderTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/ProtocolSerializationTest.java
@@ -17,28 +17,27 @@
 package org.apache.kafka.common.protocol.types;
 
 import org.apache.kafka.common.utils.ByteUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProtocolSerializationTest {
 
     private Schema schema;
     private Struct struct;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.schema = new Schema(new Field("boolean", Type.BOOLEAN),
                                  new Field("int8", Type.INT8),
@@ -155,7 +154,7 @@ public class ProtocolSerializationTest {
                 if (!f.def.type.isNullable())
                     fail("Should not allow serialization of null value.");
             } catch (SchemaException e) {
-                assertFalse(f.toString() + " should not be nullable", f.def.type.isNullable());
+                assertFalse(f.def.type.isNullable(), f.toString() + " should not be nullable");
             } finally {
                 this.struct.set(f, o);
             }
@@ -166,7 +165,7 @@ public class ProtocolSerializationTest {
     public void testDefault() {
         Schema schema = new Schema(new Field("field", Type.INT32, "doc", 42));
         Struct struct = new Struct(schema);
-        assertEquals("Should get the default value", 42, struct.get("field"));
+        assertEquals(42, struct.get("field"), "Should get the default value");
         struct.validate(); // should be valid even with missing value
     }
 
@@ -182,7 +181,7 @@ public class ProtocolSerializationTest {
         // Should use default even if the field allows null values
         Schema schema = new Schema(new Field("field", type, "doc", defaultValue));
         Struct struct = new Struct(schema);
-        assertEquals("Should get the default value", defaultValue, struct.get("field"));
+        assertEquals(defaultValue, struct.get("field"), "Should get the default value");
         struct.validate(); // should be valid even with missing value
     }
 
@@ -333,17 +332,17 @@ public class ProtocolSerializationTest {
     @Test
     public void testToString() {
         String structStr = this.struct.toString();
-        assertNotNull("Struct string should not be null.", structStr);
-        assertFalse("Struct string should not be empty.", structStr.isEmpty());
+        assertNotNull(structStr, "Struct string should not be null.");
+        assertFalse(structStr.isEmpty(), "Struct string should not be empty.");
     }
 
     private Object roundtrip(Type type, Object obj) {
         ByteBuffer buffer = ByteBuffer.allocate(type.sizeOf(obj));
         type.write(buffer, obj);
-        assertFalse("The buffer should now be full.", buffer.hasRemaining());
+        assertFalse(buffer.hasRemaining(), "The buffer should now be full.");
         buffer.rewind();
         Object read = type.read(buffer);
-        assertFalse("All bytes should have been read.", buffer.hasRemaining());
+        assertFalse(buffer.hasRemaining(), "All bytes should have been read.");
         return read;
     }
 
@@ -354,7 +353,7 @@ public class ProtocolSerializationTest {
             result = Arrays.asList((Object[]) result);
         }
         assertEquals(expectedTypeName, type.toString());
-        assertEquals("The object read back should be the same as what was written.", obj, result);
+        assertEquals(obj, result, "The object read back should be the same as what was written.");
     }
 
     @Test
@@ -417,7 +416,7 @@ public class ProtocolSerializationTest {
         oldFormat.writeTo(buffer);
         buffer.flip();
         SchemaException e = assertThrows(SchemaException.class, () -> newSchema.read(buffer));
-        assertThat(e.getMessage(), containsString("Error reading field 'field2':"));
+        assertTrue(e.getMessage().contains("Error reading field 'field2':"));
     }
 
     @Test
@@ -433,6 +432,6 @@ public class ProtocolSerializationTest {
         oldFormat.writeTo(buffer);
         buffer.flip();
         SchemaException e = assertThrows(SchemaException.class, () -> newSchema.read(buffer));
-        assertThat(e.getMessage(), containsString("Missing value for field 'field2' which has no default value"));
+        assertTrue(e.getMessage().contains("Missing value for field 'field2' which has no default value"));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/RawTaggedFieldWriterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/RawTaggedFieldWriterTest.java
@@ -18,21 +18,19 @@
 package org.apache.kafka.common.protocol.types;
 
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@Timeout(120)
 public class RawTaggedFieldWriterTest {
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testWritingZeroRawTaggedFields() {

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/StructTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/StructTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.kafka.common.protocol.types;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class StructTest {
     private static final Schema FLAT_STRUCT_SCHEMA = new Schema(

--- a/clients/src/test/java/org/apache/kafka/common/protocol/types/TypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/types/TypeTest.java
@@ -19,12 +19,12 @@ package org.apache.kafka.common.protocol.types;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TypeTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/AbstractLegacyRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/AbstractLegacyRecordBatchTest.java
@@ -19,15 +19,15 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.record.AbstractLegacyRecordBatch.ByteBufferLegacyRecordBatch;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AbstractLegacyRecordBatchTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/BufferSupplierTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/BufferSupplierTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.kafka.common.record;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class BufferSupplierTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ByteBufferLogInputStreamTest.java
@@ -17,16 +17,16 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.errors.CorruptRecordException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ByteBufferLogInputStreamTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionRatioEstimatorTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.kafka.common.record;
 
-import org.junit.Test;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionTypeTest.java
@@ -17,12 +17,12 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CompressionTypeTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordTypeTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.record;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ControlRecordTypeTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
@@ -19,13 +19,13 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ControlRecordUtilsTest {
 
@@ -33,7 +33,7 @@ public class ControlRecordUtilsTest {
     public void testInvalidControlRecordType() {
         IllegalArgumentException thrown = assertThrows(
             IllegalArgumentException.class, () -> testDeserializeRecord(ControlRecordType.COMMIT));
-        Assert.assertEquals("Expected LEADER_CHANGE control record type(3), but found COMMIT", thrown.getMessage());
+        assertEquals("Expected LEADER_CHANGE control record type(3), but found COMMIT", thrown.getMessage());
     }
 
     @Test
@@ -61,8 +61,8 @@ public class ControlRecordUtilsTest {
 
         LeaderChangeMessage deserializedData = ControlRecordUtils.deserializeLeaderChangeMessage(record);
 
-        Assert.assertEquals(leaderId, deserializedData.leaderId());
-        Assert.assertEquals(Collections.singletonList(
+        assertEquals(leaderId, deserializedData.leaderId());
+        assertEquals(Collections.singletonList(
             new Voter().setVoterId(voterId)), deserializedData.voters());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordBatchTest.java
@@ -23,17 +23,17 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.kafka.common.record.DefaultRecordBatch.RECORDS_COUNT_OFFSET;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultRecordBatchTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/DefaultRecordTest.java
@@ -22,24 +22,24 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.ByteUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DefaultRecordTest {
 
     private byte[] skipArray;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         skipArray = new byte[64];
     }

--- a/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/EndTransactionMarkerTest.java
@@ -17,12 +17,12 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.InvalidRecordException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EndTransactionMarkerTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/FileLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileLogInputStreamTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.record.FileLogInputStream.FileChannelRecordBatch;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -252,18 +253,16 @@ public class FileLogInputStreamTest {
         }
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
-    public void testNextBatchSelectionWithMaxedParams(Args args) throws IOException {
+    @Test
+    public void testNextBatchSelectionWithMaxedParams() throws IOException {
         try (FileRecords fileRecords = FileRecords.open(tempFile())) {
             FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, Integer.MAX_VALUE, Integer.MAX_VALUE);
             assertNull(logInputStream.nextBatch());
         }
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
-    public void testNextBatchSelectionWithZeroedParams(Args args) throws IOException {
+    @Test
+    public void testNextBatchSelectionWithZeroedParams() throws IOException {
         try (FileRecords fileRecords = FileRecords.open(tempFile())) {
             FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, 0, 0);
             assertNull(logInputStream.nextBatch());

--- a/clients/src/test/java/org/apache/kafka/common/record/FileLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileLogInputStreamTest.java
@@ -19,15 +19,17 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.record.FileLogInputStream.FileChannelRecordBatch;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V0;
@@ -37,25 +39,47 @@ import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
 import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
 import static org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE;
 import static org.apache.kafka.test.TestUtils.tempFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(value = Parameterized.class)
 public class FileLogInputStreamTest {
 
-    private final byte magic;
-    private final CompressionType compression;
+    private static class Args {
+        final byte magic;
+        final CompressionType compression;
 
-    public FileLogInputStreamTest(byte magic, CompressionType compression) {
-        this.magic = magic;
-        this.compression = compression;
+        public Args(byte magic, CompressionType compression) {
+            this.magic = magic;
+            this.compression = compression;
+        }
+
+        @Override
+        public String toString() {
+            return "magic=" + magic +
+                ", compression=" + compression;
+        }
     }
 
-    @Test
-    public void testWriteTo() throws IOException {
+    private static class FileLogInputStreamArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            List<Arguments> arguments = new ArrayList<>();
+            for (byte magic : asList(MAGIC_VALUE_V0, MAGIC_VALUE_V1, MAGIC_VALUE_V2))
+                for (CompressionType type: CompressionType.values())
+                    arguments.add(Arguments.of(new Args(magic, type)));
+            return arguments.stream();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testWriteTo(Args args) throws IOException {
+        CompressionType compression = args.compression;
+        byte magic = args.magic;
         if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
             return;
 
@@ -82,8 +106,11 @@ public class FileLogInputStreamTest {
         }
     }
 
-    @Test
-    public void testSimpleBatchIteration() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testSimpleBatchIteration(Args args) throws IOException {
+        CompressionType compression = args.compression;
+        byte magic = args.magic;
         if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
             return;
 
@@ -98,19 +125,22 @@ public class FileLogInputStreamTest {
             FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, 0, fileRecords.sizeInBytes());
 
             FileChannelRecordBatch firstBatch = logInputStream.nextBatch();
-            assertGenericRecordBatchData(firstBatch, 0L, 3241324L, firstBatchRecord);
+            assertGenericRecordBatchData(args, firstBatch, 0L, 3241324L, firstBatchRecord);
             assertNoProducerData(firstBatch);
 
             FileChannelRecordBatch secondBatch = logInputStream.nextBatch();
-            assertGenericRecordBatchData(secondBatch, 1L, 234280L, secondBatchRecord);
+            assertGenericRecordBatchData(args, secondBatch, 1L, 234280L, secondBatchRecord);
             assertNoProducerData(secondBatch);
 
             assertNull(logInputStream.nextBatch());
         }
     }
 
-    @Test
-    public void testBatchIterationWithMultipleRecordsPerBatch() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testBatchIterationWithMultipleRecordsPerBatch(Args args) throws IOException {
+        CompressionType compression = args.compression;
+        byte magic = args.magic;
         if (magic < MAGIC_VALUE_V2 && compression == CompressionType.NONE)
             return;
 
@@ -137,18 +167,21 @@ public class FileLogInputStreamTest {
 
             FileChannelRecordBatch firstBatch = logInputStream.nextBatch();
             assertNoProducerData(firstBatch);
-            assertGenericRecordBatchData(firstBatch, 0L, 3241324L, firstBatchRecords);
+            assertGenericRecordBatchData(args, firstBatch, 0L, 3241324L, firstBatchRecords);
 
             FileChannelRecordBatch secondBatch = logInputStream.nextBatch();
             assertNoProducerData(secondBatch);
-            assertGenericRecordBatchData(secondBatch, 1L, 238423489L, secondBatchRecords);
+            assertGenericRecordBatchData(args, secondBatch, 1L, 238423489L, secondBatchRecords);
 
             assertNull(logInputStream.nextBatch());
         }
     }
 
-    @Test
-    public void testBatchIterationV2() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testBatchIterationV2(Args args) throws IOException {
+        CompressionType compression = args.compression;
+        byte magic = args.magic;
         if (magic != MAGIC_VALUE_V2)
             return;
 
@@ -179,21 +212,24 @@ public class FileLogInputStreamTest {
 
             FileChannelRecordBatch firstBatch = logInputStream.nextBatch();
             assertProducerData(firstBatch, producerId, producerEpoch, baseSequence, false, firstBatchRecords);
-            assertGenericRecordBatchData(firstBatch, 15L, 3241324L, firstBatchRecords);
+            assertGenericRecordBatchData(args, firstBatch, 15L, 3241324L, firstBatchRecords);
             assertEquals(partitionLeaderEpoch, firstBatch.partitionLeaderEpoch());
 
             FileChannelRecordBatch secondBatch = logInputStream.nextBatch();
             assertProducerData(secondBatch, producerId, producerEpoch, baseSequence + firstBatchRecords.length,
                     true, secondBatchRecords);
-            assertGenericRecordBatchData(secondBatch, 27L, 238423489L, secondBatchRecords);
+            assertGenericRecordBatchData(args, secondBatch, 27L, 238423489L, secondBatchRecords);
             assertEquals(partitionLeaderEpoch, secondBatch.partitionLeaderEpoch());
 
             assertNull(logInputStream.nextBatch());
         }
     }
 
-    @Test
-    public void testBatchIterationIncompleteBatch() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testBatchIterationIncompleteBatch(Args args) throws IOException {
+        CompressionType compression = args.compression;
+        byte magic = args.magic;
         if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
             return;
 
@@ -210,22 +246,24 @@ public class FileLogInputStreamTest {
 
             FileChannelRecordBatch firstBatch = logInputStream.nextBatch();
             assertNoProducerData(firstBatch);
-            assertGenericRecordBatchData(firstBatch, 0L, 100L, firstBatchRecord);
+            assertGenericRecordBatchData(args, firstBatch, 0L, 100L, firstBatchRecord);
 
             assertNull(logInputStream.nextBatch());
         }
     }
 
-    @Test
-    public void testNextBatchSelectionWithMaxedParams() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testNextBatchSelectionWithMaxedParams(Args args) throws IOException {
         try (FileRecords fileRecords = FileRecords.open(tempFile())) {
             FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, Integer.MAX_VALUE, Integer.MAX_VALUE);
             assertNull(logInputStream.nextBatch());
         }
     }
 
-    @Test
-    public void testNextBatchSelectionWithZeroedParams() throws IOException {
+    @ParameterizedTest
+    @ArgumentsSource(FileLogInputStreamArgumentsProvider.class)
+    public void testNextBatchSelectionWithZeroedParams(Args args) throws IOException {
         try (FileRecords fileRecords = FileRecords.open(tempFile())) {
             FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, 0, 0);
             assertNull(logInputStream.nextBatch());
@@ -249,7 +287,10 @@ public class FileLogInputStreamTest {
         assertFalse(batch.isTransactional());
     }
 
-    private void assertGenericRecordBatchData(RecordBatch batch, long baseOffset, long maxTimestamp, SimpleRecord... records) {
+    private void assertGenericRecordBatchData(Args args, RecordBatch batch, long baseOffset, long maxTimestamp,
+                                              SimpleRecord... records) {
+        CompressionType compression = args.compression;
+        byte magic = args.magic;
         assertEquals(magic, batch.magic());
         assertEquals(compression, batch.compressionType());
 
@@ -277,14 +318,5 @@ public class FileLogInputStreamTest {
             else
                 assertEquals(records[i].timestamp(), batchRecords.get(i).timestamp());
         }
-    }
-
-    @Parameterized.Parameters(name = "magic={0}, compression={1}")
-    public static Collection<Object[]> data() {
-        List<Object[]> values = new ArrayList<>();
-        for (byte magic : asList(MAGIC_VALUE_V0, MAGIC_VALUE_V1, MAGIC_VALUE_V2))
-            for (CompressionType type: CompressionType.values())
-                values.add(new Object[] {magic, type});
-        return values;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,14 +43,14 @@ import java.util.concurrent.Future;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.utf8;
 import static org.apache.kafka.test.TestUtils.tempFile;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -68,7 +68,7 @@ public class FileRecordsTest {
     private FileRecords fileRecords;
     private Time time;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         this.fileRecords = createFileRecords(values);
         this.time = new MockTime();
@@ -199,36 +199,36 @@ public class FileRecordsTest {
         // read from second message until the end
         read = fileRecords.slice(first.sizeInBytes(), fileRecords.sizeInBytes() - first.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
-        assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
+        assertEquals(items.subList(1, items.size()), batches(read), "Read starting from the second message");
 
         // read from second message and size is past the end of the file
         read = fileRecords.slice(first.sizeInBytes(), fileRecords.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
-        assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
+        assertEquals(items.subList(1, items.size()), batches(read), "Read starting from the second message");
 
         // read from second message and position + size overflows
         read = fileRecords.slice(first.sizeInBytes(), Integer.MAX_VALUE);
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
-        assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
+        assertEquals(items.subList(1, items.size()), batches(read), "Read starting from the second message");
 
         // read from second message and size is past the end of the file on a view/slice
         read = fileRecords.slice(1, fileRecords.sizeInBytes() - 1)
                 .slice(first.sizeInBytes() - 1, fileRecords.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
-        assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
+        assertEquals(items.subList(1, items.size()), batches(read), "Read starting from the second message");
 
         // read from second message and position + size overflows on a view/slice
         read = fileRecords.slice(1, fileRecords.sizeInBytes() - 1)
                 .slice(first.sizeInBytes() - 1, Integer.MAX_VALUE);
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
-        assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
+        assertEquals(items.subList(1, items.size()), batches(read), "Read starting from the second message");
 
         // read a single message starting from second message
         RecordBatch second = items.get(1);
         read = fileRecords.slice(first.sizeInBytes(), second.sizeInBytes());
         assertEquals(second.sizeInBytes(), read.sizeInBytes());
-        assertEquals("Read a single message starting from the second message",
-                Collections.singletonList(second), batches(read));
+        assertEquals(
+                Collections.singletonList(second), batches(read), "Read a single message starting from the second message");
     }
 
     /**
@@ -244,27 +244,27 @@ public class FileRecordsTest {
         int position = 0;
 
         int message1Size = batches.get(0).sizeInBytes();
-        assertEquals("Should be able to find the first message by its offset",
+        assertEquals(
                 new FileRecords.LogOffsetPosition(0L, position, message1Size),
-                fileRecords.searchForOffsetWithSize(0, 0));
+                fileRecords.searchForOffsetWithSize(0, 0), "Should be able to find the first message by its offset");
         position += message1Size;
 
         int message2Size = batches.get(1).sizeInBytes();
-        assertEquals("Should be able to find second message when starting from 0",
+        assertEquals(
                 new FileRecords.LogOffsetPosition(1L, position, message2Size),
-                fileRecords.searchForOffsetWithSize(1, 0));
-        assertEquals("Should be able to find second message starting from its offset",
+                fileRecords.searchForOffsetWithSize(1, 0), "Should be able to find second message when starting from 0");
+        assertEquals(
                 new FileRecords.LogOffsetPosition(1L, position, message2Size),
-                fileRecords.searchForOffsetWithSize(1, position));
+                fileRecords.searchForOffsetWithSize(1, position), "Should be able to find second message starting from its offset");
         position += message2Size + batches.get(2).sizeInBytes();
 
         int message4Size = batches.get(3).sizeInBytes();
-        assertEquals("Should be able to find fourth message from a non-existent offset",
+        assertEquals(
                 new FileRecords.LogOffsetPosition(50L, position, message4Size),
-                fileRecords.searchForOffsetWithSize(3, position));
-        assertEquals("Should be able to find fourth message by correct offset",
+                fileRecords.searchForOffsetWithSize(3, position), "Should be able to find fourth message from a non-existent offset");
+        assertEquals(
                 new FileRecords.LogOffsetPosition(50L, position, message4Size),
-                fileRecords.searchForOffsetWithSize(50,  position));
+                fileRecords.searchForOffsetWithSize(50,  position), "Should be able to find fourth message by correct offset");
     }
 
     /**
@@ -411,14 +411,14 @@ public class FileRecordsTest {
         int size = batch.sizeInBytes();
         FileRecords slice = fileRecords.slice(start, size - 1);
         Records messageV0 = slice.downConvert(RecordBatch.MAGIC_VALUE_V0, 0, time).records();
-        assertTrue("No message should be there", batches(messageV0).isEmpty());
-        assertEquals("There should be " + (size - 1) + " bytes", size - 1, messageV0.sizeInBytes());
+        assertTrue(batches(messageV0).isEmpty(), "No message should be there");
+        assertEquals(size - 1, messageV0.sizeInBytes(), "There should be " + (size - 1) + " bytes");
 
         // Lazy down-conversion will not return any messages for a partial input batch
         TopicPartition tp = new TopicPartition("topic-1", 0);
         LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, slice, RecordBatch.MAGIC_VALUE_V0, 0, Time.SYSTEM);
         Iterator<ConvertedRecords<?>> it = lazyRecords.iterator(16 * 1024L);
-        assertTrue("No messages should be returned", !it.hasNext());
+        assertTrue(!it.hasNext(), "No messages should be returned");
     }
 
     @Test
@@ -447,14 +447,14 @@ public class FileRecordsTest {
                                       FileRecords.TimestampAndOffset actual,
                                       RecordVersion version) {
         if (version == RecordVersion.V0) {
-            assertNull("Expected no match for message format v0", actual);
+            assertNull(actual, "Expected no match for message format v0");
         } else {
-            assertNotNull("Expected to find timestamp for message format " + version, actual);
-            assertEquals("Expected matching timestamps for message format" + version, expected.timestamp, actual.timestamp);
-            assertEquals("Expected matching offsets for message format " + version, expected.offset, actual.offset);
+            assertNotNull(actual, "Expected to find timestamp for message format " + version);
+            assertEquals(expected.timestamp, actual.timestamp, "Expected matching timestamps for message format" + version);
+            assertEquals(expected.offset, actual.offset, "Expected matching offsets for message format " + version);
             Optional<Integer> expectedLeaderEpoch = version.value >= RecordVersion.V2.value ?
                     expected.leaderEpoch : Optional.empty();
-            assertEquals("Non-matching leader epoch for version " + version, expectedLeaderEpoch, actual.leaderEpoch);
+            assertEquals(expectedLeaderEpoch, actual.leaderEpoch, "Non-matching leader epoch for version " + version);
         }
     }
 
@@ -531,7 +531,7 @@ public class FileRecordsTest {
                 new SimpleRecord(8L, "k8".getBytes(), "running out".getBytes(), headers),
                 new SimpleRecord(9L, "k9".getBytes(), "ok, almost done".getBytes()),
                 new SimpleRecord(10L, "k10".getBytes(), "finally".getBytes(), headers));
-        assertEquals("incorrect test setup", offsets.size(), records.size());
+        assertEquals(offsets.size(), records.size(), "incorrect test setup");
 
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.MAGIC_VALUE_V0, compressionType,
@@ -624,31 +624,31 @@ public class FileRecordsTest {
 
         for (Records convertedRecords : convertedRecordsList) {
             for (RecordBatch batch : convertedRecords.batches()) {
-                assertTrue("Magic byte should be lower than or equal to " + magicByte, batch.magic() <= magicByte);
+                assertTrue(batch.magic() <= magicByte, "Magic byte should be lower than or equal to " + magicByte);
                 if (batch.magic() == RecordBatch.MAGIC_VALUE_V0)
                     assertEquals(TimestampType.NO_TIMESTAMP_TYPE, batch.timestampType());
                 else
                     assertEquals(TimestampType.CREATE_TIME, batch.timestampType());
-                assertEquals("Compression type should not be affected by conversion", compressionType, batch.compressionType());
+                assertEquals(compressionType, batch.compressionType(), "Compression type should not be affected by conversion");
                 for (Record record : batch) {
-                    assertTrue("Inner record should have magic " + magicByte, record.hasMagic(batch.magic()));
-                    assertEquals("Offset should not change", initialOffsets.get(i).longValue(), record.offset());
-                    assertEquals("Key should not change", utf8(initialRecords.get(i).key()), utf8(record.key()));
-                    assertEquals("Value should not change", utf8(initialRecords.get(i).value()), utf8(record.value()));
+                    assertTrue(record.hasMagic(batch.magic()), "Inner record should have magic " + magicByte);
+                    assertEquals(initialOffsets.get(i).longValue(), record.offset(), "Offset should not change");
+                    assertEquals(utf8(initialRecords.get(i).key()), utf8(record.key()), "Key should not change");
+                    assertEquals(utf8(initialRecords.get(i).value()), utf8(record.value()), "Value should not change");
                     assertFalse(record.hasTimestampType(TimestampType.LOG_APPEND_TIME));
                     if (batch.magic() == RecordBatch.MAGIC_VALUE_V0) {
                         assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());
                         assertFalse(record.hasTimestampType(TimestampType.CREATE_TIME));
                         assertTrue(record.hasTimestampType(TimestampType.NO_TIMESTAMP_TYPE));
                     } else if (batch.magic() == RecordBatch.MAGIC_VALUE_V1) {
-                        assertEquals("Timestamp should not change", initialRecords.get(i).timestamp(), record.timestamp());
+                        assertEquals(initialRecords.get(i).timestamp(), record.timestamp(), "Timestamp should not change");
                         assertTrue(record.hasTimestampType(TimestampType.CREATE_TIME));
                         assertFalse(record.hasTimestampType(TimestampType.NO_TIMESTAMP_TYPE));
                     } else {
-                        assertEquals("Timestamp should not change", initialRecords.get(i).timestamp(), record.timestamp());
+                        assertEquals(initialRecords.get(i).timestamp(), record.timestamp(), "Timestamp should not change");
                         assertFalse(record.hasTimestampType(TimestampType.CREATE_TIME));
                         assertFalse(record.hasTimestampType(TimestampType.NO_TIMESTAMP_TYPE));
-                        assertArrayEquals("Headers should not change", initialRecords.get(i).headers(), record.headers());
+                        assertArrayEquals(initialRecords.get(i).headers(), record.headers(), "Headers should not change");
                     }
                     i += 1;
                 }

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -227,8 +227,7 @@ public class FileRecordsTest {
         RecordBatch second = items.get(1);
         read = fileRecords.slice(first.sizeInBytes(), second.sizeInBytes());
         assertEquals(second.sizeInBytes(), read.sizeInBytes());
-        assertEquals(
-                Collections.singletonList(second), batches(read), "Read a single message starting from the second message");
+        assertEquals(Collections.singletonList(second), batches(read), "Read a single message starting from the second message");
     }
 
     /**
@@ -244,27 +243,27 @@ public class FileRecordsTest {
         int position = 0;
 
         int message1Size = batches.get(0).sizeInBytes();
-        assertEquals(
-                new FileRecords.LogOffsetPosition(0L, position, message1Size),
-                fileRecords.searchForOffsetWithSize(0, 0), "Should be able to find the first message by its offset");
+        assertEquals(new FileRecords.LogOffsetPosition(0L, position, message1Size),
+            fileRecords.searchForOffsetWithSize(0, 0),
+            "Should be able to find the first message by its offset");
         position += message1Size;
 
         int message2Size = batches.get(1).sizeInBytes();
-        assertEquals(
-                new FileRecords.LogOffsetPosition(1L, position, message2Size),
-                fileRecords.searchForOffsetWithSize(1, 0), "Should be able to find second message when starting from 0");
-        assertEquals(
-                new FileRecords.LogOffsetPosition(1L, position, message2Size),
-                fileRecords.searchForOffsetWithSize(1, position), "Should be able to find second message starting from its offset");
+        assertEquals(new FileRecords.LogOffsetPosition(1L, position, message2Size),
+            fileRecords.searchForOffsetWithSize(1, 0),
+            "Should be able to find second message when starting from 0");
+        assertEquals(new FileRecords.LogOffsetPosition(1L, position, message2Size),
+            fileRecords.searchForOffsetWithSize(1, position),
+            "Should be able to find second message starting from its offset");
         position += message2Size + batches.get(2).sizeInBytes();
 
         int message4Size = batches.get(3).sizeInBytes();
-        assertEquals(
-                new FileRecords.LogOffsetPosition(50L, position, message4Size),
-                fileRecords.searchForOffsetWithSize(3, position), "Should be able to find fourth message from a non-existent offset");
-        assertEquals(
-                new FileRecords.LogOffsetPosition(50L, position, message4Size),
-                fileRecords.searchForOffsetWithSize(50,  position), "Should be able to find fourth message by correct offset");
+        assertEquals(new FileRecords.LogOffsetPosition(50L, position, message4Size),
+            fileRecords.searchForOffsetWithSize(3, position),
+            "Should be able to find fourth message from a non-existent offset");
+        assertEquals(new FileRecords.LogOffsetPosition(50L, position, message4Size),
+            fileRecords.searchForOffsetWithSize(50,  position),
+            "Should be able to find fourth message by correct offset");
     }
 
     /**
@@ -418,7 +417,7 @@ public class FileRecordsTest {
         TopicPartition tp = new TopicPartition("topic-1", 0);
         LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(tp, slice, RecordBatch.MAGIC_VALUE_V0, 0, Time.SYSTEM);
         Iterator<ConvertedRecords<?>> it = lazyRecords.iterator(16 * 1024L);
-        assertTrue(!it.hasNext(), "No messages should be returned");
+        assertFalse(it.hasNext(), "No messages should be returned");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
@@ -22,9 +22,10 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.utils.Time;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,12 +39,13 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.utf8;
 import static org.apache.kafka.test.TestUtils.tempFile;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LazyDownConversionRecordsTest {
+
     /**
      * Test the lazy down-conversion path in the presence of commit markers. When converting to V0 or V1, these batches
      * are dropped. If there happen to be no more batches left to convert, we must get an overflow message batch after
@@ -65,92 +67,77 @@ public class LazyDownConversionRecordsTest {
         assertFalse(convertedRecords.batchIterator().hasNext());
     }
 
-    @RunWith(value = Parameterized.class)
-    public static class ParameterizedConversionTest {
-        private final CompressionType compressionType;
-        private final byte toMagic;
-
-        public ParameterizedConversionTest(CompressionType compressionType, byte toMagic) {
-            this.compressionType = compressionType;
-            this.toMagic = toMagic;
-        }
-
-        @Parameterized.Parameters(name = "compressionType={0}, toMagic={1}")
-        public static Collection<Object[]> data() {
-            List<Object[]> values = new ArrayList<>();
-            for (byte toMagic = RecordBatch.MAGIC_VALUE_V0; toMagic <= RecordBatch.CURRENT_MAGIC_VALUE; toMagic++) {
-                values.add(new Object[]{CompressionType.NONE, toMagic});
-                values.add(new Object[]{CompressionType.GZIP, toMagic});
+    private static Collection<Arguments> parameters() {
+        List<Arguments> arguments = new ArrayList<>();
+        for (byte toMagic = RecordBatch.MAGIC_VALUE_V0; toMagic <= RecordBatch.CURRENT_MAGIC_VALUE; toMagic++) {
+            for (boolean overflow : asList(true, false)) {
+                arguments.add(Arguments.of(CompressionType.NONE, toMagic, overflow));
+                arguments.add(Arguments.of(CompressionType.GZIP, toMagic, overflow));
             }
-            return values;
         }
+        return arguments;
+    }
 
-        /**
-         * Test the lazy down-conversion path.
-         */
-        @Test
-        public void testConversion() throws IOException {
-            doTestConversion(false);
-        }
+    /**
+     * Test the lazy down-conversion path.
+     *
+     * If `overflow` is true, the number of bytes we want to convert is much larger
+     * than the number of bytes we get after conversion. This causes overflow message batch(es) to be appended towards the
+     * end of the converted output.
+     */
+    @ParameterizedTest(name = "compressionType={0}, toMagic={1}, overflow={2}")
+    @MethodSource("parameters")
+    public void testConversion(CompressionType compressionType, byte toMagic, boolean overflow) throws IOException {
+        doTestConversion(compressionType, toMagic, overflow);
+    }
 
-        /**
-         * Test the lazy down-conversion path where the number of bytes we want to convert is much larger than the
-         * number of bytes we get after conversion. This causes overflow message batch(es) to be appended towards the
-         * end of the converted output.
-         */
-        @Test
-        public void testConversionWithOverflow() throws IOException {
-            doTestConversion(true);
-        }
+    private void doTestConversion(CompressionType compressionType, byte toMagic, boolean testConversionOverflow) throws IOException {
+        List<Long> offsets = asList(0L, 2L, 3L, 9L, 11L, 15L, 16L, 17L, 22L, 24L);
 
-        private void doTestConversion(boolean testConversionOverflow) throws IOException {
-            List<Long> offsets = asList(0L, 2L, 3L, 9L, 11L, 15L, 16L, 17L, 22L, 24L);
+        Header[] headers = {new RecordHeader("headerKey1", "headerValue1".getBytes()),
+            new RecordHeader("headerKey2", "headerValue2".getBytes()),
+            new RecordHeader("headerKey3", "headerValue3".getBytes())};
 
-            Header[] headers = {new RecordHeader("headerKey1", "headerValue1".getBytes()),
-                                new RecordHeader("headerKey2", "headerValue2".getBytes()),
-                                new RecordHeader("headerKey3", "headerValue3".getBytes())};
+        List<SimpleRecord> records = asList(
+            new SimpleRecord(1L, "k1".getBytes(), "hello".getBytes()),
+            new SimpleRecord(2L, "k2".getBytes(), "goodbye".getBytes()),
+            new SimpleRecord(3L, "k3".getBytes(), "hello again".getBytes()),
+            new SimpleRecord(4L, "k4".getBytes(), "goodbye for now".getBytes()),
+            new SimpleRecord(5L, "k5".getBytes(), "hello again".getBytes()),
+            new SimpleRecord(6L, "k6".getBytes(), "I sense indecision".getBytes()),
+            new SimpleRecord(7L, "k7".getBytes(), "what now".getBytes()),
+            new SimpleRecord(8L, "k8".getBytes(), "running out".getBytes(), headers),
+            new SimpleRecord(9L, "k9".getBytes(), "ok, almost done".getBytes()),
+            new SimpleRecord(10L, "k10".getBytes(), "finally".getBytes(), headers));
+        assertEquals(offsets.size(), records.size(), "incorrect test setup");
 
-            List<SimpleRecord> records = asList(
-                    new SimpleRecord(1L, "k1".getBytes(), "hello".getBytes()),
-                    new SimpleRecord(2L, "k2".getBytes(), "goodbye".getBytes()),
-                    new SimpleRecord(3L, "k3".getBytes(), "hello again".getBytes()),
-                    new SimpleRecord(4L, "k4".getBytes(), "goodbye for now".getBytes()),
-                    new SimpleRecord(5L, "k5".getBytes(), "hello again".getBytes()),
-                    new SimpleRecord(6L, "k6".getBytes(), "I sense indecision".getBytes()),
-                    new SimpleRecord(7L, "k7".getBytes(), "what now".getBytes()),
-                    new SimpleRecord(8L, "k8".getBytes(), "running out".getBytes(), headers),
-                    new SimpleRecord(9L, "k9".getBytes(), "ok, almost done".getBytes()),
-                    new SimpleRecord(10L, "k10".getBytes(), "finally".getBytes(), headers));
-            assertEquals("incorrect test setup", offsets.size(), records.size());
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType,
+                TimestampType.CREATE_TIME, 0L);
+        for (int i = 0; i < 3; i++)
+            builder.appendWithOffset(offsets.get(i), records.get(i));
+        builder.close();
 
-            ByteBuffer buffer = ByteBuffer.allocate(1024);
-            MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType,
-                    TimestampType.CREATE_TIME, 0L);
-            for (int i = 0; i < 3; i++)
-                builder.appendWithOffset(offsets.get(i), records.get(i));
-            builder.close();
+        builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
+                0L);
+        for (int i = 3; i < 6; i++)
+            builder.appendWithOffset(offsets.get(i), records.get(i));
+        builder.close();
 
-            builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
-                    0L);
-            for (int i = 3; i < 6; i++)
-                builder.appendWithOffset(offsets.get(i), records.get(i));
-            builder.close();
+        builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
+                0L);
+        for (int i = 6; i < 10; i++)
+            builder.appendWithOffset(offsets.get(i), records.get(i));
+        builder.close();
+        buffer.flip();
 
-            builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
-                    0L);
-            for (int i = 6; i < 10; i++)
-                builder.appendWithOffset(offsets.get(i), records.get(i));
-            builder.close();
-            buffer.flip();
+        MemoryRecords recordsToConvert = MemoryRecords.readableRecords(buffer);
+        int numBytesToConvert = recordsToConvert.sizeInBytes();
+        if (testConversionOverflow)
+            numBytesToConvert *= 2;
 
-            MemoryRecords recordsToConvert = MemoryRecords.readableRecords(buffer);
-            int numBytesToConvert = recordsToConvert.sizeInBytes();
-            if (testConversionOverflow)
-                numBytesToConvert *= 2;
-
-            MemoryRecords convertedRecords = convertRecords(recordsToConvert, toMagic, numBytesToConvert);
-            verifyDownConvertedRecords(records, offsets, convertedRecords, compressionType, toMagic);
-        }
+        MemoryRecords convertedRecords = convertRecords(recordsToConvert, toMagic, numBytesToConvert);
+        verifyDownConvertedRecords(records, offsets, convertedRecords, compressionType, toMagic);
     }
 
     private static MemoryRecords convertRecords(MemoryRecords recordsToConvert, byte toMagic, int bytesToConvert) throws IOException {
@@ -222,31 +209,31 @@ public class LazyDownConversionRecordsTest {
                                                    byte toMagic) {
         int i = 0;
         for (RecordBatch batch : downConvertedRecords.batches()) {
-            assertTrue("Magic byte should be lower than or equal to " + toMagic, batch.magic() <= toMagic);
+            assertTrue(batch.magic() <= toMagic, "Magic byte should be lower than or equal to " + toMagic);
             if (batch.magic() == RecordBatch.MAGIC_VALUE_V0)
                 assertEquals(TimestampType.NO_TIMESTAMP_TYPE, batch.timestampType());
             else
                 assertEquals(TimestampType.CREATE_TIME, batch.timestampType());
-            assertEquals("Compression type should not be affected by conversion", compressionType, batch.compressionType());
+            assertEquals(compressionType, batch.compressionType(), "Compression type should not be affected by conversion");
             for (Record record : batch) {
-                assertTrue("Inner record should have magic " + toMagic, record.hasMagic(batch.magic()));
-                assertEquals("Offset should not change", initialOffsets.get(i).longValue(), record.offset());
-                assertEquals("Key should not change", utf8(initialRecords.get(i).key()), utf8(record.key()));
-                assertEquals("Value should not change", utf8(initialRecords.get(i).value()), utf8(record.value()));
+                assertTrue(record.hasMagic(batch.magic()), "Inner record should have magic " + toMagic);
+                assertEquals(initialOffsets.get(i).longValue(), record.offset(), "Offset should not change");
+                assertEquals(utf8(initialRecords.get(i).key()), utf8(record.key()), "Key should not change");
+                assertEquals(utf8(initialRecords.get(i).value()), utf8(record.value()), "Value should not change");
                 assertFalse(record.hasTimestampType(TimestampType.LOG_APPEND_TIME));
                 if (batch.magic() == RecordBatch.MAGIC_VALUE_V0) {
                     assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());
                     assertFalse(record.hasTimestampType(TimestampType.CREATE_TIME));
                     assertTrue(record.hasTimestampType(TimestampType.NO_TIMESTAMP_TYPE));
                 } else if (batch.magic() == RecordBatch.MAGIC_VALUE_V1) {
-                    assertEquals("Timestamp should not change", initialRecords.get(i).timestamp(), record.timestamp());
+                    assertEquals(initialRecords.get(i).timestamp(), record.timestamp(), "Timestamp should not change");
                     assertTrue(record.hasTimestampType(TimestampType.CREATE_TIME));
                     assertFalse(record.hasTimestampType(TimestampType.NO_TIMESTAMP_TYPE));
                 } else {
-                    assertEquals("Timestamp should not change", initialRecords.get(i).timestamp(), record.timestamp());
+                    assertEquals(initialRecords.get(i).timestamp(), record.timestamp(), "Timestamp should not change");
                     assertFalse(record.hasTimestampType(TimestampType.CREATE_TIME));
                     assertFalse(record.hasTimestampType(TimestampType.NO_TIMESTAMP_TYPE));
-                    assertArrayEquals("Headers should not change", initialRecords.get(i).headers(), record.headers());
+                    assertArrayEquals(initialRecords.get(i).headers(), record.headers(), "Headers should not change");
                 }
                 i += 1;
             }

--- a/clients/src/test/java/org/apache/kafka/common/record/LegacyRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LegacyRecordTest.java
@@ -17,86 +17,111 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.errors.CorruptRecordException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(value = Parameterized.class)
 public class LegacyRecordTest {
 
-    private final byte magic;
-    private final long timestamp;
-    private final ByteBuffer key;
-    private final ByteBuffer value;
-    private final CompressionType compression;
-    private final TimestampType timestampType;
-    private final LegacyRecord record;
+    private static class Args {
+        final byte magic;
+        final long timestamp;
+        final ByteBuffer key;
+        final ByteBuffer value;
+        final CompressionType compression;
+        final TimestampType timestampType;
+        final LegacyRecord record;
 
-    public LegacyRecordTest(byte magic, long timestamp, byte[] key, byte[] value, CompressionType compression) {
-        this.magic = magic;
-        this.timestamp = timestamp;
-        this.timestampType = TimestampType.CREATE_TIME;
-        this.key = key == null ? null : ByteBuffer.wrap(key);
-        this.value = value == null ? null : ByteBuffer.wrap(value);
-        this.compression = compression;
-        this.record = LegacyRecord.create(magic, timestamp, key, value, compression, timestampType);
+        public Args(byte magic, long timestamp, byte[] key, byte[] value, CompressionType compression) {
+            this.magic = magic;
+            this.timestamp = timestamp;
+            this.timestampType = TimestampType.CREATE_TIME;
+            this.key = key == null ? null : ByteBuffer.wrap(key);
+            this.value = value == null ? null : ByteBuffer.wrap(value);
+            this.compression = compression;
+            this.record = LegacyRecord.create(magic, timestamp, key, value, compression, timestampType);
+        }
+
+        @Override
+        public String toString() {
+            return "magic=" + magic +
+                ", compression=" + compression +
+                ", timestamp=" + timestamp;
+        }
     }
 
-    @Test
-    public void testFields() {
-        assertEquals(compression, record.compressionType());
+    private static class LegacyRecordArgumentsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            byte[] payload = new byte[1000];
+            Arrays.fill(payload, (byte) 1);
+            List<Arguments> arguments = new ArrayList<>();
+            for (byte magic : Arrays.asList(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1))
+                for (long timestamp : Arrays.asList(RecordBatch.NO_TIMESTAMP, 0L, 1L))
+                    for (byte[] key : Arrays.asList(null, "".getBytes(), "key".getBytes(), payload))
+                        for (byte[] value : Arrays.asList(null, "".getBytes(), "value".getBytes(), payload))
+                            for (CompressionType compression : CompressionType.values())
+                                arguments.add(Arguments.of(new Args(magic, timestamp, key, value, compression)));
+            return arguments.stream();
+        }
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(LegacyRecordArgumentsProvider.class)
+    public void testFields(Args args) {
+        LegacyRecord record = args.record;
+        ByteBuffer key = args.key;
+        assertEquals(args.compression, record.compressionType());
         assertEquals(key != null, record.hasKey());
         assertEquals(key, record.key());
         if (key != null)
             assertEquals(key.limit(), record.keySize());
-        assertEquals(magic, record.magic());
-        assertEquals(value, record.value());
-        if (value != null)
-            assertEquals(value.limit(), record.valueSize());
-        if (magic > 0) {
-            assertEquals(timestamp, record.timestamp());
-            assertEquals(timestampType, record.timestampType());
+        assertEquals(args.magic, record.magic());
+        assertEquals(args.value, record.value());
+        if (args.value != null)
+            assertEquals(args.value.limit(), record.valueSize());
+        if (args.magic > 0) {
+            assertEquals(args.timestamp, record.timestamp());
+            assertEquals(args.timestampType, record.timestampType());
         } else {
             assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());
             assertEquals(TimestampType.NO_TIMESTAMP_TYPE, record.timestampType());
         }
     }
 
-    @Test
-    public void testChecksum() {
+    @ParameterizedTest
+    @ArgumentsSource(LegacyRecordArgumentsProvider.class)
+    public void testChecksum(Args args) {
+        LegacyRecord record = args.record;
         assertEquals(record.checksum(), record.computeChecksum());
 
-        byte attributes = LegacyRecord.computeAttributes(magic, this.compression, TimestampType.CREATE_TIME);
+        byte attributes = LegacyRecord.computeAttributes(args.magic, args.compression, TimestampType.CREATE_TIME);
         assertEquals(record.checksum(), LegacyRecord.computeChecksum(
-                magic,
+                args.magic,
                 attributes,
-                this.timestamp,
-                this.key == null ? null : this.key.array(),
-                this.value == null ? null : this.value.array()
+                args.timestamp,
+                args.key == null ? null : args.key.array(),
+                args.value == null ? null : args.value.array()
         ));
         assertTrue(record.isValid());
         for (int i = LegacyRecord.CRC_OFFSET + LegacyRecord.CRC_LENGTH; i < record.sizeInBytes(); i++) {
             LegacyRecord copy = copyOf(record);
             copy.buffer().put(i, (byte) 69);
             assertFalse(copy.isValid());
-            try {
-                copy.ensureValid();
-                fail("Should fail the above test.");
-            } catch (CorruptRecordException e) {
-                // this is good
-            }
+            assertThrows(CorruptRecordException.class, copy::ensureValid);
         }
     }
 
@@ -108,23 +133,10 @@ public class LegacyRecordTest {
         return new LegacyRecord(buffer);
     }
 
-    @Test
-    public void testEquality() {
-        assertEquals(record, copyOf(record));
-    }
-
-    @Parameters
-    public static Collection<Object[]> data() {
-        byte[] payload = new byte[1000];
-        Arrays.fill(payload, (byte) 1);
-        List<Object[]> values = new ArrayList<>();
-        for (byte magic : Arrays.asList(RecordBatch.MAGIC_VALUE_V0, RecordBatch.MAGIC_VALUE_V1))
-            for (long timestamp : Arrays.asList(RecordBatch.NO_TIMESTAMP, 0L, 1L))
-                for (byte[] key : Arrays.asList(null, "".getBytes(), "key".getBytes(), payload))
-                    for (byte[] value : Arrays.asList(null, "".getBytes(), "value".getBytes(), payload))
-                        for (CompressionType compression : CompressionType.values())
-                            values.add(new Object[] {magic, timestamp, key, value, compression});
-        return values;
+    @ParameterizedTest
+    @ArgumentsSource(LegacyRecordArgumentsProvider.class)
+    public void testEquality(Args args) {
+        assertEquals(args.record, copyOf(args.record));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/MultiRecordsSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MultiRecordsSendTest.java
@@ -19,15 +19,15 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.network.ByteBufferSend;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultiRecordsSendTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/record/SimpleLegacyRecordTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/SimpleLegacyRecordTest.java
@@ -20,14 +20,14 @@ import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataOutputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SimpleLegacyRecordTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/replica/ReplicaSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/replica/ReplicaSelectorTest.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.replica;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.util.HashSet;
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.kafka.test.TestUtils.assertOptional;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReplicaSelectorTest {
 
@@ -45,19 +45,19 @@ public class ReplicaSelectorTest {
         ReplicaSelector selector = new RackAwareReplicaSelector();
         Optional<ReplicaView> selected = selector.select(tp, metadata("rack-b"), partitionView);
         assertOptional(selected, replicaInfo -> {
-            assertEquals("Expect replica to be in rack-b", replicaInfo.endpoint().rack(), "rack-b");
-            assertEquals("Expected replica 3 since it is more caught-up", replicaInfo.endpoint().id(), 3);
+            assertEquals(replicaInfo.endpoint().rack(), "rack-b", "Expect replica to be in rack-b");
+            assertEquals(replicaInfo.endpoint().id(), 3, "Expected replica 3 since it is more caught-up");
         });
 
         selected = selector.select(tp, metadata("not-a-rack"), partitionView);
         assertOptional(selected, replicaInfo -> {
-            assertEquals("Expect leader when we can't find any nodes in given rack", replicaInfo, leader);
+            assertEquals(replicaInfo, leader, "Expect leader when we can't find any nodes in given rack");
         });
 
         selected = selector.select(tp, metadata("rack-a"), partitionView);
         assertOptional(selected, replicaInfo -> {
-            assertEquals("Expect replica to be in rack-a", replicaInfo.endpoint().rack(), "rack-a");
-            assertEquals("Expect the leader since it's in rack-a", replicaInfo, leader);
+            assertEquals(replicaInfo.endpoint().rack(), "rack-a", "Expect replica to be in rack-a");
+            assertEquals(replicaInfo, leader, "Expect the leader since it's in rack-a");
         });
 
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/AddPartitionsToTxnRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AddPartitionsToTxnRequestTest.java
@@ -19,14 +19,14 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AddPartitionsToTxnRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/AddPartitionsToTxnResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AddPartitionsToTxnResponseTest.java
@@ -23,13 +23,13 @@ import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartiti
 import org.apache.kafka.common.message.AddPartitionsToTxnResponseData.AddPartitionsToTxnTopicResultCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AddPartitionsToTxnResponseTest {
 
@@ -47,7 +47,7 @@ public class AddPartitionsToTxnResponseTest {
     protected Map<Errors, Integer> expectedErrorCounts;
     protected Map<TopicPartition, Errors> errorsMap;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         expectedErrorCounts = new HashMap<>();
         expectedErrorCounts.put(errorOne, 1);

--- a/clients/src/test/java/org/apache/kafka/common/requests/AlterReplicaLogDirsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AlterReplicaLogDirsRequestTest.java
@@ -28,11 +28,11 @@ import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData.AlterRepli
 import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData.AlterReplicaLogDirTopicCollection;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirTopicResult;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlterReplicaLogDirsRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/AlterReplicaLogDirsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AlterReplicaLogDirsResponseTest.java
@@ -22,10 +22,10 @@ import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirPartitionResult;
 import org.apache.kafka.common.message.AlterReplicaLogDirsResponseData.AlterReplicaLogDirTopicResult;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlterReplicaLogDirsResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -19,16 +19,16 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionsResponseKey;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ApiVersionsResponseTest {
 
@@ -43,28 +43,28 @@ public class ApiVersionsResponseTest {
     @Test
     public void shouldHaveCorrectDefaultApiVersionsResponse() {
         Collection<ApiVersionsResponseKey> apiVersions = ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.data().apiKeys();
-        assertEquals("API versions for all API keys must be maintained.", apiVersions.size(), ApiKeys.enabledApis().size());
+        assertEquals(apiVersions.size(), ApiKeys.enabledApis().size(), "API versions for all API keys must be maintained.");
 
         for (ApiKeys key : ApiKeys.enabledApis()) {
             ApiVersionsResponseKey version = ApiVersionsResponse.DEFAULT_API_VERSIONS_RESPONSE.apiVersion(key.id);
-            assertNotNull("Could not find ApiVersion for API " + key.name, version);
-            assertEquals("Incorrect min version for Api " + key.name, version.minVersion(), key.oldestVersion());
-            assertEquals("Incorrect max version for Api " + key.name, version.maxVersion(), key.latestVersion());
+            assertNotNull(version, "Could not find ApiVersion for API " + key.name);
+            assertEquals(version.minVersion(), key.oldestVersion(), "Incorrect min version for Api " + key.name);
+            assertEquals(version.maxVersion(), key.latestVersion(), "Incorrect max version for Api " + key.name);
 
             // Check if versions less than min version are indeed set as null, i.e., deprecated.
             for (int i = 0; i < version.minVersion(); ++i) {
-                assertNull("Request version " + i + " for API " + version.apiKey() + " must be null",
-                    key.messageType.requestSchemas()[i]);
-                assertNull("Response version " + i + " for API " + version.apiKey() + " must be null",
-                    key.messageType.responseSchemas()[i]);
+                assertNull(
+                        key.messageType.requestSchemas()[i], "Request version " + i + " for API " + version.apiKey() + " must be null");
+                assertNull(
+                        key.messageType.responseSchemas()[i], "Response version " + i + " for API " + version.apiKey() + " must be null");
             }
 
             // Check if versions between min and max versions are non null, i.e., valid.
             for (int i = version.minVersion(); i <= version.maxVersion(); ++i) {
-                assertNotNull("Request version " + i + " for API " + version.apiKey() + " must not be null",
-                    key.messageType.requestSchemas()[i]);
-                assertNotNull("Response version " + i + " for API " + version.apiKey() + " must not be null",
-                    key.messageType.responseSchemas()[i]);
+                assertNotNull(
+                        key.messageType.requestSchemas()[i], "Request version " + i + " for API " + version.apiKey() + " must not be null");
+                assertNotNull(
+                        key.messageType.responseSchemas()[i], "Response version " + i + " for API " + version.apiKey() + " must not be null");
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ApiVersionsResponseTest.java
@@ -53,18 +53,18 @@ public class ApiVersionsResponseTest {
 
             // Check if versions less than min version are indeed set as null, i.e., deprecated.
             for (int i = 0; i < version.minVersion(); ++i) {
-                assertNull(
-                        key.messageType.requestSchemas()[i], "Request version " + i + " for API " + version.apiKey() + " must be null");
-                assertNull(
-                        key.messageType.responseSchemas()[i], "Response version " + i + " for API " + version.apiKey() + " must be null");
+                assertNull(key.messageType.requestSchemas()[i],
+                    "Request version " + i + " for API " + version.apiKey() + " must be null");
+                assertNull(key.messageType.responseSchemas()[i],
+                    "Response version " + i + " for API " + version.apiKey() + " must be null");
             }
 
             // Check if versions between min and max versions are non null, i.e., valid.
             for (int i = version.minVersion(); i <= version.maxVersion(); ++i) {
-                assertNotNull(
-                        key.messageType.requestSchemas()[i], "Request version " + i + " for API " + version.apiKey() + " must not be null");
-                assertNotNull(
-                        key.messageType.responseSchemas()[i], "Response version " + i + " for API " + version.apiKey() + " must not be null");
+                assertNotNull(key.messageType.requestSchemas()[i],
+                    "Request version " + i + " for API " + version.apiKey() + " must not be null");
+                assertNotNull(key.messageType.responseSchemas()[i],
+                    "Response version " + i + " for API " + version.apiKey() + " must not be null");
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ByteBufferChannelTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ByteBufferChannelTest.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/clients/src/test/java/org/apache/kafka/common/requests/ControlledShutdownRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ControlledShutdownRequestTest.java
@@ -20,11 +20,11 @@ import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ControlledShutdownRequestData;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.protocol.ApiKeys.CONTROLLED_SHUTDOWN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ControlledShutdownRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/CreateAclsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/CreateAclsRequestTest.java
@@ -26,15 +26,15 @@ import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CreateAclsRequestTest {
     private static final short V0 = 0;
@@ -83,7 +83,7 @@ public class CreateAclsRequestTest {
     }
 
     private static void assertRequestEquals(final CreateAclsRequest original, final CreateAclsRequest actual) {
-        assertEquals("Number of Acls wrong", original.aclCreations().size(), actual.aclCreations().size());
+        assertEquals(original.aclCreations().size(), actual.aclCreations().size(), "Number of Acls wrong");
 
         for (int idx = 0; idx != original.aclCreations().size(); ++idx) {
             final AclBinding originalBinding = CreateAclsRequest.aclBinding(original.aclCreations().get(idx));

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsRequestTest.java
@@ -26,14 +26,14 @@ import org.apache.kafka.common.message.DeleteAclsRequestData;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DeleteAclsRequestTest {
     private static final short V0 = 0;
@@ -100,7 +100,7 @@ public class DeleteAclsRequestTest {
     }
 
     private static void assertRequestEquals(final DeleteAclsRequest original, final DeleteAclsRequest actual) {
-        assertEquals("Number of filters wrong", original.filters().size(), actual.filters().size());
+        assertEquals(original.filters().size(), actual.filters().size(), "Number of filters wrong");
 
         for (int idx = 0; idx != original.filters().size(); ++idx) {
             final AclBindingFilter originalFilter = original.filters().get(idx);

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteAclsResponseTest.java
@@ -25,14 +25,14 @@ import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsFilterRe
 import org.apache.kafka.common.message.DeleteAclsResponseData.DeleteAclsMatchingAcl;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DeleteAclsResponseTest {
     private static final short V0 = 0;

--- a/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DeleteGroupsResponseTest.java
@@ -20,14 +20,14 @@ import org.apache.kafka.common.message.DeleteGroupsResponseData;
 import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResult;
 import org.apache.kafka.common.message.DeleteGroupsResponseData.DeletableGroupResultCollection;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DeleteGroupsResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsRequestTest.java
@@ -25,10 +25,10 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePatternFilter;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DescribeAclsRequestTest {
     private static final short V0 = 0;

--- a/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/DescribeAclsResponseTest.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -38,8 +38,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DescribeAclsResponseTest {
     private static final short V0 = 0;

--- a/clients/src/test/java/org/apache/kafka/common/requests/EndTxnRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/EndTxnRequestTest.java
@@ -19,11 +19,11 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.EndTxnRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EndTxnRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/EndTxnResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/EndTxnResponseTest.java
@@ -19,12 +19,12 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.EndTxnResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EndTxnResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/EnvelopeRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/EnvelopeRequestTest.java
@@ -23,13 +23,13 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class EnvelopeRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/HeartbeatRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/HeartbeatRequestTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.HeartbeatRequestData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HeartbeatRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -21,15 +21,15 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class JoinGroupRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrRequestTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrParti
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,9 +43,9 @@ import java.util.stream.StreamSupport;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.kafka.common.protocol.ApiKeys.LEADER_AND_ISR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LeaderAndIsrRequestTest {
 
@@ -192,7 +192,7 @@ public class LeaderAndIsrRequestTest {
 
         LeaderAndIsrRequest v2 = builder.build((short) 2);
         LeaderAndIsrRequest v1 = builder.build((short) 1);
-        assertTrue("Expected v2 < v1: v2=" + v2.sizeInBytes() + ", v1=" + v1.sizeInBytes(), v2.sizeInBytes() < v1.sizeInBytes());
+        assertTrue(v2.sizeInBytes() < v1.sizeInBytes(), "Expected v2 < v1: v2=" + v2.sizeInBytes() + ", v1=" + v1.sizeInBytes());
     }
 
     private <T> Set<T> iterableToSet(Iterable<T> iterable) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrTopi
 import org.apache.kafka.common.message.LeaderAndIsrResponseData.LeaderAndIsrPartitionError;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,8 +32,8 @@ import java.util.Map;
 
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.protocol.ApiKeys.LEADER_AND_ISR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LeaderAndIsrResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupRequestTest.java
@@ -22,17 +22,17 @@ import org.apache.kafka.common.message.LeaveGroupRequestData.MemberIdentity;
 import org.apache.kafka.common.message.LeaveGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class LeaveGroupRequestTest {
 
@@ -47,7 +47,7 @@ public class LeaveGroupRequestTest {
     private LeaveGroupRequest.Builder builder;
     private List<MemberIdentity> members;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         members = Arrays.asList(new MemberIdentity()
                                          .setMemberId(memberIdOne)

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaveGroupResponseTest.java
@@ -21,8 +21,8 @@ import org.apache.kafka.common.message.LeaveGroupResponseData.MemberResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -32,9 +32,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LeaveGroupResponseTest {
 
@@ -47,7 +47,7 @@ public class LeaveGroupResponseTest {
 
     private List<MemberResponse> memberResponses;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         memberResponses = Arrays.asList(new MemberResponse()
                                             .setMemberId(memberIdOne)

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.kafka.common.requests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +36,7 @@ import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicR
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ListOffsetsRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/MetadataRequestTest.java
@@ -18,14 +18,14 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MetadataRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitRequestTest.java
@@ -25,8 +25,8 @@ import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResp
 import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,8 +35,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.requests.OffsetCommitRequest.getErrorResponseTopics;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OffsetCommitRequestTest {
 
@@ -56,7 +56,7 @@ public class OffsetCommitRequestTest {
     private static OffsetCommitRequestData data;
     private static List<OffsetCommitRequestTopic> topics;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         topics = Arrays.asList(
             new OffsetCommitRequestTopic()

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetCommitResponseTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.message.OffsetCommitResponseData.OffsetCommitResp
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -33,7 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OffsetCommitResponseTest {
 
@@ -51,7 +51,7 @@ public class OffsetCommitResponseTest {
     protected Map<Errors, Integer> expectedErrorCounts;
     protected Map<TopicPartition, Errors> errorsMap;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         expectedErrorCounts = new HashMap<>();
         expectedErrorCounts.put(errorOne, 1);

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
@@ -84,8 +84,8 @@ public class OffsetFetchRequestTest {
             OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
             assertEquals(Errors.NONE, response.error());
             assertFalse(response.hasError());
-            assertEquals(
-                    Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(), "Incorrect error count for version " + version);
+            assertEquals(Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(),
+                "Incorrect error count for version " + version);
 
             if (version <= 1) {
                 assertEquals(expectedData, response.responseData());

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
@@ -21,8 +21,8 @@ import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,11 +32,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OffsetFetchRequestTest {
 
@@ -49,7 +49,7 @@ public class OffsetFetchRequestTest {
     private OffsetFetchRequest.Builder builder;
     private List<TopicPartition> partitions;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         partitions = Arrays.asList(new TopicPartition(topicOne, partitionOne),
                                    new TopicPartition(topicTwo, partitionTwo));
@@ -84,8 +84,8 @@ public class OffsetFetchRequestTest {
             OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
             assertEquals(Errors.NONE, response.error());
             assertFalse(response.hasError());
-            assertEquals("Incorrect error count for version " + version,
-                    Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts());
+            assertEquals(
+                    Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(), "Incorrect error count for version " + version);
 
             if (version <= 1) {
                 assertEquals(expectedData, response.responseData());

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -89,7 +89,7 @@ public class OffsetFetchResponseTest {
         Map<TopicPartition, PartitionData> responseData = response.responseData();
         assertEquals(partitionDataMap, responseData);
         responseData.forEach(
-            (tp, data) -> Assertions.assertTrue(data.hasError())
+            (tp, data) -> assertTrue(data.hasError())
         );
     }
 
@@ -150,7 +150,7 @@ public class OffsetFetchResponseTest {
             Map<TopicPartition, PartitionData> responseData = oldResponse.responseData();
             assertEquals(expectedDataMap, responseData);
 
-            responseData.forEach((tp, data) -> Assertions.assertTrue(data.hasError()));
+            responseData.forEach((tp, data) -> assertTrue(data.hasError()));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -26,8 +26,9 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,9 +36,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OffsetFetchResponseTest {
 
@@ -56,7 +57,7 @@ public class OffsetFetchResponseTest {
 
     private Map<TopicPartition, PartitionData> partitionDataMap;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         partitionDataMap = new HashMap<>();
         partitionDataMap.put(new TopicPartition(topicOne, partitionOne), new PartitionData(
@@ -88,7 +89,7 @@ public class OffsetFetchResponseTest {
         Map<TopicPartition, PartitionData> responseData = response.responseData();
         assertEquals(partitionDataMap, responseData);
         responseData.forEach(
-            (tp, data) -> assertTrue(data.hasError())
+            (tp, data) -> Assertions.assertTrue(data.hasError())
         );
     }
 
@@ -149,7 +150,7 @@ public class OffsetFetchResponseTest {
             Map<TopicPartition, PartitionData> responseData = oldResponse.responseData();
             assertEquals(expectedDataMap, responseData);
 
-            responseData.forEach((tp, data) -> assertTrue(data.hasError()));
+            responseData.forEach((tp, data) -> Assertions.assertTrue(data.hasError()));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequestTest.java
@@ -19,10 +19,10 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopicCollection;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OffsetsForLeaderEpochRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ProduceRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ProduceRequestTest.java
@@ -302,8 +302,8 @@ public class ProduceRequestTest {
             builder.build(version).serialize();
             fail("Builder did not raise " + InvalidRecordException.class.getName() + " as expected");
         } catch (RuntimeException e) {
-            assertTrue(
-                    InvalidRecordException.class.isAssignableFrom(e.getClass()), "Unexpected exception type " + e.getClass().getName());
+            assertTrue(InvalidRecordException.class.isAssignableFrom(e.getClass()),
+                "Unexpected exception type " + e.getClass().getName());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ProduceRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ProduceRequestTest.java
@@ -27,16 +27,16 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.RecordVersion;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProduceRequestTest {
 
@@ -302,8 +302,8 @@ public class ProduceRequestTest {
             builder.build(version).serialize();
             fail("Builder did not raise " + InvalidRecordException.class.getName() + " as expected");
         } catch (RuntimeException e) {
-            assertTrue("Unexpected exception type " + e.getClass().getName(),
-                    InvalidRecordException.class.isAssignableFrom(e.getClass()));
+            assertTrue(
+                    InvalidRecordException.class.isAssignableFrom(e.getClass()), "Unexpected exception type " + e.getClass().getName());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/ProduceResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ProduceResponseTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -29,9 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProduceResponseTest {
 
@@ -70,12 +70,12 @@ public class ProduceResponseTest {
         ProduceResponse v0Response = new ProduceResponse(responseData);
         ProduceResponse v1Response = new ProduceResponse(responseData, 10);
         ProduceResponse v2Response = new ProduceResponse(responseData, 10);
-        assertEquals("Throttle time must be zero", 0, v0Response.throttleTimeMs());
-        assertEquals("Throttle time must be 10", 10, v1Response.throttleTimeMs());
-        assertEquals("Throttle time must be 10", 10, v2Response.throttleTimeMs());
-        assertEquals("Response data does not match", responseData, v0Response.responses());
-        assertEquals("Response data does not match", responseData, v1Response.responses());
-        assertEquals("Response data does not match", responseData, v2Response.responses());
+        assertEquals(0, v0Response.throttleTimeMs(), "Throttle time must be zero");
+        assertEquals(10, v1Response.throttleTimeMs(), "Throttle time must be 10");
+        assertEquals(10, v2Response.throttleTimeMs(), "Throttle time must be 10");
+        assertEquals(responseData, v0Response.responses(), "Response data does not match");
+        assertEquals(responseData, v1Response.responses(), "Response data does not match");
+        assertEquals(responseData, v2Response.responses(), "Response data does not match");
     }
 
     @SuppressWarnings("deprecation")

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -26,13 +26,13 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RequestContextTest {
 
@@ -99,7 +99,7 @@ public class RequestContextTest {
             ClientInformation.EMPTY, true);
 
         ByteBuffer buffer = context.buildResponseEnvelopePayload(new CreateTopicsResponse(expectedResponse));
-        assertEquals("Buffer limit and capacity should be the same", buffer.capacity(), buffer.limit());
+        assertEquals(buffer.capacity(), buffer.limit(), "Buffer limit and capacity should be the same");
         CreateTopicsResponse parsedResponse = (CreateTopicsResponse) AbstractResponse.parseResponse(buffer, header);
         assertEquals(expectedResponse, parsedResponse.data());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestHeaderTest.java
@@ -18,11 +18,11 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RequestHeaderTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -184,7 +184,7 @@ import org.apache.kafka.common.security.token.delegation.DelegationToken;
 import org.apache.kafka.common.security.token.delegation.TokenInformation;
 import org.apache.kafka.common.utils.SecurityUtils;
 import org.apache.kafka.common.utils.Utils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -210,13 +210,13 @@ import static org.apache.kafka.common.protocol.ApiKeys.LIST_GROUPS;
 import static org.apache.kafka.common.protocol.ApiKeys.LIST_OFFSETS;
 import static org.apache.kafka.common.protocol.ApiKeys.SYNC_GROUP;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RequestResponseTest {
 
@@ -541,25 +541,25 @@ public class RequestResponseTest {
                 DescribeConfigsResourceResult actualEntry = actualEntries.get(i);
                 DescribeConfigsResourceResult expectedEntry = expectedEntries.get(i);
                 assertEquals(expectedEntry.name(), actualEntry.name());
-                assertEquals("Non-matching values for " + actualEntry.name() + " in version " + version,
-                        expectedEntry.value(), actualEntry.value());
-                assertEquals("Non-matching readonly for " + actualEntry.name() + " in version " + version,
-                        expectedEntry.readOnly(), actualEntry.readOnly());
-                assertEquals("Non-matching isSensitive for " + actualEntry.name() + " in version " + version,
-                        expectedEntry.isSensitive(), actualEntry.isSensitive());
+                assertEquals(
+                        expectedEntry.value(), actualEntry.value(), "Non-matching values for " + actualEntry.name() + " in version " + version);
+                assertEquals(
+                        expectedEntry.readOnly(), actualEntry.readOnly(), "Non-matching readonly for " + actualEntry.name() + " in version " + version);
+                assertEquals(
+                        expectedEntry.isSensitive(), actualEntry.isSensitive(), "Non-matching isSensitive for " + actualEntry.name() + " in version " + version);
                 if (version < 3) {
-                    assertEquals("Non-matching configType for " + actualEntry.name() + " in version " + version,
-                            ConfigType.UNKNOWN.id(), actualEntry.configType());
+                    assertEquals(
+                            ConfigType.UNKNOWN.id(), actualEntry.configType(), "Non-matching configType for " + actualEntry.name() + " in version " + version);
                 } else {
-                    assertEquals("Non-matching configType for " + actualEntry.name() + " in version " + version,
-                            expectedEntry.configType(), actualEntry.configType());
+                    assertEquals(
+                            expectedEntry.configType(), actualEntry.configType(), "Non-matching configType for " + actualEntry.name() + " in version " + version);
                 }
                 if (version == 0) {
-                    assertEquals("Non matching configSource for " + actualEntry.name() + " in version " + version,
-                            DescribeConfigsResponse.ConfigSource.STATIC_BROKER_CONFIG.id(), actualEntry.configSource());
+                    assertEquals(
+                            DescribeConfigsResponse.ConfigSource.STATIC_BROKER_CONFIG.id(), actualEntry.configSource(), "Non matching configSource for " + actualEntry.name() + " in version " + version);
                 } else {
-                    assertEquals("Non-matching configSource for " + actualEntry.name() + " in version " + version,
-                            expectedEntry.configSource(), actualEntry.configSource());
+                    assertEquals(
+                            expectedEntry.configSource(), actualEntry.configSource(), "Non-matching configSource for " + actualEntry.name() + " in version " + version);
                 }
             }
         }
@@ -580,8 +580,8 @@ public class RequestResponseTest {
         checkResponse(response, req.version(), checkEqualityAndHashCode);
         if (e instanceof UnknownServerException) {
             String responseStr = response.toString();
-            assertFalse(String.format("Unknown message included in response for %s: %s ", req.apiKey(), responseStr),
-                    responseStr.contains(e.getMessage()));
+            assertFalse(
+                    responseStr.contains(e.getMessage()), String.format("Unknown message included in response for %s: %s ", req.apiKey(), responseStr));
         }
     }
 
@@ -595,7 +595,7 @@ public class RequestResponseTest {
             ByteBuffer serializedBytes2 = deserialized.serialize();
             serializedBytes.rewind();
             if (checkEquality)
-                assertEquals("Request " + req + "failed equality test", serializedBytes, serializedBytes2);
+                assertEquals(serializedBytes, serializedBytes2, "Request " + req + "failed equality test");
         } catch (Exception e) {
             throw new RuntimeException("Failed to deserialize request " + req + " with type " + req.getClass(), e);
         }
@@ -611,7 +611,7 @@ public class RequestResponseTest {
             ByteBuffer serializedBytes2 = deserialized.serialize((short) version);
             serializedBytes.rewind();
             if (checkEquality)
-                assertEquals("Response " + response + "failed equality test", serializedBytes, serializedBytes2);
+                assertEquals(serializedBytes, serializedBytes2, "Response " + response + "failed equality test");
         } catch (Exception e) {
             throw new RuntimeException("Failed to deserialize response " + response + " with type " + response.getClass(), e);
         }
@@ -710,10 +710,10 @@ public class RequestResponseTest {
 
         FetchResponse<MemoryRecords> v0Response = new FetchResponse<>(Errors.NONE, responseData, 0, INVALID_SESSION_ID);
         FetchResponse<MemoryRecords> v1Response = new FetchResponse<>(Errors.NONE, responseData, 10, INVALID_SESSION_ID);
-        assertEquals("Throttle time must be zero", 0, v0Response.throttleTimeMs());
-        assertEquals("Throttle time must be 10", 10, v1Response.throttleTimeMs());
-        assertEquals("Response data does not match", responseData, v0Response.responseData());
-        assertEquals("Response data does not match", responseData, v1Response.responseData());
+        assertEquals(0, v0Response.throttleTimeMs(), "Throttle time must be zero");
+        assertEquals(10, v1Response.throttleTimeMs(), "Throttle time must be 10");
+        assertEquals(responseData, v0Response.responseData(), "Response data does not match");
+        assertEquals(responseData, v1Response.responseData(), "Response data does not match");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -541,25 +541,25 @@ public class RequestResponseTest {
                 DescribeConfigsResourceResult actualEntry = actualEntries.get(i);
                 DescribeConfigsResourceResult expectedEntry = expectedEntries.get(i);
                 assertEquals(expectedEntry.name(), actualEntry.name());
-                assertEquals(
-                        expectedEntry.value(), actualEntry.value(), "Non-matching values for " + actualEntry.name() + " in version " + version);
-                assertEquals(
-                        expectedEntry.readOnly(), actualEntry.readOnly(), "Non-matching readonly for " + actualEntry.name() + " in version " + version);
-                assertEquals(
-                        expectedEntry.isSensitive(), actualEntry.isSensitive(), "Non-matching isSensitive for " + actualEntry.name() + " in version " + version);
+                assertEquals(expectedEntry.value(), actualEntry.value(),
+                    "Non-matching values for " + actualEntry.name() + " in version " + version);
+                assertEquals(expectedEntry.readOnly(), actualEntry.readOnly(),
+                    "Non-matching readonly for " + actualEntry.name() + " in version " + version);
+                assertEquals(expectedEntry.isSensitive(), actualEntry.isSensitive(),
+                    "Non-matching isSensitive for " + actualEntry.name() + " in version " + version);
                 if (version < 3) {
-                    assertEquals(
-                            ConfigType.UNKNOWN.id(), actualEntry.configType(), "Non-matching configType for " + actualEntry.name() + " in version " + version);
+                    assertEquals(ConfigType.UNKNOWN.id(), actualEntry.configType(),
+                        "Non-matching configType for " + actualEntry.name() + " in version " + version);
                 } else {
-                    assertEquals(
-                            expectedEntry.configType(), actualEntry.configType(), "Non-matching configType for " + actualEntry.name() + " in version " + version);
+                    assertEquals(expectedEntry.configType(), actualEntry.configType(),
+                        "Non-matching configType for " + actualEntry.name() + " in version " + version);
                 }
                 if (version == 0) {
-                    assertEquals(
-                            DescribeConfigsResponse.ConfigSource.STATIC_BROKER_CONFIG.id(), actualEntry.configSource(), "Non matching configSource for " + actualEntry.name() + " in version " + version);
+                    assertEquals(DescribeConfigsResponse.ConfigSource.STATIC_BROKER_CONFIG.id(), actualEntry.configSource(),
+                        "Non matching configSource for " + actualEntry.name() + " in version " + version);
                 } else {
-                    assertEquals(
-                            expectedEntry.configSource(), actualEntry.configSource(), "Non-matching configSource for " + actualEntry.name() + " in version " + version);
+                    assertEquals(expectedEntry.configSource(), actualEntry.configSource(),
+                        "Non-matching configSource for " + actualEntry.name() + " in version " + version);
                 }
             }
         }
@@ -580,8 +580,8 @@ public class RequestResponseTest {
         checkResponse(response, req.version(), checkEqualityAndHashCode);
         if (e instanceof UnknownServerException) {
             String responseStr = response.toString();
-            assertFalse(
-                    responseStr.contains(e.getMessage()), String.format("Unknown message included in response for %s: %s ", req.apiKey(), responseStr));
+            assertFalse(responseStr.contains(e.getMessage()),
+                String.format("Unknown message included in response for %s: %s ", req.apiKey(), responseStr));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaRequestTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.message.StopReplicaRequestData.StopReplicaTopicV1
 import org.apache.kafka.common.message.StopReplicaRequestData.StopReplicaTopicState;
 import org.apache.kafka.common.message.StopReplicaResponseData.StopReplicaPartitionError;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,10 +37,10 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.common.protocol.ApiKeys.STOP_REPLICA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StopReplicaRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.message.StopReplicaRequestData.StopReplicaTopicSt
 import org.apache.kafka.common.message.StopReplicaResponseData;
 import org.apache.kafka.common.message.StopReplicaResponseData.StopReplicaPartitionError;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,8 +30,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.common.protocol.ApiKeys.STOP_REPLICA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StopReplicaResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/SyncGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/SyncGroupRequestTest.java
@@ -18,9 +18,9 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.SyncGroupRequestData;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SyncGroupRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitRequestTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.common.message.TxnOffsetCommitRequestData.TxnOffsetCommi
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest.CommittedOffset;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
 
@@ -47,7 +47,7 @@ public class TxnOffsetCommitRequestTest extends OffsetCommitRequestTest {
     private static TxnOffsetCommitRequest.Builder builder;
     private static TxnOffsetCommitRequest.Builder builderWithGroupMetadata;
 
-    @Before
+    @BeforeEach
     @Override
     public void setUp() {
         super.setUp();

--- a/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/TxnOffsetCommitResponseTest.java
@@ -19,12 +19,12 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.message.TxnOffsetCommitResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.MessageUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TxnOffsetCommitResponseTest extends OffsetCommitResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateFeaturesRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateFeaturesRequestTest.java
@@ -19,11 +19,11 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.UpdateFeaturesRequestData;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpdateFeaturesRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateFeaturesResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateFeaturesResponseTest.java
@@ -18,11 +18,11 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.UpdateFeaturesResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UpdateFeaturesResponseTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -45,9 +45,9 @@ import java.util.stream.StreamSupport;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.kafka.common.protocol.ApiKeys.UPDATE_METADATA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UpdateMetadataRequestTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/WriteTxnMarkersRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/WriteTxnMarkersRequestTest.java
@@ -19,13 +19,13 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WriteTxnMarkersRequestTest {
 
@@ -39,7 +39,7 @@ public class WriteTxnMarkersRequestTest {
 
     private static List<WriteTxnMarkersRequest.TxnMarkerEntry> markers;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         markers = Collections.singletonList(
              new WriteTxnMarkersRequest.TxnMarkerEntry(

--- a/clients/src/test/java/org/apache/kafka/common/requests/WriteTxnMarkersResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/WriteTxnMarkersResponseTest.java
@@ -18,14 +18,14 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WriteTxnMarkersResponseTest {
 
@@ -40,7 +40,7 @@ public class WriteTxnMarkersResponseTest {
 
     private static Map<Long, Map<TopicPartition, Errors>> errorMap;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         errorMap = new HashMap<>();
         errorMap.put(producerIdOne, Collections.singletonMap(tp1, pidOneError));

--- a/clients/src/test/java/org/apache/kafka/common/resource/ResourceFilterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/resource/ResourceFilterTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.kafka.common.resource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.kafka.common.resource.ResourceType.ANY;
 import static org.apache.kafka.common.resource.ResourceType.GROUP;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourceFilterTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.common.resource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResourceTypeTest {
     private static class AclResourceTypeTestInfo {
@@ -48,8 +48,8 @@ public class ResourceTypeTest {
     @Test
     public void testIsUnknown() {
         for (AclResourceTypeTestInfo info : INFOS) {
-            assertEquals(info.resourceType + " was supposed to have unknown == " + info.unknown,
-                info.unknown, info.resourceType.isUnknown());
+            assertEquals(
+                    info.unknown, info.resourceType.isUnknown(), info.resourceType + " was supposed to have unknown == " + info.unknown);
         }
     }
 
@@ -57,10 +57,10 @@ public class ResourceTypeTest {
     public void testCode() {
         assertEquals(ResourceType.values().length, INFOS.length);
         for (AclResourceTypeTestInfo info : INFOS) {
-            assertEquals(info.resourceType + " was supposed to have code == " + info.code,
-                info.code, info.resourceType.code());
-            assertEquals("AclResourceType.fromCode(" + info.code + ") was supposed to be " +
-                info.resourceType, info.resourceType, ResourceType.fromCode((byte) info.code));
+            assertEquals(
+                    info.code, info.resourceType.code(), info.resourceType + " was supposed to have code == " + info.code);
+            assertEquals(info.resourceType, ResourceType.fromCode((byte) info.code), "AclResourceType.fromCode(" + info.code + ") was supposed to be " +
+                info.resourceType);
         }
         assertEquals(ResourceType.UNKNOWN, ResourceType.fromCode((byte) 120));
     }
@@ -68,8 +68,8 @@ public class ResourceTypeTest {
     @Test
     public void testName() {
         for (AclResourceTypeTestInfo info : INFOS) {
-            assertEquals("ResourceType.fromString(" + info.name + ") was supposed to be " +
-                info.resourceType, info.resourceType, ResourceType.fromString(info.name));
+            assertEquals(info.resourceType, ResourceType.fromString(info.name), "ResourceType.fromString(" + info.name + ") was supposed to be " +
+                info.resourceType);
         }
         assertEquals(ResourceType.UNKNOWN, ResourceType.fromString("something"));
     }

--- a/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
@@ -48,8 +48,8 @@ public class ResourceTypeTest {
     @Test
     public void testIsUnknown() {
         for (AclResourceTypeTestInfo info : INFOS) {
-            assertEquals(
-                    info.unknown, info.resourceType.isUnknown(), info.resourceType + " was supposed to have unknown == " + info.unknown);
+            assertEquals(info.unknown, info.resourceType.isUnknown(),
+                info.resourceType + " was supposed to have unknown == " + info.unknown);
         }
     }
 
@@ -57,8 +57,8 @@ public class ResourceTypeTest {
     public void testCode() {
         assertEquals(ResourceType.values().length, INFOS.length);
         for (AclResourceTypeTestInfo info : INFOS) {
-            assertEquals(
-                    info.code, info.resourceType.code(), info.resourceType + " was supposed to have code == " + info.code);
+            assertEquals(info.code, info.resourceType.code(),
+                info.resourceType + " was supposed to have code == " + info.code);
             assertEquals(info.resourceType, ResourceType.fromCode((byte) info.code), "AclResourceType.fromCode(" + info.code + ") was supposed to be " +
                 info.resourceType);
         }

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasContextTest.java
@@ -30,17 +30,17 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
 import javax.security.auth.login.Configuration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.ListenerName;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests parsing of {@link SaslConfigs#SASL_JAAS_CONFIG} property and verifies that the format
@@ -50,7 +50,7 @@ public class JaasContextTest {
 
     private File jaasConfigFile;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
         jaasConfigFile = File.createTempFile("jaas", ".conf");
         jaasConfigFile.deleteOnExit();
@@ -58,7 +58,7 @@ public class JaasContextTest {
         Configuration.setConfiguration(null);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         Files.delete(jaasConfigFile.toPath());
     }
@@ -278,7 +278,7 @@ public class JaasContextTest {
     private void checkConfiguration(String jaasConfigProp, String loginModule, LoginModuleControlFlag controlFlag, Map<String, Object> options) throws Exception {
         AppConfigurationEntry dynamicEntry = configurationEntry(JaasContext.Type.CLIENT, jaasConfigProp);
         checkEntry(dynamicEntry, loginModule, controlFlag, options);
-        assertNull("Static configuration updated", Configuration.getConfiguration().getAppConfigurationEntry(JaasContext.Type.CLIENT.name()));
+        assertNull(Configuration.getConfiguration().getAppConfigurationEntry(JaasContext.Type.CLIENT.name()), "Static configuration updated");
 
         writeConfiguration(JaasContext.Type.SERVER.name(), jaasConfigProp);
         AppConfigurationEntry staticEntry = configurationEntry(JaasContext.Type.SERVER, null);

--- a/clients/src/test/java/org/apache/kafka/common/security/SaslExtensionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/SaslExtensionsTest.java
@@ -17,19 +17,19 @@
 package org.apache.kafka.common.security;
 
 import org.apache.kafka.common.security.auth.SaslExtensions;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SaslExtensionsTest {
     Map<String, String> map;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.map = new HashMap<>();
         this.map.put("what", "42");

--- a/clients/src/test/java/org/apache/kafka/common/security/auth/DefaultKafkaPrincipalBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/auth/DefaultKafkaPrincipalBuilderTest.java
@@ -24,14 +24,14 @@ import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuild
 import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.common.security.ssl.SslPrincipalMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLSession;
 import javax.security.sasl.SaslServer;
 import java.net.InetAddress;
 import java.security.Principal;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;

--- a/clients/src/test/java/org/apache/kafka/common/security/auth/KafkaPrincipalTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/auth/KafkaPrincipalTest.java
@@ -16,8 +16,9 @@
  */
 package org.apache.kafka.common.security.auth;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class KafkaPrincipalTest {
 
@@ -27,7 +28,7 @@ public class KafkaPrincipalTest {
         KafkaPrincipal principal1 = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, name);
         KafkaPrincipal principal2 = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, name);
 
-        Assert.assertEquals(principal1.hashCode(), principal2.hashCode());
-        Assert.assertEquals(principal1, principal2);
+        assertEquals(principal1.hashCode(), principal2.hashCode());
+        assertEquals(principal1, principal2);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/ClientAuthenticationFailureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/ClientAuthenticationFailureTest.java
@@ -38,9 +38,9 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -49,7 +49,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ClientAuthenticationFailureTest {
     private static MockTime time = new MockTime(50);
@@ -60,7 +60,7 @@ public class ClientAuthenticationFailureTest {
     private final String topic = "test";
     private TestJaasConfig testJaasConfig;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         LoginManager.closeAll();
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_PLAINTEXT;
@@ -77,7 +77,7 @@ public class ClientAuthenticationFailureTest {
         server = createEchoServer(securityProtocol);
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         if (server != null)
             server.close();

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/LoginManagerTest.java
@@ -20,24 +20,24 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LoginManagerTest {
 
     private Password dynamicPlainContext;
     private Password dynamicDigestContext;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         dynamicPlainContext = new Password(PlainLoginModule.class.getName() +
                 " required user=\"plainuser\" password=\"plain-secret\";");
@@ -47,7 +47,7 @@ public class LoginManagerTest {
                 Collections.singletonList("SCRAM-SHA-256"));
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         LoginManager.closeAll();
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
@@ -33,27 +33,21 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(value = Parameterized.class)
-public class SaslAuthenticatorFailureDelayTest {
+public abstract class SaslAuthenticatorFailureDelayTest {
     private static final int BUFFER_SIZE = 4 * 1024;
 
     private final MockTime time = new MockTime(1);
@@ -72,15 +66,7 @@ public class SaslAuthenticatorFailureDelayTest {
         this.failedAuthenticationDelayMs = failedAuthenticationDelayMs;
     }
 
-    @Parameterized.Parameters(name = "failedAuthenticationDelayMs={0}")
-    public static Collection<Object[]> data() {
-        List<Object[]> values = new ArrayList<>();
-        values.add(new Object[]{0});
-        values.add(new Object[]{200});
-        return values;
-    }
-
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         LoginManager.closeAll();
         serverCertStores = new CertStores(true, "localhost");
@@ -92,15 +78,14 @@ public class SaslAuthenticatorFailureDelayTest {
         startTimeMs = time.milliseconds();
     }
 
-    @After
+    @AfterEach
     public void teardown() throws Exception {
         long now = time.milliseconds();
         if (server != null)
             this.server.close();
         if (selector != null)
             this.selector.close();
-        if (failedAuthenticationDelayMs != -1)
-            assertTrue("timeSpent: " + (now - startTimeMs), now - startTimeMs >= failedAuthenticationDelayMs);
+        assertTrue(now - startTimeMs >= failedAuthenticationDelayMs, "timeSpent: " + (now - startTimeMs));
     }
 
     /**
@@ -196,7 +181,7 @@ public class SaslAuthenticatorFailureDelayTest {
         try {
             selector.poll(50);
         } catch (IOException e) {
-            Assert.fail("Caught unexpected exception " + e);
+            throw new RuntimeException("Unexpected failure during selector poll", e);
         }
     }
 
@@ -228,12 +213,8 @@ public class SaslAuthenticatorFailureDelayTest {
     }
 
     private NioEchoServer createEchoServer(ListenerName listenerName, SecurityProtocol securityProtocol) throws Exception {
-        if (failedAuthenticationDelayMs != -1)
-            return NetworkTestUtils.createEchoServer(listenerName, securityProtocol,
-                    new TestSecurityConfig(saslServerConfigs), credentialCache, failedAuthenticationDelayMs, time);
-        else
-            return NetworkTestUtils.createEchoServer(listenerName, securityProtocol,
-                    new TestSecurityConfig(saslServerConfigs), credentialCache, time);
+        return NetworkTestUtils.createEchoServer(listenerName, securityProtocol,
+                new TestSecurityConfig(saslServerConfigs), credentialCache, time);
     }
 
     private void createClientConnection(SecurityProtocol securityProtocol, String node) throws Exception {
@@ -246,7 +227,7 @@ public class SaslAuthenticatorFailureDelayTest {
                                                            String mechanism, String expectedErrorMessage) throws Exception {
         ChannelState finalState = createAndCheckClientConnectionFailure(securityProtocol, node);
         Exception exception = finalState.exception();
-        assertTrue("Invalid exception class " + exception.getClass(), exception instanceof SaslAuthenticationException);
+        assertTrue(exception instanceof SaslAuthenticationException, "Invalid exception class " + exception.getClass());
         if (expectedErrorMessage == null)
             expectedErrorMessage = "Authentication failed during authentication due to invalid credentials with SASL mechanism " + mechanism;
         assertEquals(expectedErrorMessage, exception.getMessage());

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureNoDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureNoDelayTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.authenticator;
+
+public class SaslAuthenticatorFailureNoDelayTest extends SaslAuthenticatorFailureDelayTest {
+    public SaslAuthenticatorFailureNoDelayTest() {
+        super(0);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailurePositiveDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailurePositiveDelayTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.authenticator;
+
+public class SaslAuthenticatorFailurePositiveDelayTest extends SaslAuthenticatorFailureDelayTest {
+    public SaslAuthenticatorFailurePositiveDelayTest() {
+        super(200);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -34,7 +34,6 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
 
 import javax.security.auth.Subject;
 import java.io.IOException;
@@ -42,12 +41,14 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 import static org.apache.kafka.common.security.scram.internals.ScramMechanism.SCRAM_SHA_256;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosNameTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosNameTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.kafka.common.security.kerberos;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class KerberosNameTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosRuleTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosRuleTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common.security.kerberos;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KerberosRuleTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerExtensionsValidatorCallbackTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerExtensionsValidatorCallbackTest.java
@@ -17,15 +17,15 @@
 package org.apache.kafka.common.security.oauthbearer;
 
 import org.apache.kafka.common.security.auth.SaslExtensions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OAuthBearerExtensionsValidatorCallbackTest {
     private static final OAuthBearerToken TOKEN = new OAuthBearerTokenMock();

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModuleTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModuleTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.security.oauthbearer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -42,7 +42,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.SaslExtensionsCallback;
 import org.apache.kafka.common.security.auth.SaslExtensions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerLoginModuleTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerSaslClienCallbackHandlerTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.kafka.common.security.oauthbearer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.security.AccessController;
@@ -30,7 +30,7 @@ import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
 
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslClientCallbackHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerSaslClienCallbackHandlerTest {
     private static OAuthBearerToken createTokenWithLifetimeMillis(final long lifetimeMillis) {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerTokenCallbackTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerTokenCallbackTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.kafka.common.security.oauthbearer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Collections;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerTokenCallbackTest {
     private static final OAuthBearerToken TOKEN = new OAuthBearerToken() {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerValidatorCallbackTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerValidatorCallbackTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.kafka.common.security.oauthbearer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Collections;
 import java.util.Set;
-
-import org.junit.Test;
 
 public class OAuthBearerValidatorCallbackTest {
     private static final OAuthBearerToken TOKEN = new OAuthBearerToken() {

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.kafka.common.security.auth.SaslExtensions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.SaslExtensions;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
@@ -35,8 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OAuthBearerSaslClientTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslServerTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -48,8 +48,8 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerConfigException;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredLoginCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerSaslServerTest {
     private static final String USER = "user";
@@ -93,7 +93,7 @@ public class OAuthBearerSaslServerTest {
     }
     private OAuthBearerSaslServer saslServer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         saslServer = new OAuthBearerSaslServer(VALIDATOR_CALLBACK_HANDLER);
     }
@@ -103,7 +103,7 @@ public class OAuthBearerSaslServerTest {
         byte[] nextChallenge = saslServer
                 .evaluateResponse(clientInitialResponse(null));
         // also asserts that no authentication error is thrown if OAuthBearerExtensionsValidatorCallback is not supported
-        assertTrue("Next challenge is not empty", nextChallenge.length == 0);
+        assertTrue(nextChallenge.length == 0, "Next challenge is not empty");
     }
 
     @Test
@@ -127,7 +127,7 @@ public class OAuthBearerSaslServerTest {
         byte[] nextChallenge = saslServer
                 .evaluateResponse(clientInitialResponse(null, false, customExtensions));
 
-        assertTrue("Next challenge is not empty", nextChallenge.length == 0);
+        assertTrue(nextChallenge.length == 0, "Next challenge is not empty");
         assertEquals("value1", saslServer.getNegotiatedProperty("firstKey"));
         assertEquals("value2", saslServer.getNegotiatedProperty("secondKey"));
     }
@@ -147,8 +147,8 @@ public class OAuthBearerSaslServerTest {
         byte[] nextChallenge = saslServer
                 .evaluateResponse(clientInitialResponse(null, false, customExtensions));
 
-        assertTrue("Next challenge is not empty", nextChallenge.length == 0);
-        assertNull("Extensions not recognized by the server must be ignored", saslServer.getNegotiatedProperty("thirdKey"));
+        assertTrue(nextChallenge.length == 0, "Next challenge is not empty");
+        assertNull(saslServer.getNegotiatedProperty("thirdKey"), "Extensions not recognized by the server must be ignored");
     }
 
     /**
@@ -186,7 +186,7 @@ public class OAuthBearerSaslServerTest {
     public void authorizatonIdEqualsAuthenticationId() throws Exception {
         byte[] nextChallenge = saslServer
                 .evaluateResponse(clientInitialResponse(USER));
-        assertTrue("Next challenge is not empty", nextChallenge.length == 0);
+        assertTrue(nextChallenge.length == 0, "Next challenge is not empty");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshConfigTest.java
@@ -16,14 +16,14 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.expiring;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.SaslConfigs;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExpiringCredentialRefreshConfigTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLoginTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/expiring/ExpiringCredentialRefreshingLoginTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.expiring;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,7 +45,7 @@ import org.apache.kafka.common.security.oauthbearer.internals.expiring.ExpiringC
 import org.apache.kafka.common.utils.MockScheduler;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerScopeUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerScopeUtilsTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerScopeUtilsTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJwsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredJwsTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -26,8 +28,6 @@ import java.util.Base64;
 import java.util.Base64.Encoder;
 import java.util.HashSet;
 import java.util.List;
-
-import org.junit.Test;
 
 public class OAuthBearerUnsecuredJwsTest {
     private static final String QUOTE = "\"";

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandlerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -36,7 +36,7 @@ import org.apache.kafka.common.security.authenticator.TestJaasConfig;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.apache.kafka.common.utils.MockTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
 
@@ -82,7 +82,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
         OAuthBearerTokenCallback callback = new OAuthBearerTokenCallback();
         callbackHandler.handle(new Callback[] {callback});
         OAuthBearerUnsecuredJws jws = (OAuthBearerUnsecuredJws) callback.token();
-        assertNotNull("create token failed", jws);
+        assertNotNull(jws, "create token failed");
         long startMs = mockTime.milliseconds();
         confirmCorrectValues(jws, user, startMs, 1000 * 60 * 60);
         assertEquals(new HashSet<>(Arrays.asList("sub", "iat", "exp")), jws.claims().keySet());
@@ -118,7 +118,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandlerTest {
             OAuthBearerTokenCallback callback = new OAuthBearerTokenCallback();
             callbackHandler.handle(new Callback[] {callback});
             OAuthBearerUnsecuredJws jws = (OAuthBearerUnsecuredJws) callback.token();
-            assertNotNull("create token failed", jws);
+            assertNotNull(jws, "create token failed");
             long startMs = mockTime.milliseconds();
             confirmCorrectValues(jws, user, startMs, lifetmeSeconds * 1000);
             Map<String, Object> claims = jws.claims();

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredValidatorCallbackHandlerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,7 +37,7 @@ import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerUnsecuredValidatorCallbackHandlerTest {
     private static final String UNSECURED_JWT_HEADER_JSON = "{" + claimOrHeaderText("alg", "none") + "}";

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.security.oauthbearer.internals.unsecured;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.kafka.common.utils.Time;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OAuthBearerValidationUtilsTest {
     private static final String QUOTE = "\"";
@@ -81,16 +81,16 @@ public class OAuthBearerValidationUtilsTest {
                         OAuthBearerValidationResult result = OAuthBearerValidationUtils.validateIssuedAt(testJwt,
                                 required, whenCheckMs, allowableClockSkewMs);
                         if (required && !exists)
-                            assertTrue("useErrorValue || required && !exists",
-                                    isFailureWithMessageAndNoFailureScope(result));
+                            assertTrue(
+                                    isFailureWithMessageAndNoFailureScope(result), "useErrorValue || required && !exists");
                         else if (!required && !exists)
-                            assertTrue("!required && !exists", isSuccess(result));
+                            assertTrue(isSuccess(result), "!required && !exists");
                         else if (nowClaimValue * 1000 > whenCheckMs + allowableClockSkewMs) // issued in future
-                            assertTrue(assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs),
-                                    isFailureWithMessageAndNoFailureScope(result));
+                            assertTrue(
+                                    isFailureWithMessageAndNoFailureScope(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
                         else
-                            assertTrue(assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs),
-                                    isSuccess(result));
+                            assertTrue(
+                                    isSuccess(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
                     }
                 }
             }
@@ -115,11 +115,11 @@ public class OAuthBearerValidationUtilsTest {
                 OAuthBearerValidationResult result = OAuthBearerValidationUtils.validateExpirationTime(testJwt,
                         whenCheckMs, allowableClockSkewMs);
                 if (whenCheckMs - allowableClockSkewMs >= nowClaimValue * 1000) // expired
-                    assertTrue(assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs),
-                            isFailureWithMessageAndNoFailureScope(result));
+                    assertTrue(
+                            isFailureWithMessageAndNoFailureScope(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
                 else
-                    assertTrue(assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs),
-                            isSuccess(result));
+                    assertTrue(
+                            isSuccess(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerValidationUtilsTest.java
@@ -81,16 +81,15 @@ public class OAuthBearerValidationUtilsTest {
                         OAuthBearerValidationResult result = OAuthBearerValidationUtils.validateIssuedAt(testJwt,
                                 required, whenCheckMs, allowableClockSkewMs);
                         if (required && !exists)
-                            assertTrue(
-                                    isFailureWithMessageAndNoFailureScope(result), "useErrorValue || required && !exists");
+                            assertTrue(isFailureWithMessageAndNoFailureScope(result), "useErrorValue || required && !exists");
                         else if (!required && !exists)
                             assertTrue(isSuccess(result), "!required && !exists");
                         else if (nowClaimValue * 1000 > whenCheckMs + allowableClockSkewMs) // issued in future
-                            assertTrue(
-                                    isFailureWithMessageAndNoFailureScope(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
+                            assertTrue(isFailureWithMessageAndNoFailureScope(result),
+                                assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
                         else
-                            assertTrue(
-                                    isSuccess(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
+                            assertTrue(isSuccess(result),
+                                assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
                     }
                 }
             }
@@ -115,11 +114,10 @@ public class OAuthBearerValidationUtilsTest {
                 OAuthBearerValidationResult result = OAuthBearerValidationUtils.validateExpirationTime(testJwt,
                         whenCheckMs, allowableClockSkewMs);
                 if (whenCheckMs - allowableClockSkewMs >= nowClaimValue * 1000) // expired
-                    assertTrue(
-                            isFailureWithMessageAndNoFailureScope(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
+                    assertTrue(isFailureWithMessageAndNoFailureScope(result),
+                        assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
                 else
-                    assertTrue(
-                            isSuccess(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
+                    assertTrue(isSuccess(result), assertionFailureMessage(nowClaimValue, allowableClockSkewMs, whenCheckMs));
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/plain/internals/PlainSaslServerTest.java
@@ -17,15 +17,15 @@
 package org.apache.kafka.common.security.plain.internals;
 
 import org.apache.kafka.common.security.plain.PlainLoginModule;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.JaasContext;
@@ -40,7 +40,7 @@ public class PlainSaslServerTest {
 
     private PlainSaslServer saslServer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         TestJaasConfig jaasConfig = new TestJaasConfig();
         Map<String, Object> options = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramCredentialUtilsTest.java
@@ -22,22 +22,23 @@ import java.util.Arrays;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
 import org.apache.kafka.common.security.scram.ScramCredential;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class ScramCredentialUtilsTest {
 
     private ScramFormatter formatter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws NoSuchAlgorithmException {
         formatter = new ScramFormatter(ScramMechanism.SCRAM_SHA_256);
     }
@@ -45,9 +46,9 @@ public class ScramCredentialUtilsTest {
     @Test
     public void stringConversion() {
         ScramCredential credential = formatter.generateCredential("password", 1024);
-        assertTrue("Salt must not be empty", credential.salt().length > 0);
-        assertTrue("Stored key must not be empty", credential.storedKey().length > 0);
-        assertTrue("Server key must not be empty", credential.serverKey().length > 0);
+        assertTrue(credential.salt().length > 0, "Salt must not be empty");
+        assertTrue(credential.storedKey().length > 0, "Stored key must not be empty");
+        assertTrue(credential.serverKey().length > 0, "Server key must not be empty");
         ScramCredential credential2 = ScramCredentialUtils.credentialFromString(ScramCredentialUtils.credentialToString(credential));
         assertArrayEquals(credential.salt(), credential2.salt());
         assertArrayEquals(credential.storedKey(), credential2.storedKey());
@@ -84,14 +85,14 @@ public class ScramCredentialUtilsTest {
     public void scramCredentialCache() throws Exception {
         CredentialCache cache = new CredentialCache();
         ScramCredentialUtils.createCache(cache, Arrays.asList("SCRAM-SHA-512", "PLAIN"));
-        assertNotNull("Cache not created for enabled mechanism", cache.cache(ScramMechanism.SCRAM_SHA_512.mechanismName(), ScramCredential.class));
-        assertNull("Cache created for disabled mechanism", cache.cache(ScramMechanism.SCRAM_SHA_256.mechanismName(), ScramCredential.class));
+        assertNotNull(cache.cache(ScramMechanism.SCRAM_SHA_512.mechanismName(), ScramCredential.class), "Cache not created for enabled mechanism");
+        assertNull(cache.cache(ScramMechanism.SCRAM_SHA_256.mechanismName(), ScramCredential.class), "Cache created for disabled mechanism");
 
         CredentialCache.Cache<ScramCredential> sha512Cache = cache.cache(ScramMechanism.SCRAM_SHA_512.mechanismName(), ScramCredential.class);
         ScramFormatter formatter = new ScramFormatter(ScramMechanism.SCRAM_SHA_512);
         ScramCredential credentialA = formatter.generateCredential("password", 4096);
         sha512Cache.put("userA", credentialA);
         assertEquals(credentialA, sha512Cache.get("userA"));
-        assertNull("Invalid user credential", sha512Cache.get("userB"));
+        assertNull(sha512Cache.get("userB"), "Invalid user credential");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramFormatterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramFormatterTest.java
@@ -21,12 +21,12 @@ import org.apache.kafka.common.security.scram.internals.ScramMessages.ClientFirs
 import org.apache.kafka.common.security.scram.internals.ScramMessages.ServerFinalMessage;
 import org.apache.kafka.common.security.scram.internals.ScramMessages.ServerFirstMessage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Base64;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ScramFormatterTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramMessagesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramMessagesTest.java
@@ -28,13 +28,13 @@ import org.apache.kafka.common.security.scram.internals.ScramMessages.ClientFirs
 import org.apache.kafka.common.security.scram.internals.ScramMessages.ServerFinalMessage;
 import org.apache.kafka.common.security.scram.internals.ScramMessages.ServerFirstMessage;
 
-import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ScramMessagesTest {
 
@@ -63,7 +63,7 @@ public class ScramMessagesTest {
 
     private ScramFormatter formatter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         formatter  = new ScramFormatter(ScramMechanism.SCRAM_SHA_256);
     }
@@ -112,7 +112,7 @@ public class ScramMessagesTest {
         //optional tokenauth specified as extensions
         str = String.format("n,,n=testuser,r=%s,%s", nonce, "tokenauth=true");
         m = createScramMessage(ClientFirstMessage.class, str);
-        assertTrue("Token authentication not set from extensions", m.extensions().tokenAuthenticated());
+        assertTrue(m.extensions().tokenAuthenticated(), "Token authentication not set from extensions");
     }
 
     @Test
@@ -202,7 +202,7 @@ public class ScramMessagesTest {
         String proof = randomBytesAsString();
 
         ClientFinalMessage m = new ClientFinalMessage(toBytes(channelBinding), nonce);
-        assertNull("Invalid proof", m.proof());
+        assertNull(m.proof(), "Invalid proof");
         m.proof(toBytes(proof));
         checkClientFinalMessage(m, channelBinding, nonce, proof);
 
@@ -322,7 +322,7 @@ public class ScramMessagesTest {
     private void checkServerFinalMessage(ServerFinalMessage message, String error, String serverSignature) {
         assertEquals(error, message.error());
         if (serverSignature == null)
-            assertNull("Unexpected server signature", message.serverSignature());
+            assertNull(message.serverSignature(), "Unexpected server signature");
         else
             assertArrayEquals(Base64.getDecoder().decode(serverSignature), message.serverSignature());
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/internals/ScramSaslServerTest.java
@@ -25,11 +25,11 @@ import org.apache.kafka.common.security.authenticator.CredentialCache;
 import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScramSaslServerTest {
 
@@ -40,7 +40,7 @@ public class ScramSaslServerTest {
     private ScramFormatter formatter;
     private ScramSaslServer saslServer;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         mechanism = ScramMechanism.SCRAM_SHA_256;
         formatter  = new ScramFormatter(mechanism);
@@ -54,13 +54,13 @@ public class ScramSaslServerTest {
     @Test
     public void noAuthorizationIdSpecified() throws Exception {
         byte[] nextChallenge = saslServer.evaluateResponse(clientFirstMessage(USER_A, null));
-        assertTrue("Next challenge is empty", nextChallenge.length > 0);
+        assertTrue(nextChallenge.length > 0, "Next challenge is empty");
     }
 
     @Test
     public void authorizatonIdEqualsAuthenticationId() throws Exception {
         byte[] nextChallenge = saslServer.evaluateResponse(clientFirstMessage(USER_A, USER_A));
-        assertTrue("Next challenge is empty", nextChallenge.length > 0);
+        assertTrue(nextChallenge.length > 0, "Next challenge is empty");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -269,8 +269,8 @@ public class DefaultSslEngineFactoryTest {
         List<String> aliases = Collections.list(keyStore.aliases());
         assertEquals(Collections.singletonList("kafka"), aliases);
         assertNotNull(keyStore.getCertificate("kafka"), "Certificate not loaded");
-        assertNotNull(
-                keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()), "Private key not loaded");
+        assertNotNull(keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()),
+            "Private key not loaded");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/DefaultSslEngineFactoryTest.java
@@ -20,8 +20,8 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyStore;
 import java.util.Arrays;
@@ -30,10 +30,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DefaultSslEngineFactoryTest {
 
@@ -199,7 +199,7 @@ public class DefaultSslEngineFactoryTest {
     private DefaultSslEngineFactory factory = new DefaultSslEngineFactory();
     Map<String, Object> configs = new HashMap<>();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         factory = new DefaultSslEngineFactory();
         configs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
@@ -214,8 +214,8 @@ public class DefaultSslEngineFactoryTest {
         KeyStore trustStore = factory.truststore();
         List<String> aliases = Collections.list(trustStore.aliases());
         assertEquals(Collections.singletonList("kafka0"), aliases);
-        assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka0"));
-        assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+        assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not loaded");
+        assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
     }
 
     @Test
@@ -227,10 +227,10 @@ public class DefaultSslEngineFactoryTest {
         KeyStore trustStore = factory.truststore();
         List<String> aliases = Collections.list(trustStore.aliases());
         assertEquals(Arrays.asList("kafka0", "kafka1"), aliases);
-        assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka0"));
-        assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
-        assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka1"));
-        assertNull("Unexpected private key", trustStore.getKey("kafka1", null));
+        assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not loaded");
+        assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
+        assertNotNull(trustStore.getCertificate("kafka1"), "Certificate not loaded");
+        assertNull(trustStore.getKey("kafka1", null), "Unexpected private key");
     }
 
     @Test
@@ -268,9 +268,9 @@ public class DefaultSslEngineFactoryTest {
         KeyStore keyStore = factory.keystore();
         List<String> aliases = Collections.list(keyStore.aliases());
         assertEquals(Collections.singletonList("kafka"), aliases);
-        assertNotNull("Certificate not loaded", keyStore.getCertificate("kafka"));
-        assertNotNull("Private key not loaded",
-                keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()));
+        assertNotNull(keyStore.getCertificate("kafka"), "Certificate not loaded");
+        assertNotNull(
+                keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()), "Private key not loaded");
     }
 
     @Test
@@ -282,8 +282,8 @@ public class DefaultSslEngineFactoryTest {
         KeyStore trustStore = factory.truststore();
         List<String> aliases = Collections.list(trustStore.aliases());
         assertEquals(Collections.singletonList("kafka0"), aliases);
-        assertNotNull("Certificate not found", trustStore.getCertificate("kafka0"));
-        assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+        assertNotNull(trustStore.getCertificate("kafka0"), "Certificate not found");
+        assertNull(trustStore.getKey("kafka0", null), "Unexpected private key");
     }
 
     @Test
@@ -305,8 +305,8 @@ public class DefaultSslEngineFactoryTest {
         KeyStore keyStore = factory.keystore();
         List<String> aliases = Collections.list(keyStore.aliases());
         assertEquals(Collections.singletonList("kafka"), aliases);
-        assertNotNull("Certificate not found", keyStore.getCertificate("kafka"));
-        assertNotNull("Private key not found", keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()));
+        assertNotNull(keyStore.getCertificate("kafka"), "Certificate not found");
+        assertNotNull(keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()), "Private key not found");
     }
 
     private String pemFilePath(String pem) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslFactoryTest.java
@@ -67,7 +67,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testSslFactoryConfiguration() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
@@ -123,7 +123,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testSslFactoryWithoutPasswordConfiguration() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         // unset the password
@@ -139,7 +139,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testClientMode() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT, tlsProtocol)
+        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
                 .build();
@@ -153,7 +153,7 @@ public abstract class SslFactoryTest {
     @Test
     public void staleSslEngineFactoryShouldBeClosed() throws IOException, GeneralSecurityException {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
                 .build();
@@ -165,7 +165,7 @@ public abstract class SslFactoryTest {
         assertFalse(sslEngineFactory.closed);
 
         trustStoreFile = File.createTempFile("truststore", ".jks");
-        clientSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        clientSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         clientSslConfig.put(SslConfigs.SSL_ENGINE_FACTORY_CLASS_CONFIG, TestSslUtils.TestSslEngineFactory.class);
@@ -179,7 +179,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testReconfiguration() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
@@ -190,54 +190,48 @@ public abstract class SslFactoryTest {
         // Verify that SslEngineFactory is not recreated on reconfigure() if config and
         // file are not changed
         sslFactory.reconfigure(sslConfig);
-        assertSame(sslEngineFactory,
-                sslFactory.sslEngineFactory(), "SslEngineFactory recreated unnecessarily");
+        assertSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory recreated unnecessarily");
 
         // Verify that the SslEngineFactory is recreated on reconfigure() if config is changed
         trustStoreFile = File.createTempFile("truststore", ".jks");
-        sslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         sslFactory.reconfigure(sslConfig);
-        assertNotSame(sslEngineFactory,
-                sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
+        assertNotSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
         sslEngineFactory = sslFactory.sslEngineFactory();
 
         // Verify that builder is recreated on reconfigure() if config is not changed, but truststore file was modified
         trustStoreFile.setLastModified(System.currentTimeMillis() + 10000);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame(sslEngineFactory,
-                sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
+        assertNotSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
         sslEngineFactory = sslFactory.sslEngineFactory();
 
         // Verify that builder is recreated on reconfigure() if config is not changed, but keystore file was modified
         File keyStoreFile = new File((String) sslConfig.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
         keyStoreFile.setLastModified(System.currentTimeMillis() + 10000);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame(sslEngineFactory,
-                sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
+        assertNotSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
         sslEngineFactory = sslFactory.sslEngineFactory();
 
         // Verify that builder is recreated after validation on reconfigure() if config is not changed, but keystore file was modified
         keyStoreFile.setLastModified(System.currentTimeMillis() + 15000);
         sslFactory.validateReconfiguration(sslConfig);
         sslFactory.reconfigure(sslConfig);
-        assertNotSame(sslEngineFactory,
-                sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
+        assertNotSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory not recreated");
         sslEngineFactory = sslFactory.sslEngineFactory();
 
         // Verify that the builder is not recreated if modification time cannot be determined
         keyStoreFile.setLastModified(System.currentTimeMillis() + 20000);
         Files.delete(keyStoreFile.toPath());
         sslFactory.reconfigure(sslConfig);
-        assertSame(sslEngineFactory,
-                sslFactory.sslEngineFactory(), "SslEngineFactory recreated unnecessarily");
+        assertSame(sslEngineFactory, sslFactory.sslEngineFactory(), "SslEngineFactory recreated unnecessarily");
     }
 
     @Test
     public void testReconfigurationWithoutTruststore() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         sslConfig.remove(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
@@ -251,7 +245,7 @@ public abstract class SslFactoryTest {
                 "SSL context recreated unnecessarily");
         assertFalse(sslFactory.createSslEngine("localhost", 0).getUseClientMode());
 
-        Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         try {
@@ -265,7 +259,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testReconfigurationWithoutKeystore() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
@@ -280,7 +274,7 @@ public abstract class SslFactoryTest {
         assertFalse(sslFactory.createSslEngine("localhost", 0).getUseClientMode());
 
         File newTrustStoreFile = File.createTempFile("truststore", ".jks");
-        sslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(newTrustStoreFile)
                 .build();
         sslConfig.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
@@ -290,7 +284,7 @@ public abstract class SslFactoryTest {
         assertNotSame(sslContext, ((DefaultSslEngineFactory) sslFactory.sslEngineFactory()).sslContext(),
                 "SSL context not recreated");
 
-        sslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        sslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(newTrustStoreFile)
                 .build();
         try {
@@ -304,7 +298,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testPemReconfiguration() throws Exception {
         Properties props = new Properties();
-        props.putAll(sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        props.putAll(sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(null)
                 .usePem(true)
                 .build());
@@ -345,7 +339,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testKeyStoreTrustStoreValidation() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .build();
         SslFactory sslFactory = new SslFactory(Mode.SERVER);
@@ -357,10 +351,10 @@ public abstract class SslFactoryTest {
     public void testUntrustedKeyStoreValidationFails() throws Exception {
         File trustStoreFile1 = File.createTempFile("truststore1", ".jks");
         File trustStoreFile2 = File.createTempFile("truststore2", ".jks");
-        Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile1)
                 .build();
-        Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile2)
                 .build();
         SslFactory sslFactory = new SslFactory(Mode.SERVER, null, true);
@@ -390,7 +384,7 @@ public abstract class SslFactoryTest {
 
     private void verifyKeystoreVerifiableUsingTruststore(boolean usePem, String tlsProtocol) throws Exception {
         File trustStoreFile1 = usePem ? null : File.createTempFile("truststore1", ".jks");
-        Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig1 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile1)
                 .usePem(usePem)
                 .build();
@@ -398,7 +392,7 @@ public abstract class SslFactoryTest {
         sslFactory.configure(sslConfig1);
 
         File trustStoreFile2 = usePem ? null : File.createTempFile("truststore2", ".jks");
-        Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> sslConfig2 = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile2)
                 .usePem(usePem)
                 .build();
@@ -426,12 +420,12 @@ public abstract class SslFactoryTest {
 
     private void verifyCertificateEntriesValidation(boolean usePem, String tlsProtocol) throws Exception {
         File trustStoreFile = usePem ? null : File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .usePem(usePem)
                 .build();
         File newTrustStoreFile = usePem ? null : File.createTempFile("truststore", ".jks");
-        Map<String, Object> newCnConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> newCnConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(newTrustStoreFile)
                 .cn("Another CN")
                 .usePem(usePem)
@@ -454,7 +448,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testClientSpecifiedSslEngineFactoryUsed() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT, tlsProtocol)
+        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
                 .build();
@@ -468,7 +462,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testEngineFactoryClosed() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT, tlsProtocol)
+        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
                 .build();
@@ -487,7 +481,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testServerSpecifiedSslEngineFactoryUsed() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
                 .build();
@@ -504,7 +498,7 @@ public abstract class SslFactoryTest {
     @Test
     public void testInvalidSslEngineFactory() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
-        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT, tlsProtocol)
+        Map<String, Object> clientSslConfig = sslConfigsBuilder(Mode.CLIENT)
                 .createNewTrustStore(trustStoreFile)
                 .useClientCert(false)
                 .build();
@@ -515,7 +509,7 @@ public abstract class SslFactoryTest {
 
     @Test
     public void testUsedConfigs() throws IOException, GeneralSecurityException {
-        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER, tlsProtocol)
+        Map<String, Object> serverSslConfig = sslConfigsBuilder(Mode.SERVER)
                 .createNewTrustStore(File.createTempFile("truststore", ".jks"))
                 .useClientCert(false)
                 .build();
@@ -546,7 +540,7 @@ public abstract class SslFactoryTest {
         return store.get();
     }
 
-    private TestSslUtils.SslConfigsBuilder sslConfigsBuilder(Mode mode, String tlsProtocol) {
+    private TestSslUtils.SslConfigsBuilder sslConfigsBuilder(Mode mode) {
         return new TestSslUtils.SslConfigsBuilder(mode).tlsProtocol(tlsProtocol);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/SslPrincipalMapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/SslPrincipalMapperTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common.security.ssl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SslPrincipalMapperTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/Tls12SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/Tls12SslFactoryTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+public class Tls12SslFactoryTest extends SslFactoryTest {
+    public Tls12SslFactoryTest() {
+        super("TLSv1.2");
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/ssl/Tls13SslFactoryTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/ssl/Tls13SslFactoryTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.ssl;
+
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+@DisabledOnJre(JRE.JAVA_8)
+public class Tls13SslFactoryTest extends SslFactoryTest {
+    public Tls13SslFactoryTest() {
+        super("TLSv1.3");
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -18,7 +18,7 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.utils.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -27,11 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SerializationTest {
 
@@ -60,9 +58,9 @@ public class SerializationTest {
         for (Map.Entry<Class<?>, List<Object>> test : testData.entrySet()) {
             try (Serde<Object> serde = Serdes.serdeFrom((Class<Object>) test.getKey())) {
                 for (Object value : test.getValue()) {
-                    assertEquals("Should get the original " + test.getKey().getSimpleName() +
-                                    " after serialization and deserialization", value,
-                            serde.deserializer().deserialize(topic, serde.serializer().serialize(topic, value)));
+                    assertEquals(value,
+                            serde.deserializer().deserialize(topic, serde.serializer().serialize(topic, value)), "Should get the original " + test.getKey().getSimpleName() +
+                                            " after serialization and deserialization");
                 }
             }
         }
@@ -72,10 +70,10 @@ public class SerializationTest {
     public void allSerdesShouldSupportNull() {
         for (Class<?> cls : testData.keySet()) {
             try (Serde<?> serde = Serdes.serdeFrom(cls)) {
-                assertThat("Should support null in " + cls.getSimpleName() + " serialization",
-                        serde.serializer().serialize(topic, null), nullValue());
-                assertThat("Should support null in " + cls.getSimpleName() + " deserialization",
-                        serde.deserializer().deserialize(topic, null), nullValue());
+                assertNull(serde.serializer().serialize(topic, null),
+                    "Should support null in " + cls.getSimpleName() + " serialization");
+                assertNull(serde.deserializer().deserialize(topic, null),
+                    "Should support null in " + cls.getSimpleName() + " deserialization");
             }
         }
     }
@@ -102,8 +100,8 @@ public class SerializationTest {
 
                 Serializer<String> serializer = serDeser.serializer();
                 Deserializer<String> deserializer = serDeser.deserializer();
-                assertEquals("Should get the original string after serialization and deserialization with encoding " + encoding,
-                        str, deserializer.deserialize(topic, serializer.serialize(topic, str)));
+                assertEquals(
+                        str, deserializer.deserialize(topic, serializer.serialize(topic, str)), "Should get the original string after serialization and deserialization with encoding " + encoding);
             }
         }
     }
@@ -141,10 +139,10 @@ public class SerializationTest {
             // Because of NaN semantics we must assert based on the raw int bits.
             Float roundtrip = serde.deserializer().deserialize(topic,
                     serde.serializer().serialize(topic, someNaN));
-            assertThat(Float.floatToRawIntBits(roundtrip), equalTo(someNaNAsIntBits));
+            assertEquals(someNaNAsIntBits, Float.floatToRawIntBits(roundtrip));
             Float otherRoundtrip = serde.deserializer().deserialize(topic,
                     serde.serializer().serialize(topic, anotherNaN));
-            assertThat(Float.floatToRawIntBits(otherRoundtrip), equalTo(anotherNaNAsIntBits));
+            assertEquals(anotherNaNAsIntBits, Float.floatToRawIntBits(otherRoundtrip));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -58,9 +58,8 @@ public class SerializationTest {
         for (Map.Entry<Class<?>, List<Object>> test : testData.entrySet()) {
             try (Serde<Object> serde = Serdes.serdeFrom((Class<Object>) test.getKey())) {
                 for (Object value : test.getValue()) {
-                    assertEquals(value,
-                            serde.deserializer().deserialize(topic, serde.serializer().serialize(topic, value)), "Should get the original " + test.getKey().getSimpleName() +
-                                            " after serialization and deserialization");
+                    assertEquals(value, serde.deserializer().deserialize(topic, serde.serializer().serialize(topic, value)),
+                        "Should get the original " + test.getKey().getSimpleName() + " after serialization and deserialization");
                 }
             }
         }
@@ -100,8 +99,8 @@ public class SerializationTest {
 
                 Serializer<String> serializer = serDeser.serializer();
                 Deserializer<String> deserializer = serDeser.deserializer();
-                assertEquals(
-                        str, deserializer.deserialize(topic, serializer.serialize(topic, str)), "Should get the original string after serialization and deserialization with encoding " + encoding);
+                assertEquals(str, deserializer.deserialize(topic, serializer.serialize(topic, str)),
+                    "Should get the original string after serialization and deserialization with encoding " + encoding);
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/AbstractIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/AbstractIteratorTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AbstractIteratorTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/AppInfoParserTest.java
@@ -17,9 +17,9 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.metrics.Metrics;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -28,10 +28,10 @@ import javax.management.ObjectName;
 
 import java.lang.management.ManagementFactory;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AppInfoParserTest {
     private static final String EXPECTED_COMMIT_VERSION = AppInfoParser.DEFAULT_VALUE;
@@ -43,13 +43,13 @@ public class AppInfoParserTest {
     private Metrics metrics;
     private MBeanServer mBeanServer;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         metrics = new Metrics(new MockTime(1));
         mBeanServer = ManagementFactory.getPlatformMBeanServer();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         metrics.close();
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferInputStreamTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufferInputStreamTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferOutputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferOutputStreamTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufferOutputStreamTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferUnmapperTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferUnmapperTest.java
@@ -18,7 +18,7 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.MappedByteBuffer;

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteUtilsTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,9 +25,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ByteUtilsTest {
     private final byte x00 = 0x00;

--- a/clients/src/test/java/org/apache/kafka/common/utils/BytesTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/BytesTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class BytesTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ChecksumsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ChecksumsTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.zip.Checksum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ChecksumsTest {
 
@@ -61,7 +61,7 @@ public class ChecksumsTest {
         Checksums.updateInt(crc1, value);
         crc2.update(buffer.array(), buffer.arrayOffset(), 4);
 
-        assertEquals("Crc values should be the same", crc1.getValue(), crc2.getValue());
+        assertEquals(crc1.getValue(), crc2.getValue(), "Crc values should be the same");
     }
 
     @Test
@@ -76,7 +76,7 @@ public class ChecksumsTest {
         Checksums.updateLong(crc1, value);
         crc2.update(buffer.array(), buffer.arrayOffset(), 8);
 
-        assertEquals("Crc values should be the same", crc1.getValue(), crc2.getValue());
+        assertEquals(crc1.getValue(), crc2.getValue(), "Crc values should be the same");
     }
 
     private void doTestUpdateByteBufferWithOffsetPosition(byte[] bytes, ByteBuffer buffer, int offset) {

--- a/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/CircularIteratorTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.kafka.common.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
-
-import org.junit.Test;
 
 public class CircularIteratorTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/CollectionUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/CollectionUtilsTest.java
@@ -16,15 +16,15 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.common.utils.CollectionUtils.subtractMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 public class CollectionUtilsTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ConfigUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ConfigUtilsTest.java
@@ -17,14 +17,14 @@
 
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ConfigUtilsTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/Crc32CTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/Crc32CTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.zip.Checksum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Crc32CTest {
 
@@ -39,8 +39,8 @@ public class Crc32CTest {
         crc3.update(bytes, 0, len / 2);
         crc3.update(bytes, len / 2, len - len / 2);
 
-        assertEquals("Crc values should be the same", crc1.getValue(), crc2.getValue());
-        assertEquals("Crc values should be the same", crc1.getValue(), crc3.getValue());
+        assertEquals(crc1.getValue(), crc2.getValue(), "Crc values should be the same");
+        assertEquals(crc1.getValue(), crc3.getValue(), "Crc values should be the same");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/Crc32Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/Crc32Test.java
@@ -16,11 +16,11 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.zip.Checksum;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Crc32Test {
 
@@ -39,8 +39,8 @@ public class Crc32Test {
         crc3.update(bytes, 0, len / 2);
         crc3.update(bytes, len / 2, len - len / 2);
 
-        assertEquals("Crc values should be the same", crc1.getValue(), crc2.getValue());
-        assertEquals("Crc values should be the same", crc1.getValue(), crc3.getValue());
+        assertEquals(crc1.getValue(), crc2.getValue(), "Crc values should be the same");
+        assertEquals(crc1.getValue(), crc3.getValue(), "Crc values should be the same");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExitTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ExitTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExponentialBackoffTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExponentialBackoffTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExponentialBackoffTest {
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/utils/FixedOrderMapTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FixedOrderMapTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 import java.util.Map;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FixedOrderMapTest {
+
     @Test
     public void shouldMaintainOrderWhenAdding() {
         final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
@@ -36,10 +36,10 @@ public class FixedOrderMapTest {
         map.put("c", 2);
         map.put("b", 3);
         final Iterator<Map.Entry<String, Integer>> iterator = map.entrySet().iterator();
-        assertThat(iterator.next(), is(mkEntry("a", 0)));
-        assertThat(iterator.next(), is(mkEntry("b", 3)));
-        assertThat(iterator.next(), is(mkEntry("c", 2)));
-        assertThat(iterator.hasNext(), is(false));
+        assertEquals(mkEntry("a", 0), iterator.next());
+        assertEquals(mkEntry("b", 3), iterator.next());
+        assertEquals(mkEntry("c", 2), iterator.next());
+        assertFalse(iterator.hasNext());
     }
 
     @SuppressWarnings("deprecation")
@@ -47,13 +47,8 @@ public class FixedOrderMapTest {
     public void shouldForbidRemove() {
         final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
         map.put("a", 0);
-        try {
-            map.remove("a");
-            fail("expected exception");
-        } catch (final RuntimeException e) {
-            assertThat(e, CoreMatchers.instanceOf(UnsupportedOperationException.class));
-        }
-        assertThat(map.get("a"), is(0));
+        assertThrows(UnsupportedOperationException.class, () -> map.remove("a"));
+        assertEquals(0, map.get("a"));
     }
 
     @SuppressWarnings("deprecation")
@@ -61,12 +56,7 @@ public class FixedOrderMapTest {
     public void shouldForbidConditionalRemove() {
         final FixedOrderMap<String, Integer> map = new FixedOrderMap<>();
         map.put("a", 0);
-        try {
-            map.remove("a", 0);
-            fail("expected exception");
-        } catch (final RuntimeException e) {
-            assertThat(e, CoreMatchers.instanceOf(UnsupportedOperationException.class));
-        }
-        assertThat(map.get("a"), is(0));
+        assertThrows(UnsupportedOperationException.class, () -> map.remove("a", 0));
+        assertEquals(0, map.get("a"));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/FlattenedIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FlattenedIteratorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FlattenedIteratorTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashCollectionTest.java
@@ -16,10 +16,8 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,20 +28,19 @@ import java.util.ListIterator;
 import java.util.Random;
 import java.util.Set;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A unit test for ImplicitLinkedHashCollection.
  */
+@Timeout(120)
 public class ImplicitLinkedHashCollectionTest {
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     final static class TestElement implements ImplicitLinkedHashCollection.Element {
         private int prev = ImplicitLinkedHashCollection.INVALID_INDEX;
@@ -139,29 +136,27 @@ public class ImplicitLinkedHashCollectionTest {
         int i = 0;
         while (iterator.hasNext()) {
             TestElement element = iterator.next();
-            Assert.assertTrue("Iterator yieled " + (i + 1) + " elements, but only " +
-                    sequence.length + " were expected.", i < sequence.length);
-            Assert.assertEquals("Iterator value number " + (i + 1) + " was incorrect.",
-                    sequence[i].intValue(), element.key);
+            assertTrue(i < sequence.length, "Iterator yieled " + (i + 1) + " elements, but only " +
+                sequence.length + " were expected.");
+            assertEquals(sequence[i].intValue(), element.key, "Iterator value number " + (i + 1) + " was incorrect.");
             i = i + 1;
         }
-        Assert.assertTrue("Iterator yieled " + (i + 1) + " elements, but " +
-                sequence.length + " were expected.", i == sequence.length);
+        assertTrue(i == sequence.length, "Iterator yieled " + (i + 1) + " elements, but " +
+            sequence.length + " were expected.");
     }
 
     static void expectTraversal(Iterator<TestElement> iter, Iterator<Integer> expectedIter) {
         int i = 0;
         while (iter.hasNext()) {
             TestElement element = iter.next();
-            Assert.assertTrue("Iterator yieled " + (i + 1) + " elements, but only " +
-                    i + " were expected.", expectedIter.hasNext());
+            assertTrue(expectedIter.hasNext(), "Iterator yieled " + (i + 1) + " elements, but only " + i +
+                " were expected.");
             Integer expected = expectedIter.next();
-            Assert.assertEquals("Iterator value number " + (i + 1) + " was incorrect.",
-                    expected.intValue(), element.key);
+            assertEquals(expected.intValue(), element.key, "Iterator value number " + (i + 1) + " was incorrect.");
             i = i + 1;
         }
-        Assert.assertFalse("Iterator yieled " + i + " elements, but at least " +
-                (i + 1) + " were expected.", expectedIter.hasNext());
+        assertFalse(expectedIter.hasNext(), "Iterator yieled " + i + " elements, but at least " + (i + 1) +
+            " were expected.");
     }
 
     @Test
@@ -487,7 +482,7 @@ public class ImplicitLinkedHashCollectionTest {
         assertEquals(6, coll.size());
         expectTraversal(coll.iterator(), 0, 1, 2, 3, 4, 5);
         for (int i = 0; i < 6; i++) {
-            assertTrue("Failed to find element " + i, coll.contains(new TestElement(i)));
+            assertTrue(coll.contains(new TestElement(i)), "Failed to find element " + i);
         }
         coll.remove(new TestElement(3));
         assertEquals(23, coll.numSlots());

--- a/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollectionTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ImplicitLinkedHashMultiCollectionTest.java
@@ -17,27 +17,24 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollectionTest.TestElement;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * A unit test for ImplicitLinkedHashMultiCollection.
  */
+@Timeout(120)
 public class ImplicitLinkedHashMultiCollectionTest {
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testNullForbidden() {
@@ -93,15 +90,15 @@ public class ImplicitLinkedHashMultiCollectionTest {
         int i = 0;
         while (iterator.hasNext()) {
             TestElement element = iterator.next();
-            assertTrue("Iterator yieled " + (i + 1) + " elements, but only " +
-                sequence.length + " were expected.", i < sequence.length);
+            assertTrue(i < sequence.length, "Iterator yieled " + (i + 1) + " elements, but only " +
+                sequence.length + " were expected.");
             if (sequence[i] != element) {
                 fail("Iterator value number " + (i + 1) + " was incorrect.");
             }
             i = i + 1;
         }
-        assertTrue("Iterator yieled " + (i + 1) + " elements, but " +
-            sequence.length + " were expected.", i == sequence.length);
+        assertTrue(i == sequence.length, "Iterator yieled " + (i + 1) + " elements, but " +
+            sequence.length + " were expected.");
     }
 
     @Test
@@ -160,14 +157,14 @@ public class ImplicitLinkedHashMultiCollectionTest {
         int i = 0;
         while (iter.hasNext()) {
             TestElement element = iter.next();
-            Assert.assertTrue("Iterator yieled " + (i + 1) + " elements, but only " +
-                i + " were expected.", expectedIter.hasNext());
+            assertTrue(expectedIter.hasNext(),
+                "Iterator yieled " + (i + 1) + " elements, but only " + i + " were expected.");
             TestElement expected = expectedIter.next();
-            assertTrue("Iterator value number " + (i + 1) + " was incorrect.",
-                expected == element);
+            assertTrue(expected == element,
+                "Iterator value number " + (i + 1) + " was incorrect.");
             i = i + 1;
         }
-        Assert.assertFalse("Iterator yieled " + i + " elements, but at least " +
-            (i + 1) + " were expected.", expectedIter.hasNext());
+        assertFalse(expectedIter.hasNext(),
+            "Iterator yieled " + i + " elements, but at least " + (i + 1) + " were expected.");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -16,24 +16,24 @@
  */
 package org.apache.kafka.common.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JavaTest {
 
     private String javaVendor;
 
-    @Before
+    @BeforeEach
     public void before() {
         javaVendor = System.getProperty("java.vendor");
     }
 
-    @After
+    @AfterEach
     public void after() {
         System.setProperty("java.vendor", javaVendor);
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/LoggingSignalHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/LoggingSignalHandlerTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LoggingSignalHandlerTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/MappedIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MappedIteratorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MappedIteratorTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/MockTimeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MockTimeTest.java
@@ -16,16 +16,13 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Timeout(120)
 public class MockTimeTest extends TimeTest {
-
-    @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testAdvanceClock() {

--- a/clients/src/test/java/org/apache/kafka/common/utils/SanitizerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/SanitizerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.kafka.common.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.management.ManagementFactory;
 
@@ -28,7 +28,7 @@ import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.OperationsException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SanitizerTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/SecurityUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/SecurityUtilsTest.java
@@ -21,17 +21,16 @@ import org.apache.kafka.common.security.auth.SecurityProviderCreator;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.ssl.mock.TestPlainSaslServerProviderCreator;
 import org.apache.kafka.common.security.ssl.mock.TestScramSaslServerProviderCreator;
-import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.security.Provider;
 import java.security.Security;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SecurityUtilsTest {
 
@@ -46,14 +45,14 @@ public class SecurityUtilsTest {
         Security.removeProvider(testPlainSaslServerProvider.getName());
     }
 
-    @Before
+    @BeforeEach
     // Remove the providers if already added
     public void setUp() {
         clearTestProviders();
     }
 
     // Remove the providers after running test cases
-    @After
+    @AfterEach
     public void tearDown() {
         clearTestProviders();
     }
@@ -99,8 +98,9 @@ public class SecurityUtilsTest {
         int testScramSaslServerProviderIndex = getProviderIndexFromName(testScramSaslServerProvider.getName(), providers);
         int testPlainSaslServerProviderIndex = getProviderIndexFromName(testPlainSaslServerProvider.getName(), providers);
 
-        // validations
-        MatcherAssert.assertThat(testScramSaslServerProvider.getName() + " testProvider not found at expected index", testScramSaslServerProviderIndex == 0);
-        MatcherAssert.assertThat(testPlainSaslServerProvider.getName() + " testProvider not found at expected index", testPlainSaslServerProviderIndex == 1);
+        assertEquals(0, testScramSaslServerProviderIndex,
+            testScramSaslServerProvider.getName() + " testProvider not found at expected index");
+        assertEquals(1, testPlainSaslServerProviderIndex,
+            testPlainSaslServerProvider.getName() + " testProvider not found at expected index");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
@@ -16,20 +16,19 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Timeout(180)
 public class ShellTest {
-    @Rule
-    public final Timeout globalTimeout = Timeout.seconds(180);
 
     @Test
     public void testEchoHello() throws Exception {
@@ -60,15 +59,12 @@ public class ShellTest {
     }
 
     @Test
-    public void testRunProgramWithErrorReturn() throws Exception {
+    public void testRunProgramWithErrorReturn() {
         assumeTrue(!OperatingSystem.IS_WINDOWS);
-        try {
-            Shell.execCommand("head", "-c", "0", NONEXISTENT_PATH);
-            fail("Expected to get an exception when trying to head a nonexistent file");
-        } catch (Shell.ExitCodeException e) {
-            String message = e.getMessage();
-            assertTrue("Unexpected error message '" + message + "'",
-                    message.contains("No such file") || message.contains("illegal byte count"));
-        }
+        Shell.ExitCodeException e = assertThrows(Shell.ExitCodeException.class,
+            () -> Shell.execCommand("head", "-c", "0", NONEXISTENT_PATH));
+        String message = e.getMessage();
+        assertTrue(message.contains("No such file") || message.contains("illegal byte count"),
+            "Unexpected error message '" + message + "'");
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ThreadUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ThreadUtilsTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ThreadFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ThreadUtilsTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/TimeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/TimeTest.java
@@ -17,14 +17,14 @@
 package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.errors.TimeoutException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class TimeTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/TimerTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.kafka.common.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TimerTest {
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -622,7 +622,8 @@ public class UtilsTest {
         }
     }
 
-    @Test @Timeout(120)
+    @Timeout(120)
+    @Test
     public void testRecursiveDelete() throws IOException {
         Utils.delete(null); // delete of null does nothing.
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -18,8 +18,9 @@ package org.apache.kafka.common.utils;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.io.Closeable;
@@ -64,17 +65,13 @@ import static org.apache.kafka.common.utils.Utils.mkSet;
 import static org.apache.kafka.common.utils.Utils.murmur2;
 import static org.apache.kafka.common.utils.Utils.union;
 import static org.apache.kafka.common.utils.Utils.validHostPattern;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -366,7 +363,7 @@ public class UtilsTest {
      * Test to read content of named pipe as string. As reading/writing to a pipe can block,
      * timeout test after a minute (test finishes within 100 ms normally).
      */
-    @Test(timeout = 60 * 1000)
+    @Test @Timeout(60)
     public void testFileAsStringNamedPipe() throws Exception {
 
         // Create a temporary name for named pipe
@@ -458,24 +455,24 @@ public class UtilsTest {
             String msg = "hello, world";
             channel.write(ByteBuffer.wrap(msg.getBytes()), 0);
             channel.force(true);
-            assertEquals("Message should be written to the file channel", channel.size(), msg.length());
+            assertEquals(channel.size(), msg.length(), "Message should be written to the file channel");
 
             ByteBuffer perfectBuffer = ByteBuffer.allocate(msg.length());
             ByteBuffer smallBuffer = ByteBuffer.allocate(5);
             ByteBuffer largeBuffer = ByteBuffer.allocate(msg.length() + 1);
             // Scenario 1: test reading into a perfectly-sized buffer
             Utils.readFullyOrFail(channel, perfectBuffer, 0, "perfect");
-            assertFalse("Buffer should be filled up", perfectBuffer.hasRemaining());
-            assertEquals("Buffer should be populated correctly", msg, new String(perfectBuffer.array()));
+            assertFalse(perfectBuffer.hasRemaining(), "Buffer should be filled up");
+            assertEquals(msg, new String(perfectBuffer.array()), "Buffer should be populated correctly");
             // Scenario 2: test reading into a smaller buffer
             Utils.readFullyOrFail(channel, smallBuffer, 0, "small");
-            assertFalse("Buffer should be filled", smallBuffer.hasRemaining());
-            assertEquals("Buffer should be populated correctly", "hello", new String(smallBuffer.array()));
+            assertFalse(smallBuffer.hasRemaining(), "Buffer should be filled");
+            assertEquals("hello", new String(smallBuffer.array()), "Buffer should be populated correctly");
             // Scenario 3: test reading starting from a non-zero position
             smallBuffer.clear();
             Utils.readFullyOrFail(channel, smallBuffer, 7, "small");
-            assertFalse("Buffer should be filled", smallBuffer.hasRemaining());
-            assertEquals("Buffer should be populated correctly", "world", new String(smallBuffer.array()));
+            assertFalse(smallBuffer.hasRemaining(), "Buffer should be filled");
+            assertEquals("world", new String(smallBuffer.array()), "Buffer should be populated correctly");
             // Scenario 4: test end of stream is reached before buffer is filled up
             try {
                 Utils.readFullyOrFail(channel, largeBuffer, 0, "large");
@@ -497,9 +494,8 @@ public class UtilsTest {
         ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
         String expectedBufferContent = fileChannelMockExpectReadWithRandomBytes(channelMock, bufferSize);
         Utils.readFullyOrFail(channelMock, buffer, 0L, "test");
-        assertEquals("The buffer should be populated correctly", expectedBufferContent,
-                     new String(buffer.array()));
-        assertFalse("The buffer should be filled", buffer.hasRemaining());
+        assertEquals(expectedBufferContent, new String(buffer.array()), "The buffer should be populated correctly");
+        assertFalse(buffer.hasRemaining(), "The buffer should be filled");
         verify(channelMock, atLeastOnce()).read(any(), anyLong());
     }
 
@@ -514,9 +510,8 @@ public class UtilsTest {
         String expectedBufferContent = fileChannelMockExpectReadWithRandomBytes(channelMock, bufferSize);
         ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
         Utils.readFully(channelMock, buffer, 0L);
-        assertEquals("The buffer should be populated correctly.", expectedBufferContent,
-                     new String(buffer.array()));
-        assertFalse("The buffer should be filled", buffer.hasRemaining());
+        assertEquals(expectedBufferContent, new String(buffer.array()), "The buffer should be populated correctly.");
+        assertFalse(buffer.hasRemaining(), "The buffer should be filled");
         verify(channelMock, atLeastOnce()).read(any(), anyLong());
     }
 
@@ -615,7 +610,7 @@ public class UtilsTest {
 
         static void checkClosed(TestCloseable... closeables) {
             for (TestCloseable closeable : closeables)
-                assertTrue("Close not invoked for " + closeable.id, closeable.closed);
+                assertTrue(closeable.closed, "Close not invoked for " + closeable.id);
         }
 
         static void checkException(IOException e, TestCloseable... closeablesWithException) {
@@ -627,7 +622,7 @@ public class UtilsTest {
         }
     }
 
-    @Test(timeout = 120000)
+    @Test @Timeout(120)
     public void testRecursiveDelete() throws IOException {
         Utils.delete(null); // delete of null does nothing.
 
@@ -660,12 +655,7 @@ public class UtilsTest {
         bitField = Utils.to32BitField(bytes);
         assertEquals(bytes, Utils.from32BitField(bitField));
 
-        bytes = mkSet((byte) 0, (byte) 11, (byte) 32);
-        try {
-            Utils.to32BitField(bytes);
-            fail("Expected exception not thrown");
-        } catch (IllegalArgumentException e) {
-        }
+        assertThrows(IllegalArgumentException.class, () -> Utils.to32BitField(mkSet((byte) 0, (byte) 11, (byte) 32)));
     }
 
     @Test
@@ -674,8 +664,8 @@ public class UtilsTest {
         final Set<String> anotherSet = mkSet("c", "d", "e");
         final Set<String> union = union(TreeSet::new, oneSet, anotherSet);
 
-        assertThat(union, is(mkSet("a", "b", "c", "d", "e")));
-        assertThat(union.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("a", "b", "c", "d", "e"), union);
+        assertEquals(TreeSet.class, union.getClass());
     }
 
     @Test
@@ -683,8 +673,8 @@ public class UtilsTest {
         final Set<String> oneSet = mkSet("a", "b", "c");
         final Set<String> union = union(TreeSet::new, oneSet);
 
-        assertThat(union, is(mkSet("a", "b", "c")));
-        assertThat(union.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("a", "b", "c"), union);
+        assertEquals(TreeSet.class, union.getClass());
     }
 
     @Test
@@ -695,16 +685,16 @@ public class UtilsTest {
         final Set<String> fourSet = mkSet("x", "y", "z");
         final Set<String> union = union(TreeSet::new, oneSet, twoSet, threeSet, fourSet);
 
-        assertThat(union, is(mkSet("a", "b", "c", "d", "e", "x", "y", "z")));
-        assertThat(union.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("a", "b", "c", "d", "e", "x", "y", "z"), union);
+        assertEquals(TreeSet.class, union.getClass());
     }
 
     @Test
     public void testUnionOfNone() {
         final Set<String> union = union(TreeSet::new);
 
-        assertThat(union, is(emptySet()));
-        assertThat(union.getClass(), equalTo(TreeSet.class));
+        assertEquals(emptySet(), union);
+        assertEquals(TreeSet.class, union.getClass());
     }
 
     @Test
@@ -713,8 +703,8 @@ public class UtilsTest {
         final Set<String> anotherSet = mkSet("c", "d", "e");
         final Set<String> intersection = intersection(TreeSet::new, oneSet, anotherSet);
 
-        assertThat(intersection, is(mkSet("c")));
-        assertThat(intersection.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("c"), intersection);
+        assertEquals(TreeSet.class, intersection.getClass());
     }
 
     @Test
@@ -722,8 +712,8 @@ public class UtilsTest {
         final Set<String> oneSet = mkSet("a", "b", "c");
         final Set<String> intersection = intersection(TreeSet::new, oneSet);
 
-        assertThat(intersection, is(mkSet("a", "b", "c")));
-        assertThat(intersection.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("a", "b", "c"), intersection);
+        assertEquals(TreeSet.class, intersection.getClass());
     }
 
     @Test
@@ -731,10 +721,10 @@ public class UtilsTest {
         final Set<String> oneSet = mkSet("a", "b", "c");
         final Set<String> twoSet = mkSet("c", "d", "e");
         final Set<String> threeSet = mkSet("b", "c", "d");
-        final Set<String> union = intersection(TreeSet::new, oneSet, twoSet, threeSet);
+        final Set<String> intersection = intersection(TreeSet::new, oneSet, twoSet, threeSet);
 
-        assertThat(union, is(mkSet("c")));
-        assertThat(union.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("c"), intersection);
+        assertEquals(TreeSet.class, intersection.getClass());
     }
 
     @Test
@@ -743,10 +733,10 @@ public class UtilsTest {
         final Set<String> twoSet = mkSet("c", "d", "e");
         final Set<String> threeSet = mkSet("b", "c", "d");
         final Set<String> fourSet = mkSet("x", "y", "z");
-        final Set<String> union = intersection(TreeSet::new, oneSet, twoSet, threeSet, fourSet);
+        final Set<String> intersection = intersection(TreeSet::new, oneSet, twoSet, threeSet, fourSet);
 
-        assertThat(union, is(emptySet()));
-        assertThat(union.getClass(), equalTo(TreeSet.class));
+        assertEquals(emptySet(), intersection);
+        assertEquals(TreeSet.class, intersection.getClass());
     }
 
     @Test
@@ -755,8 +745,8 @@ public class UtilsTest {
         final Set<String> anotherSet = mkSet("c", "d", "e");
         final Set<String> diff = diff(TreeSet::new, oneSet, anotherSet);
 
-        assertThat(diff, is(mkSet("a", "b")));
-        assertThat(diff.getClass(), equalTo(TreeSet.class));
+        assertEquals(mkSet("a", "b"), diff);
+        assertEquals(TreeSet.class, diff.getClass());
     }
 
     @Test
@@ -807,11 +797,11 @@ public class UtilsTest {
 
     @Test
     public void shouldThrowOnInvalidDateFormatOrNullTimestamp() {
-        //check some invalid formats
+        // check some invalid formats
         // test null timestamp
-        assertThat(assertThrows(IllegalArgumentException.class, () -> {
+        assertTrue(assertThrows(IllegalArgumentException.class, () -> {
             Utils.getDateTime(null);
-        }).getMessage(), containsString("Error parsing timestamp with null value"));
+        }).getMessage().contains("Error parsing timestamp with null value"));
 
         // test pattern: yyyy-MM-dd'T'HH:mm:ss.X
         checkExceptionForGetDateTimeMethod(() -> {
@@ -819,9 +809,9 @@ public class UtilsTest {
         });
 
         // test pattern: yyyy-MM-dd HH:mm:ss
-        assertThat(assertThrows(ParseException.class, () -> {
+        assertTrue(assertThrows(ParseException.class, () -> {
             invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
-        }).getMessage(), containsString("It does not contain a 'T' according to ISO8601 format"));
+        }).getMessage().contains("It does not contain a 'T' according to ISO8601 format"));
 
         // KAFKA-10685: use DateTimeFormatter generate micro/nano second timestamp
         final DateTimeFormatter formatter = new DateTimeFormatterBuilder()
@@ -848,9 +838,9 @@ public class UtilsTest {
         });
     }
 
-    private void checkExceptionForGetDateTimeMethod(ThrowingRunnable runnable) {
-        assertThat(assertThrows(ParseException.class, runnable)
-            .getMessage(), containsString("Unparseable date"));
+    private void checkExceptionForGetDateTimeMethod(Executable executable) {
+        assertTrue(assertThrows(ParseException.class, executable)
+            .getMessage().contains("Unparseable date"));
     }
 
     private void invokeGetDateTimeMethod(final SimpleDateFormat format) throws ParseException {

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -363,7 +363,8 @@ public class UtilsTest {
      * Test to read content of named pipe as string. As reading/writing to a pipe can block,
      * timeout test after a minute (test finishes within 100 ms normally).
      */
-    @Test @Timeout(60)
+    @Timeout(60)
+    @Test
     public void testFileAsStringNamedPipe() throws Exception {
 
         // Create a temporary name for named pipe


### PR DESCRIPTION
* Use the packages/classes from the new version
* Move description in assert methods to last parameter
* Convert parameterized tests so that they work with JUnit 5
* Remove hamcrest, it didn't seem to add much value
* Fix Utils.mkEntry to have correct `equals` implementation
* Add a missing @Test annotation in `SslSelectorTest` override
* Adjust regex in `SaslAuthenticatorTest` due to small change in the
assert failure string in JUnit 5

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
