### PR TITLE
MINOR: tune KIP-631 configurations

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -72,7 +72,7 @@ object Defaults {
   val QueuedMaxRequestBytes = -1
   val InitialBrokerRegistrationTimeoutMs = 60000
   val BrokerHeartbeatIntervalMs = 2000
-  val BrokerSessionTimeoutMs = 18000
+  val BrokerSessionTimeoutMs = 9000
 
   /** KIP-500 Configuration */
   val EmptyNodeId: Int = -1

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -140,7 +140,7 @@ import static org.apache.kafka.raft.RaftUtil.hasValidTopicPartition;
  */
 public class KafkaRaftClient<T> implements RaftClient<T> {
     private static final int RETRY_BACKOFF_BASE_MS = 100;
-    private static final int FETCH_MAX_WAIT_MS = 1000;
+    private static final int FETCH_MAX_WAIT_MS = 500;
     static final int MAX_BATCH_SIZE = 8 * 1024 * 1024;
 
     private final AtomicReference<GracefulShutdown> shutdown = new AtomicReference<>();

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -58,18 +58,18 @@ public class RaftConfig {
     public static final String QUORUM_ELECTION_TIMEOUT_MS_CONFIG = QUORUM_PREFIX + "election.timeout.ms";
     public static final String QUORUM_ELECTION_TIMEOUT_MS_DOC = "Maximum time in milliseconds to wait " +
         "without being able to fetch from the leader before triggering a new election";
-    public static final int DEFAULT_QUORUM_ELECTION_TIMEOUT_MS = 5_000;
+    public static final int DEFAULT_QUORUM_ELECTION_TIMEOUT_MS = 1_000;
 
     public static final String QUORUM_FETCH_TIMEOUT_MS_CONFIG = QUORUM_PREFIX + "fetch.timeout.ms";
     public static final String QUORUM_FETCH_TIMEOUT_MS_DOC = "Maximum time without a successful fetch from " +
         "the current leader before becoming a candidate and triggering a election for voters; Maximum time without " +
         "receiving fetch from a majority of the quorum before asking around to see if there's a new epoch for leader";
-    public static final int DEFAULT_QUORUM_FETCH_TIMEOUT_MS = 15_000;
+    public static final int DEFAULT_QUORUM_FETCH_TIMEOUT_MS = 2_000;
 
     public static final String QUORUM_ELECTION_BACKOFF_MAX_MS_CONFIG = QUORUM_PREFIX + "election.backoff.max.ms";
     public static final String QUORUM_ELECTION_BACKOFF_MAX_MS_DOC = "Maximum time in milliseconds before starting new elections. " +
         "This is used in the binary exponential backoff mechanism that helps prevent gridlocked elections";
-    public static final int DEFAULT_QUORUM_ELECTION_BACKOFF_MAX_MS = 5_000;
+    public static final int DEFAULT_QUORUM_ELECTION_BACKOFF_MAX_MS = 1_000;
 
     public static final String QUORUM_LINGER_MS_CONFIG = QUORUM_PREFIX + "append.linger.ms";
     public static final String QUORUM_LINGER_MS_DOC = "The duration in milliseconds that the leader will " +
@@ -79,12 +79,12 @@ public class RaftConfig {
     public static final String QUORUM_REQUEST_TIMEOUT_MS_CONFIG = QUORUM_PREFIX +
         CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
     public static final String QUORUM_REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
-    public static final int DEFAULT_QUORUM_REQUEST_TIMEOUT_MS = 20_000;
+    public static final int DEFAULT_QUORUM_REQUEST_TIMEOUT_MS = 4_000;
 
     public static final String QUORUM_RETRY_BACKOFF_MS_CONFIG = QUORUM_PREFIX +
         CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;
     public static final String QUORUM_RETRY_BACKOFF_MS_DOC = CommonClientConfigs.RETRY_BACKOFF_MS_DOC;
-    public static final int DEFAULT_QUORUM_RETRY_BACKOFF_MS = 100;
+    public static final int DEFAULT_QUORUM_RETRY_BACKOFF_MS = 20;
 
     private final int requestTimeoutMs;
     private final int retryBackoffMs;

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -40,6 +40,11 @@ import java.util.stream.Collectors;
  * For example: `1@0.0.0.0:0,2@0.0.0.0:0,3@0.0.0.0:0`
  * This will assign an {@link UnknownAddressSpec} to the voter entries
  *
+ * The default raft timeouts are relatively low compared to some other timeouts such as
+ * request.timeout.ms. This is part of a general design philosophy where we see changing
+ * the leader of a Raft cluster as a relatively quick operation. For example, the KIP-631
+ * controller should be able to transition from standby to active without reloading all of
+ * the metadata. The standby is a "hot" standby, not a "cold" one.
  */
 public class RaftConfig {
 

--- a/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftConfig.java
@@ -84,7 +84,7 @@ public class RaftConfig {
     public static final String QUORUM_REQUEST_TIMEOUT_MS_CONFIG = QUORUM_PREFIX +
         CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG;
     public static final String QUORUM_REQUEST_TIMEOUT_MS_DOC = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC;
-    public static final int DEFAULT_QUORUM_REQUEST_TIMEOUT_MS = 4_000;
+    public static final int DEFAULT_QUORUM_REQUEST_TIMEOUT_MS = 2_000;
 
     public static final String QUORUM_RETRY_BACKOFF_MS_CONFIG = QUORUM_PREFIX +
         CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;


### PR DESCRIPTION
Since we expect KIP-631 controller failovers to be fairly cheap, tune
the default raft configuration parameters so that we detect node
failures more quickly.

Reduce the broker session timeout as well so that broker failures are
detected more quickly.