### PR TITLE
MINOR: Fix BaseHashTable sizing

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
@@ -63,7 +63,6 @@ class BaseHashTable<T> {
      * than MAX_CAPACITY.  We use 64-bit numbers here to avoid overflow
      * concerns.
      */
-    @SuppressWarnings("unchecked")
     static int expectedSizeToCapacity(int expectedSize) {
         long minCapacity = (long) Math.ceil((float) expectedSize / MAX_LOAD_FACTOR);
         return Math.max(MIN_CAPACITY,

--- a/metadata/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
@@ -45,11 +45,14 @@ class BaseHashTable<T> {
     final static int MIN_CAPACITY = 2;
 
     /**
-     * The maximum number of slots we can have in the hash table.
-     *
-     * This is set to the maximum 31-bit power of two.
+     * The maximum 31-bit power of two.
      */
-    final static int MAX_CAPACITY = 0x4000_0000;
+    private final static int MAX_SIGNED_POWER_OF_TWO = 0x4000_0000;
+
+    /**
+     * The maximum number of slots we can have in the hash table.
+     */
+    final static int MAX_CAPACITY = MAX_SIGNED_POWER_OF_TWO;
 
     private Object[] elements;
     private int size = 0;
@@ -71,17 +74,14 @@ class BaseHashTable<T> {
     }
 
     private static int roundUpToPowerOfTwo(int i) {
-        if (i < 0) {
+        if (i <= 0) {
             return 0;
+        } else if (i > MAX_SIGNED_POWER_OF_TWO) {
+            throw new ArithmeticException("There is no 31-bit power of two higher than " +
+                    "or equal to " + i);
+        } else {
+            return 1 << -Integer.numberOfLeadingZeros(i - 1);
         }
-        i = i - 1;
-        i |= i >> 1;
-        i |= i >> 2;
-        i |= i >> 4;
-        i |= i >> 8;
-        i |= i >> 16;
-        i = i + 1;
-        return i < 0 ? MAX_CAPACITY : i;
     }
 
     final int baseSize() {

--- a/metadata/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/BaseHashTable.java
@@ -40,14 +40,16 @@ class BaseHashTable<T> {
     private final static double MAX_LOAD_FACTOR = 0.75f;
 
     /**
-     * The natural log of 2
+     * The minimum number of slots we can have in the hash table.
      */
-    private final static double LN_2 = Math.log(2);
+    final static int MIN_CAPACITY = 2;
 
     /**
      * The maximum number of slots we can have in the hash table.
+     *
+     * This is set to the maximum 31-bit power of two.
      */
-    private final static int MAX_CAPACITY = 0x4000000;
+    final static int MAX_CAPACITY = 0x4000_0000;
 
     private Object[] elements;
     private int size = 0;
@@ -56,12 +58,30 @@ class BaseHashTable<T> {
         this.elements = new Object[expectedSizeToCapacity(expectedSize)];
     }
 
+    /**
+     * Calculate the capacity we should provision, given the expected size.
+     *
+     * Our capacity must always be a power of 2, and never less than 2.
+     */
     static int expectedSizeToCapacity(int expectedSize) {
-        if (expectedSize <= 1) {
-            return 2;
+        if (expectedSize >= MAX_CAPACITY / 2) {
+            return MAX_CAPACITY;
         }
-        double sizeToFit = expectedSize / MAX_LOAD_FACTOR;
-        return (int) Math.min(MAX_CAPACITY, Math.ceil(Math.log(sizeToFit) / LN_2));
+        return Math.max(MIN_CAPACITY, roundUpToPowerOfTwo(expectedSize * 2));
+    }
+
+    private static int roundUpToPowerOfTwo(int i) {
+        if (i < 0) {
+            return 0;
+        }
+        i = i - 1;
+        i |= i >> 1;
+        i |= i >> 2;
+        i |= i >> 4;
+        i |= i >> 8;
+        i |= i >> 16;
+        i = i + 1;
+        return i < 0 ? MAX_CAPACITY : i;
     }
 
     final int baseSize() {

--- a/metadata/src/test/java/org/apache/kafka/timeline/BaseHashTableTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/BaseHashTableTest.java
@@ -121,4 +121,19 @@ public class BaseHashTableTest {
             assertEquals(Integer.valueOf(i), table.baseRemove(Integer.valueOf(i)));
         }
     }
+
+    @Test
+    public void testExpectedSizeToCapacity() {
+        assertEquals(2, BaseHashTable.expectedSizeToCapacity(-123));
+        assertEquals(2, BaseHashTable.expectedSizeToCapacity(0));
+        assertEquals(2, BaseHashTable.expectedSizeToCapacity(1));
+        assertEquals(4, BaseHashTable.expectedSizeToCapacity(2));
+        assertEquals(8, BaseHashTable.expectedSizeToCapacity(3));
+        assertEquals(8, BaseHashTable.expectedSizeToCapacity(4));
+        assertEquals(16, BaseHashTable.expectedSizeToCapacity(5));
+        assertEquals(0x4000000, BaseHashTable.expectedSizeToCapacity(0x1010400));
+        assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(Integer.MAX_VALUE));
+        assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(BaseHashTable.MAX_CAPACITY));
+        assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(BaseHashTable.MAX_CAPACITY + 1));
+    }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/BaseHashTableTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/BaseHashTableTest.java
@@ -129,12 +129,13 @@ public class BaseHashTableTest {
         assertEquals(2, BaseHashTable.expectedSizeToCapacity(0));
         assertEquals(2, BaseHashTable.expectedSizeToCapacity(1));
         assertEquals(4, BaseHashTable.expectedSizeToCapacity(2));
-        assertEquals(8, BaseHashTable.expectedSizeToCapacity(3));
+        assertEquals(4, BaseHashTable.expectedSizeToCapacity(3));
         assertEquals(8, BaseHashTable.expectedSizeToCapacity(4));
-        assertEquals(16, BaseHashTable.expectedSizeToCapacity(5));
-        assertEquals(0x4000000, BaseHashTable.expectedSizeToCapacity(0x1010400));
+        assertEquals(16, BaseHashTable.expectedSizeToCapacity(12));
+        assertEquals(32, BaseHashTable.expectedSizeToCapacity(13));
+        assertEquals(0x2000000, BaseHashTable.expectedSizeToCapacity(0x1010400));
         assertEquals(0x4000000, BaseHashTable.expectedSizeToCapacity(0x2000000));
-        assertEquals(0x8000000, BaseHashTable.expectedSizeToCapacity(0x2000001));
+        assertEquals(0x4000000, BaseHashTable.expectedSizeToCapacity(0x2000001));
         assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(BaseHashTable.MAX_CAPACITY));
         assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(BaseHashTable.MAX_CAPACITY + 1));
         assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(Integer.MAX_VALUE - 1));

--- a/metadata/src/test/java/org/apache/kafka/timeline/BaseHashTableTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/BaseHashTableTest.java
@@ -124,6 +124,7 @@ public class BaseHashTableTest {
 
     @Test
     public void testExpectedSizeToCapacity() {
+        assertEquals(2, BaseHashTable.expectedSizeToCapacity(Integer.MIN_VALUE));
         assertEquals(2, BaseHashTable.expectedSizeToCapacity(-123));
         assertEquals(2, BaseHashTable.expectedSizeToCapacity(0));
         assertEquals(2, BaseHashTable.expectedSizeToCapacity(1));
@@ -132,8 +133,11 @@ public class BaseHashTableTest {
         assertEquals(8, BaseHashTable.expectedSizeToCapacity(4));
         assertEquals(16, BaseHashTable.expectedSizeToCapacity(5));
         assertEquals(0x4000000, BaseHashTable.expectedSizeToCapacity(0x1010400));
-        assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(Integer.MAX_VALUE));
+        assertEquals(0x4000000, BaseHashTable.expectedSizeToCapacity(0x2000000));
+        assertEquals(0x8000000, BaseHashTable.expectedSizeToCapacity(0x2000001));
         assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(BaseHashTable.MAX_CAPACITY));
         assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(BaseHashTable.MAX_CAPACITY + 1));
+        assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(Integer.MAX_VALUE - 1));
+        assertEquals(BaseHashTable.MAX_CAPACITY, BaseHashTable.expectedSizeToCapacity(Integer.MAX_VALUE));
     }
 }


### PR DESCRIPTION
The array backing BaseHashTable is intended to be sized as a power of
two.  Due to a bug, the initial array size was calculated incorrectly
in some cases.

Also make the maximum array size the largest possible 31-bit power of
two.  Previously it was a smaller size, but this was due to a typo.