### PR TITLE
MINOR: Update zstd-jni to 1.4.8-2

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -152,6 +152,7 @@
       <allow pkg="org.apache.kafka.common.protocol" />
       <allow pkg="org.apache.kafka.common.protocol.types" />
       <allow pkg="org.apache.kafka.common.errors" />
+      <allow pkg="com.github.luben.zstd" />
     </subpackage>
 
     <subpackage name="header">

--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -122,7 +122,8 @@ public enum CompressionType {
         public OutputStream wrapForOutput(ByteBufferOutputStream buffer, byte messageVersion) {
             try {
                 // Set input buffer (uncompressed) to 16 KB (none by default) to ensure reasonable performance
-                // in cases where the caller passes a small number of bytes to write (potentially a single byte)
+                // in cases where the caller passes a small number of bytes to write (potentially a single byte).
+                // It's ok to reference `RecyclingBufferPool` since it doesn't load any native libraries
                 return new BufferedOutputStream((OutputStream) ZstdConstructors.OUTPUT.invoke(buffer, RecyclingBufferPool.INSTANCE),
                     16 * 1024);
             } catch (Throwable e) {
@@ -134,7 +135,8 @@ public enum CompressionType {
         public InputStream wrapForInput(ByteBuffer buffer, byte messageVersion, BufferSupplier decompressionBufferSupplier) {
             try {
                 // Set output buffer (uncompressed) to 16 KB (none by default) to ensure reasonable performance
-                // in cases where the caller reads a small number of bytes (potentially a single byte)
+                // in cases where the caller reads a small number of bytes (potentially a single byte).
+                // It's ok to reference `RecyclingBufferPool` since it doesn't load any native libraries.
                 return new BufferedInputStream((InputStream) ZstdConstructors.INPUT.invoke(new ByteBufferInputStream(buffer),
                     RecyclingBufferPool.INSTANCE), 16 * 1024);
             } catch (Throwable e) {
@@ -223,6 +225,7 @@ public enum CompressionType {
     }
 
     private static class ZstdConstructors {
+        // It's ok to reference `BufferPool` since it doesn't load any native libraries
         static final MethodHandle INPUT = findConstructor("com.github.luben.zstd.ZstdInputStream",
             MethodType.methodType(void.class, InputStream.class, BufferPool.class));
         static final MethodHandle OUTPUT = findConstructor("com.github.luben.zstd.ZstdOutputStream",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -118,7 +118,7 @@ versions += [
   testRetryPlugin: "1.2.0",
   zinc: "1.3.5",
   zookeeper: "3.5.8",
-  zstd: "1.4.5-12"
+  zstd: "1.4.8-2"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
* The latest version zstd-jni doesn't use `RecyclingBufferPool` by default, so we
pass it via the relevant constructors to maintain the behavior before this
change.
* zstd-jni fixes an issue when using Alpine, see https://github.com/luben/zstd-jni/issues/157.
* zstd 1.4.7 includes several months of improvements across many axis,
from performance to various fixes. Details: https://github.com/facebook/zstd/releases/tag/v1.4.7
* zstd 1.4.8 is a hotfix release, details: https://github.com/facebook/zstd/releases/tag/v1.4.8

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
