### PR TITLE
MINOR: Improve confusing admin client shutdown logging

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -657,7 +657,7 @@ public class KafkaAdminClient extends AdminClient {
                 // Wait for the thread to be joined.
                 thread.join(waitTimeMs);
             }
-            log.info("Kafka admin client closed.");
+            log.debug("Kafka admin client closed.");
         } catch (InterruptedException e) {
             log.debug("Interrupted while joining I/O thread", e);
             Thread.currentThread().interrupt();
@@ -756,9 +756,9 @@ public class KafkaAdminClient extends AdminClient {
             return curNode;
         }
 
-        void abortAndFail(Throwable throwable) {
+        void abortAndFail(TimeoutException timeoutException) {
             this.aborted = true;
-            fail(time.milliseconds(), throwable);
+            fail(time.milliseconds(), timeoutException);
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -657,7 +657,7 @@ public class KafkaAdminClient extends AdminClient {
                 // Wait for the thread to be joined.
                 thread.join(waitTimeMs);
             }
-            log.debug("Kafka admin client closed.");
+            log.info("Kafka admin client closed.");
         } catch (InterruptedException e) {
             log.debug("Interrupted while joining I/O thread", e);
             Thread.currentThread().interrupt();
@@ -756,6 +756,11 @@ public class KafkaAdminClient extends AdminClient {
             return curNode;
         }
 
+        void abortAndFail(Throwable throwable) {
+            this.aborted = true;
+            fail(time.milliseconds(), throwable);
+        }
+
         /**
          * Handle a failure.
          *
@@ -818,8 +823,12 @@ public class KafkaAdminClient extends AdminClient {
                 log.debug("{} timed out at {} after {} attempt(s)", this, now, tries,
                     new Exception(prettyPrintException(cause)));
             }
-            handleFailure(new TimeoutException(this + " timed out at " + now
-                + " after " + tries + " attempt(s)", cause));
+            if (cause instanceof TimeoutException) {
+                handleFailure(cause);
+            } else {
+                handleFailure(new TimeoutException(this + " timed out at " + now
+                    + " after " + tries + " attempt(s)", cause));
+            }
         }
 
         /**
@@ -1130,7 +1139,7 @@ public class KafkaAdminClient extends AdminClient {
                     if (call.aborted) {
                         log.warn("Aborted call {} is still in callsInFlight.", call);
                     } else {
-                        log.debug("Closing connection to {} to time out {}", nodeId, call);
+                        log.debug("Closing connection to {} due to timeout while awaiting {}", nodeId, call);
                         call.aborted = true;
                         client.disconnect(nodeId);
                         numTimedOut++;
@@ -1375,7 +1384,7 @@ public class KafkaAdminClient extends AdminClient {
                 client.wakeup(); // wake the thread if it is in poll()
             } else {
                 log.debug("The AdminClient thread has exited. Timing out {}.", call);
-                call.fail(Long.MAX_VALUE, new TimeoutException("The AdminClient thread has exited."));
+                call.abortAndFail(new TimeoutException("The AdminClient thread has exited."));
             }
         }
 
@@ -1390,7 +1399,7 @@ public class KafkaAdminClient extends AdminClient {
         void call(Call call, long now) {
             if (hardShutdownTimeMs.get() != INVALID_SHUTDOWN_TIME) {
                 log.debug("The AdminClient is not accepting new calls. Timing out {}.", call);
-                call.fail(Long.MAX_VALUE, new TimeoutException("The AdminClient thread is not accepting new calls."));
+                call.abortAndFail(new TimeoutException("The AdminClient thread is not accepting new calls."));
             } else {
                 enqueue(call, now);
             }


### PR DESCRIPTION
If the admin client is shutdown with some unfinished calls, we see messages such as the following in the log:
```
2021-02-09 11:08:05.964 DEBUG [AdminClient clientId=adminclient-1] Call(callName=fetchMetadata, deadlineMs=1612843805378) timed out at 9223372036854775807 after 1 attempt(s)
```
The problem is that we are using passing `Long.MaxValue` as the current time in `Call.fail` in order to ensure the call is timed out and we are discarding the original cause. The patch fixes the problem by setting `aborted=true` instead and preserving the original exception message.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
