### PR TITLE
KAFKA-8779: Reintroduce flaky tests

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -25,6 +25,7 @@ import kafka.security.authorizer.AclEntry
 import kafka.security.authorizer.AclEntry.WildcardHost
 import kafka.server.{BaseRequestTest, KafkaConfig}
 import kafka.utils.TestUtils
+import kafka.utils.TestUtils.withLogReset
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, AlterConfigOp}
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
@@ -837,7 +838,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   }
 
   @Test
-  def testIncrementalAlterConfigsRequestRequiresClusterPermissionForBrokerLogger(): Unit = {
+  def testIncrementalAlterConfigsRequestRequiresClusterPermissionForBrokerLogger(): Unit = withLogReset {
     createTopic(topic)
 
     val data = new IncrementalAlterConfigsRequestData

--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -20,6 +20,7 @@ package kafka.utils
 import java.lang.management.ManagementFactory
 
 import javax.management.ObjectName
+import kafka.utils.TestUtils.withLogReset
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.slf4j.LoggerFactory
@@ -69,20 +70,16 @@ class LoggingTest extends Logging {
   }
 
   @Test
-  def testLoggerLevelIsResolved(): Unit = {
+  def testLoggerLevelIsResolved(): Unit = withLogReset {
     val controller = new Log4jController()
-    val previousLevel = controller.getLogLevel("kafka")
-    try {
-      controller.setLogLevel("kafka", "TRACE")
-      // Do some logging so that the Logger is created within the hierarchy
-      // (until loggers are used only loggers in the config file exist)
-      LoggerFactory.getLogger("kafka.utils.Log4jControllerTest").trace("test")
-      assertEquals("TRACE", controller.getLogLevel("kafka"))
-      assertEquals("TRACE", controller.getLogLevel("kafka.utils.Log4jControllerTest"))
-      assertTrue(controller.getLoggers.contains("kafka=TRACE"))
-      assertTrue(controller.getLoggers.contains("kafka.utils.Log4jControllerTest=TRACE"))
-    } finally {
-      controller.setLogLevel("kafka", previousLevel)
-    }
+
+    controller.setLogLevel("kafka", "TRACE")
+    // Do some logging so that the Logger is created within the hierarchy
+    // (until loggers are used only loggers in the config file exist)
+    LoggerFactory.getLogger("kafka.utils.Log4jControllerTest").trace("test")
+    assertEquals("TRACE", controller.getLogLevel("kafka"))
+    assertEquals("TRACE", controller.getLogLevel("kafka.utils.Log4jControllerTest"))
+    assertTrue(controller.getLoggers.contains("kafka=TRACE"))
+    assertTrue(controller.getLoggers.contains("kafka.utils.Log4jControllerTest=TRACE"))
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -199,13 +199,8 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
 
     createServer(Some(adminClientConfig))
 
-    val appender = LogCaptureAppender.createAndRegister()
-    val previousLevel = LogCaptureAppender.setClassLoggerLevel(classOf[AppInfoParser], Level.WARN)
-    try {
-        testAclCli(adminArgs)
-    } finally {
-      LogCaptureAppender.setClassLoggerLevel(classOf[AppInfoParser], previousLevel)
-      LogCaptureAppender.unregister(appender)
+    val appender = LogCaptureAppender.captureLogging(classOf[AppInfoParser], Level.WARN) {
+      testAclCli(adminArgs)
     }
     val warning = appender.getMessages.find(e => e.getLevel == Level.WARN &&
       e.getThrowableInformation != null &&

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -88,6 +88,7 @@ class UncleanLeaderElectionTest extends ZooKeeperTestHarness {
     // restore log levels
     kafkaApisLogger.setLevel(Level.ERROR)
     networkProcessorLogger.setLevel(Level.ERROR)
+    TestUtils.resetLogging
 
     super.tearDown()
   }

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -97,6 +97,7 @@ class SocketServerTest {
     sockets.foreach(_.close())
     sockets.clear()
     kafkaLogger.setLevel(logLevelToRestore)
+    TestUtils.resetLogging
   }
 
   def sendRequest(socket: Socket, request: Array[Byte], id: Option[Short] = None, flush: Boolean = true): Unit = {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -62,6 +62,7 @@ import org.apache.kafka.common.utils.Utils._
 import org.apache.kafka.common.{KafkaFuture, Node, TopicPartition}
 import org.apache.kafka.server.authorizer.{Authorizer => JAuthorizer}
 import org.apache.kafka.test.{TestSslUtils, TestUtils => JTestUtils}
+import org.apache.log4j.PropertyConfigurator
 import org.apache.zookeeper.KeeperException.SessionExpiredException
 import org.apache.zookeeper.ZooDefs._
 import org.apache.zookeeper.data.ACL
@@ -1853,4 +1854,27 @@ object TestUtils extends Logging {
       authorizer, resource)
   }
 
+  /**
+   * Convenience function for tests which mutate log levels which resets the logging configuration after the test.
+   */
+  def withLogReset[T](fn: => T): T = {
+    try {
+      fn
+    } finally {
+      resetLogging
+    }
+  }
+
+  /**
+    * Resets the logging configuration after the test.
+    */
+  def resetLogging[T] = {
+    org.apache.log4j.LogManager.resetConfiguration()
+    val stream = this.getClass.getResourceAsStream("/log4j.properties")
+    try {
+      PropertyConfigurator.configure(stream)
+    } finally {
+      stream.close()
+    }
+  }
 }


### PR DESCRIPTION
Enable some previously-flaky PlaintextAdminIntegrationTests.

The cause of the flakiness appears to have been lack of test isolation between those tests and other tests which manipulate log levels (which are effectively global to the JVM). In general there are quite a few tests which manipulate log4j and/or make assertions on log4j global state, so introduce some of helpers to try to get test isolation across the whole of the broker code.

1. `logLock` in `TestUtils` provides the mutual exclusion. We can't use `synchronized` on an `Object` because some tests change the logging in their `@Before(Class)` and restore in ``@After(Class)`.
2. `TestUtils.withLogLock` encapsulates the isolation logic, and it used by most of the log-changing tests, rather than them using `logLock` directly.
3. `LogCaptureAppender` now uses `withLogLock` too, and there's no reason not to apply the same state management pattern via `captureLogging`.



