### PR TITLE
MINOR: revert stream logging level back to ERROR

### DIFF
--- a/streams/src/test/resources/log4j.properties
+++ b/streams/src/test/resources/log4j.properties
@@ -19,7 +19,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.kafka=INFO
-log4j.logger.org.apache.kafka=INFO
+log4j.logger.org.apache.kafka=ERROR
 log4j.logger.org.apache.zookeeper=ERROR
 
 log4j.logger.org.apache.kafka.clients=WARN


### PR DESCRIPTION
An accidental change of logging level for streams from https://github.com/apache/kafka/pull/9579, correcting it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
