### PR TITLE
MINOR: avoid duplicate array copying from BufferValue#serialize

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorRecordContext.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.processor.api.RecordMetadata;
 
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -96,7 +97,12 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
         return size;
     }
 
-    public byte[] serialize() {
+    /**
+     * write this context to byte buffer
+     * @param bufferSupplier buffer supplier. the passed integer is the size of serialization
+     * @return buffer from supplier
+     */
+    public ByteBuffer serializeTo(final Function<Integer, ByteBuffer> bufferSupplier) {
         final byte[] topicBytes = topic.getBytes(UTF_8);
         final byte[][] headerKeysBytes;
         final byte[][] headerValuesBytes;
@@ -131,7 +137,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             }
         }
 
-        final ByteBuffer buffer = ByteBuffer.allocate(size);
+        final ByteBuffer buffer = bufferSupplier.apply(size);
         buffer.putLong(timestamp);
         buffer.putLong(offset);
 
@@ -157,7 +163,7 @@ public class ProcessorRecordContext implements RecordContext, RecordMetadata {
             }
         }
 
-        return buffer.array();
+        return buffer;
     }
 
     public static ProcessorRecordContext deserialize(final ByteBuffer buffer) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/BufferValue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/BufferValue.java
@@ -93,17 +93,11 @@ public final class BufferValue {
         final int sizeOfOldValue = oldValue == null || priorValue == oldValue ? 0 : oldValue.length;
         final int sizeOfNewValue = newValue == null ? 0 : newValue.length;
 
-        final byte[] serializedContext = recordContext.serialize();
-
-        final ByteBuffer buffer = ByteBuffer.allocate(
-            serializedContext.length
-                + sizeOfValueLength + sizeOfPriorValue
+        final ByteBuffer buffer = recordContext.serializeTo(sizeOfSerializedContext -> ByteBuffer.allocate(
+            sizeOfSerializedContext + sizeOfValueLength + sizeOfPriorValue
                 + sizeOfValueLength + sizeOfOldValue
                 + sizeOfValueLength + sizeOfNewValue
-                + endPadding
-        );
-
-        buffer.put(serializedContext);
+                + endPadding));
 
         addValue(buffer, priorValue);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/BufferValueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/BufferValueTest.java
@@ -95,7 +95,7 @@ public class BufferValueTest {
     @Test
     public void shouldSerializeNulls() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] bytes = new BufferValue(null, null, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
 
@@ -105,7 +105,7 @@ public class BufferValueTest {
     @Test
     public void shouldSerializePrior() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] priorValue = {(byte) 5};
         final byte[] bytes = new BufferValue(priorValue, null, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
@@ -116,7 +116,7 @@ public class BufferValueTest {
     @Test
     public void shouldSerializeOld() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] oldValue = {(byte) 5};
         final byte[] bytes = new BufferValue(null, oldValue, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
@@ -127,7 +127,7 @@ public class BufferValueTest {
     @Test
     public void shouldSerializeNew() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] newValue = {(byte) 5};
         final byte[] bytes = new BufferValue(null, null, newValue, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
@@ -138,7 +138,7 @@ public class BufferValueTest {
     @Test
     public void shouldCompactDuplicates() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] duplicate = {(byte) 5};
         final byte[] bytes = new BufferValue(duplicate, duplicate, null, context).serialize(0).array();
         final byte[] withoutContext = Arrays.copyOfRange(bytes, serializedContext.length, bytes.length);
@@ -149,7 +149,7 @@ public class BufferValueTest {
     @Test
     public void shouldDeserializePrior() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] priorValue = {(byte) 5};
         final ByteBuffer serialValue =
             ByteBuffer
@@ -164,7 +164,7 @@ public class BufferValueTest {
     @Test
     public void shouldDeserializeOld() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] oldValue = {(byte) 5};
         final ByteBuffer serialValue =
             ByteBuffer
@@ -178,7 +178,7 @@ public class BufferValueTest {
     @Test
     public void shouldDeserializeNew() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] newValue = {(byte) 5};
         final ByteBuffer serialValue =
             ByteBuffer
@@ -192,7 +192,7 @@ public class BufferValueTest {
     @Test
     public void shouldDeserializeCompactedDuplicates() {
         final ProcessorRecordContext context = new ProcessorRecordContext(0L, 0L, 0, "topic", null);
-        final byte[] serializedContext = context.serialize();
+        final byte[] serializedContext = context.serializeTo(ByteBuffer::allocate).array();
         final byte[] duplicate = {(byte) 5};
         final ByteBuffer serialValue =
             ByteBuffer


### PR DESCRIPTION
We can write ProcessorRecordContext to target `ByteBuffer` directly.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
