### PR TITLE
KAFKA-12491: Make rocksdb an `api` dependency for `streams`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1424,9 +1424,11 @@ project(':streams') {
       // this transitive dependency is not used in Streams, and it breaks SBT builds
       exclude module: 'javax.ws.rs-api'
     }
-
+    
+    // `org.rocksdb.Options` is part of Kafka Streams public api via RocksDBConfigSetter
+    api libs.rocksDBJni
+    
     implementation libs.slf4jApi
-    implementation libs.rocksDBJni
     implementation libs.jacksonAnnotations
     implementation libs.jacksonDatabind
 

--- a/build.gradle
+++ b/build.gradle
@@ -1425,7 +1425,7 @@ project(':streams') {
       exclude module: 'javax.ws.rs-api'
     }
     
-    // `org.rocksdb.Options` is part of Kafka Streams public api via RocksDBConfigSetter
+    // `org.rocksdb.Options` is part of Kafka Streams public api via `RocksDBConfigSetter`
     api libs.rocksDBJni
     
     implementation libs.slf4jApi


### PR DESCRIPTION
`org.rocksdb.Options` is part of Kafka Streams public api via `RocksDBConfigSetter`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
