### PR TITLE
KAFKA-10500: Add docs for failed stream thread metric

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1619,6 +1619,11 @@ All of the following metrics have a recording level of <code>info</code>:
     <td>The state of the Kafka Streams client.</td>
     <td>kafka.streams:type=stream-metrics,client-id=([-.\w]+)</td>
   </tr>
+  <tr>
+      <td>failed-stream-threads</td>
+      <td>The number of failed stream threads since the start of the Kafka Streams client.</td>
+      <td>kafka.streams:type=stream-metrics,client-id=([-.\w]+)</td>
+  </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Follow up to https://github.com/apache/kafka/pull/9614, adds documentation for failed-stream-threads metric

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
