### PR TITLE
KAFKA-12236; New meta.properties logic for KIP-500

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -105,10 +105,18 @@ public class Uuid implements Comparable<Uuid> {
      * Creates a UUID based on a base64 string encoding used in the toString() method.
      */
     public static Uuid fromString(String str) {
+        if (str.length() > 24) {
+            throw new IllegalArgumentException("Input string with prefix `"
+                + str.substring(0, 24) + "` is too long to be decoded as a base64 UUID");
+        }
+
         ByteBuffer uuidBytes = ByteBuffer.wrap(Base64.getUrlDecoder().decode(str));
         if (uuidBytes.remaining() != 16) {
-            throw new IllegalArgumentException("Failed to parse `" + str + "` as a base64-encoded UUID");
+            throw new IllegalArgumentException("Input string `" + str + "` decoded as "
+                + uuidBytes.remaining() + " bytes, which is more than the expected 16 bytes "
+                + "of a base64-encoded UUID");
         }
+
         return new Uuid(uuidBytes.getLong(), uuidBytes.getLong());
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -113,7 +113,7 @@ public class Uuid implements Comparable<Uuid> {
         ByteBuffer uuidBytes = ByteBuffer.wrap(Base64.getUrlDecoder().decode(str));
         if (uuidBytes.remaining() != 16) {
             throw new IllegalArgumentException("Input string `" + str + "` decoded as "
-                + uuidBytes.remaining() + " bytes, which is more than the expected 16 bytes "
+                + uuidBytes.remaining() + " bytes, which is not equal to the expected 16 bytes "
                 + "of a base64-encoded UUID");
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -106,6 +106,9 @@ public class Uuid implements Comparable<Uuid> {
      */
     public static Uuid fromString(String str) {
         ByteBuffer uuidBytes = ByteBuffer.wrap(Base64.getUrlDecoder().decode(str));
+        if (uuidBytes.remaining() != 16) {
+            throw new IllegalArgumentException("Failed to parse `" + str + "` as a base64-encoded UUID");
+        }
         return new Uuid(uuidBytes.getLong(), uuidBytes.getLong());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/UuidTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/UuidTest.java
@@ -18,8 +18,11 @@ package org.apache.kafka.common;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Base64;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UuidTest {
 
@@ -94,4 +97,14 @@ public class UuidTest {
         assertEquals(-1, id01.compareTo(id10));
         assertEquals(1, id10.compareTo(id01));
     }
+
+    @Test
+    public void testFromStringWithInvalidInput() {
+        String oversizeString = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[32]);
+        assertThrows(IllegalArgumentException.class, () -> Uuid.fromString(oversizeString));
+
+        String undersizeString = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[4]);
+        assertThrows(IllegalArgumentException.class, () -> Uuid.fromString(undersizeString));
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/message/SimpleExampleMessageTest.java
@@ -229,13 +229,14 @@ public class SimpleExampleMessageTest {
     public void testTaggedUuid() {
         testRoundTrip(new SimpleExampleMessageData(),
             message -> assertEquals(
-                Uuid.fromString("212d54944a8b4fdf94b388b470beb367"),
+                Uuid.fromString("H3KKO4NTRPaCWtEmm3vW7A"),
                 message.taggedUuid()));
 
+        Uuid randomUuid = Uuid.randomUuid();
         testRoundTrip(new SimpleExampleMessageData().
-                setTaggedUuid(Uuid.fromString("0123456789abcdef0123456789abcdef")),
+                setTaggedUuid(randomUuid),
             message -> assertEquals(
-                Uuid.fromString("0123456789abcdef0123456789abcdef"),
+                randomUuid,
                 message.taggedUuid()));
     }
 

--- a/clients/src/test/resources/common/message/SimpleExampleMessage.json
+++ b/clients/src/test/resources/common/message/SimpleExampleMessage.json
@@ -30,7 +30,7 @@
     { "name": "myString", "type": "string", "taggedVersions": "1+", "tag": 4 },
     { "name": "myBytes", "type": "bytes",
         "nullableVersions": "1+", "taggedVersions": "1+", "tag": 5 },
-    { "name": "taggedUuid", "type": "uuid", "default": "212d54944a8b4fdf94b388b470beb367",
+    { "name": "taggedUuid", "type": "uuid", "default": "H3KKO4NTRPaCWtEmm3vW7A",
         "taggedVersions": "1+", "tag": 6 },
     { "name": "taggedLong", "type": "int64", "default": "0xcafcacafcacafca",
         "taggedVersions": "1+", "tag": 7 },

--- a/core/src/main/scala/kafka/common/InconsistentControllerIdException.scala
+++ b/core/src/main/scala/kafka/common/InconsistentControllerIdException.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.common
+
+class InconsistentControllerIdException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+  def this(cause: Throwable) = this(null, cause)
+  def this() = this(null, null)
+}

--- a/core/src/main/scala/kafka/common/InconsistentNodeIdException.scala
+++ b/core/src/main/scala/kafka/common/InconsistentNodeIdException.scala
@@ -17,8 +17,6 @@
 
 package kafka.common
 
-class InconsistentControllerIdException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
+class InconsistentNodeIdException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
   def this(message: String) = this(message, null)
-  def this(cause: Throwable) = this(null, cause)
-  def this() = this(null, null)
 }

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -95,7 +95,8 @@ private[raft] class RaftSendThread(
 class KafkaNetworkChannel(
   time: Time,
   client: KafkaClient,
-  requestTimeoutMs: Int
+  requestTimeoutMs: Int,
+  threadNamePrefix: String
 ) extends NetworkChannel with Logging {
   import KafkaNetworkChannel._
 
@@ -105,7 +106,7 @@ class KafkaNetworkChannel(
   private val endpoints = mutable.HashMap.empty[Int, Node]
 
   private val requestThread = new RaftSendThread(
-    name = "raft-outbound-request-thread",
+    name = threadNamePrefix + "-outbound-request-thread",
     networkClient = client,
     requestTimeoutMs = requestTimeoutMs,
     time = time,

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -21,38 +21,220 @@ import java.io._
 import java.nio.file.{Files, NoSuchFileException}
 import java.util.Properties
 
+import kafka.common.InconsistentBrokerMetadataException
+import kafka.server.KafkaRaftServer.{BrokerRole, ControllerRole, ProcessRole}
+import kafka.server.RawMetaProperties._
 import kafka.utils._
+import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 
-case class BrokerMetadata(brokerId: Int,
-                          clusterId: Option[String]) {
+import scala.collection.mutable
+import scala.jdk.CollectionConverters._
+
+object RawMetaProperties {
+  val ClusterIdKey = "cluster.id"
+  val BrokerIdKey = "broker.id"
+  val ControllerIdKey = "controller.id"
+  val VersionKey = "version"
+}
+
+case class RawMetaProperties(props: Properties = new Properties()) {
+
+  def clusterId: Option[String] = {
+    Option(props.getProperty(ClusterIdKey))
+  }
+
+  def clusterId_=(id: String): Unit = {
+    props.setProperty(ClusterIdKey, id)
+  }
+
+  def brokerId: Option[Int] = {
+    intValue(BrokerIdKey)
+  }
+
+  def brokerId_=(id: Int): Unit = {
+    props.setProperty(BrokerIdKey, id.toString)
+  }
+
+  def controllerId: Option[Int] = {
+    intValue(ControllerIdKey)
+  }
+
+  def controllerId_=(id: Int): Unit = {
+    props.setProperty(ControllerIdKey, id.toString)
+  }
+
+  def version: Int = {
+    intValue(VersionKey).getOrElse(0)
+  }
+
+  def version_=(ver: Int): Unit = {
+    props.setProperty(VersionKey, ver.toString)
+  }
+
+  def requireVersion(expectedVersion: Int): Unit = {
+    if (version != expectedVersion) {
+      throw new RuntimeException(s"Expected version $expectedVersion, but got "+
+        s"version $version")
+    }
+  }
+
+  private def intValue(key: String): Option[Int] = {
+    try {
+      Option(props.getProperty(key)).map(Integer.parseInt)
+    } catch {
+      case e: Throwable => throw new RuntimeException(s"Failed to parse $key property " +
+        s"as an int: ${e.getMessage}")
+    }
+  }
+
+  override def toString: String = {
+    "RawMetaProperties(" + props.keySet().asScala.toList.asInstanceOf[List[String]].sorted.map {
+      key => key + "=" + props.get(key)
+    }.mkString(", ") + ")"
+  }
+}
+
+object MetaProperties {
+  def parse(
+    properties: RawMetaProperties,
+    processRoles: Set[ProcessRole]
+  ): MetaProperties = {
+    properties.requireVersion(expectedVersion = 1)
+    val clusterId = requireClusterId(properties)
+
+    if (processRoles.contains(BrokerRole)) {
+      require(BrokerIdKey, properties.brokerId)
+    }
+
+    if (processRoles.contains(ControllerRole)) {
+      require(ControllerIdKey, properties.controllerId)
+    }
+
+    new MetaProperties(clusterId, properties.brokerId, properties.controllerId)
+  }
+
+  def require[T](key: String, value: Option[T]): T = {
+    value.getOrElse(throw new RuntimeException(s"Failed to find required property $key."))
+  }
+
+  def requireClusterId(properties: RawMetaProperties): Uuid = {
+    val value = require(ClusterIdKey, properties.clusterId)
+    try {
+      Uuid.fromString(value)
+    } catch {
+      case e: Throwable => throw new RuntimeException(s"Failed to parse $ClusterIdKey property " +
+        s"as a UUID: ${e.getMessage}")
+    }
+  }
+}
+
+case class ZkMetaProperties(
+  clusterId: String,
+  brokerId: Int
+) {
+  def toProperties: Properties = {
+    val properties = new RawMetaProperties()
+    properties.version = 0
+    properties.clusterId = clusterId
+    properties.brokerId = brokerId
+    properties.props
+  }
+
+  override def toString: String = {
+    s"LegacyMetaProperties(brokerId=$brokerId, clusterId=$clusterId)"
+  }
+}
+
+case class MetaProperties(
+  clusterId: Uuid,
+  brokerId: Option[Int] = None,
+  controllerId: Option[Int] = None
+) {
+  def toProperties: Properties = {
+    val properties = new RawMetaProperties()
+    properties.version = 1
+    properties.clusterId = clusterId.toString
+    brokerId.foreach(properties.brokerId = _)
+    controllerId.foreach(properties.controllerId = _)
+    properties.props
+  }
 
   override def toString: String  = {
-    s"BrokerMetadata(brokerId=$brokerId, clusterId=${clusterId.map(_.toString).getOrElse("None")})"
+    s"MetaProperties(clusterId=$clusterId" +
+      s", brokerId=${brokerId.getOrElse("none")}" +
+      s", controllerId=${controllerId.getOrElse("none")}" +
+      ")"
+  }
+}
+
+object BrokerMetadataCheckpoint extends Logging {
+  def getBrokerMetadataAndOfflineDirs(
+    logDirs: collection.Seq[String],
+    ignoreMissing: Boolean
+  ): (RawMetaProperties, collection.Seq[String]) = {
+    require(logDirs.nonEmpty, "Must have at least one log dir to read meta.properties")
+
+    val brokerMetadataMap = mutable.HashMap[String, Properties]()
+    val offlineDirs = mutable.ArrayBuffer.empty[String]
+
+    for (logDir <- logDirs) {
+      val brokerCheckpointFile = new File(logDir + File.separator + "meta.properties")
+      val brokerCheckpoint = new BrokerMetadataCheckpoint(brokerCheckpointFile)
+
+      try {
+        brokerCheckpoint.read() match {
+          case Some(properties) => brokerMetadataMap += logDir -> properties
+          case None => if (ignoreMissing) {
+            logDir -> new Properties()
+          } else {
+            throw new IOException("Not found")
+          }
+        }
+      } catch {
+        case e: IOException =>
+          offlineDirs += logDir
+          error(s"Fail to read $brokerCheckpointFile", e)
+      }
+    }
+
+    if (brokerMetadataMap.isEmpty) {
+      (new RawMetaProperties(), offlineDirs)
+    } else {
+      val numDistinctMetaProperties = brokerMetadataMap.values.toSet.size
+      if (numDistinctMetaProperties > 1) {
+        val builder = new StringBuilder
+
+        for ((logDir, brokerMetadata) <- brokerMetadataMap)
+          builder ++= s"- $logDir -> $brokerMetadata\n"
+
+        throw new InconsistentBrokerMetadataException(
+          s"BrokerMetadata is not consistent across log.dirs. This could happen if multiple brokers shared a log directory (log.dirs) " +
+            s"or partial data was manually copied from another broker. Found:\n${builder.toString()}"
+        )
+      }
+
+      val rawProps = new RawMetaProperties(brokerMetadataMap.head._2)
+      (rawProps, offlineDirs)
+    }
   }
 }
 
 /**
-  * This class saves broker's metadata to a file
-  */
+ * This class saves the metadata properties to a file
+ */
 class BrokerMetadataCheckpoint(val file: File) extends Logging {
   private val lock = new Object()
 
-  def write(brokerMetadata: BrokerMetadata) = {
+  def write(properties: Properties): Unit = {
     lock synchronized {
       try {
-        val brokerMetaProps = new Properties()
-        brokerMetaProps.setProperty("version", 0.toString)
-        brokerMetaProps.setProperty("broker.id", brokerMetadata.brokerId.toString)
-        brokerMetadata.clusterId.foreach { clusterId =>
-          brokerMetaProps.setProperty("cluster.id", clusterId)
-        }
         val temp = new File(file.getAbsolutePath + ".tmp")
         val fileOutputStream = new FileOutputStream(temp)
         try {
-          brokerMetaProps.store(fileOutputStream, "")
+          properties.store(fileOutputStream, "")
           fileOutputStream.flush()
-          fileOutputStream.getFD().sync()
+          fileOutputStream.getFD.sync()
         } finally {
           Utils.closeQuietly(fileOutputStream, temp.getName)
         }
@@ -65,28 +247,20 @@ class BrokerMetadataCheckpoint(val file: File) extends Logging {
     }
   }
 
-  def read(): Option[BrokerMetadata] = {
-    Files.deleteIfExists(new File(file.getPath + ".tmp").toPath()) // try to delete any existing temp files for cleanliness
+  def read(): Option[Properties] = {
+    Files.deleteIfExists(new File(file.getPath + ".tmp").toPath) // try to delete any existing temp files for cleanliness
 
+    val absolutePath = file.getAbsolutePath
     lock synchronized {
       try {
-        val brokerMetaProps = new VerifiableProperties(Utils.loadProps(file.getAbsolutePath()))
-        val version = brokerMetaProps.getIntInRange("version", (0, Int.MaxValue))
-        version match {
-          case 0 =>
-            val brokerId = brokerMetaProps.getIntInRange("broker.id", (0, Int.MaxValue))
-            val clusterId = Option(brokerMetaProps.getString("cluster.id", null))
-            return Some(BrokerMetadata(brokerId, clusterId))
-          case _ =>
-            throw new IOException("Unrecognized version of the server meta.properties file: " + version)
-        }
+        Some(Utils.loadProps(absolutePath))
       } catch {
         case _: NoSuchFileException =>
-          warn("No meta.properties file under dir %s".format(file.getAbsolutePath()))
+          warn(s"No meta.properties file under dir $absolutePath")
           None
-        case e1: Exception =>
-          error("Failed to read meta.properties file under dir %s due to %s".format(file.getAbsolutePath(), e1.getMessage))
-          throw e1
+        case e: Exception =>
+          error(s"Failed to read meta.properties file under dir $absolutePath", e)
+          throw e
       }
     }
   }

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -37,7 +37,7 @@ object RawMetaProperties {
   val VersionKey = "version"
 }
 
-case class RawMetaProperties(props: Properties = new Properties()) {
+class RawMetaProperties(props: Properties = new Properties()) {
 
   def clusterId: Option[String] = {
     Option(props.getProperty(ClusterIdKey))

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -37,7 +37,7 @@ object RawMetaProperties {
   val VersionKey = "version"
 }
 
-class RawMetaProperties(props: Properties = new Properties()) {
+class RawMetaProperties(val props: Properties = new Properties()) {
 
   def clusterId: Option[String] = {
     Option(props.getProperty(ClusterIdKey))

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -71,6 +71,9 @@ object Defaults {
   val QueuedMaxRequests = 500
   val QueuedMaxRequestBytes = -1
 
+  /** KIP-500 Configuration */
+  val ControllerId = -1
+
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""
 
@@ -363,7 +366,11 @@ object KafkaConfig {
   val RequestTimeoutMsProp = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG
   val ConnectionSetupTimeoutMsProp = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG
   val ConnectionSetupTimeoutMaxMsProp = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG
+
+  /** KIP-500 Configuration */
   val ProcessRolesProp = "process.roles"
+  val ControllerIdProp = "controller.id"
+  val MetadataLogDirProp = "metadata.log.dir"
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameProp = "authorizer.class.name"
@@ -647,9 +654,16 @@ object KafkaConfig {
   val RequestTimeoutMsDoc = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC
   val ConnectionSetupTimeoutMsDoc = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_DOC
   val ConnectionSetupTimeoutMaxMsDoc = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_DOC
+
+  /** KIP-500 Config Documentation */
   val ProcessRolesDoc = "The roles that this process plays: 'broker', 'controller', or 'broker,controller' if it is both. " +
     "This configuration is only for clusters upgraded for KIP-500, which replaces the dependence on Zookeeper with " +
     "a self-managed Raft quorum. Leave this config undefined or empty for Zookeeper clusters."
+  val ControllerIdDoc = "The controller id for this server. This must be set to a non-negative number when running " +
+    "as a KIP-500 controller. Controller IDs should not overlap with broker IDs."
+  val MetadataLogDirDoc = "This configuration determines where we put the metadata log for clusters upgraded to " +
+    "KIP-500. If it is not set, the metadata log is placed in the first log directory from log.dirs."
+
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameDoc = s"The fully qualified name of a class that implements s${classOf[Authorizer].getName}" +
   " interface, which is used by the broker for authorization. This config also supports authorizers that implement the deprecated" +
@@ -1043,7 +1057,14 @@ object KafkaConfig {
       .define(RequestTimeoutMsProp, INT, Defaults.RequestTimeoutMs, HIGH, RequestTimeoutMsDoc)
       .define(ConnectionSetupTimeoutMsProp, LONG, Defaults.ConnectionSetupTimeoutMs, MEDIUM, ConnectionSetupTimeoutMsDoc)
       .define(ConnectionSetupTimeoutMaxMsProp, LONG, Defaults.ConnectionSetupTimeoutMaxMs, MEDIUM, ConnectionSetupTimeoutMaxMsDoc)
+
+      /*
+       * KIP-500 Configuration. Note that these configs are defined as internal. We will make
+       * them public once we are ready to enable KIP-500 in a release.
+       */
       .defineInternal(ProcessRolesProp, LIST, Collections.emptyList(), ValidList.in("broker", "controller"), HIGH, ProcessRolesDoc)
+      .defineInternal(ControllerIdProp, INT, Defaults.ControllerId, null, HIGH, ControllerIdDoc)
+      .defineInternal(MetadataLogDirProp, STRING, null, null, HIGH, MetadataLogDirDoc)
 
       /************* Authorizer Configuration ***********/
       .define(AuthorizerClassNameProp, STRING, Defaults.AuthorizerClassName, LOW, AuthorizerClassNameDoc)
@@ -1474,7 +1495,8 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val brokerIdGenerationEnable: Boolean = getBoolean(KafkaConfig.BrokerIdGenerationEnableProp)
   val maxReservedBrokerId: Int = getInt(KafkaConfig.MaxReservedBrokerIdProp)
   var brokerId: Int = getInt(KafkaConfig.BrokerIdProp)
-  val processRoles = parseProcessRoles()
+  val controllerId: Int = getInt(KafkaConfig.ControllerIdProp)
+  val processRoles: Set[ProcessRole] = parseProcessRoles()
 
   def requiresZookeeper: Boolean = processRoles.isEmpty
 
@@ -1493,6 +1515,13 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
     }
 
     distinctRoles
+  }
+
+  def metadataLogDir: String = {
+    Option(getString(KafkaConfig.MetadataLogDirProp)) match {
+      case Some(dir) => dir
+      case None => logDirs.head
+    }
   }
 
   def numNetworkThreads = getInt(KafkaConfig.NumNetworkThreadsProp)

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -16,7 +16,7 @@
  */
 package kafka.server
 
-import kafka.common.{InconsistentBrokerIdException, InconsistentControllerIdException}
+import kafka.common.{InconsistentBrokerIdException, InconsistentControllerIdException, KafkaException}
 import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}
 import kafka.raft.KafkaRaftManager
 import kafka.server.KafkaRaftServer.{BrokerRole, ControllerRole}
@@ -106,12 +106,12 @@ object KafkaRaftServer {
   case object ControllerRole extends ProcessRole
 
   def loadMetaProperties(config: KafkaConfig): (MetaProperties, Seq[String]) = {
-    val logDirs = config.logDirs ++ Seq(config.metadataLogDir)
+    val logDirs = config.logDirs :+ config.metadataLogDir
     val (rawMetaProperties, offlineDirs) = BrokerMetadataCheckpoint.
       getBrokerMetadataAndOfflineDirs(logDirs, ignoreMissing = false)
 
     if (offlineDirs.contains(config.metadataLogDir)) {
-      throw new RuntimeException("Cannot start server since `meta.properties` could not be " +
+      throw new KafkaException("Cannot start server since `meta.properties` could not be " +
         s"loaded from ${config.metadataLogDir}")
     }
 

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -18,7 +18,7 @@ package kafka.server
 
 import java.io.File
 
-import kafka.common.{InconsistentBrokerIdException, InconsistentControllerIdException, KafkaException}
+import kafka.common.{InconsistentNodeIdException, KafkaException}
 import kafka.log.Log
 import kafka.metrics.{KafkaMetricsReporter, KafkaYammerMetrics}
 import kafka.raft.KafkaRaftManager
@@ -137,20 +137,10 @@ object KafkaRaftServer {
       }
     }
 
-    val metaProperties = MetaProperties.parse(rawMetaProperties, config.processRoles)
-
-    val configuredBrokerId = if (config.brokerId < 0) None else Some(config.brokerId)
-    if (configuredBrokerId != metaProperties.brokerId) {
-      throw new InconsistentBrokerIdException(
-        s"Configured broker.id ${config.brokerId} doesn't match stored broker.id ${metaProperties.brokerId} in " +
-          "meta.properties. If you moved your data, make sure your configured broker.id matches. " +
-          "If you intend to create a new broker, you should remove all data in your data directories (log.dirs).")
-    }
-
-    val configuredControllerId = if (config.controllerId < 0) None else Some(config.controllerId)
-    if (configuredControllerId != metaProperties.controllerId) {
-      throw new InconsistentControllerIdException(
-        s"Configured controller.id ${config.controllerId} doesn't match stored controller.id ${metaProperties.controllerId} in " +
+    val metaProperties = MetaProperties.parse(rawMetaProperties)
+    if (config.nodeId != metaProperties.nodeId) {
+      throw new InconsistentNodeIdException(
+        s"Configured node.id `${config.nodeId}` doesn't match stored node.id `${metaProperties.nodeId}' in " +
           "meta.properties. If you moved your data, make sure your configured controller.id matches. " +
           "If you intend to create a new broker, you should remove all data in your data directories (log.dirs).")
     }

--- a/core/src/main/scala/kafka/server/KafkaRaftServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaRaftServer.scala
@@ -52,7 +52,7 @@ class KafkaRaftServer(
   private val metrics = Server.initializeMetrics(
     config,
     time,
-    metaProps
+    metaProps.clusterId.toString
   )
 
   private val raftManager = new KafkaRaftManager(

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import kafka.api.{KAFKA_0_9_0, KAFKA_2_2_IV0, KAFKA_2_4_IV1}
 import kafka.cluster.Broker
-import kafka.common.{GenerateBrokerIdException, InconsistentBrokerIdException, InconsistentBrokerMetadataException, InconsistentClusterIdException}
+import kafka.common.{GenerateBrokerIdException, InconsistentBrokerIdException, InconsistentClusterIdException}
 import kafka.controller.KafkaController
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
@@ -49,7 +49,7 @@ import org.apache.kafka.common.{ClusterResource, Endpoint, Node}
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.zookeeper.client.ZKClientConfig
 
-import scala.collection.{Map, Seq, mutable}
+import scala.collection.{Map, Seq}
 import scala.jdk.CollectionConverters._
 
 object KafkaServer {
@@ -144,7 +144,9 @@ class KafkaServer(
 
   val correlationId: AtomicInteger = new AtomicInteger(0)
   val brokerMetaPropsFile = "meta.properties"
-  val brokerMetadataCheckpoints = config.logDirs.map(logDir => (logDir, new BrokerMetadataCheckpoint(new File(logDir + File.separator + brokerMetaPropsFile)))).toMap
+  val brokerMetadataCheckpoints = config.logDirs.map { logDir =>
+    (logDir, new BrokerMetadataCheckpoint(new File(logDir + File.separator + brokerMetaPropsFile)))
+  }.toMap
 
   private var _clusterId: String = null
   private var _brokerTopicStats: BrokerTopicStats = null
@@ -207,7 +209,14 @@ class KafkaServer(
         info(s"Cluster ID = $clusterId")
 
         /* load metadata */
-        val (preloadedBrokerMetadataCheckpoint, initialOfflineDirs) = getBrokerMetadataAndOfflineDirs
+        val (preloadedBrokerMetadataCheckpoint, initialOfflineDirs) =
+          BrokerMetadataCheckpoint.getBrokerMetadataAndOfflineDirs(config.logDirs, ignoreMissing = true)
+
+        if (preloadedBrokerMetadataCheckpoint.version != 0) {
+          throw new RuntimeException(s"Found unexpected version in loaded `meta.properties`: " +
+            s"$preloadedBrokerMetadataCheckpoint. Zk-based brokers only support version 0 " +
+            "(which is implicit when the `version` field is missing).")
+        }
 
         /* check cluster id */
         if (preloadedBrokerMetadataCheckpoint.clusterId.isDefined && preloadedBrokerMetadataCheckpoint.clusterId.get != clusterId)
@@ -284,7 +293,7 @@ class KafkaServer(
         val brokerEpoch = zkClient.registerBroker(brokerInfo)
 
         // Now that the broker is successfully registered, checkpoint its metadata
-        checkpointBrokerMetadata(BrokerMetadata(config.brokerId, Some(clusterId)))
+        checkpointBrokerMetadata(ZkMetaProperties(clusterId, config.brokerId))
 
         /* start token manager */
         tokenManager = new DelegationTokenManager(config, tokenCache, time , zkClient)
@@ -743,58 +752,14 @@ class KafkaServer(
   def boundPort(listenerName: ListenerName): Int = socketServer.boundPort(listenerName)
 
   /**
-   * Reads the BrokerMetadata. If the BrokerMetadata doesn't match in all the log.dirs, InconsistentBrokerMetadataException is
-   * thrown.
-   *
-   * The log directories whose meta.properties can not be accessed due to IOException will be returned to the caller
-   *
-   * @return A 2-tuple containing the brokerMetadata and a sequence of offline log directories.
-   */
-  private def getBrokerMetadataAndOfflineDirs: (BrokerMetadata, Seq[String]) = {
-    val brokerMetadataMap = mutable.HashMap[String, BrokerMetadata]()
-    val brokerMetadataSet = mutable.HashSet[BrokerMetadata]()
-    val offlineDirs = mutable.ArrayBuffer.empty[String]
-
-    for (logDir <- config.logDirs) {
-      try {
-        val brokerMetadataOpt = brokerMetadataCheckpoints(logDir).read()
-        brokerMetadataOpt.foreach { brokerMetadata =>
-          brokerMetadataMap += (logDir -> brokerMetadata)
-          brokerMetadataSet += brokerMetadata
-        }
-      } catch {
-        case e: IOException =>
-          offlineDirs += logDir
-          error(s"Fail to read $brokerMetaPropsFile under log directory $logDir", e)
-      }
-    }
-
-    if (brokerMetadataSet.size > 1) {
-      val builder = new StringBuilder
-
-      for ((logDir, brokerMetadata) <- brokerMetadataMap)
-        builder ++= s"- $logDir -> $brokerMetadata\n"
-
-      throw new InconsistentBrokerMetadataException(
-        s"BrokerMetadata is not consistent across log.dirs. This could happen if multiple brokers shared a log directory (log.dirs) " +
-        s"or partial data was manually copied from another broker. Found:\n${builder.toString()}"
-      )
-    } else if (brokerMetadataSet.size == 1)
-      (brokerMetadataSet.last, offlineDirs)
-    else
-      (BrokerMetadata(-1, None), offlineDirs)
-  }
-
-
-  /**
    * Checkpoint the BrokerMetadata to all the online log.dirs
    *
    * @param brokerMetadata
    */
-  private def checkpointBrokerMetadata(brokerMetadata: BrokerMetadata) = {
+  private def checkpointBrokerMetadata(brokerMetadata: ZkMetaProperties) = {
     for (logDir <- config.logDirs if logManager.isLogDirOnline(new File(logDir).getAbsolutePath)) {
       val checkpoint = brokerMetadataCheckpoints(logDir)
-      checkpoint.write(brokerMetadata)
+      checkpoint.write(brokerMetadata.toProperties)
     }
   }
 
@@ -808,18 +773,18 @@ class KafkaServer(
    *
    * @return The brokerId.
    */
-  private def getOrGenerateBrokerId(brokerMetadata: BrokerMetadata): Int = {
+  private def getOrGenerateBrokerId(brokerMetadata: RawMetaProperties): Int = {
     val brokerId = config.brokerId
 
-    if (brokerId >= 0 && brokerMetadata.brokerId >= 0 && brokerMetadata.brokerId != brokerId)
+    if (brokerId >= 0 && brokerMetadata.brokerId.exists(_ != brokerId))
       throw new InconsistentBrokerIdException(
         s"Configured broker.id $brokerId doesn't match stored broker.id ${brokerMetadata.brokerId} in meta.properties. " +
-        s"If you moved your data, make sure your configured broker.id matches. " +
-        s"If you intend to create a new broker, you should remove all data in your data directories (log.dirs).")
-    else if (brokerMetadata.brokerId < 0 && brokerId < 0 && config.brokerIdGenerationEnable) // generate a new brokerId from Zookeeper
-      generateBrokerId
-    else if (brokerMetadata.brokerId >= 0) // pick broker.id from meta.properties
-      brokerMetadata.brokerId
+          s"If you moved your data, make sure your configured broker.id matches. " +
+          s"If you intend to create a new broker, you should remove all data in your data directories (log.dirs).")
+    else if (brokerMetadata.brokerId.isDefined)
+      brokerMetadata.brokerId.get
+    else if (brokerId < 0 && config.brokerIdGenerationEnable) // generate a new brokerId from Zookeeper
+      generateBrokerId()
     else
       brokerId
   }
@@ -829,7 +794,7 @@ class KafkaServer(
     * Users can provide brokerId in the config. To avoid conflicts between ZK generated
     * sequence id and configured brokerId, we increment the generated sequence id by KafkaConfig.MaxReservedBrokerId.
     */
-  private def generateBrokerId: Int = {
+  private def generateBrokerId(): Int = {
     try {
       zkClient.generateBrokerSequenceId() + config.maxReservedBrokerId
     } catch {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -403,7 +403,7 @@ class KafkaServer(
   }
 
   private[server] def notifyMetricsReporters(metricsReporters: Seq[AnyRef]): Unit = {
-    val metricsContext = Server.createKafkaMetricsContext(clusterId, config)
+    val metricsContext = Server.createKafkaMetricsContext(config, clusterId)
     metricsReporters.foreach {
       case x: MetricsReporter => x.contextChange(metricsContext)
       case _ => //do nothing

--- a/core/src/main/scala/kafka/server/Server.scala
+++ b/core/src/main/scala/kafka/server/Server.scala
@@ -74,15 +74,14 @@ object Server {
   val MetricsPrefix: String = "kafka.server"
   private val ClusterIdLabel: String = "kafka.cluster.id"
   private val BrokerIdLabel: String = "kafka.broker.id"
-  private val ControllerIdLabel: String = "kafka.controller.id"
+  private val NodeIdLabel: String = "kafka.node.id"
 
   private[server] def createKafkaMetricsContext(
     config: KafkaConfig,
     metaProps: MetaProperties
   ): KafkaMetricsContext = {
     val contextLabels = new java.util.HashMap[String, Object]
-    metaProps.brokerId.foreach(id => contextLabels.put(BrokerIdLabel, id.toString))
-    metaProps.controllerId.foreach(id => contextLabels.put(ControllerIdLabel, id.toString))
+    contextLabels.put(NodeIdLabel, metaProps.nodeId.toString)
     contextLabels.putAll(config.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX))
     val metricsContext = new KafkaMetricsContext(MetricsPrefix, contextLabels)
     metricsContext

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -24,7 +24,7 @@ import joptsimple.OptionException
 import kafka.network.SocketServer
 import kafka.raft.{KafkaRaftManager, RaftManager}
 import kafka.security.CredentialProvider
-import kafka.server.{KafkaConfig, KafkaRequestHandlerPool}
+import kafka.server.{KafkaConfig, KafkaRequestHandlerPool, MetaProperties}
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, CoreUtils, Exit, Logging, ShutdownableThread}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.stats.Percentiles.BucketSizing
@@ -33,7 +33,7 @@ import org.apache.kafka.common.protocol.Writable
 import org.apache.kafka.common.security.scram.internals.ScramMechanism
 import org.apache.kafka.common.security.token.delegation.internals.DelegationTokenCache
 import org.apache.kafka.common.utils.{Time, Utils}
-import org.apache.kafka.common.{TopicPartition, protocol}
+import org.apache.kafka.common.{TopicPartition, Uuid, protocol}
 import org.apache.kafka.raft.BatchReader.Batch
 import org.apache.kafka.raft.{BatchReader, RaftClient, RecordSerde}
 
@@ -54,6 +54,7 @@ class TestRaftServer(
   private val time = Time.SYSTEM
   private val metrics = new Metrics(time)
   private val shutdownLatch = new CountDownLatch(1)
+  private val threadNamePrefix = "test-raft"
 
   var socketServer: SocketServer = _
   var credentialProvider: CredentialProvider = _
@@ -69,13 +70,20 @@ class TestRaftServer(
     socketServer = new SocketServer(config, metrics, time, credentialProvider, allowControllerOnlyApis = true)
     socketServer.startup(startProcessingRequests = false)
 
+    val metaProperties = MetaProperties(
+      clusterId = Uuid.ZERO_UUID,
+      brokerId = Some(config.brokerId),
+      controllerId = None
+    )
+
     raftManager = new KafkaRaftManager[Array[Byte]](
+      metaProperties,
       config,
-      config.logDirs.head,
       new ByteArraySerde,
       partition,
       time,
-      metrics
+      metrics,
+      Some(threadNamePrefix)
     )
 
     workloadGenerator = new RaftWorkloadGenerator(

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -72,8 +72,7 @@ class TestRaftServer(
 
     val metaProperties = MetaProperties(
       clusterId = Uuid.ZERO_UUID,
-      brokerId = Some(config.brokerId),
-      controllerId = None
+      nodeId = config.nodeId
     )
 
     raftManager = new KafkaRaftManager[Array[Byte]](

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -15,7 +15,6 @@ package kafka.server
 import java.io.File
 import java.util.Properties
 
-import kafka.server.KafkaRaftServer.{BrokerRole, ControllerRole}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.test.TestUtils
@@ -66,11 +65,10 @@ class BrokerMetadataCheckpointTest {
   def testCreateMetadataProperties(): Unit = {
     val meta = MetaProperties(
       clusterId = Uuid.fromString("H3KKO4NTRPaCWtEmm3vW7A"),
-      brokerId = Some(5),
-      controllerId = None
+      nodeId = 5
     )
     val properties = RawMetaProperties(meta.toProperties)
-    val meta2 = MetaProperties.parse(properties, Set(BrokerRole))
+    val meta2 = MetaProperties.parse(properties)
     assertEquals(meta, meta2)
   }
 
@@ -78,8 +76,8 @@ class BrokerMetadataCheckpointTest {
   def testMetaPropertiesWithMissingVersion(): Unit = {
     val properties = RawMetaProperties()
     properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
-    properties.brokerId = 1
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+    properties.nodeId = 1
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 
   @Test
@@ -87,8 +85,8 @@ class BrokerMetadataCheckpointTest {
     val properties = RawMetaProperties()
     properties.version = 1
     properties.clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492"
-    properties.brokerId = 1
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+    properties.nodeId = 1
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 
   @Test
@@ -96,8 +94,8 @@ class BrokerMetadataCheckpointTest {
     val properties = RawMetaProperties()
     properties.version = 1
     properties.clusterId = "not a valid uuid"
-    properties.brokerId = 1
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+    properties.nodeId = 1
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 
   @Test
@@ -105,7 +103,7 @@ class BrokerMetadataCheckpointTest {
     val properties = RawMetaProperties()
     properties.version = 1
     properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 
   @Test
@@ -113,7 +111,7 @@ class BrokerMetadataCheckpointTest {
     val properties = RawMetaProperties()
     properties.version = 1
     properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(ControllerRole)))
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 
   @Test

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -13,28 +13,53 @@
 package kafka.server
 
 import java.io.File
+import java.util.Properties
 
-import kafka.server.KafkaRaftServer.BrokerRole
+import kafka.server.KafkaRaftServer.{BrokerRole, ControllerRole}
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.test.TestUtils
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 class BrokerMetadataCheckpointTest {
+
   @Test
   def testReadWithNonExistentFile(): Unit = {
     assertEquals(None, new BrokerMetadataCheckpoint(new File("path/that/does/not/exist")).read())
   }
 
   @Test
-  def testCreateLegacyMetadataProperties(): Unit = {
+  def testCreateZkMetadataProperties(): Unit = {
     val meta = ZkMetaProperties("7bc79ca1-9746-42a3-a35a-efb3cde44492", 3)
     val properties = meta.toProperties
     val parsed = RawMetaProperties(properties)
     assertEquals(0, parsed.version)
     assertEquals(Some(meta.clusterId), parsed.clusterId)
     assertEquals(Some(meta.brokerId), parsed.brokerId)
+  }
+
+  @Test
+  def testParseRawMetaPropertiesWithoutVersion(): Unit = {
+    val brokerId = 1
+    val clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492"
+
+    val properties = new Properties()
+    properties.put(RawMetaProperties.BrokerIdKey, brokerId.toString)
+    properties.put(RawMetaProperties.ClusterIdKey, clusterId)
+
+    val parsed = RawMetaProperties(properties)
+    assertEquals(Some(brokerId), parsed.brokerId)
+    assertEquals(Some(clusterId), parsed.clusterId)
+    assertEquals(0, parsed.version)
+  }
+
+  @Test
+  def testRawPropertiesWithInvalidBrokerId(): Unit = {
+    val properties = new Properties()
+    properties.put(RawMetaProperties.BrokerIdKey, "oof")
+    val parsed = RawMetaProperties(properties)
+    assertThrows(classOf[RuntimeException], () => parsed.brokerId)
   }
 
   @Test
@@ -50,10 +75,43 @@ class BrokerMetadataCheckpointTest {
   }
 
   @Test
+  def testMetaPropertiesWithMissingVersion(): Unit = {
+    val properties = RawMetaProperties()
+    properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    properties.brokerId = 1
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+  }
+
+  @Test
+  def testMetaPropertiesWithInvalidClusterId(): Unit = {
+    val properties = RawMetaProperties()
+    properties.version = 1
+    properties.clusterId = "not a valid uuid"
+    properties.brokerId = 1
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+  }
+
+  @Test
+  def testMetaPropertiesWithMissingBrokerId(): Unit = {
+    val properties = RawMetaProperties()
+    properties.version = 1
+    properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+  }
+
+  @Test
+  def testMetaPropertiesWithMissingControllerId(): Unit = {
+    val properties = RawMetaProperties()
+    properties.version = 1
+    properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(ControllerRole)))
+  }
+
+  @Test
   def testGetBrokerMetadataAndOfflineDirsWithNonexistentDirectories(): Unit = {
     val tempDir = TestUtils.tempDirectory()
     try {
-      assertEquals((new RawMetaProperties(), Seq(tempDir.getAbsolutePath.toString())),
+      assertEquals((new RawMetaProperties(), Seq(tempDir.getAbsolutePath)),
         BrokerMetadataCheckpoint.getBrokerMetadataAndOfflineDirs(
           Seq(tempDir.getAbsolutePath), false))
       assertEquals((new RawMetaProperties(), Seq()),

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -83,6 +83,15 @@ class BrokerMetadataCheckpointTest {
   }
 
   @Test
+  def testMetaPropertiesDoesNotAllowHexEncodedUUIDs(): Unit = {
+    val properties = RawMetaProperties()
+    properties.version = 1
+    properties.clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492"
+    properties.brokerId = 1
+    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties, Set(BrokerRole)))
+  }
+
+  @Test
   def testMetaPropertiesWithInvalidClusterId(): Unit = {
     val properties = RawMetaProperties()
     properties.version = 1

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -41,7 +41,7 @@ class KafkaNetworkChannelTest {
   private val time = new MockTime()
   private val client = new MockClient(time, new StubMetadataUpdater)
   private val topicPartition = new TopicPartition("topic", 0)
-  private val channel = new KafkaNetworkChannel(time, client, requestTimeoutMs)
+  private val channel = new KafkaNetworkChannel(time, client, requestTimeoutMs, threadNamePrefix = "test-raft")
 
   @BeforeEach
   def setupSupportedApis(): Unit = {

--- a/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/RaftManagerTest.scala
@@ -29,7 +29,7 @@ class RaftManagerTest {
   @Test
   def testShutdownIoThread(): Unit = {
     val raftClient = mock(classOf[KafkaRaftClient[String]])
-    val ioThread = new RaftIoThread(raftClient)
+    val ioThread = new RaftIoThread(raftClient, threadNamePrefix = "test-raft")
 
     when(raftClient.isRunning).thenReturn(true)
     assertTrue(ioThread.isRunning)
@@ -52,7 +52,7 @@ class RaftManagerTest {
   @Test
   def testUncaughtExceptionInIoThread(): Unit = {
     val raftClient = mock(classOf[KafkaRaftClient[String]])
-    val ioThread = new RaftIoThread(raftClient)
+    val ioThread = new RaftIoThread(raftClient, threadNamePrefix = "test-raft")
 
     when(raftClient.isRunning).thenReturn(true)
     assertTrue(ioThread.isRunning)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -619,7 +619,7 @@ class KafkaConfigTest {
         case KafkaConfig.ConnectionSetupTimeoutMaxMsProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
 
           // KIP-500 Configurations
-        case KafkaConfig.ControllerIdProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
+        case KafkaConfig.NodeIdProp => assertPropertyInvalid(baseProperties, name, "not_a_number")
         case KafkaConfig.MetadataLogDirProp => // ignore string
 
         case KafkaConfig.AuthorizerClassNameProp => //ignore string
@@ -1022,6 +1022,7 @@ class KafkaConfigTest {
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "broker")
     props.put(KafkaConfig.ListenersProp, "PLAINTEXT://127.0.0.1:9092")
+    props.put(KafkaConfig.NodeIdProp, "1")
     assertTrue(isValidKafkaConfig(props))
   }
 
@@ -1034,6 +1035,7 @@ class KafkaConfigTest {
     props.put(KafkaConfig.ProcessRolesProp, "broker")
     props.put(KafkaConfig.MetadataLogDirProp, metadataDir)
     props.put(KafkaConfig.LogDirProp, dataDir)
+    props.put(KafkaConfig.NodeIdProp, "1")
     assertTrue(isValidKafkaConfig(props))
 
     val config = KafkaConfig.fromProps(props)
@@ -1049,6 +1051,7 @@ class KafkaConfigTest {
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "broker")
     props.put(KafkaConfig.LogDirProp, s"$dataDir1,$dataDir2")
+    props.put(KafkaConfig.NodeIdProp, "1")
     assertTrue(isValidKafkaConfig(props))
 
     val config = KafkaConfig.fromProps(props)

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1025,4 +1025,35 @@ class KafkaConfigTest {
     assertTrue(isValidKafkaConfig(props))
   }
 
+  @Test
+  def testCustomMetadataLogDir(): Unit = {
+    val metadataDir = "/path/to/metadata/dir"
+    val dataDir = "/path/to/data/dir"
+
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.MetadataLogDirProp, metadataDir)
+    props.put(KafkaConfig.LogDirProp, dataDir)
+    assertTrue(isValidKafkaConfig(props))
+
+    val config = KafkaConfig.fromProps(props)
+    assertEquals(metadataDir, config.metadataLogDir)
+    assertEquals(Seq(dataDir), config.logDirs)
+  }
+
+  @Test
+  def testDefaultMetadataLogDir(): Unit = {
+    val dataDir1 = "/path/to/data/dir/1"
+    val dataDir2 = "/path/to/data/dir/2"
+
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.LogDirProp, s"$dataDir1,$dataDir2")
+    assertTrue(isValidKafkaConfig(props))
+
+    val config = KafkaConfig.fromProps(props)
+    assertEquals(dataDir1, config.metadataLogDir)
+    assertEquals(Seq(dataDir1, dataDir2), config.logDirs)
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.io.File
+import java.util.Properties
+
+import kafka.common.{InconsistentBrokerIdException, InconsistentControllerIdException}
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.test.TestUtils
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class KafkaRaftServerTest {
+
+  @Test
+  def testSuccessfulLoadMetaProperties(): Unit = {
+    testSuccessfulLoadMetaProperties(brokerId = Some(0), controllerId = None)
+    testSuccessfulLoadMetaProperties(brokerId = Some(0), controllerId = Some(10))
+    testSuccessfulLoadMetaProperties(brokerId = None, controllerId = Some(10))
+  }
+
+  def testSuccessfulLoadMetaProperties(
+    brokerId: Option[Int],
+    controllerId: Option[Int]
+  ): Unit = {
+    val metaProperties = MetaProperties(
+      clusterId = Uuid.randomUuid(),
+      brokerId = brokerId,
+      controllerId = controllerId
+    )
+
+    val configProperties = new Properties
+    val roles = Seq(brokerId.map(_ => "broker"), controllerId.map(_ => "controller")).flatten.mkString(",")
+    configProperties.put(KafkaConfig.ProcessRolesProp, roles)
+    brokerId.foreach(id => configProperties.put(KafkaConfig.BrokerIdProp, id.toString))
+    controllerId.foreach(id => configProperties.put(KafkaConfig.ControllerIdProp, id.toString))
+
+    val (loadedMetaProperties, offlineDirs) =
+      invokeLoadMetaProperties(metaProperties, configProperties)
+
+    assertEquals(metaProperties, loadedMetaProperties)
+    assertEquals(Seq.empty, offlineDirs)
+  }
+
+  @Test
+  def testLoadMetaPropertiesWithInconsistentBrokerId(): Unit = {
+    testLoadMetaPropertiesWithInconsistentBrokerId(metaBrokerId = 1, configBrokerId = Some(0))
+    testLoadMetaPropertiesWithInconsistentBrokerId(metaBrokerId = 1, configBrokerId = None)
+  }
+
+  def testLoadMetaPropertiesWithInconsistentBrokerId(
+    metaBrokerId: Int,
+    configBrokerId: Option[Int]
+  ): Unit = {
+    val metaProperties = MetaProperties(
+      clusterId = Uuid.randomUuid(),
+      brokerId = Some(metaBrokerId),
+      controllerId = None
+    )
+
+    val configProperties = new Properties
+    configProperties.put(KafkaConfig.ProcessRolesProp, "broker")
+    configBrokerId.foreach(brokerId => configProperties.put(KafkaConfig.BrokerIdProp, brokerId.toString))
+
+    assertThrows(classOf[InconsistentBrokerIdException], () =>
+      invokeLoadMetaProperties(metaProperties, configProperties))
+  }
+
+  @Test
+  def testLoadMetaPropertiesWithInconsistentControllerId(): Unit = {
+    testLoadMetaPropertiesWithInconsistentControllerId(metaControllerId = 1, configControllerId = Some(0))
+    testLoadMetaPropertiesWithInconsistentControllerId(metaControllerId = 1, configControllerId = None)
+  }
+
+  def testLoadMetaPropertiesWithInconsistentControllerId(
+    metaControllerId: Int,
+    configControllerId: Option[Int]
+  ): Unit = {
+    val metaProperties = MetaProperties(
+      clusterId = Uuid.randomUuid(),
+      brokerId = None,
+      controllerId = Some(metaControllerId)
+    )
+
+    val configProperties = new Properties
+
+    configProperties.put(KafkaConfig.ProcessRolesProp, "controller")
+    configControllerId.foreach(brokerId => configProperties.put(KafkaConfig.ControllerIdProp, brokerId.toString))
+
+    assertThrows(classOf[InconsistentControllerIdException], () =>
+      invokeLoadMetaProperties(metaProperties, configProperties))
+  }
+
+  private def invokeLoadMetaProperties(
+    metaProperties: MetaProperties,
+    configProperties: Properties
+  ): (MetaProperties, Seq[String]) = {
+    val tempLogDir = TestUtils.tempDirectory()
+    try {
+      writeMetaProperties(tempLogDir, metaProperties)
+
+      configProperties.put(KafkaConfig.LogDirProp, tempLogDir.getAbsolutePath)
+      val config = KafkaConfig.fromProps(configProperties)
+      KafkaRaftServer.loadMetaProperties(config)
+    } finally {
+      Utils.delete(tempLogDir)
+    }
+  }
+
+  private def writeMetaProperties(
+    logDir: File,
+    metaProperties: MetaProperties
+  ): Unit = {
+    val metaPropertiesFile = new File(logDir.getAbsolutePath + File.separator + "meta.properties")
+    val checkpoint = new BrokerMetadataCheckpoint(metaPropertiesFile)
+    checkpoint.write(metaProperties.toProperties)
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
@@ -183,7 +183,7 @@ class ServerGenerateBrokerIdTest extends ZooKeeperTestHarness {
         new File(logDir + File.separator + brokerMetaPropsFile)).read()
       brokerMetadataOpt match {
         case Some(properties) =>
-          val brokerMetadata = RawMetaProperties(properties)
+          val brokerMetadata = new RawMetaProperties(properties)
           if (brokerMetadata.brokerId.exists(_ != brokerId)) return false
         case _ => return false
       }

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateBrokerIdTest.scala
@@ -182,8 +182,9 @@ class ServerGenerateBrokerIdTest extends ZooKeeperTestHarness {
       val brokerMetadataOpt = new BrokerMetadataCheckpoint(
         new File(logDir + File.separator + brokerMetaPropsFile)).read()
       brokerMetadataOpt match {
-        case Some(brokerMetadata) =>
-          if (brokerMetadata.brokerId != brokerId) return false
+        case Some(properties) =>
+          val brokerMetadata = RawMetaProperties(properties)
+          if (brokerMetadata.brokerId.exists(_ != brokerId)) return false
         case _ => return false
       }
     }

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
@@ -214,7 +214,7 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
   def forgeBrokerMetadata(logDir: String, brokerId: Int, clusterId: String): Unit = {
     val checkpoint = new BrokerMetadataCheckpoint(
       new File(logDir + File.separator + brokerMetaPropsFile))
-    checkpoint.write(BrokerMetadata(brokerId, Option(clusterId)))
+    checkpoint.write(ZkMetaProperties(clusterId, brokerId).toProperties)
   }
 
   def verifyBrokerMetadata(logDirs: Seq[String], clusterId: String): Boolean = {
@@ -222,11 +222,13 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
       val brokerMetadataOpt = new BrokerMetadataCheckpoint(
         new File(logDir + File.separator + brokerMetaPropsFile)).read()
       brokerMetadataOpt match {
-        case Some(brokerMetadata) =>
-          if (brokerMetadata.clusterId.isDefined && brokerMetadata.clusterId.get != clusterId) return false
+        case Some(properties) =>
+          val brokerMetadata = RawMetaProperties(properties)
+          if (brokerMetadata.clusterId.exists(_ != clusterId)) return false
         case _ => return false
       }
     }
     true
   }
+
 }

--- a/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerGenerateClusterIdTest.scala
@@ -223,7 +223,7 @@ class ServerGenerateClusterIdTest extends ZooKeeperTestHarness {
         new File(logDir + File.separator + brokerMetaPropsFile)).read()
       brokerMetadataOpt match {
         case Some(properties) =>
-          val brokerMetadata = RawMetaProperties(properties)
+          val brokerMetadata = new RawMetaProperties(properties)
           if (brokerMetadata.clusterId.exists(_ != clusterId)) return false
         case _ => return false
       }

--- a/core/src/test/scala/unit/kafka/server/ServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ServerTest.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.util.Properties
+
+import org.apache.kafka.common.Uuid
+import org.apache.kafka.common.metrics.MetricsContext
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+import scala.jdk.CollectionConverters._
+
+class ServerTest {
+
+  @Test
+  def testCreateSelfManagedKafkaMetricsContext(): Unit = {
+    val nodeId = 0
+    val clusterId = Uuid.randomUuid().toString
+
+    val props = new Properties()
+    props.put(KafkaConfig.ProcessRolesProp, "broker")
+    props.put(KafkaConfig.NodeIdProp, nodeId.toString)
+    val config = KafkaConfig.fromProps(props)
+
+    val context = Server.createKafkaMetricsContext(config, clusterId)
+    assertEquals(Map(
+      MetricsContext.NAMESPACE -> Server.MetricsPrefix,
+      Server.ClusterIdLabel -> clusterId,
+      Server.NodeIdLabel -> nodeId.toString
+    ), context.contextLabels.asScala)
+  }
+
+  @Test
+  def testCreateZkKafkaMetricsContext(): Unit = {
+    val brokerId = 0
+    val clusterId = Uuid.randomUuid().toString
+
+    val props = new Properties()
+    props.put(KafkaConfig.BrokerIdProp, brokerId.toString)
+    props.put(KafkaConfig.ZkConnectProp, "127.0.0.1:0")
+    val config = KafkaConfig.fromProps(props)
+
+    val context = Server.createKafkaMetricsContext(config, clusterId)
+    assertEquals(Map(
+      MetricsContext.NAMESPACE -> Server.MetricsPrefix,
+      Server.ClusterIdLabel -> clusterId,
+      Server.BrokerIdLabel -> brokerId.toString
+    ), context.contextLabels.asScala)
+  }
+
+}

--- a/raft/README.md
+++ b/raft/README.md
@@ -16,7 +16,7 @@ Create 3 separate raft quorum properties as the following:
 
 `cat << EOF >> config/raft-quorum-1.properties`
     
-    broker.id=1
+    node.id=1
     listeners=PLAINTEXT://localhost:9092
     controller.quorum.voters=1@localhost:9092,2@localhost:9093,3@localhost:9094
     log.dirs=/tmp/raft-logs-1
@@ -24,7 +24,7 @@ Create 3 separate raft quorum properties as the following:
 
 `cat << EOF >> config/raft-quorum-2.properties`
     
-    broker.id=2
+    node.id=2
     listeners=PLAINTEXT://localhost:9093
     controller.quorum.voters=1@localhost:9092,2@localhost:9093,3@localhost:9094
     log.dirs=/tmp/raft-logs-2
@@ -32,7 +32,7 @@ Create 3 separate raft quorum properties as the following:
     
 `cat << EOF >> config/raft-quorum-3.properties`
     
-    broker.id=3
+    node.id=3
     listeners=PLAINTEXT://localhost:9094
     controller.quorum.voters=1@localhost:9092,2@localhost:9093,3@localhost:9094
     log.dirs=/tmp/raft-logs-3

--- a/raft/config/raft.properties
+++ b/raft/config/raft.properties
@@ -13,10 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-broker.id=0
+node.id=0
 listeners=PLAINTEXT://localhost:9092
-quorum.voters=0@localhost:9092
+controller.quorum.voters=0@localhost:9092
 log.dirs=/tmp/raft-logs
-
-# Below is not used, but is currently required by `KafkaConfig`
-zookeeper.connect=localhost:2181


### PR DESCRIPTION
This patch contains the new handling of `meta.properties` required by the KIP-500 server as specified in KIP-631. When using the self-managed quorum, the `meta.properties` file is required in each log directory with the new `version` property set to 1. It must include the `cluster.id` property and it must have a `node` matching that in the configuration.

The behavior of `meta.properties` for the Zookeeper-based `KafkaServer` does not change. We treat `meta.properties` as optional and as if it were `version=0`. We continue to generate the clusterId and/or the brokerId through Zookeeper as needed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
