### PR TITLE
KAFKA-12398: Fix flaky test `ConsumerBounceTest.testClose`

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -484,7 +484,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
       }})
 
     TestUtils.waitUntilTrue(() => {
-      consumer.poll(time.Duration.ZERO)
+      consumer.poll(time.Duration.ofMillis(100L))
       assignSemaphore.tryAcquire()
     }, "Assignment did not complete on time")
 
@@ -493,8 +493,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
     consumer.close()
   }
 
-  private class BounceBrokerScheduler(val numIters: Int) extends ShutdownableThread("daemon-bounce-broker", false)
-  {
+  private class BounceBrokerScheduler(val numIters: Int) extends ShutdownableThread("daemon-bounce-broker", false) {
     var iter: Int = 0
 
     override def doWork(): Unit = {

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -46,7 +46,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
 
   this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
 
-  override def generateConfigs = {
+  override def generateConfigs: Seq[KafkaConfig] = {
     generateKafkaConfigs()
   }
 
@@ -78,7 +78,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
 
   @Test
   @Disabled // To be re-enabled once we can make it less flaky (KAFKA-4801)
-  def testConsumptionWithBrokerFailures() = consumeWithBrokerFailures(10)
+  def testConsumptionWithBrokerFailures(): Unit = consumeWithBrokerFailures(10)
 
   /*
    * 1. Produce a bunch of messages
@@ -121,7 +121,7 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
   }
 
   @Test
-  def testSeekAndCommitWithBrokerFailures() = seekAndCommitWithBrokerFailures(5)
+  def testSeekAndCommitWithBrokerFailures(): Unit = seekAndCommitWithBrokerFailures(5)
 
   def seekAndCommitWithBrokerFailures(numIters: Int): Unit = {
     val numRecords = 1000
@@ -476,14 +476,15 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
     // New instance of consumer should be assigned partitions immediately and should see committed offsets.
     val assignSemaphore = new Semaphore(0)
     val consumer = createConsumerWithGroupId(groupId)
-    consumer.subscribe(Collections.singletonList(topic),  new ConsumerRebalanceListener {
+    consumer.subscribe(Collections.singletonList(topic), new ConsumerRebalanceListener {
       def onPartitionsAssigned(partitions: Collection[TopicPartition]): Unit = {
         assignSemaphore.release()
       }
       def onPartitionsRevoked(partitions: Collection[TopicPartition]): Unit = {
       }})
     consumer.poll(time.Duration.ofSeconds(3L))
-    assertTrue(assignSemaphore.tryAcquire(1, TimeUnit.SECONDS), "Assignment did not complete on time")
+    TestUtils.waitUntilTrue(() => assignSemaphore.tryAcquire(100, TimeUnit.MILLISECONDS),
+      "Assignment did not complete on time")
     if (committedRecords > 0)
       assertEquals(committedRecords, consumer.committed(Set(tp).asJava).get(tp).offset)
     consumer.close()

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -482,9 +482,12 @@ class ConsumerBounceTest extends AbstractConsumerTest with Logging {
       }
       def onPartitionsRevoked(partitions: Collection[TopicPartition]): Unit = {
       }})
-    consumer.poll(time.Duration.ofSeconds(3L))
-    TestUtils.waitUntilTrue(() => assignSemaphore.tryAcquire(100, TimeUnit.MILLISECONDS),
-      "Assignment did not complete on time")
+
+    TestUtils.waitUntilTrue(() => {
+      consumer.poll(time.Duration.ZERO)
+      assignSemaphore.tryAcquire()
+    }, "Assignment did not complete on time")
+
     if (committedRecords > 0)
       assertEquals(committedRecords, consumer.committed(Set(tp).asJava).get(tp).offset)
     consumer.close()


### PR DESCRIPTION
*More detailed description of your change*
The test fails some times as follow:
![Pasted Graphic](https://user-images.githubusercontent.com/26023240/109610770-286d5080-7b68-11eb-92a5-ab6b45b79c2f.png)

We'd better use `TestUtils.waitUntilTrue` instead of waiting for 1 second because sometimes 1 second is too long and sometimes is too short.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
