### PR TITLE
KAFKA-12160: Remove max.poll.interval.ms from config docs (and KSTREAMS-4881)

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -865,10 +865,6 @@
           <td>Producer</td>
           <td>100</td>
         </tr>
-        <tr class="row-odd"><td>max.poll.interval.ms</td>
-          <td>Consumer</td>
-          <td>Integer.MAX_VALUE</td>
-        </tr>
         <tr class="row-even"><td>max.poll.records</td>
           <td>Consumer</td>
           <td>1000</td>
@@ -911,10 +907,6 @@
         <tr class="row-odd"><td>linger.ms</td>
           <td>Producer</td>
           <td>100</td>
-        </tr>
-        <tr class="row-even"><td>max.poll.interval.ms</td>
-          <td>Consumer</td>
-          <td>300000</td>
         </tr>
         <tr class="row-odd"><td>max.poll.records</td>
           <td>Consumer</td>


### PR DESCRIPTION
[KAFKA-12160](https://issues.apache.org/jira/browse/KAFKA-12160): Remove `max.poll.interval.ms` from the Kafka Streams docs.