### PR TITLE
KAFKA-12329; kafka-reassign-partitions command should give a better error message when a topic does not exist

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaFilter;

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaFilter;

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -812,6 +812,26 @@ object ReassignPartitionsCommand extends Logging {
     proposedAssignments
   }
 
+  private def describeTopics(adminClient: Admin,
+                             topics: Set[String])
+                             : Map[String, TopicDescription] = {
+    adminClient.describeTopics(topics.asJava).values.asScala.map {
+      case (topicName, topicDescriptionFuture) =>
+        try {
+          topicName -> topicDescriptionFuture.get
+        }
+        catch {
+          case t: ExecutionException if t.getCause != null =>
+            if (t.getCause.isInstanceOf[UnknownTopicOrPartitionException]) {
+              throw new ExecutionException(
+                new UnknownTopicOrPartitionException(s"Topic $topicName not found."))
+            } else {
+              throw t
+            }
+        }
+    }
+  }
+
   /**
    * Get the current replica assignments for some topics.
    *
@@ -823,12 +843,10 @@ object ReassignPartitionsCommand extends Logging {
   def getReplicaAssignmentForTopics(adminClient: Admin,
                                     topics: Seq[String])
                                     : Map[TopicPartition, Seq[Int]] = {
-    adminClient.describeTopics(topics.asJava).all().get().asScala.flatMap {
-      case (topicName, topicDescription) =>
-        topicDescription.partitions.asScala.map {
-          info => (new TopicPartition(topicName, info.partition),
-            info.replicas.asScala.map(_.id))
-        }
+    describeTopics(adminClient, topics.toSet).flatMap {
+      case (topicName, topicDescription) => topicDescription.partitions.asScala.map { info =>
+        (new TopicPartition(topicName, info.partition), info.replicas.asScala.map(_.id))
+      }
     }
   }
 
@@ -843,15 +861,14 @@ object ReassignPartitionsCommand extends Logging {
   def getReplicaAssignmentForPartitions(adminClient: Admin,
                                         partitions: Set[TopicPartition])
                                         : Map[TopicPartition, Seq[Int]] = {
-    adminClient.describeTopics(partitions.map(_.topic).asJava).all().get().asScala.flatMap {
-      case (topicName, topicDescription) =>
-        topicDescription.partitions.asScala.flatMap {
-          info => if (partitions.contains(new TopicPartition(topicName, info.partition))) {
-            Some(new TopicPartition(topicName, info.partition()),
-                info.replicas.asScala.map(_.id))
-          } else {
-            None
-          }
+    describeTopics(adminClient, partitions.map(_.topic)).flatMap {
+      case (topicName, topicDescription) => topicDescription.partitions.asScala.flatMap { info =>
+        val tp = new TopicPartition(topicName, info.partition)
+        if (partitions.contains(tp)) {
+          Some(tp, info.replicas.asScala.map(_.id))
+        } else {
+          None
+        }
       }
     }
   }

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -821,8 +821,8 @@ object ReassignPartitionsCommand extends Logging {
           topicName -> topicDescriptionFuture.get
         }
         catch {
-          case t: ExecutionException if t.getCause != null =>
-            if (t.getCause.isInstanceOf[UnknownTopicOrPartitionException]) {
+          case t: ExecutionException =>
+            if (classOf[UnknownTopicOrPartitionException].isInstance(t.getCause)) {
               throw new ExecutionException(
                 new UnknownTopicOrPartitionException(s"Topic $topicName not found."))
             } else {

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
@@ -287,6 +287,20 @@ class ReassignPartitionsUnitTest {
   }
 
   @Test
+  def testGenerateAssignmentWithInvalidPartitionsFails(): Unit = {
+    val adminClient = new MockAdminClient.Builder().numBrokers(5).build()
+    try {
+      addTopics(adminClient)
+      assertStartsWith("Topic quux not found",
+        assertThrows(classOf[ExecutionException],
+          () => generateAssignment(adminClient, """{"topics":[{"topic":"foo"},{"topic":"quux"}]}""", "0,1", false),
+          () => "Expected generateAssignment to fail").getCause.getMessage)
+    } finally {
+      adminClient.close()
+    }
+  }
+
+  @Test
   def testGenerateAssignmentWithInconsistentRacks(): Unit = {
     val adminClient = new MockAdminClient.Builder().
       brokers(Arrays.asList(


### PR DESCRIPTION
`kafka-reassign-partitions` command gives a generic error message when one tries to reassign a topic which does not exist:

```
$ ./bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 --execute --reassignment-json-file reassignment.json
Error: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: This server does not host this topic-partition.
```

When the reassignment contains multiple topics, it is hard to find out the correct one. This PR improves this to give the name of the topic in the error:

```
$ ./bin/kafka-reassign-partitions.sh --bootstrap-server localhost:9092 --execute --reassignment-json-file reassignment.json
Error: org.apache.kafka.common.errors.UnknownTopicOrPartitionException: Topic test-test not found.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
