### PR TITLE
KAFKA-12263: Change MockClient.RequestMatcher to RequestAssertion

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -601,11 +601,11 @@ public class KafkaAdminClientTest {
         try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(Time.SYSTEM, cluster)) {
             Cluster discoveredCluster = mockCluster(3, 0);
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareResponse(request -> request instanceof MetadataRequest, null, true);
-            env.kafkaClient().prepareResponse(request -> request instanceof MetadataRequest,
+            env.kafkaClient().prepareResponse(request -> assertTrue(request instanceof MetadataRequest), null, true);
+            env.kafkaClient().prepareResponse(request -> assertTrue(request instanceof MetadataRequest),
                     RequestTestUtils.metadataResponse(discoveredCluster.nodes(), discoveredCluster.clusterResource().clusterId(),
                             1, Collections.emptyList()));
-            env.kafkaClient().prepareResponse(body -> body instanceof CreateTopicsRequest,
+            env.kafkaClient().prepareResponse(body -> assertTrue(body instanceof CreateTopicsRequest),
                     prepareCreateTopicsResponse("myTopic", Errors.NONE));
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
@@ -627,10 +627,10 @@ public class KafkaAdminClientTest {
                 AdminClientUnitTestEnv.clientConfigs(), unreachableNodes)) {
             Cluster discoveredCluster = mockCluster(3, 0);
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareResponse(body -> body instanceof MetadataRequest,
+            env.kafkaClient().prepareResponse(body -> assertTrue(body instanceof MetadataRequest),
                     RequestTestUtils.metadataResponse(discoveredCluster.nodes(), discoveredCluster.clusterResource().clusterId(),
                             1, Collections.emptyList()));
-            env.kafkaClient().prepareResponse(body -> body instanceof CreateTopicsRequest,
+            env.kafkaClient().prepareResponse(body -> assertTrue(body instanceof CreateTopicsRequest),
                 prepareCreateTopicsResponse("myTopic", Errors.NONE));
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
@@ -708,12 +708,12 @@ public class KafkaAdminClientTest {
 
             mockClient.prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return body instanceof CreateTopicsRequest;
+                assertTrue(body instanceof CreateTopicsRequest);
             }, null, true);
 
             mockClient.prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return body instanceof CreateTopicsRequest;
+                assertTrue(body instanceof CreateTopicsRequest);
             }, prepareCreateTopicsResponse("myTopic", Errors.NONE));
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
@@ -868,17 +868,14 @@ public class KafkaAdminClientTest {
         }
     }
 
-    private MockClient.RequestMatcher expectCreateTopicsRequestWithTopics(final String... topics) {
+    private MockClient.RequestAssertion expectCreateTopicsRequestWithTopics(final String... topics) {
         return body -> {
-            if (body instanceof CreateTopicsRequest) {
-                CreateTopicsRequest request = (CreateTopicsRequest) body;
-                for (String topic : topics) {
-                    if (request.data().topics().find(topic) == null)
-                        return false;
-                }
-                return topics.length == request.data().topics().size();
+            assertTrue(body instanceof CreateTopicsRequest);
+            CreateTopicsRequest request = (CreateTopicsRequest) body;
+            for (String topic : topics) {
+                assertNotNull(request.data().topics().find(topic));
             }
-            return false;
+            assertEquals(topics.length, request.data().topics().size());
         };
     }
 
@@ -1156,23 +1153,19 @@ public class KafkaAdminClientTest {
         }
     }
 
-    private MockClient.RequestMatcher expectDeleteTopicsRequestWithTopics(final String... topics) {
+    private MockClient.RequestAssertion expectDeleteTopicsRequestWithTopics(final String... topics) {
         return body -> {
-            if (body instanceof DeleteTopicsRequest) {
-                DeleteTopicsRequest request = (DeleteTopicsRequest) body;
-                return request.topicNames().equals(Arrays.asList(topics));
-            }
-            return false;
+            assertTrue(body instanceof DeleteTopicsRequest);
+            DeleteTopicsRequest request = (DeleteTopicsRequest) body;
+            assertEquals(request.topicNames(), Arrays.asList(topics));
         };
     }
 
-    private MockClient.RequestMatcher expectDeleteTopicsRequestWithTopicIds(final Uuid... topicIds) {
+    private MockClient.RequestAssertion expectDeleteTopicsRequestWithTopicIds(final Uuid... topicIds) {
         return body -> {
-            if (body instanceof DeleteTopicsRequest) {
-                DeleteTopicsRequest request = (DeleteTopicsRequest) body;
-                return request.topicIds().equals(Arrays.asList(topicIds));
-            }
-            return false;
+            assertTrue(body instanceof DeleteTopicsRequest);
+            DeleteTopicsRequest request = (DeleteTopicsRequest) body;
+            assertEquals(Arrays.asList(topicIds), request.topicIds());
         };
     }
 
@@ -1985,17 +1978,14 @@ public class KafkaAdminClientTest {
         }
     }
 
-    private MockClient.RequestMatcher expectCreatePartitionsRequestWithTopics(final String... topics) {
+    private MockClient.RequestAssertion expectCreatePartitionsRequestWithTopics(final String... topics) {
         return body -> {
-            if (body instanceof CreatePartitionsRequest) {
-                CreatePartitionsRequest request = (CreatePartitionsRequest) body;
-                for (String topic : topics) {
-                    if (request.data().topics().find(topic) == null)
-                        return false;
-                }
-                return topics.length == request.data().topics().size();
+            assertTrue(body instanceof CreatePartitionsRequest);
+            CreatePartitionsRequest request = (CreatePartitionsRequest) body;
+            for (String topic : topics) {
+                assertNotNull(request.data().topics().find(topic));
             }
-            return false;
+            assertEquals(topics.length, request.data().topics().size());
         };
     }
 
@@ -2282,7 +2272,7 @@ public class KafkaAdminClientTest {
 
             // Reject the describe cluster request with an unsupported exception
             env.kafkaClient().prepareUnsupportedVersionResponse(
-                request -> request instanceof DescribeClusterRequest);
+                request -> assertTrue(request instanceof DescribeClusterRequest));
 
             // Prepare the metadata response used for the first describe cluster
             env.kafkaClient().prepareResponse(
@@ -2497,8 +2487,7 @@ public class KafkaAdminClientTest {
 
             // But we cannot set a state filter with older broker
             env.kafkaClient().prepareResponse(prepareMetadataResponse(env.cluster(), Errors.NONE));
-            env.kafkaClient().prepareUnsupportedVersionResponse(
-                body -> body instanceof ListGroupsRequest);
+            env.kafkaClient().prepareUnsupportedVersionResponse(body -> assertTrue(body instanceof ListGroupsRequest));
 
             options = new ListConsumerGroupsOptions().inStates(singleton(ConsumerGroupState.STABLE));
             result = env.adminClient().listConsumerGroups(options);
@@ -2551,14 +2540,12 @@ public class KafkaAdminClientTest {
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
             mockClient.prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return true;
             }, prepareOffsetCommitResponse(tp1, Errors.NOT_COORDINATOR));
 
 
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
             mockClient.prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return true;
             }, prepareOffsetCommitResponse(tp1, Errors.NONE));
 
 
@@ -2636,7 +2623,6 @@ public class KafkaAdminClientTest {
 
             mockClient.prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return true;
             }, new DescribeGroupsResponse(data));
 
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
@@ -2653,7 +2639,6 @@ public class KafkaAdminClientTest {
 
             mockClient.prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return true;
             }, new DescribeGroupsResponse(data));
 
             final KafkaFuture<Map<String, ConsumerGroupDescription>> future =
@@ -2915,14 +2900,12 @@ public class KafkaAdminClientTest {
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
             mockClient.prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return true;
             }, new OffsetFetchResponse(Errors.NOT_COORDINATOR, Collections.emptyMap()));
 
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
 
             mockClient.prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return true;
             }, new OffsetFetchResponse(Errors.NONE, Collections.emptyMap()));
 
             final KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> future = env.adminClient().listConsumerGroupOffsets("group-0").partitionsToOffsetAndMetadata();
@@ -3041,7 +3024,6 @@ public class KafkaAdminClientTest {
 
             mockClient.prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return true;
             }, new DeleteGroupsResponse(new DeleteGroupsResponseData().setResults(validResponse)));
 
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
@@ -3053,7 +3035,6 @@ public class KafkaAdminClientTest {
 
             mockClient.prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return true;
             }, new DeleteGroupsResponse(new DeleteGroupsResponseData().setResults(validResponse)));
 
             final KafkaFuture<Void> future = env.adminClient().deleteConsumerGroups(groupIds).all();
@@ -3194,14 +3175,12 @@ public class KafkaAdminClientTest {
 
             mockClient.prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return true;
             }, prepareOffsetDeleteResponse("foo", 0, Errors.NOT_COORDINATOR));
 
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
 
             mockClient.prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return true;
             }, prepareOffsetDeleteResponse("foo", 0, Errors.NONE));
 
             final KafkaFuture<Void> future = env.adminClient().deleteConsumerGroupOffsets("group-0", Stream.of(tp1).collect(Collectors.toSet())).all();
@@ -3477,7 +3456,6 @@ public class KafkaAdminClientTest {
 
             env.kafkaClient().prepareResponse(body -> {
                 firstAttemptTime.set(time.milliseconds());
-                return true;
             }, new LeaveGroupResponse(new LeaveGroupResponseData().setErrorCode(Errors.NOT_COORDINATOR.code())));
 
             mockClient.prepareResponse(prepareFindCoordinatorResponse(Errors.NONE, env.cluster().controller()));
@@ -3487,7 +3465,6 @@ public class KafkaAdminClientTest {
                 .setErrorCode(Errors.NONE.code());
             env.kafkaClient().prepareResponse(body -> {
                 secondAttemptTime.set(time.milliseconds());
-                return true;
             }, new LeaveGroupResponse(new LeaveGroupResponseData()
                 .setErrorCode(Errors.NONE.code())
                 .setMembers(Collections.singletonList(responseOne))));
@@ -4239,7 +4216,7 @@ public class KafkaAdminClientTest {
                                     Map<String, ApiError> featureUpdateErrors) throws Exception {
         try (final AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().prepareResponse(
-                body -> body instanceof UpdateFeaturesRequest,
+                body -> assertTrue(body instanceof UpdateFeaturesRequest),
                 UpdateFeaturesResponse.createWithErrors(topLevelError, featureUpdateErrors, 0));
             final Map<String, KafkaFuture<Void>> futures = env.adminClient().updateFeatures(
                 featureUpdates,
@@ -4298,7 +4275,7 @@ public class KafkaAdminClientTest {
     public void testUpdateFeaturesHandleNotControllerException() throws Exception {
         try (final AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().prepareResponseFrom(
-                request -> request instanceof UpdateFeaturesRequest,
+                request -> assertTrue(request instanceof UpdateFeaturesRequest),
                 UpdateFeaturesResponse.createWithErrors(
                     new ApiError(Errors.NOT_CONTROLLER),
                     Utils.mkMap(),
@@ -4310,7 +4287,7 @@ public class KafkaAdminClientTest {
                 controllerId,
                 Collections.emptyList()));
             env.kafkaClient().prepareResponseFrom(
-                request -> request instanceof UpdateFeaturesRequest,
+                request -> assertTrue(request instanceof UpdateFeaturesRequest),
                 UpdateFeaturesResponse.createWithErrors(
                     ApiError.NONE,
                     Utils.mkMap(Utils.mkEntry("test_feature_1", ApiError.NONE),
@@ -4360,7 +4337,7 @@ public class KafkaAdminClientTest {
     public void testDescribeFeaturesSuccess() throws Exception {
         try (final AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().prepareResponse(
-                body -> body instanceof ApiVersionsRequest,
+                body -> assertTrue(body instanceof ApiVersionsRequest),
                 prepareApiVersionsResponseForDescribeFeatures(Errors.NONE));
             final KafkaFuture<FeatureMetadata> future = env.adminClient().describeFeatures(
                 new DescribeFeaturesOptions().timeoutMs(10000)).featureMetadata();
@@ -4373,7 +4350,7 @@ public class KafkaAdminClientTest {
     public void testDescribeFeaturesFailure() {
         try (final AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().prepareResponse(
-                body -> body instanceof ApiVersionsRequest,
+                body -> assertTrue(body instanceof ApiVersionsRequest),
                 prepareApiVersionsResponseForDescribeFeatures(Errors.INVALID_REQUEST));
             final DescribeFeaturesOptions options = new DescribeFeaturesOptions();
             options.timeoutMs(10000);
@@ -5343,7 +5320,7 @@ public class KafkaAdminClientTest {
             );
 
             env.kafkaClient().prepareResponseFrom(
-                request -> request instanceof DescribeProducersRequest,
+                request -> assertTrue(request instanceof DescribeProducersRequest),
                 response,
                 leader
             );
@@ -5410,22 +5387,23 @@ public class KafkaAdminClientTest {
             );
 
             env.kafkaClient().prepareResponseFrom(
-                request -> {
+                    (MockClient.RequestAssertion) request -> {
                     // We need a sleep here because the client will attempt to
                     // backoff after the disconnect
                     env.time().sleep(retryBackoffMs);
-                    return request instanceof DescribeProducersRequest;
+                    assertTrue(request instanceof DescribeProducersRequest);
                 },
                 response,
                 initialLeader,
-                true
+                true,
+                false
             );
 
             Node retryLeader = nodeIterator.next();
             expectMetadataRequest(env, topicPartition, retryLeader);
 
             env.kafkaClient().prepareResponseFrom(
-                request -> request instanceof DescribeProducersRequest,
+                request -> assertTrue(request instanceof DescribeProducersRequest),
                 response,
                 retryLeader
             );
@@ -5447,7 +5425,7 @@ public class KafkaAdminClientTest {
                 15, 10000L, OptionalLong.empty(), emptySet());
 
             env.kafkaClient().prepareResponse(
-                request -> request instanceof FindCoordinatorRequest,
+                request -> assertTrue(request instanceof FindCoordinatorRequest),
                 new FindCoordinatorResponse(new FindCoordinatorResponseData()
                     .setErrorCode(Errors.NONE.code())
                     .setNodeId(coordinator.id())
@@ -5456,7 +5434,7 @@ public class KafkaAdminClientTest {
             );
 
             env.kafkaClient().prepareResponseFrom(
-                request -> request instanceof DescribeTransactionsRequest,
+                request -> assertTrue(request instanceof DescribeTransactionsRequest),
                 new DescribeTransactionsResponse(new DescribeTransactionsResponseData().setTransactionStates(
                     singletonList(new DescribeTransactionsResponseData.TransactionState()
                         .setErrorCode(Errors.NONE.code())
@@ -5492,7 +5470,7 @@ public class KafkaAdminClientTest {
             Node coordinator2 = nodeIterator.next();
 
             env.kafkaClient().prepareResponse(
-                request -> request instanceof FindCoordinatorRequest,
+                request -> assertTrue(request instanceof FindCoordinatorRequest),
                 new FindCoordinatorResponse(new FindCoordinatorResponseData()
                     .setErrorCode(Errors.NONE.code())
                     .setNodeId(coordinator1.id())
@@ -5502,13 +5480,9 @@ public class KafkaAdminClientTest {
 
             env.kafkaClient().prepareResponseFrom(
                 request -> {
-                    if (!(request instanceof DescribeTransactionsRequest)) {
-                        return false;
-                    } else {
-                        // Backoff needed here for the retry of FindCoordinator
-                        time.sleep(retryBackoffMs);
-                        return true;
-                    }
+                    assertTrue(request instanceof DescribeTransactionsRequest);
+                    // Backoff needed here for the retry of FindCoordinator
+                    time.sleep(retryBackoffMs);
                 },
                 new DescribeTransactionsResponse(new DescribeTransactionsResponseData().setTransactionStates(
                     singletonList(new DescribeTransactionsResponseData.TransactionState()
@@ -5520,7 +5494,7 @@ public class KafkaAdminClientTest {
             );
 
             env.kafkaClient().prepareResponse(
-                request -> request instanceof FindCoordinatorRequest,
+                request -> assertTrue(request instanceof FindCoordinatorRequest),
                 new FindCoordinatorResponse(new FindCoordinatorResponseData()
                     .setErrorCode(Errors.NONE.code())
                     .setNodeId(coordinator2.id())
@@ -5533,7 +5507,7 @@ public class KafkaAdminClientTest {
                 15, 10000L, OptionalLong.empty(), emptySet());
 
             env.kafkaClient().prepareResponseFrom(
-                request -> request instanceof DescribeTransactionsRequest,
+                request -> assertTrue(request instanceof DescribeTransactionsRequest),
                 new DescribeTransactionsResponse(new DescribeTransactionsResponseData().setTransactionStates(
                     singletonList(new DescribeTransactionsResponseData.TransactionState()
                         .setErrorCode(Errors.NONE.code())
@@ -5607,11 +5581,9 @@ public class KafkaAdminClientTest {
 
         env.kafkaClient().prepareResponse(
             request -> {
-                if (!(request instanceof MetadataRequest)) {
-                    return false;
-                }
+                assertTrue(request instanceof MetadataRequest);
                 MetadataRequest metadataRequest = (MetadataRequest) request;
-                return metadataRequest.topics().equals(singletonList(topicPartition.topic()));
+                assertEquals(metadataRequest.topics(), singletonList(topicPartition.topic()));
             },
             new MetadataResponse(new MetadataResponseData().setTopics(responseTopics),
                 MetadataResponseData.HIGHEST_SUPPORTED_VERSION)

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -697,9 +697,9 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(joinGroupLeaderResponse(1, consumerId, memberSubscriptions, Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().containsKey(consumerId);
+            assertEquals(sync.data().memberId(), consumerId);
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(assigned, Errors.NONE));
         coordinator.poll(time.timer(Long.MAX_VALUE));
 
@@ -735,9 +735,9 @@ public abstract class ConsumerCoordinatorTest {
                     1, consumerId, singletonMap(consumerId, oldSubscription), Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().containsKey(consumerId);
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(oldAssignment, Errors.NONE));
 
         // Second correct assignment for subscription
@@ -746,9 +746,9 @@ public abstract class ConsumerCoordinatorTest {
                     1, consumerId, singletonMap(consumerId, newSubscription), Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().containsKey(consumerId);
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(newAssignment, Errors.NONE));
 
         // Poll once so that the join group future gets created and complete
@@ -821,9 +821,9 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(joinGroupLeaderResponse(1, consumerId, memberSubscriptions, Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().containsKey(consumerId);
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(assigned, Errors.NONE));
         // expect client to force updating the metadata, if yes gives it both topics
         client.prepareMetadataUpdate(metadataResponse);
@@ -867,7 +867,6 @@ public abstract class ConsumerCoordinatorTest {
             for (String topic : updatedSubscription)
                 updatedPartitions.put(topic, 1);
             client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, updatedPartitions));
-            return true;
         }, syncGroupResponse(oldAssigned, Errors.NONE));
         coordinator.poll(time.timer(Long.MAX_VALUE));
 
@@ -897,13 +896,11 @@ public abstract class ConsumerCoordinatorTest {
             ByteBuffer metadata = ByteBuffer.wrap(protocolMetadata.metadata());
             ConsumerPartitionAssignor.Subscription subscription = ConsumerProtocol.deserializeSubscription(metadata);
             metadata.rewind();
-            return subscription.topics().containsAll(updatedSubscription);
+            assertTrue(subscription.topics().containsAll(updatedSubscription));
         }, joinGroupLeaderResponse(2, consumerId, updatedSubscriptions, Errors.NONE));
         // update the metadata again back to topic1
-        client.prepareResponse(body -> {
-            client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, singletonMap(topic1, 1)));
-            return true;
-        }, syncGroupResponse(newAssigned, Errors.NONE));
+        client.prepareResponse(body -> client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, singletonMap(topic1, 1))),
+                syncGroupResponse(newAssigned, Errors.NONE));
 
         coordinator.poll(time.timer(Long.MAX_VALUE));
 
@@ -931,7 +928,7 @@ public abstract class ConsumerCoordinatorTest {
             ByteBuffer metadata = ByteBuffer.wrap(protocolMetadata.metadata());
             ConsumerPartitionAssignor.Subscription subscription = ConsumerProtocol.deserializeSubscription(metadata);
             metadata.rewind();
-            return subscription.topics().contains(topic1);
+            assertTrue(subscription.topics().contains(topic1));
         }, joinGroupLeaderResponse(3, consumerId, initialSubscription, Errors.NONE));
         client.prepareResponse(syncGroupResponse(oldAssigned, Errors.NONE));
 
@@ -970,9 +967,9 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(joinGroupFollowerResponse(1, consumerId, "leader", Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                sync.data().generationId() == 1 &&
-                sync.groupAssignments().isEmpty();
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().isEmpty());
         }, syncGroupResponse(singletonList(t1p), Errors.NONE));
 
         partitionAssignor.prepare(singletonMap(consumerId, singletonList(t1p)));
@@ -1103,9 +1100,9 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(joinGroupFollowerResponse(1, consumerId, "leader", Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().isEmpty();
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().isEmpty());
         }, syncGroupResponse(assigned, Errors.NONE));
 
         coordinator.joinGroupIfNeeded(time.timer(Long.MAX_VALUE));
@@ -1167,9 +1164,9 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(joinGroupFollowerResponse(1, consumerId, "leader", Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().isEmpty();
+            assertEquals(sync.data().memberId(), consumerId);
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().isEmpty());
         }, syncGroupResponse(assigned, Errors.NONE));
         // expect client to force updating the metadata, if yes gives it both topics
         client.prepareMetadataUpdate(metadataResponse);
@@ -1195,7 +1192,7 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(body -> {
             received.set(true);
             LeaveGroupRequest leaveRequest = (LeaveGroupRequest) body;
-            return validateLeaveGroup(groupId, consumerId, leaveRequest);
+            assertTrue(validateLeaveGroup(groupId, consumerId, leaveRequest));
         }, new LeaveGroupResponse(
             new LeaveGroupResponseData().setErrorCode(Errors.NONE.code())));
         coordinator.close(time.timer(0));
@@ -1211,7 +1208,7 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(body -> {
             received.set(true);
             LeaveGroupRequest leaveRequest = (LeaveGroupRequest) body;
-            return validateLeaveGroup(groupId, consumerId, leaveRequest);
+            assertTrue(validateLeaveGroup(groupId, consumerId, leaveRequest));
         }, new LeaveGroupResponse(new LeaveGroupResponseData().setErrorCode(Errors.NONE.code())));
         coordinator.maybeLeaveGroup("test maybe leave group");
         assertTrue(received.get());
@@ -1254,7 +1251,7 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(body -> {
             received.set(true);
             LeaveGroupRequest leaveRequest = (LeaveGroupRequest) body;
-            return validateLeaveGroup(groupId, consumerId, leaveRequest);
+            assertTrue(validateLeaveGroup(groupId, consumerId, leaveRequest));
         }, new LeaveGroupResponse(new LeaveGroupResponseData().setErrorCode(Errors.NONE.code())));
 
         coordinator.maybeLeaveGroup("pending member leaves");
@@ -1288,7 +1285,7 @@ public abstract class ConsumerCoordinatorTest {
         // now we should see a new join with the empty UNKNOWN_MEMBER_ID
         client.prepareResponse(body -> {
             JoinGroupRequest joinRequest = (JoinGroupRequest) body;
-            return joinRequest.data().memberId().equals(JoinGroupRequest.UNKNOWN_MEMBER_ID);
+            assertTrue(joinRequest.data().memberId().equals(JoinGroupRequest.UNKNOWN_MEMBER_ID));
         }, joinGroupFollowerResponse(2, consumerId, "leader", Errors.NONE));
         client.prepareResponse(syncGroupResponse(singletonList(t1p), Errors.NONE));
 
@@ -1333,7 +1330,7 @@ public abstract class ConsumerCoordinatorTest {
         // then let the full join/sync finish successfully
         client.prepareResponse(body -> {
             JoinGroupRequest joinRequest = (JoinGroupRequest) body;
-            return joinRequest.data().memberId().equals(JoinGroupRequest.UNKNOWN_MEMBER_ID);
+            assertEquals(JoinGroupRequest.UNKNOWN_MEMBER_ID, joinRequest.data().memberId());
         }, joinGroupFollowerResponse(2, consumerId, "leader", Errors.NONE));
         client.prepareResponse(syncGroupResponse(singletonList(t1p), Errors.NONE));
 
@@ -1397,17 +1394,14 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(joinGroupLeaderResponse(1, consumerId, memberSubscriptions, Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            if (sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().containsKey(consumerId)) {
-                // trigger the metadata update including both topics after the sync group request has been sent
-                Map<String, Integer> topicPartitionCounts = new HashMap<>();
-                topicPartitionCounts.put(topic1, 1);
-                topicPartitionCounts.put(topic2, 1);
-                client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, topicPartitionCounts));
-                return true;
-            }
-            return false;
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
+            // trigger the metadata update including both topics after the sync group request has been sent
+            Map<String, Integer> topicPartitionCounts = new HashMap<>();
+            topicPartitionCounts.put(topic1, 1);
+            topicPartitionCounts.put(topic2, 1);
+            client.updateMetadata(RequestTestUtils.metadataUpdateWith(1, topicPartitionCounts));
         }, syncGroupResponse(Collections.singletonList(tp1), Errors.NONE));
         coordinator.poll(time.timer(Long.MAX_VALUE));
 
@@ -1899,8 +1893,8 @@ public abstract class ConsumerCoordinatorTest {
         // the client should not reuse generation/memberId from auto-subscribed generation
         client.prepareResponse(body -> {
             OffsetCommitRequest commitRequest = (OffsetCommitRequest) body;
-            return commitRequest.data().memberId().equals(OffsetCommitRequest.DEFAULT_MEMBER_ID) &&
-                    commitRequest.data().generationId() == OffsetCommitRequest.DEFAULT_GENERATION_ID;
+            assertEquals(OffsetCommitRequest.DEFAULT_MEMBER_ID, commitRequest.data().memberId());
+            assertEquals(OffsetCommitRequest.DEFAULT_GENERATION_ID,  commitRequest.data().generationId());
         }, offsetCommitResponse(singletonMap(t1p, Errors.NONE)));
 
         AtomicBoolean success = new AtomicBoolean(false);
@@ -2286,9 +2280,9 @@ public abstract class ConsumerCoordinatorTest {
 
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                sync.data().generationId() == 1 &&
-                sync.groupAssignments().containsKey(consumerId);
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(singletonList(t1p), Errors.NONE));
         coordinator.poll(time.timer(Long.MAX_VALUE));
 
@@ -2961,12 +2955,12 @@ public abstract class ConsumerCoordinatorTest {
         client.prepareResponse(body -> {
             commitRequested.set(true);
             OffsetCommitRequest commitRequest = (OffsetCommitRequest) body;
-            return commitRequest.data().groupId().equals(groupId);
+            assertTrue(commitRequest.data().groupId().equals(groupId));
         }, new OffsetCommitResponse(new OffsetCommitResponseData()));
         client.prepareResponse(body -> {
             leaveGroupRequested.set(true);
             LeaveGroupRequest leaveRequest = (LeaveGroupRequest) body;
-            return leaveRequest.data().groupId().equals(groupId);
+            assertTrue(leaveRequest.data().groupId().equals(groupId));
         }, new LeaveGroupResponse(new LeaveGroupResponseData()
                 .setErrorCode(Errors.NONE.code())));
 
@@ -3137,9 +3131,9 @@ public abstract class ConsumerCoordinatorTest {
                         generation, consumerId, singletonMap(consumerId, subscription), Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == generation &&
-                    sync.groupAssignments().containsKey(consumerId);
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(generation, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(assignment, Errors.NONE));
     }
 
@@ -3156,24 +3150,17 @@ public abstract class ConsumerCoordinatorTest {
         client.respond(offsetCommitRequestMatcher(expectedOffsets), offsetCommitResponse(errors));
     }
 
-    private MockClient.RequestMatcher offsetCommitRequestMatcher(final Map<TopicPartition, Long> expectedOffsets) {
+    private MockClient.RequestAssertion offsetCommitRequestMatcher(final Map<TopicPartition, Long> expectedOffsets) {
         return body -> {
             OffsetCommitRequest req = (OffsetCommitRequest) body;
             Map<TopicPartition, Long> offsets = req.offsets();
-            if (offsets.size() != expectedOffsets.size())
-                return false;
+            assertEquals(expectedOffsets.size(), offsets.size());
 
             for (Map.Entry<TopicPartition, Long> expectedOffset : expectedOffsets.entrySet()) {
-                if (!offsets.containsKey(expectedOffset.getKey())) {
-                    return false;
-                } else {
-                    Long actualOffset = offsets.get(expectedOffset.getKey());
-                    if (!actualOffset.equals(expectedOffset.getValue())) {
-                        return false;
-                    }
-                }
+                assertTrue(offsets.containsKey(expectedOffset.getKey()));
+                Long actualOffset = offsets.get(expectedOffset.getKey());
+                assertEquals(expectedOffset.getValue(), actualOffset);
             }
-            return true;
         };
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinatorTest.java
@@ -254,9 +254,9 @@ public class WorkerCoordinatorTest {
         client.prepareResponse(joinGroupLeaderResponse(1, consumerId, memberConfigOffsets, Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(consumerId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.groupAssignments().containsKey(consumerId);
+            assertEquals(consumerId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.groupAssignments().containsKey(consumerId));
         }, syncGroupResponse(ConnectProtocol.Assignment.NO_ERROR, "leader", 1L, Collections.singletonList(connectorId1),
                 Collections.emptyList(), Errors.NONE));
         coordinator.ensureActiveGroup();
@@ -288,9 +288,9 @@ public class WorkerCoordinatorTest {
         client.prepareResponse(joinGroupFollowerResponse(1, memberId, "leader", Errors.NONE));
         client.prepareResponse(body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(memberId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.data().assignments().isEmpty();
+            assertEquals(memberId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.data().assignments().isEmpty());
         }, syncGroupResponse(ConnectProtocol.Assignment.NO_ERROR, "leader", 1L, Collections.emptyList(),
                 Collections.singletonList(taskId1x0), Errors.NONE));
         coordinator.ensureActiveGroup();
@@ -324,11 +324,11 @@ public class WorkerCoordinatorTest {
 
         // config mismatch results in assignment error
         client.prepareResponse(joinGroupFollowerResponse(1, memberId, "leader", Errors.NONE));
-        MockClient.RequestMatcher matcher = body -> {
+        MockClient.RequestAssertion matcher = body -> {
             SyncGroupRequest sync = (SyncGroupRequest) body;
-            return sync.data().memberId().equals(memberId) &&
-                    sync.data().generationId() == 1 &&
-                    sync.data().assignments().isEmpty();
+            assertEquals(memberId, sync.data().memberId());
+            assertEquals(1, sync.data().generationId());
+            assertTrue(sync.data().assignments().isEmpty());
         };
         client.prepareResponse(matcher, syncGroupResponse(ConnectProtocol.Assignment.CONFIG_MISMATCH, "leader", 10L,
                 Collections.emptyList(), Collections.emptyList(), Errors.NONE));

--- a/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ForwardingManagerTest.scala
@@ -25,7 +25,7 @@ import kafka.network
 import kafka.network.RequestChannel
 import kafka.utils.MockTime
 import org.apache.kafka.clients.{MockClient, NodeApiVersions}
-import org.apache.kafka.clients.MockClient.RequestMatcher
+import org.apache.kafka.clients.MockClient.RequestAssertion
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
 import org.apache.kafka.common.memory.MemoryPool
@@ -72,7 +72,7 @@ class ForwardingManagerTest {
       requestCorrelationId + 1)
 
     Mockito.when(controllerNodeProvider.get()).thenReturn(Some(new Node(0, "host", 1234)))
-    val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
+    val isEnvelopeRequest: RequestAssertion = request => assertTrue(request.isInstanceOf[EnvelopeRequest])
     client.prepareResponse(isEnvelopeRequest, new EnvelopeResponse(responseBuffer, Errors.NONE));
 
     val responseOpt = new AtomicReference[Option[AbstractResponse]]()
@@ -96,7 +96,7 @@ class ForwardingManagerTest {
       requestHeader.apiVersion, requestCorrelationId)
 
     Mockito.when(controllerNodeProvider.get()).thenReturn(Some(new Node(0, "host", 1234)))
-    val isEnvelopeRequest: RequestMatcher = request => request.isInstanceOf[EnvelopeRequest]
+    val isEnvelopeRequest: RequestAssertion = request => assertTrue(request.isInstanceOf[EnvelopeRequest])
     client.prepareResponse(isEnvelopeRequest, new EnvelopeResponse(responseBuffer, Errors.UNSUPPORTED_VERSION));
 
     val responseOpt = new AtomicReference[Option[AbstractResponse]]()


### PR DESCRIPTION
As described in [KAFKA-12263](https://issues.apache.org/jira/browse/KAFKA-12263), this PR refactors `MockClient.RequestMatcher` to become `MockClient.RequestAssertion` using assertions in the implementations.