### PR TITLE
MINOR: Update zstd and use classes with no finalizers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -226,9 +226,9 @@ public enum CompressionType {
 
     private static class ZstdConstructors {
         // It's ok to reference `BufferPool` since it doesn't load any native libraries
-        static final MethodHandle INPUT = findConstructor("com.github.luben.zstd.ZstdInputStream",
+        static final MethodHandle INPUT = findConstructor("com.github.luben.zstd.ZstdInputStreamNoFinalizer",
             MethodType.methodType(void.class, InputStream.class, BufferPool.class));
-        static final MethodHandle OUTPUT = findConstructor("com.github.luben.zstd.ZstdOutputStream",
+        static final MethodHandle OUTPUT = findConstructor("com.github.luben.zstd.ZstdOutputStreamNoFinalizer",
             MethodType.methodType(void.class, OutputStream.class, BufferPool.class));
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -118,7 +118,7 @@ versions += [
   testRetryPlugin: "1.2.0",
   zinc: "1.3.5",
   zookeeper: "3.5.9",
-  zstd: "1.4.8-2"
+  zstd: "1.4.8-4"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
The updated version includes a few optimizations that benefit us:
* Classes with no finalizers (opt-in) that have better GC behavior
* `InputStream.skip()` implementation that uses cached buffers
* Minor buffer recycler optimizations (used for OutputStream only)

Full diff:
https://github.com/luben/zstd-jni/compare/v1.4.8-2...v1.4.8-4

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
