### PR TITLE
KAFKA-12381: remove live broker checks for forwarding topic creation

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -275,7 +275,11 @@ class DefaultAutoTopicCreationManager(
       val validationError: Option[Errors] = if (!isValidTopicName(topic)) {
         Some(Errors.INVALID_TOPIC_EXCEPTION)
       } else if (!hasEnoughLiveBrokers(topic, aliveBrokers)) {
-        Some(Errors.INVALID_REPLICATION_FACTOR)
+        if (Topic.isInternal(topic)) {
+          Some(Errors.INVALID_REPLICATION_FACTOR)
+        } else {
+          Some(Errors.LEADER_NOT_AVAILABLE)
+        }
       } else if (!inflightTopics.add(topic)) {
         Some(Errors.UNKNOWN_TOPIC_OR_PARTITION)
       } else {

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicReference
 import kafka.controller.KafkaController
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
-import kafka.server.metadata.MetadataBroker
 import kafka.utils.Logging
 import org.apache.kafka.clients.ClientResponse
 import org.apache.kafka.common.errors.InvalidTopicException
@@ -82,14 +81,13 @@ object AutoTopicCreationManager {
         ))
       else
         None
-    new DefaultAutoTopicCreationManager(config, metadataCache, channelManager, adminManager,
+    new DefaultAutoTopicCreationManager(config, channelManager, adminManager,
       controller, groupCoordinator, txnCoordinator)
   }
 }
 
 class DefaultAutoTopicCreationManager(
   config: KafkaConfig,
-  metadataCache: MetadataCache,
   channelManager: Option[BrokerToControllerChannelManager],
   adminManager: Option[ZkAdminManager],
   controller: Option[KafkaController],
@@ -266,7 +264,6 @@ class DefaultAutoTopicCreationManager(
     topics: Set[String]
   ): (Map[String, CreatableTopic], Seq[MetadataResponseTopic]) = {
 
-    val aliveBrokers = metadataCache.getAliveBrokers
     val creatableTopics = mutable.Map.empty[String, CreatableTopic]
     val uncreatableTopics = mutable.Buffer.empty[MetadataResponseTopic]
 
@@ -274,12 +271,6 @@ class DefaultAutoTopicCreationManager(
       // Attempt basic topic validation before sending any requests to the controller.
       val validationError: Option[Errors] = if (!isValidTopicName(topic)) {
         Some(Errors.INVALID_TOPIC_EXCEPTION)
-      } else if (!hasEnoughLiveBrokers(topic, aliveBrokers)) {
-        if (Topic.isInternal(topic)) {
-          Some(Errors.INVALID_REPLICATION_FACTOR)
-        } else {
-          Some(Errors.LEADER_NOT_AVAILABLE)
-        }
       } else if (!inflightTopics.add(topic)) {
         Some(Errors.UNKNOWN_TOPIC_OR_PARTITION)
       } else {
@@ -299,30 +290,4 @@ class DefaultAutoTopicCreationManager(
 
     (creatableTopics, uncreatableTopics)
   }
-
-  private def hasEnoughLiveBrokers(
-    topicName: String,
-    aliveBrokers: Seq[MetadataBroker]
-  ): Boolean = {
-    val (replicationFactor, replicationFactorConfig) = topicName match {
-      case GROUP_METADATA_TOPIC_NAME =>
-        (config.offsetsTopicReplicationFactor.intValue, KafkaConfig.OffsetsTopicReplicationFactorProp)
-
-      case TRANSACTION_STATE_TOPIC_NAME =>
-        (config.transactionTopicReplicationFactor.intValue, KafkaConfig.TransactionsTopicReplicationFactorProp)
-
-      case _ =>
-        (config.defaultReplicationFactor, KafkaConfig.DefaultReplicationFactorProp)
-    }
-
-    if (aliveBrokers.size < replicationFactor) {
-      error(s"Number of alive brokers '${aliveBrokers.size}' does not meet the required replication factor " +
-        s"'$replicationFactor' for auto creation of topic '$topicName' which is configured by $replicationFactorConfig. " +
-        "This error can be ignored if the cluster is starting up and not all brokers are up yet.")
-      false
-    } else {
-      true
-    }
-  }
-
 }

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -248,7 +248,7 @@ class BrokerServer(
       val autoTopicCreationChannelManager = BrokerToControllerChannelManager(controllerNodeProvider,
         time, metrics, config, "autocreate", threadNamePrefix, 60000)
       autoTopicCreationManager = new DefaultAutoTopicCreationManager(
-        config, metadataCache, Some(autoTopicCreationChannelManager), None, None,
+        config, Some(autoTopicCreationChannelManager), None, None,
         groupCoordinator, transactionCoordinator)
       autoTopicCreationManager.start()
 

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -165,41 +165,41 @@ class AutoTopicCreationManagerTest {
   @Test
   def testTopicExistsErrorSwapForNonInternalTopics(): Unit = {
     testErrorWithCreationInZk(Errors.TOPIC_ALREADY_EXISTS, "topic", isInternal = false,
-      expectedError = Errors.LEADER_NOT_AVAILABLE)
+      expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
   }
 
   @Test
   def testTopicExistsErrorSwapForConsumerOffsetsTopic(): Unit = {
     Mockito.when(groupCoordinator.offsetsTopicConfigs).thenReturn(new Properties)
     testErrorWithCreationInZk(Errors.TOPIC_ALREADY_EXISTS, Topic.GROUP_METADATA_TOPIC_NAME, isInternal = true,
-      expectedError = Errors.LEADER_NOT_AVAILABLE)
+      expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
   }
 
   @Test
   def testTopicExistsErrorSwapForTxnOffsetTopic(): Unit = {
     Mockito.when(transactionCoordinator.transactionTopicConfigs).thenReturn(new Properties)
     testErrorWithCreationInZk(Errors.TOPIC_ALREADY_EXISTS, Topic.TRANSACTION_STATE_TOPIC_NAME, isInternal = true,
-      expectedError = Errors.LEADER_NOT_AVAILABLE)
+      expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
   }
 
   @Test
   def testRequestTimeoutErrorSwapForNonInternalTopics(): Unit = {
     testErrorWithCreationInZk(Errors.REQUEST_TIMED_OUT, "topic", isInternal = false,
-      expectedError = Errors.LEADER_NOT_AVAILABLE)
+      expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
   }
 
   @Test
   def testRequestTimeoutErrorSwapForConsumerOffsetTopic(): Unit = {
     Mockito.when(groupCoordinator.offsetsTopicConfigs).thenReturn(new Properties)
     testErrorWithCreationInZk(Errors.REQUEST_TIMED_OUT, Topic.GROUP_METADATA_TOPIC_NAME, isInternal = true,
-      expectedError = Errors.LEADER_NOT_AVAILABLE)
+      expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
   }
 
   @Test
   def testRequestTimeoutErrorSwapForTxnOffsetTopic(): Unit = {
     Mockito.when(transactionCoordinator.transactionTopicConfigs).thenReturn(new Properties)
     testErrorWithCreationInZk(Errors.REQUEST_TIMED_OUT, Topic.TRANSACTION_STATE_TOPIC_NAME, isInternal = true,
-      expectedError = Errors.LEADER_NOT_AVAILABLE)
+      expectedError = Some(Errors.LEADER_NOT_AVAILABLE))
   }
 
   @Test
@@ -222,7 +222,7 @@ class AutoTopicCreationManagerTest {
   private def testErrorWithCreationInZk(error: Errors,
                                         topicName: String,
                                         isInternal: Boolean,
-                                        expectedError: Errors = null): Unit = {
+                                        expectedError: Option[Errors] = None): Unit = {
     autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
       None,
@@ -256,8 +256,7 @@ class AutoTopicCreationManagerTest {
         .apply(topicErrors)
     })
 
-    val errorToVerify = if (expectedError != null) expectedError else error
-    createTopicAndVerifyResult(errorToVerify, topicName, isInternal = isInternal)
+    createTopicAndVerifyResult(expectedError.getOrElse(error), topicName, isInternal = isInternal)
   }
 
   private def createTopicAndVerifyResult(error: Errors,

--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -65,7 +65,7 @@ class SecurityTest(EndToEndTest):
         Test that invalid hostname in certificate results in connection failures.
         When security_protocol=SSL, client SSL handshakes are expected to fail due to hostname verification failure.
         When security_protocol=PLAINTEXT and interbroker_security_protocol=SSL, controller connections fail
-        with hostname verification failure. Hence clients are expected to fail with LEADER_NOT_AVAILABLE.
+        with hostname verification failure. Hence clients are expected to fail with INVALID_REPLICATION_FACTOR.
         """
 
         # Start Kafka with valid hostnames in the certs' SANs so that we can create the test topic via the admin client
@@ -111,7 +111,7 @@ class SecurityTest(EndToEndTest):
                 # expected
                 pass
 
-            error = 'SSLHandshakeException' if security_protocol == 'SSL' else 'LEADER_NOT_AVAILABLE'
+            error = 'SSLHandshakeException' if security_protocol == 'SSL' else 'INVALID_REPLICATION_FACTOR'
             wait_until(lambda: self.producer_consumer_have_expected_error(error), timeout_sec=30)
             self.producer.stop()
             self.consumer.stop()

--- a/tests/kafkatest/tests/core/security_test.py
+++ b/tests/kafkatest/tests/core/security_test.py
@@ -65,7 +65,10 @@ class SecurityTest(EndToEndTest):
         Test that invalid hostname in certificate results in connection failures.
         When security_protocol=SSL, client SSL handshakes are expected to fail due to hostname verification failure.
         When security_protocol=PLAINTEXT and interbroker_security_protocol=SSL, controller connections fail
-        with hostname verification failure. Hence clients are expected to fail with INVALID_REPLICATION_FACTOR.
+        with hostname verification failure. Since metadata cannot be propagated in the cluster without a valid certificate,
+        the broker's metadata caches will be empty. Hence we expect Metadata requests to fail with an INVALID_REPLICATION_FACTOR
+        error since the broker will attempt to create the topic automatically as it does not exist in the metadata cache,
+        and there will be no online brokers.
         """
 
         # Start Kafka with valid hostnames in the certs' SANs so that we can create the test topic via the admin client


### PR DESCRIPTION
We introduced a regression in https://github.com/apache/kafka/pull/9579 where originally we only return `INVALID_REPLICATION_FACTOR` for internal topic creation when there are not enough brokers. This PR addressed the fundamental problem which is a stale forwarding broker should not make the decision on whether to define a replication factor as invalid or not. This should only be verified on the active controller side.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
