### PR TITLE
MINOR: fix aggregatedJavadoc dep on compileJava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ allprojects {
   apply plugin: 'idea'
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'com.github.ben-manes.versions'
+  apply plugin: 'java'
 
   dependencyUpdates {
     revision="release"
@@ -166,11 +167,6 @@ if (file('.git').exists()) {
     ])
   }
 }
-
-// Apply 'java' to the root project so that the root-level task 'aggregatedJavadoc' can depend on compileJava
-// Weirdly, this seems to be required for some people, but not others. It doesn't seem to be harmful to add it
-// here, in any case.
-apply plugin: 'java'
 
 subprojects {
 

--- a/build.gradle
+++ b/build.gradle
@@ -2279,6 +2279,8 @@ project(':connect:mirror-client') {
   }
 }
 
+apply plugin: 'java'
+
 task aggregatedJavadoc(type: Javadoc, dependsOn: compileJava) {
   def projectsWithJavadoc = subprojects.findAll { it.javadoc.enabled }
   source = projectsWithJavadoc.collect { it.sourceSets.main.allJava }

--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,10 @@ if (file('.git').exists()) {
   }
 }
 
+// Apply 'java' to the root project so that the root-level task 'aggregatedJavadoc' can depend on compileJava
+// Weirdly, this seems to be required for some people, but not others. It doesn't seem to be harmful to add it
+// here, in any case.
+apply plugin: 'java'
 
 subprojects {
 
@@ -2278,8 +2282,6 @@ project(':connect:mirror-client') {
     dependsOn copyDependantLibs
   }
 }
-
-apply plugin: 'java'
 
 task aggregatedJavadoc(type: Javadoc, dependsOn: compileJava) {
   def projectsWithJavadoc = subprojects.findAll { it.javadoc.enabled }

--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,6 @@ subprojects {
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
   task allDepInsight(type: DependencyInsightReportTask) doLast {}
 
-  apply plugin: 'java'
   // apply the eclipse plugin only to subprojects that hold code. 'connect' is just a folder.
   if (!project.name.equals('connect')) {
     apply plugin: 'eclipse'


### PR DESCRIPTION
It seems like gradle is inconsistently failing to build the project with the
message that "compileJava" isn't defined on the root project. Applying the Java
plugin to the root project (as opposed to only the subprojects) seems to fix it.