### PR TITLE
KAFKA-12484: Enable Connect's connector log contexts by default (KIP-721)

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -30,11 +30,10 @@ log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
 log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
 
 # The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
-# in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
-# specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
+# in the log messages, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector.
 #
-connect.log.pattern=[%d] %p %m (%c:%L)%n
-#connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
+connect.log.pattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 
 log4j.appender.stdout.layout.ConversionPattern=${connect.log.pattern}
 log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}


### PR DESCRIPTION
**[KIP-721](https://cwiki.apache.org/confluence/display/KAFKA/KIP-721%3A+Enable+connector+log+contexts+in+Connect+Log4j+configuration) has been approved.**

Change the `connect-log4j.properties` file to use the connector log context by default.
This feature was previously added in KIP-449, but was not enabled by default.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
