### PR TITLE
KAFKA-12367; Ensure partition epoch is propagated to `Partition` state

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -1403,7 +1403,7 @@ class Partition(val topicPartition: TopicPartition,
             case Errors.FENCED_LEADER_EPOCH =>
               debug(s"Failed to update ISR to $proposedIsrState since we sent an old leader epoch. Giving up.")
             case Errors.INVALID_UPDATE_VERSION =>
-              debug(s"Failed to update ISR to $proposedIsrState due to invalid zk version. Giving up.")
+              debug(s"Failed to update ISR to $proposedIsrState due to invalid version. Giving up.")
             case _ =>
               warn(s"Failed to update ISR to $proposedIsrState due to unexpected $error. Retrying.")
               sendAlterIsrRequest(proposedIsrState)

--- a/core/src/test/scala/unit/kafka/server/RaftReplicaChangeDelegateTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RaftReplicaChangeDelegateTest.scala
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.util.Collections
+
+import kafka.cluster.Partition
+import kafka.controller.StateChangeLogger
+import kafka.server.checkpoints.OffsetCheckpoints
+import kafka.server.metadata.{MetadataBroker, MetadataBrokers, MetadataPartition}
+import org.apache.kafka.common.message.LeaderAndIsrRequestData
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.{Node, TopicPartition}
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
+import org.mockito.Mockito._
+
+import scala.jdk.CollectionConverters._
+
+class RaftReplicaChangeDelegateTest {
+  private val listenerName = new ListenerName("PLAINTEXT")
+
+  @ParameterizedTest
+  @ValueSource(booleans = Array(true, false))
+  def testLeaderAndIsrPropagation(isLeader: Boolean): Unit = {
+    val leaderId = 0
+    val topicPartition = new TopicPartition("foo", 5)
+    val replicas = Seq(0, 1, 2).map(Int.box).asJava
+
+    val helper = mockedHelper()
+    val partition = mock(classOf[Partition])
+    when(partition.topicPartition).thenReturn(topicPartition)
+
+    val highWatermarkCheckpoints = mock(classOf[OffsetCheckpoints])
+    when(highWatermarkCheckpoints.fetch(
+      anyString(),
+      ArgumentMatchers.eq(topicPartition)
+    )).thenReturn(None)
+
+    val metadataPartition = new MetadataPartition(
+      topicName = topicPartition.topic,
+      partitionIndex = topicPartition.partition,
+      leaderId = leaderId,
+      leaderEpoch = 27,
+      replicas = replicas,
+      isr = replicas,
+      partitionEpoch = 50,
+      offlineReplicas = Collections.emptyList(),
+      addingReplicas = Collections.emptyList(),
+      removingReplicas = Collections.emptyList()
+    )
+
+    val expectedLeaderAndIsr = new LeaderAndIsrRequestData.LeaderAndIsrPartitionState()
+      .setTopicName(topicPartition.topic)
+      .setPartitionIndex(topicPartition.partition)
+      .setIsNew(true)
+      .setLeader(leaderId)
+      .setLeaderEpoch(27)
+      .setReplicas(replicas)
+      .setIsr(replicas)
+      .setAddingReplicas(Collections.emptyList())
+      .setRemovingReplicas(Collections.emptyList())
+      .setZkVersion(50)
+
+    val delegate = new RaftReplicaChangeDelegate(helper)
+    val updatedPartitions = if (isLeader) {
+      when(partition.makeLeader(expectedLeaderAndIsr, highWatermarkCheckpoints))
+        .thenReturn(true)
+      delegate.makeLeaders(
+        prevPartitionsAlreadyExisting = Set.empty,
+        partitionStates = Map(partition -> metadataPartition),
+        highWatermarkCheckpoints,
+        metadataOffset = Some(500)
+      )
+    } else {
+      when(partition.makeFollower(expectedLeaderAndIsr, highWatermarkCheckpoints))
+        .thenReturn(true)
+      when(partition.leaderReplicaIdOpt).thenReturn(Some(leaderId))
+      delegate.makeFollowers(
+        prevPartitionsAlreadyExisting = Set.empty,
+        currentBrokers = aliveBrokers(replicas),
+        partitionStates = Map(partition -> metadataPartition),
+        highWatermarkCheckpoints,
+        metadataOffset = Some(500)
+      )
+    }
+
+    assertEquals(Set(partition), updatedPartitions)
+  }
+
+  private def aliveBrokers(replicas: java.util.List[Integer]): MetadataBrokers = {
+    def mkNode(replicaId: Int): Node = {
+      new Node(replicaId, "localhost", 9092 + replicaId, "")
+    }
+
+    val brokers = replicas.asScala.map { replicaId =>
+      replicaId -> MetadataBroker(
+        id = replicaId,
+        rack = "",
+        endpoints = Map(listenerName.value -> mkNode(replicaId)),
+        fenced = false
+      )
+    }.toMap
+
+    MetadataBrokers(brokers.values.toList.asJava, brokers.asJava)
+  }
+
+  private def mockedHelper(): RaftReplicaChangeDelegateHelper = {
+    val helper = mock(classOf[RaftReplicaChangeDelegateHelper])
+
+    val stateChangeLogger = mock(classOf[StateChangeLogger])
+    when(helper.stateChangeLogger).thenReturn(stateChangeLogger)
+    when(stateChangeLogger.isDebugEnabled).thenReturn(false)
+    when(stateChangeLogger.isTraceEnabled).thenReturn(false)
+
+    val replicaFetcherManager = mock(classOf[ReplicaFetcherManager])
+    when(helper.replicaFetcherManager).thenReturn(replicaFetcherManager)
+
+    val replicaAlterLogDirsManager = mock(classOf[ReplicaAlterLogDirsManager])
+    when(helper.replicaAlterLogDirsManager).thenReturn(replicaAlterLogDirsManager)
+
+    val config = mock(classOf[KafkaConfig])
+    when(config.interBrokerListenerName).thenReturn(listenerName)
+    when(helper.config).thenReturn(config)
+
+    helper
+  }
+
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
@@ -54,11 +54,11 @@ public class BrokersToIsrs {
 
     private final static int REPLICA_MASK = 0x7fff_ffff;
 
-    static class TopicPartition {
+    static class TopicIdPartition {
         private final Uuid topicId;
         private final int partitionId;
 
-        TopicPartition(Uuid topicId, int partitionId) {
+        TopicIdPartition(Uuid topicId, int partitionId) {
             this.topicId = topicId;
             this.partitionId = partitionId;
         }
@@ -73,8 +73,8 @@ public class BrokersToIsrs {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof TopicPartition)) return false;
-            TopicPartition other = (TopicPartition) o;
+            if (!(o instanceof TopicIdPartition)) return false;
+            TopicIdPartition other = (TopicIdPartition) o;
             return other.topicId.equals(topicId) && other.partitionId == partitionId;
         }
 
@@ -89,13 +89,13 @@ public class BrokersToIsrs {
         }
     }
 
-    static class PartitionsOnReplicaIterator implements Iterator<TopicPartition> {
+    static class PartitionsOnReplicaIterator implements Iterator<TopicIdPartition> {
         private final Iterator<Entry<Uuid, int[]>> iterator;
         private final boolean leaderOnly;
         private int offset = 0;
         Uuid uuid = Uuid.ZERO_UUID;
         int[] replicas = EMPTY;
-        private TopicPartition next = null;
+        private TopicIdPartition next = null;
 
         PartitionsOnReplicaIterator(Map<Uuid, int[]> topicMap, boolean leaderOnly) {
             this.iterator = topicMap.entrySet().iterator();
@@ -115,18 +115,18 @@ public class BrokersToIsrs {
                 }
                 int replica = replicas[offset++];
                 if ((!leaderOnly) || (replica & LEADER_FLAG) != 0) {
-                    next = new TopicPartition(uuid, replica & REPLICA_MASK);
+                    next = new TopicIdPartition(uuid, replica & REPLICA_MASK);
                     return true;
                 }
             }
         }
 
         @Override
-        public TopicPartition next() {
+        public TopicIdPartition next() {
             if (!hasNext()) {
                 throw new NoSuchElementException();
             }
-            TopicPartition result = next;
+            TopicIdPartition result = next;
             next = null;
             return result;
         }

--- a/metadata/src/test/java/org/apache/kafka/controller/BrokersToIsrsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/BrokersToIsrsTest.java
@@ -20,7 +20,7 @@ package org.apache.kafka.controller;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.controller.BrokersToIsrs.PartitionsOnReplicaIterator;
-import org.apache.kafka.controller.BrokersToIsrs.TopicPartition;
+import org.apache.kafka.controller.BrokersToIsrs.TopicIdPartition;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -38,16 +38,16 @@ public class BrokersToIsrsTest {
         Uuid.fromString("U52uRe20RsGI0RvpcTx33Q")
     };
 
-    private static Set<TopicPartition> toSet(TopicPartition... partitions) {
-        HashSet<TopicPartition> set = new HashSet<>();
-        for (TopicPartition partition : partitions) {
+    private static Set<TopicIdPartition> toSet(TopicIdPartition... partitions) {
+        HashSet<TopicIdPartition> set = new HashSet<>();
+        for (TopicIdPartition partition : partitions) {
             set.add(partition);
         }
         return set;
     }
 
-    private static Set<TopicPartition> toSet(PartitionsOnReplicaIterator iterator) {
-        HashSet<TopicPartition> set = new HashSet<>();
+    private static Set<TopicIdPartition> toSet(PartitionsOnReplicaIterator iterator) {
+        HashSet<TopicIdPartition> set = new HashSet<>();
         while (iterator.hasNext()) {
             set.add(iterator.next());
         }
@@ -61,18 +61,18 @@ public class BrokersToIsrsTest {
         assertEquals(toSet(), toSet(brokersToIsrs.iterator(1, false)));
         brokersToIsrs.update(UUIDS[0], 0, null, new int[] {1, 2, 3}, -1, 1);
         brokersToIsrs.update(UUIDS[1], 1, null, new int[] {2, 3, 4}, -1, 4);
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 0)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 0)),
             toSet(brokersToIsrs.iterator(1, false)));
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 0),
-                           new TopicPartition(UUIDS[1], 1)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 0),
+                           new TopicIdPartition(UUIDS[1], 1)),
             toSet(brokersToIsrs.iterator(2, false)));
-        assertEquals(toSet(new TopicPartition(UUIDS[1], 1)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[1], 1)),
             toSet(brokersToIsrs.iterator(4, false)));
         assertEquals(toSet(), toSet(brokersToIsrs.iterator(5, false)));
         brokersToIsrs.update(UUIDS[1], 2, null, new int[] {3, 2, 1}, -1, 3);
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 0),
-                new TopicPartition(UUIDS[1], 1),
-                new TopicPartition(UUIDS[1], 2)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 0),
+                new TopicIdPartition(UUIDS[1], 1),
+                new TopicIdPartition(UUIDS[1], 2)),
             toSet(brokersToIsrs.iterator(2, false)));
     }
 
@@ -82,14 +82,14 @@ public class BrokersToIsrsTest {
         BrokersToIsrs brokersToIsrs = new BrokersToIsrs(snapshotRegistry);
         brokersToIsrs.update(UUIDS[0], 0, null, new int[]{1, 2, 3}, -1, 1);
         brokersToIsrs.update(UUIDS[1], 1, null, new int[]{2, 3, 4}, -1, 4);
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 0)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 0)),
             toSet(brokersToIsrs.iterator(1, true)));
         assertEquals(toSet(), toSet(brokersToIsrs.iterator(2, true)));
-        assertEquals(toSet(new TopicPartition(UUIDS[1], 1)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[1], 1)),
             toSet(brokersToIsrs.iterator(4, true)));
         brokersToIsrs.update(UUIDS[0], 0, new int[]{1, 2, 3}, new int[]{1, 2, 3}, 1, 2);
         assertEquals(toSet(), toSet(brokersToIsrs.iterator(1, true)));
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 0)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 0)),
             toSet(brokersToIsrs.iterator(2, true)));
     }
 
@@ -98,12 +98,12 @@ public class BrokersToIsrsTest {
         SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
         BrokersToIsrs brokersToIsrs = new BrokersToIsrs(snapshotRegistry);
         brokersToIsrs.update(UUIDS[0], 2, null, new int[]{1, 2, 3}, -1, 3);
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 2)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 2)),
             toSet(brokersToIsrs.iterator(3, true)));
         assertEquals(toSet(), toSet(brokersToIsrs.iterator(2, true)));
         assertEquals(toSet(), toSet(brokersToIsrs.noLeaderIterator()));
         brokersToIsrs.update(UUIDS[0], 2, new int[]{1, 2, 3}, new int[]{1, 2, 3}, 3, -1);
-        assertEquals(toSet(new TopicPartition(UUIDS[0], 2)),
+        assertEquals(toSet(new TopicIdPartition(UUIDS[0], 2)),
             toSet(brokersToIsrs.noLeaderIterator()));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -32,7 +32,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCol
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
-import org.apache.kafka.controller.BrokersToIsrs.TopicPartition;
+import org.apache.kafka.controller.BrokersToIsrs.TopicIdPartition;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
 import org.apache.kafka.metadata.BrokerRegistrationReply;
 import org.apache.kafka.metalog.LocalLogManagerTestEnv;
@@ -157,9 +157,9 @@ public class QuorumControllerTest {
                             setCurrentMetadataOffset(100000L)).get());
                 assertEquals(Errors.NONE.code(), active.createTopics(
                     createTopicsRequestData).get().topics().find("foo").errorCode());
-                CompletableFuture<TopicPartition> topicPartitionFuture = active.appendReadEvent(
+                CompletableFuture<TopicIdPartition> topicPartitionFuture = active.appendReadEvent(
                     "debugGetPartition", () -> {
-                        Iterator<TopicPartition> iterator = active.
+                        Iterator<TopicIdPartition> iterator = active.
                             replicationControl().brokersToIsrs().iterator(0, true);
                         assertTrue(iterator.hasNext());
                         return iterator.next();
@@ -168,7 +168,7 @@ public class QuorumControllerTest {
                 active.unregisterBroker(0).get();
                 topicPartitionFuture = active.appendReadEvent(
                     "debugGetPartition", () -> {
-                        Iterator<TopicPartition> iterator = active.
+                        Iterator<TopicIdPartition> iterator = active.
                             replicationControl().brokersToIsrs().noLeaderIterator();
                         assertTrue(iterator.hasNext());
                         return iterator.next();


### PR DESCRIPTION
This patch fixes two problem with the `AlterIsr` handling of the quorum controller:

- Ensure that partition epoch is updated correctly after partition change records and is propagated to `Partition`
- Ensure that `AlterIsr` response includes partitions that were successfully updated

As part of this patch, I've renamed `BrokersToIsrs.TopicPartition` to `BrokersToIsrs.TopicIdPartition` to avoid confusion with the `TopicPartition` object which is used virtually everywhere. I've attempted to address some of the testing gaps as welll.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
