### PR TITLE
MINOR: Correct warning

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/HighAvailabilityTaskAssignor.java
@@ -146,7 +146,7 @@ public class HighAvailabilityTaskAssignor implements TaskAssignor {
             if (numRemainingStandbys > 0) {
                 log.warn("Unable to assign {} of {} standby tasks for task [{}]. " +
                              "There is not enough available capacity. You should " +
-                             "increase the number of threads and/or application instances " +
+                             "increase the number of application instances " +
                              "to maintain the requested number of standby replicas.",
                          numRemainingStandbys, numStandbyReplicas, task);
             }


### PR DESCRIPTION
This warning is misleading since increasing the number of threads without increasing the number of Streams clients does not improve the situation when there is not enough available capacity for standby replicas.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
