### PR TITLE
MINOR: The new KIP-500 code should treat cluster ID as a string

### DIFF
--- a/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+++ b/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
@@ -23,7 +23,7 @@
   "fields": [
     { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The broker ID." },
-    { "name": "ClusterId", "type": "uuid", "versions": "0+",
+    { "name": "ClusterId", "type": "string", "versions": "0+",
       "about": "The cluster id of the broker process." },
     { "name": "IncarnationId", "type": "uuid", "versions": "0+",
       "about": "The incarnation id of the broker process." },

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -2724,7 +2724,7 @@ public class RequestResponseTest {
     private BrokerRegistrationRequest createBrokerRegistrationRequest(short v) {
         BrokerRegistrationRequestData data = new BrokerRegistrationRequestData()
                 .setBrokerId(1)
-                .setClusterId(Uuid.randomUuid())
+                .setClusterId(Uuid.randomUuid().toString())
                 .setRack("1")
                 .setFeatures(new BrokerRegistrationRequestData.FeatureCollection(singletonList(
                         new BrokerRegistrationRequestData.Feature()).iterator()))

--- a/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerLifecycleManager.scala
@@ -148,7 +148,7 @@ class BrokerLifecycleManager(val config: KafkaConfig,
    * The cluster ID, or null if this manager has not been started yet.  This variable can
    * only be read or written from the event queue thread.
    */
-  private var _clusterId: Uuid = _
+  private var _clusterId: String = _
 
   /**
    * The listeners which this broker advertises.  This variable can only be read or
@@ -182,7 +182,7 @@ class BrokerLifecycleManager(val config: KafkaConfig,
    */
   def start(highestMetadataOffsetProvider: () => Long,
             channelManager: BrokerToControllerChannelManager,
-            clusterId: Uuid,
+            clusterId: String,
             advertisedListeners: ListenerCollection,
             supportedFeatures: util.Map[String, VersionRange]): Unit = {
     eventQueue.append(new StartupEvent(highestMetadataOffsetProvider,
@@ -245,7 +245,7 @@ class BrokerLifecycleManager(val config: KafkaConfig,
 
   private class StartupEvent(highestMetadataOffsetProvider: () => Long,
                      channelManager: BrokerToControllerChannelManager,
-                     clusterId: Uuid,
+                     clusterId: String,
                      advertisedListeners: ListenerCollection,
                      supportedFeatures: util.Map[String, VersionRange]) extends EventQueue.Event {
     override def run(): Unit = {

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -96,17 +96,13 @@ class RawMetaProperties(val props: Properties = new Properties()) {
 object MetaProperties {
   def parse(properties: RawMetaProperties): MetaProperties = {
     properties.requireVersion(expectedVersion = 1)
-    val clusterId = requireClusterId(properties)
+    val clusterId = require(ClusterIdKey, properties.clusterId)
     val nodeId = require(NodeIdKey, properties.nodeId)
     new MetaProperties(clusterId, nodeId)
   }
 
   def require[T](key: String, value: Option[T]): T = {
     value.getOrElse(throw new RuntimeException(s"Failed to find required property $key."))
-  }
-
-  def requireClusterId(properties: RawMetaProperties): String = {
-    require(ClusterIdKey, properties.clusterId)
   }
 }
 

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -24,7 +24,6 @@ import java.util.Properties
 import kafka.common.{InconsistentBrokerMetadataException, KafkaException}
 import kafka.server.RawMetaProperties._
 import kafka.utils._
-import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 
 import scala.collection.mutable
@@ -106,14 +105,8 @@ object MetaProperties {
     value.getOrElse(throw new RuntimeException(s"Failed to find required property $key."))
   }
 
-  def requireClusterId(properties: RawMetaProperties): Uuid = {
-    val value = require(ClusterIdKey, properties.clusterId)
-    try {
-      Uuid.fromString(value)
-    } catch {
-      case e: Throwable => throw new RuntimeException(s"Failed to parse $ClusterIdKey property " +
-        s"as a UUID: ${e.getMessage}")
-    }
+  def requireClusterId(properties: RawMetaProperties): String = {
+    require(ClusterIdKey, properties.clusterId)
   }
 }
 
@@ -135,13 +128,13 @@ case class ZkMetaProperties(
 }
 
 case class MetaProperties(
-  clusterId: Uuid,
+  clusterId: String,
   nodeId: Int,
 ) {
   def toProperties: Properties = {
     val properties = new RawMetaProperties()
     properties.version = 1
-    properties.clusterId = clusterId.toString
+    properties.clusterId = clusterId
     properties.nodeId = nodeId
     properties.props
   }

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -198,7 +198,7 @@ object StorageTool extends Logging {
         s"does not appear to be a valid UUID: ${e.getMessage}")
     }
     require(config.nodeId >= 0, s"The node.id must be set to a non-negative integer.")
-    new MetaProperties(effectiveClusterId, config.nodeId)
+    new MetaProperties(effectiveClusterId.toString, config.nodeId)
   }
 
   def formatCommand(stream: PrintStream,

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -74,7 +74,7 @@ class TestRaftServer(
     socketServer.startup(startProcessingRequests = false)
 
     val metaProperties = MetaProperties(
-      clusterId = Uuid.ZERO_UUID,
+      clusterId = Uuid.ZERO_UUID.toString,
       nodeId = config.nodeId
     )
 

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -15,7 +15,6 @@ package kafka.server
 import java.io.File
 import java.util.Properties
 
-import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.test.TestUtils
 import org.junit.jupiter.api.Assertions._
@@ -64,7 +63,7 @@ class BrokerMetadataCheckpointTest {
   @Test
   def testCreateMetadataProperties(): Unit = {
     val meta = MetaProperties(
-      clusterId = Uuid.fromString("H3KKO4NTRPaCWtEmm3vW7A"),
+      clusterId = "H3KKO4NTRPaCWtEmm3vW7A",
       nodeId = 5
     )
     val properties = new RawMetaProperties(meta.toProperties)
@@ -81,21 +80,21 @@ class BrokerMetadataCheckpointTest {
   }
 
   @Test
-  def testMetaPropertiesDoesNotAllowHexEncodedUUIDs(): Unit = {
+  def testMetaPropertiesAllowsHexEncodedUUIDs(): Unit = {
     val properties = new RawMetaProperties()
     properties.version = 1
     properties.clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492"
     properties.nodeId = 1
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
+    MetaProperties.parse(properties)
   }
 
   @Test
-  def testMetaPropertiesWithInvalidClusterId(): Unit = {
+  def testMetaPropertiesWithNonUuidClusterId(): Unit = {
     val properties = new RawMetaProperties()
     properties.version = 1
     properties.clusterId = "not a valid uuid"
     properties.nodeId = 1
-    assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
+    MetaProperties.parse(properties)
   }
 
   @Test

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 class BrokerMetadataCheckpointTest {
+  private val clusterIdBase64 = "H3KKO4NTRPaCWtEmm3vW7A"
 
   @Test
   def testReadWithNonExistentFile(): Unit = {
@@ -62,14 +63,13 @@ class BrokerMetadataCheckpointTest {
 
   @Test
   def testCreateMetadataProperties(): Unit = {
-    val clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
-    confirmValidForMetaProperties(clusterId)
+    confirmValidForMetaProperties(clusterIdBase64)
   }
 
   @Test
   def testMetaPropertiesWithMissingVersion(): Unit = {
     val properties = new RawMetaProperties()
-    properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    properties.clusterId = clusterIdBase64
     properties.nodeId = 1
     assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
@@ -100,7 +100,7 @@ class BrokerMetadataCheckpointTest {
   def testMetaPropertiesWithMissingBrokerId(): Unit = {
     val properties = new RawMetaProperties()
     properties.version = 1
-    properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    properties.clusterId = clusterIdBase64
     assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 
@@ -108,7 +108,7 @@ class BrokerMetadataCheckpointTest {
   def testMetaPropertiesWithMissingControllerId(): Unit = {
     val properties = new RawMetaProperties()
     properties.version = 1
-    properties.clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    properties.clusterId = clusterIdBase64
     assertThrows(classOf[RuntimeException], () => MetaProperties.parse(properties))
   }
 

--- a/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
+++ b/core/src/test/scala/kafka/server/BrokerMetadataCheckpointTest.scala
@@ -62,13 +62,8 @@ class BrokerMetadataCheckpointTest {
 
   @Test
   def testCreateMetadataProperties(): Unit = {
-    val meta = MetaProperties(
-      clusterId = "H3KKO4NTRPaCWtEmm3vW7A",
-      nodeId = 5
-    )
-    val properties = new RawMetaProperties(meta.toProperties)
-    val meta2 = MetaProperties.parse(properties)
-    assertEquals(meta, meta2)
+    val clusterId = "H3KKO4NTRPaCWtEmm3vW7A"
+    confirmValidForMetaProperties(clusterId)
   }
 
   @Test
@@ -81,20 +76,24 @@ class BrokerMetadataCheckpointTest {
 
   @Test
   def testMetaPropertiesAllowsHexEncodedUUIDs(): Unit = {
-    val properties = new RawMetaProperties()
-    properties.version = 1
-    properties.clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492"
-    properties.nodeId = 1
-    MetaProperties.parse(properties)
+    val clusterId = "7bc79ca1-9746-42a3-a35a-efb3cde44492"
+    confirmValidForMetaProperties(clusterId)
   }
 
   @Test
   def testMetaPropertiesWithNonUuidClusterId(): Unit = {
-    val properties = new RawMetaProperties()
-    properties.version = 1
-    properties.clusterId = "not a valid uuid"
-    properties.nodeId = 1
-    MetaProperties.parse(properties)
+    val clusterId = "not a valid uuid"
+    confirmValidForMetaProperties(clusterId)
+  }
+
+  private def confirmValidForMetaProperties(clusterId: String) = {
+    val meta = MetaProperties(
+      clusterId = clusterId,
+      nodeId = 5
+    )
+    val properties = new RawMetaProperties(meta.toProperties)
+    val meta2 = MetaProperties.parse(properties)
+    assertEquals(meta, meta2)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BrokerLifecycleManagerTest.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.clients.{Metadata, MockClient, NodeApiVersions}
 import org.apache.kafka.common.config.SaslConfigs
-import org.apache.kafka.common.{Node, Uuid}
+import org.apache.kafka.common.Node
 import org.apache.kafka.common.internals.ClusterResourceListeners
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion
 import org.apache.kafka.common.message.BrokerRegistrationRequestData.{Listener, ListenerCollection}
@@ -76,7 +76,7 @@ class BrokerLifecycleManagerTest {
     }.toList.asJava)
     val mockChannelManager = new MockBrokerToControllerChannelManager(mockClient,
       time, controllerNodeProvider, nodeApiVersions)
-    val clusterId = Uuid.fromString("x4AJGXQSRnephtTZzujw4w")
+    val clusterId = "x4AJGXQSRnephtTZzujw4w"
     val advertisedListeners = new ListenerCollection()
     config.advertisedListeners.foreach { ep =>
       advertisedListeners.add(new Listener().setHost(ep.host).

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -87,7 +87,7 @@ class ControllerApisTest {
       controller,
       raftManager,
       new KafkaConfig(props),
-      MetaProperties(Uuid.fromString("JgxuGe9URy-E-ceaL04lEw"), nodeId = nodeId),
+      MetaProperties("JgxuGe9URy-E-ceaL04lEw", nodeId = nodeId),
       Seq.empty,
       new SimpleApiVersionManager(ListenerType.CONTROLLER)
     )

--- a/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
@@ -19,7 +19,6 @@ package kafka.server
 import java.io.File
 import java.nio.file.Files
 import java.util.Properties
-
 import kafka.common.{InconsistentBrokerMetadataException, InconsistentNodeIdException, KafkaException}
 import kafka.log.Log
 import org.apache.kafka.common.Uuid
@@ -29,10 +28,11 @@ import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 
 class KafkaRaftServerTest {
+  private val clusterIdBase64 = "H3KKO4NTRPaCWtEmm3vW7A"
 
   @Test
   def testSuccessfulLoadMetaProperties(): Unit = {
-    val clusterId = Uuid.randomUuid().toString
+    val clusterId = clusterIdBase64
     val nodeId = 0
     val metaProperties = MetaProperties(clusterId, nodeId)
 
@@ -49,7 +49,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testLoadMetaPropertiesWithInconsistentNodeId(): Unit = {
-    val clusterId = Uuid.randomUuid().toString
+    val clusterId = clusterIdBase64
     val metaNodeId = 1
     val configNodeId = 0
 
@@ -90,7 +90,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testStartupFailsIfMetaPropertiesMissingInSomeLogDir(): Unit = {
-    val clusterId = Uuid.randomUuid().toString
+    val clusterId = clusterIdBase64
     val nodeId = 1
 
     // One log dir is online and has properly formatted `meta.properties`.
@@ -110,7 +110,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testStartupFailsIfMetaLogDirIsOffline(): Unit = {
-    val clusterId = Uuid.randomUuid().toString
+    val clusterId = clusterIdBase64
     val nodeId = 1
 
     // One log dir is online and has properly formatted `meta.properties`
@@ -131,7 +131,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testStartupDoesNotFailIfDataDirIsOffline(): Unit = {
-    val clusterId = Uuid.randomUuid().toString
+    val clusterId = clusterIdBase64
     val nodeId = 1
 
     // One log dir is online and has properly formatted `meta.properties`
@@ -155,7 +155,7 @@ class KafkaRaftServerTest {
   @Test
   def testStartupFailsIfUnexpectedMetadataDir(): Unit = {
     val nodeId = 1
-    val clusterId = Uuid.randomUuid().toString
+    val clusterId = clusterIdBase64
 
     // Create two directories with valid `meta.properties`
     val metadataDir = TestUtils.tempDirectory()

--- a/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaRaftServerTest.scala
@@ -32,7 +32,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testSuccessfulLoadMetaProperties(): Unit = {
-    val clusterId = Uuid.randomUuid()
+    val clusterId = Uuid.randomUuid().toString
     val nodeId = 0
     val metaProperties = MetaProperties(clusterId, nodeId)
 
@@ -49,7 +49,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testLoadMetaPropertiesWithInconsistentNodeId(): Unit = {
-    val clusterId = Uuid.randomUuid()
+    val clusterId = Uuid.randomUuid().toString
     val metaNodeId = 1
     val configNodeId = 0
 
@@ -90,7 +90,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testStartupFailsIfMetaPropertiesMissingInSomeLogDir(): Unit = {
-    val clusterId = Uuid.randomUuid()
+    val clusterId = Uuid.randomUuid().toString
     val nodeId = 1
 
     // One log dir is online and has properly formatted `meta.properties`.
@@ -110,7 +110,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testStartupFailsIfMetaLogDirIsOffline(): Unit = {
-    val clusterId = Uuid.randomUuid()
+    val clusterId = Uuid.randomUuid().toString
     val nodeId = 1
 
     // One log dir is online and has properly formatted `meta.properties`
@@ -131,7 +131,7 @@ class KafkaRaftServerTest {
 
   @Test
   def testStartupDoesNotFailIfDataDirIsOffline(): Unit = {
-    val clusterId = Uuid.randomUuid()
+    val clusterId = Uuid.randomUuid().toString
     val nodeId = 1
 
     // One log dir is online and has properly formatted `meta.properties`
@@ -155,7 +155,7 @@ class KafkaRaftServerTest {
   @Test
   def testStartupFailsIfUnexpectedMetadataDir(): Unit = {
     val nodeId = 1
-    val clusterId = Uuid.randomUuid()
+    val clusterId = Uuid.randomUuid().toString
 
     // Create two directories with valid `meta.properties`
     val metadataDir = TestUtils.tempDirectory()
@@ -186,7 +186,7 @@ class KafkaRaftServerTest {
 
     // Create a random clusterId in each log dir
     Seq(logDir1, logDir2).foreach { dir =>
-      writeMetaProperties(dir, MetaProperties(clusterId = Uuid.randomUuid(), nodeId))
+      writeMetaProperties(dir, MetaProperties(clusterId = Uuid.randomUuid().toString, nodeId))
     }
 
     val configProperties = new Properties

--- a/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/StorageToolTest.scala
@@ -25,7 +25,6 @@ import java.util.Properties
 
 import kafka.server.{KafkaConfig, MetaProperties}
 import kafka.utils.TestUtils
-import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.utils.Utils
 import org.junit.jupiter.api.Assertions.{assertEquals, assertThrows}
 import org.junit.jupiter.api.{Test, Timeout}
@@ -156,7 +155,7 @@ Found problem:
     val tempDir = TestUtils.tempDir()
     try {
       val metaProperties = MetaProperties(
-        clusterId = Uuid.fromString("XcZZOzUqS4yHOjhMQB6JLQ"), nodeId = 2)
+        clusterId = "XcZZOzUqS4yHOjhMQB6JLQ", nodeId = 2)
       val stream = new ByteArrayOutputStream()
       assertEquals(0, StorageTool.
         formatCommand(new PrintStream(stream), Seq(tempDir.toString), metaProperties, false))

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -139,7 +139,7 @@ public class QuorumControllerTest {
                 CompletableFuture<BrokerRegistrationReply> reply = active.registerBroker(
                     new BrokerRegistrationRequestData().
                         setBrokerId(0).
-                        setClusterId(Uuid.fromString("06B-K3N1TBCNYFgruEVP0Q")).
+                        setClusterId("06B-K3N1TBCNYFgruEVP0Q").
                         setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwBA")).
                         setListeners(listeners));
                 assertEquals(0L, reply.get().epoch());


### PR DESCRIPTION
It is possible that an existing Cluster ID in Zookeeper is not convertible to a UUID.  KIP-500 cannot constrain Cluster IDs to be convertible to a UUID and still expect such a cluster to be able to upgrade to KIP-500.  This patch removes this UUID constraint and makes KIP-500 consistent with existing RPCs, which treat Cluster ID as a String.

It is unlikely that an existing Cluster ID in Zookeeper would not be convertible to a UUID because the Cluster ID is auto-generated in the form of a UUID and stored in ZooKeeper as soon as the first broker connects.  However, there is nothing preventing someone from generating a Cluster ID that does not conform to the UUID format and manually storing/bootstrapping that in ZooKeeper before the first broker connects.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
