### PR TITLE
KAFKA-12515 ApiVersionManager should create response based on request version

### DIFF
--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -43,7 +43,7 @@
     ]},
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "1+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name":  "SupportedFeatures", "type": "[]SupportedFeatureKey",
+    { "name":  "SupportedFeatures", "type": "[]SupportedFeatureKey", "ignorable": true,
       "versions":  "3+", "tag": 0, "taggedVersions": "3+",
       "about": "Features supported by the broker.",
       "fields":  [
@@ -59,7 +59,7 @@
       "tag": 1, "taggedVersions": "3+", "default": "-1", "ignorable": true,
       "about": "The monotonically increasing epoch for the finalized features information. Valid values are >= 0. A value of -1 is special and represents unknown epoch."},
     { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey",
-      "versions":  "3+", "tag": 2, "taggedVersions": "3+",
+      "versions":  "3+", "tag": 2, "taggedVersions": "3+", "ignorable": true,
       "about": "List of cluster-wide finalized features. The information is valid only if FinalizedFeaturesEpoch >= 0.",
       "fields":  [
         {"name": "Name", "type": "string", "versions":  "3+", "mapKey": true,

--- a/clients/src/main/resources/common/message/ApiVersionsResponse.json
+++ b/clients/src/main/resources/common/message/ApiVersionsResponse.json
@@ -58,8 +58,8 @@
     { "name": "FinalizedFeaturesEpoch", "type": "int64", "versions": "3+",
       "tag": 1, "taggedVersions": "3+", "default": "-1", "ignorable": true,
       "about": "The monotonically increasing epoch for the finalized features information. Valid values are >= 0. A value of -1 is special and represents unknown epoch."},
-    { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey",
-      "versions":  "3+", "tag": 2, "taggedVersions": "3+", "ignorable": true,
+    { "name":  "FinalizedFeatures", "type": "[]FinalizedFeatureKey", "ignorable": true,
+      "versions":  "3+", "tag": 2, "taggedVersions": "3+",
       "about": "List of cluster-wide finalized features. The information is valid only if FinalizedFeaturesEpoch >= 0.",
       "fields":  [
         {"name": "Name", "type": "string", "versions":  "3+", "mapKey": true,


### PR DESCRIPTION
**Goal**
Make supported and finalized features ignorable to achieve backward compatibility for ApiVersionsRequest(version < 3).

**Backgroud**
Please check the Jira description: https://issues.apache.org/jira/browse/KAFKA-12515

**Test proof**
Currently, the feature versioning system is not used, so the backward compatibility issue is not coming up. When for example the feature versioning system is being used, for example, backward compatibility issue will come up and this patch can fix that.  
```
// kafka.server.BrokerFeatures.scala

def createDefault(): BrokerFeatures = {
    val supportedFeatures =
    Map[String, SupportedVersionRange]("feature_1" -> new SupportedVersionRange(1, 4))
    new BrokerFeatures(Features.supportedFeatures(supportedFeatures.asJava))
  }
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

