### PR TITLE
KAFKA-12190: Fix setting of file permissions on non-POSIX filesystems

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -31,7 +31,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.NoSuchFileException;
-import java.nio.file.Paths;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -108,14 +107,26 @@ public class StateDirectory {
             log.warn("Using /tmp directory in the state.dir property can cause failures with writing the checkpoint file" +
                 " due to the fact that this directory can be cleared by the OS");
         }
-        final Path basePath = Paths.get(baseDir.getPath());
-        final Path statePath = Paths.get(stateDir.getPath());
-        final Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-x---");
-        try {
-            Files.setPosixFilePermissions(basePath, perms);
-            Files.setPosixFilePermissions(statePath, perms);
-        } catch (final IOException e) {
-            log.error("Error changing permissions for the state or base directory {} ", stateDir.getPath(), e);
+        configurePermissions(baseDir);
+        configurePermissions(stateDir);
+    }
+    
+    private void configurePermissions(final File file) {
+        final Path path = file.toPath();
+        if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            final Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxr-x---");
+            try {
+                Files.setPosixFilePermissions(path, perms);
+            } catch (final IOException e) {
+                log.error("Error changing permissions for the directory {} ", path, e);
+            }
+        } else {
+            boolean set = file.setReadable(true, true);
+            set &= file.setWritable(true, true);
+            set &= file.setExecutable(true, true);
+            if (!set) {
+                log.error("Failed to change permissions for the directory {}", file);
+            }
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -35,7 +35,6 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
@@ -114,22 +113,29 @@ public class StateDirectoryTest {
 
     @Test
     public void shouldHaveSecurePermissions() {
-        final Set<PosixFilePermission> expectedPermissions = EnumSet.of(
-            PosixFilePermission.OWNER_EXECUTE,
-            PosixFilePermission.GROUP_READ,
-            PosixFilePermission.OWNER_WRITE,
-            PosixFilePermission.GROUP_EXECUTE,
-            PosixFilePermission.OWNER_READ);
-
-        final Path statePath = Paths.get(stateDir.getPath());
-        final Path basePath = Paths.get(appDir.getPath());
-        try {
-            final Set<PosixFilePermission> baseFilePermissions = Files.getPosixFilePermissions(statePath);
-            final Set<PosixFilePermission> appFilePermissions = Files.getPosixFilePermissions(basePath);
-            assertThat(expectedPermissions.equals(baseFilePermissions), is(true));
-            assertThat(expectedPermissions.equals(appFilePermissions), is(true));
-        } catch (final IOException e) {
-            fail("Should create correct files and set correct permissions");
+        assertPermissions(stateDir);
+        assertPermissions(appDir);
+    }
+    
+    private void assertPermissions(final File file) {
+        final Path path = file.toPath();
+        if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            final Set<PosixFilePermission> expectedPermissions = EnumSet.of(
+                    PosixFilePermission.OWNER_EXECUTE,
+                    PosixFilePermission.GROUP_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.GROUP_EXECUTE,
+                    PosixFilePermission.OWNER_READ);
+            try {
+                final Set<PosixFilePermission> filePermissions = Files.getPosixFilePermissions(path);
+                assertThat(expectedPermissions.equals(filePermissions), is(true));
+            } catch (final IOException e) {
+                fail("Should create correct files and set correct permissions");
+            }
+        } else {
+            assertThat(file.canRead(), is(true));
+            assertThat(file.canWrite(), is(true));
+            assertThat(file.canExecute(), is(true));
         }
     }
 


### PR DESCRIPTION
This pull request back-ports to 2.6 the changes I contributed in https://github.com/apache/kafka/pull/9947.

Previously, `StateDirectory` used `PosixFilePermissions` to configure its directories' permissions which fails on Windows as its file system is not POSIX-compliant. This PR updates `StateDirectory` to fall back to the `File` API on non-POSIX-compliant file systems. The File API doesn't allow as much control over the permissions so they're as close as the API permits.

The unit tests have been updated to also verify the behaviour on non-POSIX-compliant file systems.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)