### PR TITLE
KAFKA-12251: Add topicId and remove topic name in stopReplicaRep and stopReplicaResp

### DIFF
--- a/clients/src/main/resources/common/message/StopReplicaRequest.json
+++ b/clients/src/main/resources/common/message/StopReplicaRequest.json
@@ -24,7 +24,8 @@
   // Version 2 is the first flexible version.
   //
   // Version 3 adds the leader epoch per partition (KIP-570).
-  "validVersions": "0-3",
+  // Version 4 remove topic name and add topic id.
+  "validVersions": "0-4",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "ControllerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
@@ -51,8 +52,9 @@
     ]},
     { "name": "TopicStates", "type": "[]StopReplicaTopicState", "versions": "3+",
       "about": "Each topic.", "fields": [
-      { "name": "TopicName", "type": "string", "versions": "3+", "entityType": "topicName",
+      { "name": "TopicName", "type": "string", "versions": "3", "entityType": "topicName",
         "about": "The topic name." },
+      { "name": "TopicId", "type": "uuid", "versions": "4+", "about": "The topic id." },
       { "name": "PartitionStates", "type": "[]StopReplicaPartitionState", "versions": "3+",
         "about": "The state of each partition", "fields": [
         { "name": "PartitionIndex", "type": "int32", "versions": "3+",

--- a/clients/src/main/resources/common/message/StopReplicaResponse.json
+++ b/clients/src/main/resources/common/message/StopReplicaResponse.json
@@ -22,15 +22,17 @@
   // Version 2 is the first flexible version.
   //
   // Version 3 returns FENCED_LEADER_EPOCH if the epoch of the leader is stale (KIP-570).
-  "validVersions": "0-3",
+  // Version 4 remove topic name and add topic id.
+  "validVersions": "0-4",
   "flexibleVersions": "2+",
   "fields": [
     { "name": "ErrorCode", "type": "int16", "versions": "0+",
       "about": "The top-level error code, or 0 if there was no top-level error." },
     { "name": "PartitionErrors", "type": "[]StopReplicaPartitionError", "versions": "0+",
       "about": "The responses for each partition.", "fields": [
-      { "name": "TopicName", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "TopicName", "type": "string", "versions": "0-3", "entityType": "topicName",
         "about": "The topic name." },
+      { "name": "TopicId", "type": "uuid", "versions": "4+", "about": "The topic id." },
       { "name": "PartitionIndex", "type": "int32", "versions": "0+",
         "about": "The partition index." },
       { "name": "ErrorCode", "type": "int16", "versions": "0+",

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -112,7 +112,9 @@ object ApiVersion {
     // Flexible versioning on ListOffsets, WriteTxnMarkers and OffsetsForLeaderEpoch. Also adds topic IDs (KIP-516)
     KAFKA_2_8_IV0,
     // Introduced topic IDs to LeaderAndIsr and UpdateMetadata requests/responses (KIP-516)
-    KAFKA_2_8_IV1
+    KAFKA_2_8_IV1,
+    // Introduced topic IDs to StopReplica requests/responses (KIP-516)
+    KAFKA_2_8_IV2
   )
 
   // Map keys are the union of the short and full versions
@@ -445,6 +447,13 @@ case object KAFKA_2_8_IV1 extends DefaultApiVersion {
   val subVersion = "IV1"
   val recordVersion = RecordVersion.V2
   val id: Int = 32
+}
+
+case object KAFKA_2_8_IV2 extends DefaultApiVersion {
+  val shortVersion: String = "2.8"
+  val subVersion = "IV2"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 33
 }
 
 object ApiVersionValidator extends Validator {

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -33,9 +33,7 @@ import kafka.zk.KafkaZkClient.UpdateLeaderAndIsrResult
 import kafka.zk.TopicZNode.TopicIdReplicaAssignment
 import kafka.zk.{FeatureZNodeStatus, _}
 import kafka.zookeeper.{StateChangeHandler, ZNodeChangeHandler, ZNodeChildChangeHandler}
-import org.apache.kafka.common.ElectionType
-import org.apache.kafka.common.KafkaException
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.{ElectionType, KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException, StaleBrokerEpochException}
 import org.apache.kafka.common.message.{AlterIsrRequestData, AlterIsrResponseData}
 import org.apache.kafka.common.feature.{Features, FinalizedVersionRange}

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -82,7 +82,6 @@ class ControllerDeletionClient(controller: KafkaController, zkClient: KafkaZkCli
  *    as well as from zookeeper. This is the only time the /brokers/topics/<topic> path gets deleted. On the other hand,
  *    if no replica is in TopicDeletionStarted state and at least one replica is in TopicDeletionFailed state, then
  *    it marks the topic for deletion retry.
- * @param controller
  */
 class TopicDeletionManager(config: KafkaConfig,
                            controllerContext: ControllerContext,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -18,10 +18,14 @@
 package kafka.server
 
 import kafka.admin.AdminUtils
-import kafka.api.{ApiVersion, ElectLeadersRequestOps, KAFKA_0_11_0_IV0, KAFKA_2_3_IV0}
+import kafka.api.{ApiVersion, ElectLeadersRequestOps, KAFKA_0_11_0_IV0, KAFKA_2_3_IV0, KAFKA_2_8_IV2}
 import kafka.common.OffsetAndMetadata
 import kafka.controller.ReplicaAssignment
+<<<<<<< HEAD
 import kafka.coordinator.group._
+=======
+import kafka.coordinator.group.{GroupCoordinator, GroupOverview, JoinGroupResult, LeaveGroupResult, SyncGroupResult}
+>>>>>>> 8c0036c324... Add topicId and remove topic name in stopReplicaRep and stopReplicaResp
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
 import kafka.log.AppendOrigin
 import kafka.message.ZStdCompressionCodec
@@ -277,14 +281,34 @@ class KafkaApis(val requestChannel: RequestChannel,
         s"${stopReplicaRequest.brokerEpoch} smaller than the current broker epoch ${zkSupport.controller.brokerEpoch}")
       requestHelper.sendResponseExemptThrottle(request, new StopReplicaResponse(
         new StopReplicaResponseData().setErrorCode(Errors.STALE_BROKER_EPOCH.code)))
+    } else if (stopReplicaRequest.version() >= 4 && config.interBrokerProtocolVersion < KAFKA_2_8_IV2) {
+      // Only support topicId when from KAFKA_2_8_IV2
+      requestHelper.sendResponseExemptThrottle(request, new StopReplicaResponse(
+        new StopReplicaResponseData().setErrorCode(Errors.UNSUPPORTED_VERSION.code)))
+    } else if (stopReplicaRequest.version() >= 4 &&
+      stopReplicaRequest.topicStates().asScala.exists(topic => metadataCache.getTopicName(topic.topicId()).isEmpty)) {
+      // If one topicId is unknown, then the topic may have been deleted from MetadataCache,
+      // we should fail and make the controller try again
+      requestHelper.sendResponseExemptThrottle(request, new StopReplicaResponse(
+        new StopReplicaResponseData().setErrorCode(Errors.UNKNOWN_TOPIC_ID.code)))
     } else {
-      val partitionStates = stopReplicaRequest.partitionStates().asScala
-      val (result, error) = replicaManager.stopReplicas(
-        request.context.correlationId,
-        stopReplicaRequest.controllerId,
-        stopReplicaRequest.controllerEpoch,
-        stopReplicaRequest.brokerEpoch,
-        partitionStates)
+      val partitionStates = if (stopReplicaRequest.version() >= 4) {
+        val topicStats = stopReplicaRequest.topicStates().asScala.toArray
+
+        val topicNames = topicStats.map(_.topicId()).map(topicId => topicId -> metadataCache.getTopicName(topicId).get).toMap
+        stopReplicaRequest.partitionStates(topicNames.asJava).asScala
+      } else {
+        stopReplicaRequest.partitionStates(Collections.emptyMap()).asScala
+      }
+      val (result, error) = if (partitionStates.nonEmpty)
+        replicaManager.stopReplicas(
+          request.context.correlationId,
+          stopReplicaRequest.controllerId,
+          stopReplicaRequest.controllerEpoch,
+          stopReplicaRequest.brokerEpoch,
+          partitionStates)
+      else
+        (mutable.Map.empty[TopicPartition, Errors], Errors.NONE)
       // Clear the coordinator caches in case we were the leader. In the case of a reassignment, we
       // cannot rely on the LeaderAndIsr API for this since it is only sent to active replicas.
       result.forKeyValue { (topicPartition, error) =>
@@ -304,17 +328,24 @@ class KafkaApis(val requestChannel: RequestChannel,
         }
       }
 
-      def toStopReplicaPartition(tp: TopicPartition, error: Errors) =
-        new StopReplicaResponseData.StopReplicaPartitionError()
-          .setTopicName(tp.topic)
-          .setPartitionIndex(tp.partition)
+      def toStopReplicaPartition(topic: String, topicId: Uuid, partition: Int, error: Errors) = {
+        val data = new StopReplicaResponseData.StopReplicaPartitionError()
+          .setPartitionIndex(partition)
           .setErrorCode(error.code)
+        if (stopReplicaRequest.version() >= 4)
+          data.setTopicId(topicId)
+        else
+          data.setTopicName(topic)
+      }
+
+      val stopReplicaErrors = result.map {
+        case (tp, error) => toStopReplicaPartition(tp.topic(), metadataCache.getTopicId(tp.topic()), tp.partition(), error)
+      }.toSeq
 
       requestHelper.sendResponseExemptThrottle(request, new StopReplicaResponse(new StopReplicaResponseData()
         .setErrorCode(error.code)
-        .setPartitionErrors(result.map {
-          case (tp, error) => toStopReplicaPartition(tp, error)
-        }.toBuffer.asJava)))
+        .setPartitionErrors(stopReplicaErrors.asJava)
+      ))
     }
 
     CoreUtils.swallow(replicaManager.replicaFetcherManager.shutdownIdleFetcherThreads(), this)

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -62,6 +62,10 @@ trait MetadataCache {
 
   def getAllTopics(): collection.Set[String]
 
+  def getTopicId(topicName: String): Uuid
+
+  def getTopicName(topicId: Uuid): Option[String]
+
   def getAllPartitions(): collection.Set[TopicPartition]
 
   def getNonExistingTopics(topics: collection.Set[String]): collection.Set[String]
@@ -253,6 +257,14 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
 
   def getAllTopics(): Set[String] = {
     getAllTopics(metadataSnapshot)
+  }
+
+  def getTopicId(topicName: String): Uuid = {
+    metadataSnapshot.topicIds.getOrElse(topicName, Uuid.ZERO_UUID)
+  }
+
+  def getTopicName(topicId: Uuid): Option[String] = {
+    metadataSnapshot.topicNames.get(topicId)
   }
 
   def getAllPartitions(): Set[TopicPartition] = {
@@ -466,6 +478,8 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
                               topicIds: Map[String, Uuid],
                               controllerId: Option[Int],
                               aliveBrokers: mutable.LongMap[Broker],
-                              aliveNodes: mutable.LongMap[collection.Map[ListenerName, Node]])
+                              aliveNodes: mutable.LongMap[collection.Map[ListenerName, Node]]) {
+    val topicNames: Map[Uuid, String] = topicIds.map{case(topicName, topicId) => (topicId, topicName)}
+  }
 
 }

--- a/core/src/main/scala/kafka/server/metadata/RaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/RaftMetadataCache.scala
@@ -191,6 +191,14 @@ class RaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging {
 
   override def getAllTopics(): Set[String] = _currentImage.partitions.allTopicNames()
 
+  def getTopicId(topicName: String): Uuid = {
+    _currentImage.topicNameToId(topicName).getOrElse(Uuid.ZERO_UUID)
+  }
+
+  def getTopicName(topicId: Uuid): Option[String] = {
+    _currentImage.topicIdToName(topicId)
+  }
+
   override def getAllPartitions(): Set[TopicPartition] = {
     _currentImage.partitions.allPartitions().map {
       partition => partition.toTopicPartition

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -116,9 +116,10 @@ class ApiVersionTest {
     assertEquals(KAFKA_2_7_IV1, ApiVersion("2.7-IV1"))
     assertEquals(KAFKA_2_7_IV2, ApiVersion("2.7-IV2"))
 
-    assertEquals(KAFKA_2_8_IV1, ApiVersion("2.8"))
+    assertEquals(KAFKA_2_8_IV2, ApiVersion("2.8"))
     assertEquals(KAFKA_2_8_IV0, ApiVersion("2.8-IV0"))
     assertEquals(KAFKA_2_8_IV1, ApiVersion("2.8-IV1"))
+    assertEquals(KAFKA_2_8_IV2, ApiVersion("2.8-IV2"))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerEpochIntegrationTest.scala
@@ -198,7 +198,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
         val requestBuilder = new UpdateMetadataRequest.Builder(
           ApiKeys.UPDATE_METADATA.latestVersion, controllerId, controllerEpoch,
           epochInRequest,
-          partitionStates.asJava, liveBrokers.asJava, Collections.emptyMap())
+          partitionStates.asJava, liveBrokers.asJava, topicIds)
 
         if (epochInRequestDiffFromCurrentEpoch < 0) {
           // stale broker epoch in UPDATE_METADATA
@@ -218,6 +218,7 @@ class BrokerEpochIntegrationTest extends ZooKeeperTestHarness {
         val topicStates = Seq(
           new StopReplicaTopicState()
             .setTopicName(tp.topic())
+            .setTopicId(topicIds.getOrDefault(tp.topic(), Uuid.ZERO_UUID))
             .setPartitionStates(Seq(new StopReplicaPartitionState()
               .setPartitionIndex(tp.partition())
               .setLeaderEpoch(LeaderAndIsr.initialLeaderEpoch + 2)

--- a/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
@@ -18,17 +18,17 @@
 package kafka.server
 
 import kafka.api.LeaderAndIsr
+import kafka.network.SocketServer
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.StopReplicaRequestData.{StopReplicaPartitionState, StopReplicaTopicState}
-import org.apache.kafka.common.protocol.ApiKeys
-import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
-import scala.jdk.CollectionConverters._
 import scala.collection.Seq
+import scala.jdk.CollectionConverters._
 
 class StopReplicaRequestTest extends BaseRequestTest {
   override val logDirCount = 2
@@ -48,31 +48,51 @@ class StopReplicaRequestTest extends BaseRequestTest {
     val offlineDir = server.logManager.getLog(tp1).get.dir.getParent
     server.replicaManager.handleLogDirFailure(offlineDir, sendZkNotification = false)
 
-    val topicStates = Seq(
-      new StopReplicaTopicState()
-        .setTopicName(tp0.topic())
-        .setPartitionStates(Seq(new StopReplicaPartitionState()
-          .setPartitionIndex(tp0.partition())
-          .setLeaderEpoch(LeaderAndIsr.initialLeaderEpoch + 2)
-          .setDeletePartition(true)).asJava),
-      new StopReplicaTopicState()
-        .setTopicName(tp1.topic())
-        .setPartitionStates(Seq(new StopReplicaPartitionState()
-          .setPartitionIndex(tp1.partition())
-          .setLeaderEpoch(LeaderAndIsr.initialLeaderEpoch + 2)
-          .setDeletePartition(true)).asJava)
-    ).asJava
+    val topicId = server.metadataCache.getTopicId(topic)
 
-    for (_ <- 1 to 2) {
-      val request1 = new StopReplicaRequest.Builder(ApiKeys.STOP_REPLICA.latestVersion,
-        server.config.brokerId, server.replicaManager.controllerEpoch, server.kafkaController.brokerEpoch,
-        false, topicStates).build()
-      val response1 = connectAndReceive[StopReplicaResponse](request1, destination = controllerSocketServer)
-      val partitionErrors1 = response1.partitionErrors.asScala
-      assertEquals(Some(Errors.NONE.code),
-        partitionErrors1.find(pe => pe.topicName == tp0.topic && pe.partitionIndex == tp0.partition).map(_.errorCode))
-      assertEquals(Some(Errors.KAFKA_STORAGE_ERROR.code),
-        partitionErrors1.find(pe => pe.topicName == tp1.topic && pe.partitionIndex == tp1.partition).map(_.errorCode))
+    for (version <- ApiKeys.STOP_REPLICA.oldestVersion() to ApiKeys.STOP_REPLICA.latestVersion()) {
+      val topicStates = Seq(
+        new StopReplicaTopicState()
+          .setTopicName(tp0.topic())
+          .setTopicId(topicId)
+          .setPartitionStates(Seq(new StopReplicaPartitionState()
+            .setPartitionIndex(tp0.partition())
+            .setLeaderEpoch(LeaderAndIsr.initialLeaderEpoch + 2)
+            .setDeletePartition(true)).asJava),
+        new StopReplicaTopicState()
+          .setTopicName(tp1.topic())
+          .setTopicId(topicId)
+          .setPartitionStates(Seq(new StopReplicaPartitionState()
+            .setPartitionIndex(tp1.partition())
+            .setLeaderEpoch(LeaderAndIsr.initialLeaderEpoch + 2)
+            .setDeletePartition(true)).asJava)
+      ).asJava
+
+      for (_ <- 1 to 2) {
+        val request = new StopReplicaRequest.Builder(version.toShort,
+          server.config.brokerId, server.replicaManager.controllerEpoch, server.kafkaController.brokerEpoch,
+          false, topicStates).build()
+        val response = sendStopReplicaRequest(request, destination = Some(brokerSocketServer(0)))
+        val partitionErrors = response.partitionErrors.asScala
+        assertEquals(Some(Errors.NONE.code),
+          if (version < 4) {
+            partitionErrors.find(pe => pe.topicName == tp0.topic && pe.partitionIndex == tp0.partition).map(_.errorCode)
+          } else {
+            partitionErrors.find(pe => pe.topicId() == topicId && pe.partitionIndex == tp0.partition).map(_.errorCode)
+          })
+
+        assertEquals(Some(Errors.KAFKA_STORAGE_ERROR.code),
+          if (version < 4) {
+            partitionErrors.find(pe => pe.topicName == tp1.topic && pe.partitionIndex == tp1.partition).map(_.errorCode)
+          } else {
+            partitionErrors.find(pe => pe.topicId() == topicId && pe.partitionIndex == tp1.partition).map(_.errorCode)
+          })
+      }
     }
   }
+
+  private def sendStopReplicaRequest(request: StopReplicaRequest, destination: Option[SocketServer]/* = None*/): StopReplicaResponse = {
+    connectAndReceive[StopReplicaResponse](request, destination = destination.getOrElse(anySocketServer))
+  }
+
 }


### PR DESCRIPTION
*More detailed description of your change*
1. Add topic id and remove topicName in stopReplicaRep/stopReplicaResp
2. bump IBPversion, old-version broker will reply `UNSUPPORTED_VERSION` on new-version stopReplicaRequest
3. new-version controller will retry with topicName when receiving `UNSUPPORTED_VERSION` stopReplicaRepResponse

*Summary of testing strategy (including rationale)*
1. Unit test
2. ITCase to test retry on `UNSUPPORTED_VERSION`, this is still in progress.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
