### PR TITLE
MINOR: fix security_test for ZK case due to error change

### DIFF
--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -65,7 +65,7 @@ class SecurityTest(EndToEndTest):
         Test that invalid hostname in certificate results in connection failures.
         When security_protocol=SSL, client SSL handshakes are expected to fail due to hostname verification failure.
         When security_protocol=PLAINTEXT and interbroker_security_protocol=SSL, controller connections fail
-        with hostname verification failure. Hence clients are expected to fail with LEADER_NOT_AVAILABLE.
+        with hostname verification failure. Hence clients are expected to fail with INVALID_REPLICATION_FACTOR.
         """
 
         # Start Kafka with valid hostnames in the certs' SANs so that we can create the test topic via the admin client
@@ -97,7 +97,7 @@ class SecurityTest(EndToEndTest):
             # expected
             pass
 
-        error = 'SSLHandshakeException' if security_protocol == 'SSL' else 'LEADER_NOT_AVAILABLE'
+        error = 'SSLHandshakeException' if security_protocol == 'SSL' else 'INVALID_REPLICATION_FACTOR'
         wait_until(lambda: self.producer_consumer_have_expected_error(error), timeout_sec=30)
         self.producer.stop()
         self.consumer.stop()


### PR DESCRIPTION
The ZooKeeper version of this system test is failing because the producer is no longer seeing `LEADER_NOT_AVAILABLE`. When the broker sees a METADATA request for the test topic after it restarts the auto topic creation manager is determining that the topic needs to be created due to the TLS hostname verification failure on the inter-broker security protocol.  It also thinks there aren't enough brokers available to meet the default topic replication factor (it sees 0 available due to the TLS issue), so it returns`INVALID_REPLICATION_FACTOR` for that topic in the Metadata response. In other words, the flow has changed and the inability to produce is not manifesting as it was before, and the test is failing.  This patch updates the test to check for `INVALID_REPLICATION_FACTOR` instead of `LEADER_NOT_AVAILABLE`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
