### PR TITLE
KAFKA-12254: Ensure MM2 creates topics with source topic configs

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -372,7 +372,7 @@ public class MirrorSourceConnector extends SourceConnector {
 
     static Map<String, String> configToMap(Config config) {
         return config.entries().stream()
-                .collect(Collectors.toMap(configEntry -> configEntry.name(), configEntry -> configEntry.value()));
+                .collect(Collectors.toMap(ConfigEntry::name, ConfigEntry::value));
     }
 
     @SuppressWarnings("deprecation")

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/MirrorSourceConnectorTest.java
@@ -203,9 +203,8 @@ public class MirrorSourceConnectorTest {
         Map<String, String> configMap = MirrorSourceConnector.configToMap(topicConfig);
         assertEquals(2, configMap.size());
 
-        List<NewTopic> expectedNewTopics = Arrays.asList(
-                new NewTopic("source.topic", 1, (short) 0)
-                        .configs(configMap));
+        Map<String, NewTopic> expectedNewTopics = new HashMap<>();
+        expectedNewTopics.put("source.topic", new NewTopic("source.topic", 1, (short) 0).configs(configMap));
 
         verify(connector, times(2)).computeAndCreateTopicPartitions();
         verify(connector, times(2)).createNewTopics(eq(expectedNewTopics));


### PR DESCRIPTION
MM2 creates new topics on the destination cluster with default configurations. It has an async periodic task to refresh topic configurations from the source to destination. However, this opens up a window where the destination cluster has data produced to it with default configurations. In the worst case, this could cause data loss if the destination topic is created without the right `cleanup.policy`.

This patch fixes the above issue by ensuring that the right configurations are supplied to `AdminClient#createTopics` when MM2 creates topics on the destination cluster. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
