### PR TITLE
MINOR: further reduce StreamThread loop INFO logging to 2min summary

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Map.Entry;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.RecordsToDelete;
@@ -1053,7 +1054,7 @@ public class TaskManager {
     }
 
     private void commitOffsetsOrTransaction(final Map<Task, Map<TopicPartition, OffsetAndMetadata>> offsetsPerTask) {
-        log.debug("Committing task offsets {}", offsetsPerTask);
+        log.debug("Committing task offsets {}", offsetsPerTask.entrySet().stream().collect(Collectors.toMap(t -> t.getKey().id(), Entry::getValue))); // avoid logging actual Task objects
 
         TaskTimeoutExceptions timeoutExceptions = null;
 


### PR DESCRIPTION
One more try to get the logging levels right..the only way to log something within the main StreamThread loop without absolutely flooding the logs at a level that isn't appropriate for INFO is to just set some kind of interval to stick to. I chose to log the summary every 2 min, since this is long enough to prevent log spam but short enough to fit at least 2 summaries within the (default) poll interval of 5 min