### PR TITLE
MINOR: Reduce log level of spammy message in `LeaderEpochFileCache`

### DIFF
--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -221,7 +221,7 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
             }
           }
         }
-      debug(s"Processed end offset request for epoch $requestedEpoch and returning epoch ${epochAndOffset._1} " +
+      trace(s"Processed end offset request for epoch $requestedEpoch and returning epoch ${epochAndOffset._1} " +
         s"with end offset ${epochAndOffset._2} from epoch cache of size ${epochs.size}")
       epochAndOffset
     }


### PR DESCRIPTION
Since we do epoch validation as part of the fetch handling these days, the log message  `LeaderEpochFileCache.endOffsetFor` has become very noisy when DEBUG is enabled (which is often the default for system tests). This patch reduces the level to TRACE.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
