### PR TITLE
MINOR: Add note about topic IDs to upgrade doc

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -32,7 +32,7 @@
         <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers">KIP-516</a>.
         When using ZooKeeper, this information is stored in the TopicZNode. If the cluster is downgraded to a previous IBP or version,
         future topics will not get topic IDs and it is not guaranteed that topics will retain their topic IDs in ZooKeeper.
-        This means that upon upgrading again, topics some or all topics will be assigned new IDs.
+        This means that upon upgrading again, some topics or all topics will be assigned new IDs.
     </li>
     <li>Kafka Streams introduce a type-safe <code>split()</code> operator as a substitution for deprecated <code>KStream#branch()</code> method
         (cf. <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-418%3A+A+method-chaining+way+to+branch+KStream">KIP-418</a>).

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -23,13 +23,17 @@
 <ul>
     <li>
         The 2.8.0 release added a new method to the Authorizer Interface introduced in
-            <a href="https://cwiki.apache.org/confluen ce/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default">KIP-679</a>.
+            <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default">KIP-679</a>.
         The motivation is to unblock our future plan to enable the strongest message delivery guarantee by default.
         Custom authorizer should consider providing a more efficient implementation that supports audit logging and any custom configs or access rules.
     </li>
-</ul>
-
-<ul>
+    <li>
+        IBP 2.8 introduces topic IDs to topics as a part of
+        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers">KIP-516</a>.
+        When using ZooKeeper, this information is stored in the TopicZNode. If the cluster is downgraded to a previous IBP or version,
+        future topics will not get topic IDs and it is not guaranteed that topics will retain their topic IDs in ZooKeeper.
+        This means that upon upgrading again, topics some or all topics will be assigned new IDs.
+    </li>
     <li>Kafka Streams introduce a type-safe <code>split()</code> operator as a substitution for deprecated <code>KStream#branch()</code> method
         (cf. <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-418%3A+A+method-chaining+way+to+branch+KStream">KIP-418</a>).
     </li>


### PR DESCRIPTION
Added a note about how topic IDs will be added in version 2.8 and the implications of downgrading + reupgrading.

Also fixed small typo and made all notable changes part of a single list.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
