### PR TITLE
KAFKA-3745: Add access to read-only key in value joiner

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -1716,7 +1716,7 @@ public interface KStream<K, V> {
     /**
      * Join records of this stream with another {@code KStream}'s records using windowed left equi join with default
      * serializers and deserializers.
-     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records from this stream will
+     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join}, all records from this stream will
      * produce at least one output record (cf. below).
      * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
      * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
@@ -1727,7 +1727,7 @@ public interface KStream<K, V> {
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
      * The key of the result record is the same as for both joining input records.
      * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
-     * {@link ValueJoiner} will be called with a {@code null} value for the other stream.
+     * {@link ValueJoinerWithKey} will be called with a {@code null} value for the other stream.
      * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
      * output record will be added to the resulting {@code KStream}.
      * <p>
@@ -1741,12 +1741,12 @@ public interface KStream<K, V> {
      * <tr>
      * <td>&lt;K1:A&gt;</td>
      * <td></td>
-     * <td>&lt;K1:ValueJoiner(A,null)&gt;</td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1, A,null)&gt;</td>
      * </tr>
      * <tr>
      * <td>&lt;K2:B&gt;</td>
      * <td>&lt;K2:b&gt;</td>
-     * <td>&lt;K2:ValueJoiner(B,b)&gt;</td>
+     * <td>&lt;K2:ValueJoinerWithKey(K2, B,b)&gt;</td>
      * </tr>
      * <tr>
      * <td></td>
@@ -1785,10 +1785,10 @@ public interface KStream<K, V> {
      * @param <VO>        the value type of the other stream
      * @param <VR>        the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
      * this {@code KStream} and within the joining window intervals
-     * @see #join(KStream, ValueJoiner, JoinWindows)
-     * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
+     * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
+     * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
      */
     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
@@ -1965,6 +1965,90 @@ public interface KStream<K, V> {
                                      final StreamJoined<K, V, VO> streamJoined);
 
     /**
+     * Join records of this stream with another {@code KStream}'s records using windowed left equi join using the
+     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state stores.
+     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join}, all records from this stream will
+     * produce at least one output record (cf. below).
+     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
+     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
+     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * <p>
+     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
+     * a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * The key of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
+     * {@link ValueJoinerWithKey} will be called with a {@code null} value for the other stream.
+     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
+     * output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example (assuming all input records belong to the correct windows):
+     * <table border='1'>
+     * <tr>
+     * <th>this</th>
+     * <th>other</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,A,null)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K2:B&gt;</td>
+     * <td>&lt;K2:b&gt;</td>
+     * <td>&lt;K2:ValueJoinerWithKey(K2,B,b)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K3:c&gt;</td>
+     * <td></td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
+     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * Repartitioning can happen for one or both of the joining {@code KStream}s.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     * <p>
+     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
+     * unless a name is provided via a {@code Materialized} instance.
+     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
+     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param <VO>         the value type of the other stream
+     * @param <VR>         the value type of the result stream
+     * @param otherStream  the {@code KStream} to be joined with this stream
+     * @param joiner       a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param windows      the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * this {@code KStream} and within the joining window intervals
+     * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+     * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+     */
+    <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                     final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                     final JoinWindows windows,
+                                     final StreamJoined<K, V, VO> streamJoined);
+    /**
      * Join records of this stream with another {@code KStream}'s records using windowed outer equi join with default
      * serializers and deserializers.
      * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
@@ -2044,7 +2128,87 @@ public interface KStream<K, V> {
     <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
                                       final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                       final JoinWindows windows);
-
+    /**
+     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join with default
+     * serializers and deserializers.
+     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
+     * {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all records from both streams will produce at
+     * least one output record (cf. below).
+     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
+     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
+     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * <p>
+     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
+     * a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * The key of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of both {@code KStream}s that does not satisfy the join predicate the provided
+     * {@link ValueJoinerWithKey} will be called with a {@code null} value for the this/other stream, respectively.
+     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
+     * output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example (assuming all input records belong to the correct windows):
+     * <table border='1'>
+     * <tr>
+     * <th>this</th>
+     * <th>other</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,A,null)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K2:B&gt;</td>
+     * <td>&lt;K2:b&gt;</td>
+     * <td>&lt;K2:ValueJoinerWithKey(K2,null,b)&gt;<br></br>&lt;K2:ValueJoinerWithKey(K2,B,b)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K3:c&gt;</td>
+     * <td>&lt;K3:ValueJoinerWithKey(K3,null,c)&gt;</td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
+     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * Repartitioning can happen for one or both of the joining {@code KStream}s.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     * <p>
+     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
+     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
+     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner      a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param windows     the specification of the {@link JoinWindows}
+     * @param <VO>        the value type of the other stream
+     * @param <VR>        the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * both {@code KStream} and within the joining window intervals
+     * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
+     * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+     */
+    <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                      final JoinWindows windows);
     /**
      * Join records of this stream with another {@code KStream}'s records using windowed outer equi join using the
      * {@link Joined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value serde},
@@ -2218,6 +2382,91 @@ public interface KStream<K, V> {
                                       final StreamJoined<K, V, VO> streamJoined);
 
     /**
+     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join using the
+     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state stores.
+     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join} or
+     * {@link #leftJoin(KStream, ValueJoinerWithKey, JoinWindows) left-join}, all records from both streams will produce at
+     * least one output record (cf. below).
+     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
+     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
+     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * <p>
+     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
+     * a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * The key of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of both {@code KStream}s that does not satisfy the join predicate the provided
+     * {@link ValueJoinerWithKey} will be called with a {@code null} value for this/other stream, respectively.
+     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
+     * output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example (assuming all input records belong to the correct windows):
+     * <table border='1'>
+     * <tr>
+     * <th>this</th>
+     * <th>other</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,A,null)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K2:B&gt;</td>
+     * <td>&lt;K2:b&gt;</td>
+     * <td>&lt;K2:ValueJoinerWithKey(K2,null,b)&gt;<br></br>&lt;K2:ValueJoinerWithKey(K2,B,b)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K3:c&gt;</td>
+     * <td>&lt;K3:ValueJoinerWithKey(K3,null,c)&gt;</td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
+     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * Repartitioning can happen for one or both of the joining {@code KStream}s.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     * <p>
+     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
+     * unless a name is provided via a {@code Materialized} instance.
+     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
+     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param <VO>         the value type of the other stream
+     * @param <VR>         the value type of the result stream
+     * @param otherStream  the {@code KStream} to be joined with this stream
+     * @param joiner       a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param windows      the specification of the {@link JoinWindows}
+     * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * both {@code KStream} and within the joining window intervals
+     * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+     * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+     */
+    <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                      final JoinWindows windows,
+                                      final StreamJoined<K, V, VO> streamJoined);
+    /**
      * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
      * serializers and deserializers.
      * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
@@ -2304,6 +2553,84 @@ public interface KStream<K, V> {
      * will not produce any result records.
      * <p>
      * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     *
+     * The key of the result record is the same as for both joining input records.
+     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example:
+     * <table border='1'>
+     * <tr>
+     * <th>KStream</th>
+     * <th>KTable</th>
+     * <th>state</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td></td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:C&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
+     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
+     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}.
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * <p>
+     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     *
+     * @param table  the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param <VT>   the value type of the table
+     * @param <VR>   the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
+     * @see #leftJoin(KTable, ValueJoinerWithKey)
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
+     */
+    <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
+                                 final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
+
+    /**
+     * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
+     * serializers and deserializers.
+     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
+     * {@link KTable} state.
+     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
+     * will not produce any result records.
+     * <p>
+     * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
      * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as for both joining input records.
      * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
@@ -2370,6 +2697,87 @@ public interface KStream<K, V> {
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
                                  final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
+                                 final Joined<K, V, VT> joined);
+
+    /**
+     * Join records of this stream with {@link KTable}'s records using non-windowed inner equi join with default
+     * serializers and deserializers.
+     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
+     * {@link KTable} state.
+     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
+     * will not produce any result records.
+     * <p>
+     * For each {@code KStream} record that finds a corresponding record in {@link KTable} the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as for both joining input records.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * 
+     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example:
+     * <table border='1'>
+     * <tr>
+     * <th>KStream</th>
+     * <th>KTable</th>
+     * <th>state</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td></td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:C&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
+     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
+     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * <p>
+     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     *
+     * @param table  the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param joined      a {@link Joined} instance that defines the serdes to
+     *                    be used to serialize/deserialize inputs of the joined streams
+     * @param <VT>   the value type of the table
+     * @param <VR>   the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
+     * @see #leftJoin(KTable, ValueJoinerWithKey, Joined)
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
+     */
+    <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
+                                 final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
                                  final Joined<K, V, VT> joined);
 
     /**
@@ -2454,6 +2862,86 @@ public interface KStream<K, V> {
     /**
      * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
      * serializers and deserializers.
+     * In contrast to {@link #join(KTable, ValueJoinerWithKey) inner-join}, all records from this stream will produce an
+     * output record (cf. below).
+     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
+     * {@link KTable} state.
+     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
+     * will not produce any result records.
+     * <p>
+     * For each {@code KStream} record whether or not it finds a corresponding record in {@link KTable} the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * If no {@link KTable} record was found during lookup, a {@code null} value will be provided to {@link ValueJoinerWithKey}.
+     * The key of the result record is the same as for both joining input records.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example:
+     * <table border='1'>
+     * <tr>
+     * <th>KStream</th>
+     * <th>KTable</th>
+     * <th>state</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td></td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,A,null)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:C&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
+     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
+     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * <p>
+     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     *
+     * @param table  the {@link KTable} to be joined with this stream
+     * @param joiner a {@link ValueJoiner} that computes the join result for a pair of matching records
+     * @param <VT>   the value type of the table
+     * @param <VR>   the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @see #join(KTable, ValueJoinerWithKey)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+     */
+    <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
+                                     final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
+
+    /**
+     * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
+     * serializers and deserializers.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from this stream will produce an
      * output record (cf. below).
      * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
@@ -2534,6 +3022,89 @@ public interface KStream<K, V> {
                                      final Joined<K, V, VT> joined);
 
     /**
+     * Join records of this stream with {@link KTable}'s records using non-windowed left equi join with default
+     * serializers and deserializers.
+     * In contrast to {@link #join(KTable, ValueJoinerWithKey) inner-join}, all records from this stream will produce an
+     * output record (cf. below).
+     * The join is a primary key table lookup join with join attribute {@code stream.key == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> (i.e., processing time) internal
+     * {@link KTable} state.
+     * In contrast, processing {@link KTable} input records will only update the internal {@link KTable} state and
+     * will not produce any result records.
+     * <p>
+     * For each {@code KStream} record whether or not it finds a corresponding record in {@link KTable} the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * If no {@link KTable} record was found during lookup, a {@code null} value will be provided to {@link ValueJoinerWithKey}.
+     * The key of the result record is the same as for both joining input records.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * If an {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example:
+     * <table border='1'>
+     * <tr>
+     * <th>KStream</th>
+     * <th>KTable</th>
+     * <th>state</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td></td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,A,null)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:C&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:b&gt;</td>
+     * <td>&lt;K1:ValueJoinerWithKey(K1,C,b)&gt;</td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} for this {@code KStream}
+     * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
+     * {@link KTable}.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
+     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     * <p>
+     * Repartitioning can happen only for this {@code KStream} but not for the provided {@link KTable}.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     *
+     * @param table   the {@link KTable} to be joined with this stream
+     * @param joiner  a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param joined  a {@link Joined} instance that defines the serdes to
+     *                be used to serialize/deserialize inputs and outputs of the joined streams
+     * @param <VT>    the value type of the table
+     * @param <VR>    the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @see #join(KTable, ValueJoinerWithKey, Joined)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+     */
+    <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
+                                     final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
+                                     final Joined<K, V, VT> joined);
+
+    /**
      * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
      * The join is a primary key table lookup join with join attribute
      * {@code keyValueMapper.map(stream.keyValue) == table.key}.
@@ -2577,6 +3148,40 @@ public interface KStream<K, V> {
      * state and will not produce any result records.
      * <p>
      * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
+     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as the key of this {@code KStream}.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
+     * resulting {@code KStream}.
+     *
+     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
+     *                       to the key of the {@link GlobalKTable}
+     * @param joiner         a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param <GK>           the key type of {@link GlobalKTable}
+     * @param <GV>           the value type of the {@link GlobalKTable}
+     * @param <RV>           the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+     */
+    <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
+                                     final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                     final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner);
+
+    /**
+     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
+     * The join is a primary key table lookup join with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
+     * state.
+     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
+     * state and will not produce any result records.
+     * <p>
+     * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
      * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
      * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
@@ -2599,6 +3204,42 @@ public interface KStream<K, V> {
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
                                      final ValueJoiner<? super V, ? super GV, ? extends RV> joiner,
+                                     final Named named);
+
+    /**
+     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed inner equi join.
+     * The join is a primary key table lookup join with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
+     * state.
+     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
+     * state and will not produce any result records.
+     * <p>
+     * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
+     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as the key of this {@code KStream}.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * If {@code keyValueMapper} returns {@code null} implying no match exists, no output record will be added to the
+     * resulting {@code KStream}.
+     *
+     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
+     *                       to the key of the {@link GlobalKTable}
+     * @param joiner         a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param named          a {@link Named} config used to name the processor in the topology
+     * @param <GK>           the key type of {@link GlobalKTable}
+     * @param <GV>           the value type of the {@link GlobalKTable}
+     * @param <RV>           the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+     */
+    <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
+                                     final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                     final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner,
                                      final Named named);
 
     /**
@@ -2640,6 +3281,44 @@ public interface KStream<K, V> {
 
     /**
      * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
+     * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) inner-join}, all records from this stream
+     * will produce an output record (cf. below).
+     * The join is a primary key table lookup join with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
+     * state.
+     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
+     * state and will not produce any result records.
+     * <p>
+     * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
+     * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as this {@code KStream}.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
+     * provided to {@link ValueJoinerWithKey}.
+     * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
+     * {@link ValueJoiner}.
+     *
+     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
+     *                       to the key of the {@link GlobalKTable}
+     * @param valueJoiner    a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param <GK>           the key type of {@link GlobalKTable}
+     * @param <GV>           the value type of the {@link GlobalKTable}
+     * @param <RV>           the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+     */
+    <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
+                                         final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                         final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner);
+
+    /**
+     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
      * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner) inner-join}, all records from this stream
      * will produce an output record (cf. below).
      * The join is a primary key table lookup join with join attribute
@@ -2675,6 +3354,45 @@ public interface KStream<K, V> {
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
                                          final ValueJoiner<? super V, ? super GV, ? extends RV> valueJoiner,
+                                         final Named named);
+
+    /**
+     * Join records of this stream with {@link GlobalKTable}'s records using non-windowed left equi join.
+     * In contrast to {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) inner-join}, all records from this stream
+     * will produce an output record (cf. below).
+     * The join is a primary key table lookup join with join attribute
+     * {@code keyValueMapper.map(stream.keyValue) == table.key}.
+     * "Table lookup join" means, that results are only computed if {@code KStream} records are processed.
+     * This is done by performing a lookup for matching records in the <em>current</em> internal {@link GlobalKTable}
+     * state.
+     * In contrast, processing {@link GlobalKTable} input records will only update the internal {@link GlobalKTable}
+     * state and will not produce any result records.
+     * <p>
+     * For each {@code KStream} record whether or not it finds a corresponding record in {@link GlobalKTable} the
+     * provided {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
+     * The key of the result record is the same as this {@code KStream}.
+     * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
+     * operation and thus no output record will be added to the resulting {@code KStream}.
+     * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
+     * provided to {@link ValueJoinerWithKey}.
+     * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
+     * {@link ValueJoiner}.
+     *
+     * @param globalTable    the {@link GlobalKTable} to be joined with this stream
+     * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
+     *                       to the key of the {@link GlobalKTable}
+     * @param valueJoiner    a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param named          a {@link Named} config used to name the processor in the topology
+     * @param <GK>           the key type of {@link GlobalKTable}
+     * @param <GV>           the value type of the {@link GlobalKTable}
+     * @param <RV>           the value type of the resulting {@code KStream}
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+     */
+    <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalTable,
+                                         final KeyValueMapper<? super K, ? super V, ? extends GK> keySelector,
+                                         final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoiner,
                                          final Named named);
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -1343,7 +1343,7 @@ public interface KStream<K, V> {
      * <tr>
      * <td>&lt;K2:B&gt;</td>
      * <td>&lt;K2:b&gt;</td>
-     * <td>&lt;K2:ValueJoiner(B,b)&gt;</td>
+     * <td>&lt;K2:ValueJoinerWithKey(K1,B,b)&gt;</td>
      * </tr>
      * <tr>
      * <td></td>
@@ -1383,7 +1383,7 @@ public interface KStream<K, V> {
      * @param <VO>        the value type of the other stream
      * @param <VR>        the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key and within the joining window intervals
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
      */
@@ -1584,7 +1584,7 @@ public interface KStream<K, V> {
      * <tr>
      * <td>&lt;K2:B&gt;</td>
      * <td>&lt;K2:b&gt;</td>
-     * <td>&lt;K2:ValueJoiner(B,b)&gt;</td>
+     * <td>&lt;K2:ValueJoinerWithKey(K1,B,b)&gt;</td>
      * </tr>
      * <tr>
      * <td></td>
@@ -1626,9 +1626,9 @@ public interface KStream<K, V> {
      * @param windows        the specification of the {@link JoinWindows}
      * @param streamJoined   a {@link StreamJoined} used to configure join stores
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
-     * @see #leftJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
-     * @see #outerJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key and within the joining window intervals
+     * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+     * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      */
     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
                                  final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
@@ -2039,7 +2039,7 @@ public interface KStream<K, V> {
      * @param windows      the specification of the {@link JoinWindows}
      * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
      * this {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
@@ -2131,8 +2131,8 @@ public interface KStream<K, V> {
     /**
      * Join records of this stream with another {@code KStream}'s records using windowed outer equi join with default
      * serializers and deserializers.
-     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
-     * {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all records from both streams will produce at
+     * In contrast to {@link #join(KStream, ValueJoinerWithKey, JoinWindows) inner-join} or
+     * {@link #leftJoin(KStream, ValueJoinerWithKey, JoinWindows) left-join}, all records from both streams will produce at
      * least one output record (cf. below).
      * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
      * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
@@ -2201,7 +2201,7 @@ public interface KStream<K, V> {
      * @param <VO>        the value type of the other stream
      * @param <VR>        the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
      * both {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows)
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
@@ -2457,7 +2457,7 @@ public interface KStream<K, V> {
      * @param windows      the specification of the {@link JoinWindows}
      * @param streamJoined a {@link StreamJoined} instance to configure serdes and state stores
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key plus one for each non-matching record of
      * both {@code KStream} and within the joining window intervals
      * @see #join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
      * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
@@ -2593,7 +2593,7 @@ public interface KStream<K, V> {
      * before doing the join, specifying the same number of partitions via {@link Repartitioned} parameter as the given
      * {@link KTable}.
      * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner);
-     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoiner)}.
+     * cf. {@link #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)}.
      * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
      * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
      * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
@@ -2615,7 +2615,7 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
      * @see #leftJoin(KTable, ValueJoinerWithKey)
-     * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
                                  final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
@@ -2774,7 +2774,7 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoinerWithKey}, one for each matched record-pair with the same key
      * @see #leftJoin(KTable, ValueJoinerWithKey, Joined)
-     * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> join(final KTable<K, VT> table,
                                  final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
@@ -2928,11 +2928,11 @@ public interface KStream<K, V> {
      * correctly on its key.
      *
      * @param table  the {@link KTable} to be joined with this stream
-     * @param joiner a {@link ValueJoiner} that computes the join result for a pair of matching records
+     * @param joiner a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
      * @param <VT>   the value type of the table
      * @param <VR>   the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #join(KTable, ValueJoinerWithKey)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
@@ -3096,7 +3096,7 @@ public interface KStream<K, V> {
      * @param <VT>    the value type of the table
      * @param <VR>    the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #join(KTable, ValueJoinerWithKey, Joined)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
@@ -3164,7 +3164,7 @@ public interface KStream<K, V> {
      * @param <GV>           the value type of the {@link GlobalKTable}
      * @param <RV>           the value type of the resulting {@code KStream}
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
@@ -3217,7 +3217,7 @@ public interface KStream<K, V> {
      * state and will not produce any result records.
      * <p>
      * For each {@code KStream} record that finds a corresponding record in {@link GlobalKTable} the provided
-     * {@link ValueJoiner} will be called to compute a value (with arbitrary type) for the result record.
+     * {@link ValueJoinerWithKey} will be called to compute a value (with arbitrary type) for the result record.
      * The key of the result record is the same as the key of this {@code KStream}.
      * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
      * If a {@code KStream} input record key or value is {@code null} the record will not be included in the join
@@ -3234,7 +3234,7 @@ public interface KStream<K, V> {
      * @param <GV>           the value type of the {@link GlobalKTable}
      * @param <RV>           the value type of the resulting {@code KStream}
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalTable,
@@ -3376,7 +3376,7 @@ public interface KStream<K, V> {
      * If {@code keyValueMapper} returns {@code null} implying no match exists, a {@code null} value will be
      * provided to {@link ValueJoinerWithKey}.
      * If no {@link GlobalKTable} record was found during lookup, a {@code null} value will be provided to
-     * {@link ValueJoiner}.
+     * {@link ValueJoinerWithKey}.
      *
      * @param globalTable    the {@link GlobalKTable} to be joined with this stream
      * @param keySelector    instance of {@link KeyValueMapper} used to map from the (key, value) of this stream

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -1315,6 +1315,84 @@ public interface KStream<K, V> {
                                  final JoinWindows windows);
 
     /**
+     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join with default
+     * serializers and deserializers.
+     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
+     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
+     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * <p>
+     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
+     * a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * The key of the result record is the same as for both joining input records.
+     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
+     * output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example (assuming all input records belong to the correct windows):
+     * <table border='1'>
+     * <tr>
+     * <th>this</th>
+     * <th>other</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K2:B&gt;</td>
+     * <td>&lt;K2:b&gt;</td>
+     * <td>&lt;K2:ValueJoiner(B,b)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K3:c&gt;</td>
+     * <td></td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
+     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * Repartitioning can happen for one or both of the joining {@code KStream}s.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     * <p>
+     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
+     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
+     * in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is an
+     * internally generated name, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner      a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param windows     the specification of the {@link JoinWindows}
+     * @param <VO>        the value type of the other stream
+     * @param <VR>        the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+     * @see #leftJoin(KStream, ValueJoiner, JoinWindows)
+     * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
+     */
+    <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                 final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                 final JoinWindows windows);
+
+
+    /**
      * Join records of this stream with another {@code KStream}'s records using windowed inner equi join using the
      * {@link Joined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value serde},
      * and {@link Serde the other stream's value serde}.
@@ -1477,6 +1555,86 @@ public interface KStream<K, V> {
                                  final StreamJoined<K, V, VO> streamJoined);
 
     /**
+     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join using the
+     * {@link StreamJoined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value
+     * serde}, {@link Serde the other stream's value serde}, and used state stores.
+     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
+     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
+     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * <p>
+     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
+     * a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * The key of the result record is the same as for both joining input records.
+     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
+     * output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example (assuming all input records belong to the correct windows):
+     * <table border='1'>
+     * <tr>
+     * <th>this</th>
+     * <th>other</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td></td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K2:B&gt;</td>
+     * <td>&lt;K2:b&gt;</td>
+     * <td>&lt;K2:ValueJoiner(B,b)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K3:c&gt;</td>
+     * <td></td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
+     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * Repartitioning can happen for one or both of the joining {@code KStream}s.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     * <p>
+     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names,
+     * unless a name is provided via a {@code Materialized} instance.
+     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
+     * in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "storeName" is an
+     * internally generated name, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param <VO>           the value type of the other stream
+     * @param <VR>           the value type of the result stream
+     * @param otherStream    the {@code KStream} to be joined with this stream
+     * @param joiner         a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param windows        the specification of the {@link JoinWindows}
+     * @param streamJoined   a {@link StreamJoined} used to configure join stores
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
+     * @see #leftJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
+     * @see #outerJoin(KStream, ValueJoiner, JoinWindows, StreamJoined)
+     */
+    <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                 final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                 final JoinWindows windows,
+                                 final StreamJoined<K, V, VO> streamJoined);
+    /**
      * Join records of this stream with another {@code KStream}'s records using windowed left equi join with default
      * serializers and deserializers.
      * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records from this stream will
@@ -1554,6 +1712,86 @@ public interface KStream<K, V> {
      */
     <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                     final JoinWindows windows);
+    /**
+     * Join records of this stream with another {@code KStream}'s records using windowed left equi join with default
+     * serializers and deserializers.
+     * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records from this stream will
+     * produce at least one output record (cf. below).
+     * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
+     * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
+     * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
+     * <p>
+     * For each pair of records meeting both join predicates the provided {@link ValueJoinerWithKey} will be called to compute
+     * a value (with arbitrary type) for the result record.
+     * Note that the key is read-only and should not be modified, as this can lead to undefined behaviour.
+     * The key of the result record is the same as for both joining input records.
+     * Furthermore, for each input record of this {@code KStream} that does not satisfy the join predicate the provided
+     * {@link ValueJoiner} will be called with a {@code null} value for the other stream.
+     * If an input record key or value is {@code null} the record will not be included in the join operation and thus no
+     * output record will be added to the resulting {@code KStream}.
+     * <p>
+     * Example (assuming all input records belong to the correct windows):
+     * <table border='1'>
+     * <tr>
+     * <th>this</th>
+     * <th>other</th>
+     * <th>result</th>
+     * </tr>
+     * <tr>
+     * <td>&lt;K1:A&gt;</td>
+     * <td></td>
+     * <td>&lt;K1:ValueJoiner(A,null)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td>&lt;K2:B&gt;</td>
+     * <td>&lt;K2:b&gt;</td>
+     * <td>&lt;K2:ValueJoiner(B,b)&gt;</td>
+     * </tr>
+     * <tr>
+     * <td></td>
+     * <td>&lt;K3:c&gt;</td>
+     * <td></td>
+     * </tr>
+     * </table>
+     * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
+     * partitions.
+     * If this is not the case, you would need to call {@link #repartition(Repartitioned)} (for one input stream) before
+     * doing the join and specify the "correct" number of partitions via {@link Repartitioned} parameter.
+     * Furthermore, both input streams need to be co-partitioned on the join key (i.e., use the same partitioner).
+     * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
+     * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
+     * The repartitioning topic will be named "${applicationId}-&lt;name&gt;-repartition", where "applicationId" is
+     * user-specified in {@link StreamsConfig} via parameter
+     * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "&lt;name&gt;" is an internally generated
+     * name, and "-repartition" is a fixed suffix.
+     * <p>
+     * Repartitioning can happen for one or both of the joining {@code KStream}s.
+     * For this case, all data of the stream will be redistributed through the repartitioning topic by writing all
+     * records to it, and rereading all records from it, such that the join input {@code KStream} is partitioned
+     * correctly on its key.
+     * <p>
+     * Both of the joining {@code KStream}s will be materialized in local state stores with auto-generated store names.
+     * For failure and recovery each store will be backed by an internal changelog topic that will be created in Kafka.
+     * The changelog topic will be named "${applicationId}-&lt;storename&gt;-changelog", where "applicationId" is user-specified
+     * in {@link StreamsConfig} via parameter {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG},
+     * "storeName" is an internally generated name, and "-changelog" is a fixed suffix.
+     * <p>
+     * You can retrieve all generated internal topic names via {@link Topology#describe()}.
+     *
+     * @param otherStream the {@code KStream} to be joined with this stream
+     * @param joiner      a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param windows     the specification of the {@link JoinWindows}
+     * @param <VO>        the value type of the other stream
+     * @param <VR>        the value type of the result stream
+     * @return a {@code KStream} that contains join-records for each key and values computed by the given
+     * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
+     * this {@code KStream} and within the joining window intervals
+     * @see #join(KStream, ValueJoiner, JoinWindows)
+     * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
+     */
+    <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                     final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
                                      final JoinWindows windows);
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -1384,8 +1384,8 @@ public interface KStream<K, V> {
      * @param <VR>        the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one for each matched record-pair with the same key and within the joining window intervals
-     * @see #leftJoin(KStream, ValueJoiner, JoinWindows)
-     * @see #outerJoin(KStream, ValueJoiner, JoinWindows)
+     * @see #leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+     * @see #outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
      */
     <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
                                  final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
@@ -39,9 +39,10 @@ package org.apache.kafka.streams.kstream;
  * @see KStream#join(KTable, ValueJoinerWithKey, Joined)
  * @see KStream#leftJoin(KTable, ValueJoinerWithKey)
  * @see KStream#leftJoin(KTable, ValueJoinerWithKey, Joined)
- * @see KTable#join(KTable, ValueJoinerWithKey)
- * @see KTable#leftJoin(KTable, ValueJoinerWithKey)
- * @see KTable#outerJoin(KTable, ValueJoinerWithKey)
+ * @see KStream#join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey) 
+ * @see KStream#join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey, Named)
+ * @see KStream#leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
+ * @see KStream#leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey, Named)
  */
 public interface ValueJoinerWithKey<K1, V1, V2, VR> {
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+
+/**
+ * The {@code ValueJoinerWithKey} interface for joining two values into a new value of arbitrary type.
+ * This interface provides access to a read-only key that the user should not modify as this would lead to
+ * undefined behavior
+ * This is a stateless operation, i.e, {@link #apply(Object, Object, Object)} is invoked individually for each joining
+ * record-pair of a {@link KStream}-{@link KStream}, {@link KStream}-{@link KTable}, or {@link KTable}-{@link KTable}
+ * join.
+ *
+ * @param <K1> key value type
+ * @param <V1> first value type
+ * @param <V2> second value type
+ * @param <VR> joined value type
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows, StreamJoined)
+ * @see KStream#join(KTable, ValueJoinerWithKey)
+ * @see KStream#join(KTable, ValueJoinerWithKey, Joined)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey, Joined)
+ * @see KTable#join(KTable, ValueJoinerWithKey)
+ * @see KTable#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KTable#outerJoin(KTable, ValueJoinerWithKey)
+ */
+public interface ValueJoinerWithKey<K1, V1, V2, VR> {
+
+    /**
+     * Return a joined value consisting of {@code readOnlyKey}, {@code value1} and {@code value2}.
+     *
+     * @param readOnlyKey the key
+     * @param value1 the first value for joining
+     * @param value2 the second value for joining
+     * @return the joined value
+     */
+    VR apply(final K1 readOnlyKey, final V1 value1, final V2 value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.internals.ApiUtils;
 import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformer;
@@ -101,6 +102,10 @@ public abstract class AbstractStream<K, V> {
         return (value2, value1) -> joiner.apply(value1, value2);
     }
 
+    static <K, T2, T1, R> ValueJoinerWithKey<K, T2, T1, R> reverseJoinerWithKey(final ValueJoinerWithKey<K, T1, T2, R> joiner) {
+        return (key, value2, value1) -> joiner.apply(key, value1, value2);
+    }
+
     static <K, V, VR> ValueMapperWithKey<K, V, VR> withKey(final ValueMapper<V, VR> valueMapper) {
         Objects.requireNonNull(valueMapper, "valueMapper can't be null");
         return (readOnlyKey, value) -> valueMapper.apply(value);
@@ -137,6 +142,11 @@ public abstract class AbstractStream<K, V> {
                 return valueTransformerSupplier.stores();
             }
         };
+    }
+
+    static <K, V1, V2, VR> ValueJoinerWithKey<K, V1, V2, VR> toValueJoinerWithKey(final ValueJoiner<V1, V2, VR> valueJoiner) {
+        Objects.requireNonNull(valueJoiner, "joiner can't be null");
+        return (readOnlyKey, value1, value2) -> valueJoiner.apply(value1, value2);
     }
 
     // for testing only

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoin.java
@@ -17,19 +17,19 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
 class KStreamGlobalKTableJoin<K1, K2, R, V1, V2> implements ProcessorSupplier<K1, V1> {
 
     private final KTableValueGetterSupplier<K2, V2> valueGetterSupplier;
-    private final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
+    private final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner;
     private final KeyValueMapper<? super K1, ? super V1, ? extends K2> mapper;
     private final boolean leftJoin;
 
     KStreamGlobalKTableJoin(final KTableValueGetterSupplier<K2, V2> valueGetterSupplier,
-                            final ValueJoiner<? super V1, ? super V2, ? extends R> joiner,
+                            final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner,
                             final KeyValueMapper<? super K1, ? super V1, ? extends K2> mapper,
                             final boolean leftJoin) {
         this.valueGetterSupplier = valueGetterSupplier;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -39,6 +39,7 @@ import org.apache.kafka.streams.kstream.Repartitioned;
 import org.apache.kafka.streams.kstream.StreamJoined;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
 import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
@@ -842,7 +843,14 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     public <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                         final JoinWindows windows) {
-        return join(otherStream, joiner, windows, Joined.with(null, null, null));
+        return join(otherStream, toValueJoinerWithKey(joiner), windows);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                        final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                        final JoinWindows windows) {
+        return join(otherStream, joiner, windows, StreamJoined.with(null, null, null));
     }
 
     @Override
@@ -871,19 +879,35 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                         final JoinWindows windows,
                                         final StreamJoined<K, V, VO> streamJoined) {
 
+        return join(otherStream, toValueJoinerWithKey(joiner), windows, streamJoined);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> join(final KStream<K, VO> otherStream,
+                                        final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                        final JoinWindows windows,
+                                        final StreamJoined<K, V, VO> streamJoined) {
+
         return doJoin(
-            otherStream,
-            joiner,
-            windows,
-            streamJoined,
-            new KStreamImplJoin(builder, false, false));
+                otherStream,
+                joiner,
+                windows,
+                streamJoined,
+                new KStreamImplJoin(builder, false, false));
     }
 
     @Override
     public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                             final JoinWindows windows) {
-        return leftJoin(otherStream, joiner, windows, Joined.with(null, null, null));
+        return leftJoin(otherStream, toValueJoinerWithKey(joiner), windows);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                            final JoinWindows windows) {
+        return leftJoin(otherStream, joiner, windows, StreamJoined.with(null, null, null));
     }
 
     @Override
@@ -912,17 +936,37 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                             final StreamJoined<K, V, VO> streamJoined) {
         return doJoin(
             otherStream,
-            joiner,
+            toValueJoinerWithKey(joiner),
             windows,
             streamJoined,
             new KStreamImplJoin(builder, true, false));
     }
 
     @Override
+    public <VO, VR> KStream<K, VR> leftJoin(final KStream<K, VO> otherStream,
+                                            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                            final JoinWindows windows,
+                                            final StreamJoined<K, V, VO> streamJoined) {
+        return doJoin(
+                otherStream,
+                joiner,
+                windows,
+                streamJoined,
+                new KStreamImplJoin(builder, true, false));
+    }
+
+    @Override
     public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
                                              final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
                                              final JoinWindows windows) {
-        return outerJoin(otherStream, joiner, windows, Joined.with(null, null, null));
+        return outerJoin(otherStream, toValueJoinerWithKey(joiner), windows);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                             final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                             final JoinWindows windows) {
+        return outerJoin(otherStream, joiner, windows, StreamJoined.with(null, null, null));
     }
 
     @Override
@@ -950,11 +994,20 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                              final JoinWindows windows,
                                              final StreamJoined<K, V, VO> streamJoined) {
 
+        return outerJoin(otherStream, toValueJoinerWithKey(joiner), windows, streamJoined);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> outerJoin(final KStream<K, VO> otherStream,
+                                             final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                             final JoinWindows windows,
+                                             final StreamJoined<K, V, VO> streamJoined) {
+
         return doJoin(otherStream, joiner, windows, streamJoined, new KStreamImplJoin(builder, true, true));
     }
 
     private <VO, VR> KStream<K, VR> doJoin(final KStream<K, VO> otherStream,
-                                           final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                           final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
                                            final JoinWindows windows,
                                            final StreamJoined<K, V, VO> streamJoined,
                                            final KStreamImplJoin join) {
@@ -1080,6 +1133,12 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     @Override
     public <VO, VR> KStream<K, VR> join(final KTable<K, VO> table,
                                         final ValueJoiner<? super V, ? super VO, ? extends VR> joiner) {
+        return join(table, toValueJoinerWithKey(joiner));
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> join(final KTable<K, VO> table,
+                                        final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner) {
         return join(table, joiner, Joined.with(null, null, null));
     }
 
@@ -1090,15 +1149,25 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(table, "table can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(joined, "joined can't be null");
+        return join(table, toValueJoinerWithKey(joiner), joined);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> join(final KTable<K, VO> table,
+                                        final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                        final Joined<K, V, VO> joined) {
+        Objects.requireNonNull(table, "table can't be null");
+        Objects.requireNonNull(joiner, "joiner can't be null");
+        Objects.requireNonNull(joined, "joined can't be null");
 
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
         final String name = joinedInternal.name();
 
         if (repartitionRequired) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
-                name != null ? name : this.name,
-                joined.keySerde(),
-                joined.valueSerde()
+                    name != null ? name : this.name,
+                    joined.keySerde(),
+                    joined.valueSerde()
             );
             return thisStreamRepartitioned.doStreamTableJoin(table, joiner, joined, false);
         } else {
@@ -1108,6 +1177,11 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     @Override
     public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> table, final ValueJoiner<? super V, ? super VO, ? extends VR> joiner) {
+        return leftJoin(table, toValueJoinerWithKey(joiner));
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> table, final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner) {
         return leftJoin(table, joiner, Joined.with(null, null, null));
     }
 
@@ -1119,14 +1193,24 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(joined, "joined can't be null");
 
+        return leftJoin(table, toValueJoinerWithKey(joiner), joined);
+    }
+
+    @Override
+    public <VO, VR> KStream<K, VR> leftJoin(final KTable<K, VO> table,
+                                            final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
+                                            final Joined<K, V, VO> joined) {
+        Objects.requireNonNull(table, "table can't be null");
+        Objects.requireNonNull(joiner, "joiner can't be null");
+        Objects.requireNonNull(joined, "joined can't be null");
         final JoinedInternal<K, V, VO> joinedInternal = new JoinedInternal<>(joined);
-        final String internalName = joinedInternal.name();
+        final String name = joinedInternal.name();
 
         if (repartitionRequired) {
             final KStreamImpl<K, V> thisStreamRepartitioned = repartitionForJoin(
-                internalName != null ? internalName : name,
-                joined.keySerde(),
-                joined.valueSerde()
+                    name != null ? name : this.name,
+                    joined.keySerde(),
+                    joined.valueSerde()
             );
             return thisStreamRepartitioned.doStreamTableJoin(table, joiner, joined, true);
         } else {
@@ -1138,6 +1222,13 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     public <KG, VG, VR> KStream<K, VR> join(final GlobalKTable<KG, VG> globalTable,
                                             final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                             final ValueJoiner<? super V, ? super VG, ? extends VR> joiner) {
+        return join(globalTable, keySelector, toValueJoinerWithKey(joiner));
+    }
+
+    @Override
+    public <KG, VG, VR> KStream<K, VR> join(final GlobalKTable<KG, VG> globalTable,
+                                            final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
+                                            final ValueJoinerWithKey<? super K, ? super V, ? super VG, ? extends VR> joiner) {
         return globalTableJoin(globalTable, keySelector, joiner, false, NamedInternal.empty());
     }
 
@@ -1146,6 +1237,14 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                             final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                             final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
                                             final Named named) {
+        return join(globalTable, keySelector, toValueJoinerWithKey(joiner), named);
+    }
+
+    @Override
+    public <KG, VG, VR> KStream<K, VR> join(final GlobalKTable<KG, VG> globalTable,
+                                            final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
+                                            final ValueJoinerWithKey<? super K, ? super V, ? super VG, ? extends VR> joiner,
+                                            final Named named) {
         return globalTableJoin(globalTable, keySelector, joiner, false, named);
     }
 
@@ -1153,6 +1252,13 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
     public <KG, VG, VR> KStream<K, VR> leftJoin(final GlobalKTable<KG, VG> globalTable,
                                                 final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                                 final ValueJoiner<? super V, ? super VG, ? extends VR> joiner) {
+        return leftJoin(globalTable, keySelector, toValueJoinerWithKey(joiner));
+    }
+
+    @Override
+    public <KG, VG, VR> KStream<K, VR> leftJoin(final GlobalKTable<KG, VG> globalTable,
+                                                final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
+                                                final ValueJoinerWithKey<? super K, ? super V, ? super VG, ? extends VR> joiner) {
         return globalTableJoin(globalTable, keySelector, joiner, true, NamedInternal.empty());
     }
 
@@ -1161,12 +1267,20 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
                                                 final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
                                                 final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
                                                 final Named named) {
+        return leftJoin(globalTable, keySelector, toValueJoinerWithKey(joiner), named);
+    }
+
+    @Override
+    public <KG, VG, VR> KStream<K, VR> leftJoin(final GlobalKTable<KG, VG> globalTable,
+                                                final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
+                                                final ValueJoinerWithKey<? super K, ? super V, ? super VG, ? extends VR> joiner,
+                                                final Named named) {
         return globalTableJoin(globalTable, keySelector, joiner, true, named);
     }
 
     private <KG, VG, VR> KStream<K, VR> globalTableJoin(final GlobalKTable<KG, VG> globalTable,
                                                         final KeyValueMapper<? super K, ? super V, ? extends KG> keySelector,
-                                                        final ValueJoiner<? super V, ? super VG, ? extends VR> joiner,
+                                                        final ValueJoinerWithKey<? super K, ? super V, ? super VG, ? extends VR> joiner,
                                                         final boolean leftJoin,
                                                         final Named named) {
         Objects.requireNonNull(globalTable, "globalTable can't be null");
@@ -1201,7 +1315,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
     @SuppressWarnings("unchecked")
     private <VO, VR> KStream<K, VR> doStreamTableJoin(final KTable<K, VO> table,
-                                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
+                                                      final ValueJoinerWithKey<? super K, ? super V, ? super VO, ? extends VR> joiner,
                                                       final Joined<K, V, VO> joined,
                                                       final boolean leftJoin) {
         Objects.requireNonNull(table, "table can't be null");

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -22,11 +22,11 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.StreamJoined;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
+import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorGraphNode;
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StreamStreamJoinNode;
-import org.apache.kafka.streams.kstream.internals.graph.GraphNode;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
@@ -55,7 +55,7 @@ class KStreamImplJoin {
 
     public <K1, R, V1, V2> KStream<K1, R> join(final KStream<K1, V1> lhs,
                                                final KStream<K1, V2> other,
-                                               final ValueJoiner<? super V1, ? super V2, ? extends R> joiner,
+                                               final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner,
                                                final JoinWindows windows,
                                                final StreamJoined<K1, V1, V2> streamJoined) {
 
@@ -130,7 +130,7 @@ class KStreamImplJoin {
             thisWindowStore.name(),
             windows.afterMs,
             windows.beforeMs,
-            AbstractStream.reverseJoiner(joiner),
+            AbstractStream.reverseJoinerWithKey(joiner),
             rightOuter
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -39,13 +39,13 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
     private final long joinBeforeMs;
     private final long joinAfterMs;
 
-    private final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
+    private final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joiner;
     private final boolean outer;
 
     KStreamKStreamJoin(final String otherWindowName,
                        final long joinBeforeMs,
                        final long joinAfterMs,
-                       final ValueJoiner<? super V1, ? super V2, ? extends R> joiner,
+                       final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joiner,
                        final boolean outer) {
         this.otherWindowName = otherWindowName;
         this.joinBeforeMs = joinBeforeMs;
@@ -104,12 +104,12 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
                     final KeyValue<Long, V2> otherRecord = iter.next();
                     context().forward(
                         key,
-                        joiner.apply(value, otherRecord.value),
+                        joiner.apply(key, value, otherRecord.value),
                         To.all().withTimestamp(Math.max(inputRecordTimestamp, otherRecord.key)));
                 }
 
                 if (needOuterJoin) {
-                    context().forward(key, joiner.apply(value, null));
+                    context().forward(key, joiner.apply(key, value, null));
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
@@ -25,11 +25,11 @@ class KStreamKTableJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
 
     private final KeyValueMapper<K, V1, K> keyValueMapper = (key, value) -> key;
     private final KTableValueGetterSupplier<K, V2> valueGetterSupplier;
-    private final ValueJoiner<? super V1, ? super V2, R> joiner;
+    private final ValueJoinerWithKey<? super K, ? super V1, ? super V2, R> joiner;
     private final boolean leftJoin;
 
     KStreamKTableJoin(final KTableValueGetterSupplier<K, V2> valueGetterSupplier,
-                      final ValueJoiner<? super V1, ? super V2, R> joiner,
+                      final ValueJoinerWithKey<? super K, ? super V1, ? super V2, R> joiner,
                       final boolean leftJoin) {
         this.valueGetterSupplier = valueGetterSupplier;
         this.joiner = joiner;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -33,14 +33,14 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
 
     private final KTableValueGetter<K2, V2> valueGetter;
     private final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper;
-    private final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
+    private final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner;
     private final boolean leftJoin;
     private StreamsMetricsImpl metrics;
     private Sensor droppedRecordsSensor;
 
     KStreamKTableJoinProcessor(final KTableValueGetter<K2, V2> valueGetter,
                                final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper,
-                               final ValueJoiner<? super V1, ? super V2, ? extends R> joiner,
+                               final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner,
                                final boolean leftJoin) {
         this.valueGetter = valueGetter;
         this.keyMapper = keyMapper;
@@ -76,7 +76,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
         } else {
             final V2 value2 = getValueOrNull(valueGetter.get(mappedKey));
             if (leftJoin || value2 != null) {
-                context().forward(key, joiner.apply(value, value2));
+                context().forward(key, joiner.apply(key, value, value2));
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseJoinProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/BaseJoinProcessorNode.java
@@ -17,7 +17,7 @@
 
 package org.apache.kafka.streams.kstream.internals.graph;
 
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 
 /**
  * Utility base class containing the common fields between
@@ -28,13 +28,13 @@ abstract class BaseJoinProcessorNode<K, V1, V2, VR> extends GraphNode {
     private final ProcessorParameters<K, V1, ?, ?> joinThisProcessorParameters;
     private final ProcessorParameters<K, V2, ?, ?> joinOtherProcessorParameters;
     private final ProcessorParameters<K, VR, ?, ?> joinMergeProcessorParameters;
-    private final ValueJoiner<? super V1, ? super V2, ? extends VR> valueJoiner;
+    private final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends VR> valueJoiner;
     private final String thisJoinSideNodeName;
     private final String otherJoinSideNodeName;
 
 
     BaseJoinProcessorNode(final String nodeName,
-                          final ValueJoiner<? super V1, ? super V2, ? extends VR> valueJoiner,
+                          final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends VR> valueJoiner,
                           final ProcessorParameters<K, V1, ?, ?> joinThisProcessorParameters,
                           final ProcessorParameters<K, V2, ?, ?> joinOtherProcessorParameters,
                           final ProcessorParameters<K, VR, ?, ?> joinMergeProcessorParameters,
@@ -63,7 +63,7 @@ abstract class BaseJoinProcessorNode<K, V1, V2, VR> extends GraphNode {
         return joinMergeProcessorParameters;
     }
 
-    ValueJoiner<? super V1, ? super V2, ? extends VR> valueJoiner() {
+    ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends VR> valueJoiner() {
         return valueJoiner;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamStreamJoinNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StreamStreamJoinNode.java
@@ -18,7 +18,7 @@
 package org.apache.kafka.streams.kstream.internals.graph;
 
 import org.apache.kafka.streams.kstream.Joined;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.WindowStore;
@@ -36,7 +36,7 @@ public class StreamStreamJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
 
 
     private StreamStreamJoinNode(final String nodeName,
-                                 final ValueJoiner<? super V1, ? super V2, ? extends VR> valueJoiner,
+                                 final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends VR> valueJoiner,
                                  final ProcessorParameters<K, V1, ?, ?> joinThisProcessorParameters,
                                  final ProcessorParameters<K, V2, ?, ?> joinOtherProcessParameters,
                                  final ProcessorParameters<K, VR, ?, ?> joinMergeProcessorParameters,
@@ -96,7 +96,7 @@ public class StreamStreamJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
     public static final class StreamStreamJoinNodeBuilder<K, V1, V2, VR> {
 
         private String nodeName;
-        private ValueJoiner<? super V1, ? super V2, ? extends VR> valueJoiner;
+        private ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends VR> valueJoiner;
         private ProcessorParameters<K, V1, ?, ?> joinThisProcessorParameters;
         private ProcessorParameters<K, V2, ?, ?> joinOtherProcessorParameters;
         private ProcessorParameters<K, VR, ?, ?> joinMergeProcessorParameters;
@@ -111,7 +111,7 @@ public class StreamStreamJoinNode<K, V1, V2, VR> extends BaseJoinProcessorNode<K
         }
 
 
-        public StreamStreamJoinNodeBuilder<K, V1, V2, VR> withValueJoiner(final ValueJoiner<? super V1, ? super V2, ? extends VR> valueJoiner) {
+        public StreamStreamJoinNodeBuilder<K, V1, V2, VR> withValueJoiner(final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends VR> valueJoiner) {
             this.valueJoiner = valueJoiner;
             return this;
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -801,10 +801,10 @@ public class KStreamImplTest {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.join(
-                testStream,
-                    (ValueJoiner<? super String, ? super String, ?>) null,
-                JoinWindows.of(ofMillis(10)),
-                StreamJoined.as("name")));
+                  testStream,
+                  (ValueJoiner<? super String, ? super String, ?>) null,
+                  JoinWindows.of(ofMillis(10)),
+                  StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -946,7 +946,7 @@ public class KStreamImplTest {
             NullPointerException.class,
             () -> testStream.leftJoin(
                 testStream,
-                    (ValueJoiner<? super String, ? super String, ?>) null,
+                (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
@@ -1091,7 +1091,7 @@ public class KStreamImplTest {
             NullPointerException.class,
             () -> testStream.outerJoin(
                 testStream,
-                    (ValueJoiner<? super String, ? super String, ?>) null,
+                (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
@@ -1342,7 +1342,7 @@ public class KStreamImplTest {
             () -> testStream.join(
                 testGlobalTable,
                 MockMapper.selectValueMapper(),
-                    (ValueJoiner<? super String, ? super String, ?>) null,
+                (ValueJoiner<? super String, ? super String, ?>) null,
                 Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
@@ -1422,7 +1422,7 @@ public class KStreamImplTest {
             () -> testStream.leftJoin(
                 testGlobalTable,
                 MockMapper.selectValueMapper(),
-                    (ValueJoiner<? super String, ? super String, ?>) null,
+                (ValueJoiner<? super String, ? super String, ?>) null,
                 Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -769,7 +769,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueJoinerOnJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.join(testStream, null, JoinWindows.of(ofMillis(10))));
+            () -> testStream.join(testStream, (ValueJoiner<? super String, ? super String, ?>) null, JoinWindows.of(ofMillis(10))));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -792,7 +792,7 @@ public class KStreamImplTest {
             NullPointerException.class,
             () -> testStream.join(
                 testStream,
-                null,
+                    (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
@@ -893,7 +893,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueJoinerOnLeftJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.leftJoin(testStream, null, JoinWindows.of(ofMillis(10))));
+            () -> testStream.leftJoin(testStream, (ValueJoiner<? super String, ? super String, ?>) null, JoinWindows.of(ofMillis(10))));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -916,7 +916,7 @@ public class KStreamImplTest {
             NullPointerException.class,
             () -> testStream.leftJoin(
                 testStream,
-                null,
+                    (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
@@ -1017,7 +1017,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueJoinerOnOuterJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.outerJoin(testStream, null, JoinWindows.of(ofMillis(10))));
+            () -> testStream.outerJoin(testStream, (ValueJoiner<? super String, ? super String, ?>) null, JoinWindows.of(ofMillis(10))));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1040,7 +1040,7 @@ public class KStreamImplTest {
             NullPointerException.class,
             () -> testStream.outerJoin(
                 testStream,
-                null,
+                    (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
@@ -1124,7 +1124,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueMapperOnTableJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.join(testTable, null));
+            () -> testStream.join(testTable, (ValueJoiner<? super String, ? super String, ?>) null));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1132,7 +1132,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueMapperOnTableJoinWithJoiner() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.join(testTable, null, Joined.as("name")));
+            () -> testStream.join(testTable, (ValueJoiner<? super String, ? super String, ?>) null, Joined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1164,7 +1164,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueMapperOnTableLeftJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.leftJoin(testTable, null));
+            () -> testStream.leftJoin(testTable, (ValueJoiner<? super String, ? super String, ?>) null));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1172,7 +1172,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullValueMapperOnTableLeftJoinWithJoined() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.leftJoin(testTable, null, Joined.as("name")));
+            () -> testStream.leftJoin(testTable, (ValueJoiner<? super String, ? super String, ?>) null, Joined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1228,7 +1228,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullJoinerOnJoinWithGlobalTable() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.join(testGlobalTable, MockMapper.selectValueMapper(), null));
+            () -> testStream.join(testGlobalTable, MockMapper.selectValueMapper(), (ValueJoiner<? super String, ? super String, ?>) null));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1239,7 +1239,7 @@ public class KStreamImplTest {
             () -> testStream.join(
                 testGlobalTable,
                 MockMapper.selectValueMapper(),
-                null,
+                    (ValueJoiner<? super String, ? super String, ?>) null,
                 Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
@@ -1288,7 +1288,7 @@ public class KStreamImplTest {
     public void shouldNotAllowNullJoinerOnLeftJoinWithGlobalTable() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
-            () -> testStream.leftJoin(testGlobalTable, MockMapper.selectValueMapper(), null));
+            () -> testStream.leftJoin(testGlobalTable, MockMapper.selectValueMapper(), (ValueJoiner<? super String, ? super String, ?>) null));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1299,7 +1299,7 @@ public class KStreamImplTest {
             () -> testStream.leftJoin(
                 testGlobalTable,
                 MockMapper.selectValueMapper(),
-                null,
+                    (ValueJoiner<? super String, ? super String, ?>) null,
                 Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -1430,12 +1430,12 @@ public class KStreamImplTest {
     @Test
     public void shouldNotAllowNullValueJoinerWithKeyOnLeftJoinWithGlobalTableWithNamed() {
         final NullPointerException exception = assertThrows(
-                NullPointerException.class,
-                () -> testStream.leftJoin(
-                        testGlobalTable,
-                        MockMapper.selectValueMapper(),
-                        (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
-                        Named.as("name")));
+            NullPointerException.class,
+            () -> testStream.leftJoin(
+                    testGlobalTable,
+                    MockMapper.selectValueMapper(),
+                    (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
+                    Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -46,6 +46,7 @@ import org.apache.kafka.streams.kstream.StreamJoined;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.kstream.TransformerSupplier;
 import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformer;
@@ -773,6 +774,15 @@ public class KStreamImplTest {
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnJoin() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.join(testStream, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null, JoinWindows.of(ofMillis(10))));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+
     @Deprecated
     @Test
     public void shouldNotAllowNullValueJoinerOnJoinWithJoined() {
@@ -795,6 +805,18 @@ public class KStreamImplTest {
                     (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnJoinWithStreamJoined() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.join(
+                    testStream,
+                    (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
+                    JoinWindows.of(ofMillis(10)),
+                    StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -897,6 +919,14 @@ public class KStreamImplTest {
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnLeftJoin() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.leftJoin(testStream, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null, JoinWindows.of(ofMillis(10))));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
     @Deprecated
     @Test
     public void shouldNotAllowNullValueJoinerOnLeftJoinWithJoined() {
@@ -921,6 +951,19 @@ public class KStreamImplTest {
                 StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnLeftJoinWithStreamJoined() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.leftJoin(
+                testStream,
+                    (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
+                    JoinWindows.of(ofMillis(10)),
+                    StreamJoined.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
 
     @Test
     public void shouldNotAllowNullJoinWindowsOnLeftJoin() {
@@ -1021,6 +1064,14 @@ public class KStreamImplTest {
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnOuterJoin() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.outerJoin(testStream, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null, JoinWindows.of(ofMillis(10))));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
     @Deprecated
     @Test
     public void shouldNotAllowNullValueJoinerOnOuterJoinWithJoined() {
@@ -1043,6 +1094,18 @@ public class KStreamImplTest {
                     (ValueJoiner<? super String, ? super String, ?>) null,
                 JoinWindows.of(ofMillis(10)),
                 StreamJoined.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnOuterJoinWithStreamJoined() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.outerJoin(
+                    testStream,
+                    (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
+                    JoinWindows.of(ofMillis(10)),
+                    StreamJoined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1121,7 +1184,7 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullValueMapperOnTableJoin() {
+    public void shouldNotAllowNullValueJoinerOnTableJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.join(testTable, (ValueJoiner<? super String, ? super String, ?>) null));
@@ -1129,10 +1192,26 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullValueMapperOnTableJoinWithJoiner() {
+    public void shouldNotAllowNullValueJoinerWithKeyOnTableJoin() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.join(testTable, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerOnTableJoinWithJoiner() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.join(testTable, (ValueJoiner<? super String, ? super String, ?>) null, Joined.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnTableJoinWithJoiner() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.join(testTable, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null, Joined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1161,7 +1240,7 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullValueMapperOnTableLeftJoin() {
+    public void shouldNotAllowNullValueJoinerOnTableLeftJoin() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.leftJoin(testTable, (ValueJoiner<? super String, ? super String, ?>) null));
@@ -1169,10 +1248,26 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullValueMapperOnTableLeftJoinWithJoined() {
+    public void shouldNotAllowNullValueJoinerWithKeyOnTableLeftJoin() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.leftJoin(testTable, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerOnTableLeftJoinWithJoined() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.leftJoin(testTable, (ValueJoiner<? super String, ? super String, ?>) null, Joined.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnTableLeftJoinWithJoined() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.leftJoin(testTable, (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null, Joined.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1225,7 +1320,7 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullJoinerOnJoinWithGlobalTable() {
+    public void shouldNotAllowNullValueJoinerOnJoinWithGlobalTable() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.join(testGlobalTable, MockMapper.selectValueMapper(), (ValueJoiner<? super String, ? super String, ?>) null));
@@ -1233,7 +1328,15 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullJoinerOnJoinWithGlobalTableWithNamed() {
+    public void shouldNotAllowNullValueJoinerWithKeyOnJoinWithGlobalTable() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.join(testGlobalTable, MockMapper.selectValueMapper(), (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerOnJoinWithGlobalTableWithNamed() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.join(
@@ -1241,6 +1344,18 @@ public class KStreamImplTest {
                 MockMapper.selectValueMapper(),
                     (ValueJoiner<? super String, ? super String, ?>) null,
                 Named.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnJoinWithGlobalTableWithNamed() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.join(
+                    testGlobalTable,
+                    MockMapper.selectValueMapper(),
+                    (ValueJoiner<? super String, ? super String, ?>) null,
+                    Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 
@@ -1285,7 +1400,7 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullJoinerOnLeftJoinWithGlobalTable() {
+    public void shouldNotAllowNullValueJoinerOnLeftJoinWithGlobalTable() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.leftJoin(testGlobalTable, MockMapper.selectValueMapper(), (ValueJoiner<? super String, ? super String, ?>) null));
@@ -1293,7 +1408,15 @@ public class KStreamImplTest {
     }
 
     @Test
-    public void shouldNotAllowNullJoinerOnLeftJoinWithGlobalTableWithNamed() {
+    public void shouldNotAllowNullValueJoinerWithKeyOnLeftJoinWithGlobalTable() {
+        final NullPointerException exception = assertThrows(
+            NullPointerException.class,
+            () -> testStream.leftJoin(testGlobalTable, MockMapper.selectValueMapper(), (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerOnLeftJoinWithGlobalTableWithNamed() {
         final NullPointerException exception = assertThrows(
             NullPointerException.class,
             () -> testStream.leftJoin(
@@ -1301,6 +1424,18 @@ public class KStreamImplTest {
                 MockMapper.selectValueMapper(),
                     (ValueJoiner<? super String, ? super String, ?>) null,
                 Named.as("name")));
+        assertThat(exception.getMessage(), equalTo("joiner can't be null"));
+    }
+
+    @Test
+    public void shouldNotAllowNullValueJoinerWithKeyOnLeftJoinWithGlobalTableWithNamed() {
+        final NullPointerException exception = assertThrows(
+                NullPointerException.class,
+                () -> testStream.leftJoin(
+                        testGlobalTable,
+                        MockMapper.selectValueMapper(),
+                        (ValueJoinerWithKey<? super String, ? super String, ? super String, ?>) null,
+                        Named.as("name")));
         assertThat(exception.getMessage(), equalTo("joiner can't be null"));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplValueJoinerWithKeyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplValueJoinerWithKeyTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
+import org.apache.kafka.test.StreamsTestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import static java.time.Duration.ofMillis;
+import static org.junit.Assert.assertEquals;
+
+public class KStreamImplValueJoinerWithKeyTest {
+
+    private KStream<String, Integer> leftStream;
+    private KStream<String, Integer> rightStream;
+    private KTable<String, Integer> ktable;
+    private GlobalKTable<String, Integer> globalKTable;
+    private StreamsBuilder builder;
+
+    private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
+    private final String leftTopic = "left";
+    private final String rightTopic = "right";
+    private final String ktableTopic = "ktableTopic";
+    private final String globalTopic = "globalTopic";
+    private final String outputTopic = "joined-result";
+
+    private final ValueJoinerWithKey<String, Integer, Integer, String> valueJoinerWithKey =
+        (key, lv, rv) -> key + ":" + (lv + (rv == null ? 0 : rv));
+    private final JoinWindows joinWindows = JoinWindows.of(ofMillis(100));
+    private final StreamJoined<String, Integer, Integer> streamJoined =
+            StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
+    private final Joined<String, Integer, Integer> joined =
+            Joined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
+    private final KeyValueMapper<String, Integer, String> keyValueMapper =
+        (k, v) -> k;
+
+    @Before
+    public void setup() {
+        builder = new StreamsBuilder();
+        leftStream = builder.stream(leftTopic, Consumed.with(Serdes.String(), Serdes.Integer()));
+        rightStream = builder.stream(rightTopic, Consumed.with(Serdes.String(), Serdes.Integer()));
+        ktable = builder.table(ktableTopic, Consumed.with(Serdes.String(), Serdes.Integer()));
+        globalKTable = builder.globalTable(globalTopic, Consumed.with(Serdes.String(), Serdes.Integer()));
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamSteamJoinResults() {
+        leftStream.join(
+                rightStream,
+                valueJoinerWithKey,
+                joinWindows,
+                streamJoined
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        // Left KV A, 3, Right KV A, 5
+        runJoinTopology(builder,
+                Collections.singletonList(KeyValue.pair("A", "A:5")),
+                false,
+                rightTopic
+        );
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamLeftJoinResults() {
+        leftStream.leftJoin(
+                rightStream,
+                valueJoinerWithKey,
+                joinWindows,
+                streamJoined
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        // Left KV A, 3, Right KV A, 5
+        // TTD pipes records to left stream first, then right
+        // with TTD there's no caching, so join emits immediately with "A, 3, null" then "A, 3, 5"
+        final List<KeyValue<String, String>> expectedResults = Arrays.asList(KeyValue.pair("A", "A:3"), KeyValue.pair("A", "A:5"));
+        runJoinTopology(builder,
+                expectedResults,
+                false,
+                rightTopic
+        );
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamOuterJoinResults() {
+        leftStream.outerJoin(
+                rightStream,
+                valueJoinerWithKey,
+                joinWindows,
+                streamJoined
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+
+        // Left KV A, 3, Right KV A, 5
+        // TTD pipes records to left stream first, then right
+        // with TTD there's no caching, so join emits immediately with "A, 3, null" then "A, 3, 5"
+        final List<KeyValue<String, String>> expectedResults = Arrays.asList(KeyValue.pair("A", "A:3"), KeyValue.pair("A", "A:5"));
+        runJoinTopology(builder,
+                expectedResults,
+                false,
+                rightTopic
+        );
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamTableJoinResults() {
+        leftStream.join(
+            ktable,
+            valueJoinerWithKey,
+            joined
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        // Left KV A, 3, Table KV A, 5
+        runJoinTopology(builder,
+                Collections.singletonList(KeyValue.pair("A", "A:5")),
+                true,
+                ktableTopic
+        );
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamTableLeftJoinResults() {
+        leftStream.leftJoin(
+            ktable,
+            valueJoinerWithKey,
+            joined
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        // Left KV A, 3, Table KV A, 5
+        runJoinTopology(builder,
+                Collections.singletonList(KeyValue.pair("A", "A:5")),
+                true,
+                ktableTopic
+        );
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamGlobalTableJoinResults() {
+        leftStream.join(
+            globalKTable,
+            keyValueMapper,
+            valueJoinerWithKey
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        // Left KV A, 3, GlobalTable KV A, 5
+        runJoinTopology(builder,
+                Collections.singletonList(KeyValue.pair("A", "A:5")),
+                true,
+                globalTopic
+        );
+    }
+
+    @Test
+    public void shouldIncludeKeyInStreamGlobalTableLeftJoinResults() {
+        leftStream.leftJoin(
+            globalKTable,
+            keyValueMapper,
+           valueJoinerWithKey
+        ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
+        // Left KV A, 3, GlobalTable KV A, 5
+        runJoinTopology(builder,
+                Collections.singletonList(KeyValue.pair("A", "A:5")),
+                true,
+                globalTopic
+        );
+    }
+
+
+    private void runJoinTopology(final StreamsBuilder builder,
+                                 final List<KeyValue<String, String>> expectedResults,
+                                 final boolean isTableJoin,
+                                 final String rightTopic) {
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+
+            final TestInputTopic<String, Integer> rightInputTopic =
+                    driver.createInputTopic(rightTopic, new StringSerializer(), new IntegerSerializer());
+
+            final TestInputTopic<String, Integer> leftInputTopic =
+                    driver.createInputTopic(leftTopic, new StringSerializer(), new IntegerSerializer());
+
+            final TestOutputTopic<String, String> joinResultTopic =
+                    driver.createOutputTopic(outputTopic, new StringDeserializer(), new StringDeserializer());
+
+            // with stream table joins need to make sure records hit
+            // the table first, joins only triggered from streams side
+            if (isTableJoin) {
+                rightInputTopic.pipeInput("A", 2);
+                leftInputTopic.pipeInput("A", 3);
+            } else {
+                leftInputTopic.pipeInput("A", 3);
+                rightInputTopic.pipeInput("A", 2);
+            }
+
+            final List<KeyValue<String, String>> actualResult = joinResultTopic.readKeyValuesToList();
+            assertEquals(expectedResults, actualResult);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements adding read-only access to the key for `KStream.join` as described in [KIP-149](https://cwiki.apache.org/confluence/display/KAFKA/KIP-149%3A+Enabling+key+access+in+ValueTransformer%2C+ValueMapper%2C+and+ValueJoiner)

This PR as it stands does not affect the Streams Scala API.  Updating the Streams Scala API will be done in a follow-up PR.
Additionally, the original KIP did not include the `KTable` API, but I don't see any reason why we wouldn't want the same functionality there as well, this will be done in an additional follow-up PR after updating the existing KIP.


Tests added
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
