### PR TITLE
KAFKA-12324: Upgrade jetty to fix CVE-2020-27218

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,7 +69,7 @@ versions += [
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.5",
-  jetty: "9.4.33.v20201020",
+  jetty: "9.4.36.v20210114",
   jersey: "2.31",
   jline: "3.12.1",
   jmh: "1.27",


### PR DESCRIPTION
Here is the fix. The reason of [CVE-2020-27218](https://nvd.nist.gov/vuln/detail/CVE-2020-27218) was [Incorrect recycling of `HttpInput`](https://bugs.eclipse.org/bugs/show_bug.cgi?id=568892) and [patched in 9.4.35.v20201120](https://github.com/eclipse/jetty.project/security/advisories/GHSA-86wm-rrjm-8wh8).

This PR updates Jetty dependency into the following version, 9.4.36.v20210114.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
