### PR TITLE
MINOR: Ensure `InterBrokerSendThread` closes `NetworkClient`

### DIFF
--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -48,9 +48,9 @@ abstract class InterBrokerSendThread(
 
   override def shutdown(): Unit = {
     initiateShutdown()
-    // wake up the thread in case it is blocked inside poll
-    networkClient.wakeup()
+    networkClient.initiateClose()
     awaitShutdown()
+    networkClient.close()
   }
 
   private def drainGeneratedRequests(): Unit = {

--- a/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
+++ b/core/src/main/scala/kafka/raft/KafkaNetworkChannel.scala
@@ -179,7 +179,6 @@ class KafkaNetworkChannel(
 
   override def close(): Unit = {
     requestThread.shutdown()
-    client.close()
   }
 
 }


### PR DESCRIPTION
We should ensure `NetworkClient` is closed properly when `InterBrokerSendThread` is shutdown. Also use `initiateShutdown` instead of `wakeup()` to alert polling thread.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
