### PR TITLE
MINOR: Make JUnit 5 the default for new projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,7 +241,9 @@ subprojects {
     }
   }
 
-  def shouldUseJUnit5 = ["clients", "examples", "log4j-appender", "raft", "tools"].contains(it.project.name)
+  // Remove the relevant project name once it's converted to JUnit 5
+  def shouldUseJUnit5 = !["api", "basic-auth-extension", "connect", "core", "file", "generator", "json", "mirror",
+      "mirorr-client", "runtime", "transform", "examples", "streams-scala", "streams"].contains(it.project.name)
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
   def testShowStandardStreams = false

--- a/build.gradle
+++ b/build.gradle
@@ -242,8 +242,9 @@ subprojects {
   }
 
   // Remove the relevant project name once it's converted to JUnit 5
-  def shouldUseJUnit5 = !["api", "basic-auth-extension", "connect", "core", "file", "generator", "json", "mirror",
-      "mirorr-client", "runtime", "transform", "examples", "streams-scala", "streams"].contains(it.project.name)
+  def shouldUseJUnit5 = !(["api", "basic-auth-extension", "connect", "core", "file", "generator",
+    "json", "mirror", "mirorr-client", "runtime", "transform", "examples", "streams-scala",
+     "streams"].contains(it.project.name) || it.project.name.startsWith("upgrade-system-tests-"))
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
   def testShowStandardStreams = false


### PR DESCRIPTION
Instead of listing the projects that should use JUnit 5, list the
projects that are still using JUnit 4.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
