### PR TITLE
KAFKA-12471: Implement createPartitions in KIP-500 mode

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -273,7 +273,7 @@
     <suppress checks="CyclomaticComplexity"
               files="(ReplicationControlManager).java"/>
     <suppress checks="NPathComplexity"
-              files="KafkaEventQueue.java"/>
+              files="(KafkaEventQueue|ReplicationControlManager).java"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
             files="metadata[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 </suppressions>

--- a/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokerHeartbeatManager.java
@@ -435,6 +435,7 @@ public class BrokerHeartbeatManager {
     /**
      * Place replicas on unfenced brokers.
      *
+     * @param startPartition    The partition ID to start with.
      * @param numPartitions     The number of partitions to place.
      * @param numReplicas       The number of replicas for each partition.
      * @param idToRack          A function mapping broker id to broker rack.
@@ -444,14 +445,16 @@ public class BrokerHeartbeatManager {
      *
      * @throws InvalidReplicationFactorException    If too many replicas were requested.
      */
-    List<List<Integer>> placeReplicas(int numPartitions, short numReplicas,
+    List<List<Integer>> placeReplicas(int startPartition,
+                                      int numPartitions,
+                                      short numReplicas,
                                       Function<Integer, Optional<String>> idToRack,
                                       ReplicaPlacementPolicy policy) {
         // TODO: support using fenced brokers here if necessary to get to the desired
         // number of replicas. We probably need to add a fenced boolean in UsableBroker.
         Iterator<UsableBroker> iterator = new UsableBrokerIterator(
             unfenced.iterator(), idToRack);
-        return policy.createPlacement(numPartitions, numReplicas, iterator);
+        return policy.createPlacement(startPartition, numPartitions, numReplicas, iterator);
     }
 
     static class UsableBrokerIterator implements Iterator<UsableBroker> {

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -310,11 +310,13 @@ public class ClusterControlManager {
         }
     }
 
-    public List<List<Integer>> placeReplicas(int numPartitions, short numReplicas) {
+    public List<List<Integer>> placeReplicas(int startPartition,
+                                             int numPartitions,
+                                             short numReplicas) {
         if (heartbeatManager == null) {
             throw new RuntimeException("ClusterControlManager is not active.");
         }
-        return heartbeatManager.placeReplicas(numPartitions, numReplicas,
+        return heartbeatManager.placeReplicas(startPartition, numPartitions, numReplicas,
             id -> brokerRegistrations.get(id).rack(), placementPolicy);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.message.AlterIsrRequestData;
 import org.apache.kafka.common.message.AlterIsrResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
@@ -36,6 +38,7 @@ import org.apache.kafka.metadata.BrokerRegistrationReply;
 import org.apache.kafka.metadata.FeatureMapAndEpoch;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -194,6 +197,15 @@ public interface Controller extends AutoCloseable {
      * @return              A future yielding the epoch of the snapshot.
      */
     CompletableFuture<Long> beginWritingSnapshot();
+
+    /**
+     * Create partitions on certain topics.
+     *
+     * @param topics            The list of topics to create partitions for.
+     * @return                  A future yielding per-topic results.
+     */
+    CompletableFuture<List<CreatePartitionsTopicResult>>
+            createPartitions(List<CreatePartitionsTopic> topics);
 
     /**
      * Begin shutting down, but don't block.  You must still call close to clean up all

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -43,6 +43,8 @@ import org.apache.kafka.common.message.AlterIsrRequestData;
 import org.apache.kafka.common.message.AlterIsrResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
@@ -1092,6 +1094,16 @@ public final class QuorumController implements Controller {
                 return result;
             }
         });
+    }
+
+    @Override
+    public CompletableFuture<List<CreatePartitionsTopicResult>>
+            createPartitions(List<CreatePartitionsTopic> topics) {
+        if (topics.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+        return appendWriteEvent("createPartitions", () ->
+            replicationControl.createPartitions(topics));
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicaPlacementPolicy.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicaPlacementPolicy.java
@@ -32,6 +32,7 @@ interface ReplicaPlacementPolicy {
     /**
      * Create a new replica placement.
      *
+     * @param startPartition        The partition ID to start with.
      * @param numPartitions         The number of partitions to create placements for.
      * @param numReplicas           The number of replicas to create for each partitions.
      *                              Must be positive.
@@ -41,7 +42,9 @@ interface ReplicaPlacementPolicy {
      *
      * @throws InvalidReplicationFactorException    If too many replicas were requested.
      */
-    List<List<Integer>> createPlacement(int numPartitions, short numReplicas,
+    List<List<Integer>> createPlacement(int startPartition,
+                                        int numPartitions,
+                                        short numReplicas,
                                         Iterator<UsableBroker> iterator)
         throws InvalidReplicationFactorException;
 }

--- a/metadata/src/main/java/org/apache/kafka/controller/SimpleReplicaPlacementPolicy.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/SimpleReplicaPlacementPolicy.java
@@ -41,7 +41,8 @@ public class SimpleReplicaPlacementPolicy implements ReplicaPlacementPolicy {
     }
 
     @Override
-    public List<List<Integer>> createPlacement(int numPartitions,
+    public List<List<Integer>> createPlacement(int startPartition,
+                                               int numPartitions,
                                                short numReplicas,
                                                Iterator<UsableBroker> iterator) {
         List<UsableBroker> usable = new ArrayList<>();

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -142,7 +142,7 @@ public class ClusterControlManagerTest {
                 String.format("broker %d was not unfenced.", i));
         }
         for (int i = 0; i < 100; i++) {
-            List<List<Integer>> results = clusterControl.placeReplicas(1, (short) 3);
+            List<List<Integer>> results = clusterControl.placeReplicas(0, 1, (short) 3);
             HashSet<Integer> seen = new HashSet<>();
             for (Integer result : results.get(0)) {
                 assertTrue(result >= 0);

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -20,10 +20,14 @@ package org.apache.kafka.controller;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.message.AlterIsrRequestData;
 import org.apache.kafka.common.message.AlterIsrResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsAssignment;
+import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
+import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
@@ -57,6 +61,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.common.protocol.Errors.INVALID_PARTITIONS;
+import static org.apache.kafka.common.protocol.Errors.INVALID_REPLICA_ASSIGNMENT;
 import static org.apache.kafka.common.protocol.Errors.INVALID_TOPIC_EXCEPTION;
 import static org.apache.kafka.common.protocol.Errors.NONE;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
@@ -517,5 +523,133 @@ public class ReplicationControlManagerTest {
             new ApiError(UNKNOWN_TOPIC_OR_PARTITION))), replicationControl.findTopicIds(
                 Long.MAX_VALUE, Collections.singleton("foo")));
         assertEmptyTopicConfigs(ctx, "foo");
+    }
+
+
+    @Test
+    public void testCreatePartitions() throws Exception {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        ReplicationControlManager replicationControl = ctx.replicationControl;
+        CreateTopicsRequestData request = new CreateTopicsRequestData();
+        request.topics().add(new CreatableTopic().setName("foo").
+            setNumPartitions(3).setReplicationFactor((short) 2));
+        request.topics().add(new CreatableTopic().setName("bar").
+            setNumPartitions(4).setReplicationFactor((short) 2));
+        request.topics().add(new CreatableTopic().setName("quux").
+            setNumPartitions(2).setReplicationFactor((short) 2));
+        request.topics().add(new CreatableTopic().setName("foo2").
+            setNumPartitions(2).setReplicationFactor((short) 2));
+        registerBroker(0, ctx);
+        unfenceBroker(0, ctx);
+        registerBroker(1, ctx);
+        unfenceBroker(1, ctx);
+        ControllerResult<CreateTopicsResponseData> createTopicResult =
+            replicationControl.createTopics(request);
+        ctx.replay(createTopicResult.records());
+        List<CreatePartitionsTopic> topics = new ArrayList<>();
+        topics.add(new CreatePartitionsTopic().
+            setName("foo").setCount(5).setAssignments(null));
+        topics.add(new CreatePartitionsTopic().
+            setName("bar").setCount(3).setAssignments(null));
+        topics.add(new CreatePartitionsTopic().
+            setName("baz").setCount(3).setAssignments(null));
+        topics.add(new CreatePartitionsTopic().
+            setName("quux").setCount(2).setAssignments(null));
+        ControllerResult<List<CreatePartitionsTopicResult>> createPartitionsResult =
+            replicationControl.createPartitions(topics);
+        assertEquals(Arrays.asList(new CreatePartitionsTopicResult().
+                setName("foo").
+                setErrorCode(NONE.code()).
+                setErrorMessage(null),
+            new CreatePartitionsTopicResult().
+                setName("bar").
+                setErrorCode(INVALID_PARTITIONS.code()).
+                setErrorMessage("The topic bar currently has 4 partition(s); 3 would not be an increase."),
+            new CreatePartitionsTopicResult().
+                setName("baz").
+                setErrorCode(UNKNOWN_TOPIC_OR_PARTITION.code()).
+                setErrorMessage(null),
+            new CreatePartitionsTopicResult().
+                setName("quux").
+                setErrorCode(INVALID_PARTITIONS.code()).
+                setErrorMessage("Topic already has 2 partition(s).")),
+            createPartitionsResult.response());
+        ctx.replay(createPartitionsResult.records());
+        List<CreatePartitionsTopic> topics2 = new ArrayList<>();
+        topics2.add(new CreatePartitionsTopic().
+            setName("foo").setCount(6).setAssignments(Arrays.asList(
+                new CreatePartitionsAssignment().setBrokerIds(Arrays.asList(1, 0)))));
+        topics2.add(new CreatePartitionsTopic().
+            setName("bar").setCount(5).setAssignments(Arrays.asList(
+            new CreatePartitionsAssignment().setBrokerIds(Arrays.asList(1)))));
+        topics2.add(new CreatePartitionsTopic().
+            setName("quux").setCount(4).setAssignments(Arrays.asList(
+            new CreatePartitionsAssignment().setBrokerIds(Arrays.asList(1, 0)))));
+        topics2.add(new CreatePartitionsTopic().
+            setName("foo2").setCount(3).setAssignments(Arrays.asList(
+            new CreatePartitionsAssignment().setBrokerIds(Arrays.asList(2, 0)))));
+        ControllerResult<List<CreatePartitionsTopicResult>> createPartitionsResult2 =
+            replicationControl.createPartitions(topics2);
+        assertEquals(Arrays.asList(new CreatePartitionsTopicResult().
+                setName("foo").
+                setErrorCode(NONE.code()).
+                setErrorMessage(null),
+            new CreatePartitionsTopicResult().
+                setName("bar").
+                setErrorCode(INVALID_REPLICA_ASSIGNMENT.code()).
+                setErrorMessage("The manual partition assignment includes a partition " +
+                    "with 1 replica(s), but this is not consistent with previous " +
+                    "partitions, which have 2 replica(s)."),
+            new CreatePartitionsTopicResult().
+                setName("quux").
+                setErrorCode(INVALID_REPLICA_ASSIGNMENT.code()).
+                setErrorMessage("Attempted to add 2 additional partition(s), but only 1 assignment(s) were specified."),
+            new CreatePartitionsTopicResult().
+                setName("foo2").
+                setErrorCode(INVALID_REPLICA_ASSIGNMENT.code()).
+                setErrorMessage("The manual partition assignment includes broker 2, but " +
+                    "no such broker is registered.")),
+            createPartitionsResult2.response());
+        ctx.replay(createPartitionsResult2.records());
+    }
+
+    @Test
+    public void testValidateGoodManualPartitionAssignments() throws Exception {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        registerBroker(1, ctx);
+        registerBroker(2, ctx);
+        registerBroker(3, ctx);
+        ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1),
+            OptionalInt.of(1));
+        ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1),
+            OptionalInt.empty());
+        ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1, 2, 3),
+            OptionalInt.of(3));
+        ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1, 2, 3),
+            OptionalInt.empty());
+    }
+
+    @Test
+    public void testValidateBadManualPartitionAssignments() throws Exception {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        registerBroker(1, ctx);
+        registerBroker(2, ctx);
+        assertEquals("The manual partition assignment includes an empty replica list.",
+            assertThrows(InvalidReplicaAssignmentException.class, () ->
+                ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(),
+                    OptionalInt.empty())).getMessage());
+        assertEquals("The manual partition assignment includes broker 3, but no such " +
+            "broker is registered.", assertThrows(InvalidReplicaAssignmentException.class, () ->
+                ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1, 2, 3),
+                    OptionalInt.empty())).getMessage());
+        assertEquals("The manual partition assignment includes the broker 2 more than " +
+            "once.", assertThrows(InvalidReplicaAssignmentException.class, () ->
+                ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1, 2, 2),
+                    OptionalInt.empty())).getMessage());
+        assertEquals("The manual partition assignment includes a partition with 2 " +
+            "replica(s), but this is not consistent with previous partitions, which have " +
+                "3 replica(s).", assertThrows(InvalidReplicaAssignmentException.class, () ->
+                    ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1, 2),
+                        OptionalInt.of(3))).getMessage());
     }
 }


### PR DESCRIPTION
Implement the createPartitions RPC which adds more partitions to a topic
in the KIP-500 controller.  Factor out some of the logic for validating
manual partition assignments, so that it can be shared between
createTopics and createPartitions.  Add a startPartition argument to the
replica placer.