### PR TITLE
KAFKA-12440: ClusterId validation for Vote, BeginQuorum, EndQuorum and FetchSnapshot

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -68,7 +68,7 @@
               files="(Utils|Topic|KafkaLZ4BlockOutputStream|AclData|JoinGroupRequest).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer).java"/>
+              files="(ConsumerCoordinator|Fetcher|Sender|KafkaProducer|BufferPool|ConfigDef|RecordAccumulator|KerberosLogin|AbstractRequest|AbstractResponse|Selector|SslFactory|SslTransportLayer|SaslClientAuthenticator|SaslClientCallbackHandler|SaslServerAuthenticator|AbstractCoordinator|TransactionManager|AbstractStickyAssignor|DefaultSslEngineFactory|Authorizer|KafkaRaftClient).java"/>
 
     <suppress checks="JavaNCSS"
               files="(AbstractRequest|AbstractResponse|KerberosLogin|WorkerSinkTaskTest|TransactionManagerTest|SenderTest|KafkaAdminClient|ConsumerCoordinatorTest|KafkaAdminClientTest).java"/>

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchSnapshotRequest.java
@@ -60,6 +60,7 @@ final public class FetchSnapshotRequest extends AbstractRequest {
      * @return the created fetch snapshot request data
      */
     public static FetchSnapshotRequestData singleton(
+        String clusterId,
         TopicPartition topicPartition,
         UnaryOperator<FetchSnapshotRequestData.PartitionSnapshot> operator
     ) {
@@ -68,6 +69,7 @@ final public class FetchSnapshotRequest extends AbstractRequest {
         );
 
         return new FetchSnapshotRequestData()
+            .setClusterId(clusterId)
             .setTopics(
                 Collections.singletonList(
                     new FetchSnapshotRequestData.TopicSnapshot()

--- a/clients/src/main/resources/common/message/VoteRequest.json
+++ b/clients/src/main/resources/common/message/VoteRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterId", "type": "string", "versions": "0+",
+    { "name": "ClusterId", "type": "string", "versions": "0+",  "ignorable": true,
       "nullableVersions": "0+", "default": "null"},
     { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [

--- a/clients/src/main/resources/common/message/VoteRequest.json
+++ b/clients/src/main/resources/common/message/VoteRequest.json
@@ -21,7 +21,7 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-    { "name": "ClusterId", "type": "string", "versions": "0+",  "ignorable": true,
+    { "name": "ClusterId", "type": "string", "versions": "0+",
       "nullableVersions": "0+", "default": "null"},
     { "name": "Topics", "type": "[]TopicData",
       "versions": "0+", "fields": [

--- a/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftClientTestContext.java
@@ -96,7 +96,7 @@ public final class RaftClientTestContext {
     private int appendLingerMs;
 
     private final QuorumStateStore quorumStateStore;
-    private final Uuid clusterId;
+    final Uuid clusterId;
     private final OptionalInt localId;
     public final KafkaRaftClient<String> client;
     final Metrics metrics;
@@ -460,6 +460,18 @@ public final class RaftClientTestContext {
     }
 
     void assertSentVoteResponse(
+            Errors error
+    ) {
+        List<RaftResponse.Outbound> sentMessages = drainSentResponses(ApiKeys.VOTE);
+        assertEquals(1, sentMessages.size());
+        RaftMessage raftMessage = sentMessages.get(0);
+        assertTrue(raftMessage.data() instanceof VoteResponseData);
+        VoteResponseData response = (VoteResponseData) raftMessage.data();
+
+        assertEquals(error, Errors.forCode(response.errorCode()));
+    }
+
+    void assertSentVoteResponse(
         Errors error,
         int epoch,
         OptionalInt leaderId,
@@ -540,6 +552,17 @@ public final class RaftClientTestContext {
     }
 
     void assertSentBeginQuorumEpochResponse(
+            Errors responseError
+    ) {
+        List<RaftResponse.Outbound> sentMessages = drainSentResponses(ApiKeys.BEGIN_QUORUM_EPOCH);
+        assertEquals(1, sentMessages.size());
+        RaftMessage raftMessage = sentMessages.get(0);
+        assertTrue(raftMessage.data() instanceof BeginQuorumEpochResponseData);
+        BeginQuorumEpochResponseData response = (BeginQuorumEpochResponseData) raftMessage.data();
+        assertEquals(responseError, Errors.forCode(response.errorCode()));
+    }
+
+    void assertSentBeginQuorumEpochResponse(
         Errors partitionError,
         int epoch,
         OptionalInt leaderId
@@ -564,6 +587,17 @@ public final class RaftClientTestContext {
             epoch, Collections.singleton(destinationId));
         assertEquals(1, endQuorumRequests.size());
         return endQuorumRequests.get(0).correlationId();
+    }
+
+    void assertSentEndQuorumEpochResponse(
+            Errors responseError
+    ) {
+        List<RaftResponse.Outbound> sentMessages = drainSentResponses(ApiKeys.END_QUORUM_EPOCH);
+        assertEquals(1, sentMessages.size());
+        RaftMessage raftMessage = sentMessages.get(0);
+        assertTrue(raftMessage.data() instanceof EndQuorumEpochResponseData);
+        EndQuorumEpochResponseData response = (EndQuorumEpochResponseData) raftMessage.data();
+        assertEquals(responseError, Errors.forCode(response.errorCode()));
     }
 
     void assertSentEndQuorumEpochResponse(
@@ -668,6 +702,17 @@ public final class RaftClientTestContext {
         assertEquals(1, sentRequests.size());
 
         return sentRequests.get(0);
+    }
+
+    void assertSentFetchSnapshotResponse(Errors responseError) {
+        List<RaftResponse.Outbound> sentMessages = drainSentResponses(ApiKeys.FETCH_SNAPSHOT);
+        assertEquals(1, sentMessages.size());
+
+        RaftMessage message = sentMessages.get(0);
+        assertTrue(message.data() instanceof FetchSnapshotResponseData);
+
+        FetchSnapshotResponseData response = (FetchSnapshotResponseData) message.data();
+        assertEquals(responseError, Errors.forCode(response.errorCode()));
     }
 
     Optional<FetchSnapshotResponseData.PartitionSnapshot> assertSentFetchSnapshotResponse(TopicPartition topicPartition) {
@@ -787,6 +832,30 @@ public final class RaftClientTestContext {
         );
     }
 
+    EndQuorumEpochRequestData endEpochRequest(
+        String clusterId,
+        int epoch,
+        int leaderId,
+        List<Integer> preferredSuccessors
+    ) {
+        return EndQuorumEpochRequest.singletonRequest(
+            metadataPartition,
+            clusterId,
+            epoch,
+            leaderId,
+            preferredSuccessors
+        );
+    }
+
+    BeginQuorumEpochRequestData beginEpochRequest(String clusterId, int epoch, int leaderId) {
+        return BeginQuorumEpochRequest.singletonRequest(
+            metadataPartition,
+            clusterId,
+            epoch,
+            leaderId
+        );
+    }
+
     BeginQuorumEpochRequestData beginEpochRequest(int epoch, int leaderId) {
         return BeginQuorumEpochRequest.singletonRequest(
             metadataPartition,
@@ -808,10 +877,28 @@ public final class RaftClientTestContext {
     VoteRequestData voteRequest(int epoch, int candidateId, int lastEpoch, long lastEpochOffset) {
         return VoteRequest.singletonRequest(
             metadataPartition,
+            clusterId.toString(),
             epoch,
             candidateId,
             lastEpoch,
             lastEpochOffset
+        );
+    }
+
+    VoteRequestData voteRequest(
+        String clusterId,
+        int epoch,
+        int candidateId,
+        int lastEpoch,
+        long lastEpochOffset
+    ) {
+        return VoteRequest.singletonRequest(
+                metadataPartition,
+                clusterId,
+                epoch,
+                candidateId,
+                lastEpoch,
+                lastEpochOffset
         );
     }
 


### PR DESCRIPTION
*More detailed description of your change*
This pr follows up #10129 which add clusterId validation to FetchRequest.

*Summary of testing strategy (including rationale)*
Unit test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
