### PR TITLE
MINOR: Exclude KIP-500.md from rat check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,7 @@ if (file('.git').exists()) {
         'gradlew',
         'gradlew.bat',
         'gradle/wrapper/gradle-wrapper.properties',
+        'KIP-500.md',
         'TROGDOR.md',
         '**/README.md',
         '**/id_rsa',


### PR DESCRIPTION
Builds are failing since this file does not have a license. Similar .md files do not seem to have licenses, so I've added this file to the exclude list.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
