### PR TITLE
MINOR: Clean up group instance id handling in `GroupCoordinator`

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -404,7 +404,7 @@ class GroupCoordinator(val brokerId: Int,
         )
 
         memberErrorOpt match {
-          case Some(error) => JoinGroupResult(memberId, error)
+          case Some(error) => responseCallback(JoinGroupResult(memberId, error))
 
           case None => group.currentState match {
             case PreparingRebalance =>
@@ -938,7 +938,7 @@ class GroupCoordinator(val brokerId: Int,
         group,
         memberId,
         groupInstanceId,
-        operation = "offset-commit"
+        operation = if (isTransactional) "txn-offset-commit" else "offset-commit"
       ).orElse {
         if (generationId != group.generationId) {
           Some(Errors.ILLEGAL_GENERATION)

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -547,7 +547,7 @@ class GroupCoordinator(val brokerId: Int,
       )
 
       validationErrorOpt match {
-        case Some(error) =>  responseCallback(SyncGroupResult(error))
+        case Some(error) => responseCallback(SyncGroupResult(error))
 
         case None => group.currentState match {
           case Empty =>
@@ -778,7 +778,7 @@ class GroupCoordinator(val brokerId: Int,
         group,
         memberId,
         groupInstanceId,
-        operation = "sync-group"
+        operation = "heartbeat"
       ).orElse {
         if (generationId != group.generationId) {
           Some(Errors.ILLEGAL_GENERATION)

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -184,9 +184,9 @@ class GroupCoordinator(val brokerId: Int,
               group.remove(memberId)
               responseCallback(JoinGroupResult(JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.GROUP_MAX_SIZE_REACHED))
             } else if (isUnknownMember) {
-              doUnknownJoinGroup(group, groupInstanceId, requireKnownMemberId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs, protocolType, protocols, responseCallback)
+              doNewMemberJoinGroup(group, groupInstanceId, requireKnownMemberId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs, protocolType, protocols, responseCallback)
             } else {
-              doJoinGroup(group, memberId, groupInstanceId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs, protocolType, protocols, responseCallback)
+              doCurrentMemberJoinGroup(group, memberId, groupInstanceId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs, protocolType, protocols, responseCallback)
             }
 
             // attempt to complete JoinGroup
@@ -198,16 +198,18 @@ class GroupCoordinator(val brokerId: Int,
     }
   }
 
-  private def doUnknownJoinGroup(group: GroupMetadata,
-                                 groupInstanceId: Option[String],
-                                 requireKnownMemberId: Boolean,
-                                 clientId: String,
-                                 clientHost: String,
-                                 rebalanceTimeoutMs: Int,
-                                 sessionTimeoutMs: Int,
-                                 protocolType: String,
-                                 protocols: List[(String, Array[Byte])],
-                                 responseCallback: JoinCallback): Unit = {
+  private def doNewMemberJoinGroup(
+    group: GroupMetadata,
+    groupInstanceId: Option[String],
+    requireKnownMemberId: Boolean,
+    clientId: String,
+    clientHost: String,
+    rebalanceTimeoutMs: Int,
+    sessionTimeoutMs: Int,
+    protocolType: String,
+    protocols: List[(String, Array[Byte])],
+    responseCallback: JoinCallback
+  ): Unit = {
     group.inLock {
       if (group.is(Dead)) {
         // if the group is marked as dead, it means some other thread has just removed the group
@@ -219,67 +221,163 @@ class GroupCoordinator(val brokerId: Int,
         responseCallback(JoinGroupResult(JoinGroupRequest.UNKNOWN_MEMBER_ID, Errors.INCONSISTENT_GROUP_PROTOCOL))
       } else {
         val newMemberId = group.generateMemberId(clientId, groupInstanceId)
+        groupInstanceId match {
+          case Some(instanceId) =>
+            doStaticNewMemberJoinGroup(
+              group,
+              instanceId,
+              newMemberId,
+              clientId,
+              clientHost,
+              rebalanceTimeoutMs,
+              sessionTimeoutMs,
+              protocolType,
+              protocols,
+              responseCallback
+            )
 
-        if (group.hasStaticMember(groupInstanceId)) {
-          updateStaticMemberAndRebalance(group, newMemberId, groupInstanceId, protocols, responseCallback)
-        } else if (requireKnownMemberId) {
-            // If member id required (dynamic membership), register the member in the pending member list
-            // and send back a response to call for another join group request with allocated member id.
-          debug(s"Dynamic member with unknown member id joins group ${group.groupId} in " +
-              s"${group.currentState} state. Created a new member id $newMemberId and request the member to rejoin with this id.")
-          group.addPendingMember(newMemberId)
-          addPendingMemberExpiration(group, newMemberId, sessionTimeoutMs)
-          responseCallback(JoinGroupResult(newMemberId, Errors.MEMBER_ID_REQUIRED))
-        } else {
-          info(s"${if (groupInstanceId.isDefined) "Static" else "Dynamic"} Member with unknown member id joins group ${group.groupId} in " +
-            s"${group.currentState} state. Created a new member id $newMemberId for this member and add to the group.")
-          addMemberAndRebalance(rebalanceTimeoutMs, sessionTimeoutMs, newMemberId, groupInstanceId,
-            clientId, clientHost, protocolType, protocols, group, responseCallback)
+          case None =>
+            doDynamicNewMemberJoinGroup(
+              group,
+              requireKnownMemberId,
+              newMemberId,
+              clientId,
+              clientHost,
+              rebalanceTimeoutMs,
+              sessionTimeoutMs,
+              protocolType,
+              protocols,
+              responseCallback
+            )
         }
       }
     }
   }
 
-  private def doJoinGroup(group: GroupMetadata,
-                          memberId: String,
-                          groupInstanceId: Option[String],
-                          clientId: String,
-                          clientHost: String,
-                          rebalanceTimeoutMs: Int,
-                          sessionTimeoutMs: Int,
-                          protocolType: String,
-                          protocols: List[(String, Array[Byte])],
-                          responseCallback: JoinCallback): Unit = {
+  private def doStaticNewMemberJoinGroup(
+    group: GroupMetadata,
+    groupInstanceId: String,
+    newMemberId: String,
+    clientId: String,
+    clientHost: String,
+    rebalanceTimeoutMs: Int,
+    sessionTimeoutMs: Int,
+    protocolType: String,
+    protocols: List[(String, Array[Byte])],
+    responseCallback: JoinCallback
+  ): Unit = {
+    group.currentStaticMemberId(groupInstanceId) match {
+      case Some(oldMemberId) =>
+        info(s"Static member with groupInstanceId=$groupInstanceId and unknown member id joins " +
+          s"group ${group.groupId} in ${group.currentState} state. Replacing previously mapped " +
+          s"member $oldMemberId with this groupInstanceId.")
+        updateStaticMemberAndRebalance(group, newMemberId, oldMemberId, groupInstanceId, protocols, responseCallback)
+
+      case None =>
+        info(s"Static member with groupInstanceId=$groupInstanceId and unknown member id joins " +
+          s"group ${group.groupId} in ${group.currentState} state. Created a new member id $newMemberId " +
+          s"for this member and add to the group.")
+        addMemberAndRebalance(rebalanceTimeoutMs, sessionTimeoutMs, newMemberId, Some(groupInstanceId),
+          clientId, clientHost, protocolType, protocols, group, responseCallback)
+    }
+  }
+
+  private def doDynamicNewMemberJoinGroup(
+    group: GroupMetadata,
+    requireKnownMemberId: Boolean,
+    newMemberId: String,
+    clientId: String,
+    clientHost: String,
+    rebalanceTimeoutMs: Int,
+    sessionTimeoutMs: Int,
+    protocolType: String,
+    protocols: List[(String, Array[Byte])],
+    responseCallback: JoinCallback
+  ): Unit = {
+    if (requireKnownMemberId) {
+      // If member id required, register the member in the pending member list and send
+      // back a response to call for another join group request with allocated member id.
+      info(s"Dynamic member with unknown member id joins group ${group.groupId} in " +
+        s"${group.currentState} state. Created a new member id $newMemberId and request the " +
+        s"member to rejoin with this id.")
+      group.addPendingMember(newMemberId)
+      addPendingMemberExpiration(group, newMemberId, sessionTimeoutMs)
+      responseCallback(JoinGroupResult(newMemberId, Errors.MEMBER_ID_REQUIRED))
+    } else {
+      info(s"Dynamic Member with unknown member id joins group ${group.groupId} in " +
+        s"${group.currentState} state. Created a new member id $newMemberId for this member " +
+        s"and add to the group.")
+      addMemberAndRebalance(rebalanceTimeoutMs, sessionTimeoutMs, newMemberId, None,
+        clientId, clientHost, protocolType, protocols, group, responseCallback)
+    }
+  }
+
+  private def validateCurrentMember(
+    group: GroupMetadata,
+    memberId: String,
+    groupInstanceId: Option[String],
+    operation: String
+  ): Option[Errors] = {
+    // We are validating two things:
+    // 1. If `groupInstanceId` is present, then it exists and is mapped to `memberId`
+    // 2. The `memberId` exists in the group
+
+    groupInstanceId.flatMap { instanceId =>
+      group.currentStaticMemberId(instanceId) match {
+        case Some(currentMemberId) if currentMemberId != memberId =>
+          info(s"Request memberId=$memberId for static member with groupInstanceId=$instanceId " +
+            s"is fenced by current memberId=$currentMemberId during operation $operation")
+          Some(Errors.FENCED_INSTANCE_ID)
+        case Some(_) =>
+          None
+        case None =>
+          Some(Errors.UNKNOWN_MEMBER_ID)
+      }
+    }.orElse {
+      if (!group.has(memberId)) {
+        Some(Errors.UNKNOWN_MEMBER_ID)
+      } else {
+        None
+      }
+    }
+  }
+
+  private def doCurrentMemberJoinGroup(
+    group: GroupMetadata,
+    memberId: String,
+    groupInstanceId: Option[String],
+    clientId: String,
+    clientHost: String,
+    rebalanceTimeoutMs: Int,
+    sessionTimeoutMs: Int,
+    protocolType: String,
+    protocols: List[(String, Array[Byte])],
+    responseCallback: JoinCallback
+  ): Unit = {
     group.inLock {
       if (group.is(Dead)) {
         // if the group is marked as dead, it means some other thread has just removed the group
-        // from the coordinator metadata; this is likely that the group has migrated to some other
+        // from the coordinator metadata; it is likely that the group has migrated to some other
         // coordinator OR the group is in a transient unstable phase. Let the member retry
         // finding the correct coordinator and rejoin.
         responseCallback(JoinGroupResult(memberId, Errors.COORDINATOR_NOT_AVAILABLE))
       } else if (!group.supportsProtocols(protocolType, MemberMetadata.plainProtocolSet(protocols))) {
         responseCallback(JoinGroupResult(memberId, Errors.INCONSISTENT_GROUP_PROTOCOL))
       } else if (group.isPendingMember(memberId)) {
-        // A rejoining pending member will be accepted. Note that pending member will never be a static member.
-        if (groupInstanceId.isDefined) {
-          throw new IllegalStateException(s"the static member $groupInstanceId was not expected to be assigned " +
-            s"into pending member bucket with member id $memberId")
-        } else {
-          debug(s"Dynamic Member with specific member id $memberId joins group ${group.groupId} in " +
-            s"${group.currentState} state. Adding to the group now.")
-          addMemberAndRebalance(rebalanceTimeoutMs, sessionTimeoutMs, memberId, groupInstanceId,
-            clientId, clientHost, protocolType, protocols, group, responseCallback)
+        // A rejoining pending member will be accepted. Note that pending member cannot be a static member.
+        groupInstanceId.foreach { instanceId =>
+          throw new IllegalStateException(s"Received unexpected JoinGroup with groupInstanceId=$instanceId " +
+            s"for pending member with memberId=$memberId")
         }
+
+        debug(s"Pending dynamic member with id $memberId joins group ${group.groupId} in " +
+          s"${group.currentState} state. Adding to the group now.")
+        addMemberAndRebalance(rebalanceTimeoutMs, sessionTimeoutMs, memberId, None,
+          clientId, clientHost, protocolType, protocols, group, responseCallback)
       } else {
-        val groupInstanceIdNotFound = groupInstanceId.isDefined && !group.hasStaticMember(groupInstanceId)
-        if (group.isStaticMemberFenced(memberId, groupInstanceId, "join-group")) {
-          // given member id doesn't match with the groupInstanceId. Inform duplicate instance to shut down immediately.
-          responseCallback(JoinGroupResult(memberId, Errors.FENCED_INSTANCE_ID))
-        } else if (!group.has(memberId) || groupInstanceIdNotFound) {
-            // If the dynamic member trying to register with an unrecognized id, or
-            // the static member joins with unknown group instance id, send the response to let
-            // it reset its member id and retry.
-          responseCallback(JoinGroupResult(memberId, Errors.UNKNOWN_MEMBER_ID))
+        val memberError = validateCurrentMember(group, memberId, groupInstanceId, "join-group")
+        if (memberError.isDefined) {
+          responseCallback(JoinGroupResult(memberId, memberError.get))
         } else {
           val member = group.get(memberId)
 
@@ -369,6 +467,35 @@ class GroupCoordinator(val brokerId: Int,
     }
   }
 
+  private def validateSyncGroup(
+    group: GroupMetadata,
+    generationId: Int,
+    memberId: String,
+    protocolType: Option[String],
+    protocolName: Option[String],
+    groupInstanceId: Option[String],
+  ): Option[Errors] = {
+    if (group.is(Dead)) {
+      // if the group is marked as dead, it means some other thread has just removed the group
+      // from the coordinator metadata; this is likely that the group has migrated to some other
+      // coordinator OR the group is in a transient unstable phase. Let the member retry
+      // finding the correct coordinator and rejoin.
+      Some(Errors.COORDINATOR_NOT_AVAILABLE)
+    } else {
+      validateCurrentMember(group, memberId, groupInstanceId, "sync-group").orElse {
+        if (generationId != group.generationId) {
+          Some(Errors.ILLEGAL_GENERATION)
+        } else if (protocolType.isDefined && !group.protocolType.contains(protocolType.get)) {
+          Some(Errors.INCONSISTENT_GROUP_PROTOCOL)
+        } else if (protocolName.isDefined && !group.protocolName.contains(protocolName.get)) {
+          Some(Errors.INCONSISTENT_GROUP_PROTOCOL)
+        } else {
+          None
+        }
+      }
+    }
+  }
+
   private def doSyncGroup(group: GroupMetadata,
                           generationId: Int,
                           memberId: String,
@@ -378,22 +505,17 @@ class GroupCoordinator(val brokerId: Int,
                           groupAssignment: Map[String, Array[Byte]],
                           responseCallback: SyncCallback): Unit = {
     group.inLock {
-      if (group.is(Dead)) {
-        // if the group is marked as dead, it means some other thread has just removed the group
-        // from the coordinator metadata; this is likely that the group has migrated to some other
-        // coordinator OR the group is in a transient unstable phase. Let the member retry
-        // finding the correct coordinator and rejoin.
-        responseCallback(SyncGroupResult(Errors.COORDINATOR_NOT_AVAILABLE))
-      } else if (group.isStaticMemberFenced(memberId, groupInstanceId, "sync-group")) {
-        responseCallback(SyncGroupResult(Errors.FENCED_INSTANCE_ID))
-      } else if (!group.has(memberId)) {
-        responseCallback(SyncGroupResult(Errors.UNKNOWN_MEMBER_ID))
-      } else if (generationId != group.generationId) {
-        responseCallback(SyncGroupResult(Errors.ILLEGAL_GENERATION))
-      } else if (protocolType.isDefined && !group.protocolType.contains(protocolType.get)) {
-        responseCallback(SyncGroupResult(Errors.INCONSISTENT_GROUP_PROTOCOL))
-      } else if (protocolName.isDefined && !group.protocolName.contains(protocolName.get)) {
-        responseCallback(SyncGroupResult(Errors.INCONSISTENT_GROUP_PROTOCOL))
+      val validationErrorOpt = validateSyncGroup(
+        group,
+        generationId,
+        memberId,
+        protocolType,
+        protocolName,
+        groupInstanceId
+      )
+
+      if (validationErrorOpt.isDefined) {
+        responseCallback(SyncGroupResult(validationErrorOpt.get))
       } else {
         group.currentState match {
           case Empty =>
@@ -452,6 +574,14 @@ class GroupCoordinator(val brokerId: Int,
   def handleLeaveGroup(groupId: String,
                        leavingMembers: List[MemberIdentity],
                        responseCallback: LeaveGroupResult => Unit): Unit = {
+
+    def removeCurrentMemberFromGroup(group: GroupMetadata, memberId: String): Unit = {
+      val member = group.get(memberId)
+      removeMemberAndUpdateGroup(group, member, s"removing member $memberId on LeaveGroup")
+      removeHeartbeatForLeavingMember(group, member)
+      info(s"Member $member has left group $groupId through explicit `LeaveGroup` request")
+    }
+
     validateGroupStatus(groupId, ApiKeys.LEAVE_GROUP) match {
       case Some(error) =>
         responseCallback(leaveError(error, List.empty))
@@ -469,33 +599,31 @@ class GroupCoordinator(val brokerId: Int,
                 val memberErrors = leavingMembers.map { leavingMember =>
                   val memberId = leavingMember.memberId
                   val groupInstanceId = Option(leavingMember.groupInstanceId)
-                  if (memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID
-                    && group.isStaticMemberFenced(memberId, groupInstanceId, "leave-group")) {
-                    memberLeaveError(leavingMember, Errors.FENCED_INSTANCE_ID)
+
+                  // The LeaveGroup API allows administrative removal of members by GroupInstanceId
+                  // in which case we expect the MemberId to be undefined.
+                  if (memberId == JoinGroupRequest.UNKNOWN_MEMBER_ID) {
+                    groupInstanceId.flatMap(group.currentStaticMemberId) match {
+                      case Some(currentMemberId) =>
+                        removeCurrentMemberFromGroup(group, currentMemberId)
+                        memberLeaveError(leavingMember, Errors.NONE)
+                      case None =>
+                        memberLeaveError(leavingMember, Errors.UNKNOWN_MEMBER_ID)
+                    }
                   } else if (group.isPendingMember(memberId)) {
-                    if (groupInstanceId.isDefined) {
-                      throw new IllegalStateException(s"the static member $groupInstanceId was not expected to be leaving " +
-                        s"from pending member bucket with member id $memberId")
+                    removePendingMemberAndUpdateGroup(group, memberId)
+                    heartbeatPurgatory.checkAndComplete(MemberKey(group.groupId, memberId))
+                    info(s"Pending member with memberId=$memberId has left group ${group.groupId} " +
+                      s"through explicit `LeaveGroup` request")
+                    memberLeaveError(leavingMember, Errors.NONE)
+                  } else {
+                    val memberErrorOpt = validateCurrentMember(group, memberId, groupInstanceId, "leave-group")
+                    if (memberErrorOpt.isDefined) {
+                      memberLeaveError(leavingMember, memberErrorOpt.get)
                     } else {
-                      // if a pending member is leaving, it needs to be removed from the pending list, heartbeat cancelled
-                      // and if necessary, prompt a JoinGroup completion.
-                      info(s"Pending member $memberId is leaving group ${group.groupId}.")
-                      removePendingMemberAndUpdateGroup(group, memberId)
-                      heartbeatPurgatory.checkAndComplete(MemberKey(group.groupId, memberId))
+                      removeCurrentMemberFromGroup(group, memberId)
                       memberLeaveError(leavingMember, Errors.NONE)
                     }
-                  } else if (!group.has(memberId) && !group.hasStaticMember(groupInstanceId)) {
-                    memberLeaveError(leavingMember, Errors.UNKNOWN_MEMBER_ID)
-                  } else {
-                    val member = if (group.hasStaticMember(groupInstanceId))
-                      group.get(group.getStaticMemberId(groupInstanceId))
-                    else
-                      group.get(memberId)
-                    removeHeartbeatForLeavingMember(group, member)
-                    info(s"Member[group.instance.id ${member.groupInstanceId}, member.id ${member.memberId}] " +
-                      s"in group ${group.groupId} has left, removing it from the group")
-                    removeMemberAndUpdateGroup(group, member, s"removing member $memberId on LeaveGroup")
-                    memberLeaveError(leavingMember, Errors.NONE)
                   }
                 }
                 responseCallback(leaveError(Errors.NONE, memberErrors))
@@ -602,6 +730,25 @@ class GroupCoordinator(val brokerId: Int,
     groupError -> partitionErrors
   }
 
+  private def validateHeartbeat(
+    group: GroupMetadata,
+    generationId: Int,
+    memberId: String,
+    groupInstanceId: Option[String]
+  ): Option[Errors] = {
+    if (group.is(Dead)) {
+      Some(Errors.COORDINATOR_NOT_AVAILABLE)
+    } else {
+      validateCurrentMember(group, memberId, groupInstanceId, "sync-group").orElse {
+        if (generationId != group.generationId) {
+          Some(Errors.ILLEGAL_GENERATION)
+        } else {
+          None
+        }
+      }
+    }
+  }
+
   def handleHeartbeat(groupId: String,
                       memberId: String,
                       groupInstanceId: Option[String],
@@ -621,18 +768,15 @@ class GroupCoordinator(val brokerId: Int,
         responseCallback(Errors.UNKNOWN_MEMBER_ID)
 
       case Some(group) => group.inLock {
-        if (group.is(Dead)) {
-          // if the group is marked as dead, it means some other thread has just removed the group
-          // from the coordinator metadata; this is likely that the group has migrated to some other
-          // coordinator OR the group is in a transient unstable phase. Let the member retry
-          // finding the correct coordinator and rejoin.
-          responseCallback(Errors.COORDINATOR_NOT_AVAILABLE)
-        } else if (group.isStaticMemberFenced(memberId, groupInstanceId, "heartbeat")) {
-          responseCallback(Errors.FENCED_INSTANCE_ID)
-        } else if (!group.has(memberId)) {
-          responseCallback(Errors.UNKNOWN_MEMBER_ID)
-        } else if (generationId != group.generationId) {
-          responseCallback(Errors.ILLEGAL_GENERATION)
+        val validationErrorOpt = validateHeartbeat(
+          group,
+          generationId,
+          memberId,
+          groupInstanceId
+        )
+
+        if (validationErrorOpt.isDefined) {
+          responseCallback(validationErrorOpt.get)
         } else {
           group.currentState match {
             case Empty =>
@@ -715,6 +859,27 @@ class GroupCoordinator(val brokerId: Int,
     groupManager.scheduleHandleTxnCompletion(producerId, offsetsPartitions.map(_.partition).toSet, isCommit)
   }
 
+  private def validateTxnOffsetCommit(
+    group: GroupMetadata,
+    generationId: Int,
+    memberId: String,
+    groupInstanceId: Option[String]
+  ): Option[Errors] = {
+    if (group.is(Dead)) {
+      Some(Errors.COORDINATOR_NOT_AVAILABLE)
+    } else if (generationId >= 0 || memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID || groupInstanceId.isDefined) {
+      validateCurrentMember(group, memberId, groupInstanceId, "txn-offset-commit").orElse {
+        if (generationId != group.generationId) {
+          Some(Errors.ILLEGAL_GENERATION)
+        } else {
+          None
+        }
+      }
+    } else {
+      None
+    }
+  }
+
   private def doTxnCommitOffsets(group: GroupMetadata,
                                  memberId: String,
                                  groupInstanceId: Option[String],
@@ -724,23 +889,43 @@ class GroupCoordinator(val brokerId: Int,
                                  offsetMetadata: immutable.Map[TopicPartition, OffsetAndMetadata],
                                  responseCallback: immutable.Map[TopicPartition, Errors] => Unit): Unit = {
     group.inLock {
-      if (group.is(Dead)) {
-        // if the group is marked as dead, it means some other thread has just removed the group
-        // from the coordinator metadata; it is likely that the group has migrated to some other
-        // coordinator OR the group is in a transient unstable phase. Let the member retry
-        // finding the correct coordinator and rejoin.
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.COORDINATOR_NOT_AVAILABLE })
-      } else if (group.isStaticMemberFenced(memberId, groupInstanceId, "txn-commit-offsets")) {
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.FENCED_INSTANCE_ID })
-      } else if (memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID && !group.has(memberId)) {
-        // Enforce member id when it is set.
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.UNKNOWN_MEMBER_ID })
-      } else if (generationId >= 0 && generationId != group.generationId) {
-        // Enforce generation check when it is set.
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.ILLEGAL_GENERATION })
+      val validationErrorOpt = validateTxnOffsetCommit(
+        group,
+        generationId,
+        memberId,
+        groupInstanceId
+      )
+
+      if (validationErrorOpt.isDefined) {
+        responseCallback(offsetMetadata.map { case (k, _) => k -> validationErrorOpt.get })
       } else {
         groupManager.storeOffsets(group, memberId, offsetMetadata, responseCallback, producerId, producerEpoch)
       }
+    }
+  }
+
+
+  private def validateOffsetCommit(
+    group: GroupMetadata,
+    generationId: Int,
+    memberId: String,
+    groupInstanceId: Option[String]
+  ): Option[Errors] = {
+    if (group.is(Dead)) {
+      Some(Errors.COORDINATOR_NOT_AVAILABLE)
+    } else if (generationId >= 0 || memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID || groupInstanceId.isDefined) {
+      validateCurrentMember(group, memberId, groupInstanceId, "offset-commit").orElse {
+        if (generationId != group.generationId) {
+          Some(Errors.ILLEGAL_GENERATION)
+        } else {
+          None
+        }
+      }
+    } else if (!group.is(Empty)) {
+      // When the group is non-empty, only members can commit offsets
+      Some(Errors.UNKNOWN_MEMBER_ID)
+    } else {
+      None
     }
   }
 
@@ -751,23 +936,20 @@ class GroupCoordinator(val brokerId: Int,
                               offsetMetadata: immutable.Map[TopicPartition, OffsetAndMetadata],
                               responseCallback: immutable.Map[TopicPartition, Errors] => Unit): Unit = {
     group.inLock {
-      if (group.is(Dead)) {
-        // if the group is marked as dead, it means some other thread has just removed the group
-        // from the coordinator metadata; it is likely that the group has migrated to some other
-        // coordinator OR the group is in a transient unstable phase. Let the member retry
-        // finding the correct coordinator and rejoin.
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.COORDINATOR_NOT_AVAILABLE })
-      } else if (group.isStaticMemberFenced(memberId, groupInstanceId, "commit-offsets")) {
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.FENCED_INSTANCE_ID })
-      } else if (generationId < 0 && group.is(Empty)) {
-        // The group is only using Kafka to store offsets.
-        groupManager.storeOffsets(group, memberId, offsetMetadata, responseCallback)
-      } else if (!group.has(memberId)) {
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.UNKNOWN_MEMBER_ID })
-      } else if (generationId != group.generationId) {
-        responseCallback(offsetMetadata.map { case (k, _) => k -> Errors.ILLEGAL_GENERATION })
+      val validationErrorOpt = validateOffsetCommit(
+        group,
+        generationId,
+        memberId,
+        groupInstanceId
+      )
+
+      if (validationErrorOpt.isDefined) {
+        responseCallback(offsetMetadata.map { case (k, _) => k -> validationErrorOpt.get })
       } else {
         group.currentState match {
+          case Empty =>
+            groupManager.storeOffsets(group, memberId, offsetMetadata, responseCallback)
+
           case Stable | PreparingRebalance =>
             // During PreparingRebalance phase, we still allow a commit request since we rely
             // on heartbeat response to eventually notify the rebalance in progress signal to the consumer
@@ -982,7 +1164,6 @@ class GroupCoordinator(val brokerId: Int,
   }
 
   private def removeHeartbeatForLeavingMember(group: GroupMetadata, member: MemberMetadata): Unit = {
-    member.isLeaving = true
     val memberKey = MemberKey(group.groupId, member.memberId)
     heartbeatPurgatory.checkAndComplete(memberKey)
   }
@@ -1016,26 +1197,17 @@ class GroupCoordinator(val brokerId: Int,
     // for new members. If the new member is still there, we expect it to retry.
     completeAndScheduleNextExpiration(group, member, NewMemberJoinTimeoutMs)
 
-    if (member.isStaticMember) {
-      info(s"Adding new static member $groupInstanceId to group ${group.groupId} with member id $memberId.")
-      group.addStaticMember(groupInstanceId, memberId)
-    } else {
-      group.removePendingMember(memberId)
-    }
     maybePrepareRebalance(group, s"Adding new member $memberId with group instance id $groupInstanceId")
   }
 
   private def updateStaticMemberAndRebalance(group: GroupMetadata,
                                              newMemberId: String,
-                                             groupInstanceId: Option[String],
+                                             oldMemberId: String,
+                                             groupInstanceId: String,
                                              protocols: List[(String, Array[Byte])],
                                              responseCallback: JoinCallback): Unit = {
-    val oldMemberId = group.getStaticMemberId(groupInstanceId)
-    info(s"Static member $groupInstanceId of group ${group.groupId} with unknown member id rejoins, assigning new member id $newMemberId, while " +
-      s"old member id $oldMemberId will be removed.")
-
     val currentLeader = group.leaderOrNull
-    val member = group.replaceGroupInstance(oldMemberId, newMemberId, groupInstanceId)
+    val member = group.replaceStaticMember(groupInstanceId, oldMemberId, newMemberId)
     // Heartbeat of old member id will expire without effect since the group no longer contains that member id.
     // New heartbeat shall be scheduled with new member id.
     completeAndScheduleNextHeartbeatExpiration(group, member)
@@ -1054,11 +1226,15 @@ class GroupCoordinator(val brokerId: Int,
           val groupAssignment: Map[String, Array[Byte]] = group.allMemberMetadata.map(member => member.memberId -> member.assignment).toMap
           groupManager.storeGroup(group, groupAssignment, error => {
             if (error != Errors.NONE) {
+
+              // TODO: This logic seems questionable. The write was not committed, but that doesn't
+              //  mean it wasn't written to the log and cannot eventually become committed.
+
               warn(s"Failed to persist metadata for group ${group.groupId}: ${error.message}")
 
               // Failed to persist member.id of the given static member, revert the update of the static member in the group.
               group.updateMember(knownStaticMember, oldProtocols, null)
-              val oldMember = group.replaceGroupInstance(newMemberId, oldMemberId, groupInstanceId)
+              val oldMember = group.replaceStaticMember(groupInstanceId, newMemberId, oldMemberId)
               completeAndScheduleNextHeartbeatExpiration(group, oldMember)
               responseCallback(JoinGroupResult(
                 List.empty,
@@ -1158,14 +1334,14 @@ class GroupCoordinator(val brokerId: Int,
   }
 
   private def removePendingMemberAndUpdateGroup(group: GroupMetadata, memberId: String): Unit = {
-    group.removePendingMember(memberId)
+    group.remove(memberId)
 
     if (group.is(PreparingRebalance)) {
       joinPurgatory.checkAndComplete(GroupKey(group.groupId))
     }
   }
 
-  def tryCompleteJoin(group: GroupMetadata, forceComplete: () => Boolean) = {
+  def tryCompleteJoin(group: GroupMetadata, forceComplete: () => Boolean): Boolean = {
     group.inLock {
       if (group.hasAllMembersJoined)
         forceComplete()
@@ -1181,8 +1357,8 @@ class GroupCoordinator(val brokerId: Int,
           s"who haven't joined: ${notYetRejoinedDynamicMembers.keySet}")
 
         notYetRejoinedDynamicMembers.values foreach { failedMember =>
-          removeHeartbeatForLeavingMember(group, failedMember)
           group.remove(failedMember.memberId)
+          removeHeartbeatForLeavingMember(group, failedMember)
         }
       }
 
@@ -1260,9 +1436,9 @@ class GroupCoordinator(val brokerId: Int,
   def shouldCompleteNonPendingHeartbeat(group: GroupMetadata, memberId: String): Boolean = {
     if (group.has(memberId)) {
       val member = group.get(memberId)
-      member.hasSatisfiedHeartbeat || member.isLeaving
+      member.hasSatisfiedHeartbeat
     } else {
-      info(s"Member id $memberId was not found in ${group.groupId} during heartbeat completion check")
+      debug(s"Member id $memberId was not found in ${group.groupId} during heartbeat completion check")
       true
     }
   }

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -143,9 +143,6 @@ private object GroupMetadata extends Logging {
     group.currentStateTimestamp = currentStateTimestamp
     members.foreach { member =>
       group.add(member, null)
-      if (member.isStaticMember) {
-        group.addStaticMember(member.groupInstanceId, member.memberId)
-      }
       info(s"Loaded member $member in group $groupId with generation ${group.generationId}.")
     }
     group.subscribedTopics = group.computeSubscribedTopics()
@@ -226,11 +223,10 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def inLock[T](fun: => T): T = CoreUtils.inLock(lock)(fun)
 
-  def is(groupState: GroupState) = state == groupState
-  def not(groupState: GroupState) = state != groupState
-  def has(memberId: String) = members.contains(memberId)
-  def get(memberId: String) = members(memberId)
-  def size = members.size
+  def is(groupState: GroupState): Boolean = state == groupState
+  def has(memberId: String): Boolean = members.contains(memberId)
+  def get(memberId: String): MemberMetadata = members(memberId)
+  def size: Int = members.size
 
   def isLeader(memberId: String): Boolean = leaderId.contains(memberId)
   def leaderOrNull: String = leaderId.orNull
@@ -239,6 +235,13 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def isConsumerGroup: Boolean = protocolType.contains(ConsumerProtocol.PROTOCOL_TYPE)
 
   def add(member: MemberMetadata, callback: JoinCallback = null): Unit = {
+    member.groupInstanceId.foreach { instanceId =>
+      if (staticMembers.contains(instanceId))
+        throw new IllegalStateException(s"Static member with groupInstanceId=$instanceId " +
+          s"cannot be added to group $groupId since it is already a member")
+      staticMembers.put(instanceId, member.memberId)
+    }
+
     if (members.isEmpty)
       this.protocolType = Some(member.protocolType)
 
@@ -247,11 +250,15 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
     if (leaderId.isEmpty)
       leaderId = Some(member.memberId)
+
     members.put(member.memberId, member)
     member.supportedProtocols.foreach{ case (protocol, _) => supportedProtocols(protocol) += 1 }
     member.awaitingJoinCallback = callback
+
     if (member.isAwaitingJoin)
       numMembersAwaitingJoin += 1
+
+    pendingMembers.remove(member.memberId)
   }
 
   def remove(memberId: String): Unit = {
@@ -265,6 +272,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
     if (isLeader(memberId))
       leaderId = members.keys.headOption
+
+    pendingMembers.remove(memberId)
   }
 
   /**
@@ -302,76 +311,72 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     * [For static members only]: Replace the old member id with the new one,
     * keep everything else unchanged and return the updated member.
     */
-  def replaceGroupInstance(oldMemberId: String,
-                           newMemberId: String,
-                           groupInstanceId: Option[String]): MemberMetadata = {
-    if(groupInstanceId.isEmpty) {
-      throw new IllegalArgumentException(s"unexpected null group.instance.id in replaceGroupInstance")
-    }
-    val oldMember = members.remove(oldMemberId)
+  def replaceStaticMember(
+    groupInstanceId: String,
+    oldMemberId: String,
+    newMemberId: String
+  ): MemberMetadata = {
+    val memberMetadata = members.remove(oldMemberId)
       .getOrElse(throw new IllegalArgumentException(s"Cannot replace non-existing member id $oldMemberId"))
 
     // Fence potential duplicate member immediately if someone awaits join/sync callback.
-    maybeInvokeJoinCallback(oldMember, JoinGroupResult(oldMemberId, Errors.FENCED_INSTANCE_ID))
+    maybeInvokeJoinCallback(memberMetadata, JoinGroupResult(oldMemberId, Errors.FENCED_INSTANCE_ID))
+    maybeInvokeSyncCallback(memberMetadata, SyncGroupResult(Errors.FENCED_INSTANCE_ID))
 
-    maybeInvokeSyncCallback(oldMember, SyncGroupResult(Errors.FENCED_INSTANCE_ID))
+    memberMetadata.memberId = newMemberId
+    members.put(newMemberId, memberMetadata)
 
-    oldMember.memberId = newMemberId
-    members.put(newMemberId, oldMember)
-
-    if (isLeader(oldMemberId))
+    if (isLeader(oldMemberId)) {
       leaderId = Some(newMemberId)
-    addStaticMember(groupInstanceId, newMemberId)
-    oldMember
-  }
-
-  def isPendingMember(memberId: String): Boolean = pendingMembers.contains(memberId) && !has(memberId)
-
-  def addPendingMember(memberId: String) = pendingMembers.add(memberId)
-
-  def removePendingMember(memberId: String) = pendingMembers.remove(memberId)
-
-  def hasStaticMember(groupInstanceId: Option[String]) = groupInstanceId.isDefined && staticMembers.contains(groupInstanceId.get)
-
-  def getStaticMemberId(groupInstanceId: Option[String]) = {
-    if(groupInstanceId.isEmpty) {
-      throw new IllegalArgumentException(s"unexpected null group.instance.id in getStaticMemberId")
     }
-    staticMembers(groupInstanceId.get)
+
+    staticMembers.put(groupInstanceId, newMemberId)
+    memberMetadata
   }
 
-  def addStaticMember(groupInstanceId: Option[String], newMemberId: String) = {
-    if(groupInstanceId.isEmpty) {
-      throw new IllegalArgumentException(s"unexpected null group.instance.id in addStaticMember")
+  def isPendingMember(memberId: String): Boolean = pendingMembers.contains(memberId)
+
+  def addPendingMember(memberId: String): Boolean = {
+    if (has(memberId)) {
+      throw new IllegalStateException(s"Attempt to add pending member $memberId which is already " +
+        s"a stable member of the group")
     }
-    staticMembers.put(groupInstanceId.get, newMemberId)
+    pendingMembers.add(memberId)
   }
 
-  def currentState = state
+  def hasStaticMember(groupInstanceId: String): Boolean = {
+    staticMembers.contains(groupInstanceId)
+  }
 
-  def notYetRejoinedMembers = members.filter(!_._2.isAwaitingJoin).toMap
+  def currentStaticMemberId(groupInstanceId: String): Option[String] = {
+    staticMembers.get(groupInstanceId)
+  }
 
-  def hasAllMembersJoined = members.size == numMembersAwaitingJoin && pendingMembers.isEmpty
+  def currentState: GroupState = state
 
-  def allMembers = members.keySet
+  def notYetRejoinedMembers: Map[String, MemberMetadata] = members.filter(!_._2.isAwaitingJoin).toMap
 
-  def allStaticMembers = staticMembers.keySet
+  def hasAllMembersJoined: Boolean = members.size == numMembersAwaitingJoin && pendingMembers.isEmpty
+
+  def allMembers: collection.Set[String] = members.keySet
+
+  def allStaticMembers: collection.Set[String] = staticMembers.keySet
 
   // For testing only.
-  def allDynamicMembers = {
+  private[group] def allDynamicMembers: Set[String] = {
     val dynamicMemberSet = new mutable.HashSet[String]
     allMembers.foreach(memberId => dynamicMemberSet.add(memberId))
     staticMembers.values.foreach(memberId => dynamicMemberSet.remove(memberId))
     dynamicMemberSet.toSet
   }
 
-  def numPending = pendingMembers.size
+  def numPending: Int = pendingMembers.size
 
   def numAwaiting: Int = numMembersAwaitingJoin
 
-  def allMemberMetadata = members.values.toList
+  def allMemberMetadata: List[MemberMetadata] = members.values.toList
 
-  def rebalanceTimeoutMs = members.values.foldLeft(0) { (timeout, member) =>
+  def rebalanceTimeoutMs: Int = members.values.foldLeft(0) { (timeout, member) =>
     timeout.max(member.rebalanceTimeoutMs)
   }
 
@@ -390,20 +395,14 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     *   1. given member is a known static member to group
     *   2. group stored member.id doesn't match with given member.id
     */
-  def isStaticMemberFenced(memberId: String,
-                           groupInstanceId: Option[String],
-                           operation: String): Boolean = {
-    if (hasStaticMember(groupInstanceId)
-      && getStaticMemberId(groupInstanceId) != memberId) {
-      error(s"given member.id $memberId is identified as a known static member ${groupInstanceId.get}, " +
-        s"but not matching the expected member.id ${getStaticMemberId(groupInstanceId)} during $operation, will " +
-        s"respond with instance fenced error")
-      true
-    } else
-      false
+  def isStaticMemberFenced(
+    groupInstanceId: String,
+    memberId: String
+  ): Boolean = {
+    currentStaticMemberId(groupInstanceId).exists(_ != memberId)
   }
 
-  def canRebalance = PreparingRebalance.validPreviousStates.contains(state)
+  def canRebalance: Boolean = PreparingRebalance.validPreviousStates.contains(state)
 
   def transitionTo(groupState: GroupState): Unit = {
     assertValidTransition(groupState)
@@ -430,7 +429,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private def candidateProtocols: Set[String] = {
     // get the set of protocols that are commonly supported by all members
     val numMembers = members.size
-    supportedProtocols.filter(_._2 == numMembers).map(_._1).toSet
+    supportedProtocols.filter(_._2 == numMembers).keys.toSet
   }
 
   def supportsProtocols(memberProtocolType: String, memberProtocols: Set[String]): Boolean = {
@@ -762,7 +761,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     expiredOffsets
   }
 
-  def allOffsets = offsets.map { case (topicPartition, commitRecordMetadataAndOffset) =>
+  def allOffsets: Map[TopicPartition, OffsetAndMetadata] = offsets.map { case (topicPartition, commitRecordMetadataAndOffset) =>
     (topicPartition, commitRecordMetadataAndOffset.offsetAndMetadata)
   }.toMap
 
@@ -771,9 +770,9 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   // visible for testing
   private[group] def offsetWithRecordMetadata(topicPartition: TopicPartition): Option[CommitRecordMetadataAndOffset] = offsets.get(topicPartition)
 
-  def numOffsets = offsets.size
+  def numOffsets: Int = offsets.size
 
-  def hasOffsets = offsets.nonEmpty || pendingOffsetCommits.nonEmpty || pendingTransactionalOffsetCommits.nonEmpty
+  def hasOffsets: Boolean = offsets.nonEmpty || pendingOffsetCommits.nonEmpty || pendingTransactionalOffsetCommits.nonEmpty
 
   private def assertValidTransition(targetState: GroupState): Unit = {
     if (!targetState.validPreviousStates.contains(state))

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -252,7 +252,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       leaderId = Some(member.memberId)
 
     members.put(member.memberId, member)
-    member.supportedProtocols.foreach{ case (protocol, _) => supportedProtocols(protocol) += 1 }
+    member.supportedProtocols.foreach { case (protocol, _) => supportedProtocols(protocol) += 1 }
     member.awaitingJoinCallback = callback
 
     if (member.isAwaitingJoin)
@@ -263,7 +263,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def remove(memberId: String): Unit = {
     members.remove(memberId).foreach { member =>
-      member.supportedProtocols.foreach{ case (protocol, _) => supportedProtocols(protocol) -= 1 }
+      member.supportedProtocols.foreach { case (protocol, _) => supportedProtocols(protocol) -= 1 }
       if (member.isAwaitingJoin)
         numMembersAwaitingJoin -= 1
 
@@ -489,8 +489,8 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def updateMember(member: MemberMetadata,
                    protocols: List[(String, Array[Byte])],
                    callback: JoinCallback): Unit = {
-    member.supportedProtocols.foreach{ case (protocol, _) => supportedProtocols(protocol) -= 1 }
-    protocols.foreach{ case (protocol, _) => supportedProtocols(protocol) += 1 }
+    member.supportedProtocols.foreach { case (protocol, _) => supportedProtocols(protocol) -= 1 }
+    protocols.foreach { case (protocol, _) => supportedProtocols(protocol) += 1 }
     member.supportedProtocols = protocols
 
     if (callback != null && !member.isAwaitingJoin) {

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -63,9 +63,8 @@ private[group] class MemberMetadata(var memberId: String,
                                     var supportedProtocols: List[(String, Array[Byte])],
                                     var assignment: Array[Byte] = Array.empty[Byte]) {
 
-  var awaitingJoinCallback: JoinGroupResult => Unit = null
-  var awaitingSyncCallback: SyncGroupResult => Unit = null
-  var isLeaving: Boolean = false
+  var awaitingJoinCallback: JoinGroupResult => Unit = _
+  var awaitingSyncCallback: SyncGroupResult => Unit = _
   var isNew: Boolean = false
 
   def isStaticMember: Boolean = groupInstanceId.isDefined
@@ -77,8 +76,8 @@ private[group] class MemberMetadata(var memberId: String,
   // delayed heartbeat can be completed.
   var heartbeatSatisfied: Boolean = false
 
-  def isAwaitingJoin = awaitingJoinCallback != null
-  def isAwaitingSync = awaitingSyncCallback != null
+  def isAwaitingJoin: Boolean = awaitingJoinCallback != null
+  def isAwaitingSync: Boolean = awaitingSyncCallback != null
 
   /**
    * Get metadata corresponding to the provided protocol.

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -78,9 +78,9 @@ class GroupCoordinatorTest {
   private val protocolType = "consumer"
   private val protocolName = "range"
   private val memberId = "memberId"
-  private val groupInstanceId = Some("groupInstanceId")
-  private val leaderInstanceId = Some("leader")
-  private val followerInstanceId = Some("follower")
+  private val groupInstanceId = "groupInstanceId"
+  private val leaderInstanceId = "leader"
+  private val followerInstanceId = "follower"
   private val invalidMemberId = "invalidMember"
   private val metadata = Array[Byte]()
   private val protocols = List((protocolName, metadata))
@@ -770,13 +770,13 @@ class GroupCoordinatorTest {
     timer.advanceClock(1)
     // Old follower rejoins group will be matching current member.id.
     val oldFollowerJoinGroupFuture =
-      sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, groupInstanceId = followerInstanceId)
+      sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, groupInstanceId = Some(followerInstanceId))
 
     EasyMock.reset(replicaManager)
     timer.advanceClock(1)
     // Duplicate follower joins group with unknown member id will trigger member.id replacement.
     val duplicateFollowerJoinFuture =
-      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols, groupInstanceId = followerInstanceId)
+      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols, groupInstanceId = Some(followerInstanceId))
 
     timer.advanceClock(1)
     // Old member shall be fenced immediately upon duplicate follower joins.
@@ -785,7 +785,6 @@ class GroupCoordinatorTest {
       Errors.FENCED_INSTANCE_ID,
       -1,
       Set.empty,
-      groupId,
       PreparingRebalance,
       None)
     verifyDelayedTaskNotCompleted(duplicateFollowerJoinFuture)
@@ -797,7 +796,7 @@ class GroupCoordinatorTest {
 
     // Known leader rejoins will trigger rebalance.
     val leaderJoinGroupFuture =
-      sendJoinGroup(groupId, rebalanceResult.leaderId, protocolType, protocols, groupInstanceId = leaderInstanceId)
+      sendJoinGroup(groupId, rebalanceResult.leaderId, protocolType, protocols, groupInstanceId = Some(leaderInstanceId))
     timer.advanceClock(1)
     assertTrue(getGroup(groupId).is(PreparingRebalance))
 
@@ -805,7 +804,7 @@ class GroupCoordinatorTest {
     timer.advanceClock(1)
     // Old follower rejoins group will match current member.id.
     val oldFollowerJoinGroupFuture =
-      sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, groupInstanceId = followerInstanceId)
+      sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, groupInstanceId = Some(followerInstanceId))
 
     timer.advanceClock(1)
     val leaderJoinGroupResult = Await.result(leaderJoinGroupFuture, Duration(1, TimeUnit.MILLISECONDS))
@@ -813,7 +812,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1,
       Set(leaderInstanceId, followerInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType))
     assertEquals(rebalanceResult.leaderId, leaderJoinGroupResult.memberId)
@@ -825,7 +823,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1,
       Set.empty,
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       expectedLeaderId = leaderJoinGroupResult.memberId)
@@ -838,11 +835,11 @@ class GroupCoordinatorTest {
     // will return fenced exception while broker replaces the member identity with the duplicate follower joins.
     EasyMock.reset(replicaManager)
     val oldFollowerSyncGroupFuture = sendSyncGroupFollower(groupId, oldFollowerJoinGroupResult.generationId,
-      oldFollowerJoinGroupResult.memberId, Some(protocolType), Some(protocolName), followerInstanceId)
+      oldFollowerJoinGroupResult.memberId, Some(protocolType), Some(protocolName), Some(followerInstanceId))
 
     EasyMock.reset(replicaManager)
     val duplicateFollowerJoinFuture =
-      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols, groupInstanceId = followerInstanceId)
+      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols, groupInstanceId = Some(followerInstanceId))
     timer.advanceClock(1)
 
     val oldFollowerSyncGroupResult = Await.result(oldFollowerSyncGroupFuture, Duration(1, TimeUnit.MILLISECONDS))
@@ -857,7 +854,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 2,
       Set(followerInstanceId),   // this follower will become the new leader, and hence it would have the member list
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       expectedLeaderId = duplicateFollowerJoinGroupResult.memberId)
@@ -870,27 +866,26 @@ class GroupCoordinatorTest {
 
     // Known leader rejoins will trigger rebalance.
     val leaderJoinGroupFuture =
-      sendJoinGroup(groupId, rebalanceResult.leaderId, protocolType, protocols, groupInstanceId = leaderInstanceId)
+      sendJoinGroup(groupId, rebalanceResult.leaderId, protocolType, protocols, groupInstanceId = Some(leaderInstanceId))
     timer.advanceClock(1)
     assertTrue(getGroup(groupId).is(PreparingRebalance))
 
     EasyMock.reset(replicaManager)
     // Duplicate follower joins group will trigger member.id replacement.
     val duplicateFollowerJoinGroupFuture =
-      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols, groupInstanceId = followerInstanceId)
+      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols, groupInstanceId = Some(followerInstanceId))
 
     EasyMock.reset(replicaManager)
     timer.advanceClock(1)
     // Old follower rejoins group will fail because member.id already updated.
     val oldFollowerJoinGroupFuture =
-      sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, groupInstanceId = followerInstanceId)
+      sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, groupInstanceId = Some(followerInstanceId))
 
     val leaderRejoinGroupResult = Await.result(leaderJoinGroupFuture, Duration(1, TimeUnit.MILLISECONDS))
     checkJoinGroupResult(leaderRejoinGroupResult,
       Errors.NONE,
       rebalanceResult.generation + 1,
       Set(leaderInstanceId, followerInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType))
 
@@ -899,7 +894,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1,
       Set.empty,
-      groupId,
       CompletingRebalance,
       Some(protocolType))
     assertNotEquals(rebalanceResult.followerId, duplicateFollowerJoinGroupResult.memberId)
@@ -909,7 +903,6 @@ class GroupCoordinatorTest {
       Errors.FENCED_INSTANCE_ID,
       -1,
       Set.empty,
-      groupId,
       CompletingRebalance,
       None)
   }
@@ -922,14 +915,15 @@ class GroupCoordinatorTest {
     EasyMock.reset(replicaManager)
     val assignedMemberId = joinGroupResult.memberId
     // The second join group should return immediately since we are using the same metadata during CompletingRebalance.
-    val rejoinResponseFuture = sendJoinGroup(groupId, assignedMemberId, protocolType, protocols, groupInstanceId)
+    val rejoinResponseFuture = sendJoinGroup(groupId, assignedMemberId, protocolType, protocols, Some(groupInstanceId))
     timer.advanceClock(1)
     joinGroupResult = Await.result(rejoinResponseFuture, Duration(1, TimeUnit.MILLISECONDS))
     assertEquals(Errors.NONE, joinGroupResult.error)
     assertTrue(getGroup(groupId).is(CompletingRebalance))
 
     EasyMock.reset(replicaManager)
-    val syncGroupFuture = sendSyncGroupLeader(groupId, joinGroupResult.generationId, assignedMemberId, Some(protocolType), Some(protocolName), groupInstanceId, Map(assignedMemberId -> Array[Byte]()))
+    val syncGroupFuture = sendSyncGroupLeader(groupId, joinGroupResult.generationId, assignedMemberId,
+      Some(protocolType), Some(protocolName), Some(groupInstanceId), Map(assignedMemberId -> Array[Byte]()))
     timer.advanceClock(1)
     val syncGroupResult = Await.result(syncGroupFuture, Duration(1, TimeUnit.MILLISECONDS))
     assertEquals(Errors.NONE, syncGroupResult.error)
@@ -941,13 +935,13 @@ class GroupCoordinatorTest {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     // A static leader rejoin with unknown id will not trigger rebalance, and no assignment will be returned.
-    val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, leaderInstanceId, protocolType, protocolSuperset, clockAdvance = 1)
+    val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
+      leaderInstanceId, protocolType, protocolSuperset, clockAdvance = 1)
 
     checkJoinGroupResult(joinGroupResult,
       Errors.NONE,
       rebalanceResult.generation, // The group should be at the same generation
       Set.empty,
-      groupId,
       Stable,
       Some(protocolType),
       rebalanceResult.leaderId)
@@ -958,7 +952,8 @@ class GroupCoordinatorTest {
 
     EasyMock.reset(replicaManager)
     // Old leader will get fenced.
-    val oldLeaderSyncGroupResult = syncGroupLeader(groupId, rebalanceResult.generation, rebalanceResult.leaderId, Map.empty, None, None, leaderInstanceId)
+    val oldLeaderSyncGroupResult = syncGroupLeader(groupId, rebalanceResult.generation, rebalanceResult.leaderId,
+      Map.empty, None, None, Some(leaderInstanceId))
     assertEquals(Errors.FENCED_INSTANCE_ID, oldLeaderSyncGroupResult.error)
 
     // Calling sync on old leader.id will fail because that leader.id is no longer valid and replaced.
@@ -981,7 +976,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1, // The group has promoted to the new generation.
       Set(leaderInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       rebalanceResult.leaderId,
@@ -1025,7 +1019,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1, // The group has promoted to the new generation, and leader has changed because old one times out.
       Set(leaderInstanceId, followerInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       rebalanceResult.followerId,
@@ -1048,7 +1041,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1,
       Set(leaderInstanceId, followerInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType))
 
@@ -1064,13 +1056,13 @@ class GroupCoordinatorTest {
     val selectedProtocol = getGroup(groupId).selectProtocol
     val newProtocols = List((selectedProtocol, metadata))
     // Timeout old leader in the meantime.
-    val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, newProtocols, clockAdvance = 1, appendRecordError = Errors.MESSAGE_TOO_LARGE)
+    val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
+      followerInstanceId, protocolType, newProtocols, clockAdvance = 1, appendRecordError = Errors.MESSAGE_TOO_LARGE)
 
     checkJoinGroupResult(joinGroupResult,
       Errors.UNKNOWN_SERVER_ERROR,
       rebalanceResult.generation,
       Set.empty,
-      groupId,
       Stable,
       Some(protocolType))
 
@@ -1082,7 +1074,8 @@ class GroupCoordinatorTest {
 
     EasyMock.reset(replicaManager)
     // Sync with old member id will also not fail because the member id is not updated because of persistence failure
-    val syncGroupWithOldMemberIdResult = syncGroupFollower(groupId, rebalanceResult.generation, rebalanceResult.followerId, None, None, followerInstanceId)
+    val syncGroupWithOldMemberIdResult = syncGroupFollower(groupId, rebalanceResult.generation,
+      rebalanceResult.followerId, None, None, Some(followerInstanceId))
     assertEquals(Errors.NONE, syncGroupWithOldMemberIdResult.error)
   }
 
@@ -1095,13 +1088,13 @@ class GroupCoordinatorTest {
     val selectedProtocol = getGroup(groupId).selectProtocol
     val newProtocols = List((selectedProtocol, metadata))
     // Timeout old leader in the meantime.
-    val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, newProtocols, clockAdvance = 1)
+    val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
+      followerInstanceId, protocolType, newProtocols, clockAdvance = 1)
 
     checkJoinGroupResult(joinGroupResult,
       Errors.NONE,
       rebalanceResult.generation,
       Set.empty,
-      groupId,
       Stable,
       Some(protocolType))
 
@@ -1113,11 +1106,13 @@ class GroupCoordinatorTest {
 
     EasyMock.reset(replicaManager)
     // Sync with old member id will fail because the member id is updated
-    val syncGroupWithOldMemberIdResult = syncGroupFollower(groupId, rebalanceResult.generation, rebalanceResult.followerId, None, None, followerInstanceId)
+    val syncGroupWithOldMemberIdResult = syncGroupFollower(groupId, rebalanceResult.generation,
+      rebalanceResult.followerId, None, None, Some(followerInstanceId))
     assertEquals(Errors.FENCED_INSTANCE_ID, syncGroupWithOldMemberIdResult.error)
 
     EasyMock.reset(replicaManager)
-    val syncGroupWithNewMemberIdResult = syncGroupFollower(groupId, rebalanceResult.generation, joinGroupResult.memberId, None, None, followerInstanceId)
+    val syncGroupWithNewMemberIdResult = syncGroupFollower(groupId, rebalanceResult.generation,
+      joinGroupResult.memberId, None, None, Some(followerInstanceId))
     assertEquals(Errors.NONE, syncGroupWithNewMemberIdResult.error)
     assertEquals(rebalanceResult.followerAssignment, syncGroupWithNewMemberIdResult.memberAssignment)
   }
@@ -1127,10 +1122,12 @@ class GroupCoordinatorTest {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     // A static leader rejoin with known member id will trigger rebalance.
-    val leaderRejoinGroupFuture = sendJoinGroup(groupId, rebalanceResult.leaderId, protocolType, protocolSuperset, leaderInstanceId)
+    val leaderRejoinGroupFuture = sendJoinGroup(groupId, rebalanceResult.leaderId, protocolType,
+      protocolSuperset, Some(leaderInstanceId))
     // Rebalance complete immediately after follower rejoin.
     EasyMock.reset(replicaManager)
-    val followerRejoinWithFuture = sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocolSuperset, followerInstanceId)
+    val followerRejoinWithFuture = sendJoinGroup(groupId, rebalanceResult.followerId, protocolType,
+      protocolSuperset, Some(followerInstanceId))
 
     timer.advanceClock(1)
 
@@ -1139,7 +1136,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1, // The group has promoted to the new generation.
       Set(leaderInstanceId, followerInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       rebalanceResult.leaderId,
@@ -1149,7 +1145,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 1, // The group has promoted to the new generation.
       Set.empty,
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       rebalanceResult.leaderId,
@@ -1157,7 +1152,8 @@ class GroupCoordinatorTest {
 
     EasyMock.reset(replicaManager)
     // The follower protocol changed from protocolSuperset to general protocols.
-    val followerRejoinWithProtocolChangeFuture = sendJoinGroup(groupId, rebalanceResult.followerId, protocolType, protocols, followerInstanceId)
+    val followerRejoinWithProtocolChangeFuture = sendJoinGroup(groupId, rebalanceResult.followerId,
+      protocolType, protocols, Some(followerInstanceId))
     // The group will transit to PreparingRebalance due to protocol change from follower.
     assertTrue(getGroup(groupId).is(PreparingRebalance))
 
@@ -1166,7 +1162,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation + 2, // The group has promoted to the new generation.
       Set(followerInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       rebalanceResult.followerId,
@@ -1186,7 +1181,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation, // The group has no change.
       Set.empty,
-      groupId,
       Stable,
       Some(protocolType))
 
@@ -1211,7 +1205,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       rebalanceResult.generation, // The group has no change.
       Set.empty,
-      groupId,
       Stable,
       Some(protocolType),
       rebalanceResult.leaderId,
@@ -1238,7 +1231,8 @@ class GroupCoordinatorTest {
   def staticMemberSyncAsLeaderWithInvalidMemberId(): Unit = {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
-    val syncGroupResult = syncGroupLeader(groupId, rebalanceResult.generation, "invalid", Map.empty, None, None, leaderInstanceId)
+    val syncGroupResult = syncGroupLeader(groupId, rebalanceResult.generation, "invalid",
+      Map.empty, None, None, Some(leaderInstanceId))
     assertEquals(Errors.FENCED_INSTANCE_ID, syncGroupResult.error)
   }
 
@@ -1254,7 +1248,7 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, validHeartbeatResult)
 
     EasyMock.reset(replicaManager)
-    val invalidHeartbeatResult = heartbeat(groupId, invalidMemberId, rebalanceResult.generation, leaderInstanceId)
+    val invalidHeartbeatResult = heartbeat(groupId, invalidMemberId, rebalanceResult.generation, Some(leaderInstanceId))
     assertEquals(Errors.FENCED_INSTANCE_ID, invalidHeartbeatResult)
   }
 
@@ -1268,7 +1262,7 @@ class GroupCoordinatorTest {
       EasyMock.reset(replicaManager)
       val joinGroupResult = staticJoinGroupWithPersistence(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID,
         leaderInstanceId, protocolType, protocols, clockAdvance = timeAdvance)
-      assertTrue(joinGroupResult.memberId.startsWith(leaderInstanceId.get))
+      assertTrue(joinGroupResult.memberId.startsWith(leaderInstanceId))
       assertNotEquals(lastMemberId, joinGroupResult.memberId)
       lastMemberId = joinGroupResult.memberId
     }
@@ -1301,7 +1295,8 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, validOffsetCommitResult(tp))
 
     EasyMock.reset(replicaManager)
-    val invalidOffsetCommitResult = commitOffsets(groupId, invalidMemberId, rebalanceResult.generation, Map(tp -> offset), leaderInstanceId)
+    val invalidOffsetCommitResult = commitOffsets(groupId, invalidMemberId, rebalanceResult.generation,
+      Map(tp -> offset), Some(leaderInstanceId))
     assertEquals(Errors.FENCED_INSTANCE_ID, invalidOffsetCommitResult(tp))
   }
 
@@ -1309,43 +1304,10 @@ class GroupCoordinatorTest {
   def staticMemberJoinWithUnknownInstanceIdAndKnownMemberId(): Unit = {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
-    val joinGroupResult = staticJoinGroup(groupId, rebalanceResult.leaderId, Some("unknown_instance"), protocolType, protocolSuperset, clockAdvance = 1)
+    val joinGroupResult = staticJoinGroup(groupId, rebalanceResult.leaderId, "unknown_instance",
+      protocolType, protocolSuperset, clockAdvance = 1)
 
     assertEquals(Errors.UNKNOWN_MEMBER_ID, joinGroupResult.error)
-  }
-
-  @Test
-  def staticMemberJoinWithIllegalStateAsPendingMember(): Unit = {
-    val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
-    val group = groupCoordinator.groupManager.getGroup(groupId).get
-    group.addPendingMember(rebalanceResult.followerId)
-    group.remove(rebalanceResult.followerId)
-    EasyMock.reset(replicaManager)
-
-    // Illegal state exception shall trigger since follower id resides in pending member bucket.
-    val expectedException = assertThrows(classOf[IllegalStateException],
-      () => staticJoinGroup(groupId, rebalanceResult.followerId, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1))
-
-    val message = expectedException.getMessage
-    assertTrue(message.contains(rebalanceResult.followerId))
-    assertTrue(message.contains(followerInstanceId.get))
-  }
-
-  @Test
-  def staticMemberLeaveWithIllegalStateAsPendingMember(): Unit = {
-    val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
-    val group = groupCoordinator.groupManager.getGroup(groupId).get
-    group.addPendingMember(rebalanceResult.followerId)
-    group.remove(rebalanceResult.followerId)
-    EasyMock.reset(replicaManager)
-
-    // Illegal state exception shall trigger since follower id resides in pending member bucket.
-    val expectedException = assertThrows(classOf[IllegalStateException],
-      () => singleLeaveGroup(groupId, rebalanceResult.followerId, followerInstanceId))
-
-    val message = expectedException.getMessage
-    assertTrue(message.contains(rebalanceResult.followerId))
-    assertTrue(message.contains(followerInstanceId.get))
   }
 
   @Test
@@ -1363,23 +1325,7 @@ class GroupCoordinatorTest {
 
     val message = expectedException.getMessage
     assertTrue(message.contains(group.groupId))
-    assertTrue(message.contains(followerInstanceId.get))
-  }
-
-  @Test
-  def staticMemberReJoinWithIllegalArgumentAsMissingOldMember(): Unit = {
-    staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
-    val group = groupCoordinator.groupManager.getGroup(groupId).get
-    val invalidMemberId = "invalid_member_id"
-    group.addStaticMember(followerInstanceId, invalidMemberId)
-    EasyMock.reset(replicaManager)
-
-    // Illegal state exception shall trigger since follower corresponding id is not defined in member list.
-    val expectedException = assertThrows(classOf[IllegalArgumentException],
-      () => staticJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, followerInstanceId, protocolType, protocolSuperset, clockAdvance = 1))
-
-    val message = expectedException.getMessage
-    assertTrue(message.contains(invalidMemberId))
+    assertTrue(message.contains(followerInstanceId))
   }
 
   @Test
@@ -1405,7 +1351,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       3,
       Set(leaderInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType)
     )
@@ -1431,7 +1376,7 @@ class GroupCoordinatorTest {
 
     assertEquals(Set(rebalanceResult.leaderId, rebalanceResult.followerId,
       dynamicJoinResult.memberId), getGroup(groupId).allMembers)
-    assertEquals(Set(leaderInstanceId.get, followerInstanceId.get),
+    assertEquals(Set(leaderInstanceId, followerInstanceId),
       getGroup(groupId).allStaticMembers)
     assertEquals(Set(dynamicJoinResult.memberId), getGroup(groupId).allDynamicMembers)
 
@@ -1455,11 +1400,12 @@ class GroupCoordinatorTest {
     // Increase session timeout so that the follower won't be evicted when rebalance timeout is reached.
     val initialRebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId, sessionTimeout = DefaultRebalanceTimeout * 2)
 
-    val newMemberInstanceId = Some("newMember")
+    val newMemberInstanceId = "newMember"
 
     val leaderId = initialRebalanceResult.leaderId
 
-    val newMemberJoinGroupFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocolSuperset, newMemberInstanceId)
+    val newMemberJoinGroupFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType,
+      protocolSuperset, Some(newMemberInstanceId))
     assertGroupState(groupState = PreparingRebalance)
 
     EasyMock.reset(replicaManager)
@@ -1468,7 +1414,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       initialRebalanceResult.generation + 1,
       Set(leaderInstanceId, followerInstanceId, newMemberInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       expectedLeaderId = leaderId,
@@ -1480,7 +1425,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       initialRebalanceResult.generation + 1,
       Set.empty,
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       expectedLeaderId = leaderId)
@@ -1491,9 +1435,10 @@ class GroupCoordinatorTest {
     // Increase session timeout so that the leader won't be evicted when rebalance timeout is reached.
     val initialRebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId, sessionTimeout = DefaultRebalanceTimeout * 2)
 
-    val newMemberInstanceId = Some("newMember")
+    val newMemberInstanceId = "newMember"
 
-    val newMemberJoinGroupFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocolSuperset, newMemberInstanceId)
+    val newMemberJoinGroupFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType,
+      protocolSuperset, Some(newMemberInstanceId))
     timer.advanceClock(1)
     assertGroupState(groupState = PreparingRebalance)
 
@@ -1510,7 +1455,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       initialRebalanceResult.generation + 1,
       Set(leaderInstanceId, followerInstanceId, newMemberInstanceId),
-      groupId,
       CompletingRebalance,
       Some(protocolType))
 
@@ -1518,7 +1462,6 @@ class GroupCoordinatorTest {
       Errors.NONE,
       initialRebalanceResult.generation + 1,
       Set.empty,
-      groupId,
       CompletingRebalance,
       Some(protocolType),
       expectedLeaderId = newLeaderResult.memberId)
@@ -1529,7 +1472,7 @@ class GroupCoordinatorTest {
     // JoinGroup(leader)
     EasyMock.reset(replicaManager)
     val leaderResponseFuture = sendJoinGroup(groupId, "fake-id", protocolType,
-      protocolSuperset, leaderInstanceId, DefaultSessionTimeout)
+      protocolSuperset, Some(leaderInstanceId), DefaultSessionTimeout)
 
     // The Protocol Type is None when there is an error
     val leaderJoinGroupResult = await(leaderResponseFuture, 1)
@@ -1542,12 +1485,12 @@ class GroupCoordinatorTest {
     // JoinGroup(leader)
     EasyMock.reset(replicaManager)
     val leaderResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType,
-      protocolSuperset, leaderInstanceId, DefaultSessionTimeout)
+      protocolSuperset, Some(leaderInstanceId), DefaultSessionTimeout)
 
     // JoinGroup(follower)
     EasyMock.reset(replicaManager)
     val followerResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType,
-      protocolSuperset, followerInstanceId, DefaultSessionTimeout)
+      protocolSuperset, Some(followerInstanceId), DefaultSessionTimeout)
 
     timer.advanceClock(GroupInitialRebalanceDelay + 1)
     timer.advanceClock(DefaultRebalanceTimeout + 1)
@@ -1595,12 +1538,12 @@ class GroupCoordinatorTest {
     // JoinGroup(leader) with the Protocol Type of the group
     EasyMock.reset(replicaManager)
     val leaderResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, this.protocolType,
-      protocolSuperset, leaderInstanceId, DefaultSessionTimeout)
+      protocolSuperset, Some(leaderInstanceId), DefaultSessionTimeout)
 
     // JoinGroup(follower) with the Protocol Type of the group
     EasyMock.reset(replicaManager)
     val followerResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, this.protocolType,
-      protocolSuperset, followerInstanceId, DefaultSessionTimeout)
+      protocolSuperset, Some(followerInstanceId), DefaultSessionTimeout)
 
     timer.advanceClock(GroupInitialRebalanceDelay + 1)
     timer.advanceClock(DefaultRebalanceTimeout + 1)
@@ -1641,14 +1584,16 @@ class GroupCoordinatorTest {
     *   - follower id
     *   - follower assignment
     */
-  private def staticMembersJoinAndRebalance(leaderInstanceId: Option[String],
-                                            followerInstanceId: Option[String],
+  private def staticMembersJoinAndRebalance(leaderInstanceId: String,
+                                            followerInstanceId: String,
                                             sessionTimeout: Int = DefaultSessionTimeout): RebalanceResult = {
     EasyMock.reset(replicaManager)
-    val leaderResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocolSuperset, leaderInstanceId, sessionTimeout)
+    val leaderResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType,
+      protocolSuperset, Some(leaderInstanceId), sessionTimeout)
 
     EasyMock.reset(replicaManager)
-    val followerResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocolSuperset, followerInstanceId, sessionTimeout)
+    val followerResponseFuture = sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType,
+      protocolSuperset, Some(followerInstanceId), sessionTimeout)
     // The goal for two timer advance is to let first group initial join complete and set newMemberAdded flag to false. Next advance is
     // to trigger the rebalance as needed for follower delayed join. One large time advance won't help because we could only populate one
     // delayed join from purgatory and the new delayed op is created at that time and never be triggered.
@@ -1687,8 +1632,7 @@ class GroupCoordinatorTest {
   private def checkJoinGroupResult(joinGroupResult: JoinGroupResult,
                                    expectedError: Errors,
                                    expectedGeneration: Int,
-                                   expectedGroupInstanceIds: Set[Option[String]],
-                                   groupId: String,
+                                   expectedGroupInstanceIds: Set[String],
                                    expectedGroupState: GroupState,
                                    expectedProtocolType: Option[String],
                                    expectedLeaderId: String = JoinGroupRequest.UNKNOWN_MEMBER_ID,
@@ -1696,7 +1640,7 @@ class GroupCoordinatorTest {
     assertEquals(expectedError, joinGroupResult.error)
     assertEquals(expectedGeneration, joinGroupResult.generationId)
     assertEquals(expectedGroupInstanceIds.size, joinGroupResult.members.size)
-    val resultedGroupInstanceIds = joinGroupResult.members.map(member => Some(member.groupInstanceId())).toSet
+    val resultedGroupInstanceIds = joinGroupResult.members.map(member => member.groupInstanceId).toSet
     assertEquals(expectedGroupInstanceIds, resultedGroupInstanceIds)
     assertGroupState(groupState = expectedGroupState)
     assertEquals(expectedProtocolType, joinGroupResult.protocolType)
@@ -1737,7 +1681,7 @@ class GroupCoordinatorTest {
     val memberId = "memberId"
 
     val group = new GroupMetadata(groupId, Empty, new MockTime())
-    val member = new MemberMetadata(memberId, groupInstanceId,
+    val member = new MemberMetadata(memberId, Some(groupInstanceId),
       ClientId, ClientHost, DefaultRebalanceTimeout, DefaultSessionTimeout,
       protocolType, List(("range", Array.empty[Byte]), ("roundrobin", Array.empty[Byte])))
 
@@ -2963,15 +2907,15 @@ class GroupCoordinatorTest {
     val rebalanceResult = staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val leaderNoMemberIdCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), memberId = JoinGroupRequest.UNKNOWN_MEMBER_ID, groupInstanceId = leaderInstanceId)
-    assertEquals(Errors.FENCED_INSTANCE_ID, leaderNoMemberIdCommitOffsetResult (tp))
+      Map(tp -> offset), memberId = JoinGroupRequest.UNKNOWN_MEMBER_ID, groupInstanceId = Some(leaderInstanceId))
+    assertEquals(Errors.FENCED_INSTANCE_ID, leaderNoMemberIdCommitOffsetResult(tp))
 
     val leaderInvalidMemberIdCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), memberId = "invalid-member", groupInstanceId = leaderInstanceId)
+      Map(tp -> offset), memberId = "invalid-member", groupInstanceId = Some(leaderInstanceId))
     assertEquals(Errors.FENCED_INSTANCE_ID, leaderInvalidMemberIdCommitOffsetResult (tp))
 
     val leaderCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), rebalanceResult.leaderId, leaderInstanceId)
+      Map(tp -> offset), rebalanceResult.leaderId, Some(leaderInstanceId), rebalanceResult.generation)
     assertEquals(Errors.NONE, leaderCommitOffsetResult (tp))
   }
 
@@ -3003,10 +2947,11 @@ class GroupCoordinatorTest {
     val joinGroupError = joinGroupResult.error
     assertEquals(Errors.NONE, joinGroupError)
 
+
     EasyMock.reset(replicaManager)
     val assignedConsumerId = joinGroupResult.memberId
     val leaderCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
-      Map(tp -> offset), assignedConsumerId)
+      Map(tp -> offset), assignedConsumerId, generationId = joinGroupResult.generationId)
     assertEquals(Errors.NONE, leaderCommitOffsetResult (tp))
   }
 
@@ -3027,7 +2972,7 @@ class GroupCoordinatorTest {
     val initialGenerationId = joinGroupResult.generationId
     val illegalGenerationCommitOffsetResult = commitTransactionalOffsets(groupId, producerId, producerEpoch,
       Map(tp -> offset), memberId = assignedConsumerId, generationId = initialGenerationId + 5)
-    assertEquals(Errors.ILLEGAL_GENERATION, illegalGenerationCommitOffsetResult (tp))
+    assertEquals(Errors.ILLEGAL_GENERATION, illegalGenerationCommitOffsetResult(tp))
   }
 
   @Test
@@ -3159,7 +3104,7 @@ class GroupCoordinatorTest {
     assertEquals(Errors.NONE, joinGroupResult.error)
 
     EasyMock.reset(replicaManager)
-    val leaveGroupResults = singleLeaveGroup(groupId, "some_member", leaderInstanceId)
+    val leaveGroupResults = singleLeaveGroup(groupId, "some_member", Some(leaderInstanceId))
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.FENCED_INSTANCE_ID))
   }
 
@@ -3170,7 +3115,7 @@ class GroupCoordinatorTest {
 
     EasyMock.reset(replicaManager)
     // Having unknown member id will not affect the request processing.
-    val leaveGroupResults = singleLeaveGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, leaderInstanceId)
+    val leaveGroupResults = singleLeaveGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, Some(leaderInstanceId))
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.NONE))
   }
 
@@ -3179,7 +3124,7 @@ class GroupCoordinatorTest {
     staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val leaveGroupResults = batchLeaveGroup(groupId, List(new MemberIdentity()
-      .setGroupInstanceId(leaderInstanceId.get), new MemberIdentity().setGroupInstanceId(followerInstanceId.get)))
+      .setGroupInstanceId(leaderInstanceId), new MemberIdentity().setGroupInstanceId(followerInstanceId)))
 
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.NONE, Errors.NONE))
   }
@@ -3189,7 +3134,7 @@ class GroupCoordinatorTest {
     staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val leaveGroupResults = batchLeaveGroup("invalid-group", List(new MemberIdentity()
-      .setGroupInstanceId(leaderInstanceId.get), new MemberIdentity().setGroupInstanceId(followerInstanceId.get)))
+      .setGroupInstanceId(leaderInstanceId), new MemberIdentity().setGroupInstanceId(followerInstanceId)))
 
     verifyLeaveGroupResult(leaveGroupResults, Errors.NOT_COORDINATOR)
   }
@@ -3197,7 +3142,7 @@ class GroupCoordinatorTest {
   @Test
   def testStaticMembersUnknownGroupBatchLeaveGroup(): Unit = {
     val leaveGroupResults = batchLeaveGroup(groupId, List(new MemberIdentity()
-      .setGroupInstanceId(leaderInstanceId.get), new MemberIdentity().setGroupInstanceId(followerInstanceId.get)))
+      .setGroupInstanceId(leaderInstanceId), new MemberIdentity().setGroupInstanceId(followerInstanceId)))
 
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.UNKNOWN_MEMBER_ID, Errors.UNKNOWN_MEMBER_ID))
   }
@@ -3207,8 +3152,8 @@ class GroupCoordinatorTest {
     staticMembersJoinAndRebalance(leaderInstanceId, followerInstanceId)
 
     val leaveGroupResults = batchLeaveGroup(groupId, List(new MemberIdentity()
-      .setGroupInstanceId(leaderInstanceId.get), new MemberIdentity()
-      .setGroupInstanceId(followerInstanceId.get)
+      .setGroupInstanceId(leaderInstanceId), new MemberIdentity()
+      .setGroupInstanceId(followerInstanceId)
       .setMemberId("invalid-member")))
 
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.NONE, Errors.FENCED_INSTANCE_ID))
@@ -3220,7 +3165,7 @@ class GroupCoordinatorTest {
 
     val leaveGroupResults = batchLeaveGroup(groupId, List(new MemberIdentity()
       .setGroupInstanceId("unknown-instance"), new MemberIdentity()
-      .setGroupInstanceId(followerInstanceId.get)))
+      .setGroupInstanceId(followerInstanceId)))
 
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.UNKNOWN_MEMBER_ID, Errors.NONE))
   }
@@ -3235,25 +3180,6 @@ class GroupCoordinatorTest {
       .setMemberId(pendingMember.memberId)))
 
     verifyLeaveGroupResult(leaveGroupResults, Errors.NONE, List(Errors.UNKNOWN_MEMBER_ID, Errors.NONE))
-  }
-
-  @Test
-  def testPendingMemberWithUnexpectedInstanceIdBatchLeaveGroup(): Unit = {
-    val pendingMember = setupGroupWithPendingMember()
-
-    EasyMock.reset(replicaManager)
-
-    // Bypass the FENCED_INSTANCE_ID check by defining pending member as a static member.
-    val instanceId = "instanceId"
-    val pendingMemberId = pendingMember.memberId
-    getGroup(groupId).addStaticMember(Option(instanceId), pendingMemberId)
-    val expectedException = assertThrows(classOf[IllegalStateException],
-      () => batchLeaveGroup(groupId, List(new MemberIdentity().setGroupInstanceId("unknown-instance"),
-        new MemberIdentity().setGroupInstanceId(instanceId).setMemberId(pendingMemberId))))
-
-    val message = expectedException.getMessage
-    assertTrue(message.contains(instanceId))
-    assertTrue(message.contains(pendingMemberId))
   }
 
   @Test
@@ -3385,7 +3311,7 @@ class GroupCoordinatorTest {
     assertEquals(protocolType, summary.protocolType)
     assertEquals("range", summary.protocol)
     assertEquals(List(assignedMemberId), summary.members.map(_.memberId))
-    assertEquals(List(leaderInstanceId), summary.members.map(_.groupInstanceId))
+    assertEquals(List(leaderInstanceId), summary.members.flatMap(_.groupInstanceId))
   }
 
   @Test
@@ -3847,7 +3773,7 @@ class GroupCoordinatorTest {
                                                  memberId: String,
                                                  protocolType: String,
                                                  protocols: List[(String, Array[Byte])],
-                                                 groupInstanceId: Option[String],
+                                                 groupInstanceId: String,
                                                  sessionTimeout: Int,
                                                  rebalanceTimeout: Int,
                                                  appendRecordError: Errors,
@@ -3872,7 +3798,7 @@ class GroupCoordinatorTest {
     EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject())).andReturn(Some(RecordBatch.MAGIC_VALUE_V1)).anyTimes()
     EasyMock.replay(replicaManager)
 
-    groupCoordinator.handleJoinGroup(groupId, memberId, groupInstanceId,
+    groupCoordinator.handleJoinGroup(groupId, memberId, Some(groupInstanceId),
       requireKnownMemberId, "clientId", "clientHost", rebalanceTimeout, sessionTimeout, protocolType, protocols, responseCallback)
     responseFuture
   }
@@ -3950,13 +3876,13 @@ class GroupCoordinatorTest {
 
   private def staticJoinGroup(groupId: String,
                               memberId: String,
-                              groupInstanceId: Option[String],
+                              groupInstanceId: String,
                               protocolType: String,
                               protocols: List[(String, Array[Byte])],
                               clockAdvance: Int = GroupInitialRebalanceDelay + 1,
                               sessionTimeout: Int = DefaultSessionTimeout,
                               rebalanceTimeout: Int = DefaultRebalanceTimeout): JoinGroupResult = {
-    val responseFuture = sendJoinGroup(groupId, memberId, protocolType, protocols, groupInstanceId, sessionTimeout, rebalanceTimeout)
+    val responseFuture = sendJoinGroup(groupId, memberId, protocolType, protocols, Some(groupInstanceId), sessionTimeout, rebalanceTimeout)
 
     timer.advanceClock(clockAdvance)
     // should only have to wait as long as session timeout, but allow some extra time in case of an unexpected delay
@@ -3965,14 +3891,15 @@ class GroupCoordinatorTest {
 
   private def staticJoinGroupWithPersistence(groupId: String,
                                              memberId: String,
-                                             groupInstanceId: Option[String],
+                                             groupInstanceId: String,
                                              protocolType: String,
                                              protocols: List[(String, Array[Byte])],
                                              clockAdvance: Int,
                                              sessionTimeout: Int = DefaultSessionTimeout,
                                              rebalanceTimeout: Int = DefaultRebalanceTimeout,
                                              appendRecordError: Errors = Errors.NONE): JoinGroupResult = {
-    val responseFuture = sendStaticJoinGroupWithPersistence(groupId, memberId, protocolType, protocols, groupInstanceId, sessionTimeout, rebalanceTimeout, appendRecordError)
+    val responseFuture = sendStaticJoinGroupWithPersistence(groupId, memberId, protocolType, protocols,
+      groupInstanceId, sessionTimeout, rebalanceTimeout, appendRecordError)
 
     timer.advanceClock(clockAdvance)
     // should only have to wait as long as session timeout, but allow some extra time in case of an unexpected delay

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -60,7 +60,7 @@ class GroupMetadataManagerTest {
   var metrics: kMetrics = null
 
   val groupId = "foo"
-  val groupInstanceId = Some("bar")
+  val groupInstanceId = "bar"
   val groupPartitionId = 0
   val groupTopicPartition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, groupPartitionId)
   val protocolType = "protocolType"
@@ -845,7 +845,7 @@ class GroupMetadataManagerTest {
     val staticMemberId = "staticMemberId"
     val dynamicMemberId = "dynamicMemberId"
 
-    val staticMember = new MemberMetadata(staticMemberId, groupInstanceId, "", "", rebalanceTimeout, sessionTimeout,
+    val staticMember = new MemberMetadata(staticMemberId, Some(groupInstanceId), "", "", rebalanceTimeout, sessionTimeout,
       protocolType, List(("protocol", Array[Byte]())))
 
     val dynamicMember = new MemberMetadata(dynamicMemberId, None, "", "", rebalanceTimeout, sessionTimeout,
@@ -861,7 +861,7 @@ class GroupMetadataManagerTest {
     assertTrue(group.has(staticMemberId))
     assertTrue(group.has(dynamicMemberId))
     assertTrue(group.hasStaticMember(groupInstanceId))
-    assertEquals(staticMemberId, group.getStaticMemberId(groupInstanceId))
+    assertEquals(Some(staticMemberId), group.currentStaticMemberId(groupInstanceId))
   }
 
   @Test
@@ -876,7 +876,7 @@ class GroupMetadataManagerTest {
       ("protocol", ConsumerProtocol.serializeSubscription(new Subscription(List(topic).asJava)).array())
     )
 
-    val member = new MemberMetadata(memberId, groupInstanceId, "", "", rebalanceTimeout,
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), "", "", rebalanceTimeout,
       sessionTimeout, protocolType, subscriptions)
 
     val members = Seq(member)
@@ -916,7 +916,7 @@ class GroupMetadataManagerTest {
 
     val subscriptions = List(("protocol", Array[Byte]()))
 
-    val member = new MemberMetadata(memberId, groupInstanceId, "", "", rebalanceTimeout,
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), "", "", rebalanceTimeout,
       sessionTimeout, protocolType, subscriptions)
 
     val members = Seq(member)
@@ -1093,7 +1093,7 @@ class GroupMetadataManagerTest {
     val group = new GroupMetadata(groupId, Empty, time)
     groupMetadataManager.addGroup(group)
 
-    val member = new MemberMetadata(memberId, groupInstanceId, clientId, clientHost, rebalanceTimeout, sessionTimeout,
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), clientId, clientHost, rebalanceTimeout, sessionTimeout,
       protocolType, List(("protocol", Array[Byte]())))
     group.add(member, _ => ())
     group.transitionTo(PreparingRebalance)
@@ -1122,7 +1122,7 @@ class GroupMetadataManagerTest {
 
     val group = new GroupMetadata(groupId, Empty, time)
 
-    val member = new MemberMetadata(memberId, groupInstanceId, clientId, clientHost, rebalanceTimeout, sessionTimeout,
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), clientId, clientHost, rebalanceTimeout, sessionTimeout,
       protocolType, List(("protocol", Array[Byte]())))
     group.add(member, _ => ())
     group.transitionTo(PreparingRebalance)
@@ -1621,7 +1621,7 @@ class GroupMetadataManagerTest {
     groupMetadataManager.addGroup(group)
 
     val subscription = new Subscription(List(topic).asJava)
-    val member = new MemberMetadata(memberId, groupInstanceId, clientId, clientHost, rebalanceTimeout, sessionTimeout,
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), clientId, clientHost, rebalanceTimeout, sessionTimeout,
       protocolType, List(("protocol", ConsumerProtocol.serializeSubscription(subscription).array())))
     group.add(member, _ => ())
     group.transitionTo(PreparingRebalance)
@@ -1866,7 +1866,7 @@ class GroupMetadataManagerTest {
 
     val member = new MemberMetadata(
       memberId,
-      groupInstanceId,
+      Some(groupInstanceId),
       clientId,
       clientHost,
       rebalanceTimeout,
@@ -2304,7 +2304,7 @@ class GroupMetadataManagerTest {
                                                assignmentBytes: Array[Byte] = Array.emptyByteArray,
                                                apiVersion: ApiVersion = ApiVersion.latestVersion): SimpleRecord = {
     val memberProtocols = List((protocol, Array.emptyByteArray))
-    val member = new MemberMetadata(memberId, groupInstanceId, "clientId", "clientHost", 30000, 10000, protocolType, memberProtocols)
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), "clientId", "clientHost", 30000, 10000, protocolType, memberProtocols)
     val group = GroupMetadata.loadGroup(groupId, Stable, generation, protocolType, protocol, memberId,
       if (apiVersion >= KAFKA_2_1_IV0) Some(time.milliseconds()) else None, Seq(member), time)
     val groupMetadataKey = GroupMetadataManager.groupMetadataKey(groupId)


### PR DESCRIPTION
This is a continuation of a refactor started in #9952. The logic in `GroupCoordinator` is loose and inconsistent in the handling of the `groupInstanceId`. In some cases, such as in the JoinGroup hander, we verify that the groupInstanceId from the request is mapped to the memberId precisely. In other cases, such as Heartbeat, we check the mapping, but only to validate fencing. The patch consolidates the member validation so that all handlers follow the same logic. 

A second problem is that many of the APIs where a `groupInstanceId` is expected use optional arguments. For example:
```scala
def hasStaticMember(groupInstanceId: Option[String]): Boolean

def addStaticMember(groupInstanceId: Option[String], newMemberId: String): Unit
```
If `groupInstanceId` is `None`, then `hasStaticMember` is guaranteed to return `false` while `addStaticMember` raises an `IllegalStateException`. So the APIs suggest a generality which is not supported and does not make sense.

Finally,  the patch attempts to introduce stronger internal  invariants inside `GroupMetadata`. Currently it is possible for an inconsistent `groupInstanceId` to `memberId` mapping to exist because we expose separate APIs to modify `members` and `staticMembers`. We rely on the caller to ensure this doesn't happen.  Similarly, it is possible for a member to be in the `pendingMembers` set as well as the stable `members` map. The patch fixes this by consolidating the paths to addition and removal from these collections and adding assertions to ensure that invariants are maintained. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
