### PR TITLE
MINOR: Introduce ProducerIdGenerator trait

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/ProducerIdManager.scala
@@ -70,7 +70,12 @@ case class ProducerIdBlock(brokerId: Int, blockStartId: Long, blockEndId: Long) 
   }
 }
 
-class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends Logging {
+trait ProducerIdGenerator {
+  def generateProducerId(): Long
+  def shutdown() : Unit = {}
+}
+
+class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends ProducerIdGenerator with Logging {
 
   this.logIdent = "[ProducerId Manager " + brokerId + "]: "
 
@@ -150,7 +155,7 @@ class ProducerIdManager(val brokerId: Int, val zkClient: KafkaZkClient) extends 
     }
   }
 
-  def shutdown(): Unit = {
+  override def shutdown(): Unit = {
     info(s"Shutdown complete: last producerId assigned $nextProducerId")
   }
 }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -35,6 +35,7 @@ object TransactionCoordinator {
   def apply(config: KafkaConfig,
             replicaManager: ReplicaManager,
             scheduler: Scheduler,
+            producerIdGenerator: ProducerIdGenerator,
             zkClient: KafkaZkClient,
             metrics: Metrics,
             metadataCache: MetadataCache,
@@ -51,7 +52,6 @@ object TransactionCoordinator {
       config.transactionRemoveExpiredTransactionalIdCleanupIntervalMs,
       config.requestTimeoutMs)
 
-    val producerIdManager = new ProducerIdManager(config.brokerId, zkClient)
     val txnStateManager = new TransactionStateManager(config.brokerId, zkClient, scheduler, replicaManager, txnConfig,
       time, metrics)
 
@@ -59,7 +59,7 @@ object TransactionCoordinator {
     val txnMarkerChannelManager = TransactionMarkerChannelManager(config, metrics, metadataCache, txnStateManager,
       time, logContext)
 
-    new TransactionCoordinator(config.brokerId, txnConfig, scheduler, producerIdManager, txnStateManager, txnMarkerChannelManager,
+    new TransactionCoordinator(config.brokerId, txnConfig, scheduler, producerIdGenerator, txnStateManager, txnMarkerChannelManager,
       time, logContext)
   }
 
@@ -83,7 +83,7 @@ object TransactionCoordinator {
 class TransactionCoordinator(brokerId: Int,
                              txnConfig: TransactionConfig,
                              scheduler: Scheduler,
-                             producerIdManager: ProducerIdManager,
+                             producerIdGenerator: ProducerIdGenerator,
                              txnManager: TransactionStateManager,
                              txnMarkerChannelManager: TransactionMarkerChannelManager,
                              time: Time,
@@ -108,7 +108,7 @@ class TransactionCoordinator(brokerId: Int,
     if (transactionalId == null) {
       // if the transactional id is null, then always blindly accept the request
       // and return a new producerId from the producerId manager
-      val producerId = producerIdManager.generateProducerId()
+      val producerId = producerIdGenerator.generateProducerId()
       responseCallback(InitProducerIdResult(producerId, producerEpoch = 0, Errors.NONE))
     } else if (transactionalId.isEmpty) {
       // if transactional id is empty then return error as invalid request. This is
@@ -120,7 +120,7 @@ class TransactionCoordinator(brokerId: Int,
     } else {
       val coordinatorEpochAndMetadata = txnManager.getTransactionState(transactionalId).flatMap {
         case None =>
-          val producerId = producerIdManager.generateProducerId()
+          val producerId = producerIdGenerator.generateProducerId()
           val createdMetadata = new TransactionMetadata(transactionalId = transactionalId,
             producerId = producerId,
             lastProducerId = RecordBatch.NO_PRODUCER_ID,
@@ -224,7 +224,7 @@ class TransactionCoordinator(brokerId: Int,
             // If the epoch is exhausted and the expected epoch (if provided) matches it, generate a new producer ID
             if (txnMetadata.isProducerEpochExhausted &&
                 expectedProducerIdAndEpoch.forall(_.epoch == txnMetadata.producerEpoch)) {
-              val newProducerId = producerIdManager.generateProducerId()
+              val newProducerId = producerIdGenerator.generateProducerId()
               Right(txnMetadata.prepareProducerIdRotation(newProducerId, transactionTimeoutMs, time.milliseconds(),
                 expectedProducerIdAndEpoch.isDefined))
             } else {
@@ -615,7 +615,7 @@ class TransactionCoordinator(brokerId: Int,
     info("Shutting down.")
     isActive.set(false)
     scheduler.shutdown()
-    producerIdManager.shutdown()
+    producerIdGenerator.shutdown()
     txnManager.shutdown()
     txnMarkerChannelManager.shutdown()
     info("Shutdown complete.")

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -35,7 +35,7 @@ object TransactionCoordinator {
   def apply(config: KafkaConfig,
             replicaManager: ReplicaManager,
             scheduler: Scheduler,
-            producerIdGeneratorFactory: () => ProducerIdGenerator,
+            createProducerIdGenerator: () => ProducerIdGenerator,
             zkClient: KafkaZkClient,
             metrics: Metrics,
             metadataCache: MetadataCache,
@@ -59,7 +59,7 @@ object TransactionCoordinator {
     val txnMarkerChannelManager = TransactionMarkerChannelManager(config, metrics, metadataCache, txnStateManager,
       time, logContext)
 
-    new TransactionCoordinator(config.brokerId, txnConfig, scheduler, producerIdGeneratorFactory, txnStateManager, txnMarkerChannelManager,
+    new TransactionCoordinator(config.brokerId, txnConfig, scheduler, createProducerIdGenerator, txnStateManager, txnMarkerChannelManager,
       time, logContext)
   }
 
@@ -83,7 +83,7 @@ object TransactionCoordinator {
 class TransactionCoordinator(brokerId: Int,
                              txnConfig: TransactionConfig,
                              scheduler: Scheduler,
-                             producerIdGeneratorFactory: () => ProducerIdGenerator,
+                             createProducerIdGenerator: () => ProducerIdGenerator,
                              txnManager: TransactionStateManager,
                              txnMarkerChannelManager: TransactionMarkerChannelManager,
                              time: Time,
@@ -100,7 +100,7 @@ class TransactionCoordinator(brokerId: Int,
   /* Active flag of the coordinator */
   private val isActive = new AtomicBoolean(false)
 
-  val producerIdGenerator = producerIdGeneratorFactory()
+  val producerIdGenerator = createProducerIdGenerator()
 
   def handleInitProducerId(transactionalId: String,
                            transactionTimeoutMs: Int,

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -27,7 +27,7 @@ import kafka.cluster.Broker
 import kafka.common.{GenerateBrokerIdException, InconsistentBrokerIdException, InconsistentClusterIdException}
 import kafka.controller.KafkaController
 import kafka.coordinator.group.GroupCoordinator
-import kafka.coordinator.transaction.TransactionCoordinator
+import kafka.coordinator.transaction.{ProducerIdManager, TransactionCoordinator}
 import kafka.log.LogManager
 import kafka.metrics.{KafkaMetricsGroup, KafkaMetricsReporter, KafkaYammerMetrics, LinuxIoMetricsCollector}
 import kafka.network.SocketServer
@@ -323,7 +323,8 @@ class KafkaServer(
 
         /* start transaction coordinator, with a separate background thread scheduler for transaction expiration and log loading */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
-        transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"), zkClient, metrics, metadataCache, Time.SYSTEM)
+        transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"),
+          new ProducerIdManager(config.brokerId, zkClient), zkClient, metrics, metadataCache, Time.SYSTEM)
         transactionCoordinator.startup()
 
         /* Get the authorizer and initialize it if one is specified.*/

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -324,7 +324,7 @@ class KafkaServer(
         /* start transaction coordinator, with a separate background thread scheduler for transaction expiration and log loading */
         // Hardcode Time.SYSTEM for now as some Streams tests fail otherwise, it would be good to fix the underlying issue
         transactionCoordinator = TransactionCoordinator(config, replicaManager, new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"),
-          new ProducerIdManager(config.brokerId, zkClient), zkClient, metrics, metadataCache, Time.SYSTEM)
+          () => new ProducerIdManager(config.brokerId, zkClient), zkClient, metrics, metadataCache, Time.SYSTEM)
         transactionCoordinator.startup()
 
         /* Get the authorizer and initialize it if one is specified.*/

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -98,7 +98,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     transactionCoordinator = new TransactionCoordinator(brokerId = 0,
       txnConfig,
       scheduler,
-      pidGenerator,
+      () => pidGenerator,
       txnStateManager,
       txnMarkerChannelManager,
       time,

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -76,8 +76,8 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     for (i <- 0 until numPartitions)
       txnStateManager.addLoadedTransactionsToCache(i, coordinatorEpoch, new Pool[String, TransactionMetadata]())
 
-    val pidManager: ProducerIdManager = EasyMock.createNiceMock(classOf[ProducerIdManager])
-    EasyMock.expect(pidManager.generateProducerId())
+    val pidGenerator: ProducerIdGenerator = EasyMock.createNiceMock(classOf[ProducerIdGenerator])
+    EasyMock.expect(pidGenerator.generateProducerId())
       .andAnswer(() => if (bumpProducerId) producerId + 1 else producerId)
       .anyTimes()
     val brokerNode = new Node(0, "host", 10)
@@ -98,12 +98,12 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     transactionCoordinator = new TransactionCoordinator(brokerId = 0,
       txnConfig,
       scheduler,
-      pidManager,
+      pidGenerator,
       txnStateManager,
       txnMarkerChannelManager,
       time,
       new LogContext)
-    EasyMock.replay(pidManager)
+    EasyMock.replay(pidGenerator)
     EasyMock.replay(metadataCache)
     EasyMock.replay(networkClient)
   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -52,7 +52,7 @@ class TransactionCoordinatorTest {
   val coordinator = new TransactionCoordinator(brokerId,
     TransactionConfig(),
     scheduler,
-    pidGenerator,
+    () => pidGenerator,
     transactionManager,
     transactionMarkerChannelManager,
     time,

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -33,7 +33,7 @@ class TransactionCoordinatorTest {
   val time = new MockTime()
 
   var nextPid: Long = 0L
-  val pidManager: ProducerIdManager = EasyMock.createNiceMock(classOf[ProducerIdManager])
+  val pidGenerator: ProducerIdGenerator = EasyMock.createNiceMock(classOf[ProducerIdGenerator])
   val transactionManager: TransactionStateManager = EasyMock.createNiceMock(classOf[TransactionStateManager])
   val transactionMarkerChannelManager: TransactionMarkerChannelManager = EasyMock.createNiceMock(classOf[TransactionMarkerChannelManager])
   val capturedTxn: Capture[TransactionMetadata] = EasyMock.newCapture()
@@ -52,7 +52,7 @@ class TransactionCoordinatorTest {
   val coordinator = new TransactionCoordinator(brokerId,
     TransactionConfig(),
     scheduler,
-    pidManager,
+    pidGenerator,
     transactionManager,
     transactionMarkerChannelManager,
     time,
@@ -61,15 +61,15 @@ class TransactionCoordinatorTest {
   var result: InitProducerIdResult = _
   var error: Errors = Errors.NONE
 
-  private def mockPidManager(): Unit = {
-    EasyMock.expect(pidManager.generateProducerId()).andAnswer(() => {
+  private def mockPidGenerator(): Unit = {
+    EasyMock.expect(pidGenerator.generateProducerId()).andAnswer(() => {
       nextPid += 1
       nextPid - 1
     }).anyTimes()
   }
 
   private def initPidGenericMocks(transactionalId: String): Unit = {
-    mockPidManager()
+    mockPidGenerator()
     EasyMock.expect(transactionManager.validateTransactionTimeoutMs(EasyMock.anyInt()))
       .andReturn(true)
       .anyTimes()
@@ -77,8 +77,8 @@ class TransactionCoordinatorTest {
 
   @Test
   def shouldReturnInvalidRequestWhenTransactionalIdIsEmpty(): Unit = {
-    mockPidManager()
-    EasyMock.replay(pidManager)
+    mockPidGenerator()
+    EasyMock.replay(pidGenerator)
 
     coordinator.handleInitProducerId("", txnTimeoutMs, None, initProducerIdMockCallback)
     assertEquals(InitProducerIdResult(-1L, -1, Errors.INVALID_REQUEST), result)
@@ -88,8 +88,8 @@ class TransactionCoordinatorTest {
 
   @Test
   def shouldAcceptInitPidAndReturnNextPidWhenTransactionalIdIsNull(): Unit = {
-    mockPidManager()
-    EasyMock.replay(pidManager)
+    mockPidGenerator()
+    EasyMock.replay(pidGenerator)
 
     coordinator.handleInitProducerId(null, txnTimeoutMs, None, initProducerIdMockCallback)
     assertEquals(InitProducerIdResult(0L, 0, Errors.NONE), result)
@@ -118,7 +118,7 @@ class TransactionCoordinatorTest {
       EasyMock.capture(capturedErrorsCallback),
       EasyMock.anyObject())
     ).andAnswer(() => capturedErrorsCallback.getValue.apply(Errors.NONE)).anyTimes()
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, None, initProducerIdMockCallback)
     assertEquals(InitProducerIdResult(nextPid - 1, 0, Errors.NONE), result)
@@ -145,7 +145,7 @@ class TransactionCoordinatorTest {
       EasyMock.capture(capturedErrorsCallback),
       EasyMock.anyObject())
     ).andAnswer(() => capturedErrorsCallback.getValue.apply(Errors.NONE)).anyTimes()
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, Some(new ProducerIdAndEpoch(producerId, producerEpoch)),
       initProducerIdMockCallback)
@@ -170,7 +170,7 @@ class TransactionCoordinatorTest {
       EasyMock.anyObject()
     )).andAnswer(() => capturedErrorsCallback.getValue.apply(Errors.NONE))
 
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, None, initProducerIdMockCallback)
     assertNotEquals(producerId, result.producerId)
@@ -773,7 +773,7 @@ class TransactionCoordinatorTest {
 
   @Test
   def testInitProducerIdWithCurrentEpochProvided(): Unit = {
-    mockPidManager()
+    mockPidGenerator()
 
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, 10,
       9, txnTimeoutMs, Empty, partitions, time.milliseconds, time.milliseconds)
@@ -794,7 +794,7 @@ class TransactionCoordinatorTest {
       txnMetadata.pendingState = None
     }).times(2)
 
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     // Re-initialization should succeed and bump the producer epoch
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, Some(new ProducerIdAndEpoch(producerId, 10)),
@@ -809,7 +809,7 @@ class TransactionCoordinatorTest {
 
   @Test
   def testInitProducerIdStaleCurrentEpochProvided(): Unit = {
-    mockPidManager()
+    mockPidGenerator()
 
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, 10,
       9, txnTimeoutMs, Empty, partitions, time.milliseconds, time.milliseconds)
@@ -833,7 +833,7 @@ class TransactionCoordinatorTest {
       txnMetadata.lastProducerEpoch = capturedTxnTransitMetadata.getValue.lastProducerEpoch
     }).times(2)
 
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     // With producer epoch at 10, new producer calls InitProducerId and should get epoch 11
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, None, initProducerIdMockCallback)
@@ -851,7 +851,7 @@ class TransactionCoordinatorTest {
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, (Short.MaxValue - 1).toShort,
       (Short.MaxValue - 2).toShort, txnTimeoutMs, Empty, partitions, time.milliseconds, time.milliseconds)
 
-    EasyMock.expect(pidManager.generateProducerId())
+    EasyMock.expect(pidGenerator.generateProducerId())
       .andReturn(producerId + 1)
       .anyTimes()
 
@@ -875,7 +875,7 @@ class TransactionCoordinatorTest {
       txnMetadata.lastProducerEpoch = capturedTxnTransitMetadata.getValue.lastProducerEpoch
     }).once
 
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     // Bump epoch and cause producer ID to be rotated
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, Some(new ProducerIdAndEpoch(producerId,
@@ -894,7 +894,7 @@ class TransactionCoordinatorTest {
     val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, (Short.MaxValue - 1).toShort,
       (Short.MaxValue - 2).toShort, txnTimeoutMs, Empty, partitions, time.milliseconds, time.milliseconds)
 
-    EasyMock.expect(pidManager.generateProducerId())
+    EasyMock.expect(pidGenerator.generateProducerId())
       .andReturn(producerId + 1)
       .anyTimes()
 
@@ -918,7 +918,7 @@ class TransactionCoordinatorTest {
       txnMetadata.lastProducerEpoch = capturedTxnTransitMetadata.getValue.lastProducerEpoch
     }).once
 
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     // Bump epoch and cause producer ID to be rotated
     coordinator.handleInitProducerId(transactionalId, txnTimeoutMs, Some(new ProducerIdAndEpoch(producerId,
@@ -1094,7 +1094,7 @@ class TransactionCoordinatorTest {
   }
 
   private def validateIncrementEpochAndUpdateMetadata(state: TransactionState): Unit = {
-    EasyMock.expect(pidManager.generateProducerId())
+    EasyMock.expect(pidGenerator.generateProducerId())
       .andReturn(producerId)
       .anyTimes()
 
@@ -1117,7 +1117,7 @@ class TransactionCoordinatorTest {
       capturedErrorsCallback.getValue.apply(Errors.NONE)
     })
 
-    EasyMock.replay(pidManager, transactionManager)
+    EasyMock.replay(pidGenerator, transactionManager)
 
     val newTxnTimeoutMs = 10
     coordinator.handleInitProducerId(transactionalId, newTxnTimeoutMs, None, initProducerIdMockCallback)


### PR DESCRIPTION
`ProducerIdManager` is an existing class that talks to ZooKeeper directly.  We won't have ZooKeeper when using a Raft-based metadata quorum, so we need an abstraction for the functionality of generating producer IDs.  This PR introduces `ProducerIdGenerator` for this purpose, and we pass an implementation when instantiating `TransactionCoordinator` rather than letting `TransactionCoordinator.apply()` itself always create a ZooKeeper-based instance.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
