### PR TITLE
KAFKA-12389: Upgrade of netty-codec due to CVE-2021-21290

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -100,7 +100,7 @@ versions += [
   mavenArtifact: "3.6.3",
   metrics: "2.2.0",
   mockito: "3.6.0",
-  netty: "4.1.51.Final",
+  netty: "4.1.59.Final",
   owaspDepCheckPlugin: "6.0.3",
   powermock: "2.0.9",
   reflections: "0.9.12",


### PR DESCRIPTION
This security vulnerability was found in netty-codec-http, but [caused by netty itself](https://github.com/netty/netty/commit/c735357bf29d07856ad171c6611a2e1a0e0000ec) and [fixed in 4.1.59.Final](https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2). So, upgrade the netty version from 4.1.51.Final to 4.1.59.Final.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
