### PR TITLE
MINOR: fix kafka-metadata-shell.sh

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -135,6 +135,18 @@ do
   CLASSPATH="$CLASSPATH":"$file"
 done
 
+for file in "$base_dir"/shell/build/libs/kafka-shell*.jar;
+do
+  if should_include_file "$file"; then
+    CLASSPATH="$CLASSPATH":"$file"
+  fi
+done
+
+for dir in "$base_dir"/shell/build/dependant-libs-${SCALA_VERSION}*;
+do
+  CLASSPATH="$CLASSPATH:$dir/*"
+done
+
 for file in "$base_dir"/tools/build/libs/kafka-tools*.jar;
 do
   if should_include_file "$file"; then

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNodeManager.java
@@ -96,7 +96,7 @@ public final class MetadataNodeManager implements AutoCloseable {
         @Override
         public void handleCommits(long lastOffset, List<ApiMessage> messages) {
             appendEvent("handleCommits", () -> {
-                log.error("handleCommits " + messages + " at offset " + lastOffset);
+                log.debug("handleCommits " + messages + " at offset " + lastOffset);
                 DirectoryNode dir = data.root.mkdirs("metadataQuorum");
                 dir.create("offset").setContents(String.valueOf(lastOffset));
                 for (ApiMessage message : messages) {
@@ -108,7 +108,7 @@ public final class MetadataNodeManager implements AutoCloseable {
         @Override
         public void handleNewLeader(MetaLogLeader leader) {
             appendEvent("handleNewLeader", () -> {
-                log.error("handleNewLeader " + leader);
+                log.debug("handleNewLeader " + leader);
                 DirectoryNode dir = data.root.mkdirs("metadataQuorum");
                 dir.create("leader").setContents(leader.toString());
             }, null);

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -54,6 +54,9 @@ public final class MetadataShell {
         }
 
         public MetadataShell build() throws Exception {
+            if (snapshotPath == null) {
+                throw new RuntimeException("You must supply the log path via --snapshot");
+            }
             MetadataNodeManager nodeManager = null;
             SnapshotFileReader reader = null;
             try {
@@ -99,11 +102,15 @@ public final class MetadataShell {
         }
         if (args == null || args.isEmpty()) {
             // Interactive mode.
+            System.out.println("Loading...");
+            waitUntilCaughtUp();
+            System.out.println("Starting...");
             try (InteractiveShell shell = new InteractiveShell(nodeManager)) {
                 shell.runMainLoop();
             }
         } else {
             // Non-interactive mode.
+            waitUntilCaughtUp();
             Commands commands = new Commands(false);
             try (PrintWriter writer = new PrintWriter(new BufferedWriter(
                     new OutputStreamWriter(System.out, StandardCharsets.UTF_8)))) {
@@ -150,7 +157,6 @@ public final class MetadataShell {
                 }
             });
             MetadataShell shell = builder.build();
-            shell.waitUntilCaughtUp();
             try {
                 shell.run(res.getList("command"));
             } finally {


### PR DESCRIPTION
* Fix CLASSPATH issues in the startup script

* Fix overly verbose log messages during loading

* Update to use the new MetadataRecordSerde (this is needed now that we
  have a frame version)

* Fix initialization