### PR TITLE
MINOR: Use Gradle's JUnitPlatform for upgrade-system-tests modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,8 +242,7 @@ subprojects {
   }
 
   // Remove the relevant project name once it's converted to JUnit 5
-  def shouldUseJUnit5 = !(["core", "generator", "runtime", "examples", "streams-scala", "streams"].contains(
-    it.project.name))
+  def shouldUseJUnit5 = !(["core", "generator", "runtime", "streams-scala", "streams"].contains(it.project.name))
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
   def testShowStandardStreams = false

--- a/build.gradle
+++ b/build.gradle
@@ -1766,16 +1766,16 @@ project(':streams:upgrade-system-tests-26') {
 }
 
 project(':streams:upgrade-system-tests-27') {
-    archivesBaseName = "kafka-streams-upgrade-system-tests-27"
+  archivesBaseName = "kafka-streams-upgrade-system-tests-27"
 
-    dependencies {
-      testCompile libs.kafkaStreams_27
-      testRuntime libs.junitJupiter
-    }
+  dependencies {
+    testCompile libs.kafkaStreams_27
+    testRuntime libs.junitJupiter
+  }
 
-    systemTestLibs {
-        dependsOn testJar
-    }
+  systemTestLibs {
+    dependsOn testJar
+  }
 }
 
 project(':jmh-benchmarks') {

--- a/build.gradle
+++ b/build.gradle
@@ -242,8 +242,8 @@ subprojects {
   }
 
   // Remove the relevant project name once it's converted to JUnit 5
-  def shouldUseJUnit5 = !(["api", "connect", "core", "generator", "runtime", "examples",
-    "streams-scala", "streams"].contains(it.project.name) || it.project.name.startsWith("upgrade-system-tests-"))
+  def shouldUseJUnit5 = !(["core", "generator", "runtime", "examples", "streams-scala", "streams"].contains(
+    it.project.name))
 
   def testLoggingEvents = ["passed", "skipped", "failed"]
   def testShowStandardStreams = false
@@ -1601,6 +1601,7 @@ project(':streams:upgrade-system-tests-0100') {
 
   dependencies {
     testCompile libs.kafkaStreams_0100
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1613,6 +1614,7 @@ project(':streams:upgrade-system-tests-0101') {
 
   dependencies {
     testCompile libs.kafkaStreams_0101
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1625,6 +1627,7 @@ project(':streams:upgrade-system-tests-0102') {
 
   dependencies {
     testCompile libs.kafkaStreams_0102
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1637,6 +1640,7 @@ project(':streams:upgrade-system-tests-0110') {
 
   dependencies {
     testCompile libs.kafkaStreams_0110
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1649,6 +1653,7 @@ project(':streams:upgrade-system-tests-10') {
 
   dependencies {
     testCompile libs.kafkaStreams_10
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1661,6 +1666,7 @@ project(':streams:upgrade-system-tests-11') {
 
   dependencies {
     testCompile libs.kafkaStreams_11
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1673,6 +1679,7 @@ project(':streams:upgrade-system-tests-20') {
 
   dependencies {
     testCompile libs.kafkaStreams_20
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1685,6 +1692,7 @@ project(':streams:upgrade-system-tests-21') {
 
   dependencies {
     testCompile libs.kafkaStreams_21
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1697,6 +1705,7 @@ project(':streams:upgrade-system-tests-22') {
 
   dependencies {
     testCompile libs.kafkaStreams_22
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1709,6 +1718,7 @@ project(':streams:upgrade-system-tests-23') {
 
   dependencies {
     testCompile libs.kafkaStreams_23
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1721,6 +1731,7 @@ project(':streams:upgrade-system-tests-24') {
 
   dependencies {
     testCompile libs.kafkaStreams_24
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1733,6 +1744,7 @@ project(':streams:upgrade-system-tests-25') {
 
   dependencies {
     testCompile libs.kafkaStreams_25
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1745,6 +1757,7 @@ project(':streams:upgrade-system-tests-26') {
 
   dependencies {
     testCompile libs.kafkaStreams_26
+    testRuntime libs.junitJupiter
   }
 
   systemTestLibs {
@@ -1756,7 +1769,8 @@ project(':streams:upgrade-system-tests-27') {
     archivesBaseName = "kafka-streams-upgrade-system-tests-27"
 
     dependencies {
-        testCompile libs.kafkaStreams_27
+      testCompile libs.kafkaStreams_27
+      testRuntime libs.junitJupiter
     }
 
     systemTestLibs {


### PR DESCRIPTION
Add a runtime dependency on the jupiter engine to avoid failures
during `./gradlew unitTest/integrationTest/test` for `upgrade-system-tests-*`.

Also remove `connect` and `examples` from the JUnit 5 blocklist since they
contains no tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
