### PR TITLE
MINOR: Always apply the java-library gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,7 @@ subprojects {
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
   task allDepInsight(type: DependencyInsightReportTask) doLast {}
 
+  apply plugin: 'java-library'
   apply plugin: 'checkstyle'
   apply plugin: "com.github.spotbugs"
   apply plugin: 'org.gradle.test-retry'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ plugins {
   id 'com.diffplug.spotless' version '5.10.2'
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'idea'
+  id 'java-library'
   id 'org.owasp.dependencycheck' version '6.1.1'
 
   id "com.github.spotbugs" version '4.6.0' apply false
@@ -172,7 +173,6 @@ subprojects {
   // eg: ./gradlew allDepInsight --configuration runtime --dependency com.fasterxml.jackson.core:jackson-databind
   task allDepInsight(type: DependencyInsightReportTask) doLast {}
 
-  apply plugin: 'java-library'
   apply plugin: 'checkstyle'
   apply plugin: "com.github.spotbugs"
   apply plugin: 'org.gradle.test-retry'


### PR DESCRIPTION
As @chia7712 found, we currently apply the `java` plugin indirectly via `rat.gradle`
if the `.git` folder exists (https://github.com/apache/kafka/blob/7071ded2a61448da21c149fa1d85b3999b0d2f73/gradle/rat.gradle#L101).

This led to inconsistent behavior if the `.git` directory was not present. With
this change, the `java-library` plugin (which has slightly more features than
the `java` plugin) is always applied.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
