### PR TITLE
MINOR: Fix Typo in MirrorMaker README file

### DIFF
--- a/connect/mirror/README.md
+++ b/connect/mirror/README.md
@@ -236,7 +236,7 @@ The following metrics are emitted:
     record-age-ms-min
     record-age-ms-max
     record-age-ms-avg
-    replication-latecny-ms  # time it takes records to propagate source->target
+    replication-latency-ms  # time it takes records to propagate source->target
     replication-latency-ms-min
     replication-latency-ms-max
     replication-latency-ms-avg


### PR DESCRIPTION
Fix Typo in metric name of MirrorMaker README file from 'replication-latecny-ms' to 'replication-latency-ms'

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
