### PR TITLE
MINOR: set initial capacity of ArrayList for all json converters

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/JsonConverterGenerator.java
@@ -244,7 +244,7 @@ public final class JsonConverterGenerator implements MessageClassGenerator {
             buffer.decrementIndent();
             buffer.printf("}%n");
             String type = target.field().concreteJavaType(headerGenerator, structRegistry);
-            buffer.printf("%s _collection = new %s();%n", type, type);
+            buffer.printf("%s _collection = new %s(%s.size());%n", type, type, target.sourceVariable());
             buffer.printf("%s;%n", target.assignmentStatement("_collection"));
             headerGenerator.addImport(MessageGenerator.JSON_NODE_CLASS);
             buffer.printf("for (JsonNode _element : %s) {%n", target.sourceVariable());


### PR DESCRIPTION
the instance of ```JsonNode``` in this path must be ```ArrayNode``` so we can set initial capacity for all ```ArrayList```.


### BEFORE (AddPartitionsToTxnRequestDataJsonConverter.java)

```java
ArrayList<Integer> _collection = new ArrayList<Integer>();
_object.partitions = _collection;
for (JsonNode _element : _partitionsNode) {
    _collection.add(MessageUtil.jsonNodeToInt(_element, "AddPartitionsToTxnTopic element"));
}
```

### AFTER (AddPartitionsToTxnRequestDataJsonConverter.java)

```java
ArrayList<Integer> _collection = new ArrayList<Integer>(_partitionsNode.size());
_object.partitions = _collection;
for (JsonNode _element : _partitionsNode) {
    _collection.add(MessageUtil.jsonNodeToInt(_element, "AddPartitionsToTxnTopic element"));
}
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
