### PR TITLE
MINOR: Disable client compatibility system test for Raft quorums

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -19,7 +19,7 @@ import errno
 import time
 from random import randint
 
-from ducktape.mark import matrix, parametrize
+from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
 from ducktape.tests.test import TestContext
 
@@ -109,7 +109,7 @@ class ClientCompatibilityFeaturesTest(Test):
           raise
 
     @cluster(num_nodes=7)
-    @matrix(broker_version=[str(DEV_BRANCH)], metadata_quorum=quorum.all_non_upgrade)
+    @parametrize(broker_version=str(DEV_BRANCH))
     @parametrize(broker_version=str(LATEST_0_10_0))
     @parametrize(broker_version=str(LATEST_0_10_1))
     @parametrize(broker_version=str(LATEST_0_10_2))


### PR DESCRIPTION
The client compatibility system test cannot pass for Raft-based quorums because several APIs have not yet been implemented, and these not-yet-implemented APIs were disabled via https://github.com/apache/kafka/pull/10194/.  The client compatibility system tests now fail since that patch was merged.  This patch disables this system test for Raft-based quorums.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
