### PR TITLE
KAFKA-12287: Add WARN logging on consumer-groups when reset-offsets by timestamp or duration can't find an offset and defaults to latest

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -686,7 +686,7 @@ object ConsumerGroupCommand extends Logging {
 
       unsuccessfulOffsetsForTimes.foreach { entry =>
         println(s"\nWarn: Partition " + entry._1.partition() + " from topic " + entry._1.topic() +
-          " is empty, without a committed record. Falling back to latest known offset.")
+          " is empty. Falling back to latest known offset.")
       }
 
       successfulLogTimestampOffsets ++ getLogEndOffsets(groupId, unsuccessfulOffsetsForTimes.keySet.toSeq)

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -686,7 +686,7 @@ object ConsumerGroupCommand extends Logging {
 
       unsuccessfulOffsetsForTimes.foreach { entry =>
         println(s"\nWarn: Partition " + entry._1.partition() + " from topic " + entry._1.topic() +
-          " is empty, without a committed offset. Falling back to latest offset.")
+          " is empty, without a committed record. Falling back to latest known offset.")
       }
 
       successfulLogTimestampOffsets ++ getLogEndOffsets(groupId, unsuccessfulOffsetsForTimes.keySet.toSeq)

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -684,6 +684,11 @@ object ConsumerGroupCommand extends Logging {
         case (topicPartition, listOffsetsResultInfo) => topicPartition -> LogOffsetResult.LogOffset(listOffsetsResultInfo.offset)
       }.toMap
 
+      unsuccessfulOffsetsForTimes.foreach { entry =>
+        println(s"\nWarn: Partition " + entry._1.partition() + " from topic " + entry._1.topic() +
+          " is empty, without a committed offset. Falling back to latest offset.")
+      }
+
       successfulLogTimestampOffsets ++ getLogEndOffsets(groupId, unsuccessfulOffsetsForTimes.keySet.toSeq)
     }
 

--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -192,6 +192,16 @@ class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
   }
 
   @Test
+  def testResetOffsetsByDurationFallbackToLatestWhenNoRecords(): Unit = {
+    val topic = "foo2"
+    val args = buildArgsForGroup(group, "--topic", topic, "--by-duration", "PT1M", "--execute")
+    createTopic(topic)
+    resetAndAssertOffsets(args, expectedOffset = 0, topics = Seq("foo2"))
+
+    adminZkClient.deleteTopic(topic)
+  }
+
+  @Test
   def testResetOffsetsToEarliest(): Unit = {
     val args = buildArgsForGroup(group, "--all-topics", "--to-earliest", "--execute")
     produceConsumeAndShutdown(topic, group, totalMessages = 100)


### PR DESCRIPTION
Similar to #10042, this PR introduces a WARN logging when no offset is found in a topic partition.

Test strategy:

- Adding a test case for a topic without records.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
