### PR TITLE
KAFKA-12288: remove task-level filesystem locks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -186,7 +186,7 @@ public class ProcessorStateManager implements StateManager {
         this.changelogReader = changelogReader;
         this.sourcePartitions = sourcePartitions;
 
-        this.baseDir = stateDirectory.directoryForTask(taskId);
+        this.baseDir = stateDirectory.getOrCreateDirectoryForTask(taskId);
         this.checkpointFile = new OffsetCheckpoint(stateDirectory.checkpointFileFor(taskId));
 
         log.debug("Created state store manager for task {}", taskId);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -56,7 +56,7 @@ import static org.apache.kafka.streams.processor.internals.StateManagerUtil.CHEC
  */
 public class StateDirectory {
 
-    private static final Pattern PATH_NAME = Pattern.compile("\\d+_\\d+");
+    private static final Pattern TASK_DIR_PATH_NAME = Pattern.compile("\\d+_\\d+");
     private static final Logger log = LoggerFactory.getLogger(StateDirectory.class);
     static final String LOCK_FILE_NAME = ".lock";
 
@@ -503,7 +503,7 @@ public class StateDirectory {
         } else {
             taskDirectories =
                 stateDir.listFiles(pathname -> {
-                    if (!pathname.isDirectory() || !PATH_NAME.matcher(pathname.getName()).matches()) {
+                    if (!pathname.isDirectory() || !TASK_DIR_PATH_NAME.matcher(pathname.getName()).matches()) {
                         return false;
                     } else {
                         return !taskDirEmpty(pathname);
@@ -525,7 +525,7 @@ public class StateDirectory {
         } else {
             taskDirectories =
                 stateDir.listFiles(pathname -> pathname.isDirectory()
-                                                   && PATH_NAME.matcher(pathname.getName()).matches());
+                                                   && TASK_DIR_PATH_NAME.matcher(pathname.getName()).matches());
         }
 
         return taskDirectories == null ? new File[0] : taskDirectories;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -294,8 +294,8 @@ public class StateDirectory {
                 return false;
             }
         } else if (!stateDir.exists()) {
-            log.warn("Tried to lock task directory for {} but the state directory does not exist", taskId);
-            return false;
+            log.error("Tried to lock task directory for {} but the state directory does not exist", taskId);
+            throw new IllegalStateException("The state directory has been deleted");
         } else {
             lockedTasksToStreamThreadOwner.put(taskId, Thread.currentThread().getName());
             // make sure the task directory actually exists, and create it if not

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -293,9 +293,12 @@ public class StateDirectory {
                 // another thread owns the lock
                 return false;
             }
+        } else if (!stateDir.exists()) {
+            log.warn("Tried to lock task directory for {} but the state directory does not exist", taskId);
+            return false;
         } else {
             lockedTasksToStreamThreadOwner.put(taskId, Thread.currentThread().getName());
-            // make sure the directory actually exists, and create it if not
+            // make sure the task directory actually exists, and create it if not
             getOrCreateDirectoryForTask(taskId);
             return true;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -70,8 +70,8 @@ public class StateDirectory {
         @JsonProperty
         private final UUID processId;
 
-        StateDirectoryProcessFile() {
-            processId = null;
+        public StateDirectoryProcessFile() {
+            this.processId = null;
         }
 
         StateDirectoryProcessFile(final UUID processId) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -70,8 +70,8 @@ public class StateDirectory {
         @JsonProperty
         private final UUID processId;
 
-        public StateDirectoryProcessFile() {
-            this.processId = null;
+        StateDirectoryProcessFile() {
+            processId = null;
         }
 
         StateDirectoryProcessFile(final UUID processId) {
@@ -85,24 +85,13 @@ public class StateDirectory {
     private final File stateDir;
     private final boolean hasPersistentStores;
 
-    private final HashMap<TaskId, FileChannel> channels = new HashMap<>();
-    private final HashMap<TaskId, LockAndOwner> locks = new HashMap<>();
+    private final HashMap<TaskId, String> lockedTasksToStreamThreadOwner = new HashMap<>();
 
     private FileChannel stateDirLockChannel;
     private FileLock stateDirLock;
 
     private FileChannel globalStateChannel;
     private FileLock globalStateLock;
-
-    private static class LockAndOwner {
-        final FileLock lock;
-        final String owningThread;
-
-        LockAndOwner(final String owningThread, final FileLock lock) {
-            this.owningThread = owningThread;
-            this.lock = lock;
-        }
-    }
 
     /**
      * Ensures that the state base directory as well as the application's sub-directory are created.
@@ -224,7 +213,7 @@ public class StateDirectory {
      * @return directory for the {@link TaskId}
      * @throws ProcessorStateException if the task directory does not exists and could not be created
      */
-    public File directoryForTask(final TaskId taskId) {
+    public File getOrCreateDirectoryForTask(final TaskId taskId) {
         final File taskDir = new File(stateDir, taskId.toString());
         if (hasPersistentStores && !taskDir.exists()) {
             synchronized (taskDirCreationLock) {
@@ -245,14 +234,14 @@ public class StateDirectory {
      * @return The File handle for the checkpoint in the given task's directory
      */
     File checkpointFileFor(final TaskId taskId) {
-        return new File(directoryForTask(taskId), StateManagerUtil.CHECKPOINT_FILE_NAME);
+        return new File(getOrCreateDirectoryForTask(taskId), StateManagerUtil.CHECKPOINT_FILE_NAME);
     }
 
     /**
      * Decide if the directory of the task is empty or not
      */
     boolean directoryForTaskIsEmpty(final TaskId taskId) {
-        final File taskDir = directoryForTask(taskId);
+        final File taskDir = getOrCreateDirectoryForTask(taskId);
 
         return taskDirEmpty(taskDir);
     }
@@ -288,50 +277,28 @@ public class StateDirectory {
      * Get the lock for the {@link TaskId}s directory if it is available
      * @param taskId task id
      * @return true if successful
-     * @throws IOException if the file cannot be created or file handle cannot be grabbed, should be considered as fatal
      */
-    synchronized boolean lock(final TaskId taskId) throws IOException {
+    synchronized boolean lock(final TaskId taskId) {
         if (!hasPersistentStores) {
             return true;
         }
 
-        final File lockFile;
-        // we already have the lock so bail out here
-        final LockAndOwner lockAndOwner = locks.get(taskId);
-        if (lockAndOwner != null && lockAndOwner.owningThread.equals(Thread.currentThread().getName())) {
-            log.trace("{} Found cached state dir lock for task {}", logPrefix(), taskId);
+        final String lockOwner = lockedTasksToStreamThreadOwner.get(taskId);
+        if (lockOwner != null) {
+            if (lockOwner.equals(Thread.currentThread().getName())) {
+                log.trace("{} Found cached state dir lock for task {}", logPrefix(), taskId);
+                // we already own the lock
+                return true;
+            } else {
+                // another thread owns the lock
+                return false;
+            }
+        } else {
+            lockedTasksToStreamThreadOwner.put(taskId, Thread.currentThread().getName());
+            // make sure the directory actually exists, and create it if not
+            getOrCreateDirectoryForTask(taskId);
             return true;
-        } else if (lockAndOwner != null) {
-            // another thread owns the lock
-            return false;
         }
-
-        try {
-            lockFile = new File(directoryForTask(taskId), LOCK_FILE_NAME);
-        } catch (final ProcessorStateException e) {
-            // directoryForTask could be throwing an exception if another thread
-            // has concurrently deleted the directory
-            return false;
-        }
-
-        final FileChannel channel;
-
-        try {
-            channel = getOrCreateFileChannel(taskId, lockFile.toPath());
-        } catch (final NoSuchFileException e) {
-            // FileChannel.open(..) could throw NoSuchFileException when there is another thread
-            // concurrently deleting the parent directory (i.e. the directory of the taskId) of the lock
-            // file, in this case we will return immediately indicating locking failed.
-            return false;
-        }
-
-        final FileLock lock = tryLock(channel);
-        if (lock != null) {
-            locks.put(taskId, new LockAndOwner(Thread.currentThread().getName(), lock));
-
-            log.debug("{} Acquired state dir lock for task {}", logPrefix(), taskId);
-        }
-        return lock != null;
     }
 
     synchronized boolean lockGlobalState() throws IOException {
@@ -382,17 +349,11 @@ public class StateDirectory {
     /**
      * Unlock the state directory for the given {@link TaskId}.
      */
-    synchronized void unlock(final TaskId taskId) throws IOException {
-        final LockAndOwner lockAndOwner = locks.get(taskId);
-        if (lockAndOwner != null && lockAndOwner.owningThread.equals(Thread.currentThread().getName())) {
-            locks.remove(taskId);
-            lockAndOwner.lock.release();
+    synchronized void unlock(final TaskId taskId) {
+        final String lockOwner = lockedTasksToStreamThreadOwner.get(taskId);
+        if (lockOwner != null && lockOwner.equals(Thread.currentThread().getName())) {
+            lockedTasksToStreamThreadOwner.remove(taskId);
             log.debug("{} Released state dir lock for task {}", logPrefix(), taskId);
-
-            final FileChannel fileChannel = channels.remove(taskId);
-            if (fileChannel != null) {
-                fileChannel.close();
-            }
         }
     }
 
@@ -410,8 +371,8 @@ public class StateDirectory {
             }
 
             // all threads should be stopped and cleaned up by now, so none should remain holding a lock
-            if (locks.isEmpty()) {
-                log.error("Some task directories still locked while closing state, this indicates unclean shutdown: {}", locks);
+            if (lockedTasksToStreamThreadOwner.isEmpty()) {
+                log.error("Some task directories still locked while closing state, this indicates unclean shutdown: {}", lockedTasksToStreamThreadOwner);
             }
             if (globalStateLock != null) {
                 log.error("Global state lock is present while closing the state, this indicates unclean shutdown");
@@ -459,7 +420,7 @@ public class StateDirectory {
         for (final File taskDir : listNonEmptyTaskDirectories()) {
             final String dirName = taskDir.getName();
             final TaskId id = TaskId.parse(dirName);
-            if (!locks.containsKey(id)) {
+            if (!lockedTasksToStreamThreadOwner.containsKey(id)) {
                 try {
                     if (lock(id)) {
                         final long now = time.milliseconds();
@@ -477,15 +438,7 @@ public class StateDirectory {
                         exception
                     );
                 } finally {
-                    try {
-                        unlock(id);
-                    } catch (final IOException exception) {
-                        log.warn(
-                            String.format("%s Swallowed the following exception during unlocking after deletion of obsolete " +
-                                "state directory %s for task %s:", logPrefix(), dirName, id),
-                            exception
-                        );
-                    }
+                    unlock(id);
                 }
             }
         }
@@ -496,7 +449,7 @@ public class StateDirectory {
         for (final File taskDir : listAllTaskDirectories()) {
             final String dirName = taskDir.getName();
             final TaskId id = TaskId.parse(dirName);
-            if (!locks.containsKey(id)) {
+            if (!lockedTasksToStreamThreadOwner.containsKey(id)) {
                 try {
                     if (lock(id)) {
                         log.info("{} Deleting state directory {} for task {} as user calling cleanup.",
@@ -573,14 +526,6 @@ public class StateDirectory {
         }
 
         return taskDirectories == null ? new File[0] : taskDirectories;
-    }
-
-    private FileChannel getOrCreateFileChannel(final TaskId taskId,
-                                               final Path lockPath) throws IOException {
-        if (!channels.containsKey(taskId)) {
-            channels.put(taskId, FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE));
-        }
-        return channels.get(taskId);
     }
 
     private FileLock tryLock(final FileChannel channel) throws IOException {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -374,7 +374,7 @@ public class StateDirectory {
             }
 
             // all threads should be stopped and cleaned up by now, so none should remain holding a lock
-            if (lockedTasksToStreamThreadOwner.isEmpty()) {
+            if (!lockedTasksToStreamThreadOwner.isEmpty()) {
                 log.error("Some task directories still locked while closing state, this indicates unclean shutdown: {}", lockedTasksToStreamThreadOwner);
             }
             if (globalStateLock != null) {
@@ -434,7 +434,7 @@ public class StateDirectory {
                             Utils.delete(taskDir, Collections.singletonList(new File(taskDir, LOCK_FILE_NAME)));
                         }
                     }
-                } catch (final OverlappingFileLockException | IOException exception) {
+                } catch (final IOException exception) {
                     log.warn(
                         String.format("%s Swallowed the following exception during deletion of obsolete state directory %s for task %s:",
                             logPrefix(), dirName, id),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -86,15 +86,8 @@ final class StateManagerUtil {
         }
 
         final TaskId id = stateMgr.taskId();
-        try {
-            if (!stateDirectory.lock(id)) {
-                throw new LockException(String.format("%sFailed to lock the state directory for task %s", logPrefix, id));
-            }
-        } catch (final IOException e) {
-            throw new StreamsException(
-                String.format("%sFatal error while trying to lock the state directory for task %s", logPrefix, id),
-                e
-            );
+        if (!stateDirectory.lock(id)) {
+            throw new LockException(String.format("%sFailed to lock the state directory for task %s", logPrefix, id));
         }
         log.debug("Acquired state directory lock");
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -681,16 +681,11 @@ public class TaskManager {
         for (final File dir : stateDirectory.listNonEmptyTaskDirectories()) {
             try {
                 final TaskId id = TaskId.parse(dir.getName());
-                try {
-                    if (stateDirectory.lock(id)) {
-                        lockedTaskDirectories.add(id);
-                        if (!tasks.owned(id)) {
-                            log.debug("Temporarily locked unassigned task {} for the upcoming rebalance", id);
-                        }
+                if (stateDirectory.lock(id)) {
+                    lockedTaskDirectories.add(id);
+                    if (!tasks.owned(id)) {
+                        log.debug("Temporarily locked unassigned task {} for the upcoming rebalance", id);
                     }
-                } catch (final IOException e) {
-                    // if for any reason we can't lock this task dir, just move on
-                    log.warn(String.format("Exception caught while attempting to lock task %s:", id), e);
                 }
             } catch (final TaskIdFormatException e) {
                 // ignore any unknown files that sit in the same directory
@@ -709,14 +704,8 @@ public class TaskManager {
         while (taskIdIterator.hasNext()) {
             final TaskId id = taskIdIterator.next();
             if (!tasks.owned(id)) {
-                try {
-                    stateDirectory.unlock(id);
-                    taskIdIterator.remove();
-                } catch (final IOException e) {
-                    log.error(String.format("Caught the following exception while trying to unlock task %s", id), e);
-                    firstException.compareAndSet(null,
-                        new StreamsException(String.format("Failed to unlock task directory %s", id), e));
-                }
+                stateDirectory.unlock(id);
+                taskIdIterator.remove();
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -154,9 +154,9 @@ public class RestoreIntegrationTest {
 
         final StateDirectory stateDirectory = new StateDirectory(new StreamsConfig(props), new MockTime(), true);
         // note here the checkpointed offset is the last processed record's offset, so without control message we should write this offset - 1
-        new OffsetCheckpoint(new File(stateDirectory.directoryForTask(new TaskId(0, 0)), ".checkpoint"))
+        new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0)), ".checkpoint"))
                 .write(Collections.singletonMap(new TopicPartition(inputStream, 0), (long) offsetCheckpointed - 1));
-        new OffsetCheckpoint(new File(stateDirectory.directoryForTask(new TaskId(0, 1)), ".checkpoint"))
+        new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 1)), ".checkpoint"))
                 .write(Collections.singletonMap(new TopicPartition(inputStream, 1), (long) offsetCheckpointed - 1));
 
         final CountDownLatch startupLatch = new CountDownLatch(1);
@@ -220,9 +220,9 @@ public class RestoreIntegrationTest {
 
         final StateDirectory stateDirectory = new StateDirectory(new StreamsConfig(props), new MockTime(), true);
         // note here the checkpointed offset is the last processed record's offset, so without control message we should write this offset - 1
-        new OffsetCheckpoint(new File(stateDirectory.directoryForTask(new TaskId(0, 0)), ".checkpoint"))
+        new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0)), ".checkpoint"))
                 .write(Collections.singletonMap(new TopicPartition(changelog, 0), (long) offsetCheckpointed - 1));
-        new OffsetCheckpoint(new File(stateDirectory.directoryForTask(new TaskId(0, 1)), ".checkpoint"))
+        new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 1)), ".checkpoint"))
                 .write(Collections.singletonMap(new TopicPartition(changelog, 1), (long) offsetCheckpointed - 1));
 
         final CountDownLatch startupLatch = new CountDownLatch(1);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskEOSIntegrationTest.java
@@ -187,10 +187,10 @@ public class StandbyTaskEOSIntegrationTest {
         final StateDirectory stateDirectory = new StateDirectory(
             new StreamsConfig(props), new MockTime(), true);
 
-        new OffsetCheckpoint(new File(stateDirectory.directoryForTask(taskId), ".checkpoint"))
+        new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(taskId), ".checkpoint"))
             .write(Collections.singletonMap(new TopicPartition("unknown-topic", 0), 5L));
 
-        assertTrue(new File(stateDirectory.directoryForTask(taskId),
+        assertTrue(new File(stateDirectory.getOrCreateDirectoryForTask(taskId),
                             "rocksdb/KSTREAM-AGGREGATE-STATE-STORE-0000000001").mkdirs());
 
         builder.stream(inputTopic,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ActiveTaskCreatorTest.java
@@ -442,9 +442,9 @@ public class ActiveTaskCreatorTest {
 
         reset(builder, stateDirectory);
         expect(builder.buildSubtopology(0)).andReturn(topology).anyTimes();
-        expect(stateDirectory.directoryForTask(task00)).andReturn(mock(File.class));
+        expect(stateDirectory.getOrCreateDirectoryForTask(task00)).andReturn(mock(File.class));
         expect(stateDirectory.checkpointFileFor(task00)).andReturn(mock(File.class));
-        expect(stateDirectory.directoryForTask(task01)).andReturn(mock(File.class));
+        expect(stateDirectory.getOrCreateDirectoryForTask(task01)).andReturn(mock(File.class));
         expect(stateDirectory.checkpointFileFor(task01)).andReturn(mock(File.class));
         expect(topology.storeToChangelogTopic()).andReturn(Collections.emptyMap()).anyTimes();
         expect(topology.source("topic")).andReturn(sourceNode).anyTimes();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -135,7 +135,7 @@ public class ProcessorStateManagerTest {
                 put(StreamsConfig.STATE_DIR_CONFIG, baseDir.getPath());
             }
         }), new MockTime(), true);
-        checkpointFile = new File(stateDirectory.directoryForTask(taskId), CHECKPOINT_FILE_NAME);
+        checkpointFile = new File(stateDirectory.getOrCreateDirectoryForTask(taskId), CHECKPOINT_FILE_NAME);
         checkpoint = new OffsetCheckpoint(checkpointFile);
 
         expect(storeMetadata.changelogPartition()).andReturn(persistentStorePartition).anyTimes();
@@ -163,7 +163,7 @@ public class ProcessorStateManagerTest {
     @Test
     public void shouldReturnBaseDir() {
         final ProcessorStateManager stateMgr = getStateManager(Task.TaskType.ACTIVE);
-        assertEquals(stateDirectory.directoryForTask(taskId), stateMgr.baseDir());
+        assertEquals(stateDirectory.getOrCreateDirectoryForTask(taskId), stateMgr.baseDir());
     }
 
     // except this test for all other tests active / standby state managers acts the same, so

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -219,11 +219,11 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldNotLockTaskDirectoryIfStateDirectoryHasBeenDeleted() throws IOException {
+    public void shouldNotThrowIfStateDirectoryHasBeenDeleted() throws IOException {
         final TaskId taskId = new TaskId(0, 0);
 
         Utils.delete(stateDir);
-        assertFalse(directory.lock(taskId));
+        assertThrows(IllegalStateException.class, () -> directory.lock(taskId));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -219,6 +219,14 @@ public class StateDirectoryTest {
     }
 
     @Test
+    public void shouldNotLockTaskDirectoryIfStateDirectoryHasBeenDeleted() throws IOException {
+        final TaskId taskId = new TaskId(0, 0);
+
+        Utils.delete(stateDir);
+        assertFalse(directory.lock(taskId));
+    }
+
+    @Test
     public void shouldLockMultipleTaskDirectories() {
         final TaskId taskId = new TaskId(0, 0);
         final TaskId taskId2 = new TaskId(1, 0);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -152,33 +152,15 @@ public class StateDirectoryTest {
     @Test
     public void shouldCreateTaskStateDirectory() {
         final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
+        final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         assertTrue(taskDirectory.exists());
         assertTrue(taskDirectory.isDirectory());
     }
 
     @Test
-    public void shouldLockTaskStateDirectory() throws IOException {
+    public void shouldBeTrueIfAlreadyHoldsLock() {
         final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
-
-        directory.lock(taskId);
-
-        try (
-            final FileChannel channel = FileChannel.open(
-                new File(taskDirectory, LOCK_FILE_NAME).toPath(),
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE)
-        ) {
-            assertThrows(OverlappingFileLockException.class, channel::tryLock);
-        } finally {
-            directory.unlock(taskId);
-        }
-    }
-
-    @Test
-    public void shouldBeTrueIfAlreadyHoldsLock() throws IOException {
-        final TaskId taskId = new TaskId(0, 0);
-        directory.directoryForTask(taskId);
+        directory.getOrCreateDirectoryForTask(taskId);
         directory.lock(taskId);
         try {
             assertTrue(directory.lock(taskId));
@@ -188,7 +170,7 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldBeAbleToUnlockEvenWithoutLocking() throws IOException {
+    public void shouldBeAbleToUnlockEvenWithoutLocking() {
         final TaskId taskId = new TaskId(0, 0);
         directory.unlock(taskId);
     }
@@ -205,14 +187,14 @@ public class StateDirectoryTest {
         assertTrue(directory.directoryForTaskIsEmpty(taskId));
 
         // after writing checkpoint, it should still be empty
-        final OffsetCheckpoint checkpointFile = new OffsetCheckpoint(new File(directory.directoryForTask(taskId), CHECKPOINT_FILE_NAME));
+        final OffsetCheckpoint checkpointFile = new OffsetCheckpoint(new File(directory.getOrCreateDirectoryForTask(taskId), CHECKPOINT_FILE_NAME));
         assertTrue(directory.directoryForTaskIsEmpty(taskId));
 
         checkpointFile.write(Collections.singletonMap(new TopicPartition("topic", 0), 0L));
         assertTrue(directory.directoryForTaskIsEmpty(taskId));
 
         // if some store dir is created, it should not be empty
-        final File dbDir = new File(new File(directory.directoryForTask(taskId), "db"), "store1");
+        final File dbDir = new File(new File(directory.getOrCreateDirectoryForTask(taskId), "db"), "store1");
 
         Files.createDirectories(dbDir.getParentFile().toPath());
         Files.createDirectories(dbDir.getAbsoluteFile().toPath());
@@ -233,49 +215,24 @@ public class StateDirectoryTest {
 
         Utils.delete(stateDir);
 
-        assertThrows(ProcessorStateException.class, () -> directory.directoryForTask(taskId));
+        assertThrows(ProcessorStateException.class, () -> directory.getOrCreateDirectoryForTask(taskId));
     }
 
     @Test
-    public void shouldNotLockDeletedDirectory() throws IOException {
+    public void shouldLockMultipleTaskDirectories() {
         final TaskId taskId = new TaskId(0, 0);
-
-        Utils.delete(stateDir);
-        assertFalse(directory.lock(taskId));
-    }
-    
-    @Test
-    public void shouldLockMultipleTaskDirectories() throws IOException {
-        final TaskId taskId = new TaskId(0, 0);
-        final File task1Dir = directory.directoryForTask(taskId);
         final TaskId taskId2 = new TaskId(1, 0);
-        final File task2Dir = directory.directoryForTask(taskId2);
 
-
-        try (
-            final FileChannel channel1 = FileChannel.open(
-                new File(task1Dir, LOCK_FILE_NAME).toPath(),
-                StandardOpenOption.CREATE,
-                StandardOpenOption.WRITE);
-            final FileChannel channel2 = FileChannel.open(new File(task2Dir, LOCK_FILE_NAME).toPath(),
-                StandardOpenOption.CREATE,
-                StandardOpenOption.WRITE)
-        ) {
-            directory.lock(taskId);
-            directory.lock(taskId2);
-
-            assertThrows(OverlappingFileLockException.class, channel1::tryLock);
-            assertThrows(OverlappingFileLockException.class, channel2::tryLock);
-        } finally {
-            directory.unlock(taskId);
-            directory.unlock(taskId2);
-        }
+        assertThat(directory.lock(taskId), is(true));
+        assertThat(directory.lock(taskId2), is(true));
+        directory.unlock(taskId);
+        directory.unlock(taskId2);
     }
 
     @Test
     public void shouldReleaseTaskStateDirectoryLock() throws IOException {
         final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
+        final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
 
         directory.lock(taskId);
         directory.unlock(taskId);
@@ -291,14 +248,14 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldCleanUpTaskStateDirectoriesThatAreNotCurrentlyLocked() throws IOException {
+    public void shouldCleanUpTaskStateDirectoriesThatAreNotCurrentlyLocked() {
         final TaskId task0 = new TaskId(0, 0);
         final TaskId task1 = new TaskId(1, 0);
         final TaskId task2 = new TaskId(2, 0);
         try {
-            assertTrue(new File(directory.directoryForTask(task0), "store").mkdir());
-            assertTrue(new File(directory.directoryForTask(task1), "store").mkdir());
-            assertTrue(new File(directory.directoryForTask(task2), "store").mkdir());
+            assertTrue(new File(directory.getOrCreateDirectoryForTask(task0), "store").mkdir());
+            assertTrue(new File(directory.getOrCreateDirectoryForTask(task1), "store").mkdir());
+            assertTrue(new File(directory.getOrCreateDirectoryForTask(task2), "store").mkdir());
 
             directory.lock(task0);
             directory.lock(task1);
@@ -333,7 +290,7 @@ public class StateDirectoryTest {
 
     @Test
     public void shouldCleanupStateDirectoriesWhenLastModifiedIsLessThanNowMinusCleanupDelay() {
-        final File dir = directory.directoryForTask(new TaskId(2, 0));
+        final File dir = directory.getOrCreateDirectoryForTask(new TaskId(2, 0));
         assertTrue(new File(dir, "store").mkdir());
 
         final int cleanupDelayMs = 60000;
@@ -351,7 +308,7 @@ public class StateDirectoryTest {
 
     @Test
     public void shouldCleanupObsoleteStateDirectoriesOnlyOnce() {
-        final File dir = directory.directoryForTask(new TaskId(2, 0));
+        final File dir = directory.getOrCreateDirectoryForTask(new TaskId(2, 0));
         assertTrue(new File(dir, "store").mkdir());
         assertEquals(1, directory.listAllTaskDirectories().length);
         assertEquals(1, directory.listNonEmptyTaskDirectories().length);
@@ -426,8 +383,8 @@ public class StateDirectoryTest {
     @Test
     public void shouldOnlyListNonEmptyTaskDirectories() throws IOException {
         TestUtils.tempDirectory(stateDir.toPath(), "foo");
-        final File taskDir1 = directory.directoryForTask(new TaskId(0, 0));
-        final File taskDir2 = directory.directoryForTask(new TaskId(0, 1));
+        final File taskDir1 = directory.getOrCreateDirectoryForTask(new TaskId(0, 0));
+        final File taskDir2 = directory.getOrCreateDirectoryForTask(new TaskId(0, 1));
 
         final File storeDir = new File(taskDir1, "store");
         assertTrue(storeDir.mkdir());
@@ -458,7 +415,7 @@ public class StateDirectoryTest {
                 }
             }),
             time, true);
-        final File taskDir = stateDirectory.directoryForTask(new TaskId(0, 0));
+        final File taskDir = stateDirectory.getOrCreateDirectoryForTask(new TaskId(0, 0));
         assertTrue(stateDir.exists());
         assertTrue(taskDir.exists());
     }
@@ -497,17 +454,9 @@ public class StateDirectoryTest {
     @Test
     public void shouldNotLockStateDirLockedByAnotherThread() throws Exception {
         final TaskId taskId = new TaskId(0, 0);
-        final AtomicReference<IOException> exceptionOnThread = new AtomicReference<>();
-        final Thread thread = new Thread(() -> {
-            try {
-                directory.lock(taskId);
-            } catch (final IOException e) {
-                exceptionOnThread.set(e);
-            }
-        });
+        final Thread thread = new Thread(() -> directory.lock(taskId));
         thread.start();
         thread.join(30000);
-        assertNull("should not have had an exception during locking on other thread", exceptionOnThread.get());
         assertFalse(directory.lock(taskId));
     }
 
@@ -544,7 +493,7 @@ public class StateDirectoryTest {
     @Test
     public void shouldCleanupAllTaskDirectoriesIncludingGlobalOne() {
         final TaskId id = new TaskId(1, 0);
-        directory.directoryForTask(id);
+        directory.getOrCreateDirectoryForTask(id);
         directory.globalStateDir();
 
         final File dir0 = new File(appDir, id.toString());
@@ -573,7 +522,7 @@ public class StateDirectoryTest {
     public void shouldNotCreateTaskStateDirectory() throws IOException {
         initializeStateDirectory(false);
         final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
+        final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         assertFalse(taskDirectory.exists());
     }
 
@@ -622,7 +571,7 @@ public class StateDirectoryTest {
     @Test
     public void shouldLogManualUserCallMessage() {
         final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
+        final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
         assertThat(testFile.mkdir(), is(true));
         assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
@@ -639,7 +588,7 @@ public class StateDirectoryTest {
     @Test
     public void shouldLogStateDirCleanerMessage() {
         final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
+        final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
         final File testFile = new File(taskDirectory, "testFile");
         assertThat(testFile.mkdir(), is(true));
         assertThat(directory.directoryForTaskIsEmpty(taskId), is(false));
@@ -758,7 +707,7 @@ public class StateDirectoryTest {
         @Override
         public void run() {
             try {
-                taskDirectory = directory.directoryForTask(taskId);
+                taskDirectory = directory.getOrCreateDirectoryForTask(taskId);
             } catch (final ProcessorStateException error) {
                 passed.set(false);
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task.TaskType;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateManagerUtilTest.java
@@ -201,7 +201,6 @@ public class StateManagerUtilTest {
         expectLastCall().andThrow(new ProcessorStateException("state manager failed to close"));
 
         stateDirectory.unlock(taskId);
-        expectLastCall();
 
         ctrl.checkOrder(true);
         ctrl.replay();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1498,7 +1498,7 @@ public class StreamTaskTest {
         task.prepareCommit();
         task.postCommit(false);
         final File checkpointFile = new File(
-            stateDirectory.directoryForTask(taskId),
+            stateDirectory.getOrCreateDirectoryForTask(taskId),
             StateManagerUtil.CHECKPOINT_FILE_NAME
         );
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1727,7 +1727,7 @@ public class StreamThreadTest {
         restoreConsumer.updateEndOffsets(Collections.singletonMap(partition2, 10L));
         restoreConsumer.updateBeginningOffsets(Collections.singletonMap(partition2, 0L));
         final OffsetCheckpoint checkpoint
-            = new OffsetCheckpoint(new File(stateDirectory.directoryForTask(task3), CHECKPOINT_FILE_NAME));
+            = new OffsetCheckpoint(new File(stateDirectory.getOrCreateDirectoryForTask(task3), CHECKPOINT_FILE_NAME));
         checkpoint.write(Collections.singletonMap(partition2, 5L));
 
         thread.setState(StreamThread.State.STARTING);


### PR DESCRIPTION
The filesystem locks don't protect access between StreamThreads, only across different instances of the same Streams application. Running multiple processes in the same physical state directory is not supported, and as of [PR #9978](https://github.com/apache/kafka/pull/9978) it's explicitly guarded against), so there's no reason to continue locking the task directories with anything heavier than an in-memory map.

Ripping out out the task-level filesystem locks not only cleans up the code, but removes an occasional source of trouble due to IOExceptions. We now use only an umbrella lock of the state directory itself which is held for the lifetime of the application.

We can probably cherrypick this back to 2.6 since that's how far back we merged [PR #9978](https://github.com/apache/kafka/pull/9978)