### PR TITLE
MINOR: Reduce size of the ProducerStateEntry batchMetadata queue.

### DIFF
--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -63,7 +63,7 @@ private[log] object ProducerStateEntry {
   private[log] val NumBatchesToRetain = 5
 
   def empty(producerId: Long) = new ProducerStateEntry(producerId,
-    batchMetadata = new mutable.Queue[BatchMetadata](5),
+    batchMetadata = new mutable.Queue[BatchMetadata](NumBatchesToRetain),
     producerEpoch = RecordBatch.NO_PRODUCER_EPOCH,
     coordinatorEpoch = -1,
     lastTimestamp = RecordBatch.NO_TIMESTAMP,

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -63,7 +63,7 @@ private[log] object ProducerStateEntry {
   private[log] val NumBatchesToRetain = 5
 
   def empty(producerId: Long) = new ProducerStateEntry(producerId,
-    batchMetadata = mutable.Queue[BatchMetadata](),
+    batchMetadata = new mutable.Queue[BatchMetadata](5),
     producerEpoch = RecordBatch.NO_PRODUCER_EPOCH,
     coordinatorEpoch = -1,
     lastTimestamp = RecordBatch.NO_TIMESTAMP,


### PR DESCRIPTION
This reduces the size at construction of the batchMetadata queue from 16
entries to 5. The backing array will be sized to 8 elements, cutting the array size
in half.

We know that we will only allow a max of 5 entries in this queue, so this change will not
change the alloc/copy behavior.