### PR TITLE
KAFKA-9274: handle TimeoutException on task reset

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -88,7 +88,7 @@ public class StandbyTask extends AbstractTask implements Task {
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+    public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         if (state() == State.CREATED) {
             StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -44,13 +44,13 @@ public class StandbyTask extends AbstractTask implements Task {
     private final StreamsMetricsImpl streamsMetrics;
 
     /**
-     * @param id             the ID of this task
-     * @param partitions     input topic partitions, used for thread metadata only
-     * @param topology       the instance of {@link ProcessorTopology}
-     * @param config         the {@link StreamsConfig} specified by the user
-     * @param streamsMetrics the {@link StreamsMetrics} created by the thread
-     * @param stateMgr       the {@link ProcessorStateManager} for this task
-     * @param stateDirectory the {@link StateDirectory} created by the thread
+     * @param id              the ID of this task
+     * @param inputPartitions input topic partitions, used for thread metadata only
+     * @param topology        the instance of {@link ProcessorTopology}
+     * @param config          the {@link StreamsConfig} specified by the user
+     * @param streamsMetrics  the {@link StreamsMetrics} created by the thread
+     * @param stateMgr        the {@link ProcessorStateManager} for this task
+     * @param stateDirectory  the {@link StateDirectory} created by the thread
      */
     StandbyTask(final TaskId id,
                 final Set<TopicPartition> inputPartitions,
@@ -88,7 +88,7 @@ public class StandbyTask extends AbstractTask implements Task {
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public void initializeIfNeeded() {
+    public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         if (state() == State.CREATED) {
             StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -88,7 +88,7 @@ public class StandbyTask extends AbstractTask implements Task {
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+    public void initializeIfNeeded() {
         if (state() == State.CREATED) {
             StateManagerUtil.registerStateStores(log, logPrefix, topology, stateMgr, stateDirectory, processorContext);
 
@@ -111,7 +111,7 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void completeRestoration() {
+    public void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         throw new IllegalStateException("Standby task " + id + " should never be completing restoration");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -214,7 +214,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
      * @throws StreamsException fatal error, should close the thread
      */
     @Override
-    public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+    public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         if (state() == State.CREATED) {
             initOffsetsIfNeeded(offsetResetter);
             recordCollector.initialize();
@@ -232,7 +232,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         }
     }
 
-    private void initOffsetsIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+    private void initOffsetsIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         final Map<TopicPartition, OffsetAndMetadata> committed = mainConsumer.committed(resetOffsetsForPartitions);
         for (final Map.Entry<TopicPartition, OffsetAndMetadata> committedEntry : committed.entrySet()) {
             final OffsetAndMetadata offsetAndMetadata = committedEntry.getValue();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -421,8 +421,6 @@ public class StreamThread extends Thread {
             cache::resize
         );
 
-        taskManager.setPartitionResetter(partitions -> streamThread.resetOffsets(partitions, null));
-
         return streamThread.updateThreadMetadata(getSharedAdminClientId(clientId));
     }
 
@@ -839,7 +837,7 @@ public class StreamThread extends Thread {
             // transit to restore active is idempotent so we can call it multiple times
             changelogReader.enforceRestoreActive();
 
-            if (taskManager.tryToCompleteRestoration(now)) {
+            if (taskManager.tryToCompleteRestoration(now, partitions -> resetOffsets(partitions, null))) {
                 changelogReader.transitToUpdateStandby();
                 log.info("Restoration took {} ms for all tasks {}", time.milliseconds() - lastPartitionAssignedMs,
                     taskManager.tasks().keySet());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -107,7 +107,11 @@ public interface Task {
      * @throws LockException could happen when multi-threads within the single instance, could retry
      * @throws StreamsException fatal error, should close the thread
      */
-    void initializeIfNeeded();
+    void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter);
+
+    default void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * @throws StreamsException fatal error, should close the thread

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -107,7 +107,7 @@ public interface Task {
      * @throws LockException could happen when multi-threads within the single instance, could retry
      * @throws StreamsException fatal error, should close the thread
      */
-    void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter);
+    void initializeIfNeeded();
 
     default void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
         throw new UnsupportedOperationException();
@@ -116,7 +116,7 @@ public interface Task {
     /**
      * @throws StreamsException fatal error, should close the thread
      */
-    void completeRestoration();
+    void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter);
 
     void suspend();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -407,7 +407,7 @@ public class TaskManager {
      * @throws StreamsException if the store's change log does not contain the partition
      * @return {@code true} if all tasks are fully restored
      */
-    boolean tryToCompleteRestoration(final long now, java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+    boolean tryToCompleteRestoration(final long now, final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         boolean allRunning = true;
 
         final List<Task> activeTasks = new LinkedList<>();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -90,7 +90,6 @@ public class TaskManager {
 
     // includes assigned & initialized tasks and unassigned tasks we locked temporarily during rebalance
     private final Set<TaskId> lockedTaskDirectories = new HashSet<>();
-    private java.util.function.Consumer<Set<TopicPartition>> resetter;
 
     TaskManager(final Time time,
                 final ChangelogReader changelogReader,
@@ -227,18 +226,7 @@ public class TaskManager {
                     );
                 }
 
-                mainConsumer.pause(assignedToPauseAndReset);
-                // TODO: KIP-572 need to handle `TimeoutException`
-                final Map<TopicPartition, OffsetAndMetadata> committed = mainConsumer.committed(assignedToPauseAndReset);
-                for (final Map.Entry<TopicPartition, OffsetAndMetadata> committedEntry : committed.entrySet()) {
-                    final OffsetAndMetadata offsetAndMetadata = committedEntry.getValue();
-                    if (offsetAndMetadata != null) {
-                        mainConsumer.seek(committedEntry.getKey(), offsetAndMetadata);
-                        assignedToPauseAndReset.remove(committedEntry.getKey());
-                    }
-                }
-                // throws if anything has no configured reset policy
-                resetter.accept(assignedToPauseAndReset);
+                task.addPartitionsForOffsetReset(assignedToPauseAndReset);
             }
             task.revive();
         }
@@ -419,13 +407,13 @@ public class TaskManager {
      * @throws StreamsException if the store's change log does not contain the partition
      * @return {@code true} if all tasks are fully restored
      */
-    boolean tryToCompleteRestoration(final long now) {
+    boolean tryToCompleteRestoration(final long now, java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         boolean allRunning = true;
 
         final List<Task> activeTasks = new LinkedList<>();
         for (final Task task : tasks.allTasks()) {
             try {
-                task.initializeIfNeeded();
+                task.initializeIfNeeded(offsetResetter);
                 task.clearTaskTimeout();
             } catch (final LockException retriableException) {
                 // it is possible that if there are multiple threads within the instance that one thread
@@ -1265,10 +1253,6 @@ public class TaskManager {
 
     boolean needsInitializationOrRestoration() {
         return tasks().values().stream().anyMatch(Task::needsInitializationOrRestoration);
-    }
-
-    public void setPartitionResetter(final java.util.function.Consumer<Set<TopicPartition>> resetter) {
-        this.resetter = resetter;
     }
 
     // for testing only

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -413,7 +413,7 @@ public class TaskManager {
         final List<Task> activeTasks = new LinkedList<>();
         for (final Task task : tasks.allTasks()) {
             try {
-                task.initializeIfNeeded(offsetResetter);
+                task.initializeIfNeeded();
                 task.clearTaskTimeout();
             } catch (final LockException retriableException) {
                 // it is possible that if there are multiple threads within the instance that one thread
@@ -441,7 +441,7 @@ public class TaskManager {
             for (final Task task : activeTasks) {
                 if (restored.containsAll(task.changelogPartitions())) {
                     try {
-                        task.completeRestoration();
+                        task.completeRestoration(offsetResetter);
                         task.clearTaskTimeout();
                     } catch (final TimeoutException timeoutException) {
                         task.maybeInitTaskTimeoutOrThrow(now, timeoutException);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -167,7 +167,7 @@ public class StandbyTaskTest {
 
         task = createStandbyTask();
 
-        assertThrows(LockException.class, task::initializeIfNeeded);
+        assertThrows(LockException.class, () -> task.initializeIfNeeded(null));
         task = null;
     }
 
@@ -182,12 +182,12 @@ public class StandbyTaskTest {
 
         assertEquals(CREATED, task.state());
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         assertEquals(RUNNING, task.state());
 
         // initialize should be idempotent
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         assertEquals(RUNNING, task.state());
 
@@ -219,7 +219,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.prepareCommit();
         task.postCommit(false);  // this should not checkpoint
 
@@ -258,7 +258,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.suspend();
         task.closeDirty();
 
@@ -278,7 +278,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.suspend();
         task.closeDirty();
@@ -299,7 +299,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.suspend();
         task.prepareCommit();
         task.postCommit(true);
@@ -337,7 +337,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         // no need to commit if we've just initialized and offset not advanced much
         assertFalse(task.commitNeeded());
@@ -361,7 +361,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.suspend();
         assertThrows(RuntimeException.class, () -> task.closeClean());
@@ -386,7 +386,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.prepareCommit();
         assertThrows(RuntimeException.class, () -> task.postCommit(true));
@@ -409,7 +409,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.suspend();
         task.closeClean();
@@ -425,7 +425,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.suspend();
         task.closeDirty();
@@ -526,7 +526,7 @@ public class StandbyTaskTest {
         task = createStandbyTask();
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // CREATED
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RUNNING
 
         task.suspend();
@@ -553,7 +553,7 @@ public class StandbyTaskTest {
         EasyMock.expect(stateManager.changelogOffsets()).andStubReturn(Collections.emptyMap());
         EasyMock.replay(stateManager);
         task = createStandbyTask();
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         assertThat(task.state(), equalTo(RUNNING));
         task.suspend();
         assertThat(task.state(), equalTo(SUSPENDED));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -167,7 +167,7 @@ public class StandbyTaskTest {
 
         task = createStandbyTask();
 
-        assertThrows(LockException.class, () -> task.initializeIfNeeded(null));
+        assertThrows(LockException.class, () -> task.initializeIfNeeded());
         task = null;
     }
 
@@ -182,12 +182,12 @@ public class StandbyTaskTest {
 
         assertEquals(CREATED, task.state());
 
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         assertEquals(RUNNING, task.state());
 
         // initialize should be idempotent
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         assertEquals(RUNNING, task.state());
 
@@ -219,7 +219,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
         task.prepareCommit();
         task.postCommit(false);  // this should not checkpoint
 
@@ -258,7 +258,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
         task.suspend();
         task.closeDirty();
 
@@ -278,7 +278,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         task.suspend();
         task.closeDirty();
@@ -299,7 +299,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
         task.suspend();
         task.prepareCommit();
         task.postCommit(true);
@@ -337,7 +337,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         // no need to commit if we've just initialized and offset not advanced much
         assertFalse(task.commitNeeded());
@@ -361,7 +361,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         task.suspend();
         assertThrows(RuntimeException.class, () -> task.closeClean());
@@ -386,7 +386,7 @@ public class StandbyTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         task.prepareCommit();
         assertThrows(RuntimeException.class, () -> task.postCommit(true));
@@ -409,7 +409,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         task.suspend();
         task.closeClean();
@@ -425,7 +425,7 @@ public class StandbyTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
 
         task.suspend();
         task.closeDirty();
@@ -526,7 +526,7 @@ public class StandbyTaskTest {
         task = createStandbyTask();
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // CREATED
 
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RUNNING
 
         task.suspend();
@@ -553,7 +553,7 @@ public class StandbyTaskTest {
         EasyMock.expect(stateManager.changelogOffsets()).andStubReturn(Collections.emptyMap());
         EasyMock.replay(stateManager);
         task = createStandbyTask();
-        task.initializeIfNeeded(null);
+        task.initializeIfNeeded();
         assertThat(task.state(), equalTo(RUNNING));
         task.suspend();
         assertThat(task.state(), equalTo(SUSPENDED));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -384,6 +384,7 @@ public class StreamTaskTest {
         // because we mocked the `resetter` positions don't change
         assertThat(consumer.position(partition1), equalTo(5L));
         assertThat(consumer.position(partition2), equalTo(15L));
+        EasyMock.verify(resettter);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -277,7 +277,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), false);
 
-        assertThrows(LockException.class, task::initializeIfNeeded);
+        assertThrows(LockException.class, () -> task.initializeIfNeeded(null));
     }
 
     @Test
@@ -287,7 +287,7 @@ public class StreamTaskTest {
 
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         // should fail if lock is called
         EasyMock.verify(stateDirectory);
@@ -339,7 +339,7 @@ public class StreamTaskTest {
 
         assertEquals(RecordQueue.UNKNOWN, task.streamTime());
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         assertEquals(10L, task.streamTime());
@@ -360,14 +360,14 @@ public class StreamTaskTest {
 
         assertEquals(CREATED, task.state());
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         assertEquals(RESTORING, task.state());
         assertFalse(source1.initialized);
         assertFalse(source2.initialized);
 
         // initialize should be idempotent
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         assertEquals(RESTORING, task.state());
 
@@ -579,7 +579,7 @@ public class StreamTaskTest {
         };
 
         task = createStatelessTaskWithForwardingTopology(evenKeyForwardingSourceNode);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         final String sourceNodeName = evenKeyForwardingSourceNode.name();
@@ -895,7 +895,7 @@ public class StreamTaskTest {
     @Test
     public void shouldPunctuateOnceStreamTimeAfterGap() {
         task = createStatelessTask(createConfig(), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, asList(
@@ -983,7 +983,7 @@ public class StreamTaskTest {
     @Test
     public void shouldRespectPunctuateCancellationStreamTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, asList(
@@ -1023,7 +1023,7 @@ public class StreamTaskTest {
     @Test
     public void shouldRespectPunctuateCancellationSystemTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         final long now = time.milliseconds();
         time.sleep(10);
@@ -1037,7 +1037,7 @@ public class StreamTaskTest {
     @Test
     public void shouldRespectCommitNeeded() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         assertFalse(task.commitNeeded());
@@ -1075,7 +1075,7 @@ public class StreamTaskTest {
     @Test
     public void shouldCommitNextOffsetFromQueueIfAvailable() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, asList(
@@ -1094,7 +1094,7 @@ public class StreamTaskTest {
     @Test
     public void shouldCommitConsumerPositionIfRecordQueueIsEmpty() {
         task = createStatelessTask(createConfig(), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         consumer.addRecord(getConsumerRecordWithOffsetAsTimestamp(partition1, 0L));
@@ -1128,7 +1128,7 @@ public class StreamTaskTest {
     @Test
     public void shouldRespectCommitRequested() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.requestCommit();
@@ -1160,7 +1160,7 @@ public class StreamTaskTest {
     @Test
     public void shouldBeProcessableIfAllPartitionsBuffered() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         assertFalse(task.process(0L));
@@ -1178,7 +1178,7 @@ public class StreamTaskTest {
 
     public void shouldPunctuateSystemTimeWhenIntervalElapsed() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         final long now = time.milliseconds();
         time.sleep(10);
@@ -1198,7 +1198,7 @@ public class StreamTaskTest {
     @Test
     public void shouldNotPunctuateSystemTimeWhenIntervalNotElapsed() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         assertFalse(task.maybePunctuateSystemTime());
         time.sleep(9);
@@ -1209,7 +1209,7 @@ public class StreamTaskTest {
     @Test
     public void shouldPunctuateOnceSystemTimeAfterGap() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         final long now = time.milliseconds();
         time.sleep(100);
@@ -1235,7 +1235,7 @@ public class StreamTaskTest {
     @Test
     public void shouldWrapKafkaExceptionsWithStreamsExceptionAndAddContextWhenPunctuatingStreamTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         try {
@@ -1253,7 +1253,7 @@ public class StreamTaskTest {
     @Test
     public void shouldWrapKafkaExceptionsWithStreamsExceptionAndAddContextWhenPunctuatingWallClockTimeTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         try {
@@ -1271,7 +1271,7 @@ public class StreamTaskTest {
     @Test
     public void shouldNotShareHeadersBetweenPunctuateIterations() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.punctuate(
@@ -1297,7 +1297,7 @@ public class StreamTaskTest {
 
         task = createFaultyStatefulTask(createConfig("100"));
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, asList(
@@ -1325,7 +1325,7 @@ public class StreamTaskTest {
 
         task = createDisconnectedTask(createConfig("100"));
 
-        task.initializeIfNeeded();
+        task.transitionTo(RESTORING);
 
         assertThrows(TimeoutException.class, task::completeRestoration);
     }
@@ -1341,7 +1341,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), true);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.suspend();
 
@@ -1383,7 +1383,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), true);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.prepareCommit();
@@ -1413,7 +1413,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), true);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.prepareCommit();
         task.postCommit(true);
@@ -1434,7 +1434,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig(StreamsConfig.EXACTLY_ONCE, "100"), true);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.prepareCommit();
         task.postCommit(false);
@@ -1449,7 +1449,7 @@ public class StreamTaskTest {
     @Test
     public void shouldThrowIllegalStateExceptionIfCurrentNodeIsNotNullWhenPunctuateCalled() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.processorContext().setCurrentNode(processorStreamTime);
         try {
@@ -1463,7 +1463,7 @@ public class StreamTaskTest {
     @Test
     public void shouldCallPunctuateOnPassedInProcessorNode() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.punctuate(processorStreamTime, 5, PunctuationType.STREAM_TIME, punctuator);
         assertThat(punctuatedAt, equalTo(5L));
@@ -1474,7 +1474,7 @@ public class StreamTaskTest {
     @Test
     public void shouldSetProcessorNodeOnContextBackToNullAfterSuccessfulPunctuate() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.punctuate(processorStreamTime, 5, PunctuationType.STREAM_TIME, punctuator);
         assertThat(task.processorContext().currentNode(), nullValue());
@@ -1504,7 +1504,7 @@ public class StreamTaskTest {
 
         task = createFaultyStatefulTask(createConfig("100"));
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         assertThrows(RuntimeException.class, () -> task.suspend());
@@ -1553,7 +1553,7 @@ public class StreamTaskTest {
             context,
             logContext);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L)));
@@ -1584,7 +1584,7 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
-        task.initializeIfNeeded();
+        task.transitionTo(RESTORING);
 
         assertThrows(StreamsException.class, task::completeRestoration);
     }
@@ -1627,7 +1627,7 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStatefulTask(createConfig("100"), true);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.suspend();
         task.postCommit(true);
         EasyMock.verify(stateManager);
@@ -1643,7 +1643,7 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStatefulTask(createConfig("100"), true);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.prepareCommit();
@@ -1664,7 +1664,7 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager);
 
         task = createStatefulTask(createConfig("100"), true);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.prepareCommit();
@@ -1688,7 +1688,7 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager, recordCollector);
 
         task = createStatefulTask(createConfig(), true);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.addRecords(partition1, singleton(getConsumerRecordWithOffsetAsTimestamp(partition1, 10)));
         task.addRecords(partition2, singleton(getConsumerRecordWithOffsetAsTimestamp(partition2, 10)));
@@ -1709,7 +1709,7 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         assertEquals(singletonMap(partition1, 50L), task.changelogOffsets());
 
@@ -1757,7 +1757,7 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         task.suspend();
         task.prepareCommit();
@@ -1784,7 +1784,7 @@ public class StreamTaskTest {
         EasyMock.replay(recordCollector, stateManager);
 
         task = createOptimizedStatefulTask(createConfig(), consumer);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, consumedOffset)));
@@ -1815,7 +1815,7 @@ public class StreamTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset)));
@@ -1857,7 +1857,7 @@ public class StreamTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         // process one record to make commit needed
@@ -1892,7 +1892,7 @@ public class StreamTaskTest {
         final MetricName metricName = setupCloseTaskMetric();
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset)));
         task.process(100L);
@@ -1923,7 +1923,7 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager);
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
 
         task.suspend();
         task.closeDirty();
@@ -2009,7 +2009,7 @@ public class StreamTaskTest {
     @Test
     public void shouldThrowIfCleanClosingDirtyTask() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)));
@@ -2022,7 +2022,7 @@ public class StreamTaskTest {
     @Test
     public void shouldThrowIfRecyclingDirtyTask() {
         task = createStatelessTask(createConfig(), StreamsConfig.METRICS_LATEST);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)));
@@ -2043,7 +2043,7 @@ public class StreamTaskTest {
         task = createStatefulTask(createConfig("100"), true);
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // CREATED
 
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RESTORING
 
         task.completeRestoration();
@@ -2069,7 +2069,7 @@ public class StreamTaskTest {
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(Collections.emptyMap()).anyTimes();
         EasyMock.replay(stateManager);
         task = createStatefulTask(createConfig("100"), true);
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         assertThat(task.state(), equalTo(RESTORING));
         task.suspend();
         assertThat(task.state(), equalTo(SUSPENDED));
@@ -2080,7 +2080,7 @@ public class StreamTaskTest {
         EasyMock.expect(stateManager.changelogOffsets()).andReturn(Collections.emptyMap()).anyTimes();
         EasyMock.replay(stateManager);
         task = createFaultyStatefulTask(createConfig("100"));
-        task.initializeIfNeeded();
+        task.initializeIfNeeded(null);
         task.completeRestoration();
         assertThat(task.state(), equalTo(RUNNING));
         assertThrows(RuntimeException.class, () -> task.suspend());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1622,7 +1622,7 @@ public class StreamThreadTest {
         standbyTasks.put(task3, Collections.singleton(t2p1));
 
         thread.taskManager().handleAssignment(emptyMap(), standbyTasks);
-        thread.taskManager().tryToCompleteRestoration(mockTime.milliseconds());
+        thread.taskManager().tryToCompleteRestoration(mockTime.milliseconds(), null);
 
         thread.rebalanceListener().onPartitionsAssigned(Collections.emptyList());
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -466,7 +466,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, topologyBuilder, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         taskManager.handleRevocation(taskId00Partitions);
@@ -545,7 +545,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, topologyBuilder, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
 
@@ -599,7 +599,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, topologyBuilder, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         taskManager.handleRevocation(taskId00Partitions);
@@ -649,9 +649,8 @@ public class TaskManagerTest {
         consumer.seek(t1p0, offsetAndMetadata);
         expectLastCall();
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
-        taskManager.setPartitionResetter(tp -> assertThat(tp, is(empty())));
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), tp -> assertThat(tp, is(empty()))), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         taskManager.handleCorruption(singletonMap(taskId00, taskId00Partitions));
@@ -691,11 +690,10 @@ public class TaskManagerTest {
         expect(consumer.committed(taskId00Partitions)).andReturn(singletonMap(t1p0, offsetAndMetadata));
         consumer.seek(t1p0, offsetAndMetadata);
         expectLastCall();
-        taskManager.setPartitionResetter(tp -> assertThat(tp, is(empty())));
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), tp -> assertThat(tp, is(empty()))), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         taskManager.handleCorruption(singletonMap(taskId00, taskId00Partitions));
@@ -736,9 +734,8 @@ public class TaskManagerTest {
         consumer.seek(t1p0, offsetAndMetadata);
         expectLastCall();
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
-        taskManager.setPartitionResetter(tp -> assertThat(tp, is(empty())));
         taskManager.handleAssignment(assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), tp -> assertThat(tp, is(empty()))), is(true));
 
         assertThat(nonCorruptedTask.state(), is(Task.State.RUNNING));
         nonCorruptedTask.setCommitNeeded();
@@ -778,7 +775,7 @@ public class TaskManagerTest {
         expectLastCall();
 
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
-        taskManager.setPartitionResetter(tp -> assertThat(tp, is(empty())));
+        //taskManager.setPartitionResetter(tp -> assertThat(tp, is(empty())));
         taskManager.handleAssignment(assignment, emptyMap());
         assertThat(nonRunningNonCorruptedTask.state(), is(Task.State.CREATED));
 
@@ -814,7 +811,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, topologyBuilder, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId01Assignment, taskId00Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         // make sure this will be committed and throw
         assertThat(runningNonCorruptedActive.state(), is(Task.State.RUNNING));
@@ -841,7 +838,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(emptyMap(), taskId00Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         taskManager.handleAssignment(emptyMap(), emptyMap());
@@ -863,12 +860,12 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
 
         taskManager.handleAssignment(taskId00Assignment, taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
 
@@ -887,13 +884,13 @@ public class TaskManagerTest {
 
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         final Set<TopicPartition> newPartitionsSet = mkSet(t1p1);
         final Map<TaskId, Set<TopicPartition>> taskIdSetMap = singletonMap(taskId00, newPartitionsSet);
         taskManager.handleAssignment(taskIdSetMap, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertEquals(newPartitionsSet, task00.inputPartitions());
         verify(activeTaskCreator, consumer, changeLogReader);
@@ -918,7 +915,7 @@ public class TaskManagerTest {
 
         assertThat(task00.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(taskManager.activeTaskMap(), Matchers.equalTo(singletonMap(taskId00, task00)));
@@ -934,13 +931,13 @@ public class TaskManagerTest {
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public void initializeIfNeeded() {
+            public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
                 throw new LockException("can't lock");
             }
         };
         final Task task01 = new StateMachineTask(taskId01, taskId01Partitions, true) {
             @Override
-            public void initializeIfNeeded() {
+            public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
                 throw new TimeoutException("timed out");
             }
         };
@@ -962,7 +959,7 @@ public class TaskManagerTest {
         assertThat(task00.state(), is(Task.State.CREATED));
         assertThat(task01.state(), is(Task.State.CREATED));
 
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(false));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(false));
 
         assertThat(task00.state(), is(Task.State.CREATED));
         assertThat(task01.state(), is(Task.State.CREATED));
@@ -1002,7 +999,7 @@ public class TaskManagerTest {
 
         assertThat(task00.state(), is(Task.State.CREATED));
 
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(false));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(false));
 
         assertThat(task00.state(), is(Task.State.RESTORING));
         assertThat(
@@ -1027,7 +1024,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         taskManager.handleRevocation(taskId00Partitions);
@@ -1085,7 +1082,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignmentActive, assignmentStandby);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
         assertThat(task02.state(), is(Task.State.RUNNING));
@@ -1144,7 +1141,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignmentActive, assignmentStandby);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
         assertThat(task02.state(), is(Task.State.RUNNING));
@@ -1180,7 +1177,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignmentActive, assignmentStandby);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task10.state(), is(Task.State.RUNNING));
 
@@ -1210,7 +1207,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignmentActive, assignmentStandby);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task10.state(), is(Task.State.RUNNING));
 
@@ -1252,7 +1249,7 @@ public class TaskManagerTest {
 
         replay(activeTaskCreator, consumer, changeLogReader);
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
         assertThat(task00.state(), is(Task.State.RUNNING));
 
         assertThrows(RuntimeException.class, () -> taskManager.handleRevocation(taskId00Partitions));
@@ -1343,7 +1340,7 @@ public class TaskManagerTest {
         assertThat(task02.state(), is(Task.State.CREATED));
         assertThat(task03.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
 
         assertThat(task00.state(), is(Task.State.RESTORING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -1412,7 +1409,7 @@ public class TaskManagerTest {
 
         assertThat(task00.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
 
         assertThat(task00.state(), is(Task.State.RESTORING));
         assertThat(
@@ -1463,7 +1460,7 @@ public class TaskManagerTest {
 
         assertThat(task00.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
 
         assertThat(task00.state(), is(Task.State.RESTORING));
         assertThat(
@@ -1598,7 +1595,7 @@ public class TaskManagerTest {
         assertThat(task01.state(), is(Task.State.CREATED));
         assertThat(task02.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
 
         assertThat(task00.state(), is(Task.State.RESTORING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -1651,7 +1648,7 @@ public class TaskManagerTest {
         taskManager.handleAssignment(emptyMap(), assignment);
         assertThat(task00.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(taskManager.activeTaskMap(), Matchers.anEmptyMap());
         assertThat(taskManager.standbyTaskMap(), Matchers.equalTo(singletonMap(taskId00, task00)));
@@ -1673,7 +1670,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(taskManager.activeTaskMap(), Matchers.equalTo(singletonMap(taskId00, task00)));
@@ -1693,7 +1690,7 @@ public class TaskManagerTest {
         replay(standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(emptyMap(), taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task01.state(), is(Task.State.RUNNING));
         assertThat(taskManager.activeTaskMap(), Matchers.anEmptyMap());
@@ -1733,7 +1730,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -1777,7 +1774,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignmentActive, assignmentStandby);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -1808,7 +1805,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(Collections.emptyMap(), taskId00Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -1834,7 +1831,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, stateDirectory, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -1947,7 +1944,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -1974,7 +1971,7 @@ public class TaskManagerTest {
         replay(standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(emptyMap(), taskId01Assignment);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task01.state(), is(Task.State.RUNNING));
 
@@ -2009,7 +2006,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2045,7 +2042,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2077,7 +2074,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, adminClient, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2129,7 +2126,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignmentActive, assignmentStandby);
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -2169,7 +2166,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(task01.state(), is(Task.State.RUNNING));
@@ -2283,7 +2280,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2309,7 +2306,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2336,7 +2333,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2359,7 +2356,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2387,7 +2384,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
 
         assertThat(task00.state(), is(Task.State.RUNNING));
 
@@ -2411,7 +2408,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, changeLogReader, consumer);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
-        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(false));
+        assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(false));
         assertThat(task00.state(), is(Task.State.RESTORING));
         // this could be a bit mysterious; we're verifying _no_ interactions on the consumer,
         // since the taskManager should _not_ resume the assignment while we're still in RESTORING
@@ -2433,7 +2430,7 @@ public class TaskManagerTest {
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(TaskManager.class)) {
             taskManager.handleAssignment(taskId00Assignment, emptyMap());
-            assertThat(taskManager.tryToCompleteRestoration(time.milliseconds()), is(true));
+            assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), null), is(true));
             assertThat(task00.state(), is(Task.State.RUNNING));
 
             taskManager.handleRevocation(mkSet(t1p0, new TopicPartition("unknown", 0)));
@@ -2589,7 +2586,7 @@ public class TaskManagerTest {
         replay(activeTaskCreator, standbyTaskCreator, consumer, changeLogReader);
 
         taskManager.handleAssignment(allActiveTasksAssignment, standbyAssignment);
-        taskManager.tryToCompleteRestoration(time.milliseconds());
+        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
 
         final Map<TaskId, StateMachineTask> allTasks = new HashMap<>();
 
@@ -2969,7 +2966,7 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void initializeIfNeeded() {
+        public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
             if (state() == State.CREATED) {
                 transitionTo(State.RESTORING);
                 if (!active) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -894,7 +894,7 @@ public class TaskManagerTest {
 
         assertThat(task00.state(), is(Task.State.CREATED));
 
-        taskManager.tryToCompleteRestoration(time.milliseconds(), null);
+        taskManager.tryToCompleteRestoration(time.milliseconds(), noOpResetter -> { });
 
         assertThat(task00.state(), is(Task.State.RUNNING));
         assertThat(taskManager.activeTaskMap(), Matchers.equalTo(singletonMap(taskId00, task00)));
@@ -910,13 +910,13 @@ public class TaskManagerTest {
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+            public void initializeIfNeeded() {
                 throw new LockException("can't lock");
             }
         };
         final Task task01 = new StateMachineTask(taskId01, taskId01Partitions, true) {
             @Override
-            public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+            public void initializeIfNeeded() {
                 throw new TimeoutException("timed out");
             }
         };
@@ -957,7 +957,7 @@ public class TaskManagerTest {
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public void completeRestoration() {
+            public void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
                 throw new TimeoutException("timeout!");
             }
         };
@@ -2946,7 +2946,7 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+        public void initializeIfNeeded() {
             if (state() == State.CREATED) {
                 transitionTo(State.RESTORING);
                 if (!active) {
@@ -2961,7 +2961,7 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void completeRestoration() {
+        public void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
             if (state() == State.RUNNING) {
                 return;
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -642,12 +642,6 @@ public class TaskManagerTest {
         expectLastCall().anyTimes();
 
         expect(consumer.assignment()).andReturn(taskId00Partitions);
-        consumer.pause(taskId00Partitions);
-        expectLastCall();
-        final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(0L);
-        expect(consumer.committed(taskId00Partitions)).andReturn(singletonMap(t1p0, offsetAndMetadata));
-        consumer.seek(t1p0, offsetAndMetadata);
-        expectLastCall();
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
         assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), tp -> assertThat(tp, is(empty()))), is(true));
@@ -684,12 +678,6 @@ public class TaskManagerTest {
         topologyBuilder.addSubscribedTopicsFromAssignment(anyObject(), anyString());
         expectLastCall().anyTimes();
         expect(consumer.assignment()).andReturn(taskId00Partitions);
-        consumer.pause(taskId00Partitions);
-        expectLastCall();
-        final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(0L);
-        expect(consumer.committed(taskId00Partitions)).andReturn(singletonMap(t1p0, offsetAndMetadata));
-        consumer.seek(t1p0, offsetAndMetadata);
-        expectLastCall();
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
 
         taskManager.handleAssignment(taskId00Assignment, emptyMap());
@@ -727,12 +715,6 @@ public class TaskManagerTest {
         expectRestoreToBeCompleted(consumer, changeLogReader);
         consumer.commitSync(eq(emptyMap()));
         expect(consumer.assignment()).andReturn(taskId00Partitions);
-        consumer.pause(taskId00Partitions);
-        expectLastCall();
-        final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(0L);
-        expect(consumer.committed(taskId00Partitions)).andReturn(singletonMap(t1p0, offsetAndMetadata));
-        consumer.seek(t1p0, offsetAndMetadata);
-        expectLastCall();
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
         taskManager.handleAssignment(assignment, emptyMap());
         assertThat(taskManager.tryToCompleteRestoration(time.milliseconds(), tp -> assertThat(tp, is(empty()))), is(true));
@@ -767,12 +749,6 @@ public class TaskManagerTest {
         expectLastCall().anyTimes();
 
         expect(consumer.assignment()).andReturn(taskId00Partitions);
-        consumer.pause(taskId00Partitions);
-        expectLastCall();
-        final OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(0L);
-        expect(consumer.committed(taskId00Partitions)).andReturn(singletonMap(t1p0, offsetAndMetadata));
-        consumer.seek(t1p0, offsetAndMetadata);
-        expectLastCall();
 
         replay(activeTaskCreator, topologyBuilder, consumer, changeLogReader);
         //taskManager.setPartitionResetter(tp -> assertThat(tp, is(empty())));
@@ -931,13 +907,13 @@ public class TaskManagerTest {
         );
         final Task task00 = new StateMachineTask(taskId00, taskId00Partitions, true) {
             @Override
-            public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+            public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
                 throw new LockException("can't lock");
             }
         };
         final Task task01 = new StateMachineTask(taskId01, taskId01Partitions, true) {
             @Override
-            public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+            public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
                 throw new TimeoutException("timed out");
             }
         };
@@ -2966,13 +2942,18 @@ public class TaskManagerTest {
         }
 
         @Override
-        public void initializeIfNeeded(java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
+        public void initializeIfNeeded(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
             if (state() == State.CREATED) {
                 transitionTo(State.RESTORING);
                 if (!active) {
                     transitionTo(State.RUNNING);
                 }
             }
+        }
+
+        @Override
+        public void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
+
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -160,7 +160,7 @@ public class StreamThreadStateStoreProviderTest {
             clientSupplier,
             processorTopology,
             new TaskId(0, 0));
-        taskOne.initializeIfNeeded(null);
+        taskOne.initializeIfNeeded();
         tasks.put(new TaskId(0, 0), taskOne);
 
         final StreamTask taskTwo = createStreamsTask(
@@ -168,7 +168,7 @@ public class StreamThreadStateStoreProviderTest {
             clientSupplier,
             processorTopology,
             new TaskId(0, 1));
-        taskTwo.initializeIfNeeded(null);
+        taskTwo.initializeIfNeeded();
         tasks.put(new TaskId(0, 1), taskTwo);
 
         threadMock = EasyMock.createNiceMock(StreamThread.class);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -160,7 +160,7 @@ public class StreamThreadStateStoreProviderTest {
             clientSupplier,
             processorTopology,
             new TaskId(0, 0));
-        taskOne.initializeIfNeeded();
+        taskOne.initializeIfNeeded(null);
         tasks.put(new TaskId(0, 0), taskOne);
 
         final StreamTask taskTwo = createStreamsTask(
@@ -168,7 +168,7 @@ public class StreamThreadStateStoreProviderTest {
             clientSupplier,
             processorTopology,
             new TaskId(0, 1));
-        taskTwo.initializeIfNeeded();
+        taskTwo.initializeIfNeeded(null);
         tasks.put(new TaskId(0, 1), taskTwo);
 
         threadMock = EasyMock.createNiceMock(StreamThread.class);

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -528,7 +528,7 @@ public class TopologyTestDriver implements Closeable {
                 recordCollector,
                 context,
                 logContext);
-            task.initializeIfNeeded();
+            task.initializeIfNeeded(null);
             task.completeRestoration();
             task.processorContext().setRecordContext(null);
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -528,8 +528,8 @@ public class TopologyTestDriver implements Closeable {
                 recordCollector,
                 context,
                 logContext);
-            task.initializeIfNeeded(null);
-            task.completeRestoration();
+            task.initializeIfNeeded();
+            task.completeRestoration(noOpResetter -> { });
             task.processorContext().setRecordContext(null);
 
             // initialize the task metadata so that all topics have zero lag


### PR DESCRIPTION
 - part of KIP-572

This changes move the offset reset for the internal "main consumer" when we revive a corrupted task, from the "task cleanup" code path, to the "task init" code path. For this case, we have already logic in place to handle `TimeoutException` that might be thrown by `consumer#committed()` method call.