### PR TITLE
KAFKA-12432: AdminClient should time out nodes that are never ready

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.stream.Collectors;
 
@@ -84,6 +85,7 @@ public class MockClient implements KafkaClient {
     private volatile NodeApiVersions nodeApiVersions = NodeApiVersions.create();
     private volatile int numBlockingWakeups = 0;
     private volatile boolean active = true;
+    private volatile CompletableFuture<String> disconnectFuture;
 
     public MockClient(Time time) {
         this(time, new NoOpMetadataUpdater());
@@ -169,6 +171,10 @@ public class MockClient implements KafkaClient {
         return authenticationErrors.get(node);
     }
 
+    public void setDisconnectFuture(CompletableFuture<String> disconnectFuture) {
+        this.disconnectFuture = disconnectFuture;
+    }
+
     @Override
     public void disconnect(String node) {
         long now = time.milliseconds();
@@ -181,6 +187,10 @@ public class MockClient implements KafkaClient {
                         request.createdTimeMs(), now, true, null, null, null));
                 iter.remove();
             }
+        }
+        CompletableFuture<String> curDisconnectFuture = disconnectFuture;
+        if (curDisconnectFuture != null) {
+            curDisconnectFuture.complete(node);
         }
         connectionState(node).disconnect();
     }

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -948,6 +948,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
   def testCallInFlightTimeouts(): Unit = {
     val config = createConfig
     config.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "100000000")
+    config.put(AdminClientConfig.RETRIES_CONFIG, "0")
     val factory = new KafkaAdminClientTest.FailureInjectingTimeoutProcessorFactory()
     client = KafkaAdminClientTest.createInternal(new AdminClientConfig(config), factory)
     val future = client.createTopics(Seq("mytopic", "mytopic2").map(new NewTopic(_, 1, 1.toShort)).asJava,


### PR DESCRIPTION
Previously, if we assigned one or more calls to a remote node, but it
never became available, we would block until the calls hit their the API
timeout.  This was particularly unfortunate in the case where the calls
could have been sent to a different node in the cluster.  This PR fixes
this behavior by timing out pending connections to remote nodes if they
take longer than the request timeout.

There are a few other small cleanups in this PR: it removes the
unecessary Call#aborted, sets Call#curNode to null after the call has
failed to avoid confusion when debugging or logging, and adds a
"closing" boolean rather than setting newCalls to null when the client
is closed.  Also, it increases the log level of the log message that
indicates that we timed out some calls because AdminClient closed.
Finally, it simplifies the type of callsInFlight.