### PR TITLE
MINOR: Fix windows startup scripts to use connect-log4j.properties instead of tools-log4j.properties

### DIFF
--- a/bin/windows/connect-distributed.bat
+++ b/bin/windows/connect-distributed.bat
@@ -27,7 +27,7 @@ popd
 
 rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
-	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
+	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/connect-log4j.properties
 )
 
 "%~dp0kafka-run-class.bat" org.apache.kafka.connect.cli.ConnectDistributed %*

--- a/bin/windows/connect-standalone.bat
+++ b/bin/windows/connect-standalone.bat
@@ -27,7 +27,7 @@ popd
 
 rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
-	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
+	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/connect-log4j.properties
 )
 
 "%~dp0kafka-run-class.bat" org.apache.kafka.connect.cli.ConnectStandalone %*


### PR DESCRIPTION
Very small change.  Found that the connect-standalone.bat file uses tools-log4j.properties, but if this is used and no connector properties file is specified, the connect-standalone.bat file will exit with no errors or other output.

Output when connect-standalone.bat uses tools-log4j.properties:

![image](https://user-images.githubusercontent.com/7929462/106696379-2ff41500-660f-11eb-9ad6-37f794c255cc.png)

If connect-standalone.bat uses connect-log4j.properties, it will return an error message noting that no connector properties file is specified.  This looks to be the correct behaviour.

Output when connect-standalone.bat uses connect-log4j.properties:

![image](https://user-images.githubusercontent.com/7929462/106696471-5dd95980-660f-11eb-8d4f-52680e29c2ed.png)
