### PR TITLE
Reapply patch 10000: handle TimeoutException on task reset

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -44,13 +44,13 @@ public class StandbyTask extends AbstractTask implements Task {
     private final StreamsMetricsImpl streamsMetrics;
 
     /**
-     * @param id             the ID of this task
-     * @param inputPartitions     input topic partitions, used for thread metadata only
-     * @param topology       the instance of {@link ProcessorTopology}
-     * @param config         the {@link StreamsConfig} specified by the user
-     * @param streamsMetrics the {@link StreamsMetrics} created by the thread
-     * @param stateMgr       the {@link ProcessorStateManager} for this task
-     * @param stateDirectory the {@link StateDirectory} created by the thread
+     * @param id              the ID of this task
+     * @param inputPartitions input topic partitions, used for thread metadata only
+     * @param topology        the instance of {@link ProcessorTopology}
+     * @param config          the {@link StreamsConfig} specified by the user
+     * @param streamsMetrics  the {@link StreamsMetrics} created by the thread
+     * @param stateMgr        the {@link ProcessorStateManager} for this task
+     * @param stateDirectory  the {@link StateDirectory} created by the thread
      */
     StandbyTask(final TaskId id,
                 final Set<TopicPartition> inputPartitions,
@@ -111,7 +111,7 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void completeRestoration() {
+    public void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         throw new IllegalStateException("Standby task " + id + " should never be completing restoration");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -88,6 +88,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     private final Map<TopicPartition, Long> consumedOffsets;
     private final Map<TopicPartition, Long> committedOffsets;
     private final Map<TopicPartition, Long> highWatermark;
+    private final Set<TopicPartition> resetOffsetsForPartitions;
     private Optional<Long> timeCurrentIdlingStarted;
     private final PunctuationQueue streamTimePunctuationQueue;
     private final PunctuationQueue systemTimePunctuationQueue;
@@ -171,6 +172,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
         // initialize the consumed and committed offset cache
         consumedOffsets = new HashMap<>();
+        resetOffsetsForPartitions = new HashSet<>();
 
         recordQueueCreator = new RecordQueueCreator(this.logContext, config.defaultTimestampExtractor(), config.defaultDeserializationExceptionHandler());
 
@@ -236,17 +238,22 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         }
     }
 
+    public void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
+        mainConsumer.pause(partitionsForOffsetReset);
+        resetOffsetsForPartitions.addAll(partitionsForOffsetReset);
+    }
+
     /**
      * @throws TimeoutException if fetching committed offsets timed out
      */
     @Override
-    public void completeRestoration() {
+    public void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         switch (state()) {
             case RUNNING:
                 return;
 
             case RESTORING:
-                initializeMetadata();
+                resetOffsetsIfNeededAndInitializeMetadata(offsetResetter);
                 initializeTopology();
                 processorContext.initialize();
 
@@ -837,12 +844,27 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         return checkpointableOffsets;
     }
 
-    private void initializeMetadata() {
+    private void resetOffsetsIfNeededAndInitializeMetadata(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter) {
         try {
-            final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = mainConsumer.committed(inputPartitions()).entrySet().stream()
-                    .filter(e -> e.getValue() != null)
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            initializeTaskTime(offsetsAndMetadata);
+            final Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = mainConsumer.committed(inputPartitions());
+
+            for (final Map.Entry<TopicPartition, OffsetAndMetadata> committedEntry : offsetsAndMetadata.entrySet()) {
+                if (resetOffsetsForPartitions.contains(committedEntry.getKey())) {
+                    final OffsetAndMetadata offsetAndMetadata = committedEntry.getValue();
+                    if (offsetAndMetadata != null) {
+                        mainConsumer.seek(committedEntry.getKey(), offsetAndMetadata);
+                        resetOffsetsForPartitions.remove(committedEntry.getKey());
+                    }
+                }
+            }
+
+            offsetResetter.accept(resetOffsetsForPartitions);
+            resetOffsetsForPartitions.clear();
+
+            initializeTaskTime(offsetsAndMetadata.entrySet().stream()
+                .filter(e -> e.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+            );
         } catch (final TimeoutException timeoutException) {
             log.warn(
                 "Encountered {} while trying to fetch committed offsets, will retry initializing the metadata in the next loop." +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -422,8 +422,6 @@ public class StreamThread extends Thread {
             cache::resize
         );
 
-        taskManager.setPartitionResetter(partitions -> streamThread.resetOffsets(partitions, null));
-
         return streamThread.updateThreadMetadata(getSharedAdminClientId(clientId));
     }
 
@@ -848,7 +846,7 @@ public class StreamThread extends Thread {
             // transit to restore active is idempotent so we can call it multiple times
             changelogReader.enforceRestoreActive();
 
-            if (taskManager.tryToCompleteRestoration(now)) {
+            if (taskManager.tryToCompleteRestoration(now, partitions -> resetOffsets(partitions, null))) {
                 changelogReader.transitToUpdateStandby();
                 log.info("Restoration took {} ms for all tasks {}", time.milliseconds() - lastPartitionAssignedMs,
                     taskManager.tasks().keySet());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -108,10 +108,14 @@ public interface Task {
      */
     void initializeIfNeeded();
 
+    default void addPartitionsForOffsetReset(final Set<TopicPartition> partitionsForOffsetReset) {
+        throw new UnsupportedOperationException();
+    }
+
     /**
      * @throws StreamsException fatal error, should close the thread
      */
-    void completeRestoration();
+    void completeRestoration(final java.util.function.Consumer<Set<TopicPartition>> offsetResetter);
 
     void suspend();
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -167,7 +167,7 @@ public class StandbyTaskTest {
 
         task = createStandbyTask();
 
-        assertThrows(LockException.class, task::initializeIfNeeded);
+        assertThrows(LockException.class, () -> task.initializeIfNeeded());
         task = null;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -82,6 +82,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -276,7 +277,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), false);
 
-        assertThrows(LockException.class, task::initializeIfNeeded);
+        assertThrows(LockException.class, () -> task.initializeIfNeeded());
     }
 
     @Test
@@ -327,6 +328,69 @@ public class StreamTaskTest {
     }
 
     @Test
+    public void shouldResetOffsetsToLastCommittedForSpecifiedPartitions() {
+        task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
+        task.addPartitionsForOffsetReset(Collections.singleton(partition1));
+
+        consumer.seek(partition1, 5L);
+        consumer.commitSync();
+
+        consumer.seek(partition1, 10L);
+        consumer.seek(partition2, 15L);
+
+        final java.util.function.Consumer<Set<TopicPartition>> resetter =
+            EasyMock.mock(java.util.function.Consumer.class);
+        resetter.accept(Collections.emptySet());
+        EasyMock.expectLastCall();
+        EasyMock.replay(resetter);
+
+        task.initializeIfNeeded();
+        task.completeRestoration(resetter);
+
+        assertThat(consumer.position(partition1), equalTo(5L));
+        assertThat(consumer.position(partition2), equalTo(15L));
+    }
+
+    @Test
+    public void shouldAutoOffsetResetIfNoCommittedOffsetFound() {
+        task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
+        task.addPartitionsForOffsetReset(Collections.singleton(partition1));
+
+        final AtomicReference<AssertionError> shouldNotSeek = new AtomicReference<>();
+        final MockConsumer<byte[], byte[]> consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
+            @Override
+            public void seek(final TopicPartition partition, final long offset) {
+                final AssertionError error = shouldNotSeek.get();
+                if (error != null) {
+                    throw error;
+                }
+                super.seek(partition, offset);
+            }
+        };
+        consumer.assign(asList(partition1, partition2));
+        consumer.updateBeginningOffsets(mkMap(mkEntry(partition1, 0L), mkEntry(partition2, 0L)));
+
+        consumer.seek(partition1, 5L);
+        consumer.seek(partition2, 15L);
+
+        shouldNotSeek.set(new AssertionError("Should not seek"));
+
+        final java.util.function.Consumer<Set<TopicPartition>> resetter =
+            EasyMock.mock(java.util.function.Consumer.class);
+        resetter.accept(Collections.singleton(partition1));
+        EasyMock.expectLastCall();
+        EasyMock.replay(resetter);
+
+        task.initializeIfNeeded();
+        task.completeRestoration(resetter);
+
+        // because we mocked the `resetter` positions don't change
+        assertThat(consumer.position(partition1), equalTo(5L));
+        assertThat(consumer.position(partition2), equalTo(15L));
+        EasyMock.verify(resetter);
+    }
+
+    @Test
     public void shouldReadCommittedStreamTimeOnInitialize() {
         stateDirectory = EasyMock.createNiceMock(StateDirectory.class);
         EasyMock.replay(stateDirectory);
@@ -339,7 +403,7 @@ public class StreamTaskTest {
         assertEquals(RecordQueue.UNKNOWN, task.streamTime());
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertEquals(10L, task.streamTime());
     }
@@ -370,7 +434,7 @@ public class StreamTaskTest {
 
         assertEquals(RESTORING, task.state());
 
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertEquals(RUNNING, task.state());
         assertTrue(source1.initialized);
@@ -574,7 +638,7 @@ public class StreamTaskTest {
 
         task = createStatelessTaskWithForwardingTopology(evenKeyForwardingSourceNode);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         final String sourceNodeName = evenKeyForwardingSourceNode.name();
         final String terminalNodeName = processorStreamTime.name();
@@ -890,7 +954,7 @@ public class StreamTaskTest {
     public void shouldPunctuateOnceStreamTimeAfterGap() {
         task = createStatelessTask(createConfig(), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 20),
@@ -975,7 +1039,7 @@ public class StreamTaskTest {
     public void shouldRespectPunctuateCancellationStreamTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 20),
@@ -1015,7 +1079,7 @@ public class StreamTaskTest {
     public void shouldRespectPunctuateCancellationSystemTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         final long now = time.milliseconds();
         time.sleep(10);
         assertTrue(task.maybePunctuateSystemTime());
@@ -1029,7 +1093,7 @@ public class StreamTaskTest {
     public void shouldRespectCommitNeeded() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertFalse(task.commitNeeded());
 
@@ -1067,7 +1131,7 @@ public class StreamTaskTest {
     public void shouldCommitNextOffsetFromQueueIfAvailable() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 0L),
@@ -1086,7 +1150,7 @@ public class StreamTaskTest {
     public void shouldCommitConsumerPositionIfRecordQueueIsEmpty() {
         task = createStatelessTask(createConfig(), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         consumer.addRecord(getConsumerRecordWithOffsetAsTimestamp(partition1, 0L));
         consumer.addRecord(getConsumerRecordWithOffsetAsTimestamp(partition1, 1L));
@@ -1120,7 +1184,7 @@ public class StreamTaskTest {
     public void shouldRespectCommitRequested() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.requestCommit();
         assertTrue(task.commitRequested());
@@ -1152,7 +1216,7 @@ public class StreamTaskTest {
     public void shouldBeProcessableIfAllPartitionsBuffered() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertFalse(task.process(0L));
 
@@ -1170,7 +1234,7 @@ public class StreamTaskTest {
     public void shouldPunctuateSystemTimeWhenIntervalElapsed() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         final long now = time.milliseconds();
         time.sleep(10);
         assertTrue(task.maybePunctuateSystemTime());
@@ -1190,7 +1254,7 @@ public class StreamTaskTest {
     public void shouldNotPunctuateSystemTimeWhenIntervalNotElapsed() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         assertFalse(task.maybePunctuateSystemTime());
         time.sleep(9);
         assertFalse(task.maybePunctuateSystemTime());
@@ -1201,7 +1265,7 @@ public class StreamTaskTest {
     public void shouldPunctuateOnceSystemTimeAfterGap() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         final long now = time.milliseconds();
         time.sleep(100);
         assertTrue(task.maybePunctuateSystemTime());
@@ -1227,7 +1291,7 @@ public class StreamTaskTest {
     public void shouldWrapKafkaExceptionsWithStreamsExceptionAndAddContextWhenPunctuatingStreamTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         try {
             task.punctuate(processorStreamTime, 1, PunctuationType.STREAM_TIME, timestamp -> {
@@ -1245,7 +1309,7 @@ public class StreamTaskTest {
     public void shouldWrapKafkaExceptionsWithStreamsExceptionAndAddContextWhenPunctuatingWallClockTimeTime() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         try {
             task.punctuate(processorSystemTime, 1, PunctuationType.WALL_CLOCK_TIME, timestamp -> {
@@ -1263,7 +1327,7 @@ public class StreamTaskTest {
     public void shouldNotShareHeadersBetweenPunctuateIterations() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.punctuate(
             processorSystemTime,
@@ -1289,7 +1353,7 @@ public class StreamTaskTest {
         task = createFaultyStatefulTask(createConfig("100"));
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, asList(
             getConsumerRecordWithOffsetAsTimestamp(partition1, 10),
@@ -1317,9 +1381,9 @@ public class StreamTaskTest {
 
         task = createDisconnectedTask(createConfig("100"));
 
-        task.initializeIfNeeded();
+        task.transitionTo(RESTORING);
 
-        assertThrows(TimeoutException.class, task::completeRestoration);
+        assertThrows(TimeoutException.class, () -> task.completeRestoration(noOpResetter -> { }));
     }
 
     @Test
@@ -1347,7 +1411,7 @@ public class StreamTaskTest {
         assertFalse(source1.initialized);
         assertFalse(source2.initialized);
 
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertEquals(RUNNING, task.state());
         assertTrue(source1.initialized);
@@ -1377,7 +1441,7 @@ public class StreamTaskTest {
         task = createStatefulTask(createConfig("100"), true);
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.prepareCommit();
         task.postCommit(true);   // should checkpoint
@@ -1408,7 +1472,7 @@ public class StreamTaskTest {
         task = createStatefulTask(createConfig("100"), true);
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.prepareCommit();
         task.postCommit(true);
 
@@ -1430,7 +1494,7 @@ public class StreamTaskTest {
         task = createStatefulTask(createConfig(StreamsConfig.EXACTLY_ONCE, "100"), true);
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.prepareCommit();
         task.postCommit(false);
         final File checkpointFile = new File(
@@ -1445,7 +1509,7 @@ public class StreamTaskTest {
     public void shouldThrowIllegalStateExceptionIfCurrentNodeIsNotNullWhenPunctuateCalled() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.processorContext().setCurrentNode(processorStreamTime);
         try {
             task.punctuate(processorStreamTime, 10, PunctuationType.STREAM_TIME, punctuator);
@@ -1459,7 +1523,7 @@ public class StreamTaskTest {
     public void shouldCallPunctuateOnPassedInProcessorNode() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.punctuate(processorStreamTime, 5, PunctuationType.STREAM_TIME, punctuator);
         assertThat(punctuatedAt, equalTo(5L));
         task.punctuate(processorStreamTime, 10, PunctuationType.STREAM_TIME, punctuator);
@@ -1470,7 +1534,7 @@ public class StreamTaskTest {
     public void shouldSetProcessorNodeOnContextBackToNullAfterSuccessfulPunctuate() {
         task = createStatelessTask(createConfig("100"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.punctuate(processorStreamTime, 5, PunctuationType.STREAM_TIME, punctuator);
         assertThat(task.processorContext().currentNode(), nullValue());
     }
@@ -1500,7 +1564,7 @@ public class StreamTaskTest {
         task = createFaultyStatefulTask(createConfig("100"));
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertThrows(RuntimeException.class, () -> task.suspend());
         task.closeDirty();
@@ -1549,7 +1613,7 @@ public class StreamTaskTest {
             logContext);
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 5L)));
         task.addRecords(repartition, singletonList(getConsumerRecordWithOffsetAsTimestamp(repartition, 10L)));
@@ -1578,9 +1642,9 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
-        task.initializeIfNeeded();
+        task.transitionTo(RESTORING);
 
-        assertThrows(StreamsException.class, task::completeRestoration);
+        assertThrows(StreamsException.class, () -> task.completeRestoration(noOpResetter -> { }));
     }
 
     @Test
@@ -1638,7 +1702,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), true);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.prepareCommit();
         task.postCommit(false);
@@ -1659,7 +1723,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig("100"), true);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.prepareCommit();
         task.postCommit(false);
@@ -1683,7 +1747,7 @@ public class StreamTaskTest {
 
         task = createStatefulTask(createConfig(), true);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.addRecords(partition1, singleton(getConsumerRecordWithOffsetAsTimestamp(partition1, 10)));
         task.addRecords(partition2, singleton(getConsumerRecordWithOffsetAsTimestamp(partition2, 10)));
         task.process(100L);
@@ -1707,7 +1771,7 @@ public class StreamTaskTest {
 
         assertEquals(singletonMap(partition1, 50L), task.changelogOffsets());
 
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         assertEquals(singletonMap(partition1, Task.LATEST_OFFSET), task.changelogOffsets());
     }
@@ -1752,7 +1816,7 @@ public class StreamTaskTest {
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
 
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         task.suspend();
         task.prepareCommit();
         task.postCommit(true);
@@ -1779,7 +1843,7 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig(), consumer);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, consumedOffset)));
         task.process(100L);
@@ -1810,7 +1874,7 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset)));
         task.process(100L);
@@ -1852,7 +1916,7 @@ public class StreamTaskTest {
 
         task = createOptimizedStatefulTask(createConfig("100"), consumer);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         // process one record to make commit needed
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, offset)));
@@ -2004,7 +2068,7 @@ public class StreamTaskTest {
     public void shouldThrowIfCleanClosingDirtyTask() {
         task = createSingleSourceStateless(createConfig(AT_LEAST_ONCE, "0"), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)));
         assertTrue(task.process(0L));
@@ -2017,7 +2081,7 @@ public class StreamTaskTest {
     public void shouldThrowIfRecyclingDirtyTask() {
         task = createStatelessTask(createConfig(), StreamsConfig.METRICS_LATEST);
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
 
         task.addRecords(partition1, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition1, 0)));
         task.addRecords(partition2, singletonList(getConsumerRecordWithOffsetAsTimestamp(partition2, 0)));
@@ -2040,7 +2104,7 @@ public class StreamTaskTest {
         task.initializeIfNeeded();
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RESTORING
 
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         assertThrows(IllegalStateException.class, () -> task.closeCleanAndRecycleState()); // RUNNING
 
         task.suspend();
@@ -2075,7 +2139,7 @@ public class StreamTaskTest {
         EasyMock.replay(stateManager);
         task = createFaultyStatefulTask(createConfig("100"));
         task.initializeIfNeeded();
-        task.completeRestoration();
+        task.completeRestoration(noOpResetter -> { });
         assertThat(task.state(), equalTo(RUNNING));
         assertThrows(RuntimeException.class, () -> task.suspend());
         assertThat(task.state(), equalTo(SUSPENDED));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1739,7 +1739,7 @@ public class StreamThreadTest {
         standbyTasks.put(task3, Collections.singleton(t2p1));
 
         thread.taskManager().handleAssignment(emptyMap(), standbyTasks);
-        thread.taskManager().tryToCompleteRestoration(mockTime.milliseconds());
+        thread.taskManager().tryToCompleteRestoration(mockTime.milliseconds(), null);
 
         thread.rebalanceListener().onPartitionsAssigned(Collections.emptyList());
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -528,7 +528,7 @@ public class TopologyTestDriver implements Closeable {
                 context,
                 logContext);
             task.initializeIfNeeded();
-            task.completeRestoration();
+            task.completeRestoration(noOpResetter -> { });
             task.processorContext().setRecordContext(null);
 
         } else {


### PR DESCRIPTION
This PR was a cherry pick of https://github.com/apache/kafka/pull/10000, which was removed by accident in trunk and 2.8, bringing it back.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
