### PR TITLE
MINOR: Initialize QuorumState lazily in RaftClient.initialize()

### DIFF
--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -16,11 +16,6 @@
  */
 package kafka.raft
 
-import java.io.File
-import java.nio.file.Files
-import java.util.Random
-import java.util.concurrent.CompletableFuture
-
 import kafka.log.{Log, LogConfig, LogManager}
 import kafka.raft.KafkaRaftManager.RaftIoThread
 import kafka.server.{BrokerTopicStats, KafkaConfig, KafkaServer, LogDirFailureChannel}
@@ -34,8 +29,11 @@ import org.apache.kafka.common.protocol.ApiMessage
 import org.apache.kafka.common.requests.RequestHeader
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.utils.{LogContext, Time}
-import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, QuorumState, RaftClient, RaftConfig, RaftRequest, RecordSerde}
+import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, RaftClient, RaftConfig, RaftRequest, RecordSerde}
 
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
 object KafkaRaftManager {
@@ -119,7 +117,7 @@ class KafkaRaftManager[T](
 
   def startup(): Unit = {
     netChannel.start()
-    raftClient.initialize()
+    raftClient.initialize(config.getString(RaftConfig.QUORUM_VOTERS_CONFIG))
     raftIoThread.start()
   }
 
@@ -168,16 +166,6 @@ class KafkaRaftManager[T](
   }
 
   private def buildRaftClient(): KafkaRaftClient[T] = {
-    val quorumState = new QuorumState(
-      nodeId,
-      raftConfig.quorumVoterIds,
-      raftConfig.electionTimeoutMs,
-      raftConfig.fetchTimeoutMs,
-      new FileBasedStateStore(new File(dataDir, "quorum-state")),
-      time,
-      logContext,
-      new Random()
-    )
 
     val expirationTimer = new SystemTimer("raft-expiration-executor")
     val expirationService = new TimingWheelExpirationService(expirationTimer)
@@ -187,11 +175,12 @@ class KafkaRaftManager[T](
       recordSerde,
       netChannel,
       metadataLog,
-      quorumState,
+      new FileBasedStateStore(new File(dataDir, "quorum-state")),
       time,
       metrics,
       expirationService,
-      logContext
+      logContext,
+      nodeId
     )
   }
 

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -117,7 +117,7 @@ class KafkaRaftManager[T](
 
   def startup(): Unit = {
     netChannel.start()
-    raftClient.initialize(config.getString(RaftConfig.QUORUM_VOTERS_CONFIG))
+    raftClient.initialize(raftConfig)
     raftIoThread.start()
   }
 
@@ -171,7 +171,6 @@ class KafkaRaftManager[T](
     val expirationService = new TimingWheelExpirationService(expirationTimer)
 
     new KafkaRaftClient(
-      raftConfig,
       recordSerde,
       netChannel,
       metadataLog,

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2181,7 +2181,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         }
     }
 
-    public QuorumState quorum() {
+    QuorumState quorum() {
         return quorum;
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -318,13 +318,11 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     @Override
     public void initialize(RaftConfig raftConfig) throws IOException {
         this.raftConfig = raftConfig;
-        List<Node> quorumVoterNodes = raftConfig.quorumVoterNodes();
         Set<Integer> quorumVoterIds = raftConfig.quorumVoterIds();
         this.requestManager = new RequestManager(quorumVoterIds, raftConfig.retryBackoffMs(),
                 raftConfig.requestTimeoutMs(), random);
 
-        Map<Integer, InetSocketAddress> voterAddresses = quorumVoterNodes.stream()
-                .collect(Collectors.toMap(Node::id, node -> new InetSocketAddress(node.host(), node.port())));
+        Map<Integer, InetSocketAddress> voterAddresses = raftConfig.quorumVoterConnections();
         for (Map.Entry<Integer, InetSocketAddress> voterAddressEntry : voterAddresses.entrySet()) {
             channel.updateEndpoint(voterAddressEntry.getKey(), voterAddressEntry.getValue());
         }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -62,11 +62,12 @@ public interface RaftClient<T> extends Closeable {
     }
 
     /**
-     * Initialize the client. This should only be called once on startup.
+     * Initialize the client with the given voter string config.
+     * This should only be called once on startup.
      *
      * @throws IOException For any IO errors during initialization
      */
-    void initialize() throws IOException;
+    void initialize(String quorumVoterStrings) throws IOException;
 
     /**
      * Register a listener to get commit/leader notifications.

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -62,12 +62,13 @@ public interface RaftClient<T> extends Closeable {
     }
 
     /**
-     * Initialize the client with the given voter string config.
+     * Initialize the client with the given Raft configuration.
      * This should only be called once on startup.
      *
+     * @param raftConfig the Raft quorum configuration
      * @throws IOException For any IO errors during initialization
      */
-    void initialize(String quorumVoterStrings) throws IOException;
+    void initialize(RaftConfig raftConfig) throws IOException;
 
     /**
      * Register a listener to get commit/leader notifications.

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -136,6 +136,7 @@ public class RaftConfig extends AbstractConfig {
     private final int electionBackoffMaxMs;
     private final int fetchTimeoutMs;
     private final int appendLingerMs;
+    private final Map<Integer, InetSocketAddress> voterConnections;
 
     public RaftConfig(Map<?, ?> props) {
         this(props, true);
@@ -149,6 +150,7 @@ public class RaftConfig extends AbstractConfig {
         electionBackoffMaxMs = getInt(QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG);
         fetchTimeoutMs = getInt(QUORUM_FETCH_TIMEOUT_MS_CONFIG);
         appendLingerMs = getInt(QUORUM_LINGER_MS_CONFIG);
+        voterConnections = parseVoterConnections(getList(QUORUM_VOTERS_CONFIG));
     }
 
     public static Set<String> configNames() {
@@ -192,7 +194,7 @@ public class RaftConfig extends AbstractConfig {
     }
 
     public Map<Integer, InetSocketAddress> quorumVoterConnections() {
-        return parseVoterConnections(getList(QUORUM_VOTERS_CONFIG));
+        return voterConnections;
     }
 
     private static Integer parseVoterId(String idString) {
@@ -232,7 +234,6 @@ public class RaftConfig extends AbstractConfig {
         }
 
         return voterMap;
-
     }
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
@@ -140,24 +138,8 @@ public class RaftConfig extends AbstractConfig {
     private final int fetchTimeoutMs;
     private final int appendLingerMs;
 
-    public RaftConfig(Properties props) {
-        super(CONFIG, props);
-        requestTimeoutMs = getInt(QUORUM_REQUEST_TIMEOUT_MS_CONFIG);
-        retryBackoffMs = getInt(QUORUM_RETRY_BACKOFF_MS_CONFIG);
-        electionTimeoutMs = getInt(QUORUM_ELECTION_TIMEOUT_MS_CONFIG);
-        electionBackoffMaxMs = getInt(QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG);
-        fetchTimeoutMs = getInt(QUORUM_FETCH_TIMEOUT_MS_CONFIG);
-        appendLingerMs = getInt(QUORUM_LINGER_MS_CONFIG);
-    }
-
     public RaftConfig(Map<?, ?> props) {
-        super(CONFIG, props);
-        requestTimeoutMs = getInt(QUORUM_REQUEST_TIMEOUT_MS_CONFIG);
-        retryBackoffMs = getInt(QUORUM_RETRY_BACKOFF_MS_CONFIG);
-        electionTimeoutMs = getInt(QUORUM_ELECTION_TIMEOUT_MS_CONFIG);
-        electionBackoffMaxMs = getInt(QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG);
-        fetchTimeoutMs = getInt(QUORUM_FETCH_TIMEOUT_MS_CONFIG);
-        appendLingerMs = getInt(QUORUM_LINGER_MS_CONFIG);
+        this(props, true);
     }
 
     protected RaftConfig(Map<?, ?> props, boolean doLog) {

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -26,7 +26,6 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import static org.apache.kafka.clients.CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -17,17 +17,20 @@
 package org.apache.kafka.raft;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Utils;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.apache.kafka.clients.CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
@@ -147,6 +150,15 @@ public class RaftConfig extends AbstractConfig {
 
     public static ConfigDef configDef() {
         return new ConfigDef(CONFIG);
+    }
+
+    public static List<Node> quorumVoterStringsToNodes(String quorumVotersString) {
+        return parseVoterConnections(Arrays.stream(quorumVotersString.split(","))
+                .filter(part -> !part.isEmpty())
+                .collect(Collectors.toList())).entrySet().stream()
+                .map(voterEntry -> new Node(voterEntry.getKey(), voterEntry.getValue().getHostName(),
+                        voterEntry.getValue().getPort()))
+                .collect(Collectors.toList());
     }
 
     public static void main(String[] args) {

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -206,13 +206,6 @@ public class RaftConfig extends AbstractConfig {
         return appendLingerMs;
     }
 
-    public List<Node> quorumVoterNodes() {
-        return quorumVoterConnections().entrySet().stream()
-                .map(voterEntry -> new Node(voterEntry.getKey(), voterEntry.getValue().getHostName(),
-                        voterEntry.getValue().getPort()))
-                .collect(Collectors.toList());
-    }
-
     public Set<Integer> quorumVoterIds() {
         return quorumVoterConnections().keySet();
     }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -74,4 +75,30 @@ public class RaftConfigTest {
         assertThrows(ConfigException.class, () -> new RaftConfig(properties));
     }
 
+    @Test
+    public void testInvalidQuorumVotersAsNodes() {
+        assertInvalidQuorumVotersAsNodes("1");
+        assertInvalidQuorumVotersAsNodes("1@");
+        assertInvalidQuorumVotersAsNodes("1:");
+        assertInvalidQuorumVotersAsNodes("blah@");
+        assertInvalidQuorumVotersAsNodes("1@kafka1");
+        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2");
+        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2@");
+        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2@blah");
+        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2@blah,");
+    }
+
+    private void assertInvalidQuorumVotersAsNodes(String value) {
+        assertThrows(ConfigException.class, () -> RaftConfig.quorumVoterStringsToNodes(value));
+    }
+
+    @Test
+    public void testValidQuorumVotersAsNodes() {
+        assertValidQuorumVotersAsNodes("1@kafka1:9092");
+        assertValidQuorumVotersAsNodes("1@kafka1:9092,2@blah:9090");
+    }
+
+    private void assertValidQuorumVotersAsNodes(String value) {
+        assertDoesNotThrow(() -> RaftConfig.quorumVoterStringsToNodes(value));
+    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
@@ -74,17 +74,4 @@ public class RaftConfigTest {
         properties.put(RaftConfig.QUORUM_VOTERS_CONFIG, value);
         assertThrows(ConfigException.class, () -> new RaftConfig(properties));
     }
-
-    @Test
-    public void testValidQuorumVotersAsNodes() {
-        assertValidQuorumVotersAsNodes("1@kafka1:9092");
-        assertValidQuorumVotersAsNodes("1@kafka1:9092,2@blah:9090");
-    }
-
-    private void assertValidQuorumVotersAsNodes(String value) {
-        Properties properties = new Properties();
-        properties.put(RaftConfig.QUORUM_VOTERS_CONFIG, value);
-        RaftConfig raftConfig = new RaftConfig(properties);
-        assertDoesNotThrow(raftConfig::quorumVoterNodes);
-    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftConfigTest.java
@@ -76,29 +76,15 @@ public class RaftConfigTest {
     }
 
     @Test
-    public void testInvalidQuorumVotersAsNodes() {
-        assertInvalidQuorumVotersAsNodes("1");
-        assertInvalidQuorumVotersAsNodes("1@");
-        assertInvalidQuorumVotersAsNodes("1:");
-        assertInvalidQuorumVotersAsNodes("blah@");
-        assertInvalidQuorumVotersAsNodes("1@kafka1");
-        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2");
-        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2@");
-        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2@blah");
-        assertInvalidQuorumVotersAsNodes("1@kafka1:9092,2@blah,");
-    }
-
-    private void assertInvalidQuorumVotersAsNodes(String value) {
-        assertThrows(ConfigException.class, () -> RaftConfig.quorumVoterStringsToNodes(value));
-    }
-
-    @Test
     public void testValidQuorumVotersAsNodes() {
         assertValidQuorumVotersAsNodes("1@kafka1:9092");
         assertValidQuorumVotersAsNodes("1@kafka1:9092,2@blah:9090");
     }
 
     private void assertValidQuorumVotersAsNodes(String value) {
-        assertDoesNotThrow(() -> RaftConfig.quorumVoterStringsToNodes(value));
+        Properties properties = new Properties();
+        properties.put(RaftConfig.QUORUM_VOTERS_CONFIG, value);
+        RaftConfig raftConfig = new RaftConfig(properties);
+        assertDoesNotThrow(raftConfig::quorumVoterNodes);
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -49,9 +49,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -607,8 +605,8 @@ public class RaftEventSimulationTest {
         }
 
         OptionalLong leaderHighWatermark() {
-            Optional<RaftNode> leaderWithMaxEpoch = running.values().stream().filter(node -> node.quorum.isLeader())
-                    .max((node1, node2) -> Integer.compare(node2.quorum.epoch(), node1.quorum.epoch()));
+            Optional<RaftNode> leaderWithMaxEpoch = running.values().stream().filter(node -> node.client.quorum().isLeader())
+                    .max((node1, node2) -> Integer.compare(node2.client.quorum().epoch(), node1.client.quorum().epoch()));
             if (leaderWithMaxEpoch.isPresent()) {
                 return leaderWithMaxEpoch.get().client.highWatermark();
             } else {
@@ -618,12 +616,12 @@ public class RaftEventSimulationTest {
 
         boolean anyReachedHighWatermark(long offset) {
             return running.values().stream()
-                    .anyMatch(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L) > offset);
+                    .anyMatch(node -> node.client.quorum().highWatermark().map(hw -> hw.offset).orElse(0L) > offset);
         }
 
         long maxHighWatermarkReached() {
             return running.values().stream()
-                .map(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L))
+                .map(node -> node.client.quorum().highWatermark().map(hw -> hw.offset).orElse(0L))
                 .max(Long::compareTo)
                 .orElse(0L);
         }
@@ -631,20 +629,20 @@ public class RaftEventSimulationTest {
         long maxHighWatermarkReached(Set<Integer> nodeIds) {
             return running.values().stream()
                 .filter(node -> nodeIds.contains(node.nodeId))
-                .map(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L))
+                .map(node -> node.client.quorum().highWatermark().map(hw -> hw.offset).orElse(0L))
                 .max(Long::compareTo)
                 .orElse(0L);
         }
 
         boolean allReachedHighWatermark(long offset, Set<Integer> nodeIds) {
             return nodeIds.stream()
-                .allMatch(nodeId -> running.get(nodeId).quorum.highWatermark().map(hw -> hw.offset)
+                .allMatch(nodeId -> running.get(nodeId).client.quorum().highWatermark().map(hw -> hw.offset)
                     .orElse(0L) > offset);
         }
 
         boolean allReachedHighWatermark(long offset) {
             return running.values().stream()
-                .allMatch(node -> node.quorum.highWatermark().map(hw -> hw.offset).orElse(0L) > offset);
+                .allMatch(node -> node.client.quorum().highWatermark().map(hw -> hw.offset).orElse(0L) > offset);
         }
 
         OptionalInt latestLeader() {
@@ -652,11 +650,11 @@ public class RaftEventSimulationTest {
             int latestEpoch = 0;
 
             for (RaftNode node : running.values()) {
-                if (node.quorum.epoch() > latestEpoch) {
-                    latestLeader = node.quorum.leaderId();
-                    latestEpoch = node.quorum.epoch();
-                } else if (node.quorum.epoch() == latestEpoch && node.quorum.leaderId().isPresent()) {
-                    latestLeader = node.quorum.leaderId();
+                if (node.client.quorum().epoch() > latestEpoch) {
+                    latestLeader = node.client.quorum().leaderId();
+                    latestEpoch = node.client.quorum().epoch();
+                } else if (node.client.quorum().epoch() == latestEpoch && node.client.quorum().leaderId().isPresent()) {
+                    latestLeader = node.client.quorum().leaderId();
                 }
             }
             return latestLeader;
@@ -723,7 +721,7 @@ public class RaftEventSimulationTest {
 
         void withCurrentLeader(Consumer<RaftNode> action) {
             for (RaftNode node : running.values()) {
-                if (node.quorum.isLeader()) {
+                if (node.client.quorum().isLeader()) {
                     action.accept(node);
                 }
             }
@@ -753,11 +751,13 @@ public class RaftEventSimulationTest {
                 FETCH_TIMEOUT_MS, persistentState.store, time, logContext, random);
             Metrics metrics = new Metrics(time);
 
-            Map<Integer, InetSocketAddress> voterConnectionMap = voters.stream()
-                .collect(Collectors.toMap(
-                    Function.identity(),
-                    this::nodeAddress
-                ));
+            StringBuilder votersString = new StringBuilder();
+            String prefix = "";
+            for (Integer voter : voters) {
+                votersString.append(prefix);
+                votersString.append(voter).append('@').append(nodeAddress(voter).toString());
+                prefix = ",";
+            }
 
             persistentState.log.reopen();
 
@@ -769,29 +769,33 @@ public class RaftEventSimulationTest {
                 channel,
                 messageQueue,
                 persistentState.log,
-                quorum,
+                persistentState.store,
                 memoryPool,
                 time,
                 metrics,
                 new MockExpirationService(time),
-                voterConnectionMap,
+                ELECTION_TIMEOUT_MS,
+                FETCH_TIMEOUT_MS,
                 ELECTION_JITTER_MS,
                 RETRY_BACKOFF_MS,
                 REQUEST_TIMEOUT_MS,
                 FETCH_MAX_WAIT_MS,
                 LINGER_MS,
+                nodeId,
                 logContext,
                 random
             );
             RaftNode node = new RaftNode(
                 nodeId,
+                votersString.toString(),
                 client,
                 persistentState.log,
                 channel,
                 messageQueue,
                 persistentState.store,
-                quorum,
-                logContext
+                logContext,
+                time,
+                random
             );
             node.initialize();
             running.put(nodeId, node);
@@ -800,40 +804,46 @@ public class RaftEventSimulationTest {
 
     private static class RaftNode {
         final int nodeId;
+        final String votersString;
         final KafkaRaftClient<Integer> client;
         final MockLog log;
         final MockNetworkChannel channel;
         final MockMessageQueue messageQueue;
         final MockQuorumStateStore store;
-        final QuorumState quorum;
         final LogContext logContext;
         final ReplicatedCounter counter;
+        final Time time;
+        final Random random;
 
         private RaftNode(
             int nodeId,
+            String votersString,
             KafkaRaftClient<Integer> client,
             MockLog log,
             MockNetworkChannel channel,
             MockMessageQueue messageQueue,
             MockQuorumStateStore store,
-            QuorumState quorum,
-            LogContext logContext
+            LogContext logContext,
+            Time time,
+            Random random
         ) {
             this.nodeId = nodeId;
+            this.votersString = votersString;
             this.client = client;
             this.log = log;
             this.channel = channel;
             this.messageQueue = messageQueue;
             this.store = store;
-            this.quorum = quorum;
             this.logContext = logContext;
+            this.time = time;
+            this.random = random;
             this.counter = new ReplicatedCounter(nodeId, client, logContext);
         }
 
         void initialize() {
             try {
                 client.register(this.counter);
-                client.initialize();
+                client.initialize(votersString);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -941,7 +951,7 @@ public class RaftEventSimulationTest {
                             oldEpoch + " -> " + newEpoch);
                 }
                 cluster.ifRunning(nodeId, nodeState -> {
-                    assertEquals(newEpoch.intValue(), nodeState.quorum.epoch());
+                    assertEquals(newEpoch.intValue(), nodeState.client.quorum().epoch());
                 });
                 nodeEpochs.put(nodeId, newEpoch);
             }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftTestUtil.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftTestUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.raft;
+
+import org.apache.kafka.common.Node;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class RaftTestUtil {
+    public static RaftConfig buildRaftConfig(int requestTimeoutMs,
+                                             int retryBackoffMs,
+                                             int electionTimeoutMs,
+                                             int electionBackoffMs,
+                                             int fetchTimeoutMs,
+                                             int appendLingerMs,
+                                             List<Node> voterNodes) {
+        Properties properties = new Properties();
+        properties.put(RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
+        properties.put(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, retryBackoffMs);
+        properties.put(RaftConfig.QUORUM_ELECTION_TIMEOUT_MS_CONFIG, electionTimeoutMs);
+        properties.put(RaftConfig.QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG, electionBackoffMs);
+        properties.put(RaftConfig.QUORUM_FETCH_TIMEOUT_MS_CONFIG, fetchTimeoutMs);
+        properties.put(RaftConfig.QUORUM_LINGER_MS_CONFIG, appendLingerMs);
+
+        StringBuilder votersString = new StringBuilder();
+        String prefix = "";
+        for (Node voter : voterNodes) {
+            votersString.append(prefix);
+            votersString.append(voter.id()).append('@').append(voter.host()).append(':').append(voter.port());
+            prefix = ",";
+        }
+        properties.put(RaftConfig.QUORUM_VOTERS_CONFIG, votersString.toString());
+
+        return new RaftConfig(properties);
+    }
+
+    public static List<Node> voterNodesFromIds(Set<Integer> voterIds,
+                                               Function<Integer, InetSocketAddress> voterAddressGenerator) {
+        return voterIds.stream().map(voterId -> {
+            InetSocketAddress voterAddress = voterAddressGenerator.apply(voterId);
+            return new Node(voterId, voterAddress.getHostName(), voterAddress.getPort());
+        }).collect(Collectors.toList());
+    }
+}

--- a/raft/src/test/java/org/apache/kafka/raft/RaftTestUtil.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftTestUtil.java
@@ -26,13 +26,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class RaftTestUtil {
-    public static RaftConfig buildRaftConfig(int requestTimeoutMs,
-                                             int retryBackoffMs,
-                                             int electionTimeoutMs,
-                                             int electionBackoffMs,
-                                             int fetchTimeoutMs,
-                                             int appendLingerMs,
-                                             List<Node> voterNodes) {
+    public static RaftConfig buildRaftConfig(
+            int requestTimeoutMs,
+            int retryBackoffMs,
+            int electionTimeoutMs,
+            int electionBackoffMs,
+            int fetchTimeoutMs,
+            int appendLingerMs,
+            List<Node> voterNodes
+    ) {
         Properties properties = new Properties();
         properties.put(RaftConfig.QUORUM_REQUEST_TIMEOUT_MS_CONFIG, requestTimeoutMs);
         properties.put(RaftConfig.QUORUM_RETRY_BACKOFF_MS_CONFIG, retryBackoffMs);


### PR DESCRIPTION
- There are cases where the quorum voters connect string is not ready
  up until after the controller starts.
  Eg: If the controller is configured to choose a free port, we need to
      wait until after the controller starts to configure the right
      host:port connect string for the RaftClient to connect to

### Tested with the Raft unit-tests

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
