### PR TITLE
KAFKA-12200 Migrate connect:file module to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ subprojects {
   }
 
   // Remove the relevant project name once it's converted to JUnit 5
-  def shouldUseJUnit5 = !(["api", "connect", "core", "file", "generator", "runtime", "examples",
+  def shouldUseJUnit5 = !(["api", "connect", "core", "generator", "runtime", "examples",
     "streams-scala", "streams"].contains(it.project.name) || it.project.name.startsWith("upgrade-system-tests-"))
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
@@ -2075,10 +2075,7 @@ project(':connect:file') {
     compile libs.slf4jApi
 
     testCompile libs.easymock
-    testCompile libs.junitJupiterApi
-    testCompile libs.junitVintageEngine
-    testCompile libs.powermockJunit4
-    testCompile libs.powermockEasymock
+    testCompile libs.junitJupiter
 
     testRuntime libs.slf4jlog4j
     testCompile project(':clients').sourceSets.test.output

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSinkConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSinkConnectorTest.java
@@ -20,15 +20,15 @@ import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.easymock.EasyMockSupport;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public class FileStreamSinkConnectorTest extends EasyMockSupport {
 
@@ -39,7 +39,7 @@ public class FileStreamSinkConnectorTest extends EasyMockSupport {
     private ConnectorContext ctx;
     private Map<String, String> sinkProperties;
 
-    @Before
+    @BeforeEach
     public void setup() {
         connector = new FileStreamSinkConnector();
         ctx = createMock(ConnectorContext.class);
@@ -55,7 +55,7 @@ public class FileStreamSinkConnectorTest extends EasyMockSupport {
         replayAll();
         List<ConfigValue> configValues = connector.config().validate(sinkProperties);
         for (ConfigValue val : configValues) {
-            assertEquals("Config property errors: " + val.errorMessages(), 0, val.errorMessages().size());
+            assertEquals(0, val.errorMessages().size(), "Config property errors: " + val.errorMessages());
         }
         verifyAll();
     }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSinkTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSinkTaskTest.java
@@ -20,24 +20,21 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FileStreamSinkTaskTest {
 
@@ -45,17 +42,16 @@ public class FileStreamSinkTaskTest {
     private ByteArrayOutputStream os;
     private PrintStream printStream;
 
-    @Rule
-    public TemporaryFolder topDir = new TemporaryFolder();
+    @TempDir
+    public Path topDir;
     private String outputFile;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         os = new ByteArrayOutputStream();
         printStream = new PrintStream(os);
         task = new FileStreamSinkTask(printStream);
-        File outputDir = topDir.newFolder("file-stream-sink-" + UUID.randomUUID().toString());
-        outputFile = outputDir.getCanonicalPath() + "/connect.output";
+        outputFile = topDir.resolve("connect.output").toAbsolutePath().toString();
     }
 
     @Test

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceConnectorTest.java
@@ -21,16 +21,16 @@ import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 
 public class FileStreamSourceConnectorTest extends EasyMockSupport {
 
@@ -42,7 +42,7 @@ public class FileStreamSourceConnectorTest extends EasyMockSupport {
     private ConnectorContext ctx;
     private Map<String, String> sourceProperties;
 
-    @Before
+    @BeforeEach
     public void setup() {
         connector = new FileStreamSourceConnector();
         ctx = createMock(ConnectorContext.class);
@@ -58,7 +58,7 @@ public class FileStreamSourceConnectorTest extends EasyMockSupport {
         replayAll();
         List<ConfigValue> configValues = connector.config().validate(sourceProperties);
         for (ConfigValue val : configValues) {
-            assertEquals("Config property errors: " + val.errorMessages(), 0, val.errorMessages().size());
+            assertEquals(0, val.errorMessages().size(), "Config property errors: " + val.errorMessages());
         }
         verifyAll();
     }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -21,9 +21,9 @@ import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,8 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FileStreamSourceTaskTest extends EasyMockSupport {
 
@@ -51,7 +51,7 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
 
     private boolean verifyMocks = false;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         tempFile = File.createTempFile("file-stream-source-task-test", null);
         config = new HashMap<>();
@@ -64,7 +64,7 @@ public class FileStreamSourceTaskTest extends EasyMockSupport {
         task.initialize(context);
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         tempFile.delete();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-12200

replace junit4 methods with junit5 methods

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
