### PR TITLE
MINOR: Fix log statement whose placeholders are inconsistent with arguments

### DIFF
--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -157,7 +157,7 @@ public final class LocalLogManager implements MetaLogManager, AutoCloseable {
             }
             if (nodeId != leader.nodeId()) {
                 log.trace("tryAppend(nodeId={}, epoch={}): the given node id does not " +
-                    "match the current leader id of {}.", nodeId, leader.nodeId());
+                    "match the current leader id of {}.", nodeId, epoch, leader.nodeId());
                 return Long.MAX_VALUE;
             }
             log.trace("tryAppend(nodeId={}): appending {}.", nodeId, batch);

--- a/tools/src/main/java/org/apache/kafka/trogdor/fault/ProcessStopFaultWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/fault/ProcessStopFaultWorker.java
@@ -71,7 +71,7 @@ public class ProcessStopFaultWorker implements TaskWorker {
                 try {
                     pids.add(Integer.parseInt(components[0]));
                 } catch (NumberFormatException e) {
-                    log.error("Failed to parse process ID from line {}", e);
+                    log.error("Failed to parse process ID from line", e);
                 }
             }
         }


### PR DESCRIPTION
*More detailed description of your change*
1. When the 2nd argument is an exception we don't need a placeholder
2. Placeholders should equal to arguments. 

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
