### PR TITLE
MINOR: Fix null exception in coordinator log

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -256,8 +256,8 @@ public abstract class AbstractCoordinator implements Closeable {
                     log.debug("Coordinator discovery failed, refreshing metadata", future.exception());
                     client.awaitMetadataUpdate(timer);
                 } else {
-                    log.info("FindCoordinator request hit fatal exception", fatalException);
                     fatalException = future.exception();
+                    log.info("FindCoordinator request hit fatal exception", fatalException);
                 }
             } else if (coordinator != null && client.isUnavailable(coordinator)) {
                 // we found the coordinator, but the connection has failed, so mark
@@ -267,7 +267,7 @@ public abstract class AbstractCoordinator implements Closeable {
             }
 
             clearFindCoordinatorFuture();
-            if (fatalException !=  null)
+            if (fatalException != null)
                 throw fatalException;
         } while (coordinatorUnknown() && timer.notExpired());
 


### PR DESCRIPTION
*More detailed description of your change*
Found that the `fatalException` is always null when calling `log.info("xxx", fatalException)`, maybe we should first assign a value to it.



*Summary of testing strategy (including rationale)*
Test locally.

from
```
[2021-03-03 10:18:06,203] INFO FindCoordinator request hit fatal exception (org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator:260)
```
to

```
[2021-03-03 10:17:37,123] INFO FindCoordinator request hit fatal exception (org.apache.kafka.clients.consumer.internals.AbstractCoordinatorTest$DummyCoordinator:260)
org.apache.kafka.common.errors.AuthenticationException: Authentication failed
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
