### PR TITLE
AbstractCoordinator should log with its subclass

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -158,7 +158,7 @@ public abstract class AbstractCoordinator implements Closeable {
         Objects.requireNonNull(rebalanceConfig.groupId,
                                "Expected a non-null group id for coordinator construction");
         this.rebalanceConfig = rebalanceConfig;
-        this.log = logContext.logger(AbstractCoordinator.class);
+        this.log = logContext.logger(this.getClass());
         this.client = client;
         this.time = time;
         this.heartbeat = new Heartbeat(rebalanceConfig, time);


### PR DESCRIPTION
While debugging some group coordinator issues I noticed the consumer coordinator was logging using `org.apache.kafka.clients.consumer.internals.AbstractCoordinator` as the logger. Since there are two implementations of AbstractCoordinator, we should probably use the subclass as the logger