### PR TITLE
MINOR: Remove duplicate definition about 'the' from kafka project

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -578,7 +578,7 @@ public final class RecordAccumulator {
                         transactionManager != null ? transactionManager.producerIdAndEpoch() : null;
                     ProducerBatch batch = deque.pollFirst();
                     if (producerIdAndEpoch != null && !batch.hasSequence()) {
-                        // If the the producer id/epoch of the partition do not match the latest one
+                        // If the producer id/epoch of the partition do not match the latest one
                         // of the producer, we update it and reset the sequence. This should be
                         // only done when all its in-flight batches have completed. This is guarantee
                         // in `shouldStopDrainBatchesForPartition`.

--- a/clients/src/main/java/org/apache/kafka/common/Uuid.java
+++ b/clients/src/main/java/org/apache/kafka/common/Uuid.java
@@ -39,7 +39,7 @@ public class Uuid implements Comparable<Uuid> {
     private final long leastSignificantBits;
 
     /**
-     * Constructs a 128-bit type 4 UUID where the first long represents the the most significant 64 bits
+     * Constructs a 128-bit type 4 UUID where the first long represents the most significant 64 bits
      * and the second long represents the least significant 64 bits.
      */
     public Uuid(long mostSigBits, long leastSigBits) {

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/KafkaPrincipalSerde.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/KafkaPrincipalSerde.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common.security.auth;
 import org.apache.kafka.common.errors.SerializationException;
 
 /**
- * Serializer/Deserializer interface for {@link KafkaPrincipal} for the the purpose of inter-broker forwarding.
+ * Serializer/Deserializer interface for {@link KafkaPrincipal} for the purpose of inter-broker forwarding.
  * Any serialization/deserialization failure should raise a {@link SerializationException} to be consistent.
  */
 public interface KafkaPrincipalSerde {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/IncrementalCooperativeAssignor.java
@@ -244,7 +244,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
         Map<String, ConnectorsAndTasks> toRevoke = computeDeleted(deleted, connectorAssignments, taskAssignments);
         log.debug("Connector and task to delete assignments: {}", toRevoke);
 
-        // Revoking redundant connectors/tasks if the the workers have duplicate assignments
+        // Revoking redundant connectors/tasks if the workers have duplicate assignments
         toRevoke.putAll(computeDuplicatedAssignments(memberConfigs, connectorAssignments, taskAssignments));
         log.debug("Connector and task to revoke assignments (include duplicated assignments): {}", toRevoke);
 
@@ -456,7 +456,7 @@ public class IncrementalCooperativeAssignor implements ConnectAssignor {
                         candidateWorkerLoad.stream().map(WorkerLoad::worker).collect(Collectors.joining(",")));
                 Iterator<WorkerLoad> candidateWorkerIterator = candidateWorkerLoad.iterator();
                 for (String connector : lostAssignments.connectors()) {
-                    // Loop over the the candidate workers as many times as it takes
+                    // Loop over the candidate workers as many times as it takes
                     if (!candidateWorkerIterator.hasNext()) {
                         candidateWorkerIterator = candidateWorkerLoad.iterator();
                     }

--- a/core/src/main/scala/kafka/admin/FeatureCommand.scala
+++ b/core/src/main/scala/kafka/admin/FeatureCommand.scala
@@ -68,7 +68,7 @@ object FeatureCommand {
 class UpdateFeaturesException(message: String) extends RuntimeException(message)
 
 /**
- * A class that provides necessary APIs to bridge feature APIs provided by the the Admin client with
+ * A class that provides necessary APIs to bridge feature APIs provided by the Admin client with
  * the requirements of the CLI tool.
  *
  * @param opts the CLI options

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -77,7 +77,7 @@ trait MetadataCache {
   /**
    * Get a partition leader's endpoint
    *
-   * @return  If the leader is known, and the listener name is available, return Some(node). If the the leader is known,
+   * @return  If the leader is known, and the listener name is available, return Some(node). If the leader is known,
    *          but the listener is unavailable, return Some(Node.NO_NODE). Otherwise, if the leader is not known,
    *          return None
    */

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -171,7 +171,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     /**
      * Create a new instance.
      *
-     * Note that if the node ID is empty, then the the client will behave as a
+     * Note that if the node ID is empty, then the client will behave as a
      * non-participating observer.
      */
     public KafkaRaftClient(

--- a/raft/src/main/java/org/apache/kafka/snapshot/RawSnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/RawSnapshotWriter.java
@@ -80,7 +80,7 @@ public interface RawSnapshotWriter extends Closeable {
     /**
      * Closes the snapshot writer.
      *
-     * If close is called without first calling freeze the the snapshot is aborted.
+     * If close is called without first calling freeze the snapshot is aborted.
      *
      * @throws IOException for any IO error during close
      */

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotWriter.java
@@ -136,7 +136,7 @@ final public class SnapshotWriter<T> implements Closeable {
     /**
      * Closes the snapshot writer.
      *
-     * If close is called without first calling freeze the the snapshot is aborted.
+     * If close is called without first calling freeze the snapshot is aborted.
      *
      * @throws IOException for any IO error during close
      */

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -1023,7 +1023,7 @@ public class KafkaStreams implements AutoCloseable {
      * threads are adapted so that the sum of the cache sizes over all stream threads equals the total
      * cache size specified in configuration {@link StreamsConfig#CACHE_MAX_BYTES_BUFFERING_CONFIG}.
      *
-     * @param timeout The the length of time to wait for the thread to shutdown
+     * @param timeout The length of time to wait for the thread to shutdown
      * @throws org.apache.kafka.common.errors.TimeoutException if the thread does not stop in time
      * @return name of the removed stream thread or empty if a stream thread could not be removed because
      *         no stream threads are alive

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/BranchedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/BranchedKStream.java
@@ -56,7 +56,7 @@ import java.util.Map;
  * The values of the respective {@code Map<Stream, KStream<K, V>>} entries are formed as following:
  * <ul>
  *     <li>If no chain function or consumer is provided in {@link BranchedKStream#branch(Predicate, Branched)} via
- *     the {@link Branched} parameter, then the the branch itself is added to the {@code Map}
+ *     the {@link Branched} parameter, then the branch itself is added to the {@code Map}
  *     <li>If chain function is provided and it returns a non-null value for a given branch, then the value
  *     is the result returned by this function
  *     <li>If a chain function returns {@code null} for a given branch, then no entry is added to the map

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateManagerUtil.java
@@ -61,7 +61,7 @@ final class StateManagerUtil {
         if (enforceCheckpoint)
             return true;
 
-        // we can checkpoint if the the difference between the current and the previous snapshot is large enough
+        // we can checkpoint if the difference between the current and the previous snapshot is large enough
         long totalOffsetDelta = 0L;
         for (final Map.Entry<TopicPartition, Long> entry : newOffsetSnapshot.entrySet()) {
             totalOffsetDelta += entry.getValue() - oldOffsetSnapshot.getOrDefault(entry.getKey(), 0L);

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -228,7 +228,7 @@ public final class StreamsTestUtils {
 
     /**
      * Used to keep tests simple, and ignore calls from {@link org.apache.kafka.streams.internals.ApiUtils#checkSupplier(Supplier)} )}.
-     * @return true if the the stack context is within a {@link org.apache.kafka.streams.internals.ApiUtils#checkSupplier(Supplier)} )} call
+     * @return true if the stack context is within a {@link org.apache.kafka.streams.internals.ApiUtils#checkSupplier(Supplier)} )} call
      */
     public static boolean isCheckSupplierCall() {
         return Arrays.stream(Thread.currentThread().getStackTrace())

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -297,7 +297,7 @@ public abstract class TopologyTestDriverTest {
 
         /**
          * Used to keep tests simple, and ignore calls from {@link org.apache.kafka.streams.internals.ApiUtils#checkSupplier(Supplier)} )}.
-         * @return true if the the stack context is within a {@link org.apache.kafka.streams.internals.ApiUtils#checkSupplier(Supplier)} )} call
+         * @return true if the stack context is within a {@link org.apache.kafka.streams.internals.ApiUtils#checkSupplier(Supplier)} )} call
          */
         public boolean isCheckSupplierCall() {
             return Arrays.stream(Thread.currentThread().getStackTrace())


### PR DESCRIPTION
As the title.Here is a duplicate definition about 'the'?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
