### PR TITLE
MINOR: Fix visibility of Log.{unflushedMessages, addSegment} methods

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1997,7 +1997,7 @@ class Log(@volatile private var _dir: File,
   /**
    * The number of messages appended to the log since the last flush
    */
-  def unflushedMessages: Long = this.logEndOffset - this.recoveryPoint
+  private def unflushedMessages: Long = this.logEndOffset - this.recoveryPoint
 
   /**
    * Flush all log segments
@@ -2372,7 +2372,7 @@ class Log(@volatile private var _dir: File,
    * @param segment The segment to add
    */
   @threadsafe
-  def addSegment(segment: LogSegment): LogSegment = this.segments.put(segment.baseOffset, segment)
+  private[log] def addSegment(segment: LogSegment): LogSegment = this.segments.put(segment.baseOffset, segment)
 
   private def maybeHandleIOException[T](msg: => String)(fun: => T): T = {
     try {


### PR DESCRIPTION
I've changed the visibility of the following methods, since these need not be `public` methods:
 * The method `Log.unflushedMessages` from public to private.
 * The method `Log.addSegment` from public to package private.

**Test plan:**
Rely on existing tests.