### PR TITLE
MINOR: using INFO level to log 'no meta.properties' for broker server

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -239,7 +239,7 @@ class BrokerMetadataCheckpoint(val file: File) extends Logging {
         Some(Utils.loadProps(absolutePath))
       } catch {
         case _: NoSuchFileException =>
-          warn(s"No meta.properties file under dir $absolutePath")
+          info(s"No meta.properties file under dir $absolutePath")
           None
         case e: Exception =>
           error(s"Failed to read meta.properties file under dir $absolutePath", e)


### PR DESCRIPTION
That is expected behavior for broker server so it seems to me the "warn" level is a bit overkill. BTW, the raft server can throw exception for that case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
