### PR TITLE
KAFKA-10357: Extract setup of changelog from Streams partition assignor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.streams.processor.internals.assignment.StreamsAssignmentProtocolVersions.UNKNOWN;
+
+public class ChangelogTopics {
+
+    private final InternalTopicManager internalTopicManager;
+    private final Map<Integer, TopicsInfo> topicGroups;
+    private final Map<Integer, Set<TaskId>> tasksForTopicGroup;
+    private final Map<TaskId, Set<TopicPartition>> changelogPartitionsForTask = new HashMap<>();
+    private final Map<TaskId, Set<TopicPartition>> preExistingChangelogPartitionsForTask = new HashMap<>();
+    private final Set<TopicPartition> preExistingNonSourceTopicBasedChangelogPartitions = new HashSet<>();
+    private final Set<String> sourceTopicBasedChangelogTopics = new HashSet<>();
+    private final Set<TopicPartition> sourceTopicBasedChangelogTopicPartitions = new HashSet<>();
+    private final Logger log;
+
+    public ChangelogTopics(final InternalTopicManager internalTopicManager,
+                           final Map<Integer, TopicsInfo> topicGroups,
+                           final Map<Integer, Set<TaskId>> tasksForTopicGroup,
+                           final String logPrefix) {
+        this.internalTopicManager = internalTopicManager;
+        this.topicGroups = topicGroups;
+        this.tasksForTopicGroup = tasksForTopicGroup;
+        final LogContext logContext = new LogContext(logPrefix);
+        log = logContext.logger(getClass());
+    }
+
+    public void setup() {
+        // add tasks to state change log topic subscribers
+        final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
+        for (final Map.Entry<Integer, TopicsInfo> entry : topicGroups.entrySet()) {
+            final int topicGroupId = entry.getKey();
+            final TopicsInfo topicsInfo = entry.getValue();
+
+            final Set<TaskId> topicGroupTasks = tasksForTopicGroup.get(topicGroupId);
+            if (topicGroupTasks == null) {
+                log.debug("No tasks found for topic group {}", topicGroupId);
+                continue;
+            } else if (topicsInfo.stateChangelogTopics.isEmpty()) {
+                continue;
+            }
+
+            for (final TaskId task : topicGroupTasks) {
+                final Set<TopicPartition> changelogTopicPartitions = topicsInfo.stateChangelogTopics
+                    .keySet()
+                    .stream()
+                    .map(topic -> new TopicPartition(topic, task.partition))
+                    .collect(Collectors.toSet());
+                changelogPartitionsForTask.put(task, changelogTopicPartitions);
+            }
+
+            for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
+                // the expected number of partitions is the max value of TaskId.partition + 1
+                int numPartitions = UNKNOWN;
+                for (final TaskId task : topicGroupTasks) {
+                    if (numPartitions < task.partition + 1) {
+                        numPartitions = task.partition + 1;
+                    }
+                }
+                topicConfig.setNumberOfPartitions(numPartitions);
+                changelogTopicMetadata.put(topicConfig.name(), topicConfig);
+            }
+            sourceTopicBasedChangelogTopics.addAll(topicsInfo.sourceTopicChangelogs());
+        }
+
+        final Set<String> newlyCreatedChangelogTopics = internalTopicManager.makeReady(changelogTopicMetadata);
+        log.debug("Created state changelog topics {} from the parsed topology.", changelogTopicMetadata.values());
+
+        for (final Map.Entry<TaskId, Set<TopicPartition>> entry : changelogPartitionsForTask.entrySet()) {
+            final TaskId taskId = entry.getKey();
+            final Set<TopicPartition> topicPartitions = entry.getValue();
+            for (final TopicPartition topicPartition : topicPartitions) {
+                if (!newlyCreatedChangelogTopics.contains(topicPartition.topic())) {
+                    preExistingChangelogPartitionsForTask.computeIfAbsent(taskId, task -> new HashSet<>()).add(topicPartition);
+                    if (!sourceTopicBasedChangelogTopics.contains(topicPartition.topic())) {
+                        preExistingNonSourceTopicBasedChangelogPartitions.add(topicPartition);
+                    } else {
+                        sourceTopicBasedChangelogTopicPartitions.add(topicPartition);
+                    }
+                }
+            }
+        }
+    }
+
+    public Set<TopicPartition> preExistingNonSourceTopicBasedPartitions() {
+        return Collections.unmodifiableSet(preExistingNonSourceTopicBasedChangelogPartitions);
+    }
+
+    public Set<TopicPartition> preExistingPartitionsFor(final TaskId taskId) {
+        if (preExistingChangelogPartitionsForTask.containsKey(taskId)) {
+            return Collections.unmodifiableSet(preExistingChangelogPartitionsForTask.get(taskId));
+        }
+        return Collections.emptySet();
+    }
+
+    public Set<TopicPartition> sourceTopicBasedPartitions() {
+        return Collections.unmodifiableSet(sourceTopicBasedChangelogTopicPartitions);
+    }
+
+    public Set<TaskId> taskIds() {
+        return Collections.unmodifiableSet(changelogPartitionsForTask.keySet());
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
@@ -36,11 +36,11 @@ public class ChangelogTopics {
     private final InternalTopicManager internalTopicManager;
     private final Map<Integer, TopicsInfo> topicGroups;
     private final Map<Integer, Set<TaskId>> tasksForTopicGroup;
-    private final Map<TaskId, Set<TopicPartition>> changelogPartitionsForTask = new HashMap<>();
+    private final Map<TaskId, Set<TopicPartition>> changelogPartitionsForStatefulTask = new HashMap<>();
     private final Map<TaskId, Set<TopicPartition>> preExistingChangelogPartitionsForTask = new HashMap<>();
     private final Set<TopicPartition> preExistingNonSourceTopicBasedChangelogPartitions = new HashSet<>();
     private final Set<String> sourceTopicBasedChangelogTopics = new HashSet<>();
-    private final Set<TopicPartition> sourceTopicBasedChangelogTopicPartitions = new HashSet<>();
+    private final Set<TopicPartition> preExsitingSourceTopicBasedChangelogPartitions = new HashSet<>();
     private final Logger log;
 
     public ChangelogTopics(final InternalTopicManager internalTopicManager,
@@ -75,7 +75,7 @@ public class ChangelogTopics {
                     .stream()
                     .map(topic -> new TopicPartition(topic, task.partition))
                     .collect(Collectors.toSet());
-                changelogPartitionsForTask.put(task, changelogTopicPartitions);
+                changelogPartitionsForStatefulTask.put(task, changelogTopicPartitions);
             }
 
             for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
@@ -95,7 +95,7 @@ public class ChangelogTopics {
         final Set<String> newlyCreatedChangelogTopics = internalTopicManager.makeReady(changelogTopicMetadata);
         log.debug("Created state changelog topics {} from the parsed topology.", changelogTopicMetadata.values());
 
-        for (final Map.Entry<TaskId, Set<TopicPartition>> entry : changelogPartitionsForTask.entrySet()) {
+        for (final Map.Entry<TaskId, Set<TopicPartition>> entry : changelogPartitionsForStatefulTask.entrySet()) {
             final TaskId taskId = entry.getKey();
             final Set<TopicPartition> topicPartitions = entry.getValue();
             for (final TopicPartition topicPartition : topicPartitions) {
@@ -104,7 +104,7 @@ public class ChangelogTopics {
                     if (!sourceTopicBasedChangelogTopics.contains(topicPartition.topic())) {
                         preExistingNonSourceTopicBasedChangelogPartitions.add(topicPartition);
                     } else {
-                        sourceTopicBasedChangelogTopicPartitions.add(topicPartition);
+                        preExsitingSourceTopicBasedChangelogPartitions.add(topicPartition);
                     }
                 }
             }
@@ -122,11 +122,11 @@ public class ChangelogTopics {
         return Collections.emptySet();
     }
 
-    public Set<TopicPartition> sourceTopicBasedPartitions() {
-        return Collections.unmodifiableSet(sourceTopicBasedChangelogTopicPartitions);
+    public Set<TopicPartition> preExistingSourceTopicBasedPartitions() {
+        return Collections.unmodifiableSet(preExsitingSourceTopicBasedChangelogPartitions);
     }
 
-    public Set<TaskId> taskIds() {
-        return Collections.unmodifiableSet(changelogPartitionsForTask.keySet());
+    public Set<TaskId> statefulTaskIds() {
+        return Collections.unmodifiableSet(changelogPartitionsForStatefulTask.keySet());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -577,7 +577,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
         final Map<UUID, ClientState> clientStates = new HashMap<>();
         final boolean lagComputationSuccessful =
-                populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
+            populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
 
         final Set<TaskId> allTasks = partitionsForTask.keySet();
         statefulTasks.addAll(changelogTopics.taskIds());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -580,7 +580,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
 
         final Set<TaskId> allTasks = partitionsForTask.keySet();
-        statefulTasks.addAll(changelogTopics.taskIds());
+        statefulTasks.addAll(changelogTopics.statefulTaskIds());
 
         log.debug("Assigning tasks {} to clients {} with number of replicas {}",
             allTasks, clientStates, numStandbyReplicas());
@@ -639,7 +639,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 fetchEndOffsetsFuture(changelogTopics.preExistingNonSourceTopicBasedPartitions(), adminClient);
 
             final Map<TopicPartition, Long> sourceChangelogEndOffsets =
-                fetchCommittedOffsets(changelogTopics.sourceTopicBasedPartitions(), mainConsumerSupplier.get());
+                fetchCommittedOffsets(changelogTopics.preExistingSourceTopicBasedPartitions(), mainConsumerSupplier.get());
 
             final Map<TopicPartition, ListOffsetsResultInfo> endOffsets = ClientUtils.getEndOffsets(endOffsetsFuture);
 
@@ -650,7 +650,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             );
             fetchEndOffsetsSuccessful = true;
         } catch (final StreamsException | TimeoutException e) {
-            allTaskEndOffsetSums = changelogTopics.taskIds().stream().collect(Collectors.toMap(t -> t, t -> UNKNOWN_OFFSET_SUM));
+            allTaskEndOffsetSums = changelogTopics.statefulTaskIds().stream().collect(Collectors.toMap(t -> t, t -> UNKNOWN_OFFSET_SUM));
             fetchEndOffsetsSuccessful = false;
         }
 
@@ -677,7 +677,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                                                          final ChangelogTopics changelogTopics) {
 
         final Map<TaskId, Long> taskEndOffsetSums = new HashMap<>();
-        for (final TaskId taskId : changelogTopics.taskIds()) {
+        for (final TaskId taskId : changelogTopics.statefulTaskIds()) {
             taskEndOffsetSums.put(taskId, 0L);
             for (final TopicPartition changelogPartition : changelogTopics.preExistingPartitionsFor(taskId)) {
                 final long changelogPartitionEndOffset;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -549,58 +549,6 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     }
 
     /**
-     * Resolve changelog topic metadata and create them if necessary. Fills in the changelogsByStatefulTask map and
-     * the optimizedSourceChangelogs set and returns the set of changelogs which were newly created.
-     */
-    private Set<String> prepareChangelogTopics(final Map<Integer, TopicsInfo> topicGroups,
-                                               final Map<Integer, Set<TaskId>> tasksForTopicGroup,
-                                               final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask,
-                                               final Set<String> optimizedSourceChangelogs) {
-        // add tasks to state change log topic subscribers
-        final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
-        for (final Map.Entry<Integer, TopicsInfo> entry : topicGroups.entrySet()) {
-            final int topicGroupId = entry.getKey();
-            final TopicsInfo topicsInfo = entry.getValue();
-
-            final Set<TaskId> topicGroupTasks = tasksForTopicGroup.get(topicGroupId);
-            if (topicGroupTasks == null) {
-                log.debug("No tasks found for topic group {}", topicGroupId);
-                continue;
-            } else if (topicsInfo.stateChangelogTopics.isEmpty()) {
-                continue;
-            }
-
-            for (final TaskId task : topicGroupTasks) {
-                changelogsByStatefulTask.put(
-                    task,
-                    topicsInfo.stateChangelogTopics
-                        .keySet()
-                        .stream()
-                        .map(topic -> new TopicPartition(topic, task.partition))
-                        .collect(Collectors.toSet()));
-            }
-
-            for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
-                 // the expected number of partitions is the max value of TaskId.partition + 1
-                int numPartitions = UNKNOWN;
-                for (final TaskId task : topicGroupTasks) {
-                    if (numPartitions < task.partition + 1) {
-                        numPartitions = task.partition + 1;
-                    }
-                }
-                topicConfig.setNumberOfPartitions(numPartitions);
-                changelogTopicMetadata.put(topicConfig.name(), topicConfig);
-            }
-
-            optimizedSourceChangelogs.addAll(topicsInfo.sourceTopicChangelogs());
-        }
-
-        final Set<String> newlyCreatedTopics = internalTopicManager.makeReady(changelogTopicMetadata);
-        log.debug("Created state changelog topics {} from the parsed topology.", changelogTopicMetadata.values());
-        return newlyCreatedTopics;
-    }
-
-    /**
      * Assigns a set of tasks to each client (Streams instance) using the configured task assignor, and also
      * populate the stateful tasks that have been assigned to the clients
      * @return true if a probing rebalance should be triggered
@@ -619,23 +567,20 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = new HashMap<>();
         populateTasksForMaps(taskForPartition, tasksForTopicGroup, allSourceTopics, partitionsForTask, fullMetadata);
 
-        final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask = new HashMap<>();
-        final Set<String> optimizedSourceChangelogs = new HashSet<>();
-        final Set<String> newlyCreatedChangelogs =
-            prepareChangelogTopics(topicGroups, tasksForTopicGroup, changelogsByStatefulTask, optimizedSourceChangelogs);
+        final ChangelogTopics changelogTopics = new ChangelogTopics(
+            internalTopicManager,
+            topicGroups,
+            tasksForTopicGroup,
+            logPrefix
+        );
+        changelogTopics.setup();
 
         final Map<UUID, ClientState> clientStates = new HashMap<>();
         final boolean lagComputationSuccessful =
-            populateClientStatesMap(clientStates,
-                clientMetadataMap,
-                taskForPartition,
-                changelogsByStatefulTask,
-                newlyCreatedChangelogs,
-                optimizedSourceChangelogs
-            );
+                populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
 
         final Set<TaskId> allTasks = partitionsForTask.keySet();
-        statefulTasks.addAll(changelogsByStatefulTask.keySet());
+        statefulTasks.addAll(changelogTopics.taskIds());
 
         log.debug("Assigning tasks {} to clients {} with number of replicas {}",
             allTasks, clientStates, numStandbyReplicas());
@@ -677,55 +622,35 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
      * @param clientStates a map from each client to its state, including offset lags. Populated by this method.
      * @param clientMetadataMap a map from each client to its full metadata
      * @param taskForPartition map from topic partition to its corresponding task
-     * @param changelogsByStatefulTask map from each stateful task to its set of changelog topic partitions
+     * @param changelogTopics object that manages changelog topics
      *
      * @return whether we were able to successfully fetch the changelog end offsets and compute each client's lag
      */
     private boolean populateClientStatesMap(final Map<UUID, ClientState> clientStates,
                                             final Map<UUID, ClientMetadata> clientMetadataMap,
                                             final Map<TopicPartition, TaskId> taskForPartition,
-                                            final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask,
-                                            final Set<String> newlyCreatedChangelogs,
-                                            final Set<String> optimizedSourceChangelogs) {
+                                            final ChangelogTopics changelogTopics) {
         boolean fetchEndOffsetsSuccessful;
         Map<TaskId, Long> allTaskEndOffsetSums;
         try {
-            final Collection<TopicPartition> allChangelogPartitions =
-                changelogsByStatefulTask.values().stream()
-                    .flatMap(Collection::stream)
-                    .collect(Collectors.toList());
-
-            final Set<TopicPartition> preexistingChangelogPartitions = new HashSet<>();
-            final Set<TopicPartition> preexistingSourceChangelogPartitions = new HashSet<>();
-            final Set<TopicPartition> newlyCreatedChangelogPartitions = new HashSet<>();
-            for (final TopicPartition changelog : allChangelogPartitions) {
-                if (newlyCreatedChangelogs.contains(changelog.topic())) {
-                    newlyCreatedChangelogPartitions.add(changelog);
-                } else if (optimizedSourceChangelogs.contains(changelog.topic())) {
-                    preexistingSourceChangelogPartitions.add(changelog);
-                } else {
-                    preexistingChangelogPartitions.add(changelog);
-                }
-            }
-
             // Make the listOffsets request first so it can  fetch the offsets for non-source changelogs
             // asynchronously while we use the blocking Consumer#committed call to fetch source-changelog offsets
             final KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> endOffsetsFuture =
-                fetchEndOffsetsFuture(preexistingChangelogPartitions, adminClient);
+                fetchEndOffsetsFuture(changelogTopics.preExistingNonSourceTopicBasedPartitions(), adminClient);
 
             final Map<TopicPartition, Long> sourceChangelogEndOffsets =
-                fetchCommittedOffsets(preexistingSourceChangelogPartitions, mainConsumerSupplier.get());
+                fetchCommittedOffsets(changelogTopics.sourceTopicBasedPartitions(), mainConsumerSupplier.get());
 
             final Map<TopicPartition, ListOffsetsResultInfo> endOffsets = ClientUtils.getEndOffsets(endOffsetsFuture);
 
             allTaskEndOffsetSums = computeEndOffsetSumsByTask(
-                changelogsByStatefulTask,
                 endOffsets,
                 sourceChangelogEndOffsets,
-                newlyCreatedChangelogPartitions);
+                changelogTopics
+            );
             fetchEndOffsetsSuccessful = true;
         } catch (final StreamsException | TimeoutException e) {
-            allTaskEndOffsetSums = changelogsByStatefulTask.keySet().stream().collect(Collectors.toMap(t -> t, t -> UNKNOWN_OFFSET_SUM));
+            allTaskEndOffsetSums = changelogTopics.taskIds().stream().collect(Collectors.toMap(t -> t, t -> UNKNOWN_OFFSET_SUM));
             fetchEndOffsetsSuccessful = false;
         }
 
@@ -741,41 +666,35 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     }
 
     /**
-     * @param changelogsByStatefulTask map from stateful task to its set of changelog topic partitions
      * @param endOffsets the listOffsets result from the adminClient
      * @param sourceChangelogEndOffsets the end (committed) offsets of optimized source changelogs
-     * @param newlyCreatedChangelogPartitions any changelogs that were just created duringthis assignment
+     * @param changelogTopics object that manages changelog topics
      *
      * @return Map from stateful task to its total end offset summed across all changelog partitions
      */
-    private Map<TaskId, Long> computeEndOffsetSumsByTask(final Map<TaskId, Set<TopicPartition>> changelogsByStatefulTask,
-                                                         final Map<TopicPartition, ListOffsetsResultInfo> endOffsets,
+    private Map<TaskId, Long> computeEndOffsetSumsByTask(final Map<TopicPartition, ListOffsetsResultInfo> endOffsets,
                                                          final Map<TopicPartition, Long> sourceChangelogEndOffsets,
-                                                         final Collection<TopicPartition> newlyCreatedChangelogPartitions) {
-        final Map<TaskId, Long> taskEndOffsetSums = new HashMap<>();
-        for (final Map.Entry<TaskId, Set<TopicPartition>> taskEntry : changelogsByStatefulTask.entrySet()) {
-            final TaskId task = taskEntry.getKey();
-            final Set<TopicPartition> changelogs = taskEntry.getValue();
+                                                         final ChangelogTopics changelogTopics) {
 
-            taskEndOffsetSums.put(task, 0L);
-            for (final TopicPartition changelog : changelogs) {
-                final long changelogEndOffset;
-                if (newlyCreatedChangelogPartitions.contains(changelog)) {
-                    changelogEndOffset = 0L;
-                } else if (sourceChangelogEndOffsets.containsKey(changelog)) {
-                    changelogEndOffset = sourceChangelogEndOffsets.get(changelog);
-                } else if (endOffsets.containsKey(changelog)) {
-                    changelogEndOffset = endOffsets.get(changelog).offset();
+        final Map<TaskId, Long> taskEndOffsetSums = new HashMap<>();
+        for (final TaskId taskId : changelogTopics.taskIds()) {
+            taskEndOffsetSums.put(taskId, 0L);
+            for (final TopicPartition changelogPartition : changelogTopics.preExistingPartitionsFor(taskId)) {
+                final long changelogPartitionEndOffset;
+                if (sourceChangelogEndOffsets.containsKey(changelogPartition)) {
+                    changelogPartitionEndOffset = sourceChangelogEndOffsets.get(changelogPartition);
+                } else if (endOffsets.containsKey(changelogPartition)) {
+                    changelogPartitionEndOffset = endOffsets.get(changelogPartition).offset();
                 } else {
-                    log.debug("Fetched offsets did not contain the changelog {} of task {}", changelog, task);
-                    throw new IllegalStateException("Could not get end offset for " + changelog);
+                    log.debug("Fetched offsets did not contain the changelog {} of task {}", changelogPartition, taskId);
+                    throw new IllegalStateException("Could not get end offset for " + changelogPartition);
                 }
-                final long newEndOffsetSum = taskEndOffsetSums.get(task) + changelogEndOffset;
+                final long newEndOffsetSum = taskEndOffsetSums.get(taskId) + changelogPartitionEndOffset;
                 if (newEndOffsetSum < 0) {
-                    taskEndOffsetSums.put(task, Long.MAX_VALUE);
+                    taskEndOffsetSums.put(taskId, Long.MAX_VALUE);
                     break;
                 } else {
-                    taskEndOffsetSums.put(task, newEndOffsetSum);
+                    taskEndOffsetSums.put(taskId, newEndOffsetSum);
                 }
             }
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -47,25 +47,25 @@ public class ChangelogTopicsTest {
     private static final UnwindowedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG =
         new UnwindowedChangelogTopicConfig(CHANGELOG_TOPIC_NAME1, TOPIC_CONFIG);
 
-    private static final TopicsInfo TOPICS_INFO1  = new TopicsInfo(
+    private static final TopicsInfo TOPICS_INFO1 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
         mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
     );
-    private static final TopicsInfo TOPICS_INFO2  = new TopicsInfo(
+    private static final TopicsInfo TOPICS_INFO2 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
         mkMap()
     );
-    private static final TopicsInfo TOPICS_INFO3  = new TopicsInfo(
+    private static final TopicsInfo TOPICS_INFO3 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
         mkMap(mkEntry(SOURCE_TOPIC_NAME, CHANGELOG_TOPIC_CONFIG))
     );
-    private static final TopicsInfo TOPICS_INFO4  = new TopicsInfo(
+    private static final TopicsInfo TOPICS_INFO4 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ChangelogTopicsTest {
+
+    private static final String SOURCE_TOPIC_NAME = "source";
+    private static final String SINK_TOPIC_NAME = "sink";
+    private static final String REPARTITION_TOPIC_NAME = "repartition";
+    private static final String CHANGELOG_TOPIC_NAME1 = "changelog1";
+    private static final Map<String, String> TOPIC_CONFIG = Collections.singletonMap("config1", "val1");
+    private static final RepartitionTopicConfig REPARTITION_TOPIC_CONFIG =
+        new RepartitionTopicConfig(REPARTITION_TOPIC_NAME, TOPIC_CONFIG);
+    private static final UnwindowedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG =
+        new UnwindowedChangelogTopicConfig(CHANGELOG_TOPIC_NAME1, TOPIC_CONFIG);
+
+    private static final TopicsInfo TOPICS_INFO1  = new TopicsInfo(
+        mkSet(SINK_TOPIC_NAME),
+        mkSet(SOURCE_TOPIC_NAME),
+        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
+    );
+    private static final TopicsInfo TOPICS_INFO2  = new TopicsInfo(
+        mkSet(SINK_TOPIC_NAME),
+        mkSet(SOURCE_TOPIC_NAME),
+        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap()
+    );
+    private static final TopicsInfo TOPICS_INFO3  = new TopicsInfo(
+        mkSet(SINK_TOPIC_NAME),
+        mkSet(SOURCE_TOPIC_NAME),
+        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(mkEntry(SOURCE_TOPIC_NAME, CHANGELOG_TOPIC_CONFIG))
+    );
+    private static final TopicsInfo TOPICS_INFO4  = new TopicsInfo(
+        mkSet(SINK_TOPIC_NAME),
+        mkSet(SOURCE_TOPIC_NAME),
+        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(mkEntry(SOURCE_TOPIC_NAME, null), mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
+    );
+    private static final TaskId TASK_0_0 = new TaskId(0, 0);
+    private static final TaskId TASK_0_1 = new TaskId(0, 1);
+    private static final TaskId TASK_0_2 = new TaskId(0, 2);
+
+    final InternalTopicManager internalTopicManager = mock(InternalTopicManager.class);
+
+    @Test
+    public void shouldNotContainChangelogsForStatelessTasks() {
+        expect(internalTopicManager.makeReady(Collections.emptyMap())).andStubReturn(Collections.emptySet());
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO2));
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+                new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        changelogTopics.setup();
+
+        verify(internalTopicManager);
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
+        assertThat(changelogTopics.sourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
+    }
+
+    @Test
+    public void shouldNotContainAnyPreExistingChangelogsIfChangelogIsNewlyCreated() {
+        expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
+            .andStubReturn(mkSet(CHANGELOG_TOPIC_NAME1));
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO1));
+        final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+                new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        changelogTopics.setup();
+
+        verify(internalTopicManager);
+        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
+        assertThat(changelogTopics.sourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
+    }
+
+    @Test
+    public void shouldOnlyContainPreExistingNonSourceBasedChangelogs() {
+        expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
+            .andStubReturn(Collections.emptySet());
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO1));
+        final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+                new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        changelogTopics.setup();
+
+        verify(internalTopicManager);
+        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        final TopicPartition changelogPartition0 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 0);
+        final TopicPartition changelogPartition1 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 1);
+        final TopicPartition changelogPartition2 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 2);
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(mkSet(changelogPartition0)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(changelogPartition1)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(changelogPartition2)));
+        assertThat(changelogTopics.sourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(
+            changelogTopics.preExistingNonSourceTopicBasedPartitions(),
+            is(mkSet(changelogPartition0, changelogPartition1, changelogPartition2))
+        );
+    }
+
+    @Test
+    public void shouldOnlyContainPreExistingSourceBasedChangelogs() {
+        expect(internalTopicManager.makeReady(Collections.emptyMap())).andStubReturn(Collections.emptySet());
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO3));
+        final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+                new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        changelogTopics.setup();
+
+        verify(internalTopicManager);
+        final TopicPartition changelogPartition0 = new TopicPartition(SOURCE_TOPIC_NAME, 0);
+        final TopicPartition changelogPartition1 = new TopicPartition(SOURCE_TOPIC_NAME, 1);
+        final TopicPartition changelogPartition2 = new TopicPartition(SOURCE_TOPIC_NAME, 2);
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(mkSet(changelogPartition0)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(changelogPartition1)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(changelogPartition2)));
+        assertThat(
+            changelogTopics.sourceTopicBasedPartitions(),
+            is(mkSet(changelogPartition0, changelogPartition1, changelogPartition2))
+        );
+        assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
+    }
+
+    @Test
+    public void shouldContainBothTypesOfPreExistingChangelogs() {
+        expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
+            .andStubReturn(Collections.emptySet());
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO4));
+        final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+                new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        changelogTopics.setup();
+
+        verify(internalTopicManager);
+        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        final TopicPartition changelogPartition0 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 0);
+        final TopicPartition changelogPartition1 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 1);
+        final TopicPartition changelogPartition2 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 2);
+        final TopicPartition sourcePartition0 = new TopicPartition(SOURCE_TOPIC_NAME, 0);
+        final TopicPartition sourcePartition1 = new TopicPartition(SOURCE_TOPIC_NAME, 1);
+        final TopicPartition sourcePartition2 = new TopicPartition(SOURCE_TOPIC_NAME, 2);
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(mkSet(sourcePartition0, changelogPartition0)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(sourcePartition1, changelogPartition1)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(sourcePartition2, changelogPartition2)));
+        assertThat(
+            changelogTopics.sourceTopicBasedPartitions(),
+            is(mkSet(sourcePartition0, sourcePartition1, sourcePartition2))
+        );
+        assertThat(
+            changelogTopics.preExistingNonSourceTopicBasedPartitions(),
+            is(mkSet(changelogPartition0, changelogPartition1, changelogPartition2))
+        );
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -92,7 +92,7 @@ public class ChangelogTopicsTest {
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
-        assertThat(changelogTopics.sourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
     }
 
@@ -114,7 +114,7 @@ public class ChangelogTopicsTest {
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
-        assertThat(changelogTopics.sourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
     }
 
@@ -139,7 +139,7 @@ public class ChangelogTopicsTest {
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(mkSet(changelogPartition0)));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(changelogPartition1)));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(changelogPartition2)));
-        assertThat(changelogTopics.sourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
         assertThat(
             changelogTopics.preExistingNonSourceTopicBasedPartitions(),
             is(mkSet(changelogPartition0, changelogPartition1, changelogPartition2))
@@ -166,7 +166,7 @@ public class ChangelogTopicsTest {
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(changelogPartition1)));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(changelogPartition2)));
         assertThat(
-            changelogTopics.sourceTopicBasedPartitions(),
+            changelogTopics.preExistingSourceTopicBasedPartitions(),
             is(mkSet(changelogPartition0, changelogPartition1, changelogPartition2))
         );
         assertThat(changelogTopics.preExistingNonSourceTopicBasedPartitions(), is(Collections.emptySet()));
@@ -197,7 +197,7 @@ public class ChangelogTopicsTest {
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(sourcePartition1, changelogPartition1)));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(sourcePartition2, changelogPartition2)));
         assertThat(
-            changelogTopics.sourceTopicBasedPartitions(),
+            changelogTopics.preExistingSourceTopicBasedPartitions(),
             is(mkSet(sourcePartition0, sourcePartition1, sourcePartition2))
         );
         assertThat(


### PR DESCRIPTION
To implement the explicit user initialization of Kafka Streams as
described in KIP-698, we first need to extract the code for the
setup of the changelog topics from the Streams partition assignor
so that it can also be called outside of a rebalance.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
