### PR TITLE
KAFKA-12269: Replace partition metada with auto-generated protocal

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1085,8 +1085,8 @@ public class NetworkClient implements KafkaClient {
             // This could be a transient issue if listeners were added dynamically to brokers.
             List<TopicPartition> missingListenerPartitions = response.topicMetadata().stream().flatMap(topicMetadata ->
                 topicMetadata.partitionMetadata().stream()
-                    .filter(partitionMetadata -> partitionMetadata.error == Errors.LISTENER_NOT_FOUND)
-                    .map(partitionMetadata -> new TopicPartition(topicMetadata.topic(), partitionMetadata.partition())))
+                    .filter(partitionMetadata -> partitionMetadata.errorCode() == Errors.LISTENER_NOT_FOUND.code())
+                    .map(partitionMetadata -> new TopicPartition(topicMetadata.topic(), partitionMetadata.partitionIndex())))
                 .collect(Collectors.toList());
             if (!missingListenerPartitions.isEmpty()) {
                 int count = missingListenerPartitions.size();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/MetadataOperationContext.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/MetadataOperationContext.java
@@ -17,18 +17,18 @@
 
 package org.apache.kafka.clients.admin.internals;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-
 import org.apache.kafka.clients.admin.AbstractOptions;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidMetadataException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.MetadataResponse;
-import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
 import org.apache.kafka.common.requests.MetadataResponse.TopicMetadata;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Context class to encapsulate parameters of a call to fetch and use cluster metadata.
@@ -83,9 +83,9 @@ public final class MetadataOperationContext<T, O extends AbstractOptions<O>> {
     public static void handleMetadataErrors(MetadataResponse response) {
         for (TopicMetadata tm : response.topicMetadata()) {
             if (shouldRefreshMetadata(tm.error())) throw tm.error().exception();
-            for (PartitionMetadata pm : tm.partitionMetadata()) {
-                if (shouldRefreshMetadata(pm.error)) {
-                    throw pm.error.exception();
+            for (MetadataResponseData.MetadataResponsePartition pm : tm.partitionMetadata()) {
+                if (shouldRefreshMetadata(Errors.forCode(pm.errorCode()))) {
+                    throw Errors.forCode(pm.errorCode()).exception();
                 }
             }
         }

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestUtils.java
@@ -37,6 +37,11 @@ public final class RequestUtils {
             Optional.empty() : Optional.of(leaderEpoch);
     }
 
+    public static Optional<Integer> getLeaderId(int leaderId) {
+        return leaderId == MetadataResponse.NO_LEADER_ID ?
+            Optional.empty() : Optional.of(leaderId);
+    }
+
     public static boolean hasTransactionalRecords(ProduceRequest request) {
         return flag(request, RecordBatch::isTransactional);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataCacheTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataCacheTest.java
@@ -20,15 +20,14 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.MetadataResponse;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -47,14 +46,14 @@ public class MetadataCacheTest {
 
         TopicPartition topicPartition = new TopicPartition("topic", 0);
 
-        MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(
-                Errors.NONE,
-                topicPartition,
-                Optional.of(5),
-                Optional.of(10),
-                Arrays.asList(5, 6, 7),
-                Arrays.asList(5, 6, 7),
-                Collections.emptyList());
+        MetadataResponseData.MetadataResponsePartition partitionMetadata = new MetadataResponseData.MetadataResponsePartition()
+            .setErrorCode(Errors.NONE.code())
+            .setPartitionIndex(0)
+            .setLeaderId(5)
+            .setLeaderEpoch(10)
+            .setReplicaNodes(Arrays.asList(5, 6, 7))
+            .setIsrNodes(Arrays.asList(5, 6, 7))
+            .setOfflineReplicas(Collections.emptyList());
 
         Map<Integer, Node> nodesById = new HashMap<>();
         nodesById.put(6, new Node(6, "localhost", 2077));
@@ -62,19 +61,19 @@ public class MetadataCacheTest {
         nodesById.put(8, new Node(8, "localhost", 2079));
 
         MetadataCache cache = new MetadataCache("clusterId",
-                nodesById,
-                Collections.singleton(partitionMetadata),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                Collections.emptySet(),
-                null);
+            nodesById,
+            Collections.singletonMap(topicPartition, partitionMetadata),
+            Collections.emptySet(),
+            Collections.emptySet(),
+            Collections.emptySet(),
+            null);
 
         Cluster cluster = cache.cluster();
         assertNull(cluster.leaderFor(topicPartition));
 
         PartitionInfo partitionInfo = cluster.partition(topicPartition);
         Map<Integer, Node> replicas = Arrays.stream(partitionInfo.replicas())
-                .collect(Collectors.toMap(Node::id, Function.identity()));
+            .collect(Collectors.toMap(Node::id, Function.identity()));
         assertNull(partitionInfo.leader());
         assertEquals(3, replicas.size());
         assertTrue(replicas.get(5).isEmpty());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -112,6 +112,7 @@ import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
 import org.apache.kafka.common.message.OffsetDeleteResponseData;
@@ -215,6 +216,8 @@ import static org.apache.kafka.common.message.AlterPartitionReassignmentsRespons
 import static org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.ReassignableTopicResponse;
 import static org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingPartitionReassignment;
 import static org.apache.kafka.common.message.ListPartitionReassignmentsResponseData.OngoingTopicReassignment;
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
+import static org.apache.kafka.common.requests.MetadataResponse.NO_LEADER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -1217,9 +1220,14 @@ public class KafkaAdminClientTest {
 
             // Then we respond to the DescribeTopic request
             Node leader = initializedCluster.nodes().get(0);
-            MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(
-                    Errors.NONE, new TopicPartition(topic, 0), Optional.of(leader.id()), Optional.of(10),
-                    singletonList(leader.id()), singletonList(leader.id()), singletonList(leader.id()));
+            MetadataResponseData.MetadataResponsePartition partitionMetadata = new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(0)
+                .setLeaderId(leader.id())
+                .setLeaderEpoch(10)
+                .setReplicaNodes(singletonList(leader.id()))
+                .setIsrNodes(singletonList(leader.id()))
+                .setOfflineReplicas(singletonList(leader.id()));
             env.kafkaClient().prepareResponse(RequestTestUtils.metadataResponse(initializedCluster.nodes(),
                     initializedCluster.clusterResource().clusterId(), 1,
                     singletonList(new MetadataResponse.TopicMetadata(Errors.NONE, topic, Uuid.ZERO_UUID, false,
@@ -2016,13 +2024,23 @@ public class KafkaAdminClientTest {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(time, mockCluster(3, 0))) {
             List<Node> nodes = env.cluster().nodes();
 
-            List<MetadataResponse.PartitionMetadata> partitionMetadata = new ArrayList<>();
-            partitionMetadata.add(new MetadataResponse.PartitionMetadata(Errors.NONE, tp0,
-                    Optional.of(nodes.get(0).id()), Optional.of(5), singletonList(nodes.get(0).id()),
-                    singletonList(nodes.get(0).id()), Collections.emptyList()));
-            partitionMetadata.add(new MetadataResponse.PartitionMetadata(Errors.NONE, tp1,
-                    Optional.of(nodes.get(1).id()), Optional.of(5), singletonList(nodes.get(1).id()),
-                    singletonList(nodes.get(1).id()), Collections.emptyList()));
+            List<MetadataResponseData.MetadataResponsePartition> partitionMetadata = new ArrayList<>();
+            partitionMetadata.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(tp0.partition())
+                .setLeaderId(nodes.get(0).id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(singletonList(nodes.get(0).id()))
+                .setIsrNodes(singletonList(nodes.get(0).id()))
+                .setOfflineReplicas(Collections.emptyList()));
+            partitionMetadata.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(tp1.partition())
+                .setLeaderId(nodes.get(1).id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(singletonList(nodes.get(1).id()))
+                .setIsrNodes(singletonList(nodes.get(1).id()))
+                .setOfflineReplicas(Collections.emptyList()));
 
             List<MetadataResponse.TopicMetadata> topicMetadata = new ArrayList<>();
             topicMetadata.add(new MetadataResponse.TopicMetadata(Errors.NONE, topic, false, partitionMetadata));
@@ -2096,22 +2114,48 @@ public class KafkaAdminClientTest {
                     ).iterator())));
 
             List<MetadataResponse.TopicMetadata> t = new ArrayList<>();
-            List<MetadataResponse.PartitionMetadata> p = new ArrayList<>();
-            p.add(new MetadataResponse.PartitionMetadata(Errors.NONE, myTopicPartition0,
-                    Optional.of(nodes.get(0).id()), Optional.of(5), singletonList(nodes.get(0).id()),
-                    singletonList(nodes.get(0).id()), Collections.emptyList()));
-            p.add(new MetadataResponse.PartitionMetadata(Errors.NONE, myTopicPartition1,
-                    Optional.of(nodes.get(0).id()), Optional.of(5), singletonList(nodes.get(0).id()),
-                    singletonList(nodes.get(0).id()), Collections.emptyList()));
-            p.add(new MetadataResponse.PartitionMetadata(Errors.LEADER_NOT_AVAILABLE, myTopicPartition2,
-                    Optional.empty(), Optional.empty(), singletonList(nodes.get(0).id()),
-                    singletonList(nodes.get(0).id()), Collections.emptyList()));
-            p.add(new MetadataResponse.PartitionMetadata(Errors.NONE, myTopicPartition3,
-                    Optional.of(nodes.get(0).id()), Optional.of(5), singletonList(nodes.get(0).id()),
-                    singletonList(nodes.get(0).id()), Collections.emptyList()));
-            p.add(new MetadataResponse.PartitionMetadata(Errors.NONE, myTopicPartition4,
-                    Optional.of(nodes.get(0).id()), Optional.of(5), singletonList(nodes.get(0).id()),
-                    singletonList(nodes.get(0).id()), Collections.emptyList()));
+            List<MetadataResponseData.MetadataResponsePartition> p = new ArrayList<>();
+            p.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(myTopicPartition0.partition())
+                .setLeaderId(nodes.get(0).id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(singletonList(nodes.get(0).id()))
+                .setIsrNodes(singletonList(nodes.get(0).id()))
+                .setOfflineReplicas(Collections.emptyList()));
+
+            p.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(myTopicPartition1.partition())
+                .setLeaderId(nodes.get(0).id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(singletonList(nodes.get(0).id()))
+                .setIsrNodes(singletonList(nodes.get(0).id()))
+                .setOfflineReplicas(Collections.emptyList()));
+            p.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                .setPartitionIndex(myTopicPartition2.partition())
+                .setLeaderId(NO_LEADER_ID)
+                .setLeaderEpoch(NO_PARTITION_LEADER_EPOCH)
+                .setReplicaNodes(singletonList(nodes.get(0).id()))
+                .setIsrNodes(singletonList(nodes.get(0).id()))
+                .setOfflineReplicas(Collections.emptyList()));
+            p.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(myTopicPartition3.partition())
+                .setLeaderId(nodes.get(0).id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(singletonList(nodes.get(0).id()))
+                .setIsrNodes(singletonList(nodes.get(0).id()))
+                .setOfflineReplicas(Collections.emptyList()));
+            p.add(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(myTopicPartition4.partition())
+                .setLeaderId(nodes.get(0).id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(singletonList(nodes.get(0).id()))
+                .setIsrNodes(singletonList(nodes.get(0).id()))
+                .setOfflineReplicas(Collections.emptyList()));
 
             t.add(new MetadataResponse.TopicMetadata(Errors.NONE, "my_topic", false, p));
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
@@ -36,7 +37,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -159,9 +159,14 @@ public class ConsumerMetadataTest {
     }
 
     private MetadataResponse.TopicMetadata topicMetadata(String topic, boolean isInternal) {
-        MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(Errors.NONE,
-                new TopicPartition(topic, 0), Optional.of(node.id()), Optional.of(5),
-                singletonList(node.id()), singletonList(node.id()), singletonList(node.id()));
+        MetadataResponseData.MetadataResponsePartition partitionMetadata = new MetadataResponseData.MetadataResponsePartition()
+            .setErrorCode(Errors.NONE.code())
+            .setPartitionIndex(0)
+            .setLeaderId(node.id())
+            .setLeaderEpoch(5)
+            .setReplicaNodes(singletonList(node.id()))
+            .setIsrNodes(singletonList(node.id()))
+            .setOfflineReplicas(singletonList(node.id()));
         return new MetadataResponse.TopicMetadata(Errors.NONE, topic, isInternal, singletonList(partitionMetadata));
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -54,6 +54,7 @@ import org.apache.kafka.common.message.ListOffsetsRequestData.ListOffsetsTopic;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsPartitionResponse;
 import org.apache.kafka.common.message.ListOffsetsResponseData.ListOffsetsTopicResponse;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderPartition;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
@@ -135,7 +136,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
+import static org.apache.kafka.common.requests.MetadataResponse.NO_LEADER_ID;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH;
 import static org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.UNDEFINED_EPOCH_OFFSET;
 import static org.apache.kafka.test.TestUtils.assertOptional;
@@ -255,7 +258,7 @@ public class FetcherTest {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.MAGIC_VALUE_V0,
                 CompressionType.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis(),
-                RecordBatch.NO_PARTITION_LEADER_EPOCH);
+                NO_PARTITION_LEADER_EPOCH);
         builder.append(0L, "key".getBytes(), "1".getBytes());
         builder.append(0L, "key".getBytes(), "2".getBytes());
         MemoryRecords records = builder.build();
@@ -2020,18 +2023,12 @@ public class FetcherTest {
         //create a response based on the above one with all partitions being leaderless
         List<MetadataResponse.TopicMetadata> altTopics = new ArrayList<>();
         for (MetadataResponse.TopicMetadata item : originalResponse.topicMetadata()) {
-            List<MetadataResponse.PartitionMetadata> partitions = item.partitionMetadata();
-            List<MetadataResponse.PartitionMetadata> altPartitions = new ArrayList<>();
-            for (MetadataResponse.PartitionMetadata p : partitions) {
-                altPartitions.add(new MetadataResponse.PartitionMetadata(
-                    p.error,
-                    p.topicPartition,
-                    Optional.empty(), //no leader
-                    Optional.empty(),
-                    p.replicaIds,
-                    p.inSyncReplicaIds,
-                    p.offlineReplicaIds
-                ));
+            List<MetadataResponseData.MetadataResponsePartition> partitions = item.partitionMetadata();
+            List<MetadataResponseData.MetadataResponsePartition> altPartitions = new ArrayList<>();
+            for (MetadataResponseData.MetadataResponsePartition p : partitions) {
+                altPartitions.add(p.duplicate()
+                    .setLeaderId(NO_LEADER_ID)
+                    .setLeaderEpoch(NO_PARTITION_LEADER_EPOCH));
             }
             MetadataResponse.TopicMetadata alteredTopic = new MetadataResponse.TopicMetadata(
                 item.error(),
@@ -3473,7 +3470,7 @@ public class FetcherTest {
         // Empty control batch should not cause an exception
         DefaultRecordBatch.writeEmptyHeader(buffer, RecordBatch.MAGIC_VALUE_V2, 1L,
                 (short) 0, -1, 0, 0,
-                RecordBatch.NO_PARTITION_LEADER_EPOCH, TimestampType.CREATE_TIME, time.milliseconds(),
+                NO_PARTITION_LEADER_EPOCH, TimestampType.CREATE_TIME, time.milliseconds(),
                 true, true);
 
         currentOffset += appendTransactionalRecords(buffer, 1L, currentOffset,
@@ -3516,7 +3513,7 @@ public class FetcherTest {
     private int appendTransactionalRecords(ByteBuffer buffer, long pid, long baseOffset, int baseSequence, SimpleRecord... records) {
         MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
                 TimestampType.CREATE_TIME, baseOffset, time.milliseconds(), pid, (short) 0, baseSequence, true,
-                RecordBatch.NO_PARTITION_LEADER_EPOCH);
+                NO_PARTITION_LEADER_EPOCH);
 
         for (SimpleRecord record : records) {
             builder.append(record);
@@ -4501,15 +4498,13 @@ public class FetcherTest {
     }
 
     private MetadataResponse newMetadataResponse(String topic, Errors error) {
-        List<MetadataResponse.PartitionMetadata> partitionsMetadata = new ArrayList<>();
+        List<MetadataResponseData.MetadataResponsePartition> partitionsMetadata = new ArrayList<>();
         if (error == Errors.NONE) {
             Optional<MetadataResponse.TopicMetadata> foundMetadata = initialUpdateResponse.topicMetadata()
                     .stream()
                     .filter(topicMetadata -> topicMetadata.topic().equals(topic))
                     .findFirst();
-            foundMetadata.ifPresent(topicMetadata -> {
-                partitionsMetadata.addAll(topicMetadata.partitionMetadata());
-            });
+            foundMetadata.ifPresent(topicMetadata -> partitionsMetadata.addAll(topicMetadata.partitionMetadata()));
         }
 
         MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(error, topic, false,

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -139,6 +139,7 @@ import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
 import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
 import org.apache.kafka.common.message.OffsetCommitResponseData;
 import org.apache.kafka.common.message.OffsetDeleteRequestData;
@@ -226,7 +227,9 @@ import static org.apache.kafka.common.protocol.ApiKeys.JOIN_GROUP;
 import static org.apache.kafka.common.protocol.ApiKeys.LIST_GROUPS;
 import static org.apache.kafka.common.protocol.ApiKeys.LIST_OFFSETS;
 import static org.apache.kafka.common.protocol.ApiKeys.SYNC_GROUP;
+import static org.apache.kafka.common.record.RecordBatch.NO_PARTITION_LEADER_EPOCH;
 import static org.apache.kafka.common.requests.FetchMetadata.INVALID_SESSION_ID;
+import static org.apache.kafka.common.requests.MetadataResponse.NO_LEADER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1449,17 +1452,29 @@ public class RequestResponseTest {
 
         List<MetadataResponse.TopicMetadata> allTopicMetadata = new ArrayList<>();
         allTopicMetadata.add(new MetadataResponse.TopicMetadata(Errors.NONE, "__consumer_offsets", true,
-                asList(new MetadataResponse.PartitionMetadata(Errors.NONE,
-                        new TopicPartition("__consumer_offsets", 1),
-                        Optional.of(node.id()), Optional.of(5), replicas, isr, offlineReplicas))));
+            singletonList(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.NONE.code())
+                .setPartitionIndex(1)
+                .setLeaderId(node.id())
+                .setLeaderEpoch(5)
+                .setReplicaNodes(replicas)
+                .setIsrNodes(isr)
+                .setOfflineReplicas(offlineReplicas)
+            )));
         allTopicMetadata.add(new MetadataResponse.TopicMetadata(Errors.LEADER_NOT_AVAILABLE, "topic2", false,
                 emptyList()));
         allTopicMetadata.add(new MetadataResponse.TopicMetadata(Errors.NONE, "topic3", false,
-            asList(new MetadataResponse.PartitionMetadata(Errors.LEADER_NOT_AVAILABLE,
-                    new TopicPartition("topic3", 0), Optional.empty(),
-                    Optional.empty(), replicas, isr, offlineReplicas))));
+            singletonList(new MetadataResponseData.MetadataResponsePartition()
+                .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                .setPartitionIndex(0)
+                .setLeaderId(NO_LEADER_ID)
+                .setLeaderEpoch(NO_PARTITION_LEADER_EPOCH)
+                .setReplicaNodes(replicas)
+                .setIsrNodes(isr)
+                .setOfflineReplicas(offlineReplicas)
+            )));
 
-        return RequestTestUtils.metadataResponse(asList(node), null, MetadataResponse.NO_CONTROLLER_ID, allTopicMetadata);
+        return RequestTestUtils.metadataResponse(singletonList(node), null, MetadataResponse.NO_CONTROLLER_ID, allTopicMetadata);
     }
 
     private OffsetCommitRequest createOffsetCommitRequest(int version) {
@@ -1475,12 +1490,12 @@ public class RequestResponseTest {
                                         new OffsetCommitRequestData.OffsetCommitRequestPartition()
                                                 .setPartitionIndex(0)
                                                 .setCommittedOffset(100)
-                                                .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
+                                                .setCommittedLeaderEpoch(NO_PARTITION_LEADER_EPOCH)
                                                 .setCommittedMetadata(""),
                                         new OffsetCommitRequestData.OffsetCommitRequestPartition()
                                                 .setPartitionIndex(1)
                                                 .setCommittedOffset(200)
-                                                .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
+                                                .setCommittedLeaderEpoch(NO_PARTITION_LEADER_EPOCH)
                                                 .setCommittedMetadata(null)
                                 ))
                 ))
@@ -1930,7 +1945,7 @@ public class RequestResponseTest {
                 new OffsetForLeaderPartition()
                     .setPartition(2)
                     .setLeaderEpoch(3)
-                    .setCurrentLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH))));
+                    .setCurrentLeaderEpoch(NO_PARTITION_LEADER_EPOCH))));
         return topics;
     }
 

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -129,9 +129,9 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
 
           if (replication == -1) {
             assertEquals(configs.head.defaultReplicationFactor,
-              metadataForTopic.partitionMetadata.asScala.head.replicaIds.size, "The topic should have the default replication factor")
+              metadataForTopic.partitionMetadata.asScala.head.replicaNodes().size, "The topic should have the default replication factor")
           } else {
-            assertEquals(replication, metadataForTopic.partitionMetadata.asScala.head.replicaIds.size, "The topic should have the correct replication factor")
+            assertEquals(replication, metadataForTopic.partitionMetadata.asScala.head.replicaNodes().size, "The topic should have the correct replication factor")
           }
         }
       }

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestWithForwardingTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestWithForwardingTest.scala
@@ -20,7 +20,7 @@ package kafka.server
 import kafka.utils.TestUtils
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.common.protocol.Errors
-import org.apache.kafka.common.requests.MetadataRequest
+import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertThrows, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
@@ -100,12 +100,12 @@ class MetadataRequestWithForwardingTest extends AbstractMetadataRequestTest {
     val response2 = sendMetadataRequest(new MetadataRequest.Builder(Seq(topicCreated).asJava, true).build)
     val topicMetadata1 = response2.topicMetadata.asScala.head
     assertEquals(Errors.NONE, topicMetadata1.error)
-    assertEquals(Seq(Errors.NONE), topicMetadata1.partitionMetadata.asScala.map(_.error))
+    assertEquals(Seq(Errors.NONE.code()), topicMetadata1.partitionMetadata.asScala.map(_.errorCode()))
     assertEquals(1, topicMetadata1.partitionMetadata.size)
     val partitionMetadata = topicMetadata1.partitionMetadata.asScala.head
-    assertEquals(0, partitionMetadata.partition)
-    assertEquals(2, partitionMetadata.replicaIds.size)
-    assertTrue(partitionMetadata.leaderId.isPresent)
-    assertTrue(partitionMetadata.leaderId.get >= 0)
+    assertEquals(0, partitionMetadata.partitionIndex())
+    assertEquals(2, partitionMetadata.replicaNodes().size)
+    assertTrue(partitionMetadata.leaderId != MetadataResponse.NO_LEADER_ID)
+    assertTrue(partitionMetadata.leaderId >= 0)
   }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataResponseBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataResponseBenchmark.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.metadata;
+
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MetadataResponseBenchmark {
+    @Param({"500", "1000", "5000"})
+    private int topicCount;
+    @Param({"10", "20", "50"})
+    private int partitionCount;
+
+    private MetadataResponseData metadataResponseData;
+
+    @Setup(Level.Trial)
+    public void setup() {
+
+        List<MetadataResponseData.MetadataResponseTopic> topicStates = new ArrayList<>();
+        IntStream.range(0, topicCount).forEach(topicIndex -> {
+            String topicName = "topic-" + topicIndex;
+
+            List<MetadataResponseData.MetadataResponsePartition> partitionStates = new ArrayList<>();
+            IntStream.range(0, partitionCount).forEach(partitionId -> partitionStates.add(
+                new MetadataResponseData.MetadataResponsePartition()
+                    .setPartitionIndex(1)
+                    .setLeaderId(1)
+                    .setLeaderEpoch(1)
+                    .setReplicaNodes(Arrays.asList(1, 2, 3))
+                    .setIsrNodes(Arrays.asList(1, 2, 3))
+                    .setOfflineReplicas(Collections.emptyList())
+                    .setErrorCode(Errors.NONE.code())));
+
+            MetadataResponseData.MetadataResponseTopic topicMetadata = new MetadataResponseData.MetadataResponseTopic()
+                .setErrorCode(Errors.NONE.code())
+                .setName(topicName)
+                .setTopicId(Uuid.randomUuid())
+                .setPartitions(partitionStates)
+                .setIsInternal(false);
+
+            topicStates.add(topicMetadata);
+        });
+
+
+        MetadataResponseData.MetadataResponseTopicCollection topics =
+            new MetadataResponseData.MetadataResponseTopicCollection(topicStates.iterator());
+
+        metadataResponseData = new MetadataResponseData()
+            .setClusterId("clusterId")
+            .setControllerId(0)
+            .setTopics(topics)
+            .setBrokers(new MetadataResponseData.MetadataResponseBrokerCollection());
+    }
+
+    @Benchmark
+    public void constructMetadataResponse() {
+        new MetadataResponse(metadataResponseData, MetadataResponseData.HIGHEST_SUPPORTED_VERSION).topicMetadata();
+    }
+}


### PR DESCRIPTION
*More detailed description of your change*
MetadataResponse.PartitionMetadata is almost the same as MetadataResponsePartition so we can replace it, below is the difference that we need to notice:
1. `MetadataResponse.PartitionMetadata` contains a `TopicPartition` but `MetadataResponsePartition` only contains partitionIndex, so we need to change some method to add topic if necessary.
2. leaderId and leaderEpoch in `MetadataResponse.PartitionMetadata` are `Optional`, we use `NO_LEADER_ID` and `NO_PARTITION_LEADER_EPOCH` to replace null `Optional`.

Following work:
The `MetadataResponse.TopicMetadata` can also be replaced in a next pr, this pr only replace `MetadataResponse.PartitionMetadata` to make pr simple for review.

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
