### PR TITLE
KAFKA-12326: Corrected regresion in MirrorMaker 2 executable introduced with KAFKA-10021

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -235,7 +235,7 @@ public class MirrorMaker {
         DistributedConfig distributedConfig = new DistributedConfig(workerProps);
         String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(distributedConfig);
         // Create the admin client to be shared by all backing stores for this herder
-        Map<String, Object> adminProps = new HashMap<>(config.originals());
+        Map<String, Object> adminProps = new HashMap<>(distributedConfig.originals());
         ConnectUtils.addMetricsContextProperties(adminProps, distributedConfig, kafkaClusterId);
         SharedTopicAdmin sharedAdmin = new SharedTopicAdmin(adminProps);
         KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore(sharedAdmin);


### PR DESCRIPTION
Fixes the recent change (#9780) to the `MirrorMaker` class (used only in the MirrorMaker 2 executable) that uses a `SharedTopicAdmin` client as part of Connect, so that the class passes the distributed worker properties rather than the MM2 properties into the `SharedTopicAdmin`.

The error running the MirrorMaker 2 executable was reproduced manually without this fix, and then this one-line change was manually verified to correct the problem. Unfortunately, the `MirrorMaker` class as currently written is not easily tested, so this change only includes the fix to unblock the 2.6.2 release and relies upon the aforementioned manual testing for verification.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
