### PR TITLE
MINOR: fix client_compatibility_features_test.py

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -135,6 +135,7 @@ class ClientCompatibilityFeaturesTest(Test):
         self.kafka.start()
         features = get_broker_features(broker_version)
         if not self.zk:
-            # this is supported by zkBroker currently
+            #  this check/disabling is only necessary due to the fact that we are in early access mode with
+            #  KIP-500 and we should remove the special casing when that his fully implemented
             features["describe-acls-supported"] = False
         self.invoke_compatibility_program(features)

--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -79,18 +79,16 @@ class ClientCompatibilityFeaturesTest(Test):
             "replication-factor": 3
             }}
         self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics=self.topics)
+        # Always use the latest version of org.apache.kafka.tools.ClientCompatibilityTest
+        # so store away the path to the DEV version before we set the Kafka version
+        self.dev_script_path = self.kafka.path.script("kafka-run-class.sh", self.kafka.nodes[0])
 
     def invoke_compatibility_program(self, features):
-        if self.zk:
-            # kafka nodes are set to older version so resolved script path is linked to older assembly.
-            # run the compatibility test on the first zk node to get script path linked to latest(dev) assembly.
-            node = self.zk.nodes[0]
-        else:
-            node = self.kafka.nodes[0]
+        node = self.kafka.nodes[0]
         cmd = ("%s org.apache.kafka.tools.ClientCompatibilityTest "
                "--bootstrap-server %s "
                "--num-cluster-nodes %d "
-               "--topic %s " % (self.kafka.path.script("kafka-run-class.sh", node),
+               "--topic %s " % (self.dev_script_path,
                                self.kafka.bootstrap_servers(),
                                len(self.kafka.nodes),
                                list(self.topics.keys())[0]))

--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -84,6 +84,7 @@ class ClientCompatibilityFeaturesTest(Test):
         self.dev_script_path = self.kafka.path.script("kafka-run-class.sh", self.kafka.nodes[0])
 
     def invoke_compatibility_program(self, features):
+        # Run the compatibility test on the first Kafka node.
         node = self.kafka.nodes[0]
         cmd = ("%s org.apache.kafka.tools.ClientCompatibilityTest "
                "--bootstrap-server %s "


### PR DESCRIPTION
related to https://github.com/apache/kafka/pull/10105

kafka nodes are set to **older version** so resolved script path is linked to **older assembly**. the 0.10.x versions do not have `org.apache.kafka.tools.ClientCompatibilityTest` so the test gets failed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
