### PR TITLE
MINOR: Remove redundant inheritance from FilteringJmxReporter #onMetricRemoved

### DIFF
--- a/core/src/main/java/kafka/metrics/FilteringJmxReporter.java
+++ b/core/src/main/java/kafka/metrics/FilteringJmxReporter.java
@@ -40,11 +40,6 @@ public class FilteringJmxReporter extends JmxReporter {
         }
     }
 
-    @Override
-    public void onMetricRemoved(MetricName name) {
-        super.onMetricRemoved(name);
-    }
-
     public void updatePredicate(Predicate<MetricName> predicate) {
         this.metricPredicate = predicate;
         // re-register metrics on update


### PR DESCRIPTION
The method of inheritance is redundant.
This method that already has the same function.
So I remove it.
