### PR TITLE
KAFKA-12455: OffsetValidationTest.test_broker_rolling_bounce fail: Raft

### DIFF
--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -26,14 +26,12 @@ import signal
 class OffsetValidationTest(VerifiableConsumerTest):
     TOPIC = "test_topic"
     NUM_PARTITIONS = 1
-    DEFAULT_NUM_BROKERS = 2
 
     def __init__(self, test_context):
-        super(OffsetValidationTest, self).__init__(test_context, num_consumers=3, num_producers=1, num_zk=1,
-                                                   num_brokers= self.DEFAULT_NUM_BROKERS if not test_context.injected_args \
-                                                       else test_context.injected_args.get('num_brokers', self.DEFAULT_NUM_BROKERS),
-                                                   topics={self.TOPIC : { 'partitions': self.NUM_PARTITIONS, 'replication-factor': 2 }},
-                                                   )
+        super(OffsetValidationTest, self).__init__(test_context, num_consumers=3, num_producers=1,
+                                                     num_zk=1, num_brokers=2, topics={
+            self.TOPIC : { 'partitions': self.NUM_PARTITIONS, 'replication-factor': 2 }
+        })
 
     def rolling_bounce_consumers(self, consumer, keep_alive=0, num_bounces=5, clean_shutdown=True):
         for _ in range(num_bounces):
@@ -76,9 +74,9 @@ class OffsetValidationTest(VerifiableConsumerTest):
         self.mark_for_collect(consumer, 'verifiable_consumer_stdout')
         return consumer
 
-    @cluster(num_nodes=8)
-    @matrix(num_brokers=[3], metadata_quorum=quorum.all_non_upgrade)
-    def test_broker_rolling_bounce(self, num_brokers, metadata_quorum=quorum.zk):
+    @cluster(num_nodes=7)
+    @matrix(metadata_quorum=quorum.all_non_upgrade)
+    def test_broker_rolling_bounce(self, metadata_quorum=quorum.zk):
         """
         Verify correct consumer behavior when the brokers are consecutively restarted.
 
@@ -95,6 +93,7 @@ class OffsetValidationTest(VerifiableConsumerTest):
         partition = TopicPartition(self.TOPIC, 0)
 
         producer = self.setup_producer(self.TOPIC)
+        self.session_timeout_sec = 30
         consumer = self.setup_consumer(self.TOPIC)
 
         producer.start()

--- a/tests/kafkatest/tests/client/consumer_test.py
+++ b/tests/kafkatest/tests/client/consumer_test.py
@@ -93,6 +93,13 @@ class OffsetValidationTest(VerifiableConsumerTest):
         partition = TopicPartition(self.TOPIC, 0)
 
         producer = self.setup_producer(self.TOPIC)
+        # The consumers' session timeouts must exceed the time it takes for a broker to roll.  Consumers are likely
+        # to see cluster metadata consisting of just a single alive broker in the case where the cluster has just 2
+        # brokers and the cluster is rolling (which is what is happening here).  When the consumer sees a single alive
+        # broker, and then that broker rolls, the consumer will be unable to connect to the cluster until that broker
+        # completes its roll.  In the meantime, the consumer group will move to the group coordinator on the other
+        # broker, and that coordinator will fail the consumer and trigger a group rebalance if its session times out.
+        # This test is asserting that no rebalances occur, so we increase the session timeout for this to be the case.
         self.session_timeout_sec = 30
         consumer = self.setup_consumer(self.TOPIC)
 


### PR DESCRIPTION
OffsetValidationTest.test_broker_rolling_bounce was failing when used with a Raft-based metadata quorum but succeeding with a ZooKeeper-based quorum.  This patch increases the consumers' session timeouts to 30 seconds, which fixes the Raft case and also eliminates flakiness that has historically existed in the Zookeeper case.  This patch also fixes a minor logging bug in `RaftReplicaManager.endMetadataChangeDeferral()` that was discovered during the debugging of this issue, and it adds an extra logging statement in `RaftReplicaManager.handleMetadataRecords()` when a single metadata batch is applied to mirror the same logging statement that occurs when deferred metadata changes are applied.

In the Raft system test case the consumer was sometimes receiving a METADATA response with just 1 alive broker, and then when that broker rolled the consumer wouldn't know about any alive nodes.  It would have to wait until the broker returned before it could reconnect, and by that time the group coordinator on the second broker would have timed-out the client and initiated a group rebalance.  The test explicitly checks that no rebalances occur, so the test would fail.  It turns out that the reason why the ZooKeeper configuration wasn't seeing rebalances was just plain luck.  The brokers' metadata caches in the ZooKeeper configuration show 1 alive broker even more frequently than the Raft configuration does.  If we tweak the metadata.max.age.ms value on the consumers we can easily get the ZooKeeper test to fail, and in fact this system test has historically been flaky for the ZooKeeper configuration.  We can get the test to pass by setting session.timeout.ms=30000 (which is longer than the roll time of any broker), or we can increase the broker count so that the client never sees a METADATA response with just a single alive broker and therefore never loses contact with the cluster for an extended period of time.  We have plenty of system tests with 3+ brokers, so we choose to keep this test with 2 brokers and increase the session timeout.




### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
