### PR TITLE
MINOR: Fix log format in AbstractCoordinator

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -860,7 +860,7 @@ public abstract class AbstractCoordinator implements Closeable {
 
         @Override
         public void onFailure(RuntimeException e, RequestFuture<Void> future) {
-            log.debug("FindCoordinator request failed due to {}", e);
+            log.debug("FindCoordinator request failed due to {}", e.getMessage());
 
             if (!(e instanceof RetriableException)) {
                 // Remember the exception if fatal so we can ensure it gets thrown by the main thread


### PR DESCRIPTION
*More detailed description of your change*
Accidentally saw a log:
```
[2021-03-02 20:39:56,418] DEBUG FindCoordinator request failed due to {} (org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator:863)
org.apache.kafka.common.errors.AuthenticationException: Authentication failed
```

I fixed it to:
```
[2021-03-02 20:51:39,050] DEBUG FindCoordinator request failed due to Authentication failed (org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator:863)
```

I think the author wants to call `Logger.debug(String format, Object arg)`, but called `Logger.debug(String msg, Throwable t)`. In fact, there are 5 overloadings `Logger.debug()` so we need to be careful.

*Summary of testing strategy (including rationale)*
test locally

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
