### PR TITLE
MINOR: KRPC supports to get true type from entity type

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/EntityType.java
+++ b/generator/src/main/java/org/apache/kafka/message/EntityType.java
@@ -38,7 +38,7 @@ public enum EntityType {
     @JsonProperty("brokerId")
     BROKER_ID(FieldType.Int32FieldType.INSTANCE);
 
-    private final FieldType baseType;
+    final FieldType baseType;
 
     EntityType(FieldType baseType) {
         this.baseType = baseType;

--- a/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
+++ b/generator/src/main/java/org/apache/kafka/message/FieldSpec.java
@@ -89,7 +89,12 @@ public final class FieldSpec {
         }
         this.fields = Collections.unmodifiableList(fields == null ?
             Collections.emptyList() : new ArrayList<>(fields));
-        this.type = FieldType.parse(Objects.requireNonNull(type));
+        this.entityType = (entityType == null) ? EntityType.UNKNOWN : entityType;
+        if (type == null && entityType == EntityType.UNKNOWN) {
+            throw new RuntimeException("You must specify either type or entity type for field " + name);
+        }
+        this.type = type == null ? this.entityType.baseType : FieldType.parse(type);
+        this.entityType.verifyTypeMatches(name, this.type);
         this.mapKey = mapKey;
         this.nullableVersions = Versions.parse(nullableVersions, Versions.NONE);
         if (!this.nullableVersions.empty()) {
@@ -99,8 +104,6 @@ public final class FieldSpec {
         }
         this.fieldDefault = fieldDefault == null ? "" : fieldDefault;
         this.ignorable = ignorable;
-        this.entityType = (entityType == null) ? EntityType.UNKNOWN : entityType;
-        this.entityType.verifyTypeMatches(name, this.type);
 
         this.about = about == null ? "" : about;
         if (!this.fields().isEmpty()) {


### PR DESCRIPTION
Except for array type, the usage of `EntityType` is almost same to `type`. It makes our KRPC json file verbose. We can add a bit sugar to our KRPC that `EntityType` can be converted to true type in generated code.


### TODO (if this idea get approved)
1. remove all redundant declaration from all json files.
2. add `ThrottleTime` entity type 
3. add `TopicId` entity type 
4. add `ErrorCode` entity type

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
