### PR TITLE
KAFKA-12450: Remove deprecated methods from ReadOnlyWindowStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -66,43 +66,6 @@ public interface ReadOnlyWindowStore<K, V> {
      * |   A   |     25     |    35    |
      * +--------------------------------
      * </pre>
-     * And we call {@code store.fetch("A", 10, 20)} then the results will contain the first
-     * three windows from the table above, i.e., all those where 10 &lt;= start time &lt;= 20.
-     * <p>
-     * For each key, the iterator guarantees ordering of windows, starting from the oldest/earliest
-     * available window to the newest/latest window.
-     *
-     * @param key      the key to fetch
-     * @param timeFrom time range start (inclusive), where iteration starts.
-     * @param timeTo   time range end (inclusive), where iteration ends.
-     * @return an iterator over key-value pairs {@code <timestamp, value>}, from beginning to end of time.
-     * @throws InvalidStateStoreException if the store is not initialized
-     * @throws NullPointerException       if {@code null} is used for key.
-     * @deprecated Use {@link #fetch(Object, Instant, Instant)} instead
-     */
-    @Deprecated
-    WindowStoreIterator<V> fetch(K key, long timeFrom, long timeTo);
-
-    /**
-     * Get all the key-value pairs with the given key and the time range from all the existing windows.
-     * <p>
-     * This iterator must be closed after use.
-     * <p>
-     * The time range is inclusive and applies to the starting timestamp of the window.
-     * For example, if we have the following windows:
-     * <pre>
-     * +-------------------------------+
-     * |  key  | start time | end time |
-     * +-------+------------+----------+
-     * |   A   |     10     |    20    |
-     * +-------+------------+----------+
-     * |   A   |     15     |    25    |
-     * +-------+------------+----------+
-     * |   A   |     20     |    30    |
-     * +-------+------------+----------+
-     * |   A   |     25     |    35    |
-     * +--------------------------------
-     * </pre>
      * And we call {@code store.fetch("A", Instant.ofEpochMilli(10), Instant.ofEpochMilli(20))} then the results will contain the first
      * three windows from the table above, i.e., all those where 10 &lt;= start time &lt;= 20.
      * <p>
@@ -171,23 +134,6 @@ public interface ReadOnlyWindowStore<K, V> {
      * @return an iterator over windowed key-value pairs {@code <Windowed<K>, value>}, from beginning to end of time.
      * @throws InvalidStateStoreException if the store is not initialized
      * @throws NullPointerException       if {@code null} is used for any key.
-     * @deprecated Use {@link #fetch(Object, Object, Instant, Instant)} instead
-     */
-    @Deprecated
-    KeyValueIterator<Windowed<K>, V> fetch(K keyFrom, K keyTo, long timeFrom, long timeTo);
-
-    /**
-     * Get all the key-value pairs in the given key range and time range from all the existing windows.
-     * <p>
-     * This iterator must be closed after use.
-     *
-     * @param keyFrom     the first key in the range
-     * @param keyTo       the last key in the range
-     * @param timeFrom time range start (inclusive), where iteration starts.
-     * @param timeTo   time range end (inclusive), where iteration ends.
-     * @return an iterator over windowed key-value pairs {@code <Windowed<K>, value>}, from beginning to end of time.
-     * @throws InvalidStateStoreException if the store is not initialized
-     * @throws NullPointerException       if {@code null} is used for any key.
      * @throws IllegalArgumentException   if duration is negative or can't be represented as {@code long milliseconds}
      */
     KeyValueIterator<Windowed<K>, V> fetch(K keyFrom, K keyTo, Instant timeFrom, Instant timeTo)
@@ -232,19 +178,6 @@ public interface ReadOnlyWindowStore<K, V> {
     default KeyValueIterator<Windowed<K>, V> backwardAll() {
         throw new UnsupportedOperationException();
     }
-
-    /**
-     * Gets all the key-value pairs that belong to the windows within in the given time range.
-     *
-     * @param timeFrom the beginning of the time slot from which to search (inclusive), where iteration starts.
-     * @param timeTo   the end of the time slot from which to search (inclusive), where iteration ends.
-     * @return an iterator over windowed key-value pairs {@code <Windowed<K>, value>}, from beginning to end of time.
-     * @throws InvalidStateStoreException if the store is not initialized
-     * @throws NullPointerException       if {@code null} is used for any key
-     * @deprecated Use {@link #fetchAll(Instant, Instant)} instead
-     */
-    @Deprecated
-    KeyValueIterator<Windowed<K>, V> fetchAll(long timeFrom, long timeTo);
 
     /**
      * Gets all the key-value pairs that belong to the windows within in the given time range.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
-import org.apache.kafka.streams.internals.ApiUtils;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -27,8 +26,6 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
-
-import static org.apache.kafka.streams.internals.ApiUtils.prepareMillisCheckFailMsgPrefix;
 
 /**
  * Wrapper over the underlying {@link ReadOnlyWindowStore}s found in a {@link
@@ -68,10 +65,9 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
     }
 
     @Override
-    @Deprecated
     public WindowStoreIterator<V> fetch(final K key,
-                                        final long timeFrom,
-                                        final long timeTo) {
+                                        final Instant timeFrom,
+                                        final Instant timeTo) {
         Objects.requireNonNull(key, "key can't be null");
         final List<ReadOnlyWindowStore<K, V>> stores = provider.stores(storeName, windowStoreType);
         for (final ReadOnlyWindowStore<K, V> windowStore : stores) {
@@ -89,17 +85,6 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
             }
         }
         return KeyValueIterators.emptyWindowStoreIterator();
-    }
-
-    @SuppressWarnings("deprecation") // removing fetch(K from, long from, long to) will fix this
-    @Override
-    public WindowStoreIterator<V> fetch(final K key,
-                                        final Instant timeFrom,
-                                        final Instant timeTo) throws IllegalArgumentException {
-        return fetch(
-            key,
-            ApiUtils.validateMillisecondInstant(timeFrom, prepareMillisCheckFailMsgPrefix(timeFrom, "from")),
-            ApiUtils.validateMillisecondInstant(timeTo, prepareMillisCheckFailMsgPrefix(timeTo, "to")));
     }
 
     @Override
@@ -125,12 +110,11 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
         return KeyValueIterators.emptyWindowStoreIterator();
     }
 
-    @SuppressWarnings("deprecation") // removing fetch(K from, K to, long from, long to) will fix this
     @Override
     public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom,
                                                   final K keyTo,
-                                                  final long timeFrom,
-                                                  final long timeTo) {
+                                                  final Instant timeFrom,
+                                                  final Instant timeTo) {
         Objects.requireNonNull(keyFrom, "from can't be null");
         Objects.requireNonNull(keyTo, "to can't be null");
         final NextIteratorFunction<Windowed<K>, V, ReadOnlyWindowStore<K, V>> nextIteratorFunction =
@@ -140,18 +124,6 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
             new CompositeKeyValueIterator<>(
                 provider.stores(storeName, windowStoreType).iterator(),
                 nextIteratorFunction));
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom,
-                                                  final K keyTo,
-                                                  final Instant timeFrom,
-                                                  final Instant timeTo) throws IllegalArgumentException {
-        return fetch(
-            keyFrom,
-            keyTo,
-            ApiUtils.validateMillisecondInstant(timeFrom, prepareMillisCheckFailMsgPrefix(timeFrom, "timeFrom")),
-            ApiUtils.validateMillisecondInstant(timeTo, prepareMillisCheckFailMsgPrefix(timeTo, "timeTo")));
     }
 
     @Override
@@ -193,9 +165,8 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
     }
 
     @Override
-    @Deprecated
-    public KeyValueIterator<Windowed<K>, V> fetchAll(final long timeFrom,
-                                                     final long timeTo) {
+    public KeyValueIterator<Windowed<K>, V> fetchAll(final Instant timeFrom,
+                                                     final Instant timeTo) {
         final NextIteratorFunction<Windowed<K>, V, ReadOnlyWindowStore<K, V>> nextIteratorFunction =
             store -> store.fetchAll(timeFrom, timeTo);
         return new DelegatingPeekingKeyValueIterator<>(
@@ -203,15 +174,6 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
             new CompositeKeyValueIterator<>(
                 provider.stores(storeName, windowStoreType).iterator(),
                 nextIteratorFunction));
-    }
-
-    @SuppressWarnings("deprecation") // removing fetchAll(long from, long to) will fix this
-    @Override
-    public KeyValueIterator<Windowed<K>, V> fetchAll(final Instant timeFrom,
-                                                     final Instant timeTo) throws IllegalArgumentException {
-        return fetchAll(
-            ApiUtils.validateMillisecondInstant(timeFrom, prepareMillisCheckFailMsgPrefix(timeFrom, "from")),
-            ApiUtils.validateMillisecondInstant(timeTo, prepareMillisCheckFailMsgPrefix(timeTo, "to")));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
@@ -115,8 +115,8 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
                                                   final K keyTo,
                                                   final Instant timeFrom,
                                                   final Instant timeTo) {
-        Objects.requireNonNull(keyFrom, "from can't be null");
-        Objects.requireNonNull(keyTo, "to can't be null");
+        Objects.requireNonNull(keyFrom, "keyFrom can't be null");
+        Objects.requireNonNull(keyTo, "keyTo can't be null");
         final NextIteratorFunction<Windowed<K>, V, ReadOnlyWindowStore<K, V>> nextIteratorFunction =
             store -> store.fetch(keyFrom, keyTo, timeFrom, timeTo);
         return new DelegatingPeekingKeyValueIterator<>(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreFacade.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreFacade.java
@@ -42,14 +42,6 @@ public class ReadOnlyWindowStoreFacade<K, V> implements ReadOnlyWindowStore<K, V
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public WindowStoreIterator<V> fetch(final K key,
-                                        final long timeFrom,
-                                        final long timeTo) {
-        return new WindowStoreIteratorFacade<>(inner.fetch(key, timeFrom, timeTo));
-    }
-
-    @Override
     public WindowStoreIterator<V> fetch(final K key,
                                         final Instant timeFrom,
                                         final Instant timeTo) throws IllegalArgumentException {
@@ -61,15 +53,6 @@ public class ReadOnlyWindowStoreFacade<K, V> implements ReadOnlyWindowStore<K, V
                                                 final Instant timeFrom,
                                                 final Instant timeTo) throws IllegalArgumentException {
         return new WindowStoreIteratorFacade<>(inner.backwardFetch(key, timeFrom, timeTo));
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom,
-                                                  final K keyTo,
-                                                  final long timeFrom,
-                                                  final long timeTo) {
-        return new KeyValueIteratorFacade<>(inner.fetch(keyFrom, keyTo, timeFrom, timeTo));
     }
 
     @Override
@@ -86,13 +69,6 @@ public class ReadOnlyWindowStoreFacade<K, V> implements ReadOnlyWindowStore<K, V
                                                           final Instant timeFrom,
                                                           final Instant timeTo) throws IllegalArgumentException {
         return new KeyValueIteratorFacade<>(inner.backwardFetch(keyFrom, keyTo, timeFrom, timeTo));
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public KeyValueIterator<Windowed<K>, V> fetchAll(final long timeFrom,
-                                                     final long timeTo) {
-        return new KeyValueIteratorFacade<>(inner.fetchAll(timeFrom, timeTo));
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/NoOpWindowStore.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/NoOpWindowStore.java
@@ -86,12 +86,6 @@ public class NoOpWindowStore implements ReadOnlyWindowStore, StateStore {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public WindowStoreIterator fetch(final Object key, final long timeFrom, final long timeTo) {
-        return EMPTY_WINDOW_STORE_ITERATOR;
-    }
-
-    @Override
     public WindowStoreIterator fetch(final Object key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
         return EMPTY_WINDOW_STORE_ITERATOR;
     }
@@ -100,15 +94,6 @@ public class NoOpWindowStore implements ReadOnlyWindowStore, StateStore {
     public WindowStoreIterator backwardFetch(final  Object key,
                                              final Instant timeFrom,
                                              final Instant timeTo) throws IllegalArgumentException {
-        return EMPTY_WINDOW_STORE_ITERATOR;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public WindowStoreIterator<KeyValue> fetch(final Object keyFrom,
-                                               final Object keyTo,
-                                               final long timeFrom,
-                                               final long timeTo) {
         return EMPTY_WINDOW_STORE_ITERATOR;
     }
 
@@ -135,12 +120,6 @@ public class NoOpWindowStore implements ReadOnlyWindowStore, StateStore {
 
     @Override
     public WindowStoreIterator<KeyValue> backwardAll() {
-        return EMPTY_WINDOW_STORE_ITERATOR;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public WindowStoreIterator<KeyValue> fetchAll(final long timeFrom, final long timeTo) {
         return EMPTY_WINDOW_STORE_ITERATOR;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreFacadeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreFacadeTest.java
@@ -73,12 +73,12 @@ public class ReadOnlyWindowStoreFacadeTest {
         expect(mockedWindowTimestampIterator.next())
             .andReturn(KeyValue.pair(21L, ValueAndTimestamp.make("value1", 22L)))
             .andReturn(KeyValue.pair(42L, ValueAndTimestamp.make("value2", 23L)));
-        expect(mockedWindowTimestampStore.fetch("key1", 21L, 42L))
+        expect(mockedWindowTimestampStore.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
             .andReturn(mockedWindowTimestampIterator);
         replay(mockedWindowTimestampIterator, mockedWindowTimestampStore);
 
         final WindowStoreIterator<String> iterator =
-            readOnlyWindowStoreFacade.fetch("key1", 21L, 42L);
+            readOnlyWindowStoreFacade.fetch("key1", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(21L, "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(42L, "value2")));
@@ -111,12 +111,12 @@ public class ReadOnlyWindowStoreFacadeTest {
             .andReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.fetch("key1", "key2", 21L, 42L))
+        expect(mockedWindowTimestampStore.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
             .andReturn(mockedKeyValueWindowTimestampIterator);
         replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
 
         final KeyValueIterator<Windowed<String>, String> iterator =
-            readOnlyWindowStoreFacade.fetch("key1", "key2", 21L, 42L);
+            readOnlyWindowStoreFacade.fetch("key1", "key2", Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));
@@ -153,12 +153,12 @@ public class ReadOnlyWindowStoreFacadeTest {
             .andReturn(KeyValue.pair(
                 new Windowed<>("key2", new TimeWindow(42L, 43L)),
                 ValueAndTimestamp.make("value2", 100L)));
-        expect(mockedWindowTimestampStore.fetchAll(21L, 42L))
+        expect(mockedWindowTimestampStore.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L)))
             .andReturn(mockedKeyValueWindowTimestampIterator);
         replay(mockedKeyValueWindowTimestampIterator, mockedWindowTimestampStore);
 
         final KeyValueIterator<Windowed<String>, String> iterator =
-            readOnlyWindowStoreFacade.fetchAll(21L, 42L);
+            readOnlyWindowStoreFacade.fetchAll(Instant.ofEpochMilli(21L), Instant.ofEpochMilli(42L));
 
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key1", new TimeWindow(21L, 22L)), "value1")));
         assertThat(iterator.next(), is(KeyValue.pair(new Windowed<>("key2", new TimeWindow(42L, 43L)), "value2")));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ReadOnlyWindowStoreStub.java
@@ -61,28 +61,19 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
         }
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    public WindowStoreIterator<V> fetch(final K key, final long timeFrom, final long timeTo) {
+    public WindowStoreIterator<V> fetch(final K key, final Instant timeFrom, final Instant timeTo) {
         if (!open) {
             throw new InvalidStateStoreException("Store is not open");
         }
         final List<KeyValue<Long, V>> results = new ArrayList<>();
-        for (long now = timeFrom; now <= timeTo; now++) {
+        for (long now = timeFrom.toEpochMilli(); now <= timeTo.toEpochMilli(); now++) {
             final Map<K, V> kvMap = data.get(now);
             if (kvMap != null && kvMap.containsKey(key)) {
                 results.add(new KeyValue<>(now, kvMap.get(key)));
             }
         }
         return new TheWindowStoreIterator<>(results.iterator());
-    }
-
-    @Override
-    public WindowStoreIterator<V> fetch(final K key, final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return fetch(
-            key,
-            ApiUtils.validateMillisecondInstant(timeFrom, prepareMillisCheckFailMsgPrefix(timeFrom, "from")),
-            ApiUtils.validateMillisecondInstant(timeTo, prepareMillisCheckFailMsgPrefix(timeTo, "to")));
     }
 
     @Override
@@ -180,15 +171,14 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
         };
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    public KeyValueIterator<Windowed<K>, V> fetchAll(final long timeFrom, final long timeTo) {
+    public KeyValueIterator<Windowed<K>, V> fetchAll(final Instant timeFrom, final Instant timeTo) {
         if (!open) {
             throw new InvalidStateStoreException("Store is not open");
         }
         final List<KeyValue<Windowed<K>, V>> results = new ArrayList<>();
         for (final long now : data.keySet()) {
-            if (!(now >= timeFrom && now <= timeTo)) {
+            if (!(now >= timeFrom.toEpochMilli() && now <= timeTo.toEpochMilli())) {
                 continue;
             }
             final NavigableMap<K, V> kvMap = data.get(now);
@@ -221,13 +211,6 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
             }
 
         };
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, V> fetchAll(final Instant timeFrom, final Instant timeTo) throws IllegalArgumentException {
-        return fetchAll(
-            ApiUtils.validateMillisecondInstant(timeFrom, prepareMillisCheckFailMsgPrefix(timeFrom, "from")),
-            ApiUtils.validateMillisecondInstant(timeTo, prepareMillisCheckFailMsgPrefix(timeTo, "to")));
     }
 
     @Override
@@ -274,14 +257,13 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
         };
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom, final K keyTo, final long timeFrom, final long timeTo) {
+    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom, final K keyTo, final Instant timeFrom, final Instant timeTo) {
         if (!open) {
             throw new InvalidStateStoreException("Store is not open");
         }
         final List<KeyValue<Windowed<K>, V>> results = new ArrayList<>();
-        for (long now = timeFrom; now <= timeTo; now++) {
+        for (long now = timeFrom.toEpochMilli(); now <= timeTo.toEpochMilli(); now++) {
             final NavigableMap<K, V> kvMap = data.get(now);
             if (kvMap != null) {
                 for (final Entry<K, V> entry : kvMap.subMap(keyFrom, true, keyTo, true).entrySet()) {
@@ -312,18 +294,6 @@ public class ReadOnlyWindowStoreStub<K, V> implements ReadOnlyWindowStore<K, V>,
             }
 
         };
-    }
-
-    @Override
-    public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom,
-                                                  final K keyTo,
-                                                  final Instant timeFrom,
-                                                  final Instant timeTo) throws IllegalArgumentException {
-        return fetch(
-            keyFrom,
-            keyTo,
-            ApiUtils.validateMillisecondInstant(timeFrom, prepareMillisCheckFailMsgPrefix(timeFrom, "fromTime")),
-            ApiUtils.validateMillisecondInstant(timeTo, prepareMillisCheckFailMsgPrefix(timeTo, "toTime")));
     }
 
     @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -1264,10 +1264,21 @@ public class TopologyTestDriver implements Closeable {
         }
 
         @Override
+        public WindowStoreIterator<V> fetch(K key, long timeFrom, long timeTo) {
+            return fetch(key, Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
+        }
+
+        @Override
         public WindowStoreIterator<V> backwardFetch(final K key,
                                                     final long timeFrom,
                                                     final long timeTo) {
             return backwardFetch(key, Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, V> fetch(K keyFrom, K keyTo, long timeFrom,
+                                                      long timeTo) {
+            return fetch(keyFrom, keyTo, Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
         }
 
         @Override
@@ -1276,6 +1287,11 @@ public class TopologyTestDriver implements Closeable {
                                                               final long timeFrom,
                                                               final long timeTo) {
             return backwardFetch(keyFrom, keyTo, Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
+        }
+
+        @Override
+        public KeyValueIterator<Windowed<K>, V> fetchAll(long timeFrom, long timeTo) {
+            return fetchAll(Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
         }
 
         @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -43,17 +43,12 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.StreamsProducer;
-import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.WindowStoreIterator;
-import org.apache.kafka.streams.state.internals.ReadOnlyKeyValueStoreFacade;
-import org.apache.kafka.streams.state.internals.ReadOnlyWindowStoreFacade;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.ChangelogRegister;
 import org.apache.kafka.streams.processor.internals.ClientUtils;
@@ -71,9 +66,11 @@ import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
 import org.apache.kafka.streams.processor.internals.StateDirectory;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.streams.processor.internals.StreamsProducer;
 import org.apache.kafka.streams.processor.internals.Task;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
+import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlySessionStore;
@@ -83,6 +80,9 @@ import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.TimestampedWindowStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+import org.apache.kafka.streams.state.internals.ReadOnlyKeyValueStoreFacade;
+import org.apache.kafka.streams.state.internals.ReadOnlyWindowStoreFacade;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.streams.test.TestRecord;
 import org.slf4j.Logger;
@@ -1264,7 +1264,9 @@ public class TopologyTestDriver implements Closeable {
         }
 
         @Override
-        public WindowStoreIterator<V> fetch(K key, long timeFrom, long timeTo) {
+        public WindowStoreIterator<V> fetch(final K key,
+                                            final long timeFrom,
+                                            final long timeTo) {
             return fetch(key, Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
         }
 
@@ -1276,9 +1278,12 @@ public class TopologyTestDriver implements Closeable {
         }
 
         @Override
-        public KeyValueIterator<Windowed<K>, V> fetch(K keyFrom, K keyTo, long timeFrom,
-                                                      long timeTo) {
-            return fetch(keyFrom, keyTo, Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
+        public KeyValueIterator<Windowed<K>, V> fetch(final K keyFrom,
+                                                      final K keyTo,
+                                                      final long timeFrom,
+                                                      final long timeTo) {
+            return fetch(keyFrom, keyTo, Instant.ofEpochMilli(timeFrom),
+                Instant.ofEpochMilli(timeTo));
         }
 
         @Override
@@ -1290,12 +1295,14 @@ public class TopologyTestDriver implements Closeable {
         }
 
         @Override
-        public KeyValueIterator<Windowed<K>, V> fetchAll(long timeFrom, long timeTo) {
+        public KeyValueIterator<Windowed<K>, V> fetchAll(final long timeFrom,
+                                                         final long timeTo) {
             return fetchAll(Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
         }
 
         @Override
-        public KeyValueIterator<Windowed<K>, V> backwardFetchAll(final long timeFrom, final long timeTo) {
+        public KeyValueIterator<Windowed<K>, V> backwardFetchAll(final long timeFrom,
+                                                                 final long timeTo) {
             return backwardFetchAll(Instant.ofEpochMilli(timeFrom), Instant.ofEpochMilli(timeTo));
         }
 


### PR DESCRIPTION
Implement first part of https://cwiki.apache.org/confluence/display/KAFKA/KIP-667%3A+Remove+deprecated+methods+from+ReadOnlyWindowStore. Preparing it for v3.0

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
