### PR TITLE
MINOR: Assume unclean shutdown for metadata log

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -345,6 +345,7 @@ object KafkaMetadataLog {
       maxProducerIdExpirationMs = Int.MaxValue,
       producerIdExpirationCheckIntervalMs = Int.MaxValue,
       logDirFailureChannel = new LogDirFailureChannel(5),
+      lastShutdownClean = false,
       keepPartitionMetadataFile = false
     )
 


### PR DESCRIPTION
Since log recovery for the metadata log is not implemented at the moment
always assume that the replica was shutdown uncleanly. This is okay to because:

1. Snapshots are not fully implemented for the metadata log
2. The replicas (controllers and brokers) need to read the entire metadata log to load it into memory.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
