### PR TITLE
MINOR: Fix always-passing validation in TestRecordTest#testProducerRecord

### DIFF
--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/TestRecordTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -166,6 +167,5 @@ public class TestRecordTest {
         final TestRecord<String, Integer> testRecord = new TestRecord<>(producerRecord);
         final TestRecord<String, Integer> expectedRecord = new TestRecord<>(key, value, headers, recordTime);
         assertEquals(expectedRecord, testRecord);
-        assertNotEquals(expectedRecord, producerRecord);
     }
 }


### PR DESCRIPTION
Since the types of `ProducerRecord` and `TestRecord` are different, calling `assertNotEquals` for these instances always succeeds - and meaningless.

This commit improves `TestRecordTest` by comparing the instances deeply.

cc/ @chia7712

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
