### PR TITLE
MINOR: tighten condition for logging StreamThread summary to avoid spam under low traffic

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -749,9 +749,11 @@ public class StreamThread extends Thread {
             // multiple iterations with reasonably large max.num.records and hence is less vulnerable to outliers
             taskManager.recordTaskProcessRatio(totalProcessLatency, now);
 
-            log.info("Processed {} total records, ran {} punctuators, and committed {} total tasks " +
-                        "for active tasks {} and standby tasks {}",
-                     totalProcessed, totalPunctuated, totalCommitted, taskManager.activeTaskIds(), taskManager.standbyTaskIds());
+            // Don't log summary if no new records were processed to avoid spamming logs for low-traffic topics
+            if (totalProcessed > 0 || totalPunctuated > 0 || totalCommitted > 0) {
+                log.info("Processed {} total records, ran {} punctuators, and committed {} total tasks",
+                         totalProcessed, totalPunctuated, totalCommitted);
+            }
         }
 
         now = time.milliseconds();
@@ -824,7 +826,9 @@ public class StreamThread extends Thread {
         final long pollLatency = advanceNowAndComputeLatency();
 
         final int numRecords = records.count();
-        log.info("Main Consumer poll completed in {} ms and fetched {} records", pollLatency, numRecords);
+        if (numRecords > 0) {
+            log.info("Main Consumer poll completed in {} ms and fetched {} records", pollLatency, numRecords);
+        }
 
         pollSensor.record(pollLatency, now);
 


### PR DESCRIPTION
Noticed these messages flooding the logs on several integration tests. Since it doesn't really provide any useful information, we may as well skip the logging when there are no new records to be processed.

Should be cherrypicked back to the 2.7 branch