### PR TITLE
KAFKA-12338: Consolidate MetadataRecordSerde and MetadataParser serial/deserial code

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ByteBufferAccessor.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ByteBufferAccessor.java
@@ -133,6 +133,11 @@ public class ByteBufferAccessor implements Readable, Writable {
         return ByteUtils.readVarlong(buf);
     }
 
+    @Override
+    public int remaining() {
+        return buf.remaining();
+    }
+
     public void flip() {
         buf.flip();
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/DataInputStreamReadable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/DataInputStreamReadable.java
@@ -119,6 +119,15 @@ public class DataInputStreamReadable implements Readable, Closeable {
     }
 
     @Override
+    public int remaining() {
+        try {
+            return input.available();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public void close() {
         try {
             input.close();

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Readable.java
@@ -37,6 +37,7 @@ public interface Readable {
     ByteBuffer readByteBuffer(int length);
     int readVarint();
     long readVarlong();
+    int remaining();
 
     default String readString(int length) {
         byte[] arr = new byte[length];

--- a/raft/src/main/java/org/apache/kafka/raft/metadata/MetadataRecordSerde.java
+++ b/raft/src/main/java/org/apache/kafka/raft/metadata/MetadataRecordSerde.java
@@ -17,13 +17,12 @@
 package org.apache.kafka.raft.metadata;
 
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.metadata.MetadataRecordType;
-import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.Writable;
 import org.apache.kafka.common.utils.ByteUtils;
 import org.apache.kafka.metadata.ApiMessageAndVersion;
+import org.apache.kafka.metadata.MetadataParser;
 import org.apache.kafka.raft.RecordSerde;
 
 public class MetadataRecordSerde implements RecordSerde<ApiMessageAndVersion> {
@@ -33,18 +32,14 @@ public class MetadataRecordSerde implements RecordSerde<ApiMessageAndVersion> {
     @Override
     public int recordSize(ApiMessageAndVersion data, ObjectSerializationCache serializationCache) {
         int size = DEFAULT_FRAME_VERSION_SIZE;
-        size += ByteUtils.sizeOfUnsignedVarint(data.message().apiKey());
-        size += ByteUtils.sizeOfUnsignedVarint(data.version());
-        size += data.message().size(serializationCache, data.version());
+        size += MetadataParser.size(data.message(), data.version(), serializationCache);
         return size;
     }
 
     @Override
     public void write(ApiMessageAndVersion data, ObjectSerializationCache serializationCache, Writable out) {
         out.writeUnsignedVarint(DEFAULT_FRAME_VERSION);
-        out.writeUnsignedVarint(data.message().apiKey());
-        out.writeUnsignedVarint(data.version());
-        data.message().write(out, serializationCache, data.version());
+        MetadataParser.write(data, serializationCache, out);
     }
 
     @Override
@@ -54,13 +49,7 @@ public class MetadataRecordSerde implements RecordSerde<ApiMessageAndVersion> {
             throw new SerializationException("Could not deserialize metadata record due to unknown frame version "
                 + frameVersion + "(only frame version " + DEFAULT_FRAME_VERSION + " is supported)");
         }
-
-        short apiKey = (short) input.readUnsignedVarint();
-        short version = (short) input.readUnsignedVarint();
-        MetadataRecordType recordType = MetadataRecordType.fromId(apiKey);
-        ApiMessage record = recordType.newMetadataRecord();
-        record.read(input, version);
-        return new ApiMessageAndVersion(record, version);
+        return MetadataParser.read(input, size);
     }
 
 }


### PR DESCRIPTION
*More detailed description of your change*
The logics are duplicated except that `MetadataRecordSerde` has an extra `DEFAULT_FRAME_VERSION`, if we want to change the serial/deserial format of metadata, we should modify 2 classes, this is unreasonable.

*Summary of testing strategy (including rationale)*
unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
