### PR TITLE
MINOR: Add performAndClose default method in KeyValueIterator

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/KeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/KeyValueIterator.java
@@ -20,6 +20,7 @@ import org.apache.kafka.streams.KeyValue;
 
 import java.io.Closeable;
 import java.util.Iterator;
+import java.util.function.Consumer;
 
 /**
  * Iterator interface of {@link KeyValue}.
@@ -41,4 +42,17 @@ public interface KeyValueIterator<K, V> extends Iterator<KeyValue<K, V>>, Closea
      * @return the key of the next value that would be returned from the next call to next
      */
     K peekNextKey();
+
+    /**
+     * Perform required operation on the iterator and guarantee to close it, even in case of execution failure.
+     *
+     * @param operationToPerform operation to be performed on the iterator
+     *
+     * @since 2.10
+     */
+    default void performAndClose(Consumer<KeyValueIterator<K, V>> operationToPerform) {
+        try (KeyValueIterator<K, V> iterator = this) {
+            operationToPerform.accept(iterator);
+        }
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueIteratorFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueIteratorFacadeTest.java
@@ -25,6 +25,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.NoSuchElementException;
+
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
@@ -32,6 +34,7 @@ import static org.easymock.EasyMock.verify;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(EasyMockRunner.class)
@@ -82,6 +85,28 @@ public class KeyValueIteratorFacadeTest {
         replay(mockedKeyValueIterator);
 
         keyValueIteratorFacade.close();
+        verify(mockedKeyValueIterator);
+    }
+
+    @Test
+    public void shouldCloseIteratorAfterPerformingOperationSuccessfully() {
+        expect(mockedKeyValueIterator.peekNextKey()).andReturn("ignored");
+        mockedKeyValueIterator.close();
+        expectLastCall();
+        replay(mockedKeyValueIterator);
+
+        keyValueIteratorFacade.performAndClose(KeyValueIterator::peekNextKey);
+        verify(mockedKeyValueIterator);
+    }
+
+    @Test
+    public void shouldCloseIteratorAfterPerformingOperationWithFailure() {
+        expect(mockedKeyValueIterator.peekNextKey()).andThrow(new NoSuchElementException("Test exception"));
+        mockedKeyValueIterator.close();
+        expectLastCall();
+        replay(mockedKeyValueIterator);
+
+        assertThrows(NoSuchElementException.class, () -> keyValueIteratorFacade.performAndClose(KeyValueIterator::peekNextKey));
         verify(mockedKeyValueIterator);
     }
 }


### PR DESCRIPTION
That method intends to increase a chance to have KeyValueIterator closed
after usage, by providing a convenient performAndClose() default method which
executes a given operation and guarantee to automatically close the iterator
right after.

### Rationale

I decided to create that PR observing in different projects how often an iterator is left open after performing operations such as 
`.forEachRemaining(...)` (who reads JavaDoc after all? ;-) ). For people aware of the problem, instead of verbose try-with-resources constructions repeated in every place in code:

```
try (KeyValueIterator<String, Order> ordersKeyValueIterator =
         streamsBuilderFactoryBean
             .getKafkaStreams()
             .store(StoreQueryParameters.fromNameAndType(ORDERS_STORE,
                 QueryableStoreTypes.<String, Order>keyValueStore()))
             .all()) {
    ordersKeyValueIterator
        .forEachRemaining(kv -> {
            ...
        });
}
```
(or hidden in in-house built utility classes)

a developer using Kafka Streams has a built-in clear way to perform operations on elements contained in an iterator (and have that stream closed after that automatically):
```
streamsBuilderFactoryBean
    .getKafkaStreams()
    .store(StoreQueryParameters.fromNameAndType(ORDERS_STORE,
        QueryableStoreTypes.<String, OrderRequest>keyValueStore()))
    .all()
    .performAndClose(iterator -> iterator
        .forEachRemaining(kv -> {
            ...
        })
    );
```

I believe it can increase a rate of closed iterator in user projects.

### Testing approach

Being a default method in KeyValueIterator, I decided to test it using KeyValueIteratorFacade which already provides a nice unit testing infrastructure with mocked iterator. I don't know the implementation details, but I expect to have it behaved similarly in other implementations.
I might miss some extra cases, so feel free to point them and I will happily cover them with tests.

### Rejected extensions

For some time past, I was thinking also about covering operations that returns some value. However, at least in projects I've been observing the usage of Kafka Streams, performing side effects is more popular and implementation for that use cases might be more tricky and I decided to start with pure Consumer.

### Other information

Naming is not my area of expertise. Feel free to propose any better name or any other possible enhancements to my MR :-).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
