### PR TITLE
KAFKA-12452: Remove deprecated overloads of ProcessorContext#forward

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -190,29 +190,6 @@ public interface ProcessorContext {
     <K, V> void forward(final K key, final V value, final To to);
 
     /**
-     * Forwards a key/value pair to one of the downstream processors designated by childIndex.
-     *
-     * @param key key
-     * @param value value
-     * @param childIndex index in list of children of this node
-     * @deprecated please use {@link #forward(Object, Object, To)} instead
-     */
-    // TODO when we remove this method, we can also remove `ProcessorNode#children`
-    @Deprecated
-    <K, V> void forward(final K key, final V value, final int childIndex);
-
-    /**
-     * Forwards a key/value pair to one of the downstream processors designated by the downstream processor name.
-     *
-     * @param key key
-     * @param value value
-     * @param childName name of downstream processor
-     * @deprecated please use {@link #forward(Object, Object, To)} instead
-     */
-    @Deprecated
-    <K, V> void forward(final K key, final V value, final String childName);
-
-    /**
      * Requests a commit.
      */
     void commit();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -116,18 +116,6 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
     }
 
     @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final int childIndex) {
-        throw new StreamsException(EXPLANATION);
-    }
-
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final String childName) {
-        throw new StreamsException(EXPLANATION);
-    }
-
-    @Override
     public void commit() {
         delegate.commit();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -80,7 +80,6 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
         throw new UnsupportedOperationException("this should not happen: forward() not supported in global processor context.");
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <KIn, VIn> void forward(final KIn key, final VIn value) {
         forward(new Record<>(key, value, timestamp(), headers()));
@@ -94,24 +93,6 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
         if (!currentNode().children().isEmpty()) {
             throw new IllegalStateException("This method should only be called on 'GlobalStateStore.flush' that should not have any children.");
         }
-    }
-
-    /**
-     * @throws UnsupportedOperationException on every invocation
-     */
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final int childIndex) {
-        throw new UnsupportedOperationException("this should not happen: forward() not supported in global processor context.");
-    }
-
-    /**
-     * @throws UnsupportedOperationException on every invocation
-     */
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final String childName) {
-        throw new UnsupportedOperationException("this should not happen: forward() not supported in global processor context.");
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -173,34 +173,6 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
     }
 
     @Override
-    @Deprecated
-    public <K, V> void forward(final K key,
-                               final V value,
-                               final int childIndex) {
-        final Record<K, V> toForward = new Record<>(
-            key,
-            value,
-            timestamp(),
-            headers()
-        );
-        forward(toForward, (currentNode().children()).get(childIndex).name());
-    }
-
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key,
-                               final V value,
-                               final String childName) {
-        final Record<K, V> toForward = new Record<>(
-            key,
-            value,
-            timestamp(),
-            headers()
-        );
-        forward(toForward, childName);
-    }
-
-    @Override
     public <K, V> void forward(final K key,
                                final V value,
                                final To to) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -37,7 +37,6 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 
 public class ProcessorNode<KIn, VIn, KOut, VOut> {
 
-    // TODO: 'children' can be removed when #forward() via index is removed
     private final List<ProcessorNode<KOut, VOut, ?, ?>> children;
     private final Map<String, ProcessorNode<KOut, VOut, ?, ?>> childByName;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapter.java
@@ -109,18 +109,6 @@ public final class StoreToProcessorContextAdapter implements ProcessorContext {
         throw new UnsupportedOperationException("StateStores can't access forward.");
     }
 
-    @Deprecated
-    @Override
-    public <K, V> void forward(final K key, final V value, final int childIndex) {
-        throw new UnsupportedOperationException("StateStores can't access forward.");
-    }
-
-    @Deprecated
-    @Override
-    public <K, V> void forward(final K key, final V value, final String childName) {
-        throw new UnsupportedOperationException("StateStores can't access forward.");
-    }
-
     @Override
     public void commit() {
         throw new UnsupportedOperationException("StateStores can't access commit.");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -156,12 +156,6 @@ public class AbstractProcessorContextTest {
     }
 
     @Test
-    public void shouldThrowIllegalStateExceptionOnHeadersIfNoRecordContext() {
-        context.setRecordContext(null);
-        assertThrows(IllegalStateException.class, context::headers);
-    }
-
-    @Test
     public void appConfigsShouldReturnParsedValues() {
         assertThat(
             context.appConfigs().get(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -158,26 +158,23 @@ public class AbstractProcessorContextTest {
     @Test
     public void shouldThrowIllegalStateExceptionOnHeadersIfNoRecordContext() {
         context.setRecordContext(null);
-        try {
-            context.headers();
-        } catch (final IllegalStateException e) {
-            // pass
-        }
+        assertThrows(IllegalStateException.class, context::headers);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void appConfigsShouldReturnParsedValues() {
         assertThat(
             context.appConfigs().get(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG),
-            equalTo(RocksDBConfigSetter.class));
+            equalTo(RocksDBConfigSetter.class)
+        );
     }
 
     @Test
     public void appConfigsShouldReturnUnrecognizedValues() {
         assertThat(
             context.appConfigs().get("user.supplied.config"),
-            equalTo("user-supplied-value"));
+            equalTo("user-supplied-value")
+        );
     }
 
     private static class TestProcessorContext extends AbstractProcessorContext {
@@ -229,14 +226,6 @@ public class AbstractProcessorContextTest {
 
         @Override
         public <K, V> void forward(final K key, final V value, final To to) {}
-
-        @Override
-        @Deprecated
-        public <K, V> void forward(final K key, final V value, final int childIndex) {}
-
-        @Override
-        @Deprecated
-        public <K, V> void forward(final K key, final V value, final String childName) {}
 
         @Override
         public void commit() {}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContextTest.java
@@ -48,16 +48,4 @@ public class ForwardingDisabledProcessorContextTest {
     public void shouldThrowOnForwardWithTo() {
         assertThrows(StreamsException.class, () -> context.forward("key", "value", To.all()));
     }
-
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test
-    public void shouldThrowOnForwardWithChildIndex() {
-        assertThrows(StreamsException.class, () -> context.forward("key", "value", 1));
-    }
-
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test
-    public void shouldThrowOnForwardWithChildName() {
-        assertThrows(StreamsException.class, () -> context.forward("key", "value", "child1"));
-    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -52,7 +52,6 @@ public class GlobalProcessorContextImplTest {
     private static final String GLOBAL_TIMESTAMPED_WINDOW_STORE_NAME = "global-timestamped-window-store";
     private static final String GLOBAL_SESSION_STORE_NAME = "global-session-store";
     private static final String UNKNOWN_STORE = "unknown-store";
-    private static final String CHILD_PROCESSOR = "child";
 
     private GlobalProcessorContextImpl globalContext;
 
@@ -116,18 +115,6 @@ public class GlobalProcessorContextImplTest {
     @Test
     public void shouldFailToForwardUsingToParameter() {
         assertThrows(IllegalStateException.class, () -> globalContext.forward(null, null, To.all()));
-    }
-
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test
-    public void shouldNotSupportForwardingViaChildIndex() {
-        assertThrows(UnsupportedOperationException.class, () -> globalContext.forward(null, null, 0));
-    }
-
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test
-    public void shouldNotSupportForwardingViaChildName() {
-        assertThrows(UnsupportedOperationException.class, () -> globalContext.forward(null, null, "processorName"));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -71,7 +71,7 @@ public class ProcessorContextImplTest {
 
     private final StreamsConfig streamsConfig = streamsConfigMock();
 
-    private RecordCollector recordCollector = mock(RecordCollector.class);
+    private final RecordCollector recordCollector = mock(RecordCollector.class);
 
     private static final String KEY = "key";
     private static final Bytes KEY_BYTES = Bytes.wrap(KEY.getBytes());
@@ -439,26 +439,6 @@ public class ProcessorContextImplTest {
         );
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldThrowUnsupportedOperationExceptionOnForwardWithChildIndex() {
-        context = getStandbyContext();
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> context.forward("key", "value", 0)
-        );
-    }
-
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldThrowUnsupportedOperationExceptionOnForwardWithChildName() {
-        context = getStandbyContext();
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> context.forward("key", "value", "child-name")
-        );
-    }
-
     @Test
     public void shouldThrowUnsupportedOperationExceptionOnForwardWithTo() {
         context = getStandbyContext();
@@ -749,11 +729,10 @@ public class ProcessorContextImplTest {
     }
 
     private <T extends StateStore> void doTest(final String name, final Consumer<T> checker) {
-        final Processor processor = new Processor<String, Long>() {
+        final Processor<String, Long> processor = new Processor<String, Long>() {
             @Override
-            @SuppressWarnings("unchecked")
             public void init(final ProcessorContext context) {
-                final T store = (T) context.getStateStore(name);
+                final T store = context.getStateStore(name);
                 checker.accept(store);
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapterTest.java
@@ -79,18 +79,6 @@ public class StoreToProcessorContextAdapterTest {
         context.forward("key", "value", To.all());
     }
 
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldThrowOnForwardWithChildIndex() {
-        context.forward("key", "value", 1);
-    }
-
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldThrowOnForwardWithChildName() {
-        context.forward("key", "value", "child1");
-    }
-
     @Test(expected = UnsupportedOperationException.class)
     public void shouldThrowOnCommit() {
         context.commit();

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -322,18 +322,6 @@ public class InternalMockProcessorContext
         forward(key, value, To.all());
     }
 
-    @Override
-    @Deprecated
-    public void forward(final Object key, final Object value, final int childIndex) {
-        forward(key, value, To.child((currentNode().children()).get(childIndex).name()));
-    }
-
-    @Override
-    @Deprecated
-    public void forward(final Object key, final Object value, final String childName) {
-        forward(key, value, To.child(childName));
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public void forward(final Object key, final Object value, final To to) {

--- a/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
@@ -106,18 +106,6 @@ public class NoOpProcessorContext extends AbstractProcessorContext {
     }
 
     @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final int childIndex) {
-        forward(key, value);
-    }
-
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final String childName) {
-        forward(key, value);
-    }
-
-    @Override
     public void commit() {}
 
     @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -480,38 +480,18 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
         return new LinkedList<>(punctuators);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <K, V> void forward(final K key, final V value) {
         forward(key, value, To.all());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <K, V> void forward(final K key, final V value, final To to) {
         capturedForwards.add(
             new CapturedForward(
                 to.timestamp == -1 ? to.withTimestamp(recordTimestamp == null ? -1 : recordTimestamp) : to,
-                new KeyValue(key, value)
+                new KeyValue<>(key, value)
             )
-        );
-    }
-
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final int childIndex) {
-        throw new UnsupportedOperationException(
-            "Forwarding to a child by index is deprecated. " +
-                "Please transition processors to forward using a 'To' object instead."
-        );
-    }
-
-    @Override
-    @Deprecated
-    public <K, V> void forward(final K key, final V value, final String childName) {
-        throw new UnsupportedOperationException(
-            "Forwarding to a child by name is deprecated. " +
-                "Please transition processors to forward using 'To.child(childName)' instead."
         );
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -159,48 +159,6 @@ public class MockProcessorContextTest {
     }
 
     @Test
-    public void shouldThrowIfForwardedWithDeprecatedChildIndex() {
-        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
-            @Override
-            public void process(final String key, final Long value) {
-                context().forward(key, value, 0);
-            }
-        };
-
-        final MockProcessorContext context = new MockProcessorContext();
-
-        processor.init(context);
-
-        try {
-            processor.process("foo", 5L);
-            fail("Should have thrown an UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) {
-            // expected
-        }
-    }
-
-    @Test
-    public void shouldThrowIfForwardedWithDeprecatedChildName() {
-        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
-            @Override
-            public void process(final String key, final Long value) {
-                context().forward(key, value, "child1");
-            }
-        };
-
-        final MockProcessorContext context = new MockProcessorContext();
-
-        processor.init(context);
-
-        try {
-            processor.process("foo", 5L);
-            fail("Should have thrown an UnsupportedOperationException.");
-        } catch (final UnsupportedOperationException expected) {
-            // expected
-        }
-    }
-
-    @Test
     public void shouldCaptureCommitsAndAllowReset() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
             private int count = 0;


### PR DESCRIPTION
ProcessorContext#forward was changed via KIP-251 in 2.0.0 release. This PR removes the old and deprecated overloads.

Call for review @guozhangwang @ableegoldman 