### PR TITLE
Avoid newly replicating brokers in RackAwareReplicaSelector

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/replica/RackAwareReplicaSelector.java
+++ b/clients/src/main/java/org/apache/kafka/common/replica/RackAwareReplicaSelector.java
@@ -35,6 +35,7 @@ public class RackAwareReplicaSelector implements ReplicaSelector {
         if (clientMetadata.rackId() != null && !clientMetadata.rackId().isEmpty()) {
             Set<ReplicaView> sameRackReplicas = partitionView.replicas().stream()
                     .filter(replicaInfo -> clientMetadata.rackId().equals(replicaInfo.endpoint().rack()))
+                    .filter(replicaInfo -> replicaInfo.timeSinceLastCaughtUpMs() != Long.MAX_VALUE)
                     .collect(Collectors.toSet());
             if (sameRackReplicas.isEmpty()) {
                 return Optional.of(partitionView.leader());

--- a/clients/src/test/java/org/apache/kafka/common/replica/ReplicaSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/replica/ReplicaSelectorTest.java
@@ -60,6 +60,10 @@ public class ReplicaSelectorTest {
             assertEquals(replicaInfo, leader, "Expect the leader since it's in rack-a");
         });
 
+        selected = selector.select(tp, metadata("rack-c"), partitionView);
+        assertOptional(selected, replicaInfo -> {
+            assertEquals(replicaInfo, leader, "Expect leader when we can't find any ISR nodes in given rack");
+        });
 
     }
 
@@ -68,7 +72,8 @@ public class ReplicaSelectorTest {
                 replicaInfo(new Node(0, "host0", 1234, "rack-a"), 4, 0),
                 replicaInfo(new Node(1, "host1", 1234, "rack-a"), 2, 5),
                 replicaInfo(new Node(2, "host2", 1234, "rack-b"), 3, 3),
-                replicaInfo(new Node(3, "host3", 1234, "rack-b"), 4, 2)
+                replicaInfo(new Node(3, "host3", 1234, "rack-b"), 4, 2),
+                replicaInfo(new Node(4, "badhost", 1234, "rack-c"), 4, Long.MAX_VALUE)
 
         ).collect(Collectors.toList());
     }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1263,7 +1263,7 @@ class ReplicaManager(val config: KafkaConfig,
             .map(replica => new DefaultReplicaView(
               replicaEndpoints.getOrElse(replica.brokerId, Node.noNode()),
               replica.logEndOffset,
-              currentTimeMs - replica.lastCaughtUpTimeMs))
+              if (replica.lastCaughtUpTimeMs == 0) Long.MaxValue else currentTimeMs - replica.lastCaughtUpTimeMs))
 
           val leaderReplica = new DefaultReplicaView(
             replicaEndpoints.getOrElse(leaderReplicaId, Node.noNode()),


### PR DESCRIPTION
cross rack boundaries if my rack does not contain a replica which has _ever_ appeared in ISR. otherwise, if we have just added a new broker to the replica set and are now behind on replication, it may take a while to catch up and we may become bottlenecked/blocked until that replica catches up.

testing strategy to be determined after discussion. #6832 updated ReplicaSelectorTest so I've done so too; the Scala server stuff I'm not sure how to test. the one existing test on that function isn't informative.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
