### PR TITLE
MINOR: Fix error message in KafkaRaftClient.java

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1311,7 +1311,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
              * reseting the fetching snapshot state and sending another fetch request.
              */
             logger.trace(
-                "Leader doesn't know about snapshot id {}, returned error {} and snapshot id {}",
+                "Leader doesn't know about snapshot {}, returned error {} and snapshot id {}",
                 state.fetchingSnapshot(),
                 partitionSnapshot.errorCode(),
                 partitionSnapshot.snapshotId()

--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotWriter.java
@@ -114,4 +114,13 @@ public final class FileRawSnapshotWriter implements RawSnapshotWriter {
             snapshotId
         );
     }
+
+    @Override
+    public String toString() {
+        return "FileRawSnapshotWriter(" +
+                "tempSnapshotPath=" + tempSnapshotPath +
+                ", snapshotId=" + snapshotId +
+                ", frozen=" + frozen +
+                ')';
+    }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -1149,5 +1149,13 @@ final public class KafkaRaftClientSnapshotTest {
         public ByteBuffer buffer() {
             return data;
         }
+
+        @Override
+        public String toString() {
+            return "MemorySnapshotWriter(" +
+                    "snapshotId=" + snapshotId +
+                    ", frozen=" + frozen +
+                    ')';
+        }
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -550,6 +550,14 @@ public class MockLog implements ReplicatedLog {
 
         @Override
         public void close() {}
+
+        @Override
+        public String toString() {
+            return "MockRawSnapshotWriter(" +
+                    "snapshotId=" + snapshotId +
+                    ", frozen=" + frozen +
+                    ')';
+        }
     }
 
     final static class MockRawSnapshotReader implements RawSnapshotReader {


### PR DESCRIPTION
before

`logger.trace(
                "Leader doesn't know about snapshot id {}, returned error {} and snapshot id {}",
                state.fetchingSnapshot(),
                partitionSnapshot.errorCode(),
                partitionSnapshot.snapshotId()
            );`

after

`logger.trace(
                "Leader doesn't know about snapshot {}, returned error {} and snapshot id {}",
                state.fetchingSnapshot(),
                partitionSnapshot.errorCode(),
                partitionSnapshot.snapshotId()
            );`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
