### PR TITLE
MINOR: output meaningful error message

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -261,6 +261,19 @@ public class EmbeddedConnectCluster {
         }
     }
 
+    @Override
+    public String toString() {
+        return String.format("EmbeddedConnectCluster(name= %s, numBrokers= %d, numInitialWorkers= %d, workerProps= %s)",
+            connectClusterName,
+            numBrokers,
+            numInitialWorkers,
+            workerProps);
+    }
+
+    public String getName() {
+        return connectClusterName;
+    }
+
     /**
      * Get the workers that are up and running.
      *


### PR DESCRIPTION
Saw the test failed messages [here](https://ci-builds.apache.org/job/Kafka/job/kafka-trunk-jdk11/565/testReport/junit/org.apache.kafka.connect.mirror.integration/MirrorConnectorsIntegrationTest/testReplication__/):
```
java.lang.AssertionError: Connector MirrorCheckpointConnector tasks did not start in time on cluster: org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster@11eea3c4
```

It's not helpful for debugging because we cannot know this is which cluster: `EmbeddedConnectCluster@11eea3c4`. Improve it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
