### PR TITLE
MINOR: change modifier of ConsumerRecords(FetchedRecords) from public…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -125,7 +125,7 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
         this.metadata = metadata;
     }
 
-    public ConsumerRecords(final FetchedRecords<K, V> fetchedRecords) {
+    ConsumerRecords(final FetchedRecords<K, V> fetchedRecords) {
         this(fetchedRecords.records(), extractMetadata(fetchedRecords));
     }
 


### PR DESCRIPTION
```FetchedRecords``` is internal class so it is unnecessary to open ```ConsumerRecords(FetchedRecords)```.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
