### PR TITLE
MINOR: Remove check for comparision of 3rd IP of kafka.apache.org

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -310,9 +310,6 @@ public class ClusterConnectionStatesTest {
         connectionStates.connecting(nodeId1, time.milliseconds(), hostTwoIps, ClientDnsLookup.USE_ALL_DNS_IPS);
         InetAddress addr2 = connectionStates.currentAddress(nodeId1);
         assertNotSame(addr1, addr2);
-        connectionStates.connecting(nodeId1, time.milliseconds(), hostTwoIps, ClientDnsLookup.USE_ALL_DNS_IPS);
-        InetAddress addr3 = connectionStates.currentAddress(nodeId1);
-        assertNotSame(addr1, addr3);
     }
 
     @Test


### PR DESCRIPTION
kafka.apache.org IP resolution count keeps on varying between 2 and 3, but this should not affect the tests. Removing the test condition which depends on the fact that kafka.apache.org will resolve to 3 different IPs.

As of now, kafka.apache.org is resolving to 2 IPs, resulting in failure of the test condition below:
```
$  dig kafka.apache.org
kafka.apache.org.	42	IN	A	95.216.26.30
kafka.apache.org.	42	IN	A	207.244.88.140
```

```
org.apache.kafka.clients.ClusterConnectionStatesTest > testMultipleIPsWithUseAll FAILED
    java.lang.AssertionError: expected not same
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failSame(Assert.java:820)
        at org.junit.Assert.assertNotSame(Assert.java:799)
        at org.junit.Assert.assertNotSame(Assert.java:812)
        at org.apache.kafka.clients.ClusterConnectionStatesTest.testMultipleIPsWithUseAll(ClusterConnectionStatesTest.java:285)
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
