### PR TITLE
MINOR: fix failing ZooKeeper system tests

### DIFF
--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -382,6 +382,8 @@ class SecurityConfig(TemplateRenderer):
             sasl_mechanisms += list(self.serves_raft_sasl)
         if self.uses_raft_sasl:
             sasl_mechanisms += list(self.uses_raft_sasl)
+        if self.zk_sasl:
+            sasl_mechanisms += [SecurityConfig.SASL_MECHANISM_GSSAPI]
         return set(sasl_mechanisms)
 
     @property

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -372,6 +372,9 @@ class SecurityConfig(TemplateRenderer):
 
     @property
     def enabled_sasl_mechanisms(self):
+        """
+        :return: all the SASL mechanisms in use, including for brokers, clients, controllers, and ZooKeeper
+        """
         sasl_mechanisms = []
         if self.is_sasl(self.security_protocol):
             # .csv is supported so be sure to account for that possibility


### PR DESCRIPTION
ZooKeeper-related system tests in `zookeeper_security_upgrade_test.py` and `zookeeper_tls_test.py` broke due to https://github.com/apache/kafka/pull/10199/.  That patch changed the logic of `SecurityConfig.enabled_sasl_mechanisms()` to only add the inter-broker SASL mechanism when the inter-broker protocol was `SASL_{PLAINTEXT,SSL}`.  The inter-broker protocol is left to default to `PLAINTEXT` for the `SecurityConfig` instance associated with Zookeeper since that value doesn't apply to ZooKeeper, so the default inter-broker SASL mechanism of `GSSAPI` was not being added into the set returned by `enabled_sasl_mechanisms()`.  This is actually correct -- `GSSAPI` shouldn't be added since inter-broker communication is a Kafka concept and doesn't apply to ZooKeeper.  `GSSAPI` should be added when ZooKeeper uses it, though -- which is the case in these tests.  So the prior patch referred to above uncovered a bug: we were relying on the default inter-broker SASL mechanism to signal that Kerberos was being used by ZooKeeper even though the inter-broker protocol has nothing to do with that determination in such cases.  This patch explicitly includes `GSSAPI` in the list of enabled SASL mechanisms when SASL is enabled for use by ZooKeeper.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
