### PR TITLE
MINOR: Remove `toStruct` and `fromStruct` methods from generated protocol classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Message.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Message.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.protocol.types.RawTaggedField;
-import org.apache.kafka.common.protocol.types.Struct;
 
 import java.util.List;
 
@@ -88,30 +87,6 @@ public interface Message {
      *                      by this software.
      */
     void read(Readable readable, short version);
-
-    /**
-     * Reads this message from a Struct object.  This will overwrite all
-     * relevant fields with information from the Struct.
-     *
-     * @param struct        The source struct.
-     * @param version       The version to use.
-     *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
-     *                      If the specified struct can't be processed with the
-     *                      specified message version.
-     */
-    void fromStruct(Struct struct, short version);
-
-    /**
-     * Writes out this message to a Struct.
-     *
-     * @param version       The version to use.
-     *
-     * @throws {@see org.apache.kafka.common.errors.UnsupportedVersionException}
-     *                      If the specified version is too new to be supported
-     *                      by this software.
-     */
-    Struct toStruct(short version);
 
     /**
      * Returns a list of tagged fields which this software can't understand.

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java
@@ -181,7 +181,7 @@ public class DefaultKafkaPrincipalBuilder implements KafkaPrincipalBuilder, Kafk
     public KafkaPrincipal deserialize(byte[] bytes) {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         short version = buffer.getShort();
-        if (version < 0 || version >= DefaultPrincipalData.SCHEMAS.length) {
+        if (version < DefaultPrincipalData.LOWEST_SUPPORTED_VERSION || version > DefaultPrincipalData.HIGHEST_SUPPORTED_VERSION) {
             throw new SerializationException("Invalid principal data version " + version);
         }
 

--- a/clients/src/main/resources/common/message/README.md
+++ b/clients/src/main/resources/common/message/README.md
@@ -162,9 +162,6 @@ Deserializing Messages
 Message objects may be deserialized using the Message#read method.  This method
 overwrites all the data currently in the message object with new data.
 
-You can also deserialize a message from a Struct by calling Message#fromStruct.
-The Struct will not be modified.
-
 Any fields in the message object that are not present in the version that you
 are deserializing will be reset to default values.  Unless a custom default has
 been set:

--- a/clients/src/main/resources/common/message/README.md
+++ b/clients/src/main/resources/common/message/README.md
@@ -157,9 +157,6 @@ meaning of the request, such as a "validateOnly" boolean, should not be ignored.
 It's often useful to know how much space a message will take up before writing
 it out to a buffer.  You can find this out by calling the Message#size method.
 
-You can also convert a message to a Struct by calling Message#toStruct.  This
-allows you to use the functions that serialize Structs to buffers.
-
 Deserializing Messages
 ----------------------
 Message objects may be deserialized using the Message#read method.  This method

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -51,7 +51,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
-import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -52,7 +52,6 @@ import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
 import org.apache.kafka.common.protocol.types.SchemaException;
-import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.protocol.types.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -809,11 +808,9 @@ public final class MessageTest {
 
     private void testMessageRoundTrip(short version, Message message, Message expected) throws Exception {
         testByteBufferRoundTrip(version, message, expected);
-        testStructRoundTrip(version, message, expected);
     }
 
     private void testEquivalentMessageRoundTrip(short version, Message message) throws Exception {
-        testStructRoundTrip(version, message, message);
         testByteBufferRoundTrip(version, message, message);
         testJsonRoundTrip(version, message, message);
     }
@@ -833,15 +830,6 @@ public final class MessageTest {
             "read back in for version " + version);
         assertEquals(expected, message2, "The message object created after a round trip did not match for " +
             "version " + version);
-        assertEquals(expected.hashCode(), message2.hashCode());
-        assertEquals(expected.toString(), message2.toString());
-    }
-
-    private void testStructRoundTrip(short version, Message message, Message expected) throws Exception {
-        Struct struct = message.toStruct(version);
-        Message message2 = message.getClass().getConstructor().newInstance();
-        message2.fromStruct(struct, version);
-        assertEquals(expected, message2);
         assertEquals(expected.hashCode(), message2.hashCode());
         assertEquals(expected.toString(), message2.toString());
     }

--- a/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/MessageTest.java
@@ -636,7 +636,7 @@ public final class MessageTest {
         for (short version = 0; version <= ApiKeys.OFFSET_FETCH.latestVersion(); version++) {
             final short finalVersion = version;
             if (version < 2) {
-                assertThrows(SchemaException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, allPartitionData));
+                assertThrows(NullPointerException.class, () -> testAllMessageRoundTripsFromVersion(finalVersion, allPartitionData));
             } else {
                 testAllMessageRoundTripsFromVersion(version, allPartitionData);
             }

--- a/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/RecordsSerdeTest.java
@@ -18,14 +18,11 @@ package org.apache.kafka.common.message;
 
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
-import org.apache.kafka.common.protocol.types.Schema;
-import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,37 +68,16 @@ public class RecordsSerdeTest {
         }
     }
 
-    private void testRoundTrip(SimpleRecordsMessageData message, short version) throws IOException {
+    private void testRoundTrip(SimpleRecordsMessageData message, short version) {
         ByteBuffer buf = serialize(message, version);
-
         SimpleRecordsMessageData message2 = deserialize(buf.duplicate(), version);
         assertEquals(message, message2);
         assertEquals(message.hashCode(), message2.hashCode());
-
-        // Check struct serialization as well
-        assertEquals(buf, serializeThroughStruct(message, version));
-        SimpleRecordsMessageData messageFromStruct = deserializeThroughStruct(buf.duplicate(), version);
-        assertEquals(message, messageFromStruct);
-        assertEquals(message.hashCode(), messageFromStruct.hashCode());
-    }
-
-    private SimpleRecordsMessageData deserializeThroughStruct(ByteBuffer buffer, short version) {
-        Schema schema = SimpleRecordsMessageData.SCHEMAS[version];
-        Struct struct = schema.read(buffer);
-        return new SimpleRecordsMessageData(struct, version);
     }
 
     private SimpleRecordsMessageData deserialize(ByteBuffer buffer, short version) {
         ByteBufferAccessor readable = new ByteBufferAccessor(buffer);
         return new SimpleRecordsMessageData(readable, version);
-    }
-
-    private ByteBuffer serializeThroughStruct(SimpleRecordsMessageData message, short version) {
-        Struct struct = message.toStruct(version);
-        ByteBuffer buffer = ByteBuffer.allocate(struct.sizeOf());
-        struct.writeTo(buffer);
-        buffer.flip();
-        return buffer;
     }
 
     private ByteBuffer serialize(SimpleRecordsMessageData message, short version) {

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -21,8 +21,6 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
-import org.apache.kafka.common.protocol.types.Schema;
-import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteUtils;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleExampleMessageTest {
 
@@ -64,7 +61,6 @@ public class SimpleExampleMessageTest {
         final SimpleExampleMessageData out = new SimpleExampleMessageData().setProcessId(Uuid.randomUuid());
         assertThrows(UnsupportedVersionException.class, () ->
                 out.write(new ByteBufferAccessor(ByteBuffer.allocate(64)), new ObjectSerializationCache(), (short) 0));
-        assertThrows(UnsupportedVersionException.class, () -> out.toStruct((short) 0));
     }
 
     @Test
@@ -73,47 +69,6 @@ public class SimpleExampleMessageTest {
         assertEquals(Uuid.fromString("AAAAAAAAAAAAAAAAAAAAAA"), out.processId());
         assertEquals(ByteUtils.EMPTY_BUF, out.zeroCopyByteBuffer());
         assertEquals(ByteUtils.EMPTY_BUF, out.nullableZeroCopyByteBuffer());
-    }
-
-    @Test
-    public void shouldRoundTripFieldThroughStruct() {
-        final Uuid uuid = Uuid.randomUuid();
-        final ByteBuffer buf = ByteBuffer.wrap(new byte[] {1, 2, 3});
-        final SimpleExampleMessageData out = new SimpleExampleMessageData();
-        out.setProcessId(uuid);
-        out.setZeroCopyByteBuffer(buf);
-
-        final Struct struct = out.toStruct((short) 1);
-        final SimpleExampleMessageData in = new SimpleExampleMessageData();
-        in.fromStruct(struct, (short) 1);
-
-        buf.rewind();
-
-        assertEquals(uuid, in.processId());
-        assertEquals(buf, in.zeroCopyByteBuffer());
-        assertEquals(ByteUtils.EMPTY_BUF, in.nullableZeroCopyByteBuffer());
-    }
-
-    @Test
-    public void shouldRoundTripFieldThroughStructWithNullable() {
-        final Uuid uuid = Uuid.randomUuid();
-        final ByteBuffer buf1 = ByteBuffer.wrap(new byte[] {1, 2, 3});
-        final ByteBuffer buf2 = ByteBuffer.wrap(new byte[] {4, 5, 6});
-        final SimpleExampleMessageData out = new SimpleExampleMessageData();
-        out.setProcessId(uuid);
-        out.setZeroCopyByteBuffer(buf1);
-        out.setNullableZeroCopyByteBuffer(buf2);
-
-        final Struct struct = out.toStruct((short) 1);
-        final SimpleExampleMessageData in = new SimpleExampleMessageData();
-        in.fromStruct(struct, (short) 1);
-
-        buf1.rewind();
-        buf2.rewind();
-
-        assertEquals(uuid, in.processId());
-        assertEquals(buf1, in.zeroCopyByteBuffer());
-        assertEquals(buf2, in.nullableZeroCopyByteBuffer());
     }
 
     @Test
@@ -212,8 +167,7 @@ public class SimpleExampleMessageTest {
     @Test
     public void testMyNullableString() {
         // Verify that the tagged field reads as null when not set.
-        testRoundTrip(new SimpleExampleMessageData(),
-            message -> assertTrue(message.myNullableString() == null));
+        testRoundTrip(new SimpleExampleMessageData(), message -> assertNull(message.myNullableString()));
 
         // Verify that we can set and retrieve a string for the tagged field.
         testRoundTrip(new SimpleExampleMessageData().setMyNullableString("foobar"),
@@ -268,8 +222,7 @@ public class SimpleExampleMessageTest {
             message -> assertArrayEquals(new byte[] {0x43, 0x66},
                 message.myBytes()));
 
-        testRoundTrip(new SimpleExampleMessageData().setMyBytes(null),
-            message -> assertTrue(message.myBytes() == null));
+        testRoundTrip(new SimpleExampleMessageData().setMyBytes(null), message -> assertNull(message.myBytes()));
     }
 
     @Test
@@ -368,22 +321,6 @@ public class SimpleExampleMessageTest {
         return message;
     }
 
-    private ByteBuffer serializeThroughStruct(SimpleExampleMessageData message, short version) {
-        Struct struct = message.toStruct(version);
-        int size = struct.sizeOf();
-        ByteBuffer buf = ByteBuffer.allocate(size);
-        struct.writeTo(buf);
-        buf.flip();
-        assertEquals(size, buf.remaining());
-        return buf;
-    }
-
-    private SimpleExampleMessageData deserializeThroughStruct(ByteBuffer buf, short version) {
-        Schema schema = SimpleExampleMessageData.SCHEMAS[version];
-        Struct struct = schema.read(buf);
-        return new SimpleExampleMessageData(struct, version);
-    }
-
     private void testRoundTrip(SimpleExampleMessageData message, short version) {
         testRoundTrip(message, m -> { }, version);
     }
@@ -403,13 +340,6 @@ public class SimpleExampleMessageTest {
         validator.accept(message2);
         assertEquals(message, message2);
         assertEquals(message.hashCode(), message2.hashCode());
-
-        // Check struct serialization as well
-        assertEquals(buf, serializeThroughStruct(message, version));
-        SimpleExampleMessageData messageFromStruct = deserializeThroughStruct(buf.duplicate(), version);
-        validator.accept(messageFromStruct);
-        assertEquals(message, messageFromStruct);
-        assertEquals(message.hashCode(), messageFromStruct.hashCode());
 
         // Check JSON serialization
         JsonNode serializedJson = SimpleExampleMessageDataJsonConverter.write(message, version);

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
 
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -50,7 +52,7 @@ public class ControlRecordUtilsTest {
                                                new Voter().setVoterId(voterId)));
 
         ByteBuffer valueBuffer = ByteBuffer.allocate(256);
-        data.toStruct(data.highestSupportedVersion()).writeTo(valueBuffer);
+        data.write(new ByteBufferAccessor(valueBuffer), new ObjectSerializationCache(), data.highestSupportedVersion());
         valueBuffer.flip();
 
         byte[] keyData = new byte[]{0, 0, 0, (byte) controlRecordType.type};

--- a/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/JoinGroupRequestTest.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.requests;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.JoinGroupRequestData;
-import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -83,19 +83,15 @@ public class JoinGroupRequestTest {
     @Test
     public void testRebalanceTimeoutDefaultsToSessionTimeoutV0() {
         int sessionTimeoutMs = 30000;
+        short version = 0;
 
-        Struct struct = new JoinGroupRequestData()
+        ByteBuffer buffer = MessageUtil.toByteBuffer(new JoinGroupRequestData()
                 .setGroupId("groupId")
                 .setMemberId("consumerId")
                 .setProtocolType("consumer")
-                .setSessionTimeoutMs(sessionTimeoutMs)
-                .toStruct((short) 0);
+                .setSessionTimeoutMs(sessionTimeoutMs), version);
 
-        ByteBuffer buffer = ByteBuffer.allocate(struct.sizeOf());
-        struct.writeTo(buffer);
-        buffer.flip();
-
-        JoinGroupRequest request = JoinGroupRequest.parse(buffer, (short) 0);
+        JoinGroupRequest request = JoinGroupRequest.parse(buffer, version);
         assertEquals(sessionTimeoutMs, request.data().sessionTimeoutMs());
         assertEquals(sessionTimeoutMs, request.data().rebalanceTimeoutMs());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -21,8 +21,8 @@ import org.apache.kafka.common.message.OffsetFetchResponseData;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartition;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.utils.Utils;
@@ -107,12 +107,13 @@ public class OffsetFetchResponseTest {
         OffsetFetchResponse latestResponse = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
 
         for (short version = 0; version <= ApiKeys.OFFSET_FETCH.latestVersion(); version++) {
-            Struct struct = latestResponse.data().toStruct(version);
+            OffsetFetchResponseData data = new OffsetFetchResponseData(
+                new ByteBufferAccessor(latestResponse.serialize(version)), version);
 
-            OffsetFetchResponse oldResponse = OffsetFetchResponse.parse(latestResponse.serialize(version), version);
+            OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
 
             if (version <= 1) {
-                assertFalse(struct.hasField(ERROR_CODE));
+                assertEquals(Errors.NONE.code(), data.errorCode());
 
                 // Partition level error populated in older versions.
                 assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, oldResponse.error());
@@ -120,7 +121,7 @@ public class OffsetFetchResponseTest {
                         Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)), oldResponse.errorCounts());
 
             } else {
-                assertTrue(struct.hasField(ERROR_CODE));
+                assertEquals(Errors.NONE.code(), data.errorCode());
 
                 assertEquals(Errors.NONE, oldResponse.error());
                 assertEquals(Utils.mkMap(
@@ -149,7 +150,7 @@ public class OffsetFetchResponseTest {
             Map<TopicPartition, PartitionData> responseData = oldResponse.responseData();
             assertEquals(expectedDataMap, responseData);
 
-            responseData.forEach((tp, data) -> assertTrue(data.hasError()));
+            responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -40,9 +40,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OffsetFetchResponseTest {
-
-    private static final String ERROR_CODE = "error_code";
-
     private final int throttleTimeMs = 10;
     private final int offset = 100;
     private final String metadata = "metadata";


### PR DESCRIPTION
Update few classes that were still using the removed methods (including
tests that are no longer required).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
