### PR TITLE
Schema Exception Interface fix

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -244,7 +244,7 @@ public class ConnectSchema implements Schema {
         switch (schema.type()) {
             case STRUCT:
                 Struct struct = (Struct) value;
-                if (!struct.schema().equals(schema))
+                if (!struct.schema().equals(schema.schema()))
                     throw new DataException("Struct schemas do not match.");
                 struct.validate();
                 break;


### PR DESCRIPTION
Bug fix. I'm passing in a SchemaBuilder for schema, and this will always throw an exception since it's doing an equals comparison. The reason that I need to pass in a builder is because my schema contains possibilities for a graph, and the only way to represent this is with SchemaBuilder since ConnectSchema is not mutable.

Please let me know if this is a valid approach or if the original code is intended to function that way.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
