### PR TITLE
MINOR : add memberId to JoinGroup Success message

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -591,7 +591,7 @@ public abstract class AbstractCoordinator implements Closeable {
                                 joinResponse.data().generationId(),
                                 joinResponse.data().memberId(), joinResponse.data().protocolName());
 
-                            log.info("Successfully joined group with generation {}", AbstractCoordinator.this.generation);
+                            log.info("Successfully joined group with generation {} and memberId {}", generation.generationId, generation.memberId);
 
                             if (joinResponse.isLeader()) {
                                 onJoinLeader(joinResponse).chain(future);


### PR DESCRIPTION
Hi team,

Minor improvement to log the received memberId upon joining a group at INFO level on the memberside (consumer, worker) so that we can easily track broker logs with the member logs without the need to increase log verbosity

Thank you