### PR TITLE
MINOR: remove useless repeated method call in KafkaApiTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2992,7 +2992,7 @@ class KafkaApisTest {
       .setLeaderEpoch(1)
       .setReplicas(replicas)
       .setZkVersion(0)
-      .setReplicas(replicas)
+      .setIsr(replicas)
 
     val plaintextListener = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
     val broker = new UpdateMetadataBroker()


### PR DESCRIPTION
*More detailed description of your change*
SetReplicas was invoked twice with same params, I think the author means setIsrs

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
