### PR TITLE
KAFKA-10357: Add setup method to internal topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -115,7 +115,7 @@ public class CreateTopicsResult {
         private final int replicationFactor;
         private final Config config;
 
-        TopicMetadataAndConfig(Uuid topicId, int numPartitions, int replicationFactor, Config config) {
+        public TopicMetadataAndConfig(Uuid topicId, int numPartitions, int replicationFactor, Config config) {
             this.exception = null;
             this.topicId = topicId;
             this.numPartitions = numPartitions;
@@ -123,7 +123,7 @@ public class CreateTopicsResult {
             this.config = config;
         }
 
-        TopicMetadataAndConfig(ApiException exception) {
+        public TopicMetadataAndConfig(ApiException exception) {
             this.exception = exception;
             this.topicId = Uuid.ZERO_UUID;
             this.numPartitions = UNKNOWN;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsResult.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class DeleteTopicsResult {
     final Map<String, KafkaFuture<Void>> futures;
 
-    DeleteTopicsResult(Map<String, KafkaFuture<Void>> futures) {
+    protected DeleteTopicsResult(Map<String, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -44,6 +44,8 @@ import org.apache.kafka.streams.processor.internals.ClientUtils.QuietConsumerCon
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -186,14 +188,23 @@ public class InternalTopicManager {
                     );
                 }
 
-                maybeThrowTimeoutException(topicDescriptionsStillToValidate, topicConfigsStillToValidate, deadline);
+                maybeThrowTimeoutException(
+                    Arrays.asList(topicDescriptionsStillToValidate, topicConfigsStillToValidate),
+                    deadline,
+                    String.format("Could not validate internal topics within %d milliseconds. " +
+                        "This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs)
+                );
 
                 if (!descriptionsForTopic.isEmpty() || !configsForTopic.isEmpty()) {
                     Utils.sleep(100);
                 }
             }
 
-            maybeSleep(topicDescriptionsStillToValidate, topicConfigsStillToValidate, deadline);
+            maybeSleep(
+                Arrays.asList(topicDescriptionsStillToValidate, topicConfigsStillToValidate),
+                deadline,
+                "validated"
+            );
         }
 
         log.info("Completed validation of internal topics {}.", topicConfigs.keySet());
@@ -239,35 +250,6 @@ public class InternalTopicManager {
                     futuresForTopic.remove(topicName);
                 }
             }
-        }
-    }
-
-    private void maybeThrowTimeoutException(final Set<String> topicDescriptionsStillToValidate,
-                                            final Set<String> topicConfigsStillToValidate,
-                                            final long deadline) {
-        if (!topicDescriptionsStillToValidate.isEmpty() || !topicConfigsStillToValidate.isEmpty()) {
-            final long now = time.milliseconds();
-            if (now >= deadline) {
-                final String timeoutError = String.format("Could not validate internal topics within %d milliseconds. " +
-                    "This can happen if the Kafka cluster is temporarily not available.", retryTimeoutMs);
-                log.error(timeoutError);
-                throw new TimeoutException(timeoutError);
-            }
-        }
-    }
-
-    private void maybeSleep(final Set<String> topicDescriptionsStillToValidate,
-                            final Set<String> topicConfigsStillToValidate,
-                            final long deadline) {
-        if (!topicDescriptionsStillToValidate.isEmpty() || !topicConfigsStillToValidate.isEmpty()) {
-            final long now = time.milliseconds();
-            log.info(
-                "Internal topics {} could not be validated. Will retry in {} milliseconds. Remaining time in milliseconds: {}",
-                new HashSet<>(topicDescriptionsStillToValidate).addAll(topicConfigsStillToValidate),
-                retryBackOffMs,
-                deadline - now
-            );
-            Utils.sleep(retryBackOffMs);
         }
     }
 
@@ -579,5 +561,119 @@ public class InternalTopicManager {
         }
 
         return topicsToCreate;
+    }
+
+    /**
+     * Sets up internal topics.
+     *
+     * Either the given topic are all created or the method fails with an exception.
+     *
+     * @param topicConfigs internal topics to setup
+     */
+    public void setup(final Map<String, InternalTopicConfig> topicConfigs) {
+        log.info("Starting to setup internal topics {}.", topicConfigs.keySet());
+
+        final long now = time.milliseconds();
+        final long deadline = now + retryTimeoutMs;
+
+        final Map<String, Map<String, String>> newTopicConfigs = topicConfigs.values().stream()
+            .collect(Collectors.toMap(
+                InternalTopicConfig::name,
+                topicConfig -> topicConfig.getProperties(defaultTopicConfigs, windowChangeLogAdditionalRetention)
+            ));
+        final Set<String> topicStillToCreate = new HashSet<>(topicConfigs.keySet());
+        while (!topicStillToCreate.isEmpty()) {
+            final Set<NewTopic> newTopics = topicStillToCreate.stream()
+                .map(topicName -> new NewTopic(
+                        topicName,
+                        topicConfigs.get(topicName).numberOfPartitions(),
+                        Optional.of(replicationFactor)
+                    ).configs(newTopicConfigs.get(topicName))
+                ).collect(Collectors.toSet());
+
+            log.info("Going to create internal topics: " + newTopics);
+            final CreateTopicsResult createTopicsResult = adminClient.createTopics(newTopics);
+
+            final Map<String, KafkaFuture<Void>> createResultForTopic = createTopicsResult.values();
+            while (!createResultForTopic.isEmpty()) {
+                for (final InternalTopicConfig topicConfig : topicConfigs.values()) {
+                    final String topicName = topicConfig.name();
+                    if (!createResultForTopic.containsKey(topicName)) {
+                        throw new IllegalStateException("Create topic results do not contain internal topic " + topicName
+                            + " to setup. " + BUG_ERROR_MESSAGE);
+                    }
+                    final KafkaFuture<Void> createResult = createResultForTopic.get(topicName);
+                    if (createResult.isDone()) {
+                        try {
+                            createResult.get();
+                            topicStillToCreate.remove(topicName);
+                        } catch (final ExecutionException executionException) {
+                            final Throwable cause = executionException.getCause();
+                            if (cause instanceof TopicExistsException) {
+                                log.info("Internal topic {} already exists. Topic is probably marked for deletion. " +
+                                    "Will retry to create this topic later (to let broker complete async delete operation first)",
+                                    topicName);
+                            } else if (cause instanceof TimeoutException) {
+                                log.info("Creating internal topic {} timed out.", topicName);
+                            } else {
+                                log.error("Unexpected error during creation of internal topic: ", cause);
+                                throw new StreamsException(
+                                    String.format("Could not create internal topic %s for the following reason: ", topicName),
+                                    cause
+                                );
+                            }
+                        } catch (final InterruptedException interruptedException) {
+                            throw new InterruptException(interruptedException);
+                        } finally {
+                            createResultForTopic.remove(topicName);
+                        }
+                    }
+                }
+
+                maybeThrowTimeoutException(
+                    Collections.singletonList(topicStillToCreate),
+                    deadline,
+                    String.format("Could not create internal topics within %d milliseconds. This can happen if the " +
+                        "Kafka cluster is temporarily not available or a topic is marked for deletion and the broker " +
+                        "did not complete its deletion within the timeout.", retryTimeoutMs)
+                );
+
+                if (!topicStillToCreate.isEmpty()) {
+                    Utils.sleep(100);
+                }
+            }
+
+            maybeSleep(Collections.singletonList(topicStillToCreate), deadline, "created");
+        }
+
+        log.info("Completed setup of internal topics {}.", topicConfigs.keySet());
+    }
+
+    private void maybeThrowTimeoutException(final List<Set<String>> resultSetsStillToProcess,
+                                            final long deadline,
+                                            final String errorMessage) {
+        if (resultSetsStillToProcess.stream().anyMatch(resultSet -> !resultSet.isEmpty())) {
+            final long now = time.milliseconds();
+            if (now >= deadline) {
+                log.error(errorMessage);
+                throw new TimeoutException(errorMessage);
+            }
+        }
+    }
+
+    private void maybeSleep(final List<Set<String>> resultSetsStillToValidate,
+                            final long deadline,
+                            final String action) {
+        if (resultSetsStillToValidate.stream().anyMatch(resultSet -> !resultSet.isEmpty())) {
+            final long now = time.milliseconds();
+            log.info(
+                "Internal topics {} could not be {}. Will retry in {} milliseconds. Remaining time in milliseconds: {}",
+                resultSetsStillToValidate.stream().flatMap(Collection::stream).collect(Collectors.toSet()),
+                action,
+                retryBackOffMs,
+                deadline - now
+            );
+            Utils.sleep(retryBackOffMs);
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.CreateTopicsResult.TopicMetadataAndConfig;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
@@ -31,6 +32,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.ConfigResource.Type;
 import org.apache.kafka.common.config.TopicConfig;
@@ -62,7 +64,6 @@ import java.util.stream.Collectors;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
-import static org.easymock.EasyMock.anyObject;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
@@ -151,22 +152,78 @@ public class InternalTopicManagerTest {
     }
 
     @Test
-    public void shouldRetryWhenCreateTopicsThrowsTimeoutException() throws Exception {
-        mockAdminClient.timeoutNextRequest(1);
+    public void shouldOnlyRetryNotSuccessfulFuturesDuringSetup() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
+        createTopicFailFuture.completeExceptionally(new TopicExistsException("exists"));
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        createTopicSuccessfulFuture.complete(
+            new TopicMetadataAndConfig(Uuid.randomUuid(), 1, 1, new Config(Collections.emptyList()))
+        );
         final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        final NewTopic newTopic1 = newTopic(topic1, internalTopicConfig1, streamsConfig);
+        final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic1, newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic1, createTopicSuccessfulFuture),
+                mkEntry(topic2, createTopicFailFuture)
+            )));
+        EasyMock.expect(admin.createTopics(mkSet(newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic2, createTopicSuccessfulFuture)
+            )));
+        EasyMock.replay(admin);
 
-        internalTopicManager.setup(mkMap(
-            mkEntry(topic1, internalTopicConfig1)
+        topicManager.setup(mkMap(
+            mkEntry(topic1, internalTopicConfig1),
+            mkEntry(topic2, internalTopicConfig2)
         ));
 
-        final Set<String> newlyCreatedTopics = mockAdminClient.listTopics().names().get();
-        assertThat(newlyCreatedTopics.size(), is(1));
-        assertThat(newlyCreatedTopics, hasItem(topic1));
+        EasyMock.verify(admin);
     }
 
+    @Test
+    public void shouldRetryCreateTopicWhenCreationTimesOut() {
+        shouldRetryCreateTopicWhenRetriableExceptionIsThrown(new TimeoutException("timed out"));
+    }
 
     @Test
-    public void shouldThrowTimeoutExceptionIfTopicExists() {
+    public void shouldRetryCreateTopicWhenTopicNotYetDeleted() {
+        shouldRetryCreateTopicWhenRetriableExceptionIsThrown(new TopicExistsException("exists"));
+    }
+
+    private void shouldRetryCreateTopicWhenRetriableExceptionIsThrown(final Exception retriableException) {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
+        createTopicFailFuture.completeExceptionally(retriableException);
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        createTopicSuccessfulFuture.complete(
+            new TopicMetadataAndConfig(Uuid.randomUuid(), 1, 1, new Config(Collections.emptyList()))
+        );
+        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
+        final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic1, createTopicSuccessfulFuture)
+            )));
+        EasyMock.expect(admin.createTopics(mkSet(newTopic)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic2, createTopicSuccessfulFuture)
+            )));
+        EasyMock.replay(admin);
+
+        topicManager.setup(mkMap(
+            mkEntry(topic1, internalTopicConfig)
+        ));
+    }
+
+    @Test
+    public void shouldThrowTimeoutExceptionIfTopicExistsDuringSetup() {
         setupTopicInMockAdminClient(topic1, Collections.emptyMap());
         final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
@@ -178,42 +235,44 @@ public class InternalTopicManagerTest {
         assertThat(
             exception.getMessage(),
             is("Could not create internal topics within " +
-                (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 2 +
+                    (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 2 +
                 " milliseconds. This can happen if the Kafka cluster is temporarily not available or a topic is marked" +
-                " for deletion and the broker did not complete its deletion within the timeout.")
+                    " for deletion and the broker did not complete its deletion within the timeout." +
+                    " The last errors seen per topic are:" +
+                    " {" + topic1 + "=org.apache.kafka.common.errors.TopicExistsException: Topic test_topic exists already.}")
         );
     }
 
     @Test
     public void shouldThrowWhenCreateTopicsThrowsUnexpectedException() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
-        final InternalTopicManager topicManager = new InternalTopicManager(
-            Time.SYSTEM,
-            admin,
-            new StreamsConfig(config)
-        );
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
         createTopicFailFuture.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
-        EasyMock.expect(admin.createTopics(anyObject()))
-            .andStubAnswer(() -> new MockCreateTopicsResult(mkMap(mkEntry(topic1, createTopicFailFuture))));
+        final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic)))
+            .andStubAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic1, createTopicFailFuture)
+            )));
         EasyMock.replay(admin);
-        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
-        assertThrows(StreamsException.class, () -> topicManager.setup(Collections.singletonMap(topic1, internalTopicConfig)));
+        assertThrows(StreamsException.class, () -> topicManager.setup(mkMap(
+            mkEntry(topic1, internalTopicConfig)
+        )));
     }
 
     @Test
     public void shouldThrowWhenCreateTopicsResultsDoNotContainTopic() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
-        final InternalTopicManager topicManager = new InternalTopicManager(
-            Time.SYSTEM,
-            admin,
-            new StreamsConfig(config)
-        );
-        EasyMock.expect(admin.createTopics(anyObject()))
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
+        final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic)))
             .andStubAnswer(() -> new MockCreateTopicsResult(Collections.singletonMap(topic2, new KafkaFutureImpl<>())));
         EasyMock.replay(admin);
-        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
             IllegalStateException.class,
@@ -227,17 +286,15 @@ public class InternalTopicManagerTest {
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
-        final InternalTopicManager topicManager = new InternalTopicManager(
-            time,
-            admin,
-            new StreamsConfig(config)
-        );
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture = new KafkaFutureImpl<>();
         createTopicFailFuture.completeExceptionally(new TimeoutException());
-        EasyMock.expect(admin.createTopics(anyObject()))
+        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
+        final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic)))
             .andStubAnswer(() -> new MockCreateTopicsResult(mkMap(mkEntry(topic1, createTopicFailFuture))));
         EasyMock.replay(admin);
-        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
             TimeoutException.class,
@@ -251,21 +308,242 @@ public class InternalTopicManagerTest {
         final MockTime time = new MockTime(
             (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
         );
-        final InternalTopicManager topicManager = new InternalTopicManager(
-            time,
-            admin,
-            new StreamsConfig(config)
-        );
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
         final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFutureThatNeverCompletes = new KafkaFutureImpl<>();
-        EasyMock.expect(admin.createTopics(anyObject()))
+        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
+        final NewTopic newTopic = newTopic(topic1, internalTopicConfig, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic)))
             .andStubAnswer(() -> new MockCreateTopicsResult(mkMap(mkEntry(topic1, createTopicFutureThatNeverCompletes))));
         EasyMock.replay(admin);
-        final InternalTopicConfig internalTopicConfig = setupRepartitionTopicConfig(topic1, 1);
 
         assertThrows(
             TimeoutException.class,
             () -> topicManager.setup(Collections.singletonMap(topic1, internalTopicConfig))
         );
+    }
+
+    @Test
+    public void shouldCleanUpWhenUnexpectedExceptionIsThrownDuringSetup() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final MockTime time = new MockTime(
+            (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
+        );
+        final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        setupCleanUpScenario(admin, streamsConfig, internalTopicConfig1, internalTopicConfig2);
+        final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        deleteTopicSuccessfulFuture.complete(null);
+        EasyMock.expect(admin.deleteTopics(mkSet(topic1)))
+            .andAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+        EasyMock.replay(admin);
+
+        assertThrows(
+            StreamsException.class,
+            () -> topicManager.setup(mkMap(
+                mkEntry(topic1, internalTopicConfig1),
+                mkEntry(topic2, internalTopicConfig2)
+            ))
+        );
+
+        EasyMock.verify(admin);
+    }
+
+    @Test
+    public void shouldCleanUpWhenCreateTopicsResultsDoNotContainTopic() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture1 = new KafkaFutureImpl<>();
+        createTopicFailFuture1.completeExceptionally(new TopicExistsException("exists"));
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        createTopicSuccessfulFuture.complete(
+            new TopicMetadataAndConfig(Uuid.randomUuid(), 1, 1, new Config(Collections.emptyList()))
+        );
+        final NewTopic newTopic1 = newTopic(topic1, internalTopicConfig1, streamsConfig);
+        final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic1, newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic1, createTopicSuccessfulFuture),
+                mkEntry(topic2, createTopicFailFuture1)
+            )));
+        EasyMock.expect(admin.createTopics(mkSet(newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic3, createTopicSuccessfulFuture)
+            )));
+        final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        deleteTopicSuccessfulFuture.complete(null);
+        EasyMock.expect(admin.deleteTopics(mkSet(topic1)))
+            .andAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+        EasyMock.replay(admin);
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> topicManager.setup(mkMap(
+                mkEntry(topic1, internalTopicConfig1),
+                mkEntry(topic2, internalTopicConfig2)
+            ))
+        );
+
+        EasyMock.verify(admin);
+    }
+
+    @Test
+    public void shouldCleanUpWhenCreateTopicsTimesOut() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final MockTime time = new MockTime(
+            (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
+        );
+        final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture1 = new KafkaFutureImpl<>();
+        createTopicFailFuture1.completeExceptionally(new TopicExistsException("exists"));
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        createTopicSuccessfulFuture.complete(
+            new TopicMetadataAndConfig(Uuid.randomUuid(), 1, 1, new Config(Collections.emptyList()))
+        );
+        final NewTopic newTopic1 = newTopic(topic1, internalTopicConfig1, streamsConfig);
+        final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic1, newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic1, createTopicSuccessfulFuture),
+                mkEntry(topic2, createTopicFailFuture1)
+            )));
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFutureThatNeverCompletes = new KafkaFutureImpl<>();
+        EasyMock.expect(admin.createTopics(mkSet(newTopic2)))
+            .andStubAnswer(() -> new MockCreateTopicsResult(mkMap(mkEntry(topic2, createTopicFutureThatNeverCompletes))));
+        final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        deleteTopicSuccessfulFuture.complete(null);
+        EasyMock.expect(admin.deleteTopics(mkSet(topic1)))
+            .andAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+        EasyMock.replay(admin);
+
+        assertThrows(
+            TimeoutException.class,
+            () -> topicManager.setup(mkMap(
+                mkEntry(topic1, internalTopicConfig1),
+                mkEntry(topic2, internalTopicConfig2)
+            ))
+        );
+
+        EasyMock.verify(admin);
+    }
+
+    @Test
+    public void shouldRetryDeleteTopicWhenTopicUnknown() {
+        shouldRetryDeleteTopicWhenRetriableException(new UnknownTopicOrPartitionException());
+    }
+
+    @Test
+    public void shouldRetryDeleteTopicWhenLeaderNotAvailable() {
+        shouldRetryDeleteTopicWhenRetriableException(new LeaderNotAvailableException("leader not available"));
+    }
+
+    @Test
+    public void shouldRetryDeleteTopicWhenFutureTimesOut() {
+        shouldRetryDeleteTopicWhenRetriableException(new TimeoutException("timed out"));
+    }
+
+    private void shouldRetryDeleteTopicWhenRetriableException(final Exception retriableException) {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        setupCleanUpScenario(admin, streamsConfig, internalTopicConfig1, internalTopicConfig2);
+        final KafkaFutureImpl<Void> deleteTopicFailFuture = new KafkaFutureImpl<>();
+        deleteTopicFailFuture.completeExceptionally(retriableException);
+        final KafkaFutureImpl<Void> deleteTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        deleteTopicSuccessfulFuture.complete(null);
+        EasyMock.expect(admin.deleteTopics(mkSet(topic1)))
+            .andAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicFailFuture))))
+            .andAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicSuccessfulFuture))));
+        EasyMock.replay(admin);
+
+        assertThrows(
+            StreamsException.class,
+            () -> topicManager.setup(mkMap(
+                mkEntry(topic1, internalTopicConfig1),
+                mkEntry(topic2, internalTopicConfig2)
+            ))
+        );
+        EasyMock.verify();
+    }
+
+    @Test
+    public void shouldThrowTimeoutExceptionWhenFuturesNeverCompleteDuringCleanUp() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final MockTime time = new MockTime(
+            (Integer) config.get(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) / 3
+        );
+        final InternalTopicManager topicManager = new InternalTopicManager(time, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        setupCleanUpScenario(admin, streamsConfig, internalTopicConfig1, internalTopicConfig2);
+        final KafkaFutureImpl<Void> deleteTopicFutureThatNeverCompletes = new KafkaFutureImpl<>();
+        EasyMock.expect(admin.deleteTopics(mkSet(topic1)))
+            .andStubAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicFutureThatNeverCompletes))));
+        EasyMock.replay(admin);
+
+        assertThrows(
+            TimeoutException.class,
+            () -> topicManager.setup(mkMap(
+                mkEntry(topic1, internalTopicConfig1),
+                mkEntry(topic2, internalTopicConfig2)
+            ))
+        );
+    }
+
+    @Test
+    public void shouldThrowWhenDeleteTopicsThrowsUnexpectedException() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        final InternalTopicManager topicManager = new InternalTopicManager(Time.SYSTEM, admin, streamsConfig);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+        setupCleanUpScenario(admin, streamsConfig, internalTopicConfig1, internalTopicConfig2);
+        final KafkaFutureImpl<Void> deleteTopicFailFuture = new KafkaFutureImpl<>();
+        deleteTopicFailFuture.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
+        EasyMock.expect(admin.deleteTopics(mkSet(topic1)))
+            .andStubAnswer(() -> new MockDeleteTopicsResult(mkMap(mkEntry(topic1, deleteTopicFailFuture))));
+        EasyMock.replay(admin);
+
+        assertThrows(
+            StreamsException.class,
+            () -> topicManager.setup(mkMap(
+                mkEntry(topic1, internalTopicConfig1),
+                mkEntry(topic2, internalTopicConfig2)
+            ))
+        );
+    }
+
+    private void setupCleanUpScenario(final AdminClient admin, final StreamsConfig streamsConfig, final InternalTopicConfig internalTopicConfig1, final InternalTopicConfig internalTopicConfig2) {
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture1 = new KafkaFutureImpl<>();
+        createTopicFailFuture1.completeExceptionally(new TopicExistsException("exists"));
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicFailFuture2 = new KafkaFutureImpl<>();
+        createTopicFailFuture2.completeExceptionally(new IllegalStateException("Nobody expects the Spanish inquisition"));
+        final KafkaFutureImpl<TopicMetadataAndConfig> createTopicSuccessfulFuture = new KafkaFutureImpl<>();
+        createTopicSuccessfulFuture.complete(
+            new TopicMetadataAndConfig(Uuid.randomUuid(), 1, 1, new Config(Collections.emptyList()))
+        );
+        final NewTopic newTopic1 = newTopic(topic1, internalTopicConfig1, streamsConfig);
+        final NewTopic newTopic2 = newTopic(topic2, internalTopicConfig2, streamsConfig);
+        EasyMock.expect(admin.createTopics(mkSet(newTopic1, newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic1, createTopicSuccessfulFuture),
+                mkEntry(topic2, createTopicFailFuture1)
+            )));
+        EasyMock.expect(admin.createTopics(mkSet(newTopic2)))
+            .andAnswer(() -> new MockCreateTopicsResult(mkMap(
+                mkEntry(topic2, createTopicFailFuture2)
+            )));
     }
 
     @Test
@@ -1007,6 +1285,63 @@ public class InternalTopicManagerTest {
     }
 
     @Test
+    public void shouldOnlyRetryNotSuccessfulFuturesDuringValidation() {
+        final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
+        final InternalTopicManager topicManager = new InternalTopicManager(
+            Time.SYSTEM,
+            admin,
+            new StreamsConfig(config)
+        );
+        final KafkaFutureImpl<TopicDescription> topicDescriptionFailFuture = new KafkaFutureImpl<>();
+        topicDescriptionFailFuture.completeExceptionally(new LeaderNotAvailableException("Leader Not Available!"));
+        final KafkaFutureImpl<TopicDescription> topicDescriptionSuccessfulFuture1 = new KafkaFutureImpl<>();
+        topicDescriptionSuccessfulFuture1.complete(new TopicDescription(
+            topic1,
+            false,
+            Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
+        ));
+        final KafkaFutureImpl<TopicDescription> topicDescriptionSuccessfulFuture2 = new KafkaFutureImpl<>();
+        topicDescriptionSuccessfulFuture2.complete(new TopicDescription(
+            topic2,
+            false,
+            Collections.singletonList(new TopicPartitionInfo(0, broker1, cluster, Collections.emptyList()))
+        ));
+        EasyMock.expect(admin.describeTopics(mkSet(topic1, topic2)))
+            .andAnswer(() -> new MockDescribeTopicsResult(mkMap(
+                mkEntry(topic1, topicDescriptionSuccessfulFuture1),
+                mkEntry(topic2, topicDescriptionFailFuture)
+            )));
+        EasyMock.expect(admin.describeTopics(mkSet(topic2)))
+            .andAnswer(() -> new MockDescribeTopicsResult(mkMap(
+                mkEntry(topic2, topicDescriptionSuccessfulFuture2)
+            )));
+        final KafkaFutureImpl<Config> topicConfigSuccessfulFuture = new KafkaFutureImpl<>();
+        topicConfigSuccessfulFuture.complete(
+            new Config(repartitionTopicConfig().entrySet().stream()
+                .map(entry -> new ConfigEntry(entry.getKey(), entry.getValue())).collect(Collectors.toSet()))
+        );
+        final ConfigResource topicResource1 = new ConfigResource(Type.TOPIC, topic1);
+        final ConfigResource topicResource2 = new ConfigResource(Type.TOPIC, topic2);
+        EasyMock.expect(admin.describeConfigs(mkSet(topicResource1, topicResource2)))
+            .andAnswer(() -> new MockDescribeConfigsResult(mkMap(
+                mkEntry(topicResource1, topicConfigSuccessfulFuture),
+                mkEntry(topicResource2, topicConfigSuccessfulFuture)
+            )));
+        EasyMock.replay(admin);
+        final InternalTopicConfig internalTopicConfig1 = setupRepartitionTopicConfig(topic1, 1);
+        final InternalTopicConfig internalTopicConfig2 = setupRepartitionTopicConfig(topic2, 1);
+
+        final ValidationResult validationResult = topicManager.validate(mkMap(
+            mkEntry(topic1, internalTopicConfig1),
+            mkEntry(topic2, internalTopicConfig2)
+        ));
+
+        assertThat(validationResult.missingTopics(), empty());
+        assertThat(validationResult.misconfigurationsForTopics(), anEmptyMap());
+        EasyMock.verify(admin);
+    }
+
+    @Test
     public void shouldThrowWhenDescribeTopicsThrowsUnexpectedExceptionDuringValidation() {
         final AdminClient admin = EasyMock.createNiceMock(AdminClient.class);
         final InternalTopicManager topicManager = new InternalTopicManager(
@@ -1262,6 +1597,19 @@ public class InternalTopicManagerTest {
         );
     }
 
+    private NewTopic newTopic(final String topicName,
+                              final InternalTopicConfig topicConfig,
+                              final StreamsConfig streamsConfig) {
+        return new NewTopic(
+            topicName,
+            topicConfig.numberOfPartitions(),
+            Optional.of(streamsConfig.getInt(StreamsConfig.REPLICATION_FACTOR_CONFIG).shortValue())
+        ).configs(topicConfig.getProperties(
+            Collections.emptyMap(),
+            streamsConfig.getLong(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG))
+        );
+    }
+
     private Map<String, String> repartitionTopicConfig() {
         return mkMap(
             mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE),
@@ -1320,21 +1668,24 @@ public class InternalTopicManagerTest {
     }
 
     private static class MockCreateTopicsResult extends CreateTopicsResult {
-
         MockCreateTopicsResult(final Map<String, KafkaFuture<TopicMetadataAndConfig>> futures) {
             super(futures);
         }
     }
 
-    private static class MockDescribeTopicsResult extends DescribeTopicsResult {
+    private static class MockDeleteTopicsResult extends DeleteTopicsResult {
+        MockDeleteTopicsResult(final Map<String, KafkaFuture<Void>> futures) {
+            super(futures);
+        }
+    }
 
+    private static class MockDescribeTopicsResult extends DescribeTopicsResult {
         MockDescribeTopicsResult(final Map<String, KafkaFuture<TopicDescription>> futures) {
             super(futures);
         }
     }
 
     private static class MockDescribeConfigsResult extends DescribeConfigsResult {
-
         MockDescribeConfigsResult(final Map<ConfigResource, KafkaFuture<Config>> futures) {
             super(futures);
         }


### PR DESCRIPTION
For KIP-698, we need a way to setup internal topics without
validating them. This PR adds a setup method to the
InternalTopicManager for that purpose.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
