### PR TITLE
KAFKA-12230: do not interrupt execution on failure to `setPosixFilePermissions` on Windows machines

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -117,7 +117,7 @@ public class StateDirectory {
             try {
                 Files.setPosixFilePermissions(basePath, perms);
                 Files.setPosixFilePermissions(statePath, perms);
-            } catch (final IOException e) {
+            } catch (final IOException | UnsupportedOperationException e) {
                 log.error("Error changing permissions for the state or base directory {} ", stateDir.getPath(), e);
             }
         }


### PR DESCRIPTION
`StateDirectory` constructor should catch not only `IOException`, but also `UnsupportedOperationException`
 in order to work correctly on Windows machines (see [KAFKA-12230](https://issues.apache.org/jira/browse/KAFKA-12230))


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
