### PR TITLE
MINOR: add toString to Subscription classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -132,6 +132,16 @@ public interface ConsumerPartitionAssignor {
         public Optional<String> groupInstanceId() {
             return groupInstanceId;
         }
+
+        @Override
+        public String toString() {
+            return "Subscription(" +
+                "topics=" + topics +
+                ", userData=" + userData +
+                ", ownedPartitions=" + ownedPartitions +
+                (groupInstanceId.isPresent() ? ", groupInstanceId=" + groupInstanceId.get() : "") +
+                ")";
+        }
     }
 
     final class Assignment {
@@ -158,9 +168,9 @@ public interface ConsumerPartitionAssignor {
         @Override
         public String toString() {
             return "Assignment(" +
-                    "partitions=" + partitions +
-                    (userData == null ? "" : ", userDataSize=" + userData.remaining()) +
-                    ')';
+                "partitions=" + partitions +
+                (userData == null ? "" : ", userDataSize=" + userData.remaining()) +
+                ')';
         }
     }
 
@@ -174,6 +184,13 @@ public interface ConsumerPartitionAssignor {
         public Map<String, Subscription> groupSubscription() {
             return subscriptions;
         }
+
+        @Override
+        public String toString() {
+            return "GroupSubscription(" +
+                "subscriptions=" + subscriptions +
+                ")";
+        }
     }
 
     final class GroupAssignment {
@@ -185,6 +202,13 @@ public interface ConsumerPartitionAssignor {
 
         public Map<String, Assignment> groupAssignment() {
             return assignments;
+        }
+
+        @Override
+        public String toString() {
+            return "GroupAssignment(" +
+                "assignments=" + assignments +
+                ")";
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java
@@ -137,9 +137,9 @@ public interface ConsumerPartitionAssignor {
         public String toString() {
             return "Subscription(" +
                 "topics=" + topics +
-                ", userData=" + userData +
+                (userData == null ? "" : ", userDataSize=" + userData.remaining()) +
                 ", ownedPartitions=" + ownedPartitions +
-                (groupInstanceId.isPresent() ? ", groupInstanceId=" + groupInstanceId.get() : "") +
+                ", groupInstanceId=" + (groupInstanceId.map(String::toString).orElse("null")) +
                 ")";
         }
     }


### PR DESCRIPTION
We now have the debug log [here](https://github.com/apache/kafka/blob/ea8ae976504e7a3f5c6f4a7efa5069d03316b093/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L587): 
```java
log.debug("Performing assignment using strategy {} with subscriptions {}", assignor.name(), subscriptions);
```
But we didn't override the toString method for subscription class, so user will get the useless debug info:
```
Performing assignment using strategy cooperative-sticky with subscriptions {consumer-groupId-1-7fd39d50-5dc1-46f0-860e-f0361eb2afc0=org.apache.kafka.clients.consumer.ConsumerPartitionAssignor$Subscription@247d8ae, 
consumer-groupId-1-09ffd69e-ce6c-4212-9d2c-218d60ad8d19=org.apache.kafka.clients.consumer.ConsumerPartitionAssignor$Subscription@48974e45}
```


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
