### PR TITLE
MINOR: Remove redundant log close in `KafkaRaftClient`

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2262,7 +2262,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
     @Override
     public void close() {
-        log.close();
         if (kafkaRaftMetrics != null) {
             kafkaRaftMetrics.close();
         }


### PR DESCRIPTION
This patch fixes a small shutdown bug. Current logic closes the log twice: once in `KafkaRaftClient`, and once in `RaftManager`. This can lead to errors like the following:

```
[2021-02-18 18:35:12,643] WARN  (kafka.utils.CoreUtils$)
java.nio.channels.ClosedChannelException
        at java.base/sun.nio.ch.FileChannelImpl.ensureOpen(FileChannelImpl.java:150)
        at java.base/sun.nio.ch.FileChannelImpl.force(FileChannelImpl.java:452)
        at org.apache.kafka.common.record.FileRecords.flush(FileRecords.java:197)
        at org.apache.kafka.common.record.FileRecords.close(FileRecords.java:204)
        at kafka.log.LogSegment.$anonfun$close$4(LogSegment.scala:592)
        at kafka.utils.CoreUtils$.swallow(CoreUtils.scala:68)
        at kafka.log.LogSegment.close(LogSegment.scala:592)
        at kafka.log.Log.$anonfun$close$4(Log.scala:1038)
        at kafka.log.Log.$anonfun$close$4$adapted(Log.scala:1038)
        at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
        at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:919)
        at kafka.log.Log.$anonfun$close$3(Log.scala:1038)
        at kafka.log.Log.close(Log.scala:2433)
        at kafka.raft.KafkaMetadataLog.close(KafkaMetadataLog.scala:295)
        at kafka.raft.KafkaRaftManager.shutdown(RaftManager.scala:150)
```

I have tended to view `RaftManager` as owning the lifecycle of the log, so I removed the extra call to close in `KafkaRaftClient`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
