### PR TITLE
KAFKA-12310: Update zookeeper to 3.5.9

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -117,7 +117,7 @@ versions += [
   spotlessPlugin: "5.8.2",
   testRetryPlugin: "1.2.0",
   zinc: "1.3.5",
-  zookeeper: "3.5.8",
+  zookeeper: "3.5.9",
   zstd: "1.4.8-2"
 ]
 libs += [


### PR DESCRIPTION
A few important fixes:
* ZOOKEEPER-3829: Zookeeper refuses request after node expansion
* ZOOKEEPER-3842: Rolling scale up of zookeeper cluster does not work with reconfigEnabled=false
* ZOOKEEPER-3830: After add a new node, zookeeper cluster won't commit any proposal if this new node is leader

Full release notes: https://zookeeper.apache.org/doc/r3.5.9/releasenotes.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
