### PR TITLE
KAFKA-12400: Upgrade jetty to fix CVE-2020-27223

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
-  jetty: "9.4.36.v20210114",
+  jetty: "9.4.38.v20210224",
   jersey: "2.31",
   jline: "3.12.1",
   jmh: "1.27",


### PR DESCRIPTION
Here is the fix. The reason of [CVE-2020-27223](https://nvd.nist.gov/vuln/detail/CVE-2020-27223) was DOS vulnerability for Quoted Quality CSV headers and [patched in 9.4.37.v20210219](https://github.com/eclipse/jetty.project/security/advisories/GHSA-m394-8rww-3jr7).

This PR updates Jetty dependency into the following version, 9.4.38.v20210224.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
