### PR TITLE
MINOR: remove unused import in TopicIdWithOldInterBrokerProtocolTest

### DIFF
--- a/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
@@ -21,7 +21,6 @@ import java.util.{Arrays, Properties}
 
 import kafka.api.KAFKA_2_7_IV0
 import kafka.network.SocketServer
-import kafka.server.{BaseRequestTest, KafkaConfig}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.message.DeleteTopicsRequestData


### PR DESCRIPTION
*More detailed description of your change*
I found a warning message in every QA Jenkins build:
```
[2021-02-03T01ː12ː51.812Z] [Warn] /home/jenkins/jenkins-agent/workspace/Kafka_kafka-pr_PR-10031/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scalaː24ː imported ‘BaseRequestTest‘ is permanently hidden by definition of class BaseRequestTest in package server
```
just remove the unsed import.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
