### PR TITLE
MINOR: Move `configurations.all` to be a child of `allprojects`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,28 +70,28 @@ allprojects {
         }
       }
     }
-    configurations.all {
-      // zinc is the Scala incremental compiler, it has a configuration for its own dependencies
-      // that are unrelated to the project dependencies, we should not change them
-      if (name != "zinc") {
-        resolutionStrategy {
-          force(
-            // be explicit about the javassist dependency version instead of relying on the transitive version
-            libs.javassist,
-            // ensure we have a single version in the classpath despite transitive dependencies
-            libs.scalaLibrary,
-            libs.scalaReflect,
-            libs.jacksonAnnotations,
-            // be explicit about the Netty dependency version instead of relying on the version set by
-            // ZooKeeper (potentially older and containing CVEs)
-            libs.nettyHandler,
-            libs.nettyTransportNativeEpoll
-          )
-        }
+  }
+
+  configurations.all {
+    // zinc is the Scala incremental compiler, it has a configuration for its own dependencies
+    // that are unrelated to the project dependencies, we should not change them
+    if (name != "zinc") {
+      resolutionStrategy {
+        force(
+          // be explicit about the javassist dependency version instead of relying on the transitive version
+          libs.javassist,
+          // ensure we have a single version in the classpath despite transitive dependencies
+          libs.scalaLibrary,
+          libs.scalaReflect,
+          libs.jacksonAnnotations,
+          // be explicit about the Netty dependency version instead of relying on the version set by
+          // ZooKeeper (potentially older and containing CVEs)
+          libs.nettyHandler,
+          libs.nettyTransportNativeEpoll
+        )
       }
     }
   }
-
 }
 
 ext {


### PR DESCRIPTION
It was incorrectly set within `dependencyUpdates` and it still worked.
That is, this is a no-op in terms of behavior, but makes it easier to
read and understand.

I tested that `releaseTarGz` produced a tar with two versions of
`javassist` _without this block_ and a single version with it (in either
position).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
