### PR TITLE
KAFKA-12407: Document Controller Health Metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1273,7 +1273,7 @@ checkpoint-latency-ms-avg
       </tr>
       <tr>
         <td>Controller Request rate from Broker</td>
-        <td>kafka.controller:type=ControllerChannelManager,name=RequestRateAndQueueTimeMs,brokerId=([-.\w]+)</td>
+        <td>kafka.controller:type=ControllerChannelManager,name=RequestRateAndQueueTimeMs,brokerId=([0-9]+)</td>
         <td>The rate (requests per second) at which the ControllerChannelManager takes requests from the
             queue of the given broker. And the time it takes for a request to stay in this queue before
             it is taken from the queue.</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1272,6 +1272,24 @@ checkpoint-latency-ms-avg
         <td></td>
       </tr>
       <tr>
+        <td>Controller Request rate from Broker</td>
+        <td>kafka.controller:type=ControllerChannelManager,name=RequestRateAndQueueTimeMs,brokerId=([-.\w]+)</td>
+        <td>The rate (requests per second) at which the ControllerChannelManager takes requests from the
+            queue of the given broker. And the time it takes for a request to stay in this queue before
+            it is taken from the queue.</td>
+      </tr>
+      <tr>
+        <td>Controller Event queue size</td>
+        <td>kafka.controller:type=ControllerEventManager,name=EventQueueSize</td>
+        <td>Size of the ControllerEventManager's queue.</td>
+      </tr>
+      <tr>
+        <td>Controller Event queue time</td>
+        <td>kafka.controller:type=ControllerEventManager,name=EventQueueTimeMs</td>
+        <td>Time that takes for any event (except the Idle event) to wait in the ControllerEventManager's
+            queue before being processed</td>
+      </tr>
+      <tr>
         <td>Request rate</td>
         <td>kafka.network:type=RequestMetrics,name=RequestsPerSec,request={Produce|FetchConsumer|FetchFollower},version=([0-9]+)</td>
         <td></td>


### PR DESCRIPTION
This PR fills the omitted documentation of:

- `kafka.controller:type=ControllerChannelManager,name=RequestRateAndQueueTimeMs,brokerId=([-.\w]+)`
- `kafka.controller:type=ControllerEventManager,name=EventQueueSize`
- `kafka.controller:type=ControllerEventManager,name=EventQueueTimeMs`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
