### PR TITLE
KAFKA-12522: Cast SMT should allow null value records to pass through

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java
@@ -120,6 +120,10 @@ public abstract class Cast<R extends ConnectRecord<R>> implements Transformation
 
     @Override
     public R apply(R record) {
+        if (operatingValue(record) == null) {
+            return record;
+        }
+
         if (operatingSchema(record) == null) {
             return applySchemaless(record);
         } else {

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -90,6 +90,42 @@ public class CastTest {
     }
 
     @Test
+    public void castNullValueRecordWithSchema() {
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int64"));
+        SourceRecord original = new SourceRecord(null, null, "topic", 0,
+            Schema.STRING_SCHEMA, "key", Schema.STRING_SCHEMA, null);
+        SourceRecord transformed = xformValue.apply(original);
+        assertEquals(original, transformed);
+    }
+
+    @Test
+    public void castNullValueRecordSchemaless() {
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int64"));
+        SourceRecord original = new SourceRecord(null, null, "topic", 0,
+            Schema.STRING_SCHEMA, "key", null, null);
+        SourceRecord transformed = xformValue.apply(original);
+        assertEquals(original, transformed);
+    }
+
+    @Test
+    public void castNullKeyRecordWithSchema() {
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int64"));
+        SourceRecord original = new SourceRecord(null, null, "topic", 0,
+            Schema.STRING_SCHEMA, null, Schema.STRING_SCHEMA, "value");
+        SourceRecord transformed = xformKey.apply(original);
+        assertEquals(original, transformed);
+    }
+
+    @Test
+    public void castNullKeyRecordSchemaless() {
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int64"));
+        SourceRecord original = new SourceRecord(null, null, "topic", 0,
+            null, null, Schema.STRING_SCHEMA, "value");
+        SourceRecord transformed = xformKey.apply(original);
+        assertEquals(original, transformed);
+    }
+
+    @Test
     public void castWholeRecordKeyWithSchema() {
         xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
         SourceRecord transformed = xformKey.apply(new SourceRecord(null, null, "topic", 0,


### PR DESCRIPTION
**Problem**
The [current Cast SMT](https://github.com/apache/kafka/blob/trunk/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Cast.java) fails on a null record value (or a null record key), which is problematic for tombstone records. When a tombstone record reaches the transformation the error below is thrown:

With schema:
```
Cannot list fields on non-struct type
org.apache.kafka.connect.errors.DataException: Cannot list fields on non-struct type
	at org.apache.kafka.connect.data.ConnectSchema.fields(ConnectSchema.java:179)
	at org.apache.kafka.connect.transforms.Cast.getOrBuildSchema(Cast.java:190)
```

For schemaless:
```
Caused by: org.apache.kafka.connect.errors.DataException: Only Map objects supported in absence of schema for [cast types], found: null
at org.apache.kafka.connect.transforms.util.Requirements.requireMap(Requirements.java:38)
```

**Solution**
Null value records should instead be allowed to pass through as there is no cast transformation to be done, with the benefit of allowing the connector to handle the tombstone records as intended. 

**Testing**
Added SMT unit tests to verify the records pass through when the keys or values are null. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
