### PR TITLE
MINOR: Word count should account for extra whitespaces between words

### DIFF
--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountDemo.java
@@ -76,7 +76,7 @@ public final class WordCountDemo {
         final KStream<String, String> source = builder.stream(INPUT_TOPIC);
 
         final KTable<String, Long> counts = source
-            .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split(" ")))
+            .flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
             .groupBy((key, value) -> value)
             .count();
 

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountDemoTest.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountDemoTest.java
@@ -93,8 +93,8 @@ public class WordCountDemoTest {
     @Test
     public void testCountListOfWords() {
         final List<String> inputValues = Arrays.asList(
-                "Apache Kafka Streams Example",
-                "Using Kafka Streams Test Utils",
+                "Apache   Kafka Streams   Example",
+                "Using  \t\t Kafka   Streams\tTest Utils",
                 "Reading and Writing Kafka Topic"
         );
         final Map<String, Long> expectedWordCounts = new HashMap<>();


### PR DESCRIPTION
Currently, the word count demo only accounts for single whitespaces between words. This fix uses a more generic regex to skip multiple spaces or tabs that may occur between words. Corresponding unit tests were updated. 

Also, the quickstart docs already use the correct regex.

Signed-off-by: Arjun Satish <arjun@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
