### PR TITLE
MINOR: disable test_produce_bench_transactions for Raft metadata quorum

### DIFF
--- a/tests/kafkatest/tests/core/produce_bench_test.py
+++ b/tests/kafkatest/tests/core/produce_bench_test.py
@@ -66,7 +66,6 @@ class ProduceBenchTest(Test):
         self.logger.info("TASKS: %s\n" % json.dumps(tasks, sort_keys=True, indent=2))
 
     @cluster(num_nodes=8)
-    @matrix(metadata_quorum=quorum.all_non_upgrade)
     def test_produce_bench_transactions(self, metadata_quorum=quorum.zk):
         spec = ProduceBenchWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
                                         self.workload_service.producer_node,


### PR DESCRIPTION
Transactions are not supported in the KIP-500 early access release.  This patch disables a system test for Raft metadata quorums that uses transactions and that was still enabled after https://github.com/apache/kafka/pull/10194. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
