### PR TITLE
KAFKA-12201: Migrate connect:basic-auth-extensio module to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,8 +242,8 @@ subprojects {
   }
 
   // Remove the relevant project name once it's converted to JUnit 5
-  def shouldUseJUnit5 = !(["api", "basic-auth-extension", "connect", "core", "file", "generator",
-    "json", "mirror", "mirror-client", "runtime", "transform", "examples", "streams-scala",
+  def shouldUseJUnit5 = !(["api", "connect", "core", "file", "generator",
+    "json", "mirror", "mirror-client", "runtime", "transform", "streams-scala",
      "streams"].contains(it.project.name) || it.project.name.startsWith("upgrade-system-tests-"))
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
@@ -2118,10 +2118,7 @@ project(':connect:basic-auth-extension') {
 
     testCompile libs.bcpkix
     testCompile libs.easymock
-    testCompile libs.junitJupiterApi
-    testCompile libs.junitVintageEngine
-    testCompile libs.powermockJunit4
-    testCompile libs.powermockEasymock
+    testCompile libs.junitJupiter
     testCompile project(':clients').sourceSets.test.output
 
     testRuntime libs.slf4jlog4j

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/BasicAuthSecurityRestExtensionTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/BasicAuthSecurityRestExtensionTest.java
@@ -20,31 +20,31 @@ package org.apache.kafka.connect.rest.basic.auth.extension;
 import org.apache.kafka.connect.rest.ConnectRestExtensionContext;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.security.auth.login.Configuration;
 import javax.ws.rs.core.Configurable;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class BasicAuthSecurityRestExtensionTest {
 
     Configuration priorConfiguration;
 
-    @Before
+    @BeforeEach
     public void setup() {
         priorConfiguration = Configuration.getConfiguration();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         Configuration.setConfiguration(priorConfiguration);
     }
-  
-    @Test
+
     @SuppressWarnings("unchecked")
+    @Test
     public void testJaasConfigurationNotOverwritten() {
         Capture<JaasBasicAuthFilter> jaasFilter = EasyMock.newCapture();
         Configurable<? extends Configurable<?>> configurable = EasyMock.mock(Configurable.class);
@@ -52,7 +52,7 @@ public class BasicAuthSecurityRestExtensionTest {
   
         ConnectRestExtensionContext context = EasyMock.mock(ConnectRestExtensionContext.class);
         EasyMock.expect(context.configurable()).andReturn((Configurable) configurable);
-  
+
         EasyMock.replay(configurable, context);
   
         BasicAuthSecurityRestExtension extension = new BasicAuthSecurityRestExtension();
@@ -60,10 +60,7 @@ public class BasicAuthSecurityRestExtensionTest {
         Configuration.setConfiguration(overwrittenConfiguration);
         extension.register(context);
   
-        assertNotEquals(
-            "Overwritten JAAS configuration should not be used by basic auth REST extension",
-            overwrittenConfiguration,
-            jaasFilter.getValue().configuration
-        );
+        assertNotEquals(overwrittenConfiguration, jaasFilter.getValue().configuration,
+            "Overwritten JAAS configuration should not be used by basic auth REST extension");
     }
 }

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
@@ -26,10 +26,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.kafka.common.security.authenticator.TestJaasConfig;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.easymock.EasyMock;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,11 +41,9 @@ import java.util.Map;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertThrows;
 import static org.easymock.EasyMock.replay;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.*")
 public class JaasBasicAuthFilterTest {
 
     private static final String LOGIN_MODULE =


### PR DESCRIPTION
Also:
* Remove unused powermock dependency
* Remove "examples" from the JUnit 4 list since one module was already
converted and the other has no tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
