### PR TITLE
MINOR: Exclude junit 3 transitive dependency from jfreechart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -787,7 +787,9 @@ project(':core') {
     testCompile libs.apachedsJdbmPartition
     testCompile libs.junitJupiter
     testCompile libs.slf4jlog4j
-    testCompile libs.jfreechart
+    testCompile(libs.jfreechart) {
+      exclude group: 'junit', module: 'junit'
+    }
   }
 
   if (userEnableTestCoverage) {


### PR DESCRIPTION
This was causing IntelliJ to choose the vintage runner when running `core` tests
which would then fail.

Verified that `core` tests work in IntelliJ again after this change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
