### PR TITLE
KAFKA-10877

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -86,12 +86,7 @@ object AclCommand extends Logging {
     def listAcls(): Unit
   }
 
-  object AdminClientService extends Logging {
-
-  }
-
   class AdminClientService(val opts: AclCommandOptions) extends AclCommandService {
-    import AdminClientService._
 
     private def withAdminClient(opts: AclCommandOptions)(f: Admin => Unit): Unit = {
       val props = if (opts.options.has(opts.commandConfigOpt))
@@ -198,7 +193,6 @@ object AclCommand extends Logging {
 
   }
   class AuthorizerService(val authorizerClassName: String, val opts: AclCommandOptions) extends AclCommandService {
-    import AuthorizerService._
 
     private def withAuthorizer()(f: Authorizer => Unit): Unit = {
       // It is possible that zookeeper.set.acl could be true without SASL if mutual certificate authentication is configured.

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -86,7 +86,12 @@ object AclCommand extends Logging {
     def listAcls(): Unit
   }
 
-  class AdminClientService(val opts: AclCommandOptions) extends AclCommandService with Logging {
+  object AdminClientService extends Logging {
+
+  }
+
+  class AdminClientService(val opts: AclCommandOptions) extends AclCommandService {
+    import AdminClientService._
 
     private def withAdminClient(opts: AclCommandOptions)(f: Admin => Unit): Unit = {
       val props = if (opts.options.has(opts.commandConfigOpt))
@@ -189,7 +194,11 @@ object AclCommand extends Logging {
     }
   }
 
-  class AuthorizerService(val authorizerClassName: String, val opts: AclCommandOptions) extends AclCommandService with Logging {
+  object AuthorizerService extends Logging {
+
+  }
+  class AuthorizerService(val authorizerClassName: String, val opts: AclCommandOptions) extends AclCommandService {
+    import AuthorizerService._
 
     private def withAuthorizer()(f: Authorizer => Unit): Unit = {
       // It is possible that zookeeper.set.acl could be true without SASL if mutual certificate authentication is configured.
@@ -218,7 +227,7 @@ object AclCommand extends Logging {
         authZ.configure(authorizerProperties.asJava)
         f(authZ)
       }
-      finally CoreUtils.swallow(authZ.close(), this)
+      finally CoreUtils.swallow(authZ.close(), AuthorizerService)
     }
 
     def addAcls(): Unit = {

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -106,7 +106,9 @@ object BrokerApiVersionsCommand {
                             val requestTimeoutMs: Int,
                             val retryBackoffMs: Long,
                             val client: ConsumerNetworkClient,
-                            val bootstrapBrokers: List[Node]) extends Logging {
+                            val bootstrapBrokers: List[Node]) {
+
+    import AdminClient._
 
     @volatile var running: Boolean = true
     val pendingFutures = new ConcurrentLinkedQueue[RequestFuture[ClientResponse]]()
@@ -203,7 +205,7 @@ object BrokerApiVersionsCommand {
 
   }
 
-  private object AdminClient {
+  private object AdminClient extends Logging {
     val DefaultConnectionMaxIdleMs = 9 * 60 * 1000
     val DefaultRequestTimeoutMs = 5000
     val DefaultSocketConnectionSetupMs = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -41,7 +41,6 @@ import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, S
 import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
 import org.apache.zookeeper.client.ZKClientConfig
 
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.collection._
 
@@ -307,7 +306,6 @@ object ConfigCommand extends Config {
     }
   }
 
-  @nowarn("cat=deprecation")
   private[admin] def alterConfig(adminClient: Admin, opts: ConfigCommandOptions): Unit = {
     val entityTypes = opts.entityTypes
     val entityNames = opts.entityNames

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -41,6 +41,7 @@ import org.apache.kafka.common.security.scram.internals.{ScramCredentialUtils, S
 import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
 import org.apache.zookeeper.client.ZKClientConfig
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.collection._
 
@@ -306,6 +307,7 @@ object ConfigCommand extends Config {
     }
   }
 
+  @nowarn("cat=deprecation")
   private[admin] def alterConfig(adminClient: Admin, opts: ConfigCommandOptions): Unit = {
     val entityTypes = opts.entityTypes
     val entityNames = opts.entityNames

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -162,7 +162,8 @@ object ZkSecurityMigrator extends Logging {
   }
 }
 
-class ZkSecurityMigrator(zkClient: KafkaZkClient) extends Logging {
+class ZkSecurityMigrator(zkClient: KafkaZkClient) {
+  import ZkSecurityMigrator._
   private val zkSecurityMigratorUtils = new ZkSecurityMigratorUtils(zkClient)
   private val futures = new Queue[Future[String]]
 

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -70,7 +70,8 @@ class DelayedOperations(topicPartition: TopicPartition,
   def numDelayedDelete: Int = deleteRecords.numDelayed
 }
 
-object Partition extends KafkaMetricsGroup {
+
+object Partition extends Logging with KafkaMetricsGroup {
   def apply(topicPartition: TopicPartition,
             time: Time,
             replicaManager: ReplicaManager): Partition = {
@@ -204,7 +205,6 @@ case class CommittedIsr(
   }
 }
 
-
 /**
  * Data structure that represents a topic partition. The leader maintains the AR, ISR, CUR, RAR
  *
@@ -233,7 +233,9 @@ class Partition(val topicPartition: TopicPartition,
                 delayedOperations: DelayedOperations,
                 metadataCache: MetadataCache,
                 logManager: LogManager,
-                alterIsrManager: AlterIsrManager) extends Logging with KafkaMetricsGroup {
+                alterIsrManager: AlterIsrManager) extends KafkaMetricsGroup {
+
+  import Partition._
 
   def topic: String = topicPartition.topic
   def partitionId: Int = topicPartition.partition
@@ -268,7 +270,7 @@ class Partition(val topicPartition: TopicPartition,
    * In addition to the leader, the controller can also send the epoch of the controller that elected the leader for
    * each partition. */
   private var controllerEpoch: Int = KafkaController.InitialControllerEpoch
-  this.logIdent = s"[Partition $topicPartition broker=$localBrokerId] "
+  protected implicit val logIdent = Some(LogIdent(s"[Partition $topicPartition broker=$localBrokerId] "))
 
   private val tags = Map("topic" -> topic, "partition" -> partitionId.toString)
 

--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -22,7 +22,13 @@ import kafka.server.LogOffsetMetadata
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 
-class Replica(val brokerId: Int, val topicPartition: TopicPartition) extends Logging {
+object Replica extends Logging {
+
+}
+
+class Replica(val brokerId: Int, val topicPartition: TopicPartition) {
+  import Replica._
+
   // the log end offset value, kept in all replicas;
   // for local replica it is the log's end offset, for remote replicas its value is only updated by follower fetch
   @volatile private[this] var _logEndOffsetMetadata = LogOffsetMetadata.UnknownOffsetMetadata

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -18,8 +18,7 @@ package kafka.common
 
 import java.util.Map.Entry
 import java.util.{ArrayDeque, ArrayList, Collection, Collections, HashMap, Iterator}
-
-import kafka.utils.ShutdownableThread
+import kafka.utils.{Logging, ShutdownableThread}
 import org.apache.kafka.clients.{ClientRequest, ClientResponse, KafkaClient, RequestCompletionHandler}
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.errors.AuthenticationException
@@ -28,6 +27,10 @@ import org.apache.kafka.common.requests.AbstractRequest
 import org.apache.kafka.common.utils.Time
 
 import scala.jdk.CollectionConverters._
+
+object InterBrokerSendThread extends Logging {
+
+}
 
 /**
  *  Class for inter-broker send thread that utilize a non-blocking network client.
@@ -39,6 +42,8 @@ abstract class InterBrokerSendThread(
   time: Time,
   isInterruptible: Boolean = true
 ) extends ShutdownableThread(name, isInterruptible) {
+
+  import InterBrokerSendThread._
 
   private val unsentRequests = new UnsentRequests
 

--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -35,6 +35,9 @@ trait NotificationHandler {
   def processNotification(notificationMessage: Array[Byte]): Unit
 }
 
+object ZkNodeChangeNotificationListener extends Logging {
+
+}
 /**
  * A listener that subscribes to seqNodeRoot for any child changes where all children are assumed to be sequence node
  * with seqNodePrefix. When a child is added under seqNodeRoot this class gets notified, it looks at lastExecutedChange
@@ -54,7 +57,9 @@ class ZkNodeChangeNotificationListener(private val zkClient: KafkaZkClient,
                                        private val seqNodePrefix: String,
                                        private val notificationHandler: NotificationHandler,
                                        private val changeExpirationMs: Long = 15 * 60 * 1000,
-                                       private val time: Time = Time.SYSTEM) extends Logging {
+                                       private val time: Time = Time.SYSTEM) {
+  import ZkNodeChangeNotificationListener._
+
   private var lastExecutedChange = -1L
   private val queue = new LinkedBlockingQueue[ChangeNotification]
   private val thread = new ChangeEventProcessThread(s"$seqNodeRoot-event-process-thread")

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -337,9 +337,15 @@ class ControllerBrokerRequestBatch(config: KafkaConfig,
 
 }
 
+object AbstractControllerBrokerRequestBatch extends Logging {
+
+}
+
 abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
                                                     controllerContext: ControllerContext,
-                                                    stateChangeLogger: StateChangeLogger) extends Logging {
+                                                    stateChangeLogger: StateChangeLogger) {
+  import AbstractControllerBrokerRequestBatch._
+
   val controllerId: Int = config.brokerId
   val leaderAndIsrRequestMap = mutable.Map.empty[Int, mutable.Map[TopicPartition, LeaderAndIsrPartitionState]]
   val stopReplicaRequestMap = mutable.Map.empty[Int, mutable.Map[TopicPartition, StopReplicaPartitionState]]

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -230,7 +230,7 @@ class RequestSendThread(val controllerId: Int,
   extends ShutdownableThread(name = name) {
 
   import RequestSendThread._
-  protected implicit val logIdent = Some(LogIdent(s"[RequestSendThread controllerId=$controllerId] "))
+  override protected implicit val logIdent = Some(LogIdent(s"[RequestSendThread controllerId=$controllerId] "))
 
   private val socketTimeoutMs = config.controllerSocketTimeoutMs
 

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -43,7 +43,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable.HashMap
 import scala.collection.{Seq, Set, mutable}
 
-object ControllerChannelManager {
+object ControllerChannelManager extends Logging {
   val QueueSizeMetricName = "QueueSize"
   val RequestRateAndQueueTimeMetricName = "RequestRateAndQueueTimeMs"
 }
@@ -53,12 +53,12 @@ class ControllerChannelManager(controllerContext: ControllerContext,
                                time: Time,
                                metrics: Metrics,
                                stateChangeLogger: StateChangeLogger,
-                               threadNamePrefix: Option[String] = None) extends Logging with KafkaMetricsGroup {
+                               threadNamePrefix: Option[String] = None) extends KafkaMetricsGroup {
   import ControllerChannelManager._
 
   protected val brokerStateInfo = new HashMap[Int, ControllerBrokerStateInfo]
   private val brokerLock = new Object
-  this.logIdent = "[Channel manager on controller " + config.brokerId + "]: "
+  protected implicit val logIdent = Some(LogIdent("[Channel manager on controller " + config.brokerId + "]: "))
 
   newGauge("TotalQueueSize",
     () => brokerLock synchronized {
@@ -213,6 +213,10 @@ class ControllerChannelManager(controllerContext: ControllerContext,
 case class QueueItem(apiKey: ApiKeys, request: AbstractControlRequest.Builder[_ <: AbstractControlRequest],
                      callback: AbstractResponse => Unit, enqueueTimeMs: Long)
 
+object RequestSendThread extends Logging {
+
+}
+
 class RequestSendThread(val controllerId: Int,
                         val controllerContext: ControllerContext,
                         val queue: BlockingQueue[QueueItem],
@@ -225,7 +229,8 @@ class RequestSendThread(val controllerId: Int,
                         name: String)
   extends ShutdownableThread(name = name) {
 
-  logIdent = s"[RequestSendThread controllerId=$controllerId] "
+  import RequestSendThread._
+  protected implicit val logIdent = Some(LogIdent(s"[RequestSendThread controllerId=$controllerId] "))
 
   private val socketTimeoutMs = config.controllerSocketTimeoutMs
 

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -119,7 +119,7 @@ class ControllerEventManager(controllerId: Int,
 
   class ControllerEventThread(name: String) extends ShutdownableThread(name = name, isInterruptible = false) {
     import ControllerEventThread._
-    protected implicit val logIdent = Some(LogIdent(s"[ControllerEventThread controllerId=$controllerId] "))
+    override protected implicit val logIdent = Some(LogIdent(s"[ControllerEventThread controllerId=$controllerId] "))
 
     override def doWork(): Unit = {
       val dequeued = pollFromEventQueue()

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -21,10 +21,9 @@ import java.util.ArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{CountDownLatch, LinkedBlockingQueue, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
-
 import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
 import kafka.utils.CoreUtils.inLock
-import kafka.utils.ShutdownableThread
+import kafka.utils.{LogIdent, Logging, ShutdownableThread}
 import org.apache.kafka.common.utils.Time
 
 import scala.collection._
@@ -114,8 +113,13 @@ class ControllerEventManager(controllerId: Int,
 
   def isEmpty: Boolean = queue.isEmpty
 
+  object ControllerEventThread extends Logging {
+
+  }
+
   class ControllerEventThread(name: String) extends ShutdownableThread(name = name, isInterruptible = false) {
-    logIdent = s"[ControllerEventThread controllerId=$controllerId] "
+    import ControllerEventThread._
+    protected implicit val logIdent = Some(LogIdent(s"[ControllerEventThread controllerId=$controllerId] "))
 
     override def doWork(): Unit = {
       val dequeued = pollFromEventQueue()

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -80,7 +80,7 @@ class KafkaController(val config: KafkaConfig,
                       threadNamePrefix: Option[String] = None)
   extends ControllerEventProcessor with Logging with KafkaMetricsGroup {
 
-  this.logIdent = s"[Controller id=${config.brokerId}] "
+  protected implicit val logIndent = Some(LogIdent(s"[Controller id=${config.brokerId}] "))
 
   @volatile private var brokerInfo = initialBrokerInfo
   @volatile private var _brokerEpoch = initialBrokerEpoch

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -78,9 +78,11 @@ class KafkaController(val config: KafkaConfig,
                       brokerFeatures: BrokerFeatures,
                       featureCache: FinalizedFeatureCache,
                       threadNamePrefix: Option[String] = None)
-  extends ControllerEventProcessor with Logging with KafkaMetricsGroup {
+  extends ControllerEventProcessor with KafkaMetricsGroup {
 
-  protected implicit val logIndent = Some(LogIdent(s"[Controller id=${config.brokerId}] "))
+  import KafkaController._
+
+  protected implicit val logIdent = Some(LogIdent(s"[Controller id=${config.brokerId}] "))
 
   @volatile private var brokerInfo = initialBrokerInfo
   @volatile private var _brokerEpoch = initialBrokerEpoch

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -32,7 +32,13 @@ import org.apache.zookeeper.KeeperException.Code
 
 import scala.collection.{Map, Seq, mutable}
 
-abstract class PartitionStateMachine(controllerContext: ControllerContext) extends Logging {
+object PartitionStateMachine extends Logging {
+
+}
+
+abstract class PartitionStateMachine(controllerContext: ControllerContext) extends {
+  import PartitionStateMachine._
+
   /**
    * Invoked on successful controller election.
    */
@@ -132,6 +138,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
                               controllerBrokerRequestBatch: ControllerBrokerRequestBatch)
   extends PartitionStateMachine(controllerContext) {
 
+  import PartitionStateMachine._
   private val controllerId = config.brokerId
   protected implicit val logIdent = Some(LogIdent(s"[PartitionStateMachine controllerId=$controllerId] "))
 
@@ -342,7 +349,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
       finishedElections ++= finished
 
       if (remaining.nonEmpty)
-        logger.info(s"Retrying leader election with strategy $partitionLeaderElectionStrategy for partitions $remaining")
+        info(s"Retrying leader election with strategy $partitionLeaderElectionStrategy for partitions $remaining")
     }
 
     finishedElections.toMap

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -21,7 +21,7 @@ import kafka.common.StateChangeFailedException
 import kafka.controller.Election._
 import kafka.server.KafkaConfig
 import kafka.utils.Implicits._
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import kafka.zk.KafkaZkClient
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicPartitionStateZNode
@@ -29,6 +29,7 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.Code
+
 import scala.collection.{Map, Seq, mutable}
 
 abstract class PartitionStateMachine(controllerContext: ControllerContext) extends Logging {
@@ -132,7 +133,7 @@ class ZkPartitionStateMachine(config: KafkaConfig,
   extends PartitionStateMachine(controllerContext) {
 
   private val controllerId = config.brokerId
-  this.logIdent = s"[PartitionStateMachine controllerId=$controllerId] "
+  protected implicit val logIdent = Some(LogIdent(s"[PartitionStateMachine controllerId=$controllerId] "))
 
   /**
    * Try to change the state of the given partitions to the given targetState, using the given

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -20,16 +20,23 @@ import kafka.api.LeaderAndIsr
 import kafka.common.StateChangeFailedException
 import kafka.server.KafkaConfig
 import kafka.utils.Implicits._
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import kafka.zk.KafkaZkClient
 import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicPartitionStateZNode
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.zookeeper.KeeperException.Code
+
 import scala.collection.{Seq, mutable}
 
-abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends Logging {
+object ReplicaStateMachine extends Logging {
+
+}
+
+abstract class ReplicaStateMachine(controllerContext: ControllerContext) {
+  import ReplicaStateMachine._
+
   /**
    * Invoked on successful controller election.
    */
@@ -75,6 +82,9 @@ abstract class ReplicaStateMachine(controllerContext: ControllerContext) extends
   def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit
 }
 
+object ZkReplicaStateMachine extends Logging {
+
+}
 /**
  * This class represents the state machine for replicas. It defines the states that a replica can be in, and
  * transitions to move the replica to another legal state. The different states that a replica can be in are -
@@ -99,10 +109,11 @@ class ZkReplicaStateMachine(config: KafkaConfig,
                             controllerContext: ControllerContext,
                             zkClient: KafkaZkClient,
                             controllerBrokerRequestBatch: ControllerBrokerRequestBatch)
-  extends ReplicaStateMachine(controllerContext) with Logging {
+  extends ReplicaStateMachine(controllerContext) {
 
+  import ZkReplicaStateMachine._
   private val controllerId = config.brokerId
-  this.logIdent = s"[ReplicaStateMachine controllerId=$controllerId] "
+  protected implicit val logIndent = Some(LogIdent(s"[ReplicaStateMachine controllerId=$controllerId] "))
 
   override def handleStateChanges(replicas: Seq[PartitionAndReplica], targetState: ReplicaState): Unit = {
     if (replicas.nonEmpty) {

--- a/core/src/main/scala/kafka/controller/StateChangeLogger.scala
+++ b/core/src/main/scala/kafka/controller/StateChangeLogger.scala
@@ -18,7 +18,7 @@
 package kafka.controller
 
 import com.typesafe.scalalogging.Logger
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 
 object StateChangeLogger {
   private val logger = Logger("state.change.logger")
@@ -36,10 +36,11 @@ class StateChangeLogger(brokerId: Int, inControllerContext: Boolean, controllerE
 
   override lazy val logger = StateChangeLogger.logger
 
+  protected implicit var logIndent : Option[LogIdent] = None
   locally {
     val prefix = if (inControllerContext) "Controller" else "Broker"
     val epochEntry = controllerEpoch.fold("")(epoch => s" epoch=$epoch")
-    logIdent = s"[$prefix id=$brokerId$epochEntry] "
+    logIndent = Some(LogIdent(s"[$prefix id=$brokerId$epochEntry] "))
   }
 
   def withControllerEpoch(controllerEpoch: Int): StateChangeLogger =

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -17,7 +17,7 @@
 package kafka.controller
 
 import kafka.server.KafkaConfig
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 
@@ -49,6 +49,10 @@ class ControllerDeletionClient(controller: KafkaController, zkClient: KafkaZkCli
   override def sendMetadataUpdate(partitions: Set[TopicPartition]): Unit = {
     controller.sendUpdateMetadataRequest(controller.controllerContext.liveOrShuttingDownBrokerIds.toSeq, partitions)
   }
+}
+
+object TopicDeletionManager extends Logging {
+
 }
 
 /**
@@ -88,8 +92,10 @@ class TopicDeletionManager(config: KafkaConfig,
                            controllerContext: ControllerContext,
                            replicaStateMachine: ReplicaStateMachine,
                            partitionStateMachine: PartitionStateMachine,
-                           client: DeletionClient) extends Logging {
-  this.logIdent = s"[Topic Deletion Manager ${config.brokerId}] "
+                           client: DeletionClient) {
+  import TopicDeletionManager._
+
+  protected implicit val logIndent = Some(LogIdent(s"[Topic Deletion Manager ${config.brokerId}] "))
   val isDeleteTopicEnabled: Boolean = config.deleteTopicEnable
 
   def init(initialTopicsToBeDeleted: Set[String], initialTopicsIneligibleForDeletion: Set[String]): Unit = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -18,12 +18,11 @@ package kafka.coordinator.group
 
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
-
 import kafka.common.OffsetAndMetadata
 import kafka.log.LogConfig
 import kafka.message.ProducerCompressionCodec
 import kafka.server._
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.internals.Topic
@@ -57,7 +56,7 @@ class GroupCoordinator(val brokerId: Int,
                        val heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat],
                        val joinPurgatory: DelayedOperationPurgatory[DelayedJoin],
                        time: Time,
-                       metrics: Metrics) extends Logging {
+                       metrics: Metrics) {
   import GroupCoordinator._
 
   type JoinCallback = JoinGroupResult => Unit
@@ -84,7 +83,7 @@ class GroupCoordinator(val brokerId: Int,
       "group-coordinator-metrics",
       "The total number of completed rebalance")))
 
-  this.logIdent = "[GroupCoordinator " + brokerId + "]: "
+  protected implicit val logIdent = LogIdent("[GroupCoordinator " + brokerId + "]: ")
 
   private val isActive = new AtomicBoolean(false)
 
@@ -1311,7 +1310,7 @@ class GroupCoordinator(val brokerId: Int,
   private def isCoordinatorLoadInProgress(groupId: String) = groupManager.isGroupLoading(groupId)
 }
 
-object GroupCoordinator {
+object GroupCoordinator extends Logging {
 
   val NoState = ""
   val NoProtocolType = ""

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -181,6 +181,7 @@ case class CommitRecordMetadataAndOffset(appendedBatchOffset: Option[Long], offs
   def olderThan(that: CommitRecordMetadataAndOffset): Boolean = appendedBatchOffset.get < that.appendedBatchOffset.get
 }
 
+
 /**
  * Group contains the following metadata:
  *
@@ -195,7 +196,9 @@ case class CommitRecordMetadataAndOffset(appendedBatchOffset: Option[Long], offs
  *  3. leader id
  */
 @nonthreadsafe
-private[group] class GroupMetadata(val groupId: String, initialState: GroupState, time: Time) extends Logging {
+private[group] class GroupMetadata(val groupId: String, initialState: GroupState, time: Time) {
+  import GroupMetadata._
+
   type JoinCallback = JoinGroupResult => Unit
 
   private[group] val lock = new ReentrantLock

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -59,7 +59,9 @@ class GroupMetadataManager(brokerId: Int,
                            val replicaManager: ReplicaManager,
                            zkClient: KafkaZkClient,
                            time: Time,
-                           metrics: Metrics) extends Logging with KafkaMetricsGroup {
+                           metrics: Metrics) extends KafkaMetricsGroup {
+
+  import GroupMetadataManager._
 
   private val compressionType: CompressionType = CompressionType.forId(config.offsetsTopicCompressionCodec.codec)
 
@@ -118,7 +120,7 @@ class GroupMetadataManager(brokerId: Int,
       "group-coordinator-metrics",
       "The total number of expired offsets")))
 
-  this.logIdent = s"[GroupMetadataManager brokerId=$brokerId] "
+  protected implicit val logIdent = Some(LogIdent(s"[GroupMetadataManager brokerId=$brokerId] "))
 
   private def recreateGauge[T](name: String, gauge: Gauge[T]): Gauge[T] = {
     removeMetric(name)
@@ -991,7 +993,7 @@ class GroupMetadataManager(brokerId: Int,
  * key version 2:       group metadata
  *    -> value version 0:       [protocol_type, generation, protocol, leader, members]
  */
-object GroupMetadataManager {
+object GroupMetadataManager extends Logging {
   // Metrics names
   val MetricsGroup: String = "group-coordinator-metrics"
   val LoadTimeSensor: String = "GroupPartitionLoadTime"

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -59,9 +59,7 @@ class GroupMetadataManager(brokerId: Int,
                            val replicaManager: ReplicaManager,
                            zkClient: KafkaZkClient,
                            time: Time,
-                           metrics: Metrics) extends KafkaMetricsGroup {
-
-  import GroupMetadataManager._
+                           metrics: Metrics) extends KafkaMetricsGroup with Logging {
 
   private val compressionType: CompressionType = CompressionType.forId(config.offsetsTopicCompressionCodec.codec)
 
@@ -993,7 +991,7 @@ class GroupMetadataManager(brokerId: Int,
  * key version 2:       group metadata
  *    -> value version 0:       [protocol_type, generation, protocol, leader, members]
  */
-object GroupMetadataManager extends Logging {
+object GroupMetadataManager {
   // Metrics names
   val MetricsGroup: String = "group-coordinator-metrics"
   val LoadTimeSensor: String = "GroupPartitionLoadTime"

--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -17,8 +17,7 @@
 package kafka.coordinator.transaction
 
 import java.nio.charset.StandardCharsets
-
-import kafka.utils.{Json, Logging}
+import kafka.utils.{Json, LogIdent, Logging}
 import kafka.zk.{KafkaZkClient, ProducerIdBlockZNode}
 import org.apache.kafka.common.KafkaException
 
@@ -70,9 +69,9 @@ case class ProducerIdBlock(brokerId: Int, blockStartId: Long, blockEndId: Long) 
   }
 }
 
-class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends Logging {
-
-  this.logIdent = "[ProducerId Manager " + brokerId + "]: "
+class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) {
+  import ProducerIdManager._
+  protected implicit val logIndent  = Some(LogIdent("[ProducerId Manager " + brokerId + "]: "))
 
   private var currentProducerIdBlock: ProducerIdBlock = null
   private var nextProducerId: Long = -1L

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -20,7 +20,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.server.{KafkaConfig, MetadataCache, ReplicaManager}
-import kafka.utils.{Logging, Scheduler}
+import kafka.utils.{Logging, LogIdent, Scheduler}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.internals.Topic
@@ -30,7 +30,7 @@ import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.utils.{LogContext, ProducerIdAndEpoch, Time}
 
-object TransactionCoordinator {
+object TransactionCoordinator extends Logging {
 
   def apply(config: KafkaConfig,
             replicaManager: ReplicaManager,
@@ -87,10 +87,9 @@ class TransactionCoordinator(brokerId: Int,
                              txnManager: TransactionStateManager,
                              txnMarkerChannelManager: TransactionMarkerChannelManager,
                              time: Time,
-                             logContext: LogContext) extends Logging {
-  this.logIdent = logContext.logPrefix
-
+                             logContext: LogContext) {
   import TransactionCoordinator._
+  protected implicit val logIdent = Some(LogIdent(logContext.logPrefix))
 
   type InitProducerIdCallback = InitProducerIdResult => Unit
   type AddPartitionsCallback = Errors => Unit

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -19,13 +19,12 @@ package kafka.coordinator.transaction
 
 import java.util
 import java.util.concurrent.{BlockingQueue, ConcurrentHashMap, LinkedBlockingQueue}
-
 import kafka.api.KAFKA_2_8_IV0
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.{KafkaConfig, MetadataCache}
 import kafka.utils.Implicits._
-import kafka.utils.{CoreUtils, Logging}
+import kafka.utils.{CoreUtils, LogIdent, Logging}
 import org.apache.kafka.clients._
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network._
@@ -39,7 +38,7 @@ import org.apache.kafka.common.{Node, Reconfigurable, TopicPartition}
 import scala.collection.{concurrent, immutable}
 import scala.jdk.CollectionConverters._
 
-object TransactionMarkerChannelManager {
+object TransactionMarkerChannelManager extends Logging {
   def apply(config: KafkaConfig,
             metrics: Metrics,
             metadataCache: MetadataCache,
@@ -134,9 +133,10 @@ class TransactionMarkerChannelManager(
   txnStateManager: TransactionStateManager,
   time: Time
 ) extends InterBrokerSendThread("TxnMarkerSenderThread-" + config.brokerId, networkClient, config.requestTimeoutMs, time)
-  with Logging with KafkaMetricsGroup {
+  with KafkaMetricsGroup {
+  import TransactionMarkerChannelManager._
 
-  this.logIdent = "[Transaction Marker Channel Manager " + config.brokerId + "]: "
+  protected implicit val logIndent = Some(LogIdent("[Transaction Marker Channel Manager " + config.brokerId + "]: "))
 
   private val interBrokerListenerName: ListenerName = config.interBrokerListenerName
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
@@ -17,7 +17,7 @@
 
 package kafka.coordinator.transaction
 
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import org.apache.kafka.clients.{ClientResponse, RequestCompletionHandler}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
@@ -26,12 +26,17 @@ import org.apache.kafka.common.requests.WriteTxnMarkersResponse
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
+object TransactionMarkerRequestCompletionHandler extends Logging {
+
+}
+
 class TransactionMarkerRequestCompletionHandler(brokerId: Int,
                                                 txnStateManager: TransactionStateManager,
                                                 txnMarkerChannelManager: TransactionMarkerChannelManager,
-                                                txnIdAndMarkerEntries: java.util.List[TxnIdAndMarkerEntry]) extends RequestCompletionHandler with Logging {
+                                                txnIdAndMarkerEntries: java.util.List[TxnIdAndMarkerEntry]) extends RequestCompletionHandler {
 
-  this.logIdent = "[Transaction Marker Request Completion Handler " + brokerId + "]: "
+  import TransactionMarkerRequestCompletionHandler._
+  protected implicit val logIndent = Some(LogIdent("[Transaction Marker Request Completion Handler " + brokerId + "]: "))
 
   override def onComplete(response: ClientResponse): Unit = {
     val requestHeader = response.requestHeader

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -84,7 +84,7 @@ private[transaction] case object Dead extends TransactionState { val byte: Byte 
 
 private[transaction] case object PrepareEpochFence extends TransactionState { val byte: Byte = 7}
 
-private[transaction] object TransactionMetadata {
+private[transaction] object TransactionMetadata extends Logging {
   def apply(transactionalId: String, producerId: Long, producerEpoch: Short, txnTimeoutMs: Int, timestamp: Long) =
     new TransactionMetadata(transactionalId, producerId, RecordBatch.NO_PRODUCER_ID, producerEpoch,
       RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, Empty, collection.mutable.Set.empty[TopicPartition], timestamp, timestamp)
@@ -176,7 +176,8 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
                                                var state: TransactionState,
                                                val topicPartitions: mutable.Set[TopicPartition],
                                                @volatile var txnStartTimestamp: Long = -1,
-                                               @volatile var txnLastUpdateTimestamp: Long) extends Logging {
+                                               @volatile var txnLastUpdateTimestamp: Long) {
+  import TransactionMetadata._
 
   // pending state is used to indicate the state that this transaction is going to
   // transit to, and for blocking future attempts to transit it again if it is not legal;

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -21,12 +21,11 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantReadWriteLock
-
 import kafka.log.{AppendOrigin, LogConfig}
 import kafka.message.UncompressedCodec
 import kafka.server.{Defaults, FetchLogEnd, ReplicaManager}
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
-import kafka.utils.{Logging, Pool, Scheduler}
+import kafka.utils.{LogIdent, Logging, Pool, Scheduler}
 import kafka.utils.Implicits._
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.internals.Topic
@@ -43,7 +42,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 
-object TransactionStateManager {
+object TransactionStateManager extends Logging {
   // default transaction management config values
   val DefaultTransactionsMaxTimeoutMs: Int = TimeUnit.MINUTES.toMillis(15).toInt
   val DefaultTransactionalIdExpirationMs: Int = TimeUnit.DAYS.toMillis(7).toInt
@@ -77,9 +76,11 @@ class TransactionStateManager(brokerId: Int,
                               replicaManager: ReplicaManager,
                               config: TransactionConfig,
                               time: Time,
-                              metrics: Metrics) extends Logging {
+                              metrics: Metrics) {
 
-  this.logIdent = "[Transaction State Manager " + brokerId + "]: "
+  import TransactionStateManager._
+
+  protected implicit val logIdent = Some(LogIdent("[Transaction State Manager " + brokerId + "]: "))
 
   type SendTxnMarkersCallback = (Int, TransactionResult, TransactionMetadata, TxnTransitMetadata) => Unit
 

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -253,7 +253,7 @@ class Log(@volatile private var _dir: File,
 
   import kafka.log.Log._
 
-  this.logIdent = s"[Log partition=$topicPartition, dir=${dir.getParent}] "
+  protected implicit val logIdent = Some(LogIdent(s"[Log partition=$topicPartition, dir=${dir.getParent}] "))
 
   /* A lock that guards all modifications to the log */
   private val lock = new Object

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -63,9 +63,6 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
                                      val logDirFailureChannel: LogDirFailureChannel) extends KafkaMetricsGroup {
   import LogCleanerManager._
 
-
-  protected override def loggerName = classOf[LogCleaner].getName
-
   // package-private for testing
   private[log] val offsetCheckpointFile = "cleaner-offset-checkpoint"
 
@@ -528,6 +525,8 @@ private case class OffsetsToClean(firstDirtyOffset: Long,
 }
 
 private[log] object LogCleanerManager extends Logging {
+
+  override protected def loggerName = classOf[LogCleaner].getName
 
   def isCompactAndDelete(log: Log): Boolean = {
     log.config.compact && log.config.delete

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -60,7 +60,7 @@ private[log] class LogCleaningException(val log: Log,
   */
 private[log] class LogCleanerManager(val logDirs: Seq[File],
                                      val logs: Pool[TopicPartition, Log],
-                                     val logDirFailureChannel: LogDirFailureChannel) extends Logging with KafkaMetricsGroup {
+                                     val logDirFailureChannel: LogDirFailureChannel) extends KafkaMetricsGroup {
   import LogCleanerManager._
 
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -493,7 +493,7 @@ class LogManager(logDirs: Seq[File],
 
           // mark that the shutdown was clean by creating marker file
           debug(s"Writing clean shutdown marker at $dir")
-          CoreUtils.swallow(Files.createFile(new File(dir, Log.CleanShutdownFile).toPath), this)
+          CoreUtils.swallow(Files.createFile(new File(dir, Log.CleanShutdownFile).toPath), LogManager)
         }
       }
     } finally {

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -63,7 +63,7 @@ class LogManager(logDirs: Seq[File],
                  val brokerState: BrokerState,
                  brokerTopicStats: BrokerTopicStats,
                  logDirFailureChannel: LogDirFailureChannel,
-                 time: Time) extends Logging with KafkaMetricsGroup {
+                 time: Time) extends KafkaMetricsGroup {
 
   import LogManager._
 
@@ -223,7 +223,7 @@ class LogManager(logDirs: Seq[File],
 
       warn(s"Logs for partitions ${offlineCurrentTopicPartitions.mkString(",")} are offline and " +
            s"logs for future partitions ${offlineFutureTopicPartitions.mkString(",")} are offline due to failure on log directory $dir")
-      dirLocks.filter(_.file.getParent == dir).foreach(dir => CoreUtils.swallow(dir.destroy(), this))
+      dirLocks.filter(_.file.getParent == dir).foreach(dir => CoreUtils.swallow(dir.destroy(), LogManager))
     }
   }
 
@@ -452,7 +452,7 @@ class LogManager(logDirs: Seq[File],
 
     // stop the cleaner first
     if (cleaner != null) {
-      CoreUtils.swallow(cleaner.shutdown(), this)
+      CoreUtils.swallow(cleaner.shutdown(), LogManager)
     }
 
     val localLogsByDir = logsByDir
@@ -1158,7 +1158,7 @@ class LogManager(logDirs: Seq[File],
   }
 }
 
-object LogManager {
+object LogManager extends Logging {
 
   /**
    * Wait all jobs to complete

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -60,7 +60,9 @@ class LogSegment private[log] (val log: FileRecords,
                                val baseOffset: Long,
                                val indexIntervalBytes: Int,
                                val rollJitterMs: Long,
-                               val time: Time) extends Logging {
+                               val time: Time) {
+
+  import LogSegment._
 
   def offsetIndex: OffsetIndex = lazyOffsetIndex.get
 
@@ -587,21 +589,21 @@ class LogSegment private[log] (val log: FileRecords,
   def close(): Unit = {
     if (_maxTimestampSoFar.nonEmpty || _offsetOfMaxTimestampSoFar.nonEmpty)
       CoreUtils.swallow(timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestampSoFar,
-        skipFullCheck = true), this)
-    CoreUtils.swallow(lazyOffsetIndex.close(), this)
-    CoreUtils.swallow(lazyTimeIndex.close(), this)
-    CoreUtils.swallow(log.close(), this)
-    CoreUtils.swallow(txnIndex.close(), this)
+        skipFullCheck = true), LogSegment)
+    CoreUtils.swallow(lazyOffsetIndex.close(), LogSegment)
+    CoreUtils.swallow(lazyTimeIndex.close(), LogSegment)
+    CoreUtils.swallow(log.close(), LogSegment)
+    CoreUtils.swallow(txnIndex.close(), LogSegment)
   }
 
   /**
     * Close file handlers used by the log segment but don't write to disk. This is used when the disk may have failed
     */
   def closeHandlers(): Unit = {
-    CoreUtils.swallow(lazyOffsetIndex.closeHandler(), this)
-    CoreUtils.swallow(lazyTimeIndex.closeHandler(), this)
-    CoreUtils.swallow(log.closeHandlers(), this)
-    CoreUtils.swallow(txnIndex.close(), this)
+    CoreUtils.swallow(lazyOffsetIndex.closeHandler(), LogSegment)
+    CoreUtils.swallow(lazyTimeIndex.closeHandler(), LogSegment)
+    CoreUtils.swallow(log.closeHandlers(), LogSegment)
+    CoreUtils.swallow(txnIndex.close(), LogSegment)
   }
 
   /**
@@ -655,7 +657,7 @@ class LogSegment private[log] (val log: FileRecords,
 
 }
 
-object LogSegment {
+object LogSegment extends Logging {
 
   def open(dir: File, baseOffset: Long, config: LogConfig, time: Time, fileAlreadyExists: Boolean = false,
            initFileSize: Int = 0, preallocate: Boolean = false, fileSuffix: String = ""): LogSegment = {

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -162,6 +162,10 @@ private[log] class ProducerStateEntry(val producerId: Long,
   }
 }
 
+object ProducerAppendInfo extends Logging {
+
+}
+
 /**
  * This class is used to validate the records appended by a given producer before they are written to the log.
  * It is initialized with the producer's state after the last successful append, and transitively validates the
@@ -181,8 +185,9 @@ private[log] class ProducerStateEntry(val producerId: Long,
 private[log] class ProducerAppendInfo(val topicPartition: TopicPartition,
                                       val producerId: Long,
                                       val currentEntry: ProducerStateEntry,
-                                      val origin: AppendOrigin) extends Logging {
+                                      val origin: AppendOrigin) {
 
+  import ProducerAppendInfo._
   private val transactions = ListBuffer.empty[TxnMetadata]
   private val updatedEntry = ProducerStateEntry.empty(producerId)
 

--- a/core/src/main/scala/kafka/log/TransactionIndex.scala
+++ b/core/src/main/scala/kafka/log/TransactionIndex.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.{Files, StandardOpenOption}
 
-import kafka.utils.{Logging, nonthreadsafe}
+import kafka.utils.{nonthreadsafe}
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction
 import org.apache.kafka.common.utils.Utils
@@ -42,7 +42,7 @@ private[log] case class TxnIndexSearchResult(abortedTransactions: List[AbortedTx
  * order to find the start of the transactions.
  */
 @nonthreadsafe
-class TransactionIndex(val startOffset: Long, @volatile private var _file: File) extends Logging {
+class TransactionIndex(val startOffset: Long, @volatile private var _file: File) {
 
   // note that the file is not created until we need it
   @volatile private var maybeChannel: Option[FileChannel] = None

--- a/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
@@ -31,9 +31,12 @@ import org.apache.kafka.common.utils.Utils
 
 private trait KafkaCSVMetricsReporterMBean extends KafkaMetricsReporterMBean
 
+private object KafkaCSVMetricsReporter extends Logging {
+
+}
+
 private class KafkaCSVMetricsReporter extends KafkaMetricsReporter
-                              with KafkaCSVMetricsReporterMBean
-                              with Logging {
+                              with KafkaCSVMetricsReporterMBean {
 
   private var csvDir: File = null
   private var underlying: CsvReporter = null

--- a/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
@@ -38,6 +38,8 @@ private object KafkaCSVMetricsReporter extends Logging {
 private class KafkaCSVMetricsReporter extends KafkaMetricsReporter
                               with KafkaCSVMetricsReporterMBean {
 
+  import KafkaCSVMetricsReporter._
+
   private var csvDir: File = null
   private var underlying: CsvReporter = null
   private var running = false

--- a/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaMetricsGroup.scala
@@ -20,10 +20,10 @@ package kafka.metrics
 import java.util.concurrent.TimeUnit
 
 import com.yammer.metrics.core.{Gauge, MetricName, Meter, Histogram, Timer}
-import kafka.utils.Logging
 import org.apache.kafka.common.utils.Sanitizer
 
-trait KafkaMetricsGroup extends Logging {
+// Please think about performance before adding inheriting from Logging
+trait KafkaMetricsGroup {
 
   /**
    * Creates a new MetricName object for gauges, meters, etc. created for this

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -78,7 +78,9 @@ class SocketServer(val config: KafkaConfig,
                    val time: Time,
                    val credentialProvider: CredentialProvider,
                    val allowDisabledApis: Boolean = false)
-  extends Logging with KafkaMetricsGroup with BrokerReconfigurable {
+  extends KafkaMetricsGroup with BrokerReconfigurable {
+
+  import kafka.network.SocketServer._
 
   private val maxQueuedRequests = config.queuedMaxRequests
 
@@ -442,7 +444,7 @@ class SocketServer(val config: KafkaConfig,
 
 }
 
-object SocketServer {
+object SocketServer extends Logging {
   val MetricsGroup = "socket-server-metrics"
   val DataPlaneThreadPrefix = "data-plane"
   val ControlPlaneThreadPrefix = "control-plane"
@@ -458,10 +460,15 @@ object SocketServer {
   val ListenerReconfigurableConfigs = Set(KafkaConfig.MaxConnectionsProp, KafkaConfig.MaxConnectionCreationRateProp)
 }
 
+private[kafka] object AbstractServerThread extends Logging {
+
+}
+
 /**
  * A base class with some helper variables and methods
  */
-private[kafka] abstract class AbstractServerThread(connectionQuotas: ConnectionQuotas) extends Runnable with Logging {
+private[kafka] abstract class AbstractServerThread(connectionQuotas: ConnectionQuotas) extends Runnable {
+  import AbstractServerThread._
 
   private val startupLatch = new CountDownLatch(1)
 
@@ -528,8 +535,8 @@ private[kafka] abstract class AbstractServerThread(connectionQuotas: ConnectionQ
   }
 
   protected def closeSocket(channel: SocketChannel): Unit = {
-    CoreUtils.swallow(channel.socket().close(), this, Level.ERROR)
-    CoreUtils.swallow(channel.close(), this, Level.ERROR)
+    CoreUtils.swallow(channel.socket().close(), AbstractServerThread, Level.ERROR)
+    CoreUtils.swallow(channel.close(), AbstractServerThread, Level.ERROR)
   }
 }
 
@@ -544,6 +551,7 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
                               metricPrefix: String,
                               time: Time) extends AbstractServerThread(connectionQuotas) with KafkaMetricsGroup {
 
+  import AbstractServerThread._
   private val nioSelector = NSelector.open()
   val serverChannel = openServerSocket(endPoint.host, endPoint.port)
   private val processors = new ArrayBuffer[Processor]()
@@ -625,8 +633,8 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
       }
     } finally {
       debug("Closing server socket, selector, and any throttled sockets.")
-      CoreUtils.swallow(serverChannel.close(), this, Level.ERROR)
-      CoreUtils.swallow(nioSelector.close(), this, Level.ERROR)
+      CoreUtils.swallow(serverChannel.close(), AbstractServerThread, Level.ERROR)
+      CoreUtils.swallow(nioSelector.close(), AbstractServerThread, Level.ERROR)
       throttledSockets.foreach(throttledSocket => closeSocket(throttledSocket.socket))
       throttledSockets.clear()
       shutdownComplete()
@@ -890,7 +898,7 @@ private[kafka] class Processor(val id: Int,
       }
     } finally {
       debug(s"Closing selector - processor $id")
-      CoreUtils.swallow(closeAll(), this, Level.ERROR)
+      CoreUtils.swallow(closeAll(), AbstractServerThread, Level.ERROR)
       shutdownComplete()
     }
   }
@@ -1244,7 +1252,7 @@ sealed trait ConnectionQuotaEntity {
   def metricTags: Map[String, String]
 }
 
-object ConnectionQuotas {
+object ConnectionQuotas extends Logging {
   private val InactiveSensorExpirationTimeSeconds = TimeUnit.HOURS.toSeconds(1)
   private val ConnectionRateSensorName = "Connection-Accept-Rate"
   private val ConnectionRateMetricName = "connection-accept-rate"
@@ -1274,7 +1282,8 @@ object ConnectionQuotas {
   }
 }
 
-class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extends Logging with AutoCloseable {
+class ConnectionQuotas(config: KafkaConfig, time: Time, metrics: Metrics) extends AutoCloseable {
+  import ConnectionQuotas._
 
   @volatile private var defaultMaxConnectionsPerIp: Int = config.maxConnectionsPerIp
   @volatile private var maxConnectionsPerIpOverrides = config.maxConnectionsPerIpOverrides.map { case (host, count) => (InetAddress.getByName(host), count) }

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -83,7 +83,7 @@ class SocketServer(val config: KafkaConfig,
   private val maxQueuedRequests = config.queuedMaxRequests
 
   private val logContext = new LogContext(s"[SocketServer brokerId=${config.brokerId}] ")
-  this.logIdent = logContext.logPrefix
+  protected implicit val logIdent = Some(LogIdent(logContext.logPrefix))
 
   private val memoryPoolSensor = metrics.sensor("MemoryPoolUtilization")
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", MetricsGroup)

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.raft.{NetworkChannel, RaftRequest, RaftResponse, RaftUti
 
 import scala.collection.mutable
 
-object KafkaNetworkChannel {
+object KafkaNetworkChannel extends Logging {
 
   private[raft] def buildRequest(requestData: ApiMessage): AbstractRequest.Builder[_ <: AbstractRequest] = {
     requestData match {
@@ -97,7 +97,8 @@ class KafkaNetworkChannel(
   time: Time,
   client: KafkaClient,
   requestTimeoutMs: Int
-) extends NetworkChannel with Logging {
+) extends NetworkChannel  {
+
   import KafkaNetworkChannel._
 
   type ResponseHandler = AbstractResponse => Unit

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 @deprecated("Use kafka.security.authorizer.AclAuthorizer", "Since 2.4")
-object SimpleAclAuthorizer {
+object SimpleAclAuthorizer extends Logging {
   //optional override zookeeper cluster configuration where acls will be stored, if not specified acls will be stored in
   //same zookeeper where all other kafka broker info is stored.
   val ZkUrlProp = AclAuthorizer.ZkUrlProp
@@ -69,7 +69,9 @@ object SimpleAclAuthorizer {
 }
 
 @deprecated("Use kafka.security.authorizer.AclAuthorizer", "Since 2.4")
-class SimpleAclAuthorizer extends Authorizer with Logging {
+class SimpleAclAuthorizer extends Authorizer {
+
+  import SimpleAclAuthorizer._
 
   private val aclAuthorizer = new BaseAuthorizer
 

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -19,7 +19,6 @@ package kafka.security.auth
 import java.util
 
 import kafka.network.RequestChannel.Session
-import kafka.security.auth.SimpleAclAuthorizer.BaseAuthorizer
 import kafka.security.authorizer.{AclAuthorizer, AuthorizerUtils, AuthorizerWrapper}
 import kafka.utils._
 import kafka.zk.ZkVersion

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.{CompletableFuture, CompletionStage}
 
 import com.typesafe.scalalogging.Logger
 import kafka.api.KAFKA_2_0_IV1
-import kafka.security.authorizer.AclAuthorizer.{AclSeqs, ResourceOrdering, VersionedAcls}
 import kafka.security.authorizer.AclEntry.ResourceSeparator
 import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils._
@@ -46,7 +45,7 @@ import scala.collection.{Seq, immutable, mutable}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Random, Success, Try}
 
-object AclAuthorizer {
+object AclAuthorizer extends Logging {
   // Optional override zookeeper cluster configuration where acls will be stored. If not specified,
   // acls will be stored in the same zookeeper where all other kafka broker metadata is stored.
   val configPrefix = "authorizer."
@@ -120,7 +119,8 @@ object AclAuthorizer {
   }
 }
 
-class AclAuthorizer extends Authorizer with Logging {
+class AclAuthorizer extends Authorizer {
+  import AclAuthorizer._
   private[security] val authorizerLogger = Logger("kafka.authorizer.logger")
   private var superUsers = Set.empty[KafkaPrincipal]
   private var shouldAllowEveryoneIfNoAclIsFound = false

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -20,21 +20,26 @@ package kafka.server
 import kafka.cluster.BrokerEndPoint
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.Implicits._
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.utils.Utils
 
 import scala.collection.{Map, Set, mutable}
 
+object AbstractFetcherManager extends Logging {
+
+}
+
 abstract class AbstractFetcherManager[T <: AbstractFetcherThread](val name: String, clientId: String, numFetchers: Int)
-  extends Logging with KafkaMetricsGroup {
+  extends KafkaMetricsGroup {
+  import AbstractFetcherManager._
   // map of (source broker_id, fetcher_id per source broker) => fetcher.
   // package private for test
   private[server] val fetcherThreadMap = new mutable.HashMap[BrokerIdAndFetcherId, T]
   private val lock = new Object
   private var numFetchersPerBroker = numFetchers
   val failedPartitions = new FailedPartitions
-  this.logIdent = "[" + name + "] "
+  protected implicit val logIdent = Some(LogIdent("[" + name + "] "))
 
   private val tags = Map("clientId" -> clientId)
 

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -21,9 +21,8 @@ import java.nio.ByteBuffer
 import java.util
 import java.util.Optional
 import java.util.concurrent.locks.ReentrantLock
-
 import kafka.cluster.BrokerEndPoint
-import kafka.utils.{DelayedItem, Pool, ShutdownableThread}
+import kafka.utils.{DelayedItem, Logging, Pool, ShutdownableThread}
 import kafka.utils.Implicits._
 import org.apache.kafka.common.errors._
 import kafka.common.ClientIdAndBroker
@@ -36,10 +35,7 @@ import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
-
 import kafka.log.LogAppendInfo
-import kafka.server.AbstractFetcherThread.ReplicaFetch
-import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import org.apache.kafka.common.{InvalidRecordException, TopicPartition}
 import org.apache.kafka.common.internals.PartitionStates
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData
@@ -61,6 +57,8 @@ abstract class AbstractFetcherThread(name: String,
                                      isInterruptible: Boolean = true,
                                      val brokerTopicStats: BrokerTopicStats) //BrokerTopicStats's lifecycle managed by ReplicaManager
   extends ShutdownableThread(name, isInterruptible) {
+
+  import AbstractFetcherThread._
 
   type FetchData = FetchResponse.PartitionData[Records]
   type EpochData = OffsetForLeaderEpochRequestData.OffsetForLeaderPartition
@@ -745,7 +743,7 @@ abstract class AbstractFetcherThread(name: String,
   }
 }
 
-object AbstractFetcherThread {
+object AbstractFetcherThread extends Logging {
 
   case class ReplicaFetch(partitionData: util.Map[TopicPartition, FetchRequest.PartitionData], fetchRequest: FetchRequest.Builder)
   case class ResultWithPartitions[R](result: R, partitionsWithError: Set[TopicPartition])

--- a/core/src/main/scala/kafka/server/ActionQueue.scala
+++ b/core/src/main/scala/kafka/server/ActionQueue.scala
@@ -21,12 +21,18 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import kafka.utils.Logging
 
+object ActionQueue extends Logging {
+
+}
+
 /**
  * This queue is used to collect actions which need to be executed later. One use case is that ReplicaManager#appendRecords
  * produces record changes so we need to check and complete delayed requests. In order to avoid conflicting locking,
  * we add those actions to this queue and then complete them at the end of KafkaApis.handle() or DelayedJoin.onExpiration.
  */
-class ActionQueue extends Logging {
+class ActionQueue {
+  import ActionQueue._
+
   private val queue = new ConcurrentLinkedQueue[() => Unit]()
 
   /**

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -57,12 +57,18 @@ import org.apache.kafka.common.utils.Sanitizer
 import scala.collection.{Map, mutable, _}
 import scala.jdk.CollectionConverters._
 
+object AdminManager extends Logging {
+
+}
+
 class AdminManager(val config: KafkaConfig,
                    val metrics: Metrics,
                    val metadataCache: MetadataCache,
-                   val zkClient: KafkaZkClient) extends Logging with KafkaMetricsGroup {
+                   val zkClient: KafkaZkClient) extends KafkaMetricsGroup {
 
-  this.logIdent = "[Admin Manager on Broker " + config.brokerId + "]: "
+  import AdminManager._
+
+  protected implicit val logIdent = Some(LogIdent("[Admin Manager on Broker " + config.brokerId + "]: "))
 
   private val topicPurgatory = DelayedOperationPurgatory[DelayedOperation]("topic", config.brokerId)
   private val adminZkClient = new AdminZkClient(zkClient)
@@ -708,8 +714,8 @@ class AdminManager(val config: KafkaConfig,
 
   def shutdown(): Unit = {
     topicPurgatory.shutdown()
-    CoreUtils.swallow(createTopicPolicy.foreach(_.close()), this)
-    CoreUtils.swallow(alterConfigPolicy.foreach(_.close()), this)
+    CoreUtils.swallow(createTopicPolicy.foreach(_.close()), AdminManager)
+    CoreUtils.swallow(alterConfigPolicy.foreach(_.close()), AdminManager)
   }
 
   private def resourceNameToBrokerId(resourceName: String): Int = {

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -103,14 +103,18 @@ object AlterIsrManager {
 
 }
 
+object DefaultAlterIsrManager extends Logging {
+
+}
+
 class DefaultAlterIsrManager(
   val controllerChannelManager: BrokerToControllerChannelManager,
   val scheduler: Scheduler,
   val time: Time,
   val brokerId: Int,
   val brokerEpochSupplier: () => Long
-) extends AlterIsrManager with Logging with KafkaMetricsGroup {
-
+) extends AlterIsrManager with KafkaMetricsGroup {
+  import DefaultAlterIsrManager._
   // Used to allow only one pending ISR update per partition (visible for testing)
   private[server] val unsentIsrUpdates: util.Map[TopicPartition, AlterIsrItem] = new ConcurrentHashMap[TopicPartition, AlterIsrItem]()
 

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -32,10 +32,16 @@ case class BrokerMetadata(brokerId: Int,
   }
 }
 
+object BrokerMetadataCheckpoint extends Logging {
+
+}
+
 /**
   * This class saves broker's metadata to a file
   */
-class BrokerMetadataCheckpoint(val file: File) extends Logging {
+class BrokerMetadataCheckpoint(val file: File) {
+  import BrokerMetadataCheckpoint._
+
   private val lock = new Object()
 
   def write(brokerMetadata: BrokerMetadata) = {

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -32,6 +32,11 @@ import org.apache.kafka.common.utils.{LogContext, Time}
 
 import scala.jdk.CollectionConverters._
 
+
+object BrokerToControllerChannelManager extends Logging {
+
+}
+
 /**
  * This class manages the connection between a broker and the controller. It runs a single
  * [[BrokerToControllerRequestThread]] which uses the broker's metadata cache as its own metadata to find
@@ -47,7 +52,9 @@ class BrokerToControllerChannelManager(
   channelName: String,
   threadNamePrefix: Option[String],
   retryTimeoutMs: Long
-) extends Logging {
+)  {
+  import BrokerToControllerChannelManager._
+
   private val logContext = new LogContext(s"[broker-${config.brokerId}-to-controller] ")
   private val manualMetadataUpdater = new ManualMetadataUpdater()
   private val requestThread = newRequestThread
@@ -167,6 +174,8 @@ class BrokerToControllerRequestThread(
   threadName: String,
   retryTimeoutMs: Long
 ) extends InterBrokerSendThread(threadName, networkClient, config.controllerSocketTimeoutMs, time, isInterruptible = false) {
+
+  import InterBrokerSendThread._
 
   private val requestQueue = new LinkedBlockingDeque[BrokerToControllerQueueItem]()
   private var activeController: Option[Node] = None

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -72,7 +72,7 @@ object QuotaTypes {
   val CustomQuotas = 8 // No metric update optimizations are used with custom quotas
 }
 
-object ClientQuotaManager extends Logging {
+object ClientQuotaManager {
   // Purge sensors after 1 hour of inactivity
   val InactiveSensorExpirationTimeSeconds = 3600
 
@@ -190,8 +190,8 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
                          private val quotaType: QuotaType,
                          private val time: Time,
                          private val threadNamePrefix: String,
-                         private val clientQuotaCallback: Option[ClientQuotaCallback] = None) {
-  import ClientQuotaManager.{debug}
+                         private val clientQuotaCallback: Option[ClientQuotaCallback] = None) extends Logging {
+
   private val lock = new ReentrantReadWriteLock()
   private val sensorAccessor = new SensorAccess(lock, metrics)
   private val quotaCallback = clientQuotaCallback.getOrElse(new DefaultQuotaCallback)

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -72,7 +72,7 @@ object QuotaTypes {
   val CustomQuotas = 8 // No metric update optimizations are used with custom quotas
 }
 
-object ClientQuotaManager {
+object ClientQuotaManager extends Logging {
   // Purge sensors after 1 hour of inactivity
   val InactiveSensorExpirationTimeSeconds = 3600
 
@@ -190,8 +190,8 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
                          private val quotaType: QuotaType,
                          private val time: Time,
                          private val threadNamePrefix: String,
-                         private val clientQuotaCallback: Option[ClientQuotaCallback] = None) extends Logging {
-
+                         private val clientQuotaCallback: Option[ClientQuotaCallback] = None) {
+  import ClientQuotaManager.{debug}
   private val lock = new ReentrantReadWriteLock()
   private val sensorAccessor = new SensorAccess(lock, metrics)
   private val quotaCallback = clientQuotaCallback.getOrElse(new DefaultQuotaCallback)

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -47,11 +47,16 @@ trait ConfigHandler {
   def processConfigChanges(entityName: String, value: Properties): Unit
 }
 
+object TopicConfigHandler extends Logging {
+
+}
+
 /**
   * The TopicConfigHandler will process topic config changes in ZK.
   * The callback provides the topic name and the full properties set read from ZK
   */
-class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaConfig, val quotas: QuotaManagers, kafkaController: KafkaController) extends ConfigHandler with Logging  {
+class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaConfig, val quotas: QuotaManagers, kafkaController: KafkaController) extends ConfigHandler {
+  import TopicConfigHandler._
 
   private def updateLogConfig(topic: String,
                               topicConfig: Properties,
@@ -187,7 +192,7 @@ class UserConfigHandler(private val quotaManagers: QuotaManagers, val credential
   }
 }
 
-class IpConfigHandler(private val connectionQuotas: ConnectionQuotas) extends ConfigHandler with Logging {
+class IpConfigHandler(private val connectionQuotas: ConnectionQuotas) extends ConfigHandler {
 
   def processConfigChanges(ip: String, config: Properties): Unit = {
     val ipConnectionRateQuota = Option(config.getProperty(DynamicConfig.Ip.IpConnectionRateOverrideProp)).map(_.toInt)
@@ -211,7 +216,7 @@ class IpConfigHandler(private val connectionQuotas: ConnectionQuotas) extends Co
   * This implementation reports the overrides to the respective ReplicationQuotaManager objects
   */
 class BrokerConfigHandler(private val brokerConfig: KafkaConfig,
-                          private val quotaManagers: QuotaManagers) extends ConfigHandler with Logging {
+                          private val quotaManagers: QuotaManagers) extends ConfigHandler {
 
   def processConfigChanges(brokerId: String, properties: Properties): Unit = {
     def getOrDefault(prop: String): Long = {

--- a/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
+++ b/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
@@ -51,6 +51,8 @@ class DelayedCreatePartitions(delayMs: Long,
                               responseCallback: Map[String, ApiError] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   /**
     * The operation can be completed if all of the topics that do not have an error exist and every partition has a
     * leader in the controller.

--- a/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
@@ -48,6 +48,8 @@ class DelayedDeleteRecords(delayMs: Long,
                            responseCallback: Map[TopicPartition, DeleteRecordsResponseData.DeleteRecordsPartitionResult] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   // first update the acks pending variable according to the error code
   deleteRecordsStatus.forKeyValue { (topicPartition, status) =>
     if (status.responseStatus.errorCode == Errors.NONE.code) {

--- a/core/src/main/scala/kafka/server/DelayedDeleteTopics.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteTopics.scala
@@ -42,6 +42,8 @@ class DelayedDeleteTopics(delayMs: Long,
                           responseCallback: Map[String, Errors] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   /**
     * The operation can be completed if all of the topics not in error have been removed
     */

--- a/core/src/main/scala/kafka/server/DelayedElectLeader.scala
+++ b/core/src/main/scala/kafka/server/DelayedElectLeader.scala
@@ -34,6 +34,8 @@ class DelayedElectLeader(
   responseCallback: Map[TopicPartition, ApiError] => Unit
 ) extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   private val waitingPartitions = mutable.Map() ++= expectedLeaders
   private val fullResults = mutable.Map() ++= results
 

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -69,6 +69,8 @@ class DelayedFetch(delayMs: Long,
                    responseCallback: Seq[(TopicPartition, FetchPartitionData)] => Unit)
   extends DelayedOperation(delayMs) {
 
+  import DelayedOperation._
+
   /**
    * The operation can be completed if:
    *

--- a/core/src/main/scala/kafka/server/DelayedFuture.scala
+++ b/core/src/main/scala/kafka/server/DelayedFuture.scala
@@ -34,6 +34,8 @@ class DelayedFuture[T](timeoutMs: Long,
                        responseCallback: () => Unit)
   extends DelayedOperation(timeoutMs) {
 
+  import DelayedOperation._
+
   /**
    * The operation can be completed if all the futures have completed successfully
    * or failed with exceptions.

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -131,7 +131,7 @@ abstract class DelayedOperation(override val delayMs: Long,
   }
 }
 
-object DelayedOperationPurgatory {
+object DelayedOperationPurgatory extends Logging {
 
   private val Shards = 512 // Shard the watcher list to reduce lock contention
 
@@ -155,7 +155,9 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
                                                              purgeInterval: Int = 1000,
                                                              reaperEnabled: Boolean = true,
                                                              timerEnabled: Boolean = true)
-        extends Logging with KafkaMetricsGroup {
+        extends KafkaMetricsGroup {
+  import DelayedOperationPurgatory._
+
   /* a list of operation watching keys */
   private class WatcherList {
     val watchersByKey = new Pool[Any, Watchers](Some((key: Any) => new Watchers(key)))

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -29,6 +29,9 @@ import kafka.utils.timer._
 import scala.collection._
 import scala.collection.mutable.ListBuffer
 
+object DelayedOperation extends Logging {
+
+}
 /**
  * An operation whose processing needs to be delayed for at most the given delayMs. For example
  * a delayed produce operation could be waiting for specified number of acks; or
@@ -47,8 +50,7 @@ import scala.collection.mutable.ListBuffer
  */
 abstract class DelayedOperation(override val delayMs: Long,
                                 lockOpt: Option[Lock] = None)
-  extends TimerTask with Logging {
-
+  extends TimerTask {
   private val completed = new AtomicBoolean(false)
   // Visible for testing
   private[server] val lock: Lock = lockOpt.getOrElse(new ReentrantLock)

--- a/core/src/main/scala/kafka/server/DelayedProduce.scala
+++ b/core/src/main/scala/kafka/server/DelayedProduce.scala
@@ -57,6 +57,8 @@ class DelayedProduce(delayMs: Long,
                      lockOpt: Option[Lock] = None)
   extends DelayedOperation(delayMs, lockOpt) {
 
+  import DelayedOperation._
+
   // first update the acks pending variable according to the error code
   produceMetadata.produceStatus.forKeyValue { (topicPartition, status) =>
     if (status.responseStatus.error == Errors.NONE) {

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -21,12 +21,11 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.security.InvalidKeyException
 import java.util.Base64
-
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.{Mac, SecretKey}
 import kafka.common.{NotificationHandler, ZkNodeChangeNotificationListener}
 import kafka.metrics.KafkaMetricsGroup
-import kafka.utils.{CoreUtils, Json, Logging}
+import kafka.utils.{CoreUtils, Json, LogIdent, Logging}
 import kafka.zk.{DelegationTokenChangeNotificationSequenceZNode, DelegationTokenChangeNotificationZNode, DelegationTokensZNode, KafkaZkClient}
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.security.auth.KafkaPrincipal
@@ -39,7 +38,7 @@ import org.apache.kafka.common.utils.{Sanitizer, SecurityUtils, Time}
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
-object DelegationTokenManager {
+object DelegationTokenManager extends Logging {
   val DefaultHmacAlgorithm = "HmacSHA512"
   val OwnerKey ="owner"
   val RenewersKey = "renewers"
@@ -160,8 +159,8 @@ object DelegationTokenManager {
 class DelegationTokenManager(val config: KafkaConfig,
                              val tokenCache: DelegationTokenCache,
                              val time: Time,
-                             val zkClient: KafkaZkClient) extends Logging with KafkaMetricsGroup {
-  this.logIdent = s"[Token Manager on Broker ${config.brokerId}]: "
+                             val zkClient: KafkaZkClient) extends KafkaMetricsGroup {
+  protected implicit val logIdent = Some(LogIdent(s"[Token Manager on Broker ${config.brokerId}]: "))
 
   import DelegationTokenManager._
 

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -73,7 +73,7 @@ import scala.jdk.CollectionConverters._
   * </ul>
   *
   */
-object DynamicBrokerConfig extends Logging {
+object DynamicBrokerConfig {
 
   private[server] val DynamicSecurityConfigs = SslConfigs.RECONFIGURABLE_CONFIGS.asScala
 
@@ -195,9 +195,7 @@ object DynamicBrokerConfig extends Logging {
   }
 }
 
-class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) {
-
-  import kafka.server.DynamicBrokerConfig.{error, info, debug, trace}
+class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging {
 
   private[server] val staticBrokerConfigs = ConfigDef.convertToStringMapWithPasswordValues(kafkaConfig.originalsFromThisConfig).asScala
   private[server] val staticDefaultConfigs = ConfigDef.convertToStringMapWithPasswordValues(KafkaConfig.defaultValues.asJava).asScala

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -73,7 +73,7 @@ import scala.jdk.CollectionConverters._
   * </ul>
   *
   */
-object DynamicBrokerConfig {
+object DynamicBrokerConfig extends Logging {
 
   private[server] val DynamicSecurityConfigs = SslConfigs.RECONFIGURABLE_CONFIGS.asScala
 
@@ -195,7 +195,9 @@ object DynamicBrokerConfig {
   }
 }
 
-class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) extends Logging {
+class DynamicBrokerConfig(private val kafkaConfig: KafkaConfig) {
+
+  import kafka.server.DynamicBrokerConfig.{error, info, debug, trace}
 
   private[server] val staticBrokerConfigs = ConfigDef.convertToStringMapWithPasswordValues(kafkaConfig.originalsFromThisConfig).asScala
   private[server] val staticDefaultConfigs = ConfigDef.convertToStringMapWithPasswordValues(KafkaConfig.defaultValues.asJava).asScala

--- a/core/src/main/scala/kafka/server/DynamicConfigManager.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfigManager.scala
@@ -46,6 +46,10 @@ object ConfigEntityName {
   val Default = "<default>"
 }
 
+object DynamicConfigManager extends Logging {
+
+}
+
 /**
  * This class initiates and carries out config changes for all entities defined in ConfigType.
  *
@@ -87,7 +91,8 @@ object ConfigEntityName {
 class DynamicConfigManager(private val zkClient: KafkaZkClient,
                            private val configHandlers: Map[String, ConfigHandler],
                            private val changeExpirationMs: Long = 15*60*1000,
-                           private val time: Time = Time.SYSTEM) extends Logging {
+                           private val time: Time = Time.SYSTEM) {
+  import DynamicConfigManager._
   val adminZkClient = new AdminZkClient(zkClient)
 
   object ConfigChangedNotificationHandler extends NotificationHandler {

--- a/core/src/main/scala/kafka/server/FinalizedFeatureCache.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureCache.scala
@@ -34,6 +34,10 @@ case class FinalizedFeaturesAndEpoch(features: Features[FinalizedVersionRange], 
   }
 }
 
+object FinalizedFeatureCache extends Logging {
+
+}
+
 /**
  * A common mutable cache containing the latest finalized features and epoch. By default the contents of
  * the cache are empty. This cache needs to be populated at least once for its contents to become
@@ -44,7 +48,8 @@ case class FinalizedFeaturesAndEpoch(features: Features[FinalizedVersionRange], 
  *
  * @see FinalizedFeatureChangeListener
  */
-class FinalizedFeatureCache(private val brokerFeatures: BrokerFeatures) extends Logging {
+class FinalizedFeatureCache(private val brokerFeatures: BrokerFeatures) {
+  import FinalizedFeatureCache._
   @volatile private var featuresAndEpoch: Option[FinalizedFeaturesAndEpoch] = Option.empty
 
   /**

--- a/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureChangeListener.scala
@@ -26,6 +26,10 @@ import org.apache.kafka.common.internals.FatalExitError
 
 import scala.concurrent.TimeoutException
 
+object FinalizedFeatureChangeListener extends Logging {
+
+}
+
 /**
  * Listens to changes in the ZK feature node, via the ZK client. Whenever a change notification
  * is received from ZK, the feature cache in FinalizedFeatureCache is asynchronously updated
@@ -36,8 +40,8 @@ import scala.concurrent.TimeoutException
  * @param zkClient                the Zookeeper client
  */
 class FinalizedFeatureChangeListener(private val finalizedFeatureCache: FinalizedFeatureCache,
-                                     private val zkClient: KafkaZkClient) extends Logging {
-
+                                     private val zkClient: KafkaZkClient) {
+  import FinalizedFeatureChangeListener._
   /**
    * Helper class used to update the FinalizedFeatureCache.
    *

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -63,9 +63,15 @@ object ForwardingManager {
   }
 }
 
+object ForwardingManagerImpl extends Logging {
+
+}
+
 class ForwardingManagerImpl(
   channelManager: BrokerToControllerChannelManager
-) extends ForwardingManager with Logging {
+) extends ForwardingManager {
+
+  import ForwardingManagerImpl._
 
   override def start(): Unit = {
     channelManager.start()

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -39,7 +39,7 @@ import kafka.message.ZStdCompressionCodec
 import kafka.network.RequestChannel
 import kafka.security.authorizer.{AclEntry, AuthorizerUtils}
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
-import kafka.utils.{CoreUtils, LogIdent, Logging}
+import kafka.utils.{CoreUtils, Logging, LogIdent}
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
@@ -124,6 +124,7 @@ class KafkaApis(val requestChannel: RequestChannel,
   import KafkaApis._
   type FetchResponseStats = Map[TopicPartition, RecordConversionStats]
   protected implicit val logIdent = Some(LogIdent("[KafkaApi-%d] ".format(brokerId)))
+
   val adminZkClient = new AdminZkClient(zkClient)
   private val alterAclsPurgatory = new DelayedFuturePurgatory(purgatoryName = "AlterAcls", brokerId = config.brokerId)
 
@@ -584,6 +585,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     // The construction of ProduceResponse is able to accept auto-generated protocol data so
     // KafkaApis#handleProduceRequest should apply auto-generated protocol to avoid extra conversion.
     // https://issues.apache.org/jira/browse/KAFKA-10730
+    @nowarn("cat=deprecation")
     def sendResponseCallback(responseStatus: Map[TopicPartition, PartitionResponse]): Unit = {
       val mergedResponseStatus = responseStatus ++ unauthorizedTopicResponses ++ nonExistingTopicResponses ++ invalidRequestResponses
       var errorInResponse = false

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -39,7 +39,7 @@ import kafka.message.ZStdCompressionCodec
 import kafka.network.RequestChannel
 import kafka.security.authorizer.{AclEntry, AuthorizerUtils}
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
-import kafka.utils.{CoreUtils, Logging}
+import kafka.utils.{CoreUtils, LogIdent, Logging}
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
@@ -119,10 +119,11 @@ class KafkaApis(val requestChannel: RequestChannel,
                 time: Time,
                 val tokenManager: DelegationTokenManager,
                 val brokerFeatures: BrokerFeatures,
-                val finalizedFeatureCache: FinalizedFeatureCache) extends ApiRequestHandler with Logging {
+                val finalizedFeatureCache: FinalizedFeatureCache) extends ApiRequestHandler {
 
+  import KafkaApis._
   type FetchResponseStats = Map[TopicPartition, RecordConversionStats]
-  this.logIdent = "[KafkaApi-%d] ".format(brokerId)
+  protected implicit val logIdent = Some(LogIdent("[KafkaApi-%d] ".format(brokerId)))
   val adminZkClient = new AdminZkClient(zkClient)
   private val alterAclsPurgatory = new DelayedFuturePurgatory(purgatoryName = "AlterAcls", brokerId = config.brokerId)
 
@@ -331,7 +332,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         }.toBuffer.asJava)))
     }
 
-    CoreUtils.swallow(replicaManager.replicaFetcherManager.shutdownIdleFetcherThreads(), this)
+    CoreUtils.swallow(replicaManager.replicaFetcherManager.shutdownIdleFetcherThreads(), KafkaApis)
   }
 
   def handleUpdateMetadataRequest(request: RequestChannel.Request): Unit = {
@@ -583,7 +584,6 @@ class KafkaApis(val requestChannel: RequestChannel,
     // The construction of ProduceResponse is able to accept auto-generated protocol data so
     // KafkaApis#handleProduceRequest should apply auto-generated protocol to avoid extra conversion.
     // https://issues.apache.org/jira/browse/KAFKA-10730
-    @nowarn("cat=deprecation")
     def sendResponseCallback(responseStatus: Map[TopicPartition, PartitionResponse]): Unit = {
       val mergedResponseStatus = responseStatus ++ unauthorizedTopicResponses ++ nonExistingTopicResponses ++ invalidRequestResponses
       var errorInResponse = false
@@ -3587,7 +3587,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
 }
 
-object KafkaApis {
+object KafkaApis extends Logging {
   // Traffic from both in-sync and out of sync replicas are accounted for in replication quota to ensure total replication
   // traffic doesn't exceed quota.
   private[server] def sizeOfThrottledPartitions(versionId: Short,

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -271,7 +271,7 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
   def close(): Unit = metricTypeMap.values.foreach(_.close())
 }
 
-object BrokerTopicStats {
+object BrokerTopicStats extends Logging {
   val MessagesInPerSec = "MessagesInPerSec"
   val BytesInPerSec = "BytesInPerSec"
   val BytesOutPerSec = "BytesOutPerSec"
@@ -296,7 +296,7 @@ object BrokerTopicStats {
   private val valueFactory = (k: String) => new BrokerTopicMetrics(Some(k))
 }
 
-class BrokerTopicStats extends Logging {
+class BrokerTopicStats {
   import BrokerTopicStats._
 
   private val stats = new Pool[String, BrokerTopicMetrics](Some(valueFactory))

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -34,6 +34,10 @@ trait ApiRequestHandler {
   def handle(request: RequestChannel.Request): Unit
 }
 
+object KafkaRequestHandler extends Logging {
+
+}
+
 /**
  * A thread that answers kafka requests.
  */
@@ -43,8 +47,10 @@ class KafkaRequestHandler(id: Int,
                           val totalHandlerThreads: AtomicInteger,
                           val requestChannel: RequestChannel,
                           apis: ApiRequestHandler,
-                          time: Time) extends Runnable with Logging {
-  this.logIdent = "[Kafka Request Handler " + id + " on Broker " + brokerId + "], "
+                          time: Time) extends Runnable {
+  import KafkaRequestHandler._
+
+  protected implicit val logIdent = Some(LogIdent("[Kafka Request Handler " + id + " on Broker " + brokerId + "], "))
   private val shutdownComplete = new CountDownLatch(1)
   @volatile private var stopped = false
 
@@ -97,19 +103,23 @@ class KafkaRequestHandler(id: Int,
 
 }
 
+object KafkaRequestHandlerPool extends Logging {
+
+}
 class KafkaRequestHandlerPool(val brokerId: Int,
                               val requestChannel: RequestChannel,
                               val apis: ApiRequestHandler,
                               time: Time,
                               numThreads: Int,
                               requestHandlerAvgIdleMetricName: String,
-                              logAndThreadNamePrefix : String) extends Logging with KafkaMetricsGroup {
+                              logAndThreadNamePrefix : String) extends KafkaMetricsGroup {
 
+  import KafkaRequestHandlerPool._
   private val threadPoolSize: AtomicInteger = new AtomicInteger(numThreads)
   /* a meter to track the average free capacity of the request handlers */
   private val aggregateIdleMeter = newMeter(requestHandlerAvgIdleMetricName, "percent", TimeUnit.NANOSECONDS)
 
-  this.logIdent = "[" + logAndThreadNamePrefix + " Kafka Request Handler on Broker " + brokerId + "], "
+  protected implicit val logIdent = Some(LogIdent("[" + logAndThreadNamePrefix + " Kafka Request Handler on Broker " + brokerId + "], "))
   val runnables = new mutable.ArrayBuffer[KafkaRequestHandler](numThreads)
   for (i <- 0 until numThreads) {
     createHandler(i)

--- a/core/src/main/scala/kafka/server/KafkaServerStartable.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerStartable.scala
@@ -24,7 +24,7 @@ import kafka.utils.{Exit, Logging, VerifiableProperties}
 
 import scala.collection.Seq
 
-object KafkaServerStartable {
+object KafkaServerStartable extends Logging {
   def fromProps(serverProps: Properties): KafkaServerStartable = {
     fromProps(serverProps, None)
   }
@@ -35,7 +35,8 @@ object KafkaServerStartable {
   }
 }
 
-class KafkaServerStartable(val staticServerConfig: KafkaConfig, reporters: Seq[KafkaMetricsReporter], threadNamePrefix: Option[String] = None) extends Logging {
+class KafkaServerStartable(val staticServerConfig: KafkaConfig, reporters: Seq[KafkaMetricsReporter], threadNamePrefix: Option[String] = None) {
+  import KafkaServerStartable._
   private val server = new KafkaServer(staticServerConfig, kafkaMetricsReporters = reporters, threadNamePrefix = threadNamePrefix)
 
   def this(serverConfig: KafkaConfig) = this(serverConfig, Seq.empty)

--- a/core/src/main/scala/kafka/server/LogDirFailureChannel.scala
+++ b/core/src/main/scala/kafka/server/LogDirFailureChannel.scala
@@ -23,6 +23,10 @@ import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap}
 
 import kafka.utils.Logging
 
+object LogDirFailureChannel extends Logging {
+
+}
+
 /*
  * LogDirFailureChannel allows an external thread to block waiting for new offline log dirs.
  *
@@ -34,7 +38,8 @@ import kafka.utils.Logging
  * An offline log directory will stay offline until the broker is restarted.
  *
  */
-class LogDirFailureChannel(logDirNum: Int) extends Logging {
+class LogDirFailureChannel(logDirNum: Int) {
+  import LogDirFailureChannel._
 
   private val offlineLogDirs = new ConcurrentHashMap[String, String]
   private val offlineLogDirQueue = new ArrayBlockingQueue[String](logDirNum)

--- a/core/src/main/scala/kafka/server/PartitionMetadataFile.scala
+++ b/core/src/main/scala/kafka/server/PartitionMetadataFile.scala
@@ -29,7 +29,7 @@ import org.apache.kafka.common.utils.Utils
 
 
 
-object PartitionMetadataFile {
+object PartitionMetadataFile extends Logging {
   private val PartitionMetadataFilename = "partition.metadata"
   private val WhiteSpacesPattern = Pattern.compile(":\\s+")
   private val CurrentVersion = 0
@@ -85,9 +85,8 @@ object PartitionMetadataFile {
 
 class PartitionMetadata(val version: Int, val topicId: Uuid)
 
-
 class PartitionMetadataFile(val file: File,
-                            logDirFailureChannel: LogDirFailureChannel) extends Logging {
+                            logDirFailureChannel: LogDirFailureChannel) {
   import kafka.server.PartitionMetadataFile.{CurrentVersion, PartitionMetadataFileFormatter, PartitionMetadataReadBuffer}
 
   private val path = file.toPath.toAbsolutePath

--- a/core/src/main/scala/kafka/server/PartitionMetadataFile.scala
+++ b/core/src/main/scala/kafka/server/PartitionMetadataFile.scala
@@ -43,9 +43,13 @@ object PartitionMetadataFile {
 
   }
 
+  object PartitionMetadataReadBuffer extends Logging {
+
+  }
+
   class PartitionMetadataReadBuffer[T](location: String,
                                        reader: BufferedReader,
-                                       version: Int) extends Logging {
+                                       version: Int) {
     def read(): PartitionMetadata = {
       def malformedLineException(line: String) =
         new IOException(s"Malformed line in checkpoint file ($location): '$line'")

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsManager.scala
@@ -29,6 +29,8 @@ class ReplicaAlterLogDirsManager(brokerConfig: KafkaConfig,
     clientId = "ReplicaAlterLogDirs",
     numFetchers = brokerConfig.getNumReplicaAlterLogDirsThreads) {
 
+  import AbstractFetcherManager._
+
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaAlterLogDirsThread = {
     val threadName = s"ReplicaAlterLogDirsThread-$fetcherId"
     new ReplicaAlterLogDirsThread(threadName, sourceBroker, brokerConfig, failedPartitions, replicaManager,

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -23,8 +23,6 @@ import java.util.Optional
 import kafka.api.Request
 import kafka.cluster.BrokerEndPoint
 import kafka.log.{LeaderOffsetIncremented, LogAppendInfo}
-import kafka.server.AbstractFetcherThread.ReplicaFetch
-import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import kafka.server.QuotaFactory.UnboundedQuota
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.KafkaStorageException
@@ -54,6 +52,8 @@ class ReplicaAlterLogDirsThread(name: String,
                                 fetchBackOffMs = brokerConfig.replicaFetchBackoffMs,
                                 isInterruptible = false,
                                 brokerTopicStats) {
+
+  import AbstractFetcherThread._
 
   private val replicaId = brokerConfig.brokerId
   private val maxBytes = brokerConfig.replicaFetchResponseMaxBytes

--- a/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherManager.scala
@@ -32,6 +32,8 @@ class ReplicaFetcherManager(brokerConfig: KafkaConfig,
         clientId = "Replica",
         numFetchers = brokerConfig.numReplicaFetchers) {
 
+  import AbstractFetcherManager._
+
   override def createFetcherThread(fetcherId: Int, sourceBroker: BrokerEndPoint): ReplicaFetcherThread = {
     val prefix = threadNamePrefix.map(tp => s"$tp:").getOrElse("")
     val threadName = s"${prefix}ReplicaFetcherThread-$fetcherId-${sourceBroker.id}"

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -19,13 +19,11 @@ package kafka.server
 
 import java.util.Collections
 import java.util.Optional
-
 import kafka.api._
 import kafka.cluster.BrokerEndPoint
 import kafka.log.{LeaderOffsetIncremented, LogAppendInfo}
-import kafka.server.AbstractFetcherThread.ReplicaFetch
-import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import kafka.utils.Implicits._
+import kafka.utils.LogIdent
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.KafkaStorageException
@@ -61,10 +59,11 @@ class ReplicaFetcherThread(name: String,
                                 isInterruptible = false,
                                 replicaMgr.brokerTopicStats) {
 
+  import AbstractFetcherThread._
   private val replicaId = brokerConfig.brokerId
   private val logContext = new LogContext(s"[ReplicaFetcher replicaId=$replicaId, leaderId=${sourceBroker.id}, " +
     s"fetcherId=$fetcherId] ")
-  this.logIdent = logContext.logPrefix
+  override protected implicit val logIdent = Some(LogIdent(logContext.logPrefix))
 
   private val leaderEndpoint = leaderEndpointBlockingSend.getOrElse(
     new ReplicaFetcherBlockingSend(sourceBroker, brokerConfig, metrics, time, fetcherId,

--- a/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
@@ -78,6 +78,8 @@ class ReplicationQuotaManager(val config: ReplicationQuotaManagerConfig,
                               private val metrics: Metrics,
                               private val replicationType: QuotaType,
                               private val time: Time) extends ReplicaQuota {
+  import ReplicationQuotaManager._
+
   private val lock = new ReentrantReadWriteLock()
   private val throttledPartitions = new ConcurrentHashMap[String, Seq[Int]]()
   private var quota: Quota = null

--- a/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
@@ -62,6 +62,10 @@ object Constants {
   val AllReplicas = Seq[Int](-1)
 }
 
+object ReplicationQuotaManager extends Logging {
+
+}
+
 /**
   * Tracks replication metrics and comparing them to any quotas for throttled partitions.
   *
@@ -73,7 +77,7 @@ object Constants {
 class ReplicationQuotaManager(val config: ReplicationQuotaManagerConfig,
                               private val metrics: Metrics,
                               private val replicationType: QuotaType,
-                              private val time: Time) extends Logging with ReplicaQuota {
+                              private val time: Time) extends ReplicaQuota {
   private val lock = new ReentrantReadWriteLock()
   private val throttledPartitions = new ConcurrentHashMap[String, Seq[Int]]()
   private var quota: Quota = null

--- a/core/src/main/scala/kafka/server/ThrottledChannel.scala
+++ b/core/src/main/scala/kafka/server/ThrottledChannel.scala
@@ -25,6 +25,9 @@ import kafka.network.RequestChannel.Response
 import kafka.utils.Logging
 import org.apache.kafka.common.utils.Time
 
+object ThrottledChannel extends Logging {
+
+}
 
 /**
   * Represents a request whose response has been delayed.
@@ -35,8 +38,9 @@ import org.apache.kafka.common.utils.Time
   */
 class ThrottledChannel(val request: RequestChannel.Request, val time: Time, val throttleTimeMs: Int,
                        channelThrottlingCallback: Response => Unit)
-  extends Delayed with Logging {
+  extends Delayed {
 
+  import ThrottledChannel._
   private val endTimeNanos = time.nanoseconds() + TimeUnit.MILLISECONDS.toNanos(throttleTimeMs)
 
   // Notify the socket server that throttling has started for this channel.

--- a/core/src/main/scala/kafka/server/ZkIsrManager.scala
+++ b/core/src/main/scala/kafka/server/ZkIsrManager.scala
@@ -33,7 +33,7 @@ import scala.collection.mutable
  */
 case class IsrChangePropagationConfig(checkIntervalMs: Long, maxDelayMs: Long, lingerMs: Long)
 
-object ZkIsrManager {
+object ZkIsrManager extends Logging {
   // This field is mutable to allow overriding change notification behavior in test cases
   @volatile var DefaultIsrPropagationConfig: IsrChangePropagationConfig = IsrChangePropagationConfig(
     checkIntervalMs = 2500,
@@ -42,7 +42,8 @@ object ZkIsrManager {
   )
 }
 
-class ZkIsrManager(scheduler: Scheduler, time: Time, zkClient: KafkaZkClient) extends AlterIsrManager with Logging {
+class ZkIsrManager(scheduler: Scheduler, time: Time, zkClient: KafkaZkClient) extends AlterIsrManager {
+  import ZkIsrManager._
 
   private val isrChangeNotificationConfig = ZkIsrManager.DefaultIsrPropagationConfig
   // Visible for testing

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointFile.scala
@@ -33,10 +33,13 @@ trait CheckpointFileFormatter[T]{
   def fromLine(line: String): Option[T]
 }
 
+object CheckpointReadBuffer {
+
+}
 class CheckpointReadBuffer[T](location: String,
                               reader: BufferedReader,
                               version: Int,
-                              formatter: CheckpointFileFormatter[T]) extends Logging {
+                              formatter: CheckpointFileFormatter[T]) {
   def read(): Seq[T] = {
     def malformedLineException(line: String) =
       new IOException(s"Malformed line in checkpoint file ($location): '$line'")
@@ -75,11 +78,14 @@ class CheckpointReadBuffer[T](location: String,
   }
 }
 
+object CheckpointFile extends Logging {
+
+}
 class CheckpointFile[T](val file: File,
                         version: Int,
                         formatter: CheckpointFileFormatter[T],
                         logDirFailureChannel: LogDirFailureChannel,
-                        logDir: String) extends Logging {
+                        logDir: String) {
   private val path = file.toPath.toAbsolutePath
   private val tempPath = Paths.get(path.toString + ".tmp")
   private val lock = new Object()

--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -18,15 +18,18 @@ package kafka.server.epoch
 
 import java.util
 import java.util.concurrent.locks.ReentrantReadWriteLock
-
 import kafka.server.checkpoints.LeaderEpochCheckpoint
 import kafka.utils.CoreUtils._
-import kafka.utils.Logging
+import kafka.utils.{LogIdent, Logging}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED_EPOCH, UNDEFINED_EPOCH_OFFSET}
 
 import scala.collection.{Seq, mutable}
 import scala.jdk.CollectionConverters._
+
+object LeaderEpochFileCache extends Logging {
+
+}
 
 /**
  * Represents a cache of (LeaderEpoch => Offset) mappings for a particular replica.
@@ -40,8 +43,9 @@ import scala.jdk.CollectionConverters._
  */
 class LeaderEpochFileCache(topicPartition: TopicPartition,
                            logEndOffset: () => Long,
-                           checkpoint: LeaderEpochCheckpoint) extends Logging {
-  this.logIdent = s"[LeaderEpochCache $topicPartition] "
+                           checkpoint: LeaderEpochCheckpoint) {
+  import LeaderEpochFileCache._
+  protected implicit val logIdent = Some(LogIdent(s"[LeaderEpochCache $topicPartition] "))
 
   private val lock = new ReentrantReadWriteLock()
   private val epochs = new util.TreeMap[Int, EpochEntry]()

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -256,10 +256,15 @@ private case class TopicPartitionReplica(topic: String, partitionId: Int, replic
 
 private case class MessageInfo(replicaId: Int, offset: Long, nextOffset: Long, checksum: Long)
 
+private object ReplicaBuffer extends Logging {
+
+}
+
 private class ReplicaBuffer(expectedReplicasPerTopicPartition: collection.Map[TopicPartition, Int],
                             initialOffsets: collection.Map[TopicPartition, Long],
                             expectedNumFetchers: Int,
-                            reportInterval: Long) extends Logging {
+                            reportInterval: Long) {
+  import ReplicaBuffer._
   private val fetchOffsetMap = new Pool[TopicPartition, Long]
   private val recordsCache = new Pool[TopicPartition, Pool[Int, FetchResponse.PartitionData[MemoryRecords]]]
   private val fetcherBarrier = new AtomicReference(new CountDownLatch(expectedNumFetchers))
@@ -385,6 +390,7 @@ private class ReplicaFetcher(name: String, sourceBroker: Node, topicPartitions: 
                              fetcherId: Int)
   extends ShutdownableThread(name) {
 
+  import ShutdownableThread._
   private val fetchEndpoint = new ReplicaFetcherBlockingSend(sourceBroker, new ConsumerConfig(consumerConfig), new Metrics(), Time.SYSTEM, fetcherId,
     s"broker-${Request.DebuggingConsumerId}-fetcher-$fetcherId")
 

--- a/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftRequestHandler.scala
@@ -31,6 +31,10 @@ import org.apache.kafka.common.utils.Time
 
 import scala.jdk.CollectionConverters._
 
+object TestRaftRequestHandler extends Logging {
+
+}
+
 /**
  * Simple request handler implementation for use by [[TestRaftServer]].
  */
@@ -38,7 +42,9 @@ class TestRaftRequestHandler(
   raftManager: RaftManager[_],
   requestChannel: RequestChannel,
   time: Time,
-) extends ApiRequestHandler with Logging {
+) extends ApiRequestHandler {
+
+  import TestRaftRequestHandler._
 
   override def handle(request: RequestChannel.Request): Unit = {
     try {

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -109,15 +109,15 @@ class TestRaftServer(
 
   def shutdown(): Unit = {
     if (raftManager != null)
-      CoreUtils.swallow(raftManager.shutdown(), this)
+      CoreUtils.swallow(raftManager.shutdown(), kafka.tools.TestRaftServer)
     if (workloadGenerator != null)
-      CoreUtils.swallow(workloadGenerator.shutdown(), this)
+      CoreUtils.swallow(workloadGenerator.shutdown(), TestRaftServer)
     if (dataPlaneRequestHandlerPool != null)
-      CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), this)
+      CoreUtils.swallow(dataPlaneRequestHandlerPool.shutdown(), TestRaftServer)
     if (socketServer != null)
-      CoreUtils.swallow(socketServer.shutdown(), this)
+      CoreUtils.swallow(socketServer.shutdown(), kafka.tools.TestRaftServer)
     if (metrics != null)
-      CoreUtils.swallow(metrics.close(), this)
+      CoreUtils.swallow(metrics.close(), kafka.tools.TestRaftServer)
     shutdownLatch.countDown()
   }
 

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -47,7 +47,7 @@ class TestRaftServer(
   val config: KafkaConfig,
   val throughput: Int,
   val recordSize: Int
-) extends Logging {
+)  {
   import kafka.tools.TestRaftServer._
 
   private val partition = new TopicPartition("__cluster_metadata", 0)
@@ -251,7 +251,6 @@ class TestRaftServer(
 }
 
 object TestRaftServer extends Logging {
-
   case class PendingAppend(
     offset: Long,
     appendTimeMs: Long

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -64,16 +64,16 @@ object CoreUtils {
     * @param logging The logging instance to use for logging the thrown exception.
     * @param logLevel The log level to use for logging.
     */
-  def swallow(action: => Unit, logging: Logging, logLevel: Level = Level.WARN): Unit = {
+  def swallow(action: => Unit, logging: Logging, logLevel: Level = Level.WARN)(implicit logIndent : Option[LogIdent] = None): Unit = {
     try {
       action
     } catch {
       case e: Throwable => logLevel match {
-        case Level.ERROR => logger.error(e.getMessage, e)
-        case Level.WARN => logger.warn(e.getMessage, e)
-        case Level.INFO => logger.info(e.getMessage, e)
-        case Level.DEBUG => logger.debug(e.getMessage, e)
-        case Level.TRACE => logger.trace(e.getMessage, e)
+        case Level.ERROR => logging.error(e.getMessage, e)
+        case Level.WARN => logging.warn(e.getMessage, e)
+        case Level.INFO => logging.info(e.getMessage, e)
+        case Level.DEBUG => logging.debug(e.getMessage, e)
+        case Level.TRACE => logging.trace(e.getMessage, e)
       }
     }
   }

--- a/core/src/main/scala/kafka/utils/DelayedItem.scala
+++ b/core/src/main/scala/kafka/utils/DelayedItem.scala
@@ -23,7 +23,7 @@ import org.apache.kafka.common.utils.Time
 
 import scala.math._
 
-class DelayedItem(val delayMs: Long) extends Delayed with Logging {
+class DelayedItem(val delayMs: Long) extends Delayed {
 
   private val dueMs = Time.SYSTEM.milliseconds + delayMs
 

--- a/core/src/main/scala/kafka/utils/FileLock.scala
+++ b/core/src/main/scala/kafka/utils/FileLock.scala
@@ -20,12 +20,17 @@ import java.io._
 import java.nio.channels._
 import java.nio.file.StandardOpenOption
 
+object FileLock extends Logging {
+
+}
+
 /**
  * A file lock a la flock/funlock
  * 
  * The given path will be created and opened if it doesn't exist.
  */
-class FileLock(val file: File) extends Logging {
+class FileLock(val file: File) {
+  import FileLock._
 
   private val channel = FileChannel.open(file.toPath, StandardOpenOption.CREATE, StandardOpenOption.READ,
     StandardOpenOption.WRITE)

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -56,6 +56,10 @@ trait Scheduler {
   def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) : ScheduledFuture[_]
 }
 
+object KafkaScheduler extends Logging {
+
+}
+
 /**
  * A scheduler based on java.util.concurrent.ScheduledThreadPoolExecutor
  * 
@@ -68,7 +72,8 @@ trait Scheduler {
 @threadsafe
 class KafkaScheduler(val threads: Int, 
                      val threadNamePrefix: String = "kafka-scheduler-", 
-                     daemon: Boolean = true) extends Scheduler with Logging {
+                     daemon: Boolean = true) extends Scheduler {
+  import KafkaScheduler._
   private var executor: ScheduledThreadPoolExecutor = null
   private val schedulerThreadId = new AtomicInteger(0)
 

--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -38,46 +38,42 @@ private object Logging {
   private val FatalMarker: Marker = MarkerFactory.getMarker("FATAL")
 }
 
+/** Used as an implicit parameter to format log messages */
+case class LogIdent(prefix : String)
+
 trait Logging {
 
   protected lazy val logger = Logger(LoggerFactory.getLogger(loggerName))
-
-  protected var logIdent: String = _
 
   Log4jControllerRegistration
 
   protected def loggerName: String = getClass.getName
 
-  protected def msgWithLogIdent(msg: String): String =
-    if (logIdent == null) msg else logIdent + msg
+  protected def msgWithLogIdent(msg: String)(implicit logIndent : Option[LogIdent]): String =
+    logIndent match {
+      case None => msg
+      case Some(LogIdent(prefix)) => prefix + msg
+    }
 
-  def trace(msg: => String): Unit = logger.trace(msgWithLogIdent(msg))
-
-  def trace(msg: => String, e: => Throwable): Unit = logger.trace(msgWithLogIdent(msg),e)
+  def trace(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None): Unit =
+    if (e == null) logger.trace(msgWithLogIdent(msg)) else logger.trace(msgWithLogIdent(msg),e)
 
   def isDebugEnabled: Boolean = logger.underlying.isDebugEnabled
 
   def isTraceEnabled: Boolean = logger.underlying.isTraceEnabled
 
-  def debug(msg: => String): Unit = logger.debug(msgWithLogIdent(msg))
+  def debug(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None): Unit =
+    if (e == null) logger.debug(msgWithLogIdent(msg)) else logger.debug(msgWithLogIdent(msg), e)
 
-  def debug(msg: => String, e: => Throwable): Unit = logger.debug(msgWithLogIdent(msg),e)
+  def info(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None): Unit =
+    if (e == null) logger.info(msgWithLogIdent(msg)) else logger.info(msgWithLogIdent(msg), e)
 
-  def info(msg: => String): Unit = logger.info(msgWithLogIdent(msg))
+  def warn(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None): Unit =
+    if (e == null) logger.warn(msgWithLogIdent(msg)) else logger.warn(msgWithLogIdent(msg),e)
 
-  def info(msg: => String,e: => Throwable): Unit = logger.info(msgWithLogIdent(msg),e)
+  def error(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None): Unit =
+    if (e == null) logger.error(msgWithLogIdent(msg)) else logger.error(msgWithLogIdent(msg),e)
 
-  def warn(msg: => String): Unit = logger.warn(msgWithLogIdent(msg))
-
-  def warn(msg: => String, e: => Throwable): Unit = logger.warn(msgWithLogIdent(msg),e)
-
-  def error(msg: => String): Unit = logger.error(msgWithLogIdent(msg))
-
-  def error(msg: => String, e: => Throwable): Unit = logger.error(msgWithLogIdent(msg),e)
-
-  def fatal(msg: => String): Unit =
-    logger.error(Logging.FatalMarker, msgWithLogIdent(msg))
-
-  def fatal(msg: => String, e: => Throwable): Unit =
-    logger.error(Logging.FatalMarker, msgWithLogIdent(msg), e)
+  def fatal(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None): Unit =
+    if (e == null) logger.error(Logging.FatalMarker, msgWithLogIdent(msg)) else logger.error(Logging.FatalMarker, msgWithLogIdent(msg), e)
 }

--- a/core/src/main/scala/kafka/utils/PasswordEncoder.scala
+++ b/core/src/main/scala/kafka/utils/PasswordEncoder.scala
@@ -59,7 +59,7 @@ class PasswordEncoder(secret: Password,
                       keyFactoryAlgorithm: Option[String],
                       cipherAlgorithm: String,
                       keyLength: Int,
-                      iterations: Int) extends Logging {
+                      iterations: Int) {
 
   private val secureRandom = new SecureRandom
   private val cipherParamsEncoder = cipherParamsInstance(cipherAlgorithm)

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -21,10 +21,15 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import org.apache.kafka.common.internals.FatalExitError
 
+object ShutdownableThread extends Logging {
+
+}
+
 abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean = true)
-        extends Thread(name) with Logging {
+        extends Thread(name) {
+  import ShutdownableThread._
   this.setDaemon(false)
-  this.logIdent = "[" + name + "]: "
+  protected implicit val logIdent = Some(LogIdent("[" + name + "]: "))
   private val shutdownInitiated = new CountDownLatch(1)
   private val shutdownComplete = new CountDownLatch(1)
   @volatile private var isStarted: Boolean = false

--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -41,8 +41,9 @@ class Throttler(desiredRatePerSec: Double,
                 throttleDown: Boolean = true,
                 metricName: String = "throttler",
                 units: String = "entries",
-                time: Time = Time.SYSTEM) extends Logging with KafkaMetricsGroup {
-  
+                time: Time = Time.SYSTEM) extends KafkaMetricsGroup {
+
+  import Throttler._
   private val lock = new Object
   private val meter = newMeter(metricName, units, TimeUnit.SECONDS)
   private val checkIntervalNs = TimeUnit.MILLISECONDS.toNanos(checkIntervalMs)
@@ -81,7 +82,7 @@ class Throttler(desiredRatePerSec: Double,
 
 }
 
-object Throttler {
+object Throttler extends Logging {
   
   def main(args: Array[String]): Unit = {
     val rand = new Random()

--- a/core/src/main/scala/kafka/utils/TopicFilter.scala
+++ b/core/src/main/scala/kafka/utils/TopicFilter.scala
@@ -21,7 +21,7 @@ import java.util.regex.{Pattern, PatternSyntaxException}
 
 import org.apache.kafka.common.internals.Topic
 
-sealed abstract class TopicFilter(rawRegex: String) extends Logging {
+sealed abstract class TopicFilter(rawRegex: String) {
 
   val regex = rawRegex
           .trim
@@ -43,7 +43,13 @@ sealed abstract class TopicFilter(rawRegex: String) extends Logging {
   def isTopicAllowed(topic: String, excludeInternalTopics: Boolean): Boolean
 }
 
+object IncludeList extends Logging {
+
+}
+
 case class IncludeList(rawRegex: String) extends TopicFilter(rawRegex) {
+  import IncludeList._
+
   override def isTopicAllowed(topic: String, excludeInternalTopics: Boolean) = {
     val allowed = topic.matches(regex) && !(Topic.isInternal(topic) && excludeInternalTopics)
 

--- a/core/src/main/scala/kafka/utils/VerifiableProperties.scala
+++ b/core/src/main/scala/kafka/utils/VerifiableProperties.scala
@@ -23,8 +23,12 @@ import scala.collection._
 import kafka.message.{CompressionCodec, NoCompressionCodec}
 import scala.jdk.CollectionConverters._
 
+object VerifiableProperties extends Logging {
 
-class VerifiableProperties(val props: Properties) extends Logging {
+}
+
+class VerifiableProperties(val props: Properties) {
+  import VerifiableProperties._
   private val referenceSet = mutable.HashSet[String]()
 
   def this() = this(new Properties)

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -32,14 +32,18 @@ import org.apache.zookeeper.KeeperException.NodeExistsException
 
 import scala.collection.{Map, Seq}
 
+object AdminZkClient extends Logging {
+
+}
+
 /**
  * Provides admin related methods for interacting with ZooKeeper.
  *
  * This is an internal class and no compatibility guarantees are provided,
  * see org.apache.kafka.clients.admin.AdminClient for publicly supported APIs.
  */
-class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
-
+class AdminZkClient(zkClient: KafkaZkClient) {
+  import AdminZkClient._
   /**
    * Creates the topic with given configuration
    * @param topic topic name to create

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -51,8 +51,8 @@ import scala.collection.{Map, Seq, mutable}
  * easier to migrate away from `ZkUtils` (since removed). We should revisit this. We should also consider whether a
  * monolithic [[kafka.zk.ZkData]] is the way to go.
  */
-class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boolean, time: Time) extends AutoCloseable with
-  Logging with KafkaMetricsGroup {
+class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boolean, time: Time) extends AutoCloseable
+  with KafkaMetricsGroup {
 
   override def metricName(name: String, metricTags: scala.collection.Map[String, String]): MetricName = {
     explicitMetricName("kafka.server", "ZooKeeperClientMetrics", name, metricTags)
@@ -887,7 +887,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
       case Code.OK =>
         ReassignPartitionsZNode.decode(getDataResponse.data) match {
           case Left(e) =>
-            logger.warn(s"Ignoring partition reassignment due to invalid json: ${e.getMessage}", e)
+            warn(s"Ignoring partition reassignment due to invalid json: ${e.getMessage}", e)
             Map.empty[TopicPartition, Seq[Int]]
           case Right(assignments) => assignments
         }
@@ -1917,7 +1917,7 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
   }
 }
 
-object KafkaZkClient {
+object KafkaZkClient extends Logging {
 
   /**
    * @param finishedPartitions Partitions that finished either in successfully

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1829,7 +1829,12 @@ class KafkaZkClient private[zk] (zooKeeperClient: ZooKeeperClient, isSecure: Boo
     currentZooKeeperSessionId = newSessionId
   }
 
-  private class CheckedEphemeral(path: String, data: Array[Byte]) extends Logging {
+  object CheckedEphemeral extends Logging {
+
+  }
+
+  private class CheckedEphemeral(path: String, data: Array[Byte]) {
+    import CheckedEphemeral._
     def create(): Stat = {
       val response = retryRequestUntilConnected(
         MultiRequest(Seq(

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -40,6 +40,8 @@ import scala.collection.{Map, Seq, mutable}
 import scala.jdk.CollectionConverters._
 
 class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
+  import ZooKeeperTestHarness._
+
   @Rule
   def globalTimeout: Timeout = Timeout.millis(300000)
 
@@ -283,7 +285,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness {
             result.partStates(new TopicPartition("foo", 0)).targetReplicas)
           assertEquals(Seq(3, 2, 1),
             result.partStates(new TopicPartition("baz", 2)).targetReplicas)
-          logger.info(s"Current result: ${result}")
+          info(s"Current result: ${result}")
           waitForInterBrokerThrottle(Set(0, 1, 2, 3), interBrokerThrottle)
           false
         }

--- a/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AbstractConsumerTest.scala
@@ -19,12 +19,11 @@ package kafka.api
 import java.time.Duration
 import java.util
 import java.util.Properties
-
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.TopicPartition
-import kafka.utils.{ShutdownableThread, TestUtils}
+import kafka.utils.{Logging, ShutdownableThread, TestUtils}
 import kafka.server.{BaseRequestTest, KafkaConfig}
 import org.junit.Assert._
 import org.junit.Before
@@ -36,10 +35,16 @@ import org.apache.kafka.common.errors.WakeupException
 
 import scala.collection.mutable
 
+object AbstractConsumerTest extends Logging {
+
+}
+
 /**
  * Extension point for consumer integration tests.
  */
 abstract class AbstractConsumerTest extends BaseRequestTest {
+
+  import AbstractConsumerTest._
 
   val epsilon = 0.1
   override def brokerCount: Int = 3

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -64,6 +64,8 @@ import scala.jdk.CollectionConverters._
   * would end up with ZooKeeperTestHarness twice.
   */
 abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with SaslSetup {
+  import IntegrationTestHarness._
+
   override val brokerCount = 3
 
   override def configureSecurityBeforeServersStart(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/EndToEndClusterIdTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndClusterIdTest.scala
@@ -47,7 +47,7 @@ import org.apache.kafka.test.TestUtils.isValidClusterId
   * 9. All the components receive the same cluster id.
   */
 
-object EndToEndClusterIdTest {
+object EndToEndClusterIdTest extends Logging {
 
   object MockConsumerMetricsReporter {
     val CLUSTER_META = new AtomicReference[ClusterResource]

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -18,12 +18,11 @@
 package kafka.api
 
 import java.time.Duration
-
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
-import kafka.utils.TestUtils
+import kafka.utils.{Logging, TestUtils}
 import kafka.utils.Implicits._
-import java.util.Properties
 
+import java.util.Properties
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig}
 import kafka.server.KafkaConfig
 import kafka.integration.KafkaServerTestHarness
@@ -34,6 +33,10 @@ import org.junit.{After, Before}
 
 import scala.collection.mutable
 import scala.collection.Seq
+
+object IntegrationTestHarness extends Logging {
+
+}
 
 /**
  * A helper class for writing integration tests that involve producers, consumers, and servers

--- a/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
@@ -32,6 +32,8 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 class TransactionsBounceTest extends IntegrationTestHarness {
+  import IntegrationTestHarness._
+
   private val producerBufferSize =  65536
   private val serverMessageMaxBytes =  producerBufferSize/2
   private val numPartitions = 3

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -22,10 +22,9 @@ import java.nio.charset.StandardCharsets
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.{Optional, Properties}
-
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
-import kafka.utils.TestUtils
+import kafka.utils.{Logging, TestUtils}
 import kafka.utils.TestUtils.consumeRecords
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
@@ -39,7 +38,13 @@ import scala.collection.Seq
 import scala.collection.mutable.Buffer
 import scala.concurrent.ExecutionException
 
+object TransactionsTest extends Logging {
+
+}
+
 class TransactionsTest extends KafkaServerTestHarness {
+  import TransactionsTest._
+
   val numServers = 3
   val transactionalProducerCount = 2
   val transactionalConsumerCount = 1

--- a/core/src/test/scala/unit/kafka/admin/UserScramCredentialsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/UserScramCredentialsCommandTest.scala
@@ -25,6 +25,8 @@ import org.junit.Assert._
 import org.junit.Test
 
 class UserScramCredentialsCommandTest extends BaseRequestTest {
+  import kafka.api.IntegrationTestHarness._
+
   override def brokerCount = 1
   var exitStatus: Option[Int] = None
   var exitMessage: Option[String] = None

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -21,8 +21,8 @@ import java.lang.management.ManagementFactory
 import java.nio.ByteBuffer
 import java.util.concurrent.locks.ReentrantLock
 import java.util.{Collections, Optional}
-
 import com.yammer.metrics.core.Gauge
+
 import javax.management.ObjectName
 import kafka.api._
 import kafka.cluster.Partition
@@ -30,7 +30,7 @@ import kafka.common.OffsetAndMetadata
 import kafka.log.{AppendOrigin, Log, LogAppendInfo}
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server.{FetchDataInfo, FetchLogEnd, HostedPartition, KafkaConfig, LogOffsetMetadata, ReplicaManager}
-import kafka.utils.{KafkaScheduler, MockTime, TestUtils}
+import kafka.utils.{KafkaScheduler, LogIdent, MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Subscription
@@ -44,7 +44,7 @@ import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.utils.Utils
 import org.easymock.{Capture, EasyMock, IAnswer}
-import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertTrue, assertThrows}
+import org.junit.Assert.{assertEquals, assertFalse, assertNull, assertThrows, assertTrue}
 import org.junit.{Before, Test}
 
 import scala.jdk.CollectionConverters._
@@ -110,7 +110,7 @@ class GroupMetadataManagerTest {
       override def cleanupGroupMetadata(groups: Iterable[GroupMetadata],
                                         selector: GroupMetadata => Map[TopicPartition, OffsetAndMetadata]): Int = expiredOffsets
 
-      override def info(msg: => String): Unit = infoCount += 1
+      override def info(msg: => String, e: => Throwable = null)(implicit logIndent : Option[LogIdent] = None) = infoCount += 1
     }
 
     // if there are no offsets to expire, we skip to log

--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -43,6 +43,8 @@ import scala.util.Random
   */
 class FetchRequestTest extends BaseRequestTest {
 
+  import kafka.api.IntegrationTestHarness._
+
   private var producer: KafkaProducer[String, String] = null
 
   override def brokerPropertyOverrides(properties: Properties): Unit = {

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -82,7 +82,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
       val kafkaConfig = KafkaConfig.fromProps(props)
       val logDir = new File(kafkaConfig.logDirs.head)
       // Make log directory of the partition on the leader broker inaccessible by replacing it with a file
-      CoreUtils.swallow(Utils.delete(logDir), this)
+      CoreUtils.swallow(Utils.delete(logDir), IntegrationTestHarness)
       logDir.createNewFile()
       assertTrue(logDir.isFile)
 

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -57,6 +57,8 @@ import scala.jdk.CollectionConverters._
 
 class RequestQuotaTest extends BaseRequestTest {
 
+  import kafka.api.IntegrationTestHarness._
+
   override def brokerCount: Int = 1
 
   private val topic = "topic-1"

--- a/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
@@ -35,8 +35,9 @@ import org.apache.kafka.clients.admin.AdminClientUnitTestEnv
 import org.apache.kafka.common.utils.Time
 import org.apache.zookeeper.{WatchedEvent, Watcher, ZooKeeper}
 
+
 @Category(Array(classOf[IntegrationTest]))
-abstract class ZooKeeperTestHarness extends Logging {
+abstract class ZooKeeperTestHarness {
 
   val zkConnectionTimeout = 10000
   val zkSessionTimeout = 15000 // Allows us to avoid ZK session expiration due to GC up to 2/3 * 15000ms = 10 secs
@@ -65,7 +66,7 @@ abstract class ZooKeeperTestHarness extends Logging {
     if (zkClient != null)
      zkClient.close()
     if (zookeeper != null)
-      CoreUtils.swallow(zookeeper.shutdown(), this)
+      CoreUtils.swallow(zookeeper.shutdown(), ZooKeeperTestHarness)
     Configuration.setConfiguration(null)
   }
 
@@ -82,7 +83,7 @@ abstract class ZooKeeperTestHarness extends Logging {
   }
 }
 
-object ZooKeeperTestHarness {
+object ZooKeeperTestHarness extends Logging {
   val ZkClientEventThreadSuffix = "-EventThread"
 
   // Threads which may cause transient failures in subsequent tests if not shutdown.


### PR DESCRIPTION
This moves the Logging trait into companion objects so the loggers are only instantiated once.  Classes import the methods from their companion objects.  Classes that were using inheritance to gain access to logging methods are now accessing them though importing their super class' companion object.  In this way any log4j(2) configuration that were configuring the super class logger should still work.

Since classes no longer inherit from Logging they can't change the logIdent string through inheritance.  This PR introduces a new class LogIndent which is used to wrap String so it can be passed as an implicit variable to calls to info(), debug(), etc...  So none of the actual log statements need to change.

CoreUtils.swallow is changed so that it accepts the LogIdent objects.  It seems like CoreUtils.swallow never used to logger that was passed to it only it's own logger which seems like bug.  Calls to swallow need pass the companion object and not this.

There are 10 spot bugs problems flagged.  But I'm not able to figure out what spotbugs is complaining about.

