### PR TITLE
KAFKA-12305: Fix Flatten SMT for array types

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java
@@ -124,6 +124,7 @@ public abstract class Flatten<R extends ConnectRecord<R>> implements Transformat
                 case BOOLEAN:
                 case STRING:
                 case BYTES:
+                case ARRAY:
                     newRecord.put(fieldName(fieldNamePrefix, entry.getKey()), entry.getValue());
                     break;
                 case MAP:
@@ -189,6 +190,7 @@ public abstract class Flatten<R extends ConnectRecord<R>> implements Transformat
                 case BOOLEAN:
                 case STRING:
                 case BYTES:
+                case ARRAY:
                     newSchema.field(fieldName, convertFieldSchema(field.schema(), fieldIsOptional, fieldDefaultValue));
                     break;
                 case STRUCT:
@@ -237,6 +239,7 @@ public abstract class Flatten<R extends ConnectRecord<R>> implements Transformat
                 case BOOLEAN:
                 case STRING:
                 case BYTES:
+                case ARRAY:
                     newRecord.put(fieldName, record.get(field));
                     break;
                 case STRUCT:

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java
@@ -42,7 +42,7 @@ public abstract class Flatten<R extends ConnectRecord<R>> implements Transformat
     public static final String OVERVIEW_DOC =
             "Flatten a nested data structure, generating names for each field by concatenating the field names at each "
                     + "level with a configurable delimiter character. Applies to Struct when schema present, or a Map "
-                    + "in the case of schemaless data. The default delimiter is '.'."
+                    + "in the case of schemaless data. Array fields and their contents are not modified. The default delimiter is '.'."
                     + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
                     + "or value (<code>" + Value.class.getName() + "</code>).";
 

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/SchemaUtil.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/SchemaUtil.java
@@ -24,7 +24,13 @@ import java.util.Map;
 public class SchemaUtil {
 
     public static SchemaBuilder copySchemaBasics(Schema source) {
-        return copySchemaBasics(source, new SchemaBuilder(source.type()));
+        SchemaBuilder builder;
+        if (source.type() == Schema.Type.ARRAY) {
+            builder = SchemaBuilder.array(source.valueSchema());
+        } else {
+            builder = new SchemaBuilder(source.type());
+        }
+        return copySchemaBasics(source, builder);
     }
 
     public static SchemaBuilder copySchemaBasics(Schema source, SchemaBuilder builder) {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
@@ -262,10 +262,23 @@ public class FlattenTest {
     }
 
     @Test
-    public void testArray() {
-        xformValue.configure(Collections.<String, String>emptyMap());
+    public void testSchemalessArray() {
+        xformValue.configure(Collections.emptyMap());
         Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
         assertEquals(value, xformValue.apply(new SourceRecord(null, null, "topic", null, null, null, value)).value());
+    }
+
+    @Test
+    public void testArrayWithSchema() {
+        xformValue.configure(Collections.emptyMap());
+        Schema structSchema = SchemaBuilder.struct()
+            .field("foo", SchemaBuilder.array(Schema.STRING_SCHEMA).doc("durk").build())
+            .build();
+        Struct value = new Struct(structSchema);
+        value.put("foo", Arrays.asList("bar", "baz"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", null, null, structSchema, value)); 
+        assertEquals(value, transformed.value());
+        assertEquals(structSchema, transformed.valueSchema());
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
@@ -262,11 +262,10 @@ public class FlattenTest {
     }
 
     @Test
-    public void testUnsupportedTypeInMap() {
+    public void testArray() {
         xformValue.configure(Collections.<String, String>emptyMap());
         Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
-        assertThrows(DataException.class, () -> xformValue.apply(new SourceRecord(null, null,
-                "topic", 0, null, value)));
+        assertEquals(value, xformValue.apply(new SourceRecord(null, null, "topic", null, null, null, value)).value());
     }
 
     @Test


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-12305)

(Copied from Jira):

The `Flatten` SMT fails for array types. A sophisticated approach that tries to flatten arrays might be desirable in some cases, and may have been punted during the early design phase of the transform, but in the interim, it's probably not worth it to make array data and the SMT mutually exclusive.

A naive approach that preserves arrays as-are and doesn't attempt to flatten them seems fair for now.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
