### PR TITLE
KAFKA-12268: Make early poll return opt-in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1120,7 +1120,6 @@ project(':clients') {
     testCompile libs.bcpkix
     testCompile libs.junitJupiter
     testCompile libs.mockitoCore
-    testCompile libs.hamcrest
 
     testRuntime libs.slf4jlog4j
     testRuntime libs.jacksonDatabind

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -71,6 +71,21 @@ public class ConsumerConfig extends AbstractConfig {
     /** <code>max.poll.interval.ms</code> */
     public static final String MAX_POLL_INTERVAL_MS_CONFIG = CommonClientConfigs.MAX_POLL_INTERVAL_MS_CONFIG;
     private static final String MAX_POLL_INTERVAL_MS_DOC = CommonClientConfigs.MAX_POLL_INTERVAL_MS_DOC;
+
+    /** <code>long.poll.mode</code> */
+    public static final String LONG_POLL_RETURN_ON_RECORDS = "return_on_records";
+    public static final String LONG_POLL_RETURN_ON_RESPONSE = "return_on_response";
+    public static final String LONG_POLL_MODE_CONFIG = "long.poll.mode";
+    public static final String LONG_POLL_MODE_DOC = "Whether a call to Consumer#poll(...) should block until" +
+        " records are received (return_on_records), or should return early if a metadata-only response is received" +
+        " from the brokers (return_on_metadata). The 'return_on_records' mode is the default, and it matches prior" +
+        " behavior. The 'return_on_response' mode allows callers to witness topic metadata changes via" +
+        " ConsumerRecords#metadata() as soon as they are received in a fetch response, even if there are no records" +
+        " included in the response. Callers who are only interested in seeing records should leave the default in" +
+        " place, and callers who are interested in maintaining fresh local information about the current lag should" +
+        " enable 'return_on_response'." +
+        " Note that the Consumer metrics are always updated upon receipt of the fetch responses.";
+
     /**
      * <code>session.timeout.ms</code>
      */
@@ -519,6 +534,12 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(1),
                                         Importance.MEDIUM,
                                         MAX_POLL_INTERVAL_MS_DOC)
+                                .define(LONG_POLL_MODE_CONFIG,
+                                        Type.STRING,
+                                        LONG_POLL_RETURN_ON_RECORDS,
+                                        in(LONG_POLL_RETURN_ON_RECORDS, LONG_POLL_RETURN_ON_RESPONSE),
+                                        Importance.LOW,
+                                        LONG_POLL_MODE_DOC)
                                 .define(EXCLUDE_INTERNAL_TOPICS_CONFIG,
                                         Type.BOOLEAN,
                                         DEFAULT_EXCLUDE_INTERNAL_TOPICS,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.clients.consumer;
 
-import org.apache.kafka.clients.consumer.internals.FetchedRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.AbstractIterator;
 
@@ -99,21 +98,6 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
         }
     }
 
-    private static <K, V> Map<TopicPartition, Metadata> extractMetadata(final FetchedRecords<K, V> fetchedRecords) {
-        final Map<TopicPartition, Metadata> metadata = new HashMap<>();
-        for (final Map.Entry<TopicPartition, FetchedRecords.FetchMetadata> entry : fetchedRecords.metadata().entrySet()) {
-            metadata.put(
-                entry.getKey(),
-                new Metadata(
-                    entry.getValue().receivedTimestamp(),
-                    entry.getValue().position() == null ? null : entry.getValue().position().offset,
-                    entry.getValue().endOffset()
-                )
-            );
-        }
-        return metadata;
-    }
-
     public ConsumerRecords(final Map<TopicPartition, List<ConsumerRecord<K, V>>> records) {
         this.records = records;
         this.metadata = new HashMap<>();
@@ -123,10 +107,6 @@ public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
                            final Map<TopicPartition, Metadata> metadata) {
         this.records = records;
         this.metadata = metadata;
-    }
-
-    ConsumerRecords(final FetchedRecords<K, V> fetchedRecords) {
-        this(fetchedRecords.records(), extractMetadata(fetchedRecords));
     }
 
     /**

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -583,7 +583,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     consumer.seekToEnd(List(tp).asJava)
     assertEquals(totalRecords, consumer.position(tp))
-    assertTrue(pollForRecord(consumer, Duration.ofMillis(50)).isEmpty)
+    assertTrue(consumer.poll(Duration.ofMillis(50)).isEmpty)
 
     consumer.seekToBeginning(List(tp).asJava)
     assertEquals(0L, consumer.position(tp))
@@ -601,7 +601,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     consumer.seekToEnd(List(tp2).asJava)
     assertEquals(totalRecords, consumer.position(tp2))
-    assertTrue(pollForRecord(consumer, Duration.ofMillis(50)).isEmpty)
+    assertTrue(consumer.poll(Duration.ofMillis(50)).isEmpty)
 
     consumer.seekToBeginning(List(tp2).asJava)
     assertEquals(0L, consumer.position(tp2))
@@ -670,7 +670,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer.pause(partitions)
     startingTimestamp = System.currentTimeMillis()
     sendRecords(producer, numRecords = 5, tp, startingTimestamp = startingTimestamp)
-    assertTrue(pollForRecord(consumer, Duration.ofMillis(100)).isEmpty)
+    assertTrue(consumer.poll(Duration.ofMillis(100)).isEmpty)
     consumer.resume(partitions)
     consumeAndVerifyRecords(consumer = consumer, numRecords = 5, startingOffset = 5, startingTimestamp = startingTimestamp)
   }
@@ -718,8 +718,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // consuming a record that is too large should succeed since KIP-74
     consumer.assign(List(tp).asJava)
-    val duration = Duration.ofMillis(20000)
-    val records = pollForRecord(consumer, duration)
+    val records = consumer.poll(Duration.ofMillis(20000))
     assertEquals(1, records.count)
     val consumerRecord = records.iterator().next()
     assertEquals(0L, consumerRecord.offset)
@@ -751,7 +750,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // we should only get the small record in the first `poll`
     consumer.assign(List(tp).asJava)
-    val records = pollForRecord(consumer, Duration.ofMillis(20000))
+    val records = consumer.poll(Duration.ofMillis(20000))
     assertEquals(1, records.count)
     val consumerRecord = records.iterator().next()
     assertEquals(0L, consumerRecord.offset)
@@ -1805,12 +1804,12 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer3.assign(asList(tp))
     consumer3.seek(tp, 1)
 
-    val numRecords1 = pollForRecord(consumer1, Duration.ofMillis(5000)).count()
+    val numRecords1 = consumer1.poll(Duration.ofMillis(5000)).count()
     assertThrows(classOf[InvalidGroupIdException], () => consumer1.commitSync())
     assertThrows(classOf[InvalidGroupIdException], () => consumer2.committed(Set(tp).asJava))
 
-    val numRecords2 = pollForRecord(consumer2, Duration.ofMillis(5000)).count()
-    val numRecords3 = pollForRecord(consumer3, Duration.ofMillis(5000)).count()
+    val numRecords2 = consumer2.poll(Duration.ofMillis(5000)).count()
+    val numRecords3 = consumer3.poll(Duration.ofMillis(5000)).count()
 
     consumer1.unsubscribe()
     consumer2.unsubscribe()
@@ -1859,10 +1858,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumer1.assign(asList(tp))
     consumer2.assign(asList(tp))
 
-    val records1 = pollForRecord(consumer1, Duration.ofMillis(5000))
+    val records1 = consumer1.poll(Duration.ofMillis(5000))
     consumer1.commitSync()
 
-    val records2 = pollForRecord(consumer2, Duration.ofMillis(5000))
+    val records2 = consumer2.poll(Duration.ofMillis(5000))
     consumer2.commitSync()
 
     consumer1.close()
@@ -1872,20 +1871,5 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       "Expected consumer1 to consume one message from offset 0")
     assertTrue(records2.count() == 1 && records2.records(tp).asScala.head.offset == 1,
       "Expected consumer2 to consume one message from offset 1, which is the committed offset of consumer1")
-  }
-
-  /**
-   * Consumer#poll returns early if there is metadata to return even if there are no records,
-   * so when we intend to wait for records, we can't just rely on long polling in the Consumer.
-   */
-  private def pollForRecord(consumer: KafkaConsumer[Array[Byte], Array[Byte]], duration: Duration) = {
-    val deadline = System.currentTimeMillis() + duration.toMillis
-    var durationRemaining = deadline - System.currentTimeMillis()
-    var result = consumer.poll(Duration.ofMillis(durationRemaining))
-    while (result.count() == 0 && durationRemaining > 0) {
-      result = consumer.poll(Duration.ofMillis(durationRemaining))
-      durationRemaining = deadline - System.currentTimeMillis()
-    }
-    result
   }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -1201,6 +1201,9 @@ public class StreamsConfig extends AbstractConfig {
         // disable auto topic creation
         consumerProps.put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, "false");
 
+        // enable early return on metadata
+        consumerProps.put(ConsumerConfig.LONG_POLL_MODE_CONFIG, ConsumerConfig.LONG_POLL_RETURN_ON_RECORDS);
+
         // verify that producer batch config is no larger than segment size, then add topic configs required for creating topics
         final Map<String, Object> topicProps = originalsWithPrefix(TOPIC_PREFIX, false);
         final Map<String, Object> producerProps = getClientPropsWithPrefix(PRODUCER_PREFIX, ProducerConfig.configNames());


### PR DESCRIPTION
* Revert the default Consumer#poll behavior back to early return on records only
* Add config to enable early return on metadata or records
* Set the return-on-metadata config in Streams to support KIP-695
* Revert the undesired addition of Hamcrest to the Client module
* Revert the now unnecessary poll-until-records logic in PlaintextConsumerTest

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
