### PR TITLE
KAFKA-12237: Support non-routable quorum voter addresses

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -16,9 +16,6 @@
  */
 package kafka.raft
 
-import java.net.InetSocketAddress
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicInteger
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ClientResponse, KafkaClient}
@@ -30,6 +27,8 @@ import org.apache.kafka.common.utils.Time
 import org.apache.kafka.raft.RaftConfig.InetAddressSpec
 import org.apache.kafka.raft.{NetworkChannel, RaftRequest, RaftResponse, RaftUtil}
 
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 
 object KafkaNetworkChannel {

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -34,7 +34,6 @@ import scala.collection.mutable
 
 object KafkaNetworkChannel {
 
-  val nonRoutableAddress = new InetSocketAddress("0.0.0.0", 0)
   private[raft] def buildRequest(requestData: ApiMessage): AbstractRequest.Builder[_ <: AbstractRequest] = {
     requestData match {
       case voteRequest: VoteRequestData =>

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -19,7 +19,6 @@ package kafka.raft
 import java.net.InetSocketAddress
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
-
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ClientResponse, KafkaClient}
@@ -28,6 +27,7 @@ import org.apache.kafka.common.message._
 import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.raft.RaftConfig.InetAddressSpec
 import org.apache.kafka.raft.{NetworkChannel, RaftRequest, RaftResponse, RaftUtil}
 
 import scala.collection.mutable
@@ -166,12 +166,9 @@ class KafkaNetworkChannel(
     RaftUtil.errorResponse(apiKey, error)
   }
 
-  def updateEndpoint(id: Int, address: InetSocketAddress): Unit = {
-    // We update the endpoint only if it's routable/valid
-    if (!address.equals(nonRoutableAddress)) {
-      val node = new Node(id, address.getHostString, address.getPort)
-      endpoints.put(id, node)
-    }
+  def updateEndpoint(id: Int, spec: InetAddressSpec): Unit = {
+    val node = new Node(id, spec.address.getHostString, spec.address.getPort)
+    endpoints.put(id, node)
   }
 
   def start(): Unit = {

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -128,7 +128,7 @@ class KafkaRaftManager[T](
         }
         case invalid: AddressSpec => {
           logger.warn(s"Skipping channel update for destination ID: ${voterAddressEntry.getKey} " +
-            s"because of invalid endpoint: ${invalid.address().toString}")
+            s"because of invalid endpoint: ${invalid.address.toString}")
         }
       }
     }

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -16,12 +16,6 @@
  */
 package kafka.raft
 
-import java.util.OptionalInt
-
-import java.io.File
-import java.nio.file.Files
-import java.util.concurrent.CompletableFuture
-
 import kafka.log.{Log, LogConfig, LogManager}
 import kafka.raft.KafkaRaftManager.RaftIoThread
 import kafka.server.{BrokerTopicStats, KafkaConfig, LogDirFailureChannel}
@@ -37,6 +31,12 @@ import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, RaftClient, RaftConfig, RaftRequest, RecordSerde}
 
+import java.io.File
+import java.net.InetSocketAddress
+import java.nio.file.Files
+import java.util
+import java.util.OptionalInt
+import java.util.concurrent.CompletableFuture
 import scala.jdk.CollectionConverters._
 
 object KafkaRaftManager {
@@ -104,6 +104,7 @@ class KafkaRaftManager[T](
   metrics: Metrics
 ) extends RaftManager[T] with Logging {
 
+  private val raftConfig = new RaftConfig(config)
   private val nodeId = config.brokerId
   private val logContext = new LogContext(s"[RaftManager $nodeId] ")
   this.logIdent = logContext.logPrefix()
@@ -118,9 +119,12 @@ class KafkaRaftManager[T](
   private val raftIoThread = new RaftIoThread(raftClient)
 
   def startup(): Unit = {
+    // Update the voter endpoints with what's in RaftConfig
+    val voterAddresses: util.Map[Integer, InetSocketAddress] = raftConfig.quorumVoterConnections
+    for (voterAddressEntry <- voterAddresses.entrySet.asScala) {
+      netChannel.updateEndpoint(voterAddressEntry.getKey, voterAddressEntry.getValue)
+    }
     netChannel.start()
-    val raftConfig = new RaftConfig(config)
-    raftClient.initialize(raftConfig)
     raftIoThread.start()
   }
 
@@ -173,7 +177,7 @@ class KafkaRaftManager[T](
     val expirationService = new TimingWheelExpirationService(expirationTimer)
     val quorumStateStore = new FileBasedStateStore(new File(dataDir, "quorum-state"))
 
-    new KafkaRaftClient(
+    val client = new KafkaRaftClient(
       recordSerde,
       netChannel,
       metadataLog,
@@ -182,8 +186,11 @@ class KafkaRaftManager[T](
       metrics,
       expirationService,
       logContext,
-      OptionalInt.of(nodeId)
+      OptionalInt.of(nodeId),
+      raftConfig
     )
+    client.initialize()
+    client
   }
 
   private def buildNetworkChannel(): KafkaNetworkChannel = {

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -123,17 +123,14 @@ class KafkaRaftManager[T](
     val voterAddresses: util.Map[Integer, AddressSpec] = raftConfig.quorumVoterConnections
     for (voterAddressEntry <- voterAddresses.entrySet.asScala) {
       voterAddressEntry.getValue match {
-        case spec: InetAddressSpec => {
+        case spec: InetAddressSpec =>
           netChannel.updateEndpoint(voterAddressEntry.getKey, spec)
-        }
-        case _: UnknownAddressSpec => {
+        case _: UnknownAddressSpec =>
           logger.info(s"Skipping channel update for destination ID: ${voterAddressEntry.getKey} " +
             s"because of non-routable endpoint: ${NON_ROUTABLE_ADDRESS.toString}")
-        }
-        case invalid: AddressSpec => {
+        case invalid: AddressSpec =>
           logger.warn(s"Unexpected address spec (type: ${invalid.getClass}) for channel update for " +
             s"destination ID: ${voterAddressEntry.getKey}")
-        }
       }
     }
     netChannel.start()

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -145,25 +145,6 @@ class KafkaNetworkChannelTest {
     }
   }
 
-  @Test
-  def testNonRoutableAddressUpdateRequest(): Unit = {
-    val destinationId = 2
-    assertThrows(classOf[IllegalArgumentException],
-      () => new InetAddressSpec(new InetSocketAddress("0.0.0.0", 0)))
-
-    // Update channel with a valid endpoint
-    val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetAddressSpec(
-      new InetSocketAddress(destinationNode.host, destinationNode.port)))
-
-    for (apiKey <- RaftApis) {
-      val expectedError = Errors.NONE
-      val response = buildResponse(buildTestErrorResponse(apiKey, expectedError))
-      client.prepareResponseFrom(response, destinationNode)
-      sendAndAssertErrorResponse(apiKey, destinationId, expectedError)
-    }
-  }
-
   private def sendTestRequest(
     apiKey: ApiKeys,
     destinationId: Int,

--- a/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/raft/KafkaNetworkChannelTest.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.protocol.{ApiKeys, ApiMessage, Errors}
 import org.apache.kafka.common.requests.{AbstractResponse, ApiVersionsResponse, BeginQuorumEpochRequest, BeginQuorumEpochResponse, EndQuorumEpochRequest, EndQuorumEpochResponse, FetchResponse, VoteRequest, VoteResponse}
 import org.apache.kafka.common.utils.{MockTime, Time}
 import org.apache.kafka.common.{Node, TopicPartition}
+import org.apache.kafka.raft.RaftConfig.InetAddressSpec
 import org.apache.kafka.raft.{RaftRequest, RaftUtil}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{BeforeEach, Test}
@@ -58,7 +59,8 @@ class KafkaNetworkChannelTest {
   def testSendToBlackedOutDestination(): Unit = {
     val destinationId = 2
     val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
+    channel.updateEndpoint(destinationId, new InetAddressSpec(
+      new InetSocketAddress(destinationNode.host, destinationNode.port)))
     client.backoff(destinationNode, 500)
     assertBrokerNotAvailable(destinationId)
   }
@@ -67,7 +69,8 @@ class KafkaNetworkChannelTest {
   def testWakeupClientOnSend(): Unit = {
     val destinationId = 2
     val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
+    channel.updateEndpoint(destinationId, new InetAddressSpec(
+      new InetSocketAddress(destinationNode.host, destinationNode.port)))
 
     client.enableBlockingUntilWakeup(1)
 
@@ -95,7 +98,8 @@ class KafkaNetworkChannelTest {
   def testSendAndDisconnect(): Unit = {
     val destinationId = 2
     val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
+    channel.updateEndpoint(destinationId, new InetAddressSpec(
+      new InetSocketAddress(destinationNode.host, destinationNode.port)))
 
     for (apiKey <- RaftApis) {
       val response = buildResponse(buildTestErrorResponse(apiKey, Errors.INVALID_REQUEST))
@@ -108,7 +112,8 @@ class KafkaNetworkChannelTest {
   def testSendAndFailAuthentication(): Unit = {
     val destinationId = 2
     val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
+    channel.updateEndpoint(destinationId, new InetAddressSpec(
+      new InetSocketAddress(destinationNode.host, destinationNode.port)))
 
     for (apiKey <- RaftApis) {
       client.createPendingAuthenticationError(destinationNode, 100)
@@ -129,7 +134,8 @@ class KafkaNetworkChannelTest {
   def testSendAndReceiveOutboundRequest(): Unit = {
     val destinationId = 2
     val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
+    channel.updateEndpoint(destinationId, new InetAddressSpec(
+      new InetSocketAddress(destinationNode.host, destinationNode.port)))
 
     for (apiKey <- RaftApis) {
       val expectedError = Errors.INVALID_REQUEST
@@ -140,21 +146,15 @@ class KafkaNetworkChannelTest {
   }
 
   @Test
-  def testNonRoutableAddressRequest(): Unit = {
-    val destinationId = 2
-    channel.updateEndpoint(destinationId, KafkaNetworkChannel.nonRoutableAddress)
-    assertBrokerNotAvailable(destinationId)
-  }
-
-  @Test
   def testNonRoutableAddressUpdateRequest(): Unit = {
     val destinationId = 2
-    channel.updateEndpoint(destinationId, KafkaNetworkChannel.nonRoutableAddress)
-    assertBrokerNotAvailable(destinationId)
+    assertThrows(classOf[IllegalArgumentException],
+      () => new InetAddressSpec(new InetSocketAddress("0.0.0.0", 0)))
 
     // Update channel with a valid endpoint
     val destinationNode = new Node(destinationId, "127.0.0.1", 9092)
-    channel.updateEndpoint(destinationId, new InetSocketAddress(destinationNode.host, destinationNode.port))
+    channel.updateEndpoint(destinationId, new InetAddressSpec(
+      new InetSocketAddress(destinationNode.host, destinationNode.port)))
 
     for (apiKey <- RaftApis) {
       val expectedError = Errors.NONE

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.raft.RaftConfig
+import org.apache.kafka.raft.RaftConfig.{AddressSpec, InetAddressSpec, UnknownAddressSpec}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -976,20 +977,24 @@ class KafkaConfigTest {
 
   @Test
   def testValidQuorumVotersConfig(): Unit = {
-    val expected = new util.HashMap[Integer, InetSocketAddress]()
+    val expected = new util.HashMap[Integer, AddressSpec]()
     assertValidQuorumVoters("", expected)
 
-    expected.put(1, new InetSocketAddress("127.0.0.1", 9092))
+    expected.put(1, new InetAddressSpec(new InetSocketAddress("127.0.0.1", 9092)))
     assertValidQuorumVoters("1@127.0.0.1:9092", expected)
 
     expected.clear()
-    expected.put(1, new InetSocketAddress("kafka1", 9092))
-    expected.put(2, new InetSocketAddress("kafka2", 9092))
-    expected.put(3, new InetSocketAddress("kafka3", 9092))
+    expected.put(1, new UnknownAddressSpec())
+    assertValidQuorumVoters("1@0.0.0.0:0", expected)
+
+    expected.clear()
+    expected.put(1, new InetAddressSpec(new InetSocketAddress("kafka1", 9092)))
+    expected.put(2, new InetAddressSpec(new InetSocketAddress("kafka2", 9092)))
+    expected.put(3, new InetAddressSpec(new InetSocketAddress("kafka3", 9092)))
     assertValidQuorumVoters("1@kafka1:9092,2@kafka2:9092,3@kafka3:9092", expected)
   }
 
-  private def assertValidQuorumVoters(value: String, expectedVoters: util.Map[Integer, InetSocketAddress]): Unit = {
+  private def assertValidQuorumVoters(value: String, expectedVoters: util.Map[Integer, AddressSpec]): Unit = {
     val props = TestUtils.createBrokerConfig(0, TestUtils.MockZkConnect)
     props.put(RaftConfig.QUORUM_VOTERS_CONFIG, value)
     val raftConfig = new RaftConfig(KafkaConfig.fromProps(props))

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.raft.RaftConfig
-import org.apache.kafka.raft.RaftConfig.{AddressSpec, InetAddressSpec, UnknownAddressSpec}
+import org.apache.kafka.raft.RaftConfig.{AddressSpec, InetAddressSpec, UNKNOWN_ADDRESS_SPEC_INSTANCE}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
@@ -984,7 +984,7 @@ class KafkaConfigTest {
     assertValidQuorumVoters("1@127.0.0.1:9092", expected)
 
     expected.clear()
-    expected.put(1, new UnknownAddressSpec())
+    expected.put(1, UNKNOWN_ADDRESS_SPEC_INSTANCE)
     assertValidQuorumVoters("1@0.0.0.0:0", expected)
 
     expected.clear()
@@ -999,6 +999,12 @@ class KafkaConfigTest {
     props.put(RaftConfig.QUORUM_VOTERS_CONFIG, value)
     val raftConfig = new RaftConfig(KafkaConfig.fromProps(props))
     assertEquals(expectedVoters, raftConfig.quorumVoterConnections())
+  }
+
+  @Test
+  def testNonRoutableAddressSpecException(): Unit = {
+    assertThrows(classOf[IllegalArgumentException],
+      () => new InetAddressSpec(new InetSocketAddress("0.0.0.0", 0)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -1002,12 +1002,6 @@ class KafkaConfigTest {
   }
 
   @Test
-  def testNonRoutableAddressSpecException(): Unit = {
-    assertThrows(classOf[IllegalArgumentException],
-      () => new InetAddressSpec(new InetSocketAddress("0.0.0.0", 0)))
-  }
-
-  @Test
   def testZookeeperConnectRequiredIfEmptyProcessRoles(): Unit = {
     val props = new Properties()
     props.put(KafkaConfig.ProcessRolesProp, "")

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -179,7 +179,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         LogContext logContext,
         OptionalInt nodeId,
         RaftConfig raftConfig
-    ) throws IOException {
+    ) {
         this(serde,
             channel,
             new BlockingMessageQueue(),
@@ -211,7 +211,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         LogContext logContext,
         Random random,
         RaftConfig raftConfig
-    ) throws IOException {
+    ) {
         this.serde = serde;
         this.channel = channel;
         this.messageQueue = messageQueue;

--- a/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
+++ b/raft/src/main/java/org/apache/kafka/raft/NetworkChannel.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.raft;
 
 import java.io.Closeable;
-import java.net.InetSocketAddress;
 
 /**
  * A simple network interface with few assumptions. We do not assume ordering
@@ -37,11 +36,6 @@ public interface NetworkChannel extends Closeable {
      * (i.e. an instance of {@link org.apache.kafka.raft.RaftResponse.Outbound}).
      */
     void send(RaftRequest.Outbound request);
-
-    /**
-     * Update connection information for the given id.
-     */
-    void updateEndpoint(int id, InetSocketAddress address);
 
     default void close() {}
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -62,13 +62,13 @@ public interface RaftClient<T> extends Closeable {
     }
 
     /**
-     * Initialize the client with the given Raft configuration.
+     * Initialize the client.
      * This should only be called once on startup.
      *
      * @param raftConfig the Raft quorum configuration
      * @throws IOException For any IO errors during initialization
      */
-    void initialize(RaftConfig raftConfig) throws IOException;
+    void initialize() throws IOException;
 
     /**
      * Register a listener to get commit/leader notifications.

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -36,7 +36,9 @@ public class RaftConfig {
     public static final String QUORUM_VOTERS_CONFIG = QUORUM_PREFIX + "voters";
     public static final String QUORUM_VOTERS_DOC = "Map of id/endpoint information for " +
         "the set of voters in a comma-separated list of `{id}@{host}:{port}` entries. " +
-        "For example: `1@localhost:9092,2@localhost:9093,3@localhost:9094`";
+        "For example: `1@localhost:9092,2@localhost:9093,3@localhost:9094.`" +
+        "If the voter endpoints are not known at startup, a non-routable address can be provided instead." +
+        "For example: `1@0.0.0.0:0,2@0.0.0.0:0,3@0.0.0.0:0.";
     public static final List<String> DEFAULT_QUORUM_VOTERS = Collections.emptyList();
 
     public static final String QUORUM_ELECTION_TIMEOUT_MS_CONFIG = QUORUM_PREFIX + "election.timeout.ms";
@@ -97,13 +99,13 @@ public class RaftConfig {
         int fetchTimeoutMs,
         int appendLingerMs
     ) {
+        this.voterConnections = voterConnections;
         this.requestTimeoutMs = requestTimeoutMs;
         this.retryBackoffMs = retryBackoffMs;
         this.electionTimeoutMs = electionTimeoutMs;
         this.electionBackoffMaxMs = electionBackoffMaxMs;
         this.fetchTimeoutMs = fetchTimeoutMs;
         this.appendLingerMs = appendLingerMs;
-        this.voterConnections = voterConnections;
     }
 
     public int requestTimeoutMs() {
@@ -146,7 +148,7 @@ public class RaftConfig {
         }
     }
 
-    private static Map<Integer, InetSocketAddress> parseVoterConnections(List<String> voterEntries) {
+    public static Map<Integer, InetSocketAddress> parseVoterConnections(List<String> voterEntries) {
         Map<Integer, InetSocketAddress> voterMap = new HashMap<>();
         for (String voterMapEntry : voterEntries) {
             String[] idAndAddress = voterMapEntry.split("@");

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -99,8 +99,8 @@ public class RaftConfig {
         public final InetSocketAddress address;
 
         public InetAddressSpec(InetSocketAddress address) {
-            if (address != null && address.equals(NON_ROUTABLE_ADDRESS)) {
-                throw new IllegalArgumentException("Address not routable");
+            if (address == null || address.equals(NON_ROUTABLE_ADDRESS)) {
+                throw new IllegalArgumentException("Invalid address: " + address);
             }
             this.address = address;
         }

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -47,7 +47,7 @@ public class RaftConfig {
     public static final String QUORUM_VOTERS_CONFIG = QUORUM_PREFIX + "voters";
     public static final String QUORUM_VOTERS_DOC = "Map of id/endpoint information for " +
         "the set of voters in a comma-separated list of `{id}@{host}:{port}` entries. " +
-        "For example: `1@localhost:9092,2@localhost:9093,3@localhost:9094.`";
+        "For example: `1@localhost:9092,2@localhost:9093,3@localhost:9094`";
     public static final List<String> DEFAULT_QUORUM_VOTERS = Collections.emptyList();
 
     public static final String QUORUM_ELECTION_TIMEOUT_MS_CONFIG = QUORUM_PREFIX + "election.timeout.ms";

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -99,7 +99,7 @@ public class RaftConfig {
         public final InetSocketAddress address;
 
         public InetAddressSpec(InetSocketAddress address) {
-            if (address.equals(NON_ROUTABLE_ADDRESS)) {
+            if (address != null && address.equals(NON_ROUTABLE_ADDRESS)) {
                 throw new IllegalArgumentException("Address not routable");
             }
             this.address = address;
@@ -127,16 +127,6 @@ public class RaftConfig {
 
     public static class UnknownAddressSpec implements AddressSpec {
         private UnknownAddressSpec() {
-        }
-
-        @Override
-        public int hashCode() {
-            return NON_ROUTABLE_ADDRESS.hashCode();
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return obj != null && getClass() == obj.getClass();
         }
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -191,7 +191,7 @@ public final class RaftClientTestContext {
             MockNetworkChannel channel = new MockNetworkChannel(voters);
             LogContext logContext = new LogContext();
             MockListener listener = new MockListener();
-            Map<Integer, InetSocketAddress> voterAddressMap = voters.stream()
+            Map<Integer, RaftConfig.AddressSpec> voterAddressMap = voters.stream()
                 .collect(Collectors.toMap(id -> id, RaftClientTestContext::mockAddress));
             RaftConfig raftConfig = new RaftConfig(voterAddressMap, requestTimeoutMs, RETRY_BACKOFF_MS, electionTimeoutMs,
                     ELECTION_BACKOFF_MAX_MS, FETCH_TIMEOUT_MS, appendLingerMs);
@@ -709,8 +709,8 @@ public final class RaftClientTestContext {
         return response.responses().get(0).partitionResponses().get(0);
     }
 
-    private static InetSocketAddress mockAddress(int id) {
-        return new InetSocketAddress("localhost", 9990 + id);
+    private static RaftConfig.AddressSpec mockAddress(int id) {
+        return new RaftConfig.InetAddressSpec(new InetSocketAddress("localhost", 9990 + id));
     }
 
     EndQuorumEpochResponseData endEpochResponse(

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -188,7 +188,7 @@ public final class RaftClientTestContext {
 
         public RaftClientTestContext build() throws IOException {
             Metrics metrics = new Metrics(time);
-            MockNetworkChannel channel = new MockNetworkChannel();
+            MockNetworkChannel channel = new MockNetworkChannel(voters);
             LogContext logContext = new LogContext();
             MockListener listener = new MockListener();
             Map<Integer, InetSocketAddress> voterAddressMap = voters.stream()
@@ -209,11 +209,12 @@ public final class RaftClientTestContext {
                 FETCH_MAX_WAIT_MS,
                 localId,
                 logContext,
-                random
+                random,
+                raftConfig
             );
 
             client.register(listener);
-            client.initialize(raftConfig);
+            client.initialize();
 
             return new RaftClientTestContext(
                 localId,

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -203,11 +203,7 @@ public class RaftEventSimulationTest {
             long highWatermark = cluster.maxHighWatermarkReached();
 
             // Restart the node and verify it catches up
-            try {
-                cluster.start(leaderId);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to start leader ID: " + leaderId);
-            }
+            cluster.start(leaderId);
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(highWatermark + 10));
         }
     }
@@ -250,11 +246,7 @@ public class RaftEventSimulationTest {
             Iterator<Integer> nodeIdsIterator = cluster.nodes().iterator();
             for (int i = 0; i < cluster.majoritySize(); i++) {
                 Integer nodeId = nodeIdsIterator.next();
-                try {
-                    cluster.start(nodeId);
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to start node ID: " + nodeId);
-                }
+                cluster.start(nodeId);
             }
 
             scheduler.runUntil(() -> cluster.allReachedHighWatermark(highWatermark + 10));
@@ -730,24 +722,20 @@ public class RaftEventSimulationTest {
             if (!running.isEmpty())
                 throw new IllegalStateException("Some nodes are already started");
             for (int voterId : nodes.keySet()) {
-                try {
-                    start(voterId);
-                } catch (IOException e) {
-                    throw new RuntimeException("Failed to start voter ID: " + voterId);
-                }
+                start(voterId);
             }
         }
 
-        private static InetSocketAddress nodeAddress(int id) {
-            return new InetSocketAddress("localhost", 9990 + id);
+        private static RaftConfig.AddressSpec nodeAddress(int id) {
+            return new RaftConfig.InetAddressSpec(new InetSocketAddress("localhost", 9990 + id));
         }
 
-        void start(int nodeId) throws IOException {
+        void start(int nodeId) {
             LogContext logContext = new LogContext("[Node " + nodeId + "] ");
             PersistentState persistentState = nodes.get(nodeId);
             MockNetworkChannel channel = new MockNetworkChannel(correlationIdCounter, voters);
             MockMessageQueue messageQueue = new MockMessageQueue();
-            Map<Integer, InetSocketAddress> voterAddressMap = voters.stream()
+            Map<Integer, RaftConfig.AddressSpec> voterAddressMap = voters.stream()
                 .collect(Collectors.toMap(id -> id, Cluster::nodeAddress));
             RaftConfig raftConfig = new RaftConfig(voterAddressMap, REQUEST_TIMEOUT_MS, RETRY_BACKOFF_MS, ELECTION_TIMEOUT_MS,
                     ELECTION_JITTER_MS, FETCH_TIMEOUT_MS, LINGER_MS);


### PR DESCRIPTION
With KIP-595, we expect the RaftConfig to specify the quorum voter endpoints upfront on startup. In the general case, this works fine. However, for testing we need a more lazy approach that discovers the other voters in the quorum after startup (i.e. controller port bind). This approach also lends itself well to cases where we might have an observer that discovers the voter endpoints from, say a `DescribeQuorum` event.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
