### PR TITLE
MINOR: Added missing import to kafka.py

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -31,6 +31,7 @@ from kafkatest.services.security.minikdc import MiniKdc
 from kafkatest.services.security.listener_security_config import ListenerSecurityConfig
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.version import DEV_BRANCH
+from kafkatest.version import KafkaVersion
 from kafkatest.services.kafka.util import fix_opts_for_new_jvm
 
 


### PR DESCRIPTION
An import got removed from kafka.py and caused `downgrade_test` to fail. This PR adds the import back in.
Should also be applied to trunk.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
