### PR TITLE
MINOR: Tag `RaftEventSimulationTest` as `integration` and tweak it

### DIFF
--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.raft.MockLog.LogBatch;
 import org.apache.kafka.raft.MockLog.LogEntry;
 import org.apache.kafka.raft.internals.BatchMemoryPool;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -59,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@Tag("integration")
 public class RaftEventSimulationTest {
     private static final TopicPartition METADATA_PARTITION = new TopicPartition("__cluster_metadata", 0);
     private static final int ELECTION_TIMEOUT_MS = 1000;
@@ -140,44 +142,44 @@ public class RaftEventSimulationTest {
     }
 
     private void testElectionAfterLeaderFailure(QuorumConfig config) {
-        testElectionAfterLeaderShutdown(config, false);
+        checkElectionAfterLeaderShutdown(config, false);
     }
 
     @Test
     public void testElectionAfterLeaderGracefulShutdownQuorumSizeThree() {
-        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(3, 0));
+        checkElectionAfterLeaderGracefulShutdown(new QuorumConfig(3, 0));
     }
 
     @Test
     public void testElectionAfterLeaderGracefulShutdownQuorumSizeThreeAndTwoObservers() {
-        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(3, 2));
+        checkElectionAfterLeaderGracefulShutdown(new QuorumConfig(3, 2));
     }
 
     @Test
     public void testElectionAfterLeaderGracefulShutdownQuorumSizeFour() {
-        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(4, 0));
+        checkElectionAfterLeaderGracefulShutdown(new QuorumConfig(4, 0));
     }
 
     @Test
     public void testElectionAfterLeaderGracefulShutdownQuorumSizeFourAndTwoObservers() {
-        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(4, 2));
+        checkElectionAfterLeaderGracefulShutdown(new QuorumConfig(4, 2));
     }
 
     @Test
     public void testElectionAfterLeaderGracefulShutdownQuorumSizeFive() {
-        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(5, 0));
+        checkElectionAfterLeaderGracefulShutdown(new QuorumConfig(5, 0));
     }
 
     @Test
     public void testElectionAfterLeaderGracefulShutdownQuorumSizeFiveAndThreeObservers() {
-        testElectionAfterLeaderGracefulShutdown(new QuorumConfig(5, 3));
+        checkElectionAfterLeaderGracefulShutdown(new QuorumConfig(5, 3));
     }
 
-    private void testElectionAfterLeaderGracefulShutdown(QuorumConfig config) {
-        testElectionAfterLeaderShutdown(config, true);
+    private void checkElectionAfterLeaderGracefulShutdown(QuorumConfig config) {
+        checkElectionAfterLeaderShutdown(config, true);
     }
 
-    private void testElectionAfterLeaderShutdown(QuorumConfig config, boolean isGracefulShutdown) {
+    private void checkElectionAfterLeaderShutdown(QuorumConfig config, boolean isGracefulShutdown) {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -214,20 +216,20 @@ public class RaftEventSimulationTest {
 
     @Test
     public void testRecoveryAfterAllNodesFailQuorumSizeThree() {
-        testRecoveryAfterAllNodesFail(new QuorumConfig(3));
+        checkRecoveryAfterAllNodesFail(new QuorumConfig(3));
     }
 
     @Test
     public void testRecoveryAfterAllNodesFailQuorumSizeFour() {
-        testRecoveryAfterAllNodesFail(new QuorumConfig(4));
+        checkRecoveryAfterAllNodesFail(new QuorumConfig(4));
     }
 
     @Test
     public void testRecoveryAfterAllNodesFailQuorumSizeFive() {
-        testRecoveryAfterAllNodesFail(new QuorumConfig(5));
+        checkRecoveryAfterAllNodesFail(new QuorumConfig(5));
     }
 
-    private void testRecoveryAfterAllNodesFail(QuorumConfig config) {
+    private void checkRecoveryAfterAllNodesFail(QuorumConfig config) {
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
@@ -259,35 +261,35 @@ public class RaftEventSimulationTest {
 
     @Test
     public void testElectionAfterLeaderNetworkPartitionQuorumSizeThree() {
-        testElectionAfterLeaderNetworkPartition(new QuorumConfig(3));
+        checkElectionAfterLeaderNetworkPartition(new QuorumConfig(3));
     }
 
     @Test
     public void testElectionAfterLeaderNetworkPartitionQuorumSizeThreeAndTwoObservers() {
-        testElectionAfterLeaderNetworkPartition(new QuorumConfig(3, 2));
+        checkElectionAfterLeaderNetworkPartition(new QuorumConfig(3, 2));
     }
 
     @Test
     public void testElectionAfterLeaderNetworkPartitionQuorumSizeFour() {
-        testElectionAfterLeaderNetworkPartition(new QuorumConfig(4));
+        checkElectionAfterLeaderNetworkPartition(new QuorumConfig(4));
     }
 
     @Test
     public void testElectionAfterLeaderNetworkPartitionQuorumSizeFourAndTwoObservers() {
-        testElectionAfterLeaderNetworkPartition(new QuorumConfig(4, 2));
+        checkElectionAfterLeaderNetworkPartition(new QuorumConfig(4, 2));
     }
 
     @Test
     public void testElectionAfterLeaderNetworkPartitionQuorumSizeFive() {
-        testElectionAfterLeaderNetworkPartition(new QuorumConfig(5));
+        checkElectionAfterLeaderNetworkPartition(new QuorumConfig(5));
     }
 
     @Test
     public void testElectionAfterLeaderNetworkPartitionQuorumSizeFiveAndThreeObservers() {
-        testElectionAfterLeaderNetworkPartition(new QuorumConfig(5, 3));
+        checkElectionAfterLeaderNetworkPartition(new QuorumConfig(5, 3));
     }
 
-    private void testElectionAfterLeaderNetworkPartition(QuorumConfig config) {
+    private void checkElectionAfterLeaderNetworkPartition(QuorumConfig config) {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -318,15 +320,15 @@ public class RaftEventSimulationTest {
 
     @Test
     public void testElectionAfterMultiNodeNetworkPartitionQuorumSizeFive() {
-        testElectionAfterMultiNodeNetworkPartition(new QuorumConfig(5));
+        checkElectionAfterMultiNodeNetworkPartition(new QuorumConfig(5));
     }
 
     @Test
     public void testElectionAfterMultiNodeNetworkPartitionQuorumSizeFiveAndTwoObservers() {
-        testElectionAfterMultiNodeNetworkPartition(new QuorumConfig(5, 2));
+        checkElectionAfterMultiNodeNetworkPartition(new QuorumConfig(5, 2));
     }
 
-    private void testElectionAfterMultiNodeNetworkPartition(QuorumConfig config) {
+    private void checkElectionAfterMultiNodeNetworkPartition(QuorumConfig config) {
         // We need at least three voters to run this tests
         assumeTrue(config.numVoters > 2);
 
@@ -372,15 +374,15 @@ public class RaftEventSimulationTest {
 
     @Test
     public void testBackToBackLeaderFailuresQuorumSizeThree() {
-        testBackToBackLeaderFailures(new QuorumConfig(3));
+        checkBackToBackLeaderFailures(new QuorumConfig(3));
     }
 
     @Test
     public void testBackToBackLeaderFailuresQuorumSizeFiveAndTwoObservers() {
-        testBackToBackLeaderFailures(new QuorumConfig(5, 2));
+        checkBackToBackLeaderFailures(new QuorumConfig(5, 2));
     }
 
-    private void testBackToBackLeaderFailures(QuorumConfig config) {
+    private void checkBackToBackLeaderFailures(QuorumConfig config) {
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
@@ -430,24 +432,19 @@ public class RaftEventSimulationTest {
         }
     }
 
-    @FunctionalInterface
-    private interface Action {
-        void execute();
-    }
-
     private static abstract class Event implements Comparable<Event> {
         final int eventId;
         final long deadlineMs;
-        final Action action;
+        final Runnable action;
 
-        protected Event(Action action, int eventId, long deadlineMs) {
+        protected Event(Runnable action, int eventId, long deadlineMs) {
             this.action = action;
             this.eventId = eventId;
             this.deadlineMs = deadlineMs;
         }
 
         void execute(EventScheduler scheduler) {
-            action.execute();
+            action.run();
         }
 
         public int compareTo(Event other) {
@@ -463,7 +460,7 @@ public class RaftEventSimulationTest {
         final int periodMs;
         final int jitterMs;
 
-        protected PeriodicEvent(Action action,
+        protected PeriodicEvent(Runnable action,
                                 int eventId,
                                 Random random,
                                 long deadlineMs,
@@ -483,7 +480,7 @@ public class RaftEventSimulationTest {
         }
     }
 
-    private static class SequentialAppendAction implements Action {
+    private static class SequentialAppendAction implements Runnable {
         final Cluster cluster;
 
         private SequentialAppendAction(Cluster cluster) {
@@ -491,7 +488,7 @@ public class RaftEventSimulationTest {
         }
 
         @Override
-        public void execute() {
+        public void run() {
             cluster.withCurrentLeader(node -> {
                 if (!node.client.isShuttingDown() && node.counter.isWritable())
                     node.counter.increment();
@@ -531,7 +528,7 @@ public class RaftEventSimulationTest {
             validations.add(validation);
         }
 
-        void schedule(Action action, int delayMs, int periodMs, int jitterMs) {
+        void schedule(Runnable action, int delayMs, int periodMs, int jitterMs) {
             long initialDeadlineMs = time.milliseconds() + delayMs;
             int eventId = eventIdGenerator.incrementAndGet();
             PeriodicEvent event = new PeriodicEvent(action, eventId, random, initialDeadlineMs, periodMs, jitterMs);

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -58,7 +58,6 @@ import static org.apache.kafka.raft.RaftTestUtil.voterNodesFromIds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @Tag("integration")
 public class RaftEventSimulationTest {
@@ -180,9 +179,6 @@ public class RaftEventSimulationTest {
     }
 
     private void checkElectionAfterLeaderShutdown(QuorumConfig config, boolean isGracefulShutdown) {
-        // We need at least three voters to run this tests
-        assumeTrue(config.numVoters > 2);
-
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
@@ -290,9 +286,6 @@ public class RaftEventSimulationTest {
     }
 
     private void checkElectionAfterLeaderNetworkPartition(QuorumConfig config) {
-        // We need at least three voters to run this tests
-        assumeTrue(config.numVoters > 2);
-
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
@@ -329,9 +322,6 @@ public class RaftEventSimulationTest {
     }
 
     private void checkElectionAfterMultiNodeNetworkPartition(QuorumConfig config) {
-        // We need at least three voters to run this tests
-        assumeTrue(config.numVoters > 2);
-
         for (int seed = 0; seed < 100; seed++) {
             Cluster cluster = new Cluster(config, seed);
             MessageRouter router = new MessageRouter(cluster);
@@ -496,7 +486,6 @@ public class RaftEventSimulationTest {
         }
     }
 
-    @FunctionalInterface
     private interface Invariant {
         void verify();
     }


### PR DESCRIPTION
The test takes over 1 minute to run, so it should not be considered a
unit test.

Also:
* Replace `test` prefix with `check` prefix for helper methods. A common
mistake is to forget to add the @Test annotation, so it's good to use a
different naming convention for methods that should have the annotation
versus methods that should not.
* Replace `Action` functional interface with built-in `Runnable`.
* Remove unnecessary `assumeTrue`.
* Remove `@FunctionalInterface` from `Invariant` since it's not used
in that way.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
