### PR TITLE
MINOR: fix failing system test delegation_token_test

### DIFF
--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -375,7 +375,7 @@ class SecurityConfig(TemplateRenderer):
         sasl_mechanisms = []
         if self.is_sasl(self.security_protocol):
             # .csv is supported so be sure to account for that possibility
-            sasl_mechanisms += self.client_sasl_mechanism.strip().split(',')
+            sasl_mechanisms += [mechanism.strip() for mechanism in self.client_sasl_mechanism.split(',')]
         if self.is_sasl(self.interbroker_security_protocol):
             sasl_mechanisms += [self.interbroker_sasl_mechanism]
         if self.serves_raft_sasl:

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -374,7 +374,8 @@ class SecurityConfig(TemplateRenderer):
     def enabled_sasl_mechanisms(self):
         sasl_mechanisms = []
         if self.is_sasl(self.security_protocol):
-            sasl_mechanisms += [self.client_sasl_mechanism]
+            # .csv is supported so be sure to account for that possibility
+            sasl_mechanisms += self.client_sasl_mechanism.strip().split(',')
         if self.is_sasl(self.interbroker_security_protocol):
             sasl_mechanisms += [self.interbroker_sasl_mechanism]
         if self.serves_raft_sasl:


### PR DESCRIPTION
The system test in `delegation_token_test.py` broke due to https://github.com/apache/kafka/pull/10199/. 
 That patch changed the logic of `SecurityConfig.enabled_sasl_mechanisms()` to only add the inter-broker SASL mechanism when the inter-broker protocol was `SASL_{PLAINTEXT,SSL}`.  The inter-broker protocol is `PLAINTEXT` in `delegation_token_test.py`, so the default inter-broker SASL mechanism of `GSSAPI` was not being added into the set returned by `enabled_sasl_mechanisms()`.  This is actually correct -- it shouldn't be added if it isn't used for inter-broker communication.  It should be added because clients use it, of course -- `SASL_PLAINTEXT` is the security protocol on an advertised listener, and `client_sasl_mechanism` is set to the .csv value `"GSSAPI,SCRAM-SHA-256"`in `delegation_token_test`.  Unfortunately in https://github.com/apache/kafka/pull/10199/ we did not take into account the possibility that `client_sasl_mechanism` could be a .csv value, and we therefore fail to create a `krb5.conf` file, which causes `kafka-delegation_tokens.sh` to fail.  This bug of .csv omission therefore uncovered a different bug -- we were relying on the default inter-broker SASL mechanism to signal that Kerberos was being used even though the inter-broker protocol wasn't SASL.  This patch explicitly includes the elements of the `client_sasl_mechanism` .csv value (which in most cases is just a single value but in `delegation_token_test` it is not).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
