### PR TITLE
KAFKA-12520: Ensure log loading does not truncate producer state unless required

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -721,7 +721,7 @@ class Log(@volatile private var _dir: File,
    * @throws LogSegmentOffsetOverflowException if the segment contains messages that cause index offset overflow
    */
   private def recoverSegment(segment: LogSegment,
-                             leaderEpochCache: Option[LeaderEpochFileCache] = None): Int = lock synchronized {
+                             leaderEpochCache: Option[LeaderEpochFileCache]): Int = lock synchronized {
     val producerStateManager = new ProducerStateManager(topicPartition, dir, maxProducerIdExpirationMs)
     rebuildProducerState(segment.baseOffset, reloadFromCleanShutdown = false, producerStateManager)
     val bytesTruncated = segment.recover(producerStateManager, leaderEpochCache)

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -749,7 +749,8 @@ class Log(@volatile private var _dir: File,
         time = time,
         fileSuffix = SwapFileSuffix)
       info(s"Found log file ${swapFile.getPath} from interrupted swap operation, repairing.")
-      recoverSegment(swapSegment)
+      if (swapSegment.validateSegmentAndRebuildIndices() > 0)
+        throw new KafkaStorageException("Found invalid or corrupted messages in swap segment " + swapSegment.log.file());
 
       // We create swap files for two cases:
       // (1) Log cleaning where multiple segments are merged into one, and

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -366,6 +366,11 @@ class LogSegment private[log] (val log: FileRecords,
           .format(log.file.getAbsolutePath, validBytes, e.getMessage, e.getCause))
     }
 
+    offsetIndex.trimToValidSize()
+    // A normally closed segment always appends the biggest timestamp ever seen into log segment, we do this as well.
+    timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestampSoFar, skipFullCheck = true)
+    timeIndex.trimToValidSize()
+
     log.sizeInBytes - validBytes
   }
 
@@ -397,10 +402,6 @@ class LogSegment private[log] (val log: FileRecords,
       debug(s"Truncating $invalidBytes invalid bytes at the end of segment ${log.file.getAbsoluteFile} during recovery")
 
     log.truncateTo(validBytes)
-    offsetIndex.trimToValidSize()
-    // A normally closed segment always appends the biggest timestamp ever seen into log segment, we do this as well.
-    timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestampSoFar, skipFullCheck = true)
-    timeIndex.trimToValidSize()
     invalidBytes
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -17,18 +17,17 @@
 
 package kafka.log
 
-import java.io.{File, RandomAccessFile}
+import java.io.{BufferedWriter, File, FileWriter, RandomAccessFile}
 import java.nio._
 import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 import java.util.Properties
 import java.util.concurrent.{CountDownLatch, TimeUnit}
-
 import kafka.common._
 import kafka.server.{BrokerTopicStats, LogDirFailureChannel}
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.CorruptRecordException
+import org.apache.kafka.common.errors.{CorruptRecordException, KafkaStorageException}
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.utils.Utils
 import org.junit.jupiter.api.Assertions._
@@ -1424,6 +1423,87 @@ class LogCleanerTest {
     //    is not yet complete. Clean operation is resumed during recovery.
     log = recoverAndCheck(config, cleanedKeys)
     log.close()
+  }
+
+  @Test
+  def testRecoveryRebuildsIndices(): Unit = {
+    val cleaner = makeCleaner(Int.MaxValue)
+    val logProps = new Properties()
+    logProps.put(LogConfig.SegmentBytesProp, 300: java.lang.Integer)
+    logProps.put(LogConfig.IndexIntervalBytesProp, 1: java.lang.Integer)
+    logProps.put(LogConfig.FileDeleteDelayMsProp, 10: java.lang.Integer)
+
+    val config = LogConfig.fromProps(logConfig.originals, logProps)
+
+    // create a log and append some messages
+    var log = makeLog(config = config)
+    var messageCount = 0
+    while (log.numberOfSegments < 10) {
+      log.appendAsLeader(record(log.logEndOffset.toInt, log.logEndOffset.toInt), leaderEpoch = 0)
+      messageCount += 1
+    }
+
+    // pretend we have odd-numbered keys
+    val offsetMap = new FakeOffsetMap(Int.MaxValue)
+    for (k <- 1 until messageCount by 2)
+      offsetMap.put(key(k), Long.MaxValue)
+
+    // clean the log
+    cleaner.cleanSegments(log, log.logSegments.take(5).toSeq, offsetMap, 0L, new CleanerStats(),
+      new CleanedTransactionMetadata)
+    // clear scheduler so that async deletes don't run
+    time.scheduler.clear()
+    val cleanedKeys = LogTest.keysInLog(log)
+
+    // pretend we are cleaning one of the segments in the log
+    val segmentBeingCleaned = log.logSegments.take(5).last
+    val offsetIndex = segmentBeingCleaned.offsetIndex
+    offsetIndex.sanityCheck()
+    val allEntries =
+      for (entryNum <- 0 until offsetIndex.entries)
+        yield offsetIndex.entry(entryNum)
+
+    // Simulate log recovery after swap file is created and old segment is deleted. Also delete the corresponding
+    // offset index and validate that it is recreated after recovery.
+    log.close()
+    segmentBeingCleaned.changeFileSuffixes("", Log.SwapFileSuffix)
+    segmentBeingCleaned.offsetIndex.deleteIfExists()
+    log = recoverAndCheck(config, cleanedKeys)
+    val recoveredSegment = log.logSegments.find(_.baseOffset == segmentBeingCleaned.baseOffset).get
+    val recoveredOffsetIndex = recoveredSegment.offsetIndex
+    val recoveredEntries =
+      for (entryNum <- 0 until recoveredOffsetIndex.entries)
+        yield recoveredOffsetIndex.entry(entryNum)
+    assertEquals(allEntries, recoveredEntries)
+  }
+
+  @Test
+  def testRecoveryWithCorruptedSegment(): Unit = {
+    val logProps = new Properties()
+    logProps.put(LogConfig.SegmentBytesProp, 300: java.lang.Integer)
+    logProps.put(LogConfig.IndexIntervalBytesProp, 1: java.lang.Integer)
+    logProps.put(LogConfig.FileDeleteDelayMsProp, 10: java.lang.Integer)
+
+    val config = LogConfig.fromProps(logConfig.originals, logProps)
+
+    // create a log and append some messages
+    val log = makeLog(config = config)
+    var messageCount = 0
+    while (log.numberOfSegments < 10) {
+      log.appendAsLeader(record(log.logEndOffset.toInt, log.logEndOffset.toInt), leaderEpoch = 0)
+      messageCount += 1
+    }
+    log.close()
+
+    // pretend we are cleaning one of the segments in the log
+    val segmentBeingCleaned = log.logSegments.take(5).last
+    segmentBeingCleaned.changeFileSuffixes("", Log.SwapFileSuffix)
+    val bw = new BufferedWriter(new FileWriter(segmentBeingCleaned.log.file))
+    bw.write("corruptRecord")
+    bw.close()
+
+    // reopening the log will fail because of the corrupted log
+    assertThrows(classOf[KafkaStorageException], () => makeLog(config = config))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1462,6 +1462,7 @@ class LogCleanerTest {
     val allEntries =
       for (entryNum <- 0 until offsetIndex.entries)
         yield offsetIndex.entry(entryNum)
+    val offsetIndexLength = offsetIndex.length
 
     // Simulate log recovery after swap file is created and old segment is deleted. Also delete the corresponding
     // offset index and validate that it is recreated after recovery.
@@ -1475,6 +1476,7 @@ class LogCleanerTest {
       for (entryNum <- 0 until recoveredOffsetIndex.entries)
         yield recoveredOffsetIndex.entry(entryNum)
     assertEquals(allEntries, recoveredEntries)
+    assertEquals(offsetIndexLength, recoveredOffsetIndex.length)
   }
 
   @Test


### PR DESCRIPTION
When we find a `.swap` file on startup, we typically want to rename and replace it as `.log`, `.index`, `.timeindex`, etc. as a way to complete any ongoing replace operations. These swap files are usually known to have been flushed to disk before the replace operation begins.

One flaw in the current logic is that we recover these swap files on startup and as part of that, end up truncating the producer state and rebuild it from scratch. This is unneeded as the replace operation does not mutate the producer state by itself. It is only meant to replace the `.log` file along with corresponding indices. Because of this unneeded producer state rebuild operation, we have seen multi-hour startup times for clusters that have large compacted topics.

This patch fixes the issue by doing a sanity check of all records in the segment to swap and rebuilds corresponding indices without mutating the producer state. Similarly, we also rebuild indices without truncating the producer state when we find a missing or corrupted index in the middle of the log.

The patch also adds an extra sanity check to detect invalid bytes at the end of swap segments. Before this patch, we would truncate invalid bytes from the swap segment which could leave us with holes in the log. Because this is an unexpected scenario, we now raise an exception in such cases which will fail the broker on startup.