### PR TITLE
MINOR: remove redundant null check when testing specified type

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/UUIDDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/UUIDDeserializer.java
@@ -36,7 +36,7 @@ public class UUIDDeserializer implements Deserializer<UUID> {
         Object encodingValue = configs.get(propertyName);
         if (encodingValue == null)
             encodingValue = configs.get("deserializer.encoding");
-        if (encodingValue != null && encodingValue instanceof String)
+        if (encodingValue instanceof String)
             encoding = (String) encodingValue;
     }
 

--- a/shell/src/main/java/org/apache/kafka/shell/CommandUtils.java
+++ b/shell/src/main/java/org/apache/kafka/shell/CommandUtils.java
@@ -113,7 +113,7 @@ public final class CommandUtils {
                 pathComponents.size() : pathComponents.size() - 1;
             for (int i = 0; i < numDirectories; i++) {
                 MetadataNode node = directory.child(pathComponents.get(i));
-                if (node == null || !(node instanceof DirectoryNode)) {
+                if (!(node instanceof DirectoryNode)) {
                     return;
                 }
                 directory = (DirectoryNode) node;

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataNode.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataNode.java
@@ -54,7 +54,7 @@ public interface MetadataNode {
             DirectoryNode node = this;
             for (int i = 0; i < names.length - 1; i++) {
                 MetadataNode nextNode = node.children.get(names[i]);
-                if (nextNode == null || !(nextNode instanceof DirectoryNode)) {
+                if (!(nextNode instanceof DirectoryNode)) {
                     throw new RuntimeException("Unable to locate directory /" +
                         String.join("/", names));
                 }
@@ -95,7 +95,7 @@ public interface MetadataNode {
             DirectoryNode node = this;
             for (int i = 0; i < names.length; i++) {
                 MetadataNode nextNode = node.children.get(names[i]);
-                if (nextNode == null || !(nextNode instanceof DirectoryNode)) {
+                if (!(nextNode instanceof DirectoryNode)) {
                     throw new RuntimeException("Unable to locate directory /" +
                         String.join("/", names));
                 }
@@ -111,14 +111,14 @@ public interface MetadataNode {
             DirectoryNode node = this;
             for (int i = 0; i < names.length - 1; i++) {
                 MetadataNode nextNode = node.children.get(names[i]);
-                if (nextNode == null || !(nextNode instanceof DirectoryNode)) {
+                if (!(nextNode instanceof DirectoryNode)) {
                     throw new RuntimeException("Unable to locate file /" +
                         String.join("/", names));
                 }
                 node = (DirectoryNode) nextNode;
             }
             MetadataNode nextNode = node.child(names[names.length -  1]);
-            if (nextNode == null || !(nextNode instanceof FileNode)) {
+            if (!(nextNode instanceof FileNode)) {
                 throw new RuntimeException("Unable to locate file /" +
                     String.join("/", names));
             }


### PR DESCRIPTION
inspired by https://github.com/apache/kafka/pull/10141#discussion_r589425927

the `instanceof` includes null check already so we can get rid of redundant null check.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
