### PR TITLE
KAFKA-12226: Prevent source task offset failure when producer is overwhelmed

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -136,7 +136,7 @@
               files="(KafkaConfigBackingStore|Values).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|TopicAdmin).java"/>
+              files="(DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|TopicAdmin|WorkerSourceTask).java"/>
 
     <!-- connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -100,7 +100,7 @@ class WorkerSourceTask extends WorkerTask {
     private IdentityHashMap<ProducerRecord<byte[], byte[]>, ProducerRecord<byte[], byte[]>> outstandingMessagesBacklog;
     private boolean recordFlushPending;
     private boolean offsetFlushPending;
-    private CountDownLatch stopRequestedLatch;
+    private final CountDownLatch stopRequestedLatch;
 
     private Map<String, String> taskConfig;
     private boolean started = false;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -98,7 +98,8 @@ class WorkerSourceTask extends WorkerTask {
     private IdentityHashMap<ProducerRecord<byte[], byte[]>, ProducerRecord<byte[], byte[]>> outstandingMessages;
     // A second buffer is used while an offset flush is running
     private IdentityHashMap<ProducerRecord<byte[], byte[]>, ProducerRecord<byte[], byte[]>> outstandingMessagesBacklog;
-    private boolean flushing;
+    private boolean recordFlushPending;
+    private boolean offsetFlushPending;
     private CountDownLatch stopRequestedLatch;
 
     private Map<String, String> taskConfig;
@@ -144,7 +145,7 @@ class WorkerSourceTask extends WorkerTask {
         this.lastSendFailed = false;
         this.outstandingMessages = new IdentityHashMap<>();
         this.outstandingMessagesBacklog = new IdentityHashMap<>();
-        this.flushing = false;
+        this.recordFlushPending = false;
         this.stopRequestedLatch = new CountDownLatch(1);
         this.sourceTaskMetricsGroup = new SourceTaskMetricsGroup(id, connectMetrics);
         this.producerSendException = new AtomicReference<>();
@@ -335,7 +336,7 @@ class WorkerSourceTask extends WorkerTask {
             // messages and update the offsets.
             synchronized (this) {
                 if (!lastSendFailed) {
-                    if (!flushing) {
+                    if (!recordFlushPending) {
                         outstandingMessages.put(producerRecord, producerRecord);
                     } else {
                         outstandingMessagesBacklog.put(producerRecord, producerRecord);
@@ -453,12 +454,12 @@ class WorkerSourceTask extends WorkerTask {
     private synchronized void recordSent(final ProducerRecord<byte[], byte[]> record) {
         ProducerRecord<byte[], byte[]> removed = outstandingMessages.remove(record);
         // While flushing, we may also see callbacks for items in the backlog
-        if (removed == null && flushing)
+        if (removed == null && recordFlushPending)
             removed = outstandingMessagesBacklog.remove(record);
         // But if neither one had it, something is very wrong
         if (removed == null) {
             log.error("{} CRITICAL Saw callback for record that was not present in the outstanding message set: {}", this, record);
-        } else if (flushing && outstandingMessages.isEmpty()) {
+        } else if (recordFlushPending && outstandingMessages.isEmpty()) {
             // flush thread may be waiting on the outstanding messages to clear
             this.notifyAll();
         }
@@ -475,11 +476,15 @@ class WorkerSourceTask extends WorkerTask {
         synchronized (this) {
             // First we need to make sure we snapshot everything in exactly the current state. This
             // means both the current set of messages we're still waiting to finish, stored in this
-            // class, which setting flushing = true will handle by storing any new values into a new
+            // class, which setting recordFlushPending = true will handle by storing any new values into a new
             // buffer; and the current set of user-specified offsets, stored in the
             // OffsetStorageWriter, for which we can use beginFlush() to initiate the snapshot.
-            flushing = true;
-            boolean flushStarted = offsetWriter.beginFlush();
+            // No need to begin a new offset flush if we timed out waiting for records to be flushed to
+            // Kafka in a prior attempt.
+            if (!recordFlushPending) {
+                recordFlushPending = true;
+                offsetFlushPending = offsetWriter.beginFlush();
+            }
             // Still wait for any producer records to flush, even if there aren't any offsets to write
             // to persistent storage
 
@@ -490,7 +495,6 @@ class WorkerSourceTask extends WorkerTask {
                     long timeoutMs = timeout - time.milliseconds();
                     if (timeoutMs <= 0) {
                         log.error("{} Failed to flush, timed out while waiting for producer to flush outstanding {} messages", this, outstandingMessages.size());
-                        finishFailedFlush();
                         recordCommitFailure(time.milliseconds() - started, null);
                         return false;
                     }
@@ -506,7 +510,7 @@ class WorkerSourceTask extends WorkerTask {
                 }
             }
 
-            if (!flushStarted) {
+            if (!offsetFlushPending) {
                 // There was nothing in the offsets to process, but we still waited for the data in the
                 // buffer to flush. This is useful since this can feed into metrics to monitor, e.g.
                 // flush time, which can be used for monitoring even if the connector doesn't record any
@@ -583,7 +587,8 @@ class WorkerSourceTask extends WorkerTask {
         offsetWriter.cancelFlush();
         outstandingMessages.putAll(outstandingMessagesBacklog);
         outstandingMessagesBacklog.clear();
-        flushing = false;
+        recordFlushPending = false;
+        offsetFlushPending = false;
     }
 
     private synchronized void finishSuccessfulFlush() {
@@ -591,7 +596,8 @@ class WorkerSourceTask extends WorkerTask {
         IdentityHashMap<ProducerRecord<byte[], byte[]>, ProducerRecord<byte[], byte[]>> temp = outstandingMessages;
         outstandingMessages = outstandingMessagesBacklog;
         outstandingMessagesBacklog = temp;
-        flushing = false;
+        recordFlushPending = false;
+        offsetFlushPending = false;
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -1233,7 +1233,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         double activeCountMax = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-active-count-max");
         assertEquals(0, activeCount, 0.000001d);
         if (minimumPollCountExpected > 0) {
-            assertEquals(activeCountMaxExpected, activeCountMaxExpected, 0.000001d);
+            assertEquals(activeCountMaxExpected, activeCountMax, 0.000001d);
         }
     }
 


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-12226)

When a task fails to commit offsets because all outstanding records haven't been ack'd by the broker yet, it's better to retry that same batch. Otherwise, the set of outstanding records can grow indefinitely and all subsequent offset commit attempts can fail. By retrying the same batch, it becomes possible to eventually commit offsets, even when the producer is unable to keep up with the throughput of the records provided to it by the task.

Two unit tests are added to verify this behavior.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
