### PR TITLE
KAFKA-12375: don't reuse thread.id until a thread has fully shut down

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -120,6 +120,7 @@
     <module name="ClassDataAbstractionCoupling">
       <!-- default is 7 -->
       <property name="max" value="25"/>
+      <property name="excludeClassesRegexps" value="AtomicInteger"/>
     </module>
     <module name="BooleanExpressionComplexity">
       <!-- default is 3 -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -161,7 +161,7 @@
               files="StreamThread.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(KStreamImpl|KTableImpl).java"/>
+              files="(KafkaStreams|KStreamImpl|KTableImpl).java"/>
 
     <suppress checks="CyclomaticComplexity"
               files="(StreamsPartitionAssignor|StreamThread|TaskManager|PartitionGroup).java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -161,7 +161,7 @@
               files="StreamThread.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(KafkaStreams|KStreamImpl|KTableImpl).java"/>
+              files="(KStreamImpl|KTableImpl).java"/>
 
     <suppress checks="CyclomaticComplexity"
               files="(StreamsPartitionAssignor|StreamThread|TaskManager|PartitionGroup).java"/>

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1101,7 +1101,7 @@ public class KafkaStreams implements AutoCloseable {
 
     private int getNextThreadIndex() {
         final HashSet<String> allLiveThreadNames = new HashSet<>();
-        AtomicInteger maxThreadId = new AtomicInteger(1);
+        final AtomicInteger maxThreadId = new AtomicInteger(1);
         synchronized (threads) {
             processStreamThread(thread -> {
                 // trim any DEAD threads from the list so we can reuse the thread.id
@@ -1110,7 +1110,7 @@ public class KafkaStreams implements AutoCloseable {
                     threads.remove(thread);
                 } else {
                     allLiveThreadNames.add(thread.getName());
-                    int threadId = thread.getName().charAt(thread.getName().length() - 1);
+                    final int threadId = thread.getName().charAt(thread.getName().length() - 1);
                     if (threadId > maxThreadId.get()) {
                         maxThreadId.set(threadId);
                     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -232,8 +232,8 @@ public class KafkaStreamsTest {
         EasyMock.expect(StreamThread.processingMode(anyObject(StreamsConfig.class))).andReturn(StreamThread.ProcessingMode.AT_LEAST_ONCE).anyTimes();
         EasyMock.expect(streamThreadOne.getId()).andReturn(0L).anyTimes();
         EasyMock.expect(streamThreadTwo.getId()).andReturn(1L).anyTimes();
-        prepareStreamThread(streamThreadOne, true);
-        prepareStreamThread(streamThreadTwo, false);
+        prepareStreamThread(streamThreadOne, 1, true);
+        prepareStreamThread(streamThreadTwo, 2, false);
 
         // setup global threads
         final AtomicReference<GlobalStreamThread.State> globalThreadState = new AtomicReference<>(GlobalStreamThread.State.CREATED);
@@ -293,7 +293,7 @@ public class KafkaStreamsTest {
         );
     }
 
-    private void prepareStreamThread(final StreamThread thread, final boolean terminable) throws Exception {
+    private void prepareStreamThread(final StreamThread thread, final int threadId, final boolean terminable) throws Exception {
         final AtomicReference<StreamThread.State> state = new AtomicReference<>(StreamThread.State.CREATED);
         EasyMock.expect(thread.state()).andAnswer(state::get).anyTimes();
 
@@ -321,7 +321,7 @@ public class KafkaStreamsTest {
         }).anyTimes();
         EasyMock.expect(thread.getGroupInstanceID()).andStubReturn(Optional.empty());
         EasyMock.expect(thread.threadMetadata()).andReturn(new ThreadMetadata(
-                "newThead",
+                "processId-StreamThread-" + threadId,
                 "DEAD",
                 "",
                 "",
@@ -337,7 +337,7 @@ public class KafkaStreamsTest {
         EasyMock.expectLastCall().anyTimes();
         thread.requestLeaveGroupDuringShutdown();
         EasyMock.expectLastCall().anyTimes();
-        EasyMock.expect(thread.getName()).andStubReturn("newThread");
+        EasyMock.expect(thread.getName()).andStubReturn("processId-StreamThread-" + threadId);
         thread.shutdown();
         EasyMock.expectLastCall().andAnswer(() -> {
             supplier.consumer.close();
@@ -564,7 +564,7 @@ public class KafkaStreamsTest {
         streams.start();
         final int oldSize = streams.threads.size();
         TestUtils.waitForCondition(() -> streams.state() == KafkaStreams.State.RUNNING, 15L, "wait until running");
-        assertThat(streams.addStreamThread(), equalTo(Optional.of("newThread")));
+        assertThat(streams.addStreamThread(), equalTo(Optional.of("processId-StreamThread-" + 2)));
         assertThat(streams.threads.size(), equalTo(oldSize + 1));
     }
 
@@ -613,7 +613,7 @@ public class KafkaStreamsTest {
         final int oldSize = streams.threads.size();
         TestUtils.waitForCondition(() -> streams.state() == KafkaStreams.State.RUNNING, 15L,
             "Kafka Streams client did not reach state RUNNING");
-        assertThat(streams.removeStreamThread(), equalTo(Optional.of("newThread")));
+        assertThat(streams.removeStreamThread(), equalTo(Optional.of("processId-StreamThread-" + 1)));
         assertThat(streams.threads.size(), equalTo(oldSize - 1));
     }
 


### PR DESCRIPTION
Basically any id that isn't actively being used by a non-DEAD thread in the `threads` list is fair game. This is relevant in two scenarios:

`REPLACE_THREAD`: when choosing to replace a thread after a recoverable error, we should just grab a new (and free) thread.id rather than reusing the id of the dying thread, to avoid a race condition between the old thread shutting down and the new thread starting up. 

`#removeStreamThread()`: in this case, if we haven't explicitly waited for the thread to complete the shutdown, then we should not remove it from the `threads` list since this will allow reusing that thread.id. This can happen if a thread is removing itself, or if we timed out waiting for it to reach the `DEAD` state.

In all of these scenarios, the `threads` list is considered the source of truth about available thread.ids. When trying to start up a new thread and computing the next available id, we'll trim any `DEAD` threads from this list

Should be cherrypicked to the 2.8 branch cc @vvcephei 