### PR TITLE
KAFKA-12189 ShellTest can replace 'assumeTrue' by (junit 5) condition…

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
@@ -18,28 +18,27 @@ package org.apache.kafka.common.utils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Timeout(180)
+@DisabledOnOs(OS.WINDOWS)
 public class ShellTest {
 
     @Test
     public void testEchoHello() throws Exception {
-        assumeTrue(!OperatingSystem.IS_WINDOWS);
         String output = Shell.execCommand("echo", "hello");
         assertEquals("hello\n", output);
     }
 
     @Test
     public void testHeadDevZero() throws Exception {
-        assumeTrue(!OperatingSystem.IS_WINDOWS);
         final int length = 100000;
         String output = Shell.execCommand("head", "-c", Integer.toString(length), "/dev/zero");
         assertEquals(length, output.length());
@@ -49,18 +48,13 @@ public class ShellTest {
 
     @Test
     public void testAttemptToRunNonExistentProgram() {
-        assumeTrue(!OperatingSystem.IS_WINDOWS);
-        try {
-            Shell.execCommand(NONEXISTENT_PATH);
-            fail("Expected to get an exception when trying to run a program that does not exist");
-        } catch (IOException e) {
-            assertTrue(e.getMessage().contains("No such file"));
-        }
+        IOException e = assertThrows(IOException.class, () -> Shell.execCommand(NONEXISTENT_PATH),
+                "Expected to get an exception when trying to run a program that does not exist");
+        assertTrue(e.getMessage().contains("No such file"), "Unexpected error message '" + e.getMessage() + "'");
     }
 
     @Test
     public void testRunProgramWithErrorReturn() {
-        assumeTrue(!OperatingSystem.IS_WINDOWS);
         Shell.ExitCodeException e = assertThrows(Shell.ExitCodeException.class,
             () -> Shell.execCommand("head", "-c", "0", NONEXISTENT_PATH));
         String message = e.getMessage();


### PR DESCRIPTION
ShellTest can replace 'assumeTrue' by (junit 5) conditional test

I also test in windows .
```
ShellTest > testEchoHello() SKIPPED
ShellTest > testRunProgramWithErrorReturn() SKIPPED
ShellTest > testHeadDevZero() SKIPPED
ShellTest > testAttemptToRunNonExistentProgram() SKIPPED

```