### PR TITLE
KAFKA-12460; Do not allow raft truncation below high watermark

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -152,6 +152,10 @@ final class KafkaMetadataLog private (
   }
 
   override def truncateTo(offset: Long): Unit = {
+    if (offset < highWatermark.offset) {
+      throw new IllegalArgumentException(s"Attempt to truncate to offset $offset, which is below " +
+        s"the current high watermark ${highWatermark.offset}")
+    }
     log.truncateTo(offset)
   }
 

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -443,6 +443,22 @@ final class KafkaMetadataLogTest {
     assertEquals(0L, appendInfo.firstOffset)
   }
 
+  @Test
+  def testTruncateBelowHighWatermark(): Unit = {
+    val log = buildMetadataLog(tempDir, mockTime)
+    val numRecords = 10
+    val epoch = 5
+
+    append(log, numRecords, epoch)
+    assertEquals(numRecords.toLong, log.endOffset.offset)
+
+    log.updateHighWatermark(new LogOffsetMetadata(numRecords))
+    assertEquals(numRecords.toLong, log.highWatermark.offset)
+
+    assertThrows(classOf[IllegalArgumentException], () => log.truncateTo(5L))
+    assertEquals(numRecords.toLong, log.highWatermark.offset)
+  }
+
   private def buildFullBatch(
     leaderEpoch: Int,
     recordSize: Int,

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -134,6 +134,16 @@ public class MockLogTest {
     }
 
     @Test
+    public void testTruncateBelowHighWatermark() {
+        appendBatch(5, 1);
+        LogOffsetMetadata highWatermark = new LogOffsetMetadata(5L);
+        log.updateHighWatermark(highWatermark);
+        assertEquals(highWatermark, log.highWatermark());
+        assertThrows(IllegalArgumentException.class, () -> log.truncateTo(4L));
+        assertEquals(highWatermark, log.highWatermark());
+    }
+
+    @Test
     public void testUpdateHighWatermark() {
         appendBatch(5, 1);
         LogOffsetMetadata newOffset = new LogOffsetMetadata(5L);


### PR DESCRIPTION
Initially we want to be strict about the loss of committed data for the `@metadata` topic. This patch ensures that truncation below the high watermark is not allowed. Note that `MockLog` already had the logic to do so, so the patch adds a similar check to `KafkaMetadataLog`. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
