### PR TITLE
MINOR: Revert assertion in MockProducerTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -114,7 +114,7 @@ public class MockProducerTest {
 
         Future<RecordMetadata> md3 = producer.send(record1);
         Future<RecordMetadata> md4 = producer.send(record2);
-        assertFalse(md3.isDone() || md4.isDone(), "Requests should not be completed.");
+        assertTrue(!md3.isDone() && !md4.isDone(), "Requests should not be completed.");
         producer.flush();
         assertTrue(md3.isDone() && md4.isDone(), "Requests should be completed.");
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -114,7 +114,7 @@ public class MockProducerTest {
 
         Future<RecordMetadata> md3 = producer.send(record1);
         Future<RecordMetadata> md4 = producer.send(record2);
-        assertFalse(md3.isDone() && !md4.isDone(), "Requests should not be completed.");
+        assertFalse(md3.isDone() || md4.isDone(), "Requests should not be completed.");
         producer.flush();
         assertTrue(md3.isDone() && md4.isDone(), "Requests should be completed.");
     }


### PR DESCRIPTION
*More detailed description of your change*
In #9955 I made a mistake,  !A && !B = ! (A || B), thank @g1geordie  for pointing out my mistake.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
