### PR TITLE
MINOR: apply FilterByKeyIterator and FlattenedIterator to code base

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.header.internals;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.record.Record;
-import org.apache.kafka.common.utils.AbstractIterator;
+import org.apache.kafka.common.utils.FilterByKeyIterator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,7 +96,7 @@ public class RecordHeaders implements Headers {
     @Override
     public Iterable<Header> headers(final String key) {
         checkKey(key);
-        return () -> new FilterByKeyIterator(headers.iterator(), key);
+        return () -> new FilterByKeyIterator<>(iterator(), header -> header.key().equals(key));
     }
 
     @Override
@@ -166,29 +166,5 @@ public class RecordHeaders implements Headers {
                "headers = " + headers +
                ", isReadOnly = " + isReadOnly +
                ')';
-    }
-
-    private static final class FilterByKeyIterator extends AbstractIterator<Header> {
-
-        private final Iterator<Header> original;
-        private final String key;
-
-        private FilterByKeyIterator(Iterator<Header> original, String key) {
-            this.original = original;
-            this.key = key;
-        }
-
-        protected Header makeNext() {
-            while (true) {
-                if (original.hasNext()) {
-                    Header header = original.next();
-                    if (!header.key().equals(key))
-                        continue;
-
-                    return header;
-                }
-                return this.allDone();
-            }
-        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.utils.AbstractIterator;
+import org.apache.kafka.common.utils.FlattenedIterator;
 import org.apache.kafka.common.utils.Utils;
 
 import java.nio.ByteBuffer;
@@ -67,23 +67,7 @@ public abstract class AbstractRecords implements Records {
     }
 
     private Iterator<Record> recordsIterator() {
-        return new AbstractIterator<Record>() {
-            private final Iterator<? extends RecordBatch> batches = batches().iterator();
-            private Iterator<Record> records;
-
-            @Override
-            protected Record makeNext() {
-                if (records != null && records.hasNext())
-                    return records.next();
-
-                if (batches.hasNext()) {
-                    records = batches.next().iterator();
-                    return makeNext();
-                }
-
-                return allDone();
-            }
-        };
+        return new FlattenedIterator<>(batches().iterator(), Iterable::iterator);
     }
 
     public static int estimateSizeInBytes(byte magic,

--- a/clients/src/main/java/org/apache/kafka/common/utils/FilterByKeyIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FilterByKeyIterator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+/**
+ * this implementation is faster than java stream (see FilterByKeyIteratorBenchmark)
+ */
+public class FilterByKeyIterator<V> extends AbstractIterator<V> {
+
+    private final Iterator<V> original;
+    private final Predicate<V> predicate;
+
+    public FilterByKeyIterator(Iterator<V> original, Predicate<V> predicate) {
+        this.original = original;
+        this.predicate = predicate;
+    }
+
+    @Override
+    protected V makeNext() {
+        while (original.hasNext()) {
+            V v = original.next();
+            if (!predicate.test(v)) {
+                continue;
+            }
+            return v;
+        }
+        return this.allDone();
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/FilterByKeyIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FilterByKeyIterator.java
@@ -35,11 +35,8 @@ public class FilterByKeyIterator<V> extends AbstractIterator<V> {
     @Override
     protected V makeNext() {
         while (original.hasNext()) {
-            V v = original.next();
-            if (!predicate.test(v)) {
-                continue;
-            }
-            return v;
+            V value = original.next();
+            if (predicate.test(value)) return value;
         }
         return this.allDone();
     }

--- a/clients/src/main/java/org/apache/kafka/common/utils/FlattenedIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FlattenedIterator.java
@@ -45,8 +45,7 @@ public final class FlattenedIterator<O, I> extends AbstractIterator<I> {
         while (innerIterator == null || !innerIterator.hasNext()) {
             if (outerIterator.hasNext()) {
                 O outerValue = outerIterator.next();
-                if (!outerPredicate.test(outerValue)) continue;
-                innerIterator = innerIteratorFunction.apply(outerValue);
+                if (outerPredicate.test(outerValue)) innerIterator = innerIteratorFunction.apply(outerValue);
             } else return allDone();
         }
         return innerIterator.next();

--- a/clients/src/main/java/org/apache/kafka/common/utils/FlattenedIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/FlattenedIterator.java
@@ -18,27 +18,36 @@ package org.apache.kafka.common.utils;
 
 import java.util.Iterator;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Provides a flattened iterator over the inner elements of an outer iterator.
+ * this implementation is faster than java stream (see FlattenedIteratorBenchmark)
  */
 public final class FlattenedIterator<O, I> extends AbstractIterator<I> {
     private final Iterator<O> outerIterator;
+    private final Predicate<O> outerPredicate;
     private final Function<O, Iterator<I>> innerIteratorFunction;
     private Iterator<I> innerIterator;
 
     public FlattenedIterator(Iterator<O> outerIterator, Function<O, Iterator<I>> innerIteratorFunction) {
+        this(outerIterator, s -> true, innerIteratorFunction);
+    }
+
+    public FlattenedIterator(Iterator<O> outerIterator, Predicate<O> outerPredicate, Function<O, Iterator<I>> innerIteratorFunction) {
         this.outerIterator = outerIterator;
         this.innerIteratorFunction = innerIteratorFunction;
+        this.outerPredicate = outerPredicate;
     }
 
     @Override
     public I makeNext() {
         while (innerIterator == null || !innerIterator.hasNext()) {
-            if (outerIterator.hasNext())
-                innerIterator = innerIteratorFunction.apply(outerIterator.next());
-            else
-                return allDone();
+            if (outerIterator.hasNext()) {
+                O outerValue = outerIterator.next();
+                if (!outerPredicate.test(outerValue)) continue;
+                innerIterator = innerIteratorFunction.apply(outerValue);
+            } else return allDone();
         }
         return innerIterator.next();
     }

--- a/clients/src/test/java/org/apache/kafka/common/utils/FilterByKeyIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FilterByKeyIteratorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FilterByKeyIteratorTest {
+
+    @Test
+    public void testFilterByKey() {
+        List<Header> headers = Arrays.asList(new RecordHeader("a", "b".getBytes()),
+            new RecordHeader("b", "b".getBytes()),
+            new RecordHeader("c", "b".getBytes()));
+
+        Iterator<Header> iter = new FilterByKeyIterator<>(headers.iterator(), h -> h.key().equals("c"));
+        assertTrue(iter.hasNext());
+        assertEquals(new RecordHeader("c", "b".getBytes()), iter.next());
+        assertFalse(iter.hasNext());
+    }
+}
+

--- a/clients/src/test/java/org/apache/kafka/common/utils/FlattenedIteratorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/FlattenedIteratorTest.java
@@ -19,12 +19,17 @@ package org.apache.kafka.common.utils;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FlattenedIteratorTest {
 
@@ -111,5 +116,22 @@ public class FlattenedIteratorTest {
         assertEquals(list.stream().flatMap(l -> l.stream()).collect(Collectors.toList()), flattened);
     }
 
+    @Test
+    public void testFilter() {
+        Map<String, List<String>> map = new HashMap<>();
+        map.put("a", asList("ee", "dd"));
+        map.put("b", asList("ee", "dd"));
+        map.put("c", asList("ee", "dd"));
+
+        Iterator<String> iter = new FlattenedIterator<>(map.entrySet().iterator(),
+            e -> e.getKey().equals("a"),
+            e -> e.getValue().iterator());
+
+        assertTrue(iter.hasNext());
+        assertEquals("ee", iter.next());
+        assertTrue(iter.hasNext());
+        assertEquals("dd", iter.next());
+        assertFalse(iter.hasNext());
+    }
 }
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.connect.header;
 
-import org.apache.kafka.common.utils.AbstractIterator;
+import org.apache.kafka.common.utils.FilterByKeyIterator;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
@@ -239,7 +239,7 @@ public class ConnectHeaders implements Headers {
 
     @Override
     public Iterator<Header> allWithName(String key) {
-        return new FilterByKeyIterator(iterator(), key);
+        return new FilterByKeyIterator<>(iterator(), header -> header.key().equals(key));
     }
 
     @Override
@@ -469,29 +469,6 @@ public class ConnectHeaders implements Headers {
                 }
                 throw new DataException("The value " + value + " is not compatible with the schema " + schema);
             }
-        }
-    }
-
-    private static final class FilterByKeyIterator extends AbstractIterator<Header> {
-
-        private final Iterator<Header> original;
-        private final String key;
-
-        private FilterByKeyIterator(Iterator<Header> original, String key) {
-            this.original = original;
-            this.key = key;
-        }
-
-        @Override
-        protected Header makeNext() {
-            while (original.hasNext()) {
-                Header header = original.next();
-                if (!header.key().equals(key)) {
-                    continue;
-                }
-                return header;
-            }
-            return this.allDone();
         }
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/FilterByKeyIteratorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/FilterByKeyIteratorBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.common;
+
+import org.apache.kafka.common.utils.FilterByKeyIterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FilterByKeyIteratorBenchmark {
+    private static final List<String> LIST = new ArrayList<>(IntStream.range(0, 100).mapToObj(String::valueOf).collect(Collectors.toList()));
+    private static final Predicate<String> PREDICATE = s -> s.equals("aa");
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public String benchmarkFilterByKeyIterator() {
+        String last = null;
+        Iterable<String> iterable = () -> new FilterByKeyIterator<>(LIST.iterator(), PREDICATE);
+        for (String s : iterable) {
+            last = s;
+        }
+        return last;
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public String benchmarkStreamIterator() {
+        String last = null;
+        Iterable<String> iterable = () -> LIST.stream().filter(PREDICATE).iterator();
+        for (String s : iterable) {
+            last = s;
+        }
+        return last;
+    }
+
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/FlattenedIteratorBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/FlattenedIteratorBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.common;
+
+import org.apache.kafka.common.utils.FlattenedIterator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FlattenedIteratorBenchmark {
+    private static final List<String> FLATTEN = new ArrayList<>(IntStream.range(0, 100).mapToObj(String::valueOf).collect(Collectors.toList()));
+    private static final List<List<String>> COLLECTION = new ArrayList<>(IntStream.range(0, 100).mapToObj(i -> FLATTEN).collect(Collectors.toList()));
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public String benchmarkFlattenedIterator() {
+        String last = null;
+        Iterable<String> iterable = () -> new FlattenedIterator<>(COLLECTION.iterator(), List::iterator);
+        for (String s : iterable) {
+            last = s;
+        }
+        return last;
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public String benchmarkStreamIterator() {
+        String last = null;
+        Iterable<String> iterable = () -> COLLECTION.stream().flatMap(Collection::stream).iterator();
+        for (String s : iterable) {
+            last = s;
+        }
+        return last;
+    }
+
+}


### PR DESCRIPTION
### Changes

1. add public ```FilterByKeyIterator``` to replace private ```FilterByKeyIterator``` in ```RecordHeaders``` and ```ConnectHeaders```
1. apply ```FlattenedIterator``` to code base
1. add benchmarks for ```FlattenedIterator``` and ```FilterByKeyIterator``` to prove those implementations are faster than java stream

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
