### PR TITLE
MINOR: Refer user to `kafka-storage.sh` if `meta.properties` is missing

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -372,10 +372,10 @@ class BrokerLifecycleManager(val config: KafkaConfig,
                 _state = BrokerState.RECOVERY
                 initialCatchUpFuture.complete(null)
               } else {
-                info(s"The broker is STARTING. Still waiting to catch up with cluster metadata.")
+                debug(s"The broker is STARTING. Still waiting to catch up with cluster metadata.")
               }
               // Schedule the heartbeat after only 10 ms so that in the case where
-              //there is no recovery work to be done, we start up a bit quicker.
+              // there is no recovery work to be done, we start up a bit quicker.
               scheduleNextCommunication(NANOSECONDS.convert(10, MILLISECONDS))
             case BrokerState.RECOVERY =>
               if (!message.data().isFenced()) {

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -171,7 +171,8 @@ object BrokerMetadataCheckpoint extends Logging {
             brokerMetadataMap += logDir -> properties
           case None =>
             if (!ignoreMissing) {
-              throw new KafkaException(s"No `meta.properties` found in $logDir")
+              throw new KafkaException(s"No `meta.properties` found in $logDir " +
+                "(have you run `kafka-storage.sh` to format the directory?)")
             }
         }
       } catch {


### PR DESCRIPTION
The KIP-500 server requires users to run kafka-storage.sh to format log directories before the server will start. If the directory is not formatted, the error message complains about a missing `meta.properties` file. It is useful for the message to refer the user to `kafka-storage.sh` directly since this is a new thing.

I've also reduced the log level of a very spammy log message in `BrokerLifecycleManager`. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
