### PR TITLE
KAFKA-12211: don't change perm for base/state dir when no persistent store

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -560,9 +560,13 @@ public class StateDirectoryTest {
 
     @Test
     public void shouldNotCreateBaseDirectory() throws IOException {
-        initializeStateDirectory(false);
-        assertFalse(stateDir.exists());
-        assertFalse(appDir.exists());
+        try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(StateDirectory.class)) {
+            initializeStateDirectory(false);
+            assertThat(stateDir.exists(), is(false));
+            assertThat(appDir.exists(), is(false));
+            assertThat(appender.getMessages(),
+                       not(hasItem(containsString("Error changing permissions for the state or base directory"))));
+        }
     }
 
     @Test


### PR DESCRIPTION
We improved the state directory folder/file permission setting in #9583 . But we forgot to consider one situation: if user doesn't have Persistent Stores, we won't create base dir and state dir. And if there's no such dir, and when we tried to set permission to them, we'll have NoSuchFileException.

Port of https://github.com/apache/kafka/pull/9904 to the 2.6 branch