### PR TITLE
MINOR: Build modules in parallel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,4 @@ version=2.8.0-SNAPSHOT
 scalaVersion=2.13.4
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC
+org.gradle.parallel=true


### PR DESCRIPTION
- According to https://docs.gradle.org/current/userguide/performance.html#parallel_execution gradle executes builds serially by default.
- With this change, the build performance is significantly better (~2x) on multi-core machines

### With this change
**Here's a terminal recording of a build with this change:**
https://ascii.purplpkg.com/a/kuBqEKEeLgvKXTUJEkq8MNk5v

**Here's a build scan with this change:**
https://gradle.com/s/kqmmxwwu6r4lk

### Current default
**Here's a terminal recording of a build with the default:**
https://ascii.purplpkg.com/a/P7W6Z4FmKtaKkPazFWGKwNmTC

**Here's a build scan with the default:**
https://gradle.com/s/e4mkzj53gbu2k

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [  ] Verify documentation (including upgrade notes)
