### PR TITLE
MINOR: set copyright year to 2021

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Kafka
-Copyright 2020 The Apache Software Foundation.
+Copyright 2021 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
2020 is over (thank god) so we need to bump the year for the 2.6.2 release