### PR TITLE
HOTFIX: fix Scala 2.12 build error caused by ControllerApisTest.scala

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -67,7 +67,7 @@ class ControllerApisTest {
   private def createControllerApis(authorizer: Option[Authorizer],
                                    supportedFeatures: Map[String, VersionRange] = Map.empty): ControllerApis = {
     val props = new Properties()
-    props.put(KafkaConfig.NodeIdProp, nodeId)
+    props.put(KafkaConfig.NodeIdProp, nodeId: java.lang.Integer)
     props.put(KafkaConfig.ProcessRolesProp, "controller")
     new ControllerApis(
       requestChannel,


### PR DESCRIPTION
related to #10113

### Error Message

`
14:01:06 > Task :core:compileTestScala
14:01:06 [Error] /home/jenkins/agent/workspace/LoopTest-Kafka/kafka/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala:70: the result type of an implicit conversion must be more specific than Object
`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
