### PR TITLE
MINOR: AbstractCoordinatorTest should close coordinator explicitly

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -107,6 +107,7 @@ public class AbstractCoordinatorTest {
     @AfterEach
     public void closeCoordinator() {
         Utils.closeQuietly(coordinator, "close coordinator");
+        Utils.closeQuietly(consumerClient, "close consumer client");
     }
 
     private void setupCoordinator() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -51,7 +51,9 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
@@ -101,6 +103,11 @@ public class AbstractCoordinatorTest {
     private final String memberId = "memberId";
     private final String leaderId = "leaderId";
     private final int defaultGeneration = -1;
+
+    @AfterEach
+    public void closeCoordinator() {
+        Utils.closeQuietly(coordinator, "close coordinator");
+    }
 
     private void setupCoordinator() {
         setupCoordinator(RETRY_BACKOFF_MS, REBALANCE_TIMEOUT_MS,


### PR DESCRIPTION
I noticed this issue when digging into some flaky by JVM profiler. ```AbstractCoordinatorTest``` does not close coordinator so it can cause a lot of idle heartbeat threads in the following tests.

```
"kafka-coordinator-heartbeat-thread | dummy-group" #239 daemon prio=5 os_prio=0 cpu=4.40ms elapsed=29.26s tid=0x00007f4798c34000 nid=0x11b6 in Object.wait()  [0x00007f471dbf5000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1398)
	- waiting to re-lock in wait() <0x000000008152b250> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)

"kafka-coordinator-heartbeat-thread | dummy-group" #240 daemon prio=5 os_prio=0 cpu=4.15ms elapsed=29.16s tid=0x00007f4798c36800 nid=0x11b7 in Object.wait()  [0x00007f471d7f4000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1398)
	- waiting to re-lock in wait() <0x000000008152e9c0> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)

"kafka-coordinator-heartbeat-thread | dummy-group" #242 daemon prio=5 os_prio=0 cpu=0.23ms elapsed=29.04s tid=0x00007f4798c39000 nid=0x11b9 in Object.wait()  [0x00007f471d3f3000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at java.lang.Object.wait(java.base@11.0.9.1/Object.java:328)
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1355)
	- waiting to re-lock in wait() <0x00000000815107f8> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)

"kafka-coordinator-heartbeat-thread | dummy-group" #244 daemon prio=5 os_prio=0 cpu=3.62ms elapsed=29.03s tid=0x00007f4798c3b000 nid=0x11bb in Object.wait()  [0x00007f471cff2000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1398)
	- waiting to re-lock in wait() <0x00000000815330b0> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)

"kafka-coordinator-heartbeat-thread | dummy-group" #245 daemon prio=5 os_prio=0 cpu=4.09ms elapsed=28.93s tid=0x00007f4798c3d800 nid=0x11bc in Object.wait()  [0x00007f471cbf1000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1398)
	- waiting to re-lock in wait() <0x00000000815387e8> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)

"kafka-coordinator-heartbeat-thread | dummy-group" #246 daemon prio=5 os_prio=0 cpu=4.14ms elapsed=28.83s tid=0x00007f4798c3f000 nid=0x11bd in Object.wait()  [0x00007f471c7f0000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1398)
	- waiting to re-lock in wait() <0x00000000815389d8> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)

"kafka-coordinator-heartbeat-thread | dummy-group" #247 daemon prio=5 os_prio=0 cpu=4.08ms elapsed=28.72s tid=0x00007f4798c41800 nid=0x11be in Object.wait()  [0x00007f46e3ffe000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(java.base@11.0.9.1/Native Method)
	- waiting on <no object reference available>
	at org.apache.kafka.clients.consumer.internals.AbstractCoordinator$HeartbeatThread.run(AbstractCoordinator.java:1398)
	- waiting to re-lock in wait() <0x0000000081538bc8> (a org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator)
```

I don't observe the relationship between this issue and flaky. However, it seems to me explicitly releasing idle resource is always a good pattern.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
