### PR TITLE
KAFKA-12456: Log "Listeners are not identical across brokers" message at WARN/INFO instead of ERROR

### DIFF
--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -392,7 +392,7 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
       aliveNodes.get(brokerId).foreach { listenerMap =>
         val listeners = listenerMap.keySet
         if (!aliveNodes.values.forall(_.keySet == listeners))
-          error(s"Listeners are not identical across brokers: $aliveNodes")
+          info(s"Listeners are not identical across brokers: $aliveNodes")
       }
 
       val newTopicIds = updateMetadataRequest.topicStates().asScala

--- a/core/src/main/scala/kafka/server/metadata/MetadataBrokers.scala
+++ b/core/src/main/scala/kafka/server/metadata/MetadataBrokers.scala
@@ -107,7 +107,7 @@ object MetadataBrokers {
       }
     }
     if (!listenersIdenticalAcrossBrokers) {
-      log.error("Listeners are not identical across alive brokers. " +
+      log.info("Listeners are not identical across alive brokers. " +
         _aliveBrokers.asScala.map(
           broker => s"${broker.id}: ${broker.endpoints.keySet.mkString(", ")}"))
     }


### PR DESCRIPTION
Minor modification suggested in the following issue: https://issues.apache.org/jira/projects/KAFKA/issues/KAFKA-12456?filter=addedrecently

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
