### PR TITLE
MINOR: Update raft README and add a more specific error message.

### DIFF
--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -26,6 +26,7 @@ import kafka.raft.{KafkaRaftManager, RaftManager}
 import kafka.security.CredentialProvider
 import kafka.server.{KafkaConfig, KafkaRequestHandlerPool, MetaProperties}
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, CoreUtils, Exit, Logging, ShutdownableThread}
+import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.metrics.stats.Percentiles.BucketSizing
 import org.apache.kafka.common.metrics.stats.{Meter, Percentile, Percentiles}
@@ -419,6 +420,9 @@ object TestRaftServer extends Logging {
         "Standalone raft server for performance testing")
 
       val configFile = opts.options.valueOf(opts.configOpt)
+      if (configFile == null) {
+        throw new InvalidConfigurationException("Missing configuration file. Should specify with '--config'")
+      }
       val serverProps = Utils.loadProps(configFile)
 
       // KafkaConfig requires either `process.roles` or `zookeeper.connect`. Neither are

--- a/raft/README.md
+++ b/raft/README.md
@@ -9,7 +9,7 @@ we have a standalone test server which can be used for performance testing.
 Below we describe the details to set this up.
 
 ### Run Single Quorum ###
-    bin/test-raft-server-start.sh config/raft.properties
+    bin/test-raft-server-start.sh --config config/raft.properties
 
 ### Run Multi Node Quorum ###
 Create 3 separate raft quorum properties as the following:


### PR DESCRIPTION
`test-raft-server-start.sh` requires the config to be specified with `--config`. I've included this in the README and added an error message for this specific case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
