### PR TITLE
KAFKA-10348: Share client channel between forwarding and auto creation manager

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -44,10 +44,6 @@ trait AutoTopicCreationManager {
     topicNames: Set[String],
     controllerMutationQuota: ControllerMutationQuota
   ): Seq[MetadataResponseTopic]
-
-  def start(): Unit
-
-  def shutdown(): Unit
 }
 
 object AutoTopicCreationManager {
@@ -80,13 +76,6 @@ class DefaultAutoTopicCreationManager(
   }
 
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
-
-  override def start(): Unit = {
-  }
-
-  override def shutdown(): Unit = {
-    inflightTopics.clear()
-  }
 
   override def createTopics(
     topics: Set[String],

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -32,10 +32,8 @@ import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, TRANS
 import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreateableTopicConfig, CreateableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
-import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{ApiError, CreateTopicsRequest}
-import org.apache.kafka.common.utils.Time
 
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
@@ -57,30 +55,13 @@ object AutoTopicCreationManager {
   def apply(
     config: KafkaConfig,
     metadataCache: MetadataCache,
-    time: Time,
-    metrics: Metrics,
     threadNamePrefix: Option[String],
+    channelManager: Option[BrokerToControllerChannelManager],
     adminManager: Option[ZkAdminManager],
     controller: Option[KafkaController],
     groupCoordinator: GroupCoordinator,
     txnCoordinator: TransactionCoordinator,
-    enableForwarding: Boolean
   ): AutoTopicCreationManager = {
-
-    val channelManager =
-      if (enableForwarding)
-        Some(new BrokerToControllerChannelManagerImpl(
-          controllerNodeProvider = MetadataCacheControllerNodeProvider(
-            config, metadataCache),
-          time = time,
-          metrics = metrics,
-          config = config,
-          channelName = "autoTopicCreationChannel",
-          threadNamePrefix = threadNamePrefix,
-          retryTimeoutMs = config.requestTimeoutMs.longValue
-        ))
-      else
-        None
     new DefaultAutoTopicCreationManager(config, channelManager, adminManager,
       controller, groupCoordinator, txnCoordinator)
   }
@@ -101,11 +82,9 @@ class DefaultAutoTopicCreationManager(
   private val inflightTopics = Collections.newSetFromMap(new ConcurrentHashMap[String, java.lang.Boolean]())
 
   override def start(): Unit = {
-    channelManager.foreach(_.start())
   }
 
   override def shutdown(): Unit = {
-    channelManager.foreach(_.shutdown())
     inflightTopics.clear()
   }
 

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -186,7 +186,7 @@ class BrokerServer(
         time,
         metrics,
         config,
-        channelName = "clientToControllerChannel",
+        channelName = "controllerForwardingChannel",
         threadNamePrefix,
         retryTimeoutMs = 60000
       )

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -102,6 +102,8 @@ class BrokerServer(
 
   var transactionCoordinator: TransactionCoordinator = null
 
+  var clientToControllerChannelManager: BrokerToControllerChannelManager = null
+
   var forwardingManager: ForwardingManager = null
 
   var alterIsrManager: AlterIsrManager = null
@@ -179,17 +181,16 @@ class BrokerServer(
       val controllerNodes = RaftConfig.quorumVoterStringsToNodes(controllerQuorumVotersFuture.get()).asScala
       val controllerNodeProvider = RaftControllerNodeProvider(metaLogManager, config, controllerNodes)
 
-      val forwardingChannelManager = BrokerToControllerChannelManager(
+      clientToControllerChannelManager = BrokerToControllerChannelManager(
         controllerNodeProvider,
         time,
         metrics,
         config,
-        channelName = "forwarding",
+        channelName = "clientToControllerChannel",
         threadNamePrefix,
         retryTimeoutMs = 60000
       )
-      forwardingManager = new ForwardingManagerImpl(forwardingChannelManager)
-      forwardingManager.start()
+      forwardingManager = new ForwardingManagerImpl(clientToControllerChannelManager)
 
       val apiVersionManager = ApiVersionManager(
         ListenerType.BROKER,
@@ -245,12 +246,9 @@ class BrokerServer(
         new KafkaScheduler(threads = 1, threadNamePrefix = "transaction-log-manager-"),
         createTemporaryProducerIdManager, metrics, metadataCache, Time.SYSTEM)
 
-      val autoTopicCreationChannelManager = BrokerToControllerChannelManager(controllerNodeProvider,
-        time, metrics, config, "autocreate", threadNamePrefix, 60000)
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
-        config, Some(autoTopicCreationChannelManager), None, None,
+        config, Some(clientToControllerChannelManager), None, None,
         groupCoordinator, transactionCoordinator)
-      autoTopicCreationManager.start()
 
       /* Add all reconfigurables for config change notification before starting the metadata listener */
       config.dynamicConfig.addReconfigurables(this)
@@ -449,11 +447,8 @@ class BrokerServer(
       if (alterIsrManager != null)
         CoreUtils.swallow(alterIsrManager.shutdown(), this)
 
-      if (forwardingManager != null)
-        CoreUtils.swallow(forwardingManager.shutdown(), this)
-
-      if (autoTopicCreationManager != null)
-        CoreUtils.swallow(autoTopicCreationManager.shutdown(), this)
+      if (clientToControllerChannelManager != null)
+        CoreUtils.swallow(clientToControllerChannelManager.shutdown(), this)
 
       if (logManager != null)
         CoreUtils.swallow(logManager.shutdown(), this)

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -23,10 +23,8 @@ import kafka.network.RequestChannel
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ClientResponse, NodeApiVersions}
 import org.apache.kafka.common.errors.TimeoutException
-import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, EnvelopeRequest, EnvelopeResponse, RequestHeader}
-import org.apache.kafka.common.utils.Time
 
 import scala.compat.java8.OptionConverters._
 
@@ -44,25 +42,9 @@ trait ForwardingManager {
 }
 
 object ForwardingManager {
-
   def apply(
-    config: KafkaConfig,
-    metadataCache: MetadataCache,
-    time: Time,
-    metrics: Metrics,
-    threadNamePrefix: Option[String]
+    channelManager: BrokerToControllerChannelManager
   ): ForwardingManager = {
-    val nodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache)
-
-    val channelManager = BrokerToControllerChannelManager(
-      controllerNodeProvider = nodeProvider,
-      time = time,
-      metrics = metrics,
-      config = config,
-      channelName = "forwardingChannel",
-      threadNamePrefix = threadNamePrefix,
-      retryTimeoutMs = config.requestTimeoutMs.longValue
-    )
     new ForwardingManagerImpl(channelManager)
   }
 }
@@ -72,11 +54,9 @@ class ForwardingManagerImpl(
 ) extends ForwardingManager with Logging {
 
   override def start(): Unit = {
-    channelManager.start()
   }
 
   override def shutdown(): Unit = {
-    channelManager.shutdown()
   }
 
   /**

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -35,10 +35,6 @@ trait ForwardingManager {
   ): Unit
 
   def controllerApiVersions: Option[NodeApiVersions]
-
-  def start(): Unit = {}
-
-  def shutdown(): Unit = {}
 }
 
 object ForwardingManager {
@@ -52,12 +48,6 @@ object ForwardingManager {
 class ForwardingManagerImpl(
   channelManager: BrokerToControllerChannelManager
 ) extends ForwardingManager with Logging {
-
-  override def start(): Unit = {
-  }
-
-  override def shutdown(): Unit = {
-  }
 
   /**
    * Forward given request to the active controller.

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -265,7 +265,7 @@ class KafkaServer(
             time = time,
             metrics = metrics,
             config = config,
-            channelName = "clientToControllerChannel",
+            channelName = "controllerForwardingChannel",
             threadNamePrefix = threadNamePrefix,
             retryTimeoutMs = config.requestTimeoutMs.longValue)
           brokerToControllerManager.start()


### PR DESCRIPTION
We want to consolidate forwarding and auto creation channel into one channel to reduce the unnecessary connections maintained between brokers and controller.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
