### PR TITLE
KAFKA-9524: increase retention time for window and grace periods longer than one day

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -19,8 +19,10 @@ package org.apache.kafka.streams.kstream;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.Map;
 
+import static java.time.Duration.ofDays;
 import static java.time.Duration.ofMillis;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
@@ -53,9 +55,16 @@ public class TimeWindowsTest {
 
     @SuppressWarnings("deprecation") // specifically testing deprecated APIs
     @Test
-    public void shouldUseWindowSizeAsRentitionTimeIfWindowSizeIsLargerThanDefaultRetentionTime() {
+    public void shouldUseWindowSizeAsRetentionTimeIfWindowSizeIsLargerThanDefaultRetentionTime() {
         final long windowSize = 2 * TimeWindows.of(ofMillis(1)).maintainMs();
         assertEquals(windowSize, TimeWindows.of(ofMillis(windowSize)).maintainMs());
+    }
+
+    @Test
+    public void shouldUseWindowSizeAndGraceAsRetentionTimeIfBothCombinedAreLargerThanDefaultRetentionTime() {
+        final Duration windowsSize = ofDays(1).minus(ofMillis(1));
+        final Duration gracePeriod = ofMillis(2);
+        assertEquals(windowsSize.toMillis() + gracePeriod.toMillis(), TimeWindows.of(windowsSize).grace(gracePeriod).maintainMs());
     }
 
     @Test


### PR DESCRIPTION
**Reproducing:**
The bug can be easily reproduced for any TimeWindow where window + grace period > 1 day. Changing any test in TimeWindowedKStreamImplTest.java for this condition will reproduce the bug.

**Cause:**
The root cause is that .grace(...) never updates the default maintainDurationMs field value. The value is thus always 1 day - throwing the IllegalArgumentException when validating it at a later stage.

**Implementation comments:**
I believe that a minimum retention period of 1 day is desired because of log compaction - thus I used the Math.Max(window+grace, default maintainDurationMs-1 day-) to calculate the minimum retention period.

I am a bit unsure about the test - currently it indirectly tests the bug. The bug would throw a IllegalArgumentException, preventing the test scenario from working with any aggregation (count, reduce, etc). I've implemented the test with count operation to ensure consistency of the window behaviour. If this is not required, maybe just calling processData() and asserting that the original reported exception is not thrown should be enough. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
