### PR TITLE
KAFKA-12454: Add ERROR logging on kafka-log-dirs when given brokerIds do not  exist in current kafka cluster

### DIFF
--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -21,7 +21,7 @@ import java.io.PrintStream
 import java.util.Properties
 
 import kafka.utils.{CommandDefaultOptions, CommandLineUtils, Json}
-import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, DescribeLogDirsResult, LogDirDescription}
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, LogDirDescription}
 import org.apache.kafka.common.utils.Utils
 
 import scala.jdk.CollectionConverters._
@@ -50,10 +50,10 @@ object LogDirsCommand {
             }
 
             if (nonExistingBrokers.nonEmpty) {
-                out.println(s"ERROR: The given node(s) does not exist from broker-list: ${nonExistingBrokers.mkString(",")}. Current cluster exist node(s): ${clusterBrokers.mkString(",")}")
+                out.println(s"ERROR: The given broker(s) does not exist from --broker-list: ${nonExistingBrokers.mkString(",")}. Current cluster exist broker(s): ${clusterBrokers.mkString(",")}")
             } else {
                 out.println("Querying brokers for log directories information")
-                val describeLogDirsResult: DescribeLogDirsResult = adminClient.describeLogDirs(existingBrokers.map(Integer.valueOf).toSeq.asJava)
+                val describeLogDirsResult = adminClient.describeLogDirs(existingBrokers.map(Integer.valueOf).toSeq.asJava)
                 val logDirInfosByBroker = describeLogDirsResult.allDescriptions.get().asScala.map { case (k, v) => k -> v.asScala }
 
                 out.println(s"Received log directory information from brokers ${existingBrokers.mkString(",")}")

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -45,7 +45,7 @@ object LogDirsCommand {
             val (existingBrokers, nonExistingBrokers) = Option(opts.options.valueOf(opts.brokerListOpt)) match {
                 case Some(brokerListStr) =>
                     val inputBrokers = brokerListStr.split(',').filter(_.nonEmpty).map(_.toInt).toSet
-                    (inputBrokers, inputBrokers.diff(clusterBrokers))
+                    (inputBrokers.intersect(clusterBrokers), inputBrokers.diff(clusterBrokers))
                 case None => (clusterBrokers, Set.empty)
             }
 

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -39,8 +39,8 @@ object LogDirsCommand {
     def describe(args: Array[String], out: PrintStream): Unit = {
         val opts = new LogDirsCommandOptions(args)
         val adminClient = createAdminClient(opts)
-        val topicList = opts.options.valueOf(opts.topicListOpt).split(",").filter(_.nonEmpty)
         try {
+            val topicList = opts.options.valueOf(opts.topicListOpt).split(",").filter(_.nonEmpty)
             val clusterBrokers = adminClient.describeCluster().nodes().get().asScala.map(_.id()).toSet
             val (existingBrokers, nonExistingBrokers) = Option(opts.options.valueOf(opts.brokerListOpt)) match {
                 case Some(brokerListStr) =>
@@ -50,7 +50,8 @@ object LogDirsCommand {
             }
 
             if (nonExistingBrokers.nonEmpty) {
-                out.println(s"ERROR: The given brokers do not exist from --broker-list: ${nonExistingBrokers.mkString(",")}. Current cluster exist brokers: ${clusterBrokers.mkString(",")}")
+                out.println(s"ERROR: The given brokers do not exist from --broker-list: ${nonExistingBrokers.mkString(",")}." +
+                  s" Current existent brokers: ${clusterBrokers.mkString(",")}")
             } else {
                 out.println("Querying brokers for log directories information")
                 val describeLogDirsResult = adminClient.describeLogDirs(existingBrokers.map(Integer.valueOf).toSeq.asJava)

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -50,7 +50,7 @@ object LogDirsCommand {
             }
 
             if (nonExistingBrokers.nonEmpty) {
-                out.println(s"ERROR: The given broker(s) does not exist from --broker-list: ${nonExistingBrokers.mkString(",")}. Current cluster exist broker(s): ${clusterBrokers.mkString(",")}")
+                out.println(s"ERROR: The given brokers do not exist from --broker-list: ${nonExistingBrokers.mkString(",")}. Current cluster exist brokers: ${clusterBrokers.mkString(",")}")
             } else {
                 out.println("Querying brokers for log directories information")
                 val describeLogDirsResult = adminClient.describeLogDirs(existingBrokers.map(Integer.valueOf).toSeq.asJava)

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -41,23 +41,26 @@ object LogDirsCommand {
         val adminClient = createAdminClient(opts)
         val topicList = opts.options.valueOf(opts.topicListOpt).split(",").filter(!_.isEmpty)
         val clusterBrokers: Array[Int] = adminClient.describeCluster().nodes().get().asScala.map(_.id()).toArray
+        var nonExistBrokers: Array[Int] = Array.emptyIntArray
         val brokerList = Option(opts.options.valueOf(opts.brokerListOpt)) match {
-            case Some(brokerListStr) => brokerListStr.split(',').filter(!_.isEmpty).map(_.toInt)
+            case Some(brokerListStr) => {
+                val inputBrokers: Array[Int] = brokerListStr.split(',').filter(!_.isEmpty).map(_.toInt)
+                nonExistBrokers = inputBrokers.filterNot(brokerId => clusterBrokers.contains(brokerId))
+                inputBrokers
+            }
             case None => clusterBrokers
         }
 
-        val nonExistBrokers: Array[Int] = brokerList.filterNot(brokerId => clusterBrokers.contains(brokerId))
         if (!nonExistBrokers.isEmpty) {
-          System.err.println(s"The given node(s) does not exist from broker-list ${nonExistBrokers.mkString(",")}")
-          sys.exit(1)
+            out.println(s"ERROR: The given node(s) does not exist from broker-list ${nonExistBrokers.mkString(",")}")
+        } else {
+            out.println("Querying brokers for log directories information")
+            val describeLogDirsResult: DescribeLogDirsResult = adminClient.describeLogDirs(brokerList.map(Integer.valueOf).toSeq.asJava)
+            val logDirInfosByBroker = describeLogDirsResult.allDescriptions.get().asScala.map { case (k, v) => k -> v.asScala }
+
+            out.println(s"Received log directory information from brokers ${brokerList.mkString(",")}")
+            out.println(formatAsJson(logDirInfosByBroker, topicList.toSet))
         }
-
-        out.println("Querying brokers for log directories information")
-        val describeLogDirsResult: DescribeLogDirsResult = adminClient.describeLogDirs(brokerList.map(Integer.valueOf).toSeq.asJava)
-        val logDirInfosByBroker = describeLogDirsResult.allDescriptions.get().asScala.map { case (k, v) => k -> v.asScala }
-
-        out.println(s"Received log directory information from brokers ${brokerList.mkString(",")}")
-        out.println(formatAsJson(logDirInfosByBroker, topicList.toSet))
         adminClient.close()
     }
 

--- a/core/src/main/scala/kafka/admin/LogDirsCommand.scala
+++ b/core/src/main/scala/kafka/admin/LogDirsCommand.scala
@@ -47,8 +47,10 @@ object LogDirsCommand {
         }
 
         val nonExistBrokers: Array[Int] = brokerList.filterNot(brokerId => clusterBrokers.contains(brokerId))
-        if (!nonExistBrokers.isEmpty)
-            System.err.println(s"The given node(s) does not exist from broker-list ${nonExistBrokers.mkString(",")}")
+        if (!nonExistBrokers.isEmpty) {
+          System.err.println(s"The given node(s) does not exist from broker-list ${nonExistBrokers.mkString(",")}")
+          sys.exit(1)
+        }
 
         out.println("Querying brokers for log directories information")
         val describeLogDirsResult: DescribeLogDirsResult = adminClient.describeLogDirs(brokerList.map(Integer.valueOf).toSeq.asJava)

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -14,12 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package unit.kafka.admin
+package kafka.admin
 
 import java.io.{ByteArrayOutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 
-import kafka.admin.LogDirsCommand
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package unit.kafka.admin
 
 import java.io.{ByteArrayOutputStream, PrintStream}

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -1,0 +1,52 @@
+package unit.kafka.admin
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.nio.charset.StandardCharsets
+
+import kafka.admin.LogDirsCommand
+import kafka.integration.KafkaServerTestHarness
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+import scala.collection.Seq
+
+class LogDirsCommandTest extends KafkaServerTestHarness {
+
+  def generateConfigs: Seq[KafkaConfig] = {
+    TestUtils.createBrokerConfigs(1, zkConnect)
+      .map(KafkaConfig.fromProps)
+  }
+
+  @Test
+  def checkLogDirsCommandOutput(): Unit = {
+    val byteArrayOutputStream = new ByteArrayOutputStream
+    val printStream = new PrintStream(byteArrayOutputStream, false, StandardCharsets.UTF_8.name())
+    //input exist brokerList
+    LogDirsCommand.describe(Array("--bootstrap-server", brokerList, "--broker-list", "0", "--describe"), printStream)
+    val existBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
+    val existBrokersLineIter = existBrokersContent.split("\n").iterator
+
+    assertTrue(existBrokersLineIter.hasNext)
+    assertTrue(existBrokersLineIter.next().contains(s"Querying brokers for log directories information"))
+
+    //input nonExist brokerList
+    byteArrayOutputStream.reset()
+    LogDirsCommand.describe(Array("--bootstrap-server", brokerList, "--broker-list", "0,1,2", "--describe"), printStream)
+    val nonExistBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
+    val nonExistBrokersLineIter = nonExistBrokersContent.split("\n").iterator
+
+    assertTrue(nonExistBrokersLineIter.hasNext)
+    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given node(s) does not exist from broker-list 1,2"))
+
+    //use all brokerList for current cluster
+    byteArrayOutputStream.reset()
+    LogDirsCommand.describe(Array("--bootstrap-server", brokerList, "--describe"), printStream)
+    val allBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
+    val allBrokersLineIter = allBrokersContent.split("\n").iterator
+
+    assertTrue(allBrokersLineIter.hasNext)
+    assertTrue(allBrokersLineIter.next().contains(s"Querying brokers for log directories information"))
+  }
+}

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -38,7 +38,7 @@ class LogDirsCommandTest extends KafkaServerTestHarness {
     val nonExistBrokersLineIter = nonExistBrokersContent.split("\n").iterator
 
     assertTrue(nonExistBrokersLineIter.hasNext)
-    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given node(s) does not exist from broker-list 1,2"))
+    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given node(s) does not exist from broker-list: 1,2. Current cluster exist node(s): 0"))
 
     //use all brokerList for current cluster
     byteArrayOutputStream.reset()

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -41,20 +41,29 @@ class LogDirsCommandTest extends KafkaServerTestHarness {
     val printStream = new PrintStream(byteArrayOutputStream, false, StandardCharsets.UTF_8.name())
     //input exist brokerList
     LogDirsCommand.describe(Array("--bootstrap-server", brokerList, "--broker-list", "0", "--describe"), printStream)
-    val existBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
-    val existBrokersLineIter = existBrokersContent.split("\n").iterator
+    val existingBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
+    val existingBrokersLineIter = existingBrokersContent.split("\n").iterator
 
-    assertTrue(existBrokersLineIter.hasNext)
-    assertTrue(existBrokersLineIter.next().contains(s"Querying brokers for log directories information"))
+    assertTrue(existingBrokersLineIter.hasNext)
+    assertTrue(existingBrokersLineIter.next().contains(s"Querying brokers for log directories information"))
 
-    //input nonExist brokerList
+    //input nonexistent brokerList
     byteArrayOutputStream.reset()
     LogDirsCommand.describe(Array("--bootstrap-server", brokerList, "--broker-list", "0,1,2", "--describe"), printStream)
-    val nonExistBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
-    val nonExistBrokersLineIter = nonExistBrokersContent.split("\n").iterator
+    val nonExistingBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
+    val nonExistingBrokersLineIter = nonExistingBrokersContent.split("\n").iterator
 
-    assertTrue(nonExistBrokersLineIter.hasNext)
-    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given brokers do not exist from --broker-list: 1,2. Current cluster exist brokers: 0"))
+    assertTrue(nonExistingBrokersLineIter.hasNext)
+    assertTrue(nonExistingBrokersLineIter.next().contains(s"ERROR: The given brokers do not exist from --broker-list: 1,2. Current existent brokers: 0"))
+
+    //input duplicate ids
+    byteArrayOutputStream.reset()
+    LogDirsCommand.describe(Array("--bootstrap-server", brokerList, "--broker-list", "0,0,1,2,2", "--describe"), printStream)
+    val duplicateBrokersContent = new String(byteArrayOutputStream.toByteArray, StandardCharsets.UTF_8)
+    val duplicateBrokersLineIter = duplicateBrokersContent.split("\n").iterator
+
+    assertTrue(duplicateBrokersLineIter.hasNext)
+    assertTrue(duplicateBrokersLineIter.next().contains(s"ERROR: The given brokers do not exist from --broker-list: 1,2. Current existent brokers: 0"))
 
     //use all brokerList for current cluster
     byteArrayOutputStream.reset()

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -54,7 +54,7 @@ class LogDirsCommandTest extends KafkaServerTestHarness {
     val nonExistBrokersLineIter = nonExistBrokersContent.split("\n").iterator
 
     assertTrue(nonExistBrokersLineIter.hasNext)
-    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given broker(s) does not exist from --broker-list: 1,2. Current cluster exist broker(s): 0"))
+    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given brokers do not exist from --broker-list: 1,2. Current cluster exist brokers: 0"))
 
     //use all brokerList for current cluster
     byteArrayOutputStream.reset()

--- a/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LogDirsCommandTest.scala
@@ -54,7 +54,7 @@ class LogDirsCommandTest extends KafkaServerTestHarness {
     val nonExistBrokersLineIter = nonExistBrokersContent.split("\n").iterator
 
     assertTrue(nonExistBrokersLineIter.hasNext)
-    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given node(s) does not exist from broker-list: 1,2. Current cluster exist node(s): 0"))
+    assertTrue(nonExistBrokersLineIter.next().contains(s"ERROR: The given broker(s) does not exist from --broker-list: 1,2. Current cluster exist broker(s): 0"))
 
     //use all brokerList for current cluster
     byteArrayOutputStream.reset()


### PR DESCRIPTION
When non-existent brokerIds value are given, the kafka-log-dirs tool will have a timeout error:

Exception in thread "main" java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeLogDirs
at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45)
at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32)
at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:89)
at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:260)
at kafka.admin.LogDirsCommand$.describe(LogDirsCommand.scala:50)
at kafka.admin.LogDirsCommand$.main(LogDirsCommand.scala:36)
at kafka.admin.LogDirsCommand.main(LogDirsCommand.scala)
Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: describeLogDirs

 

When the brokerId entered by the user does not exist, an error message indicating that the node is not present should be printed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
