### PR TITLE
KAFKA-12170: Fix for Connect Cast SMT to correctly transform a Byte array into a string

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -361,6 +361,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             throw new DataException("Unexpected type in Cast transformation: " + value.getClass());
     }
 
+
     private static String castToString(Object value) {
         if (value instanceof java.util.Date) {
             java.util.Date dateValue = (java.util.Date) value;
@@ -369,15 +370,22 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         else if (value instanceof ByteBuffer) {
             ByteBuffer byteBuffer = (ByteBuffer) value;
 
-            StringBuilder sbuf = new StringBuilder();
-            for (byte b : byteBuffer.array()) {
-                sbuf.append(String.format("%02X", b));
-            }
-            return sbuf.toString();
+            return castByteArrayToString(byteBuffer.array());
+        }
+        else if (value.getClass() == byte[].class) {
+            return castByteArrayToString((byte[]) value);
         }
         else {
             return value.toString();
         }
+    }
+
+    private static String castByteArrayToString(byte[] array) {
+        StringBuilder sbuf = new StringBuilder();
+        for (byte b : array) {
+            sbuf.append(String.format("%02X", b));
+        }
+        return sbuf.toString();
     }
 
     protected abstract Schema operatingSchema(R record);

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -41,7 +41,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.Base64;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -59,7 +59,8 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
     // allow casting nested fields.
     public static final String OVERVIEW_DOC =
             "Cast fields or the entire key or value to a specific type, e.g. to force an integer field to a smaller "
-                    + "width. Only simple primitive types are supported -- integers, floats, boolean, and string. "
+                    + "width. Cast from integers, floats, boolean and string to any other type, "
+                    + "and cast binary to string (base64 encoded)."
                     + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 
@@ -85,7 +86,7 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             ConfigDef.Importance.HIGH,
             "List of fields and the type to cast them to of the form field1:type,field2:type to cast fields of "
                     + "Maps or Structs. A single type to cast the entire value. Valid types are int8, int16, int32, "
-                    + "int64, float32, float64, boolean, and string.");
+                    + "int64, float32, float64, boolean, and string. Note that binary fields can only be cast to string.");
 
     private static final String PURPOSE = "cast types";
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
@@ -367,16 +368,10 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             return Values.dateFormatFor(dateValue).format(dateValue);
         } else if (value instanceof ByteBuffer) {
             ByteBuffer byteBuffer = (ByteBuffer) value;
-            if (byteBuffer.hasArray()) {
-                return castByteArrayToString(byteBuffer.array());
-            }
-            else {
-                byte[] array = new byte[byteBuffer.remaining()];
-                byteBuffer.get(array);
-                return castByteArrayToString(array);
-            }
+            return castByteArrayToString(Utils.readBytes(byteBuffer));
         } else if (value instanceof byte[]) {
-            return castByteArrayToString((byte[]) value);
+            byte[] rawBytes = (byte[]) value;
+            return castByteArrayToString(rawBytes);
         } else {
             return value.toString();
         }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -367,7 +367,14 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             return Values.dateFormatFor(dateValue).format(dateValue);
         } else if (value instanceof ByteBuffer) {
             ByteBuffer byteBuffer = (ByteBuffer) value;
-            return castByteArrayToString(byteBuffer.array());
+            if (byteBuffer.hasArray()) {
+                return castByteArrayToString(byteBuffer.array());
+            }
+            else {
+                byte[] array = new byte[byteBuffer.remaining()];
+                byteBuffer.get(array);
+                return castByteArrayToString(array);
+            }
         } else if (value instanceof byte[]) {
             return castByteArrayToString((byte[]) value);
         } else {

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -41,12 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
@@ -368,21 +363,13 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             return Values.dateFormatFor(dateValue).format(dateValue);
         } else if (value instanceof ByteBuffer) {
             ByteBuffer byteBuffer = (ByteBuffer) value;
-            return castByteArrayToString(Utils.readBytes(byteBuffer));
+            return Base64.getEncoder().encodeToString(Utils.readBytes(byteBuffer));
         } else if (value instanceof byte[]) {
             byte[] rawBytes = (byte[]) value;
-            return castByteArrayToString(rawBytes);
+            return Base64.getEncoder().encodeToString(rawBytes);
         } else {
             return value.toString();
         }
-    }
-
-    private static String castByteArrayToString(byte[] array) {
-        StringBuilder sbuf = new StringBuilder();
-        for (byte b : array) {
-            sbuf.append(String.format("%02X", b));
-        }
-        return sbuf.toString();
     }
 
     protected abstract Schema operatingSchema(R record);

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.ByteBuffer;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -364,7 +365,17 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         if (value instanceof java.util.Date) {
             java.util.Date dateValue = (java.util.Date) value;
             return Values.dateFormatFor(dateValue).format(dateValue);
-        } else {
+        }
+        else if (value instanceof ByteBuffer) {
+            ByteBuffer byteBuffer = (ByteBuffer) value;
+
+            StringBuilder sbuf = new StringBuilder();
+            for (byte b : byteBuffer.array()) {
+                sbuf.append(String.format("%02X", b));
+            }
+            return sbuf.toString();
+        }
+        else {
             return value.toString();
         }
     }

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -361,16 +361,14 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
             throw new DataException("Unexpected type in Cast transformation: " + value.getClass());
     }
 
-
     private static String castToString(Object value) {
         if (value instanceof java.util.Date) {
             java.util.Date dateValue = (java.util.Date) value;
             return Values.dateFormatFor(dateValue).format(dateValue);
         } else if (value instanceof ByteBuffer) {
             ByteBuffer byteBuffer = (ByteBuffer) value;
-
             return castByteArrayToString(byteBuffer.array());
-        } else if (value.getClass() == byte[].class) {
+        } else if (value instanceof byte[]) {
             return castByteArrayToString((byte[]) value);
         } else {
             return value.toString();

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -366,16 +366,13 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
         if (value instanceof java.util.Date) {
             java.util.Date dateValue = (java.util.Date) value;
             return Values.dateFormatFor(dateValue).format(dateValue);
-        }
-        else if (value instanceof ByteBuffer) {
+        } else if (value instanceof ByteBuffer) {
             ByteBuffer byteBuffer = (ByteBuffer) value;
 
             return castByteArrayToString(byteBuffer.array());
-        }
-        else if (value.getClass() == byte[].class) {
+        } else if (value.getClass() == byte[].class) {
             return castByteArrayToString((byte[]) value);
-        }
-        else {
+        } else {
             return value.toString();
         }
     }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -426,18 +426,8 @@ public class CastTest {
     @Test
     public void castFieldsWithSchema() {
         Date day = new Date(MILLIS_PER_DAY);
-        ByteBuffer byteBuffer = ByteBuffer.allocate(8);
-        byteBuffer.put((byte) 0xFE);
-        byteBuffer.put((byte) 0xDC);
-        byteBuffer.put((byte) 0xBA);
-        byteBuffer.put((byte) 0x98);
-        byteBuffer.put((byte) 0x76);
-        byteBuffer.put((byte) 0x54);
-        byteBuffer.put((byte) 0x32);
-        byteBuffer.put((byte) 0x10);
-        byteBuffer.flip();
-
-        byte[] byteArray = Arrays.copyOf(byteBuffer.array(), byteBuffer.array().length);
+        byte[] byteArray = new byte[] {(byte) 0xFE, (byte) 0xDC, (byte) 0xBA, (byte) 0x98, 0x76, 0x54, 0x32, 0x10};
+        ByteBuffer byteBuffer = ByteBuffer.wrap(Arrays.copyOf(byteArray, byteArray.length));
 
         xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG,
                 "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32,bigdecimal:string,date:string,optional:int32,bytes:string,byteArray:string"));

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -486,8 +486,8 @@ public class CastTest {
         assertEquals("42", ((Struct) transformed.value()).get("bigdecimal"));
         assertEquals(Values.dateFormatFor(day).format(day), ((Struct) transformed.value()).get("date"));
         assertEquals(new Date(0), ((Struct) transformed.value()).get("timestamp"));
-        assertEquals("FEDCBA9876543210", ((Struct) transformed.value()).get("bytes"));
-        assertEquals("FEDCBA9876543210", ((Struct) transformed.value()).get("byteArray"));
+        assertEquals("/ty6mHZUMhA=", ((Struct) transformed.value()).get("bytes"));
+        assertEquals("/ty6mHZUMhA=", ((Struct) transformed.value()).get("byteArray"));
 
         assertNull(((Struct) transformed.value()).get("optional"));
 


### PR DESCRIPTION
Cast SMT transformation for bytes -> string.
Without this fix, the conversion becomes

ByteBuffer.toString(), which always gives one of these useless results:
    "java.nio.HeapByteBuffer[pos=0 lim=4 cap=4]" 
    "[B@5ec0a365" (for byte array)
    

With this change, the byte array is converted into a hex string of the
byte buffer content, for example

    "FEDCBA9876543210"

Completed with test case and successfully tried out in a
real database conversion.


### Committer Checklist (excluded from commit message)
- [X ] Verify design and implementation 
- [ X] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
