### PR TITLE
MINOR: Log project, gradle, java and scala versions at the start of the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ if (file('.git').exists()) {
   }
 }
 
+println("Starting build with version $version using Gradle $gradleVersion, Java ${JavaVersion.current()} and Scala ${versions.scala}")
 
 subprojects {
 
@@ -751,8 +752,6 @@ tasks.create(name: "jarConnect", dependsOn: connectPkgs.collect { it + ":jar" })
 tasks.create(name: "testConnect", dependsOn: connectPkgs.collect { it + ":test" }) {}
 
 project(':core') {
-  println "Building project 'core' with Scala version ${versions.scala}"
-
   apply plugin: 'scala'
   
   // scaladoc generation is configured at the sub-module level with an artifacts
@@ -1554,7 +1553,6 @@ project(':streams') {
 }
 
 project(':streams:streams-scala') {
-  println "Building project 'streams-scala' with Scala version ${versions.scala}"
   apply plugin: 'scala'
   archivesBaseName = "kafka-streams-scala_${versions.baseScala}"
   dependencies {


### PR DESCRIPTION
This is useful when debugging build issues. I also removed two printlns that are now redundant, so
this makes the build more informative and less noisy at the same time. Example output:

> Starting build with version 3.0.0-SNAPSHOT using Gradle 6.8.3, Java 15 and Scala 2.13.5

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
