### PR TITLE
MINOR: document restriction against running multiple Streams apps on same state.dir

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -87,6 +87,11 @@
         More details about the new config <code>StreamsConfig#TOPOLOGY_OPTIMIZATION</code> can be found in <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-295%3A+Add+Streams+Configuration+Allowing+for+Optional+Topology+Optimization">KIP-295</a>.
     </p>
 
+    <p>
+      Note: Kafka Streams does not support running multiple instances of the same application as different processes on the same physical state directory. Starting in 2.8.0 (as well as 2.7.1 and 2.6.2),
+      this restriction will be enforced. If you wish to run more than one instance of Kafka Streams, you must configure them with different values for <code>state.dir</code>.
+    </p>
+
     <h3><a id="streams_api_changes_280" href="#streams_api_changes_280">Streams API changes in 2.8.0</a></h3>
     <p>
         We extended <code>StreamJoined</code> to include the options <code>withLoggingEnabled()</code> and <code>withLoggingDisabled()</code> in


### PR DESCRIPTION
Running more than one Streams instance on the same physical state directory has never been supported, but until now it's also not really been enforced. Since we fixed Streams to fail fast in the case of this misconfiguration instead of offering vague symptoms, we will throw an exception on startup if it is detected. We should document this clearly as some users may have been using this setup for testing (note: there's no reason to do this in a real production app, as you should either scale up by adding more threads and/or scale out by adding new instances with their own storage)