### PR TITLE
KAFKA-12441: remove deprecated method StreamsBuilder#addGlobalStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -491,29 +491,6 @@ public class StreamsBuilder {
     }
 
     /**
-     * @deprecated Use {@link #addGlobalStore(StoreBuilder, String, Consumed, ProcessorSupplier)} instead.
-     */
-    @Deprecated
-    public synchronized <K, V>  StreamsBuilder addGlobalStore(final StoreBuilder<?> storeBuilder,
-                                                              final String topic,
-                                                              final String sourceName,
-                                                              final Consumed<K, V> consumed,
-                                                              final String processorName,
-                                                              final org.apache.kafka.streams.processor.ProcessorSupplier<K, V> stateUpdateSupplier) {
-        Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
-        Objects.requireNonNull(consumed, "consumed can't be null");
-        internalStreamsBuilder.addGlobalStore(
-            storeBuilder,
-            sourceName,
-            topic,
-            new ConsumedInternal<>(consumed),
-            processorName,
-            () -> ProcessorAdapter.adapt(stateUpdateSupplier.get())
-        );
-        return this;
-    }
-
-    /**
      * Adds a global {@link StateStore} to the topology.
      * The {@link StateStore} sources its data from all partitions of the provided input topic.
      * There will be exactly one instance of this {@link StateStore} per Kafka Streams instance.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -203,11 +203,13 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     }
 
     public synchronized <KIn, VIn> void addGlobalStore(final StoreBuilder<?> storeBuilder,
-                                                       final String sourceName,
                                                        final String topic,
                                                        final ConsumedInternal<KIn, VIn> consumed,
-                                                       final String processorName,
                                                        final org.apache.kafka.streams.processor.api.ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
+        // explicitly disable logging for global stores
+        storeBuilder.withLoggingDisabled();
+        final String sourceName = newProcessorName(KStreamImpl.SOURCE_NAME);
+        final String processorName = newProcessorName(KTableImpl.SOURCE_NAME);
 
         final GraphNode globalStoreNode = new GlobalStoreNode<>(
             storeBuilder,
@@ -219,24 +221,6 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         );
 
         addGraphNode(root, globalStoreNode);
-    }
-
-    public synchronized <KIn, VIn> void addGlobalStore(final StoreBuilder<?> storeBuilder,
-                                                       final String topic,
-                                                       final ConsumedInternal<KIn, VIn> consumed,
-                                                       final org.apache.kafka.streams.processor.api.ProcessorSupplier<KIn, VIn, Void, Void> stateUpdateSupplier) {
-        // explicitly disable logging for global stores
-        storeBuilder.withLoggingDisabled();
-        final String sourceName = newProcessorName(KStreamImpl.SOURCE_NAME);
-        final String processorName = newProcessorName(KTableImpl.SOURCE_NAME);
-        addGlobalStore(
-            storeBuilder,
-            sourceName,
-            topic,
-            consumed,
-            processorName,
-            stateUpdateSupplier
-        );
     }
 
     void addGraphNode(final GraphNode parent,

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -101,7 +101,6 @@ public class StreamsBuilderTest {
             () -> new Processor<String, String, Void, Void>() {
                 private KeyValueStore<String, String> store;
 
-                @SuppressWarnings("unchecked")
                 @Override
                 public void init(final ProcessorContext<Void, Void> context) {
                     store = context.getStateStore("store");
@@ -636,7 +635,6 @@ public class StreamsBuilderTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForTransformValuesWithKey() {
         builder.stream(STREAM_TOPIC).transformValues(() -> new NoopValueTransformerWithKey<>(), Named.as(STREAM_OPERATION_NAME));
         builder.build();
@@ -876,7 +874,6 @@ public class StreamsBuilderTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public void shouldUseSpecifiedNameForFlatTransformValueOperation() {
         builder.stream(STREAM_TOPIC).flatTransformValues(() -> new NoopValueTransformer<>(), Named.as(STREAM_OPERATION_NAME));
         builder.build();


### PR DESCRIPTION
The method StreamsBuilder#addGlobalStore was simplified via KIP-233 in
1.1.0 release. This PR removes the old and deprecated overload.

Call for review @guozhangwang @ableegoldman 