### PR TITLE
MINOR: Fix meaningless message in assertNull validation

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -260,7 +260,7 @@ public abstract class AbstractKeyValueStoreTest {
         assertEquals("one", driver.flushedEntryStored(1));
         assertEquals("two", driver.flushedEntryStored(2));
         assertEquals("four", driver.flushedEntryStored(4));
-        assertNull(null, driver.flushedEntryStored(5));
+        assertNull(driver.flushedEntryStored(5));
 
         assertFalse(driver.flushedEntryRemoved(0));
         assertFalse(driver.flushedEntryRemoved(1));


### PR DESCRIPTION
*More detailed description of your change*

I think the author wants to say assertEquals(null, xxx)

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
