### PR TITLE
KAFKA-9203: Check for buggy LZ4 libraries and remove corresponding workarounds

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/compress/KafkaLZ4BlockInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/KafkaLZ4BlockInputStream.java
@@ -78,11 +78,6 @@ public final class KafkaLZ4BlockInputStream extends InputStream {
         this.bufferSupplier = bufferSupplier;
         readHeader();
         decompressionBuffer = bufferSupplier.get(maxBlockSize);
-        if (!decompressionBuffer.hasArray() || decompressionBuffer.arrayOffset() != 0) {
-            // require array backed decompression buffer with zero offset
-            // to simplify workaround for https://github.com/lz4/lz4-java/pull/65
-            throw new RuntimeException("decompression buffer must have backing array with zero array offset");
-        }
         finished = false;
     }
 
@@ -132,10 +127,7 @@ public final class KafkaLZ4BlockInputStream extends InputStream {
 
         int len = in.position() - in.reset().position();
 
-        int hash = in.hasArray() ?
-                       // workaround for https://github.com/lz4/lz4-java/pull/65
-                       CHECKSUM.hash(in.array(), in.arrayOffset() + in.position(), len, 0) :
-                       CHECKSUM.hash(in, in.position(), len, 0);
+        int hash = CHECKSUM.hash(in, in.position(), len, 0);
         in.position(in.position() + len);
         if (in.get() != (byte) ((hash >> 8) & 0xFF)) {
             throw new IOException(DESCRIPTOR_HASH_MISMATCH);
@@ -173,22 +165,8 @@ public final class KafkaLZ4BlockInputStream extends InputStream {
 
         if (compressed) {
             try {
-                // workaround for https://github.com/lz4/lz4-java/pull/65
-                final int bufferSize;
-                if (in.hasArray()) {
-                    bufferSize = DECOMPRESSOR.decompress(
-                        in.array(),
-                        in.position() + in.arrayOffset(),
-                        blockSize,
-                        decompressionBuffer.array(),
-                        0,
-                        maxBlockSize
-                    );
-                } else {
-                    // decompressionBuffer has zero arrayOffset, so we don't need to worry about
-                    // https://github.com/lz4/lz4-java/pull/65
-                    bufferSize = DECOMPRESSOR.decompress(in, in.position(), blockSize, decompressionBuffer, 0, maxBlockSize);
-                }
+                final int bufferSize = DECOMPRESSOR.decompress(in, in.position(), blockSize, decompressionBuffer, 0,
+                    maxBlockSize);
                 decompressionBuffer.position(0);
                 decompressionBuffer.limit(bufferSize);
                 decompressedBuffer = decompressionBuffer;
@@ -202,10 +180,7 @@ public final class KafkaLZ4BlockInputStream extends InputStream {
 
         // verify checksum
         if (flg.isBlockChecksumSet()) {
-            // workaround for https://github.com/lz4/lz4-java/pull/65
-            int hash = in.hasArray() ?
-                       CHECKSUM.hash(in.array(), in.arrayOffset() + in.position(), blockSize, 0) :
-                       CHECKSUM.hash(in, in.position(), blockSize, 0);
+            int hash = CHECKSUM.hash(in, in.position(), blockSize, 0);
             in.position(in.position() + blockSize);
             if (hash != in.getInt()) {
                 throw new IOException(BLOCK_HASH_MISMATCH);


### PR DESCRIPTION
* Remove the workarounds that were added back in https://github.com/apache/kafka/pull/7769
* Add a check to detect buggy LZ4 library versions

This check allows us to safely remove the workarounds for buggy
LZ4 versions without users encountering cryptic errors if they
accidentally have an older LZ4 library on the classpath, as
described in KAFKA-9203.

With this change the use will get a clear error message indicating
what the problem might be if they encounter this situation.

Note: This now instantiates a compressor in the decompression code.
This should be safe with respect to JNI libraries, since we always use
`LZ4Factory.fastestInstance()` which takes care of falling back to a pure
Java implementation if JNI libraries are not present.

This was tested with lz4 1.3.0 to make sure it triggers the exception when running `KafkaLZ4Test`