### PR TITLE
KAFKA-12205: Delete snapshots less than the snapshot at the log start

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -281,8 +281,7 @@ final class KafkaMetadataLog private (
   }
 
   /**
-   * remove all snapshots whose end offset is less than the giving offset, also delete the corresponding
-   * snapshot files.
+   * Removes all snapshots on the log directory whose epoch and end offset is less than the giving epoch and end offset.
    */
   private def removeSnapshotFileBefore(logStartSnapshotId: OffsetAndEpoch): Unit = {
     val expiredSnapshotIds = snapshotIds.headSet(logStartSnapshotId)

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -345,6 +345,7 @@ object KafkaMetadataLog {
 
     val metadataLog = new KafkaMetadataLog(
       log,
+      scheduler,
       recoverSnapshots(log),
       topicPartition,
       maxFetchSizeInBytes

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -298,9 +298,12 @@ final class KafkaMetadataLog private (
         Utils.atomicMoveWithFallback(path, destination)
       } catch {
         case e: IOException =>
-          warn("Error renaming snapshot file: " + path + " to :" + destination + ", " + e.getMessage)
+          error(s"Error renaming snapshot file: $path to $destination", e)
       }
-      scheduler.schedule("delete-snapshot-file", () => Snapshots.deleteSnapshotIfExists(log.dir.toPath, snapshotId))
+      scheduler.schedule(
+        "delete-snapshot-file",
+        () => Snapshots.deleteSnapshotIfExists(log.dir.toPath, snapshotId),
+        60 * 1000L)
     }
   }
 

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -19,11 +19,10 @@ package kafka.raft
 import java.io.File
 import java.nio.file.Files
 import java.util
-import java.util.{OptionalInt, Properties}
+import java.util.OptionalInt
 import java.util.concurrent.CompletableFuture
 
-import kafka.api.ApiVersion
-import kafka.log.{Log, LogConfig}
+import kafka.log.Log
 import kafka.raft.KafkaRaftManager.RaftIoThread
 import kafka.server.{KafkaConfig, MetaProperties}
 import kafka.utils.timer.SystemTimer
@@ -242,16 +241,8 @@ class KafkaRaftManager[T](
   }
 
   private def buildMetadataLog(): KafkaMetadataLog = {
-    val props = new Properties()
-    props.put(LogConfig.MaxMessageBytesProp, KafkaRaftClient.MAX_BATCH_SIZE_BYTES.toString)
-    props.put(LogConfig.MessageFormatVersionProp, ApiVersion.latestVersion.toString)
-
-    LogConfig.validateValues(props)
-    val defaultLogConfig = LogConfig(props)
-
     KafkaMetadataLog(
       topicPartition,
-      defaultLogConfig,
       dataDir,
       time,
       scheduler,

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -144,8 +144,7 @@ final class KafkaMetadataLogTest {
 
   @Test
   def testUpdateLogStartOffsetWillRemoveOlderSnapshot(): Unit = {
-    val topicPartition = new TopicPartition("cluster-metadata", 0)
-    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime, topicPartition)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val offset = 10
     val epoch = 0
 
@@ -248,8 +247,7 @@ final class KafkaMetadataLogTest {
   @Test
   def testTruncateWillRemoveOlderSnapshot(): Unit = {
 
-    val topicPartition = new TopicPartition("cluster-metadata", 0)
-    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime, topicPartition)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val numberOfRecords = 10
     val epoch = 1
 
@@ -386,7 +384,7 @@ final class KafkaMetadataLogTest {
 
     log.close()
 
-    val secondLog = buildMetadataLog(tempDir, mockTime, topicPartition)
+    val secondLog = buildMetadataLog(tempDir, mockTime)
 
     assertEquals(greaterSnapshotId, secondLog.latestSnapshotId().get)
     assertEquals(3 * numberOfRecords, secondLog.startOffset)

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -32,13 +32,13 @@ import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.raft.internals.BatchBuilder
 import org.apache.kafka.raft.{KafkaRaftClient, LogAppendInfo, LogOffsetMetadata, OffsetAndEpoch, RecordSerde, ReplicatedLog}
 import org.apache.kafka.snapshot.{SnapshotPath, Snapshots}
-import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertThrows, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotEquals, assertThrows, assertTrue}
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
 final class KafkaMetadataLogTest {
   import KafkaMetadataLogTest._
 
-  var tempDir: File = null
+  var tempDir: File = _
   val mockTime = new MockTime()
 
   @BeforeEach
@@ -143,6 +143,39 @@ final class KafkaMetadataLogTest {
   }
 
   @Test
+  def testUpdateLogStartOffsetWillRemoveOlderSnapshot(): Unit = {
+    val topicPartition = new TopicPartition("cluster-metadata", 0)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime, topicPartition)
+    val offset = 10
+    val epoch = 0
+
+    append(log, offset, epoch)
+    val oldSnapshotId = new OffsetAndEpoch(offset, epoch)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    append(log, offset, epoch, log.endOffset.offset)
+    val newSnapshotId = new OffsetAndEpoch(offset * 2, epoch)
+    TestUtils.resource(log.createSnapshot(newSnapshotId)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    log.updateHighWatermark(new LogOffsetMetadata(offset * 2))
+    assertTrue(log.deleteBeforeSnapshot(newSnapshotId))
+    log.close()
+
+    // Assert that the log dir doesn't contain any older snapshots
+    Files
+      .walk(logDir, 1)
+      .map[Optional[SnapshotPath]](Snapshots.parse)
+      .filter(_.isPresent)
+      .forEach { path =>
+        assertFalse(path.get.snapshotId.offset < log.startOffset)
+      }
+  }
+
+  @Test
   def testUpdateLogStartOffsetWithMissingSnapshot(): Unit = {
     val log = buildMetadataLog(tempDir, mockTime)
     val offset = 10
@@ -213,6 +246,53 @@ final class KafkaMetadataLogTest {
   }
 
   @Test
+  def testTruncateWillRemoveOlderSnapshot(): Unit = {
+
+    val topicPartition = new TopicPartition("cluster-metadata", 0)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime, topicPartition)
+    val numberOfRecords = 10
+    val epoch = 1
+
+    append(log, 1, epoch - 1)
+    val oldSnapshotId1 = new OffsetAndEpoch(1, epoch - 1)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId1)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    append(log, 1, epoch, log.endOffset.offset)
+    val oldSnapshotId2 = new OffsetAndEpoch(2, epoch)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId2)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    append(log, numberOfRecords - 2, epoch, log.endOffset.offset)
+    val oldSnapshotId3 = new OffsetAndEpoch(numberOfRecords, epoch)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId3)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    val greaterSnapshotId = new OffsetAndEpoch(3 * numberOfRecords, epoch)
+    append(log, numberOfRecords, epoch, log.endOffset.offset)
+    TestUtils.resource(log.createSnapshot(greaterSnapshotId)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    assertNotEquals(log.earliestSnapshotId(), log.latestSnapshotId())
+    assertTrue(log.truncateToLatestSnapshot())
+    assertEquals(log.earliestSnapshotId(), log.latestSnapshotId())
+    log.close()
+
+    // Assert that the log dir doesn't contain any older snapshots
+    Files
+      .walk(logDir, 1)
+      .map[Optional[SnapshotPath]](Snapshots.parse)
+      .filter(_.isPresent)
+      .forEach { path =>
+        assertFalse(path.get.snapshotId.offset < log.startOffset)
+      }
+  }
+
+  @Test
   def testDoesntTruncateFully(): Unit = {
     val log = buildMetadataLog(tempDir, mockTime)
     val numberOfRecords = 10
@@ -238,7 +318,7 @@ final class KafkaMetadataLogTest {
   }
 
   @Test
-  def testCleanupSnapshots(): Unit = {
+  def testCleanupPartialSnapshots(): Unit = {
     val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val numberOfRecords = 10
     val epoch = 1
@@ -258,7 +338,7 @@ final class KafkaMetadataLogTest {
 
     val secondLog = buildMetadataLog(tempDir, mockTime)
 
-    assertEquals(snapshotId, secondLog.latestSnapshotId.get)
+    assertEquals(snapshotId, secondLog.latestSnapshotId().get)
     assertEquals(0, log.startOffset)
     assertEquals(epoch, log.lastFetchedEpoch)
     assertEquals(numberOfRecords, log.endOffset().offset)
@@ -271,6 +351,54 @@ final class KafkaMetadataLogTest {
       .filter(_.isPresent)
       .forEach { path =>
         assertFalse(path.get.partial)
+      }
+  }
+
+  @Test
+  def testCleanupOlderSnapshots(): Unit = {
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
+    val numberOfRecords = 10
+    val epoch = 1
+
+    append(log, 1, epoch - 1)
+    val oldSnapshotId1 = new OffsetAndEpoch(1, epoch - 1)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId1)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    append(log, 1, epoch, log.endOffset.offset)
+    val oldSnapshotId2 = new OffsetAndEpoch(2, epoch)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId2)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    append(log, numberOfRecords - 2, epoch, log.endOffset.offset)
+    val oldSnapshotId3 = new OffsetAndEpoch(numberOfRecords, epoch)
+    TestUtils.resource(log.createSnapshot(oldSnapshotId3)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    val greaterSnapshotId = new OffsetAndEpoch(3 * numberOfRecords, epoch)
+    append(log, numberOfRecords, epoch, log.endOffset.offset)
+    TestUtils.resource(log.createSnapshot(greaterSnapshotId)) { snapshot =>
+      snapshot.freeze()
+    }
+
+    log.close()
+
+    val secondLog = buildMetadataLog(tempDir, mockTime, topicPartition)
+
+    assertEquals(greaterSnapshotId, secondLog.latestSnapshotId().get)
+    assertEquals(3 * numberOfRecords, secondLog.startOffset)
+    assertEquals(epoch, secondLog.lastFetchedEpoch)
+
+    // Assert that the log dir doesn't contain any older snapshots
+    Files
+      .walk(logDir, 1)
+      .map[Optional[SnapshotPath]](Snapshots.parse)
+      .filter(_.isPresent)
+      .forEach { path =>
+        assertFalse(path.get.snapshotId.offset < log.startOffset)
       }
   }
 
@@ -290,7 +418,7 @@ final class KafkaMetadataLogTest {
 
     val secondLog = buildMetadataLog(tempDir, mockTime)
 
-    assertEquals(snapshotId, secondLog.latestSnapshotId.get)
+    assertEquals(snapshotId, secondLog.latestSnapshotId().get)
     assertEquals(snapshotId.offset, secondLog.startOffset)
     assertEquals(snapshotId.epoch, secondLog.lastFetchedEpoch)
     assertEquals(snapshotId.offset, secondLog.endOffset().offset)
@@ -406,7 +534,7 @@ object KafkaMetadataLogTest {
   private def createLogDirectory(logDir: File, logDirName: String): File = {
     val logDirPath = logDir.getAbsolutePath
     val dir = new File(logDirPath, logDirName)
-    if (!Files.exists((dir.toPath))) {
+    if (!Files.exists(dir.toPath)) {
       Files.createDirectories(dir.toPath)
     }
     dir

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -19,10 +19,9 @@ package kafka.raft
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Path}
-import java.util.{Collections, Optional, Properties}
+import java.util.{Collections, Optional}
 
-import kafka.api.ApiVersion
-import kafka.log.{Log, LogConfig}
+import kafka.log.Log
 import kafka.server.KafkaRaftServer
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.errors.{OffsetOutOfRangeException, RecordTooLargeException}
@@ -145,7 +144,7 @@ final class KafkaMetadataLogTest {
 
   @Test
   def testUpdateLogStartOffsetWillRemoveOlderSnapshot(): Unit = {
-    val (logDir, log, config) = buildMetadataLogAndDir(tempDir, mockTime)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val offset = 10
     val epoch = 0
 
@@ -165,7 +164,7 @@ final class KafkaMetadataLogTest {
     assertTrue(log.deleteBeforeSnapshot(newSnapshotId))
     log.close()
 
-    mockTime.sleep(config.fileDeleteDelayMs)
+    mockTime.sleep(log.fileDeleteDelayMs)
     // Assert that the log dir doesn't contain any older snapshots
     Files
       .walk(logDir, 1)
@@ -249,7 +248,7 @@ final class KafkaMetadataLogTest {
   @Test
   def testTruncateWillRemoveOlderSnapshot(): Unit = {
 
-    val (logDir, log, config) = buildMetadataLogAndDir(tempDir, mockTime)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val numberOfRecords = 10
     val epoch = 1
 
@@ -282,7 +281,7 @@ final class KafkaMetadataLogTest {
     assertEquals(log.earliestSnapshotId(), log.latestSnapshotId())
     log.close()
 
-    mockTime.sleep(config.fileDeleteDelayMs)
+    mockTime.sleep(log.fileDeleteDelayMs)
     // Assert that the log dir doesn't contain any older snapshots
     Files
       .walk(logDir, 1)
@@ -320,7 +319,7 @@ final class KafkaMetadataLogTest {
 
   @Test
   def testCleanupPartialSnapshots(): Unit = {
-    val (logDir, log, _) = buildMetadataLogAndDir(tempDir, mockTime)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val numberOfRecords = 10
     val epoch = 1
     val snapshotId = new OffsetAndEpoch(1, epoch)
@@ -357,7 +356,7 @@ final class KafkaMetadataLogTest {
 
   @Test
   def testCleanupOlderSnapshots(): Unit = {
-    val (logDir, log, config) = buildMetadataLogAndDir(tempDir, mockTime)
+    val (logDir, log) = buildMetadataLogAndDir(tempDir, mockTime)
     val numberOfRecords = 10
     val epoch = 1
 
@@ -392,7 +391,7 @@ final class KafkaMetadataLogTest {
     assertEquals(greaterSnapshotId, secondLog.latestSnapshotId().get)
     assertEquals(3 * numberOfRecords, secondLog.startOffset)
     assertEquals(epoch, secondLog.lastFetchedEpoch)
-    mockTime.sleep(config.fileDeleteDelayMs)
+    mockTime.sleep(log.fileDeleteDelayMs)
 
     // Assert that the log dir doesn't contain any older snapshots
     Files
@@ -492,22 +491,15 @@ object KafkaMetadataLogTest {
     time: MockTime,
     maxBatchSizeInBytes: Int = KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
     maxFetchSizeInBytes: Int = KafkaRaftClient.MAX_FETCH_SIZE_BYTES
-  ): (Path, KafkaMetadataLog, LogConfig) = {
+  ): (Path, KafkaMetadataLog) = {
 
     val logDir = createLogDirectory(
       tempDir,
       Log.logDirName(KafkaRaftServer.MetadataPartition)
     )
 
-    val props = new Properties()
-    props.put(LogConfig.MaxMessageBytesProp, maxBatchSizeInBytes.toString)
-    props.put(LogConfig.MessageFormatVersionProp, ApiVersion.latestVersion.toString)
-    LogConfig.validateValues(props)
-    val defaultLogConfig = LogConfig(props)
-
     val metadataLog = KafkaMetadataLog(
       KafkaRaftServer.MetadataPartition,
-      defaultLogConfig,
       logDir,
       time,
       time.scheduler,
@@ -515,7 +507,7 @@ object KafkaMetadataLogTest {
       maxFetchSizeInBytes
     )
 
-    (logDir.toPath, metadataLog, defaultLogConfig)
+    (logDir.toPath, metadataLog)
   }
 
   def buildMetadataLog(
@@ -524,7 +516,7 @@ object KafkaMetadataLogTest {
     maxBatchSizeInBytes: Int = KafkaRaftClient.MAX_BATCH_SIZE_BYTES,
     maxFetchSizeInBytes: Int = KafkaRaftClient.MAX_FETCH_SIZE_BYTES
   ): KafkaMetadataLog = {
-    val (_, log, _) = buildMetadataLogAndDir(tempDir, time, maxBatchSizeInBytes, maxFetchSizeInBytes)
+    val (_, log) = buildMetadataLogAndDir(tempDir, time, maxBatchSizeInBytes, maxFetchSizeInBytes)
     log
   }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2155,7 +2155,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private void maybeUpdateOldestSnapshotId() {
-        log.latestSnapshotId().ifPresent(snapshotId -> log.deleteBeforeSnapshot(snapshotId));
+        log.latestSnapshotId().ifPresent(log::deleteBeforeSnapshot);
     }
 
     private void wakeup() {

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedLog.java
@@ -85,10 +85,10 @@ public interface ReplicatedLog extends Closeable {
         if (startOffset() == 0 && offset == 0) {
             return ValidOffsetAndEpoch.valid(new OffsetAndEpoch(0, 0));
         } else if (
-                oldestSnapshotId().isPresent() &&
+                earliestSnapshotId().isPresent() &&
                 ((offset < startOffset()) ||
-                 (offset == startOffset() && epoch != oldestSnapshotId().get().epoch) ||
-                 (epoch < oldestSnapshotId().get().epoch))
+                 (offset == startOffset() && epoch != earliestSnapshotId().get().epoch) ||
+                 (epoch < earliestSnapshotId().get().epoch))
         ) {
             /* Send a snapshot if the leader has a snapshot at the log start offset and
              * 1. the fetch offset is less than the log start offset or
@@ -96,15 +96,12 @@ public interface ReplicatedLog extends Closeable {
              *    the oldest snapshot or
              * 3. last fetch epoch is less than the oldest snapshot's epoch
              */
-
-            OffsetAndEpoch latestSnapshotId = latestSnapshotId().orElseThrow(() -> {
-                return new IllegalStateException(
-                    String.format(
-                        "Log start offset (%s) is greater than zero but latest snapshot was not found",
-                        startOffset()
-                    )
-                );
-            });
+            OffsetAndEpoch latestSnapshotId = latestSnapshotId().orElseThrow(() -> new IllegalStateException(
+                String.format(
+                    "Log start offset (%s) is greater than zero but latest snapshot was not found",
+                    startOffset()
+                )
+            ));
 
             return ValidOffsetAndEpoch.snapshot(latestSnapshotId);
         } else {
@@ -263,7 +260,7 @@ public interface ReplicatedLog extends Closeable {
      * @return an Optional snapshot id at the log start offset if nonzero, otherwise returns an empty
      *         Optional
      */
-    Optional<OffsetAndEpoch> oldestSnapshotId();
+    Optional<OffsetAndEpoch> earliestSnapshotId();
 
     /**
      * Notifies the replicated log when a new snapshot is available.

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotPath.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotPath.java
@@ -23,11 +23,13 @@ public final class SnapshotPath {
     public final Path path;
     public final OffsetAndEpoch snapshotId;
     public final boolean partial;
+    public final boolean deleted;
 
-    public SnapshotPath(Path path, OffsetAndEpoch snapshotId, boolean partial) {
+    public SnapshotPath(Path path, OffsetAndEpoch snapshotId, boolean partial, boolean deleted) {
         this.path = path;
         this.snapshotId = snapshotId;
         this.partial = partial;
+        this.deleted = deleted;
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -16,12 +16,13 @@
  */
 package org.apache.kafka.snapshot;
 
+import org.apache.kafka.raft.OffsetAndEpoch;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.Optional;
-import org.apache.kafka.raft.OffsetAndEpoch;
 
 public final class Snapshots {
     private static final String SUFFIX =  ".checkpoint";
@@ -92,4 +93,13 @@ public final class Snapshots {
 
         return Optional.of(new SnapshotPath(path, new OffsetAndEpoch(endOffset, epoch), partial));
     }
+
+    /**
+     * Delete this snapshot from the filesystem.
+     */
+    public static boolean deleteSnapshotIfExists(Path logDir, OffsetAndEpoch snapshotId) throws IOException {
+        Path path = snapshotPath(logDir, snapshotId);
+        return Files.deleteIfExists(path);
+    }
+
 }

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -117,7 +117,7 @@ public final class Snapshots {
             }
             return Files.deleteIfExists(destination);
         } catch (IOException e) {
-            log.warn("Error deleting snapshot file " + destination + ":" + e.getMessage());
+            log.error("Error deleting snapshot file " + destination, e);
             return false;
         }
     }

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -62,7 +62,6 @@ public class MockLog implements ReplicatedLog {
     private long nextId = ID_GENERATOR.getAndIncrement();
     private LogOffsetMetadata highWatermark = new LogOffsetMetadata(0, Optional.empty());
     private long lastFlushedOffset = 0;
-    private Optional<OffsetAndEpoch> oldestSnapshotId = Optional.empty();
 
     public MockLog(TopicPartition topicPartition) {
         this.topicPartition = topicPartition;
@@ -89,7 +88,7 @@ public class MockLog implements ReplicatedLog {
 
                 batches.clear();
                 epochStartOffsets.clear();
-                oldestSnapshotId = Optional.of(snapshotId);
+                snapshots.headMap(snapshotId, false).clear();
                 updateHighWatermark(new LogOffsetMetadata(snapshotId.offset));
                 flush();
 
@@ -174,14 +173,12 @@ public class MockLog implements ReplicatedLog {
 
     @Override
     public int lastFetchedEpoch() {
-        return logLastFetchedEpoch().orElseGet(() -> {
-            return latestSnapshotId().map(id -> id.epoch).orElse(0);
-        });
+        return logLastFetchedEpoch().orElseGet(() -> latestSnapshotId().map(id -> id.epoch).orElse(0));
     }
 
     @Override
     public OffsetAndEpoch endOffsetForEpoch(int epoch) {
-        int epochLowerBound = oldestSnapshotId.map(id -> id.epoch).orElse(0);
+        int epochLowerBound = earliestSnapshotId().map(id -> id.epoch).orElse(0);
         for (EpochStartOffset epochStartOffset : epochStartOffsets) {
             if (epochStartOffset.epoch > epoch) {
                 return new OffsetAndEpoch(epochStartOffset.startOffset, epochLowerBound);
@@ -216,7 +213,7 @@ public class MockLog implements ReplicatedLog {
     }
 
     private long logStartOffset() {
-        return oldestSnapshotId.map(id -> id.offset).orElse(0L);
+        return earliestSnapshotId().map(id -> id.offset).orElse(0L);
     }
 
     private List<LogEntry> buildEntries(RecordBatch batch, Function<Record, Long> offsetSupplier) {
@@ -416,7 +413,11 @@ public class MockLog implements ReplicatedLog {
 
     @Override
     public Optional<OffsetAndEpoch> earliestSnapshotId() {
-        return oldestSnapshotId;
+        try {
+            return Optional.of(snapshots.firstKey());
+        } catch (NoSuchElementException e) {
+            return Optional.empty();
+        }
     }
 
     @Override
@@ -441,11 +442,11 @@ public class MockLog implements ReplicatedLog {
         Optional<OffsetAndEpoch> snapshotIdOpt = latestSnapshotId();
         if (snapshotIdOpt.isPresent()) {
             OffsetAndEpoch snapshotId = snapshotIdOpt.get();
-            if (logStartOffset() < logStartSnapshotId.offset &&
+            if (startOffset() < logStartSnapshotId.offset &&
                 highWatermark.offset >= logStartSnapshotId.offset &&
                 snapshotId.offset >= logStartSnapshotId.offset) {
 
-                oldestSnapshotId = Optional.of(logStartSnapshotId);
+                snapshots.headMap(logStartSnapshotId, false).clear();
 
                 batches.removeIf(entry -> entry.lastOffset() < logStartSnapshotId.offset);
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -415,7 +415,7 @@ public class MockLog implements ReplicatedLog {
     }
 
     @Override
-    public Optional<OffsetAndEpoch> oldestSnapshotId() {
+    public Optional<OffsetAndEpoch> earliestSnapshotId() {
         return oldestSnapshotId;
     }
 

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.snapshot.RawSnapshotReader;
 import org.apache.kafka.snapshot.RawSnapshotWriter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +56,11 @@ public class MockLogTest {
     @BeforeEach
     public void setup() {
         log = new MockLog(topicPartition);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        log.close();
     }
 
     @Test
@@ -592,6 +598,53 @@ public class MockLogTest {
         }
 
         assertFalse(log.truncateToLatestSnapshot());
+    }
+
+    @Test
+    public void testTruncateWillRemoveOlderSnapshot() throws IOException {
+        int numberOfRecords = 10;
+        int epoch = 0;
+
+        OffsetAndEpoch sameEpochSnapshotId = new OffsetAndEpoch(numberOfRecords, epoch);
+        appendBatch(numberOfRecords, epoch);
+
+        try (RawSnapshotWriter snapshot = log.createSnapshot(sameEpochSnapshotId)) {
+            snapshot.freeze();
+        }
+
+        OffsetAndEpoch greaterEpochSnapshotId = new OffsetAndEpoch(2 * numberOfRecords, epoch + 1);
+        appendBatch(numberOfRecords, epoch);
+
+        try (RawSnapshotWriter snapshot = log.createSnapshot(greaterEpochSnapshotId)) {
+            snapshot.freeze();
+        }
+
+        assertTrue(log.truncateToLatestSnapshot());
+        assertEquals(Optional.empty(), log.readSnapshot(sameEpochSnapshotId));
+    }
+
+    @Test
+    public void testUpdateLogStartOffsetWillRemoveOlderSnapshot() throws IOException {
+        int numberOfRecords = 10;
+        int epoch = 0;
+
+        OffsetAndEpoch sameEpochSnapshotId = new OffsetAndEpoch(numberOfRecords, epoch);
+        appendBatch(numberOfRecords, epoch);
+
+        try (RawSnapshotWriter snapshot = log.createSnapshot(sameEpochSnapshotId)) {
+            snapshot.freeze();
+        }
+
+        OffsetAndEpoch greaterEpochSnapshotId = new OffsetAndEpoch(2 * numberOfRecords, epoch + 1);
+        appendBatch(numberOfRecords, epoch);
+
+        try (RawSnapshotWriter snapshot = log.createSnapshot(greaterEpochSnapshotId)) {
+            snapshot.freeze();
+        }
+
+        log.updateHighWatermark(new LogOffsetMetadata(greaterEpochSnapshotId.offset));
+        assertTrue(log.deleteBeforeSnapshot(greaterEpochSnapshotId));
+        assertEquals(Optional.empty(), log.readSnapshot(sameEpochSnapshotId));
     }
 
     private Optional<OffsetRange> readOffsets(long startOffset, Isolation isolation) {

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
@@ -89,12 +89,12 @@ final public class SnapshotsTest {
         Path logDirPath = TestUtils.tempDirectory().toPath();
         try (FileRawSnapshotWriter snapshot = FileRawSnapshotWriter.create(logDirPath, snapshotId, Optional.empty())) {
             snapshot.freeze();
+
+            Path snapshotPath = Snapshots.snapshotPath(logDirPath, snapshotId);
+            assertTrue(Files.exists(snapshotPath));
+
+            Snapshots.deleteSnapshotIfExists(logDirPath, snapshot.snapshotId());
+            assertFalse(Files.exists(snapshotPath));
         }
-
-        Path snapshotPath = Snapshots.snapshotPath(logDirPath, snapshotId);
-        assertTrue(Files.exists(snapshotPath));
-
-        Snapshots.deleteSnapshotIfExists(logDirPath, snapshot.snapshotId());
-        assertFalse(Files.exists(snapshotPath));
     }
 }

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
@@ -87,8 +87,9 @@ final public class SnapshotsTest {
         );
 
         Path logDirPath = TestUtils.tempDirectory().toPath();
-        FileRawSnapshotWriter snapshot = FileRawSnapshotWriter.create(logDirPath, snapshotId, Optional.empty());
-        snapshot.freeze();
+        try (FileRawSnapshotWriter snapshot = FileRawSnapshotWriter.create(logDirPath, snapshotId, Optional.empty())) {
+            snapshot.freeze();
+        }
 
         Path snapshotPath = Snapshots.snapshotPath(logDirPath, snapshotId);
         assertTrue(Files.exists(snapshotPath));


### PR DESCRIPTION
*More detailed description of your change*
3 times to delete a snapshot:
1. When a follower completing fetch snapshot and truncate the log to the latest snapshot
2. When a controller pollCurrentState and delete old segment
3. When restarting the RaftClient.

*Summary of testing strategy (including rationale)*
Unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
