### PR TITLE
KAFKA-12233: Align the length passed to FileChannel by `FileRecords.writeTo`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -278,7 +278,6 @@ public class FileRecords extends AbstractRecords implements Closeable {
                     file.getAbsolutePath(), oldSize, newSize));
 
         long position = start + offset;
-//        int count = Math.min(length, oldSize);
         long count = Math.min(length, oldSize - offset);
         return destChannel.transferFrom(channel, position, count);
     }

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -278,7 +278,8 @@ public class FileRecords extends AbstractRecords implements Closeable {
                     file.getAbsolutePath(), oldSize, newSize));
 
         long position = start + offset;
-        int count = Math.min(length, oldSize);
+//        int count = Math.min(length, oldSize);
+        long count = Math.min(length, oldSize - offset);
         return destChannel.transferFrom(channel, position, count);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.File;

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -518,7 +518,7 @@ public class FileRecordsTest {
     }
 
     @Test
-    public void testWriteTo() throws IOException {
+    public void testBytesLengthOfWriteTo() throws IOException {
 
         int size = fileRecords.sizeInBytes();
         long firstWritten = size / 3;

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -525,7 +525,7 @@ public class FileRecordsTest {
 
         TransferableChannel channel = Mockito.mock(TransferableChannel.class);
 
-        // Firstly we wrote
+        // Firstly we wrote some of the data
         fileRecords.writeTo(channel, 0, (int) firstWritten);
         verify(channel).transferFrom(any(), anyLong(), eq(firstWritten));
 

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -20,11 +20,14 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +54,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -510,6 +515,25 @@ public class FileRecordsTest {
         doTestConversion(CompressionType.GZIP, RecordBatch.MAGIC_VALUE_V1);
         doTestConversion(CompressionType.NONE, RecordBatch.MAGIC_VALUE_V2);
         doTestConversion(CompressionType.GZIP, RecordBatch.MAGIC_VALUE_V2);
+    }
+
+    @Test
+    public void testWriteTo() throws IOException {
+
+        int size = fileRecords.sizeInBytes();
+        long firstWritten = size / 3;
+
+        TransferableChannel channel = Mockito.mock(TransferableChannel.class);
+
+        // Firstly we wrote
+        fileRecords.writeTo(channel, 0, (int) firstWritten);
+        verify(channel).transferFrom(any(), anyLong(), eq(firstWritten));
+
+        // Ensure (length > size - firstWritten)
+        int secondWrittenLength = size - (int) firstWritten + 1;
+        fileRecords.writeTo(channel, firstWritten, secondWrittenLength);
+        // But we still only write (size - firstWritten), which is not fulfilled in the old version
+        verify(channel).transferFrom(any(), anyLong(), eq(size - firstWritten));
     }
 
     private void doTestConversion(CompressionType compressionType, byte toMagic) throws IOException {


### PR DESCRIPTION
*More detailed description of your change*
See https://issues.apache.org/jira/browse/KAFKA-12233

*Summary of testing strategy (including rationale)*
unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
