### PR TITLE
KAFKA-12420: Kafka network Selector class has many constructors; use a Builder pattern instead

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -514,8 +514,14 @@ public class KafkaAdminClient extends AdminClient {
             metrics = new Metrics(metricConfig, reporters, time, metricsContext);
             String metricGrpPrefix = "admin-client";
             channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
-            selector = new Selector(config.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                    metrics, time, metricGrpPrefix, channelBuilder, logContext);
+            Selector.Builder selectorBuilder = new Selector.Builder();
+            selectorBuilder.withConnectionMaxIdleMs(config.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG))
+                    .withMetrics(metrics)
+                    .withTime(time)
+                    .withMetricGrpPrefix(metricGrpPrefix)
+                    .withChannelBuilder(channelBuilder)
+                    .withLogContext(logContext);
+            selector = selectorBuilder.build();
             networkClient = new NetworkClient(
                 selector,
                 metadataManager.updater(),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -743,8 +743,15 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             int heartbeatIntervalMs = config.getInt(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG);
 
             ApiVersions apiVersions = new ApiVersions();
+            Selector.Builder selectorBuilder = new Selector.Builder();
+            selectorBuilder.withConnectionMaxIdleMs(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG))
+                    .withMetrics(metrics)
+                    .withTime(time)
+                    .withMetricGrpPrefix(metricGrpPrefix)
+                    .withChannelBuilder(channelBuilder)
+                    .withLogContext(logContext);
             NetworkClient netClient = new NetworkClient(
-                    new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
+                    selectorBuilder.build(),
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice for max in-flight requests

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -449,8 +449,13 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         ProducerMetrics metricsRegistry = new ProducerMetrics(this.metrics);
         Sensor throttleTimeSensor = Sender.throttleTimeSensor(metricsRegistry.senderMetrics);
         KafkaClient client = kafkaClient != null ? kafkaClient : new NetworkClient(
-                new Selector(producerConfig.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                        this.metrics, time, "producer", channelBuilder, logContext),
+                new Selector.Builder().withConnectionMaxIdleMs(producerConfig.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG))
+                        .withMetrics(this.metrics)
+                        .withTime(time)
+                        .withMetricGrpPrefix("producer")
+                        .withChannelBuilder(channelBuilder)
+                        .withLogContext(logContext)
+                        .build(),
                 metadata,
                 clientId,
                 maxInflightRequests,

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -112,7 +112,6 @@ public class Selector implements Selectable, AutoCloseable {
             this.memoryPool = MemoryPool.NONE;
         }
 
-
         public Builder withMaxReceiveSize(int maxReceiveSize) {
             this.maxReceiveSize = maxReceiveSize;
             return this;

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -275,52 +275,10 @@ public class Selector implements Selectable, AutoCloseable {
         this.delayedClosingChannels = (failedAuthenticationDelayMs > NO_FAILED_AUTHENTICATION_DELAY) ? new LinkedHashMap<String, DelayedAuthenticationFailureClose>() : null;
     }
 
-    public Selector(int maxReceiveSize,
-                    long connectionMaxIdleMs,
-                    Metrics metrics,
-                    Time time,
-                    String metricGrpPrefix,
-                    Map<String, String> metricTags,
-                    boolean metricsPerConnection,
-                    boolean recordTimePerConnection,
-                    ChannelBuilder channelBuilder,
-                    MemoryPool memoryPool,
-                    LogContext logContext) {
-        this(maxReceiveSize, connectionMaxIdleMs, NO_FAILED_AUTHENTICATION_DELAY, metrics, time, metricGrpPrefix, metricTags,
-                metricsPerConnection, recordTimePerConnection, channelBuilder, memoryPool, logContext);
-    }
-
-    public Selector(int maxReceiveSize,
-                    long connectionMaxIdleMs,
-                    int failedAuthenticationDelayMs,
-                    Metrics metrics,
-                    Time time,
-                    String metricGrpPrefix,
-                    Map<String, String> metricTags,
-                    boolean metricsPerConnection,
-                    ChannelBuilder channelBuilder,
-                    LogContext logContext) {
-        this(maxReceiveSize, connectionMaxIdleMs, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, metricTags, metricsPerConnection, false, channelBuilder, MemoryPool.NONE, logContext);
-    }
-
-    public Selector(int maxReceiveSize,
-                    long connectionMaxIdleMs,
-                    Metrics metrics,
-                    Time time,
-                    String metricGrpPrefix,
-                    Map<String, String> metricTags,
-                    boolean metricsPerConnection,
-                    ChannelBuilder channelBuilder,
-                    LogContext logContext) {
-        this(maxReceiveSize, connectionMaxIdleMs, NO_FAILED_AUTHENTICATION_DELAY, metrics, time, metricGrpPrefix, metricTags, metricsPerConnection, channelBuilder, logContext);
-    }
-
-    public Selector(long connectionMaxIdleMS, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
-        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, metrics, time, metricGrpPrefix, Collections.emptyMap(), true, channelBuilder, logContext);
-    }
-
-    public Selector(long connectionMaxIdleMS, int failedAuthenticationDelayMs, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
-        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, failedAuthenticationDelayMs, metrics, time, metricGrpPrefix, Collections.<String, String>emptyMap(), true, channelBuilder, logContext);
+    // used for anonymous class for testing purposes
+    protected Selector(long connectionMaxIdleMS, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
+        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, NO_FAILED_AUTHENTICATION_DELAY, metrics, time, metricGrpPrefix, Collections.emptyMap(),
+                true, false, channelBuilder, MemoryPool.NONE, logContext);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -106,7 +106,7 @@ public class Selector implements Selectable, AutoCloseable {
         public Builder() {
             this.maxReceiveSize = NetworkReceive.UNLIMITED;
             this.failedAuthenticationDelayMs = NO_FAILED_AUTHENTICATION_DELAY;
-            this.recordTimePerConnection = true;
+            this.metricsPerConnection = true;
             this.metricTags = Collections.emptyMap();
             this.recordTimePerConnection = false;
             this.memoryPool = MemoryPool.NONE;

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -85,9 +85,101 @@ import java.util.concurrent.atomic.AtomicReference;
  * This class is not thread safe!
  */
 public class Selector implements Selectable, AutoCloseable {
-
     public static final long NO_IDLE_TIMEOUT_MS = -1;
     public static final int NO_FAILED_AUTHENTICATION_DELAY = 0;
+
+    public static final class Builder {
+
+        private int maxReceiveSize;
+        private long connectionMaxIdleMs;
+        private int failedAuthenticationDelayMs;
+        private Metrics metrics;
+        private Time time;
+        private String metricGrpPrefix;
+        private Map<String, String> metricTags;
+        private boolean metricsPerConnection;
+        private boolean recordTimePerConnection;
+        private ChannelBuilder channelBuilder;
+        private MemoryPool memoryPool;
+        private LogContext logContext;
+
+        public Builder() {
+            this.maxReceiveSize = NetworkReceive.UNLIMITED;
+            this.failedAuthenticationDelayMs = NO_FAILED_AUTHENTICATION_DELAY;
+            this.recordTimePerConnection = true;
+            this.metricTags = Collections.emptyMap();
+            this.recordTimePerConnection = false;
+            this.memoryPool = MemoryPool.NONE;
+        }
+
+
+        public Builder withMaxReceiveSize(int maxReceiveSize) {
+            this.maxReceiveSize = maxReceiveSize;
+            return this;
+        }
+
+        public Builder withConnectionMaxIdleMs(long connectionMaxIdleMs) {
+            this.connectionMaxIdleMs = connectionMaxIdleMs;
+            return this;
+        }
+
+        public Builder withFailedAuthenticationDelayMs(int failedAuthenticationDelayMs) {
+            this.failedAuthenticationDelayMs = failedAuthenticationDelayMs;
+            return this;
+        }
+
+        public Builder withMetrics(Metrics metrics) {
+            this.metrics = metrics;
+            return this;
+        }
+
+        public Builder withTime(Time time) {
+            this.time = time;
+            return this;
+        }
+
+        public Builder withMetricGrpPrefix(String metricGrpPrefix) {
+            this.metricGrpPrefix = metricGrpPrefix;
+            return this;
+        }
+
+        public Builder withMetricTags(Map<String, String> metricTags) {
+            this.metricTags = metricTags;
+            return this;
+        }
+
+        public Builder withMetricsPerConnection(boolean metricsPerConnection) {
+            this.metricsPerConnection = metricsPerConnection;
+            return this;
+        }
+
+        public Builder withRecordTimePerConnection(boolean recordTimePerConnection) {
+            this.recordTimePerConnection = recordTimePerConnection;
+            return this;
+        }
+
+        public Builder withChannelBuilder(ChannelBuilder channelBuilder) {
+            this.channelBuilder = channelBuilder;
+            return this;
+        }
+
+        public Builder withMemoryPool(MemoryPool memoryPool) {
+            this.memoryPool = memoryPool;
+            return this;
+        }
+
+        public Builder withLogContext(LogContext logContext) {
+            this.logContext = logContext;
+            return this;
+        }
+
+        public Selector build() {
+            return new Selector(maxReceiveSize, connectionMaxIdleMs, failedAuthenticationDelayMs, metrics,
+                    time, metricGrpPrefix, metricTags, metricsPerConnection, recordTimePerConnection, channelBuilder, memoryPool, logContext);
+        }
+    }
+
+
 
     private enum CloseMode {
         GRACEFUL(true),            // process outstanding buffered receives, notify disconnect

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -234,7 +234,7 @@ public class Selector implements Selectable, AutoCloseable {
      * @param channelBuilder Channel builder for every new connection
      * @param logContext Context for logging with additional info
      */
-    public Selector(int maxReceiveSize,
+    Selector(int maxReceiveSize,
             long connectionMaxIdleMs,
             int failedAuthenticationDelayMs,
             Metrics metrics,
@@ -273,12 +273,6 @@ public class Selector implements Selectable, AutoCloseable {
         this.lowMemThreshold = (long) (0.1 * this.memoryPool.size());
         this.failedAuthenticationDelayMs = failedAuthenticationDelayMs;
         this.delayedClosingChannels = (failedAuthenticationDelayMs > NO_FAILED_AUTHENTICATION_DELAY) ? new LinkedHashMap<String, DelayedAuthenticationFailureClose>() : null;
-    }
-
-    // used for anonymous class for testing purposes
-    protected Selector(long connectionMaxIdleMS, Metrics metrics, Time time, String metricGrpPrefix, ChannelBuilder channelBuilder, LogContext logContext) {
-        this(NetworkReceive.UNLIMITED, connectionMaxIdleMS, NO_FAILED_AUTHENTICATION_DELAY, metrics, time, metricGrpPrefix, Collections.emptyMap(),
-                true, false, channelBuilder, MemoryPool.NONE, logContext);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -234,7 +234,7 @@ public class Selector implements Selectable, AutoCloseable {
      * @param channelBuilder Channel builder for every new connection
      * @param logContext Context for logging with additional info
      */
-    Selector(int maxReceiveSize,
+    public Selector(int maxReceiveSize,
             long connectionMaxIdleMs,
             int failedAuthenticationDelayMs,
             Metrics metrics,

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.auth.SecurityProtocol;

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -62,7 +63,14 @@ public class NetworkTestUtils {
     }
 
     public static Selector createSelector(ChannelBuilder channelBuilder, Time time) {
-        return new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(new Metrics())
+                .withTime(time)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        return selectorBuilder.build();
     }
 
     public static void checkClientConnection(Selector selector, String node, int minMessageSize, int messageCount) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -122,8 +122,15 @@ public class NioEchoServer extends Thread {
                 securityProtocol, config, credentialCache, tokenCache, time, logContext,
                 () -> ApiVersionsResponse.defaultApiVersionsResponse(ApiMessageType.ListenerType.ZK_BROKER));
         this.metrics = new Metrics();
-        this.selector = new Selector(10000, failedAuthenticationDelayMs, metrics, time,
-                "MetricGroup", channelBuilder, logContext);
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(10000)
+                .withFailedAuthenticationDelayMs(failedAuthenticationDelayMs)
+                .withMetrics(metrics)
+                .withTime(time)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(logContext);
+        this.selector = selectorBuilder.build();
         acceptorThread = new AcceptorThread();
         this.time = time;
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.network;
 
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.memory.MemoryPool;

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.network;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.memory.MemoryPool;
@@ -96,7 +97,14 @@ public class SelectorTest {
         this.channelBuilder = new PlaintextChannelBuilder(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT));
         this.channelBuilder.configure(clientConfigs());
         this.metrics = new Metrics();
-        this.selector = new Selector(5000, this.metrics, time, METRIC_GROUP, channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(this.metrics)
+                .withTime(time)
+                .withMetricGrpPrefix(METRIC_GROUP)
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        this.selector = selectorBuilder.build();
     }
 
     @AfterEach
@@ -422,7 +430,14 @@ public class SelectorTest {
             }
         };
         channelBuilder.configure(clientConfigs());
-        Selector selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(new Metrics())
+                .withTime(new MockTime())
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        Selector selector = selectorBuilder.build();
         selector.connect("0", new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
         selector.connect("1", new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
         assertThrows(RuntimeException.class, selector::close);
@@ -441,7 +456,14 @@ public class SelectorTest {
             public void close() {
             }
         };
-        Selector selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(new Metrics())
+                .withTime(new MockTime())
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        Selector selector = selectorBuilder.build();
         SocketChannel socketChannel = SocketChannel.open();
         socketChannel.configureBlocking(false);
         IOException e = assertThrows(IOException.class, () -> selector.register("1", socketChannel));
@@ -496,7 +518,8 @@ public class SelectorTest {
                                              String metricGrpPrefix,
                                              ChannelBuilder channelBuilder,
                                              LogContext logContext) {
-            super(connectionMaxIdleMS, metrics, time, metricGrpPrefix, channelBuilder, logContext);
+            super(NetworkReceive.UNLIMITED, connectionMaxIdleMS, NO_FAILED_AUTHENTICATION_DELAY, metrics, time, metricGrpPrefix, Collections.emptyMap(),
+                    true, false, channelBuilder, MemoryPool.NONE, logContext);
         }
 
         @Override
@@ -689,8 +712,19 @@ public class SelectorTest {
         //clean up default selector, replace it with one that uses a finite mem pool
         selector.close();
         MemoryPool pool = new SimpleMemoryPool(900, 900, false, null);
-        selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup",
-            new HashMap<String, String>(), true, false, channelBuilder, pool, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                .withConnectionMaxIdleMs(5000)
+                .withMetrics(metrics)
+                .withTime(time)
+                .withMetricGrpPrefix("MetricGroup")
+                .withMetricTags(new HashMap<>())
+                .withMetricsPerConnection(true)
+                .withRecordTimePerConnection(false)
+                .withChannelBuilder(channelBuilder)
+                .withMemoryPool(pool)
+                .withLogContext(new LogContext());
+        selector = selectorBuilder.build();
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
             ss.bind(new InetSocketAddress(0));

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.network;
 import java.nio.channels.SelectionKey;
 import javax.net.ssl.SSLEngine;
 
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.common.config.SecurityConfig;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.memory.SimpleMemoryPool;
@@ -53,7 +52,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -80,7 +80,7 @@ public class SslSelectorTest extends SelectorTest {
         this.metrics = new Metrics();
         Selector.Builder selectorBuilder = new Selector.Builder();
         selectorBuilder.withConnectionMaxIdleMs(5000)
-                .withMetrics(new Metrics())
+                .withMetrics(metrics)
                 .withTime(time)
                 .withMetricGrpPrefix("MetricGroup")
                 .withChannelBuilder(channelBuilder)
@@ -131,7 +131,7 @@ public class SslSelectorTest extends SelectorTest {
         Metrics metrics = new Metrics();
         Selector.Builder selectorBuilder = new Selector.Builder();
         selectorBuilder.withConnectionMaxIdleMs(5000)
-                .withMetrics(new Metrics())
+                .withMetrics(metrics)
                 .withTime(time)
                 .withMetricGrpPrefix("MetricGroup")
                 .withChannelBuilder(channelBuilder)
@@ -324,6 +324,7 @@ public class SslSelectorTest extends SelectorTest {
                 .withMetricsPerConnection(true)
                 .withRecordTimePerConnection(false)
                 .withChannelBuilder(channelBuilder)
+                .withMemoryPool(pool)
                 .withLogContext(new LogContext());
         selector = selectorBuilder.build();
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -224,7 +224,7 @@ public class SslSelectorTest extends SelectorTest {
 
         this.channelBuilder = new TestSslChannelBuilder(Mode.CLIENT);
         this.channelBuilder.configure(sslClientConfigs);
-        this.selector = new Selector(5000, metrics, time, "MetricGroup", channelBuilder, new LogContext()) {
+        this.selector = new Selector(NetworkReceive.UNLIMITED, 5000, Selector.NO_FAILED_AUTHENTICATION_DELAY, metrics, time, "MetricGroup", Collections.emptyMap(), true, false, channelBuilder, MemoryPool.NONE, new LogContext()) {
             @Override
             void pollSelectionKeys(Set<SelectionKey> selectionKeys, boolean isImmediatelyConnected, long currentTimeNanos) {
                 for (SelectionKey key : selectionKeys) {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -779,8 +779,19 @@ public class SslTransportLayerTest {
         LogContext logContext = new LogContext();
         ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
         channelBuilder.configure(args.sslClientConfigs);
-        try (Selector selector = new Selector(NetworkReceive.UNLIMITED, Selector.NO_IDLE_TIMEOUT_MS, new Metrics(), Time.SYSTEM,
-                "MetricGroup", new HashMap<>(), false, true, channelBuilder, MemoryPool.NONE, logContext)) {
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                .withConnectionMaxIdleMs(Selector.NO_IDLE_TIMEOUT_MS)
+                .withMetrics(new Metrics())
+                .withTime(Time.SYSTEM)
+                .withMetricGrpPrefix("MetricGroup")
+                .withMetricTags(new HashMap<>())
+                .withMetricsPerConnection(false)
+                .withRecordTimePerConnection(true)
+                .withMemoryPool(MemoryPool.NONE)
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        try (Selector selector = selectorBuilder.build()) {
 
             String node = "0";
             server = createEchoServer(args, SecurityProtocol.SSL);
@@ -896,7 +907,14 @@ public class SslTransportLayerTest {
             channelBuilder.flushFailureAction = flushFailureAction;
             channelBuilder.failureIndex = i;
             channelBuilder.configure(args.sslClientConfigs);
-            this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
+            Selector.Builder selectorBuilder = new Selector.Builder();
+            selectorBuilder.withConnectionMaxIdleMs(5000)
+                    .withMetrics(new Metrics())
+                    .withTime(time)
+                    .withMetricGrpPrefix("MetricGroup")
+                    .withChannelBuilder(channelBuilder)
+                    .withLogContext(new LogContext());
+            this.selector = selectorBuilder.build();
 
             InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
             selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
@@ -975,7 +993,14 @@ public class SslTransportLayerTest {
         String node = "0";
         server = createEchoServer(args, securityProtocol);
         clientChannelBuilder.configure(args.sslClientConfigs);
-        this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", clientChannelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(new Metrics())
+                .withTime(time)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(clientChannelBuilder)
+                .withLogContext(new LogContext());
+        this.selector = selectorBuilder.build();
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
@@ -1288,7 +1313,14 @@ public class SslTransportLayerTest {
         TestSslChannelBuilder channelBuilder = new TestSslChannelBuilder(Mode.CLIENT);
         channelBuilder.configureBufferSizes(netReadBufSize, netWriteBufSize, appBufSize);
         channelBuilder.configure(sslClientConfigs);
-        this.selector = new Selector(100 * 5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(100 * 5000)
+                .withMetrics(new Metrics())
+                .withTime(time)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        this.selector = selectorBuilder.build();
         return selector;
     }
 
@@ -1304,7 +1336,14 @@ public class SslTransportLayerTest {
         LogContext logContext = new LogContext();
         ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
         channelBuilder.configure(args.sslClientConfigs);
-        selector = new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, logContext);
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(new Metrics())
+                .withTime(time)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(logContext);
+        selector = selectorBuilder.build();
         return selector;
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportTls12Tls13Test.java
@@ -53,7 +53,14 @@ public class SslTransportTls12Tls13Test {
         LogContext logContext = new LogContext();
         ChannelBuilder channelBuilder = new SslChannelBuilder(Mode.CLIENT, null, false, logContext);
         channelBuilder.configure(sslClientConfigs);
-        this.selector = new Selector(5000, new Metrics(), TIME, "MetricGroup", channelBuilder, logContext);
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(5000)
+                .withMetrics(new Metrics())
+                .withTime(TIME)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(logContext);
+        this.selector = selectorBuilder.build();
     }
 
     @AfterEach
@@ -160,6 +167,13 @@ public class SslTransportTls12Tls13Test {
         SslTransportLayerTest.TestSslChannelBuilder channelBuilder = new SslTransportLayerTest.TestSslChannelBuilder(Mode.CLIENT);
         channelBuilder.configureBufferSizes(null, null, null);
         channelBuilder.configure(sslClientConfigs);
-        this.selector = new Selector(100 * 5000, new Metrics(), TIME, "MetricGroup", channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(100 * 5000)
+                .withMetrics(new Metrics())
+                .withTime(TIME)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        this.selector = selectorBuilder.build();
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslVersionsTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslVersionsTransportLayerTest.java
@@ -167,6 +167,13 @@ public class SslVersionsTransportLayerTest {
             new SslTransportLayerTest.TestSslChannelBuilder(Mode.CLIENT);
         channelBuilder.configureBufferSizes(null, null, null);
         channelBuilder.configure(sslClientConfigs);
-        return new Selector(100 * 5000, new Metrics(), TIME, "MetricGroup", channelBuilder, new LogContext());
+        Selector.Builder selectorBuilder = new Selector.Builder();
+        selectorBuilder.withConnectionMaxIdleMs(100 * 5000)
+                .withMetrics(new Metrics())
+                .withTime(TIME)
+                .withMetricGrpPrefix("MetricGroup")
+                .withChannelBuilder(channelBuilder)
+                .withLogContext(new LogContext());
+        return selectorBuilder.build();
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -113,8 +113,15 @@ public class WorkerGroupMember {
             this.metadata.bootstrap(addresses);
             String metricGrpPrefix = "connect";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time, logContext);
+            Selector.Builder selectorBuilder = new Selector.Builder();
+            selectorBuilder.withConnectionMaxIdleMs(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG))
+                    .withMetrics(metrics)
+                    .withTime(time)
+                    .withMetricGrpPrefix(metricGrpPrefix)
+                    .withChannelBuilder(channelBuilder)
+                    .withLogContext(logContext);
             NetworkClient netClient = new NetworkClient(
-                    new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
+                    selectorBuilder.build(),
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -294,14 +294,15 @@ object BrokerApiVersionsCommand {
       val clientDnsLookup = config.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG)
       val brokerAddresses = ClientUtils.parseAndValidateAddresses(brokerUrls, clientDnsLookup)
       metadata.bootstrap(brokerAddresses)
+      val selectorBuilder = new Selector.Builder()
+      selectorBuilder.withConnectionMaxIdleMs(DefaultConnectionMaxIdleMs)
+                          .withMetrics(metrics)
+                          .withTime(time)
+                          .withMetricGrpPrefix("admin")
+                          .withChannelBuilder(channelBuilder)
+                          .withLogContext(logContext);
 
-      val selector = new Selector(
-        DefaultConnectionMaxIdleMs,
-        metrics,
-        time,
-        "admin",
-        channelBuilder,
-        logContext)
+      val selector = selectorBuilder.build()
 
       val networkClient = new NetworkClient(
         selector,

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -133,17 +133,17 @@ class ControllerChannelManager(controllerContext: ControllerContext,
           Some(reconfigurable)
         case _ => None
       }
-      val selector = new Selector(
-        NetworkReceive.UNLIMITED,
-        Selector.NO_IDLE_TIMEOUT_MS,
-        metrics,
-        time,
-        "controller-channel",
-        Map("broker-id" -> brokerNode.idString).asJava,
-        false,
-        channelBuilder,
-        logContext
-      )
+      val selectorBuilder = new Selector.Builder()
+            selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                .withConnectionMaxIdleMs(Selector.NO_IDLE_TIMEOUT_MS)
+                                .withMetrics(metrics)
+                                .withTime(time)
+                                .withMetricGrpPrefix("controller-channel")
+                                .withMetricTags(Map("broker-id" -> brokerNode.idString).asJava)
+                                .withMetricsPerConnection(false)
+                                .withChannelBuilder(channelBuilder)
+                                .withLogContext(logContext);
+      val selector = selectorBuilder.build()
       val networkClient = new NetworkClient(
         selector,
         new ManualMetadataUpdater(Seq(brokerNode).asJava),

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -60,17 +60,17 @@ object TransactionMarkerChannelManager {
       case reconfigurable: Reconfigurable => config.addReconfigurable(reconfigurable)
       case _ =>
     }
-    val selector = new Selector(
-      NetworkReceive.UNLIMITED,
-      config.connectionsMaxIdleMs,
-      metrics,
-      time,
-      "txn-marker-channel",
-      Map.empty[String, String].asJava,
-      false,
-      channelBuilder,
-      logContext
-    )
+    val selectorBuilder = new Selector.Builder()
+    selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                  .withConnectionMaxIdleMs(config.connectionsMaxIdleMs)
+                                  .withMetrics(metrics)
+                                  .withTime(time)
+                                  .withMetricGrpPrefix("txn-marker-channel")
+                                  .withMetricsPerConnection(false)
+                                  .withChannelBuilder(channelBuilder)
+                                  .withLogContext(logContext);
+
+    val selector = selectorBuilder.build()
     val networkClient = new NetworkClient(
       selector,
       new ManualMetadataUpdater(),

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -860,19 +860,19 @@ private[kafka] class Processor(val id: Int,
       case reconfigurable: Reconfigurable => config.addReconfigurable(reconfigurable)
       case _ =>
     }
-    new KSelector(
-      maxRequestSize,
-      connectionsMaxIdleMs,
-      failedAuthenticationDelayMs,
-      metrics,
-      time,
-      "socket-server",
-      metricTags,
-      false,
-      true,
-      channelBuilder,
-      memoryPool,
-      logContext)
+    new KSelector.Builder().withMaxReceiveSize(maxRequestSize)
+            .withConnectionMaxIdleMs(connectionsMaxIdleMs)
+            .withFailedAuthenticationDelayMs(failedAuthenticationDelayMs)
+            .withMetrics(metrics)
+            .withTime(time)
+            .withMetricGrpPrefix("socket-server")
+            .withMetricTags(metricTags)
+            .withMetricsPerConnection(false)
+            .withRecordTimePerConnection(true)
+            .withChannelBuilder(channelBuilder)
+            .withMemoryPool(memoryPool)
+            .withLogContext(new LogContext())
+            .build()
   }
 
   // Connection ids have the format `localAddr:localPort-remoteAddr:remotePort-index`. The index is a

--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -268,17 +268,17 @@ class KafkaRaftManager[T](
     val metricGroupPrefix = "raft-channel"
     val collectPerConnectionMetrics = false
 
-    val selector = new Selector(
-      NetworkReceive.UNLIMITED,
-      config.connectionsMaxIdleMs,
-      metrics,
-      time,
-      metricGroupPrefix,
-      Map.empty[String, String].asJava,
-      collectPerConnectionMetrics,
-      channelBuilder,
-      logContext
-    )
+    val selectorBuilder = new Selector.Builder()
+    selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                  .withConnectionMaxIdleMs(config.connectionsMaxIdleMs)
+                                  .withMetrics(metrics)
+                                  .withTime(time)
+                                  .withMetricGrpPrefix(metricGroupPrefix)
+                                  .withMetricsPerConnection(collectPerConnectionMetrics)
+                                  .withChannelBuilder(channelBuilder)
+                                  .withLogContext(logContext);
+
+    val selector = selectorBuilder.build()
 
     val clientId = s"raft-client-${config.nodeId}"
     val maxInflightRequestsPerConnection = 1

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -195,17 +195,18 @@ class BrokerToControllerChannelManagerImpl(
         config.saslInterBrokerHandshakeRequestEnable,
         logContext
       )
-      val selector = new Selector(
-        NetworkReceive.UNLIMITED,
-        Selector.NO_IDLE_TIMEOUT_MS,
-        metrics,
-        time,
-        channelName,
-        Map("BrokerId" -> config.brokerId.toString).asJava,
-        false,
-        channelBuilder,
-        logContext
-      )
+      val selectorBuilder = new Selector.Builder()
+      selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                    .withConnectionMaxIdleMs(Selector.NO_IDLE_TIMEOUT_MS)
+                                    .withMetrics(metrics)
+                                    .withTime(time)
+                                    .withMetricGrpPrefix(channelName)
+                                    .withMetricTags(Map("BrokerId" -> config.brokerId.toString).asJava)
+                                    .withMetricsPerConnection(false)
+                                    .withChannelBuilder(channelBuilder)
+                                    .withLogContext(logContext);
+
+      val selector = selectorBuilder.build()
       new NetworkClient(
         selector,
         manualMetadataUpdater,

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -513,17 +513,16 @@ class KafkaServer(
           time,
           config.saslInterBrokerHandshakeRequestEnable,
           logContext)
-        val selector = new Selector(
-          NetworkReceive.UNLIMITED,
-          config.connectionsMaxIdleMs,
-          metrics,
-          time,
-          "kafka-server-controlled-shutdown",
-          Map.empty.asJava,
-          false,
-          channelBuilder,
-          logContext
-        )
+          val selectorBuilder = new Selector.Builder()
+          selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                      .withConnectionMaxIdleMs(config.connectionsMaxIdleMs)
+                                      .withMetrics(metrics)
+                                      .withTime(time)
+                                      .withMetricGrpPrefix("kafka-server-controlled-shutdown")
+                                      .withMetricsPerConnection(false)
+                                      .withChannelBuilder(channelBuilder)
+                                      .withLogContext(logContext);
+        val selector = selectorBuilder.build();
         new NetworkClient(
           selector,
           metadataUpdater,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
@@ -68,17 +68,17 @@ class ReplicaFetcherBlockingSend(sourceBroker: BrokerEndPoint,
         Some(reconfigurable)
       case _ => None
     }
-    val selector = new Selector(
-      NetworkReceive.UNLIMITED,
-      brokerConfig.connectionsMaxIdleMs,
-      metrics,
-      time,
-      "replica-fetcher",
-      Map("broker-id" -> sourceBroker.id.toString, "fetcher-id" -> fetcherId.toString).asJava,
-      false,
-      channelBuilder,
-      logContext
-    )
+    val selectorBuilder = new Selector.Builder()
+    selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                .withConnectionMaxIdleMs(brokerConfig.connectionsMaxIdleMs)
+                                .withMetrics(metrics)
+                                .withTime(time)
+                                .withMetricGrpPrefix("replica-fetcher")
+                                .withMetricTags(Map("broker-id" -> sourceBroker.id.toString, "fetcher-id" -> fetcherId.toString).asJava)
+                                .withMetricsPerConnection(false)
+                                .withChannelBuilder(channelBuilder)
+                                .withLogContext(logContext);
+    val selector = selectorBuilder.build()
     val networkClient = new NetworkClient(
       selector,
       new ManualMetadataUpdater(),

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -455,17 +455,17 @@ private class ReplicaFetcherBlockingSend(sourceNode: Node,
   private val networkClient = {
     val logContext = new LogContext()
     val channelBuilder = org.apache.kafka.clients.ClientUtils.createChannelBuilder(consumerConfig, time, logContext)
-    val selector = new Selector(
-      NetworkReceive.UNLIMITED,
-      consumerConfig.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-      metrics,
-      time,
-      "replica-fetcher",
-      Map("broker-id" -> sourceNode.id.toString, "fetcher-id" -> fetcherId.toString).asJava,
-      false,
-      channelBuilder,
-      logContext
-    )
+    val selectorBuilder = new Selector.Builder()
+    selectorBuilder.withMaxReceiveSize(NetworkReceive.UNLIMITED)
+                                .withConnectionMaxIdleMs(consumerConfig.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG))
+                                .withMetrics(metrics)
+                                .withTime(time)
+                                .withMetricGrpPrefix("replica-fetcher")
+                                .withMetricTags(Map("broker-id" -> sourceNode.id.toString, "fetcher-id" -> fetcherId.toString).asJava)
+                                .withMetricsPerConnection(false)
+                                .withChannelBuilder(channelBuilder)
+                                .withLogContext(logContext);
+    val selector = selectorBuilder.build()
     new NetworkClient(
       selector,
       new ManualMetadataUpdater(),

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -163,8 +163,14 @@ public class ConnectionStressWorker implements TaskWorker {
                 // channelBuilder will be closed as part of Selector.close()
                 ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(conf, TIME, logContext);
                 try (Metrics metrics = new Metrics()) {
-                    try (Selector selector = new Selector(conf.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                        metrics, TIME, "", channelBuilder, logContext)) {
+                    Selector.Builder selectorBuilder = new Selector.Builder();
+                    selectorBuilder.withConnectionMaxIdleMs(conf.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG))
+                            .withMetrics(metrics)
+                            .withTime(TIME)
+                            .withMetricGrpPrefix("")
+                            .withChannelBuilder(channelBuilder)
+                            .withLogContext(logContext);
+                    try (Selector selector = selectorBuilder.build()) {
                         try (NetworkClient client = new NetworkClient(selector,
                             updater,
                             "ConnectionStressWorker",


### PR DESCRIPTION
Replace the 6 network selector constructors with a builder that can be used to specify the needed parameters instead of using one of the 6 defined constructors.


This pull requests updates all usages of the network selector and does not add any tests. Existing tests already tests the correctness of the network selector and our solution only changes the instance creation of the selector. All tests ran correctly..

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)