### PR TITLE
MINOR: main function of o.a.k.c.p.t.Type does not show all types

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -248,7 +248,7 @@ public abstract class Type {
             if (item instanceof Integer)
                 return (Integer) item;
             else
-                throw new SchemaException(item + " is not an a Integer (encoding an unsigned short)");
+                throw new SchemaException(item + " is not an Integer (using two bytes as an unsigned short)");
         }
 
         @Override
@@ -320,7 +320,7 @@ public abstract class Type {
             if (item instanceof Long)
                 return (Long) item;
             else
-                throw new SchemaException(item + " is not an a Long (encoding an unsigned integer).");
+                throw new SchemaException(item + " is not an Long (using four bytes as an unsigned integer).");
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Type.java
@@ -294,7 +294,7 @@ public abstract class Type {
         }
     };
 
-    public static final DocumentedType UNSIGNED_INT32 = new DocumentedType() {
+    public static final DocumentedType UINT32 = new DocumentedType() {
         @Override
         public void write(ByteBuffer buffer, Object o) {
             ByteUtils.writeUnsignedInt(buffer, (long) o);
@@ -1100,10 +1100,10 @@ public abstract class Type {
     private static String toHtml() {
         DocumentedType[] types = {
             BOOLEAN, INT8, INT16, INT32, INT64,
-            UNSIGNED_INT32, VARINT, VARLONG, UUID, FLOAT64,
+            UINT16, UINT32, VARINT, VARLONG, UUID, FLOAT64,
             STRING, COMPACT_STRING, NULLABLE_STRING, COMPACT_NULLABLE_STRING,
             BYTES, COMPACT_BYTES, NULLABLE_BYTES, COMPACT_NULLABLE_BYTES,
-            RECORDS, new ArrayOf(STRING), new CompactArrayOf(COMPACT_STRING)};
+            RECORDS, COMPACT_RECORDS, new ArrayOf(STRING), new CompactArrayOf(COMPACT_STRING)};
         final StringBuilder b = new StringBuilder();
         b.append("<table class=\"data-table\"><tbody>\n");
         b.append("<tr>");

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -375,7 +375,7 @@ object ProducerStateManager {
     new Field(CurrentTxnFirstOffsetField, Type.INT64, "The first offset of the on-going transaction (-1 if there is none)"))
   val PidSnapshotMapSchema = new Schema(
     new Field(VersionField, Type.INT16, "Version of the snapshot file"),
-    new Field(CrcField, Type.UNSIGNED_INT32, "CRC of the snapshot data"),
+    new Field(CrcField, Type.UINT32, "CRC of the snapshot data"),
     new Field(ProducerEntriesField, new ArrayOf(ProducerSnapshotEntrySchema), "The entries in the producer table"))
 
   def readSnapshot(file: File): Iterable[ProducerStateEntry] = {


### PR DESCRIPTION
This PR includes following changes

1. rename `UNSIGNED_INT32` to `UINT32` (consistent to `UINT16`)
1. make sure Type.toHtml shows `UINT16`, `UINT32` and `COMPACT_RECORDS`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
