### PR TITLE
KAFKA-12442: Upgrade ZSTD JNI from 1.4.8-4 to 1.4.9-1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -113,7 +113,7 @@ versions += [
   spotbugs: "4.1.4",
   zinc: "1.3.5",
   zookeeper: "3.5.9",
-  zstd: "1.4.8-4"
+  zstd: "1.4.9-1"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
This PR aims to upgrade ZSTD JNI from 1.4.8-4 to 1.4.9-1.

`ZStandard 1.4.9 and its corresponding JNI brings the following bug fixes and improvements.
- https://github.com/facebook/zstd/releases/tag/v1.4.9

One of notable improvement of ZStandard 1.4.9 is 2x faster Long Distance Mode, but we are not using it yet.

Since this is a dependency change, this should pass all the existing CIs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
