### PR TITLE
MINOR: Extract ApiVersions logic from the `SocketServer` to the `KafkaApis`

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -20,7 +20,6 @@ package kafka.network
 import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.util.concurrent._
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.Logger
 import com.yammer.metrics.core.Meter
@@ -34,6 +33,7 @@ import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData._
+import org.apache.kafka.common.network.ChannelMetadataRegistry
 import org.apache.kafka.common.network.Send
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, ObjectSerializationCache}
 import org.apache.kafka.common.requests._
@@ -86,6 +86,7 @@ object RequestChannel extends Logging {
                 val memoryPool: MemoryPool,
                 @volatile var buffer: ByteBuffer,
                 metrics: RequestChannel.Metrics,
+                val channelMetadataRegistry: ChannelMetadataRegistry,
                 val envelope: Option[RequestChannel.Request] = None) extends BaseRequest {
     // These need to be volatile because the readers are in the network thread and the writers are in the request
     // handler threads or the purgatory threads

--- a/core/src/main/scala/kafka/server/EnvelopeUtils.scala
+++ b/core/src/main/scala/kafka/server/EnvelopeUtils.scala
@@ -19,10 +19,10 @@ package kafka.server
 
 import java.net.{InetAddress, UnknownHostException}
 import java.nio.ByteBuffer
-
 import kafka.network.RequestChannel
 import org.apache.kafka.common.errors.{InvalidRequestException, PrincipalDeserializationException, UnsupportedVersionException}
 import org.apache.kafka.common.network.ClientInformation
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.requests.{EnvelopeRequest, RequestContext, RequestHeader}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 
@@ -90,6 +90,7 @@ object EnvelopeUtils {
         envelope.memoryPool,
         buffer,
         requestChannelMetrics,
+        new DefaultChannelMetadataRegistry,
         Some(envelope)
       )
     } catch {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -57,6 +57,7 @@ import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetFor
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData.{EpochEndOffset, OffsetForLeaderTopicResult, OffsetForLeaderTopicResultCollection}
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.ClientInformation
 import org.apache.kafka.common.network.{ListenerName, Send}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record._
@@ -1690,6 +1691,10 @@ class KafkaApis(val requestChannel: RequestChannel,
       } else if (!apiVersionRequest.isValid) {
         apiVersionRequest.getErrorResponse(requestThrottleMs, Errors.INVALID_REQUEST.exception)
       } else {
+        request.channelMetadataRegistry.registerClientInformation(new ClientInformation(
+          apiVersionRequest.data.clientSoftwareName,
+          apiVersionRequest.data.clientSoftwareVersion))
+
         apiVersionManager.apiVersionResponse(requestThrottleMs)
       }
     }

--- a/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestChannelTest.scala
@@ -22,7 +22,6 @@ import java.io.IOException
 import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.util.Collections
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import kafka.network
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
@@ -31,6 +30,7 @@ import org.apache.kafka.common.config.{ConfigResource, SaslConfigs, SslConfigs, 
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData
 import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData._
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.requests.AlterConfigsRequest._
@@ -198,7 +198,8 @@ class RequestChannelTest {
       startTimeNanos = 0,
       createNiceMock(classOf[MemoryPool]),
       buffer,
-      createNiceMock(classOf[RequestChannel.Metrics])
+      createNiceMock(classOf[RequestChannel.Metrics]),
+      new DefaultChannelMetadataRegistry
     )
   }
 

--- a/core/src/test/scala/unit/kafka/network/RequestConvertToJsonTest.scala
+++ b/core/src/test/scala/unit/kafka/network/RequestConvertToJsonTest.scala
@@ -19,12 +19,12 @@ package kafka.network
 
 import java.net.InetAddress
 import java.nio.ByteBuffer
-
 import com.fasterxml.jackson.databind.node.{BooleanNode, DoubleNode, JsonNodeFactory, LongNode, ObjectNode, TextNode}
 import kafka.network
 import kafka.network.RequestConvertToJson.requestHeaderNode
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message._
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.network.{ClientInformation, ListenerName, NetworkSend}
 import org.junit.jupiter.api.Test
 import org.apache.kafka.common.protocol.{ApiKeys, ByteBufferAccessor, ObjectSerializationCache}
@@ -179,7 +179,8 @@ class RequestConvertToJsonTest {
       startTimeNanos = 0,
       createNiceMock(classOf[MemoryPool]),
       buffer,
-      createNiceMock(classOf[RequestChannel.Metrics])
+      createNiceMock(classOf[RequestChannel.Metrics]),
+      new DefaultChannelMetadataRegistry
     )
   }
 

--- a/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
@@ -17,23 +17,34 @@
 
 package kafka.server
 
+import integration.kafka.server.IntegrationTestUtils
 import kafka.test.{ClusterConfig, ClusterInstance}
-import org.apache.kafka.common.message.ApiVersionsRequestData
-import org.apache.kafka.common.protocol.{ApiKeys, Errors}
-import org.apache.kafka.common.requests.ApiVersionsRequest
 import kafka.test.annotation.ClusterTest
 import kafka.test.junit.ClusterTestExtensions
+import kafka.network.Processor.ListenerMetricTag
+import kafka.network.Processor.NetworkProcessorMetricTag
+import kafka.utils.TestUtils
+import org.apache.kafka.common.message.ApiVersionsRequestData
+import org.apache.kafka.common.metrics.KafkaMetric
+import org.apache.kafka.common.network.ClientInformation.UNKNOWN_NAME_OR_VERSION
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 
+import scala.jdk.CollectionConverters._
 
 @ExtendWith(value = Array(classOf[ClusterTestExtensions]))
 class ApiVersionsRequestTest(cluster: ClusterInstance) extends AbstractApiVersionsRequestTest(cluster) {
 
   @BeforeEach
   def setup(config: ClusterConfig): Unit = {
-    super.brokerPropertyOverrides(config.serverProperties())
+    this.brokerPropertyOverrides(config.serverProperties())
+    // These configurations are set to make `testClientInformation` predictable.
+    config.serverProperties().put(KafkaConfig.NumIoThreadsProp, "1")
+    config.serverProperties().put(KafkaConfig.NumNetworkThreadsProp, "1")
   }
 
   @ClusterTest
@@ -54,33 +65,109 @@ class ApiVersionsRequestTest(cluster: ClusterInstance) extends AbstractApiVersio
   def testApiVersionsRequestWithUnsupportedVersion(): Unit = {
     val apiVersionsRequest = new ApiVersionsRequest.Builder().build()
     val apiVersionsResponse = sendUnsupportedApiVersionRequest(apiVersionsRequest)
-    assertEquals(Errors.UNSUPPORTED_VERSION.code(), apiVersionsResponse.data.errorCode())
-    assertFalse(apiVersionsResponse.data.apiKeys().isEmpty)
-    val apiVersion = apiVersionsResponse.data.apiKeys().find(ApiKeys.API_VERSIONS.id)
-    assertEquals(ApiKeys.API_VERSIONS.id, apiVersion.apiKey())
-    assertEquals(ApiKeys.API_VERSIONS.oldestVersion(), apiVersion.minVersion())
-    assertEquals(ApiKeys.API_VERSIONS.latestVersion(), apiVersion.maxVersion())
+    assertEquals(Errors.UNSUPPORTED_VERSION.code, apiVersionsResponse.data.errorCode)
+    assertFalse(apiVersionsResponse.data.apiKeys.isEmpty)
+    val apiVersion = apiVersionsResponse.data.apiKeys.find(ApiKeys.API_VERSIONS.id)
+    assertEquals(ApiKeys.API_VERSIONS.id, apiVersion.apiKey)
+    assertEquals(ApiKeys.API_VERSIONS.oldestVersion, apiVersion.minVersion)
+    assertEquals(ApiKeys.API_VERSIONS.latestVersion, apiVersion.maxVersion)
   }
 
   @ClusterTest
   def testApiVersionsRequestValidationV0(): Unit = {
-    val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0.asInstanceOf[Short])
+    val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0.toShort)
     val apiVersionsResponse = sendApiVersionsRequest(apiVersionsRequest, cluster.clientListener())
     validateApiVersionsResponse(apiVersionsResponse)
   }
 
   @ClusterTest
   def testApiVersionsRequestValidationV0ThroughControlPlaneListener(): Unit = {
-    val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0.asInstanceOf[Short])
+    val apiVersionsRequest = new ApiVersionsRequest.Builder().build(0.toShort)
     val apiVersionsResponse = sendApiVersionsRequest(apiVersionsRequest, super.controlPlaneListenerName)
     validateApiVersionsResponse(apiVersionsResponse)
   }
 
   @ClusterTest
-  def testApiVersionsRequestValidationV3(): Unit = {
-    // Invalid request because Name and Version are empty by default
-    val apiVersionsRequest = new ApiVersionsRequest(new ApiVersionsRequestData(), 3.asInstanceOf[Short])
-    val apiVersionsResponse = sendApiVersionsRequest(apiVersionsRequest, cluster.clientListener())
-    assertEquals(Errors.INVALID_REQUEST.code(), apiVersionsResponse.data.errorCode())
+  def testClientInformationValidation(): Unit = {
+    for (version <- ApiKeys.API_VERSIONS.oldestVersion to ApiKeys.API_VERSIONS.latestVersion) {
+      // Invalid request for any version >= 3 because Name and Version are empty by default
+      val apiVersionsRequest = new ApiVersionsRequest(
+        new ApiVersionsRequestData(),
+        version.toShort)
+      val apiVersionsResponse = sendApiVersionsRequest(apiVersionsRequest, cluster.clientListener())
+
+      if (version >= 3)
+        assertEquals(Errors.INVALID_REQUEST.code, apiVersionsResponse.data.errorCode)
+      else
+        assertEquals(Errors.NONE.code, apiVersionsResponse.data.errorCode)
+    }
+  }
+
+  @ClusterTest
+  def testClientInformation(): Unit = {
+    val softwareName = "name"
+    val softwareVersion = "version"
+
+    for (version <- ApiKeys.API_VERSIONS.oldestVersion to ApiKeys.API_VERSIONS.latestVersion) {
+      val socket = IntegrationTestUtils.connect(cluster.anyBrokerSocketServer(), cluster.clientListener())
+      waitClientInformation(UNKNOWN_NAME_OR_VERSION, UNKNOWN_NAME_OR_VERSION, 1)
+
+      try {
+        val apiVersionsRequest = new ApiVersionsRequest(
+          new ApiVersionsRequestData()
+            .setClientSoftwareName(softwareName)
+            .setClientSoftwareVersion(softwareVersion),
+          version.toShort)
+        val apiVersionsResponse = IntegrationTestUtils.sendAndReceive[ApiVersionsResponse](apiVersionsRequest, socket)
+        assertEquals(Errors.NONE.code, apiVersionsResponse.data.errorCode)
+
+        if (version >= 3) {
+          waitClientInformation(softwareName, softwareVersion, 1)
+          waitClientInformation(UNKNOWN_NAME_OR_VERSION, UNKNOWN_NAME_OR_VERSION, 0)
+        } else {
+          waitClientInformation(UNKNOWN_NAME_OR_VERSION, UNKNOWN_NAME_OR_VERSION, 1)
+        }
+      } finally socket.close()
+
+      if (version >= 3) {
+        waitClientInformation(softwareName, softwareVersion, 0)
+      }
+      waitClientInformation(UNKNOWN_NAME_OR_VERSION, UNKNOWN_NAME_OR_VERSION, 0)
+    }
+  }
+
+  private def waitClientInformation(
+    softwareName: String,
+    softwareVersion: String,
+    expectedCount: Int
+  ): Unit = {
+    TestUtils.retry(JTestUtils.DEFAULT_MAX_WAIT_MS) {
+      clientInformationMetric(softwareName, softwareVersion) match {
+        case Some(metric) =>
+          assertEquals(expectedCount, metric.metricValue())
+
+        case None =>
+          fail(s"Metric for '$softwareName' and '$softwareVersion' is not defined")
+      }
+    }
+  }
+
+  private def clientInformationMetric(
+    softwareName: String,
+    softwareVersion: String
+  ): Option[KafkaMetric] = {
+    val metrics = cluster.anyBrokerSocketServer().metrics
+    val tags = Map(
+      ListenerMetricTag -> cluster.clientListener().value,
+      NetworkProcessorMetricTag -> "1", // The harness is configured to have only one processor
+      "clientSoftwareName" -> softwareName,
+      "clientSoftwareVersion" -> softwareVersion
+    )
+    val metricName = metrics.metricName(
+      "connections",
+      "socket-server-metrics",
+      "The number of connections with this client and version.",
+      tags.asJava)
+    Option(metrics.metric(metricName))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseClientQuotaManagerTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.metrics.MetricConfig
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.ClientInformation
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.requests.{AbstractRequest, FetchRequest, RequestContext, RequestHeader, RequestTestUtils}
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
@@ -66,7 +67,7 @@ class BaseClientQuotaManagerTest {
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
       listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false)
     (request, new RequestChannel.Request(processor = 1, context = context, startTimeNanos =  0, MemoryPool.NONE, buffer,
-      requestChannelMetrics))
+      requestChannelMetrics, new DefaultChannelMetadataRegistry))
   }
 
   protected def buildSession(user: String): Session = {

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -21,7 +21,6 @@ import java.net.InetAddress
 import java.util
 import java.util.Properties
 import java.util.concurrent.ExecutionException
-
 import kafka.network.RequestChannel
 import kafka.raft.RaftManager
 import kafka.server.QuotaFactory.QuotaManagers
@@ -35,6 +34,7 @@ import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.message.DeleteTopicsRequestData.DeleteTopicState
 import org.apache.kafka.common.message.DeleteTopicsResponseData.DeletableTopicResult
 import org.apache.kafka.common.message.{BrokerRegistrationRequestData, DeleteTopicsRequestData}
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, BrokerRegistrationRequest, BrokerRegistrationResponse, RequestContext, RequestHeader, RequestTestUtils}
@@ -113,7 +113,7 @@ class ControllerApisTest {
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
       listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false)
     new RequestChannel.Request(processor = 1, context = context, startTimeNanos = 0, MemoryPool.NONE, buffer,
-      requestChannelMetrics)
+      requestChannelMetrics, new DefaultChannelMetadataRegistry)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -31,6 +31,7 @@ import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.message.{AlterConfigsResponseData, ApiVersionsResponseData}
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, AlterConfigsRequest, AlterConfigsResponse, EnvelopeRequest, EnvelopeResponse, RequestContext, RequestHeader, RequestTestUtils}
@@ -239,6 +240,7 @@ class ForwardingManagerTest {
       memoryPool = MemoryPool.NONE,
       buffer = requestBuffer,
       metrics = new RequestChannel.Metrics(ListenerType.CONTROLLER),
+      channelMetadataRegistry = new DefaultChannelMetadataRegistry,
       envelope = None
     )
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -23,7 +23,6 @@ import java.util
 import java.util.Arrays.asList
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Optional, Properties, Random}
-
 import kafka.api.{ApiVersion, KAFKA_0_10_2_IV0, KAFKA_2_2_IV1, LeaderAndIsr}
 import kafka.cluster.{Broker, Partition}
 import kafka.controller.{ControllerContext, KafkaController}
@@ -55,6 +54,7 @@ import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartit
 import org.apache.kafka.common.message.UpdateMetadataRequestData.{UpdateMetadataBroker, UpdateMetadataEndpoint, UpdateMetadataPartitionState}
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity}
@@ -3121,7 +3121,8 @@ class KafkaApisTest {
       startTimeNanos = time.nanoseconds(),
       memoryPool = MemoryPool.NONE,
       buffer = envelopeBuffer,
-      metrics = requestChannelMetrics
+      metrics = requestChannelMetrics,
+      channelMetadataRegistry = new DefaultChannelMetadataRegistry
     )
   }
 
@@ -3138,7 +3139,7 @@ class KafkaApisTest {
       listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, fromPrivilegedListener,
       Optional.of(kafkaPrincipalSerde))
     new RequestChannel.Request(processor = 1, context = context, startTimeNanos = 0, MemoryPool.NONE, buffer,
-      requestChannelMetrics, envelope = None)
+      requestChannelMetrics, new DefaultChannelMetadataRegistry, envelope = None)
   }
 
   private def expectNoThrottling(request: RequestChannel.Request): Capture[AbstractResponse] = {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataE
 import org.apache.kafka.common.message.UpdateMetadataRequestData.UpdateMetadataPartitionState;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.DefaultChannelMetadataRegistry;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.MetadataRequest;
@@ -207,7 +208,8 @@ public class MetadataRequestBenchmark {
         RequestContext context = new RequestContext(header, "1", null, principal,
             ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
             SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
-        return new RequestChannel.Request(1, context, 0, MemoryPool.NONE, bodyBuffer, requestChannelMetrics, Option.empty());
+        return new RequestChannel.Request(1, context, 0, MemoryPool.NONE, bodyBuffer,
+            requestChannelMetrics, new DefaultChannelMetadataRegistry(), Option.empty());
     }
 
     @Benchmark


### PR DESCRIPTION
When we implement KIP-511, we put the logic to extract the `SoftwareName` and the `SoftwareVersion` from the `ApiVersionsRequest` in the `SocketServer` to avoid having to wire the `ChannelMetadataRegistry` up to the `KafkaApis` layer. In retrospect, this was not a good idea because it spreads the logic to handle that request in multiple places. This patch is an attempt to move that logic to `KafkaApis`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
