### PR TITLE
KAFKA-12408: Document omitted ReplicaManager metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1576,17 +1576,17 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Partition counts</td>
         <td>kafka.server:type=ReplicaManager,name=PartitionCount</td>
-        <td>The number of partitions assigned to the broker.</td>
+        <td>mostly even across brokers</td>
       </tr>
       <tr>
         <td>Offline Replica counts</td>
         <td>kafka.server:type=ReplicaManager,name=OfflineReplicaCount</td>
-        <td>The number of offline partitions assigned to the broker.</td>
+        <td>0</td>
       </tr>
       <tr>
         <td>Leader replica counts</td>
         <td>kafka.server:type=ReplicaManager,name=LeaderCount</td>
-        <td>The number of leader partitions assigned to the broker.</td>
+        <td>mostly even across brokers</td>
       </tr>
       <tr>
         <td>ISR shrink rate</td>
@@ -1604,7 +1604,7 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Failed ISR update rate</td>
         <td>kafka.server:type=ReplicaManager,name=FailedIsrUpdatesPerSec</td>
-        <td>The rate of new ISR update failure.</td>
+        <td>0</td>
       </tr>
       <tr>
         <td>Max lag in messages btw follower and leader replicas</td>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1576,12 +1576,17 @@ $ bin/kafka-acls.sh \
       <tr>
         <td>Partition counts</td>
         <td>kafka.server:type=ReplicaManager,name=PartitionCount</td>
-        <td>mostly even across brokers</td>
+        <td>The number of partitions assigned to the broker.</td>
+      </tr>
+      <tr>
+        <td>Offline Replica counts</td>
+        <td>kafka.server:type=ReplicaManager,name=OfflineReplicaCount</td>
+        <td>The number of offline partitions assigned to the broker.</td>
       </tr>
       <tr>
         <td>Leader replica counts</td>
         <td>kafka.server:type=ReplicaManager,name=LeaderCount</td>
-        <td>mostly even across brokers</td>
+        <td>The number of leader partitions assigned to the broker.</td>
       </tr>
       <tr>
         <td>ISR shrink rate</td>
@@ -1595,6 +1600,11 @@ $ bin/kafka-acls.sh \
         <td>ISR expansion rate</td>
         <td>kafka.server:type=ReplicaManager,name=IsrExpandsPerSec</td>
         <td>See above</td>
+      </tr>
+      <tr>
+        <td>Failed ISR update rate</td>
+        <td>kafka.server:type=ReplicaManager,name=FailedIsrUpdatesPerSec</td>
+        <td>The rate of new ISR update failure.</td>
       </tr>
       <tr>
         <td>Max lag in messages btw follower and leader replicas</td>


### PR DESCRIPTION
I found it while configuring a JMX monitoring.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
