### PR TITLE
MINOR: Remove ZK dependency for __transaction_state partition count

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -52,6 +52,18 @@ object TransactionStateManager {
 
   val MetricsGroup: String = "transaction-coordinator-metrics"
   val LoadTimeSensor: String = "TransactionsPartitionLoadTime"
+
+  def apply(brokerId: Int,
+            zkClient: KafkaZkClient,
+            scheduler: Scheduler,
+            replicaManager: ReplicaManager,
+            config: TransactionConfig,
+            time: Time,
+            metrics: Metrics) = {
+    new TransactionStateManager(brokerId,
+      new TransactionStateTopicPartitionCountViaZooKeeper(zkClient, config.transactionLogNumPartitions).transactionStateTopicPartitionCount,
+      scheduler, replicaManager, config, time, metrics)
+  }
 }
 
 /**
@@ -72,7 +84,7 @@ object TransactionStateManager {
  * </ul>
  */
 class TransactionStateManager(brokerId: Int,
-                              zkClient: KafkaZkClient,
+                              transactionTopicPartitionCountFunc: () => Int,
                               scheduler: Scheduler,
                               replicaManager: ReplicaManager,
                               config: TransactionConfig,
@@ -96,7 +108,20 @@ class TransactionStateManager(brokerId: Int,
   private[transaction] val transactionMetadataCache: mutable.Map[Int, TxnMetadataCacheEntry] = mutable.Map()
 
   /** number of partitions for the transaction log topic */
-  private val transactionTopicPartitionCount = getTransactionTopicPartitionCount
+  private var _transactionTopicPartitionCount: Option[Int] = Option.empty // lazy, once-only evaluation
+  private def transactionTopicPartitionCount: Int = {
+    _transactionTopicPartitionCount match {
+      case Some(partitionCount) => partitionCount
+      case None => synchronized { // make sure we only invoke the function once
+        _transactionTopicPartitionCount match {
+          case Some(partitionCount) => partitionCount // another thread beat us to it
+          case None =>
+            _transactionTopicPartitionCount = Some(transactionTopicPartitionCountFunc())
+            _transactionTopicPartitionCount.get
+        }
+      }
+    }
+  }
 
   /** setup metrics*/
   private val partitionLoadSensor = metrics.sensor(TransactionStateManager.LoadTimeSensor)
@@ -275,14 +300,6 @@ class TransactionStateManager(brokerId: Int,
   }
 
   def partitionFor(transactionalId: String): Int = Utils.abs(transactionalId.hashCode) % transactionTopicPartitionCount
-
-  /**
-   * Gets the partition count of the transaction log topic from ZooKeeper.
-   * If the topic does not exist, the default partition count is returned.
-   */
-  private def getTransactionTopicPartitionCount: Int = {
-    zkClient.getTopicPartitionCount(Topic.TRANSACTION_STATE_TOPIC_NAME).getOrElse(config.transactionLogNumPartitions)
-  }
 
   private def loadTransactionMetadata(topicPartition: TopicPartition, coordinatorEpoch: Int): Pool[String, TransactionMetadata] =  {
     def logEndOffset = replicaManager.getLogEndOffset(topicPartition).getOrElse(-1L)
@@ -472,9 +489,10 @@ class TransactionStateManager(brokerId: Int,
   }
 
   private def validateTransactionTopicPartitionCountIsStable(): Unit = {
-    val curTransactionTopicPartitionCount = getTransactionTopicPartitionCount
-    if (transactionTopicPartitionCount != curTransactionTopicPartitionCount)
-      throw new KafkaException(s"Transaction topic number of partitions has changed from $transactionTopicPartitionCount to $curTransactionTopicPartitionCount")
+    val alreadyDeterminedPartitionCount = transactionTopicPartitionCount
+    val curTransactionTopicPartitionCount = transactionTopicPartitionCountFunc()
+    if (curTransactionTopicPartitionCount != alreadyDeterminedPartitionCount)
+      throw new KafkaException(s"Transaction topic number of partitions has changed from $alreadyDeterminedPartitionCount to $curTransactionTopicPartitionCount")
   }
 
   def appendTransactionToLog(transactionalId: String,

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -71,7 +71,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
       .anyTimes()
     EasyMock.replay(zkClient)
 
-    txnStateManager = new TransactionStateManager(0, zkClient, scheduler, replicaManager, txnConfig, time,
+    txnStateManager = TransactionStateManager(0, zkClient, scheduler, replicaManager, txnConfig, time,
       new Metrics())
     for (i <- 0 until numPartitions)
       txnStateManager.addLoadedTransactionsToCache(i, coordinatorEpoch, new Pool[String, TransactionMetadata]())

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -63,7 +63,7 @@ class TransactionStateManagerTest {
   val metrics = new Metrics()
 
   val txnConfig = TransactionConfig()
-  val transactionManager: TransactionStateManager = new TransactionStateManager(0, zkClient, scheduler,
+  val transactionManager: TransactionStateManager = TransactionStateManager(0, zkClient, scheduler,
     replicaManager, txnConfig, time, metrics)
 
   val transactionalId1: String = "one"


### PR DESCRIPTION
`TransactionStateManager` currently uses ZooKeeper to obtain any non-default value for the `__transaction_state` partition count.  ZooKeeper will not be available when the broker uses a Raft-based metadata quorum.  This PR removes the hard dependency on ZooKeeper by allowing a function returning an `Int` to be provided instead.  Providing a ZooKeeper client is still supported in `apply()` methods, but those methods transparently wrap the client with a function and pass that function instead.

Existing tests are sufficient to detect bugs and regressions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
