### PR TITLE
MINOR: Use Java 11 for generating aggregated javadoc in release.py

### DIFF
--- a/release.py
+++ b/release.py
@@ -253,7 +253,7 @@ def command_stage_docs():
         sys.exit("%s doesn't exist or does not appear to be the kafka-site repository" % kafka_site_repo_path)
 
     prefs = load_prefs()
-    jdk8_env = get_jdk(prefs, 8)
+    jdk11_env = get_jdk(prefs, 11)
     save_prefs(prefs)
 
     version = get_version()
@@ -262,7 +262,7 @@ def command_stage_docs():
     # version due to already having bumped the bugfix version number.
     gradle_version_override = docs_release_version(version)
 
-    cmd("Building docs", "./gradlew -Pversion=%s clean siteDocsTar aggregatedJavadoc" % gradle_version_override, cwd=REPO_HOME, env=jdk8_env)
+    cmd("Building docs", "./gradlew -Pversion=%s clean siteDocsTar aggregatedJavadoc" % gradle_version_override, cwd=REPO_HOME, env=jdk11_env)
 
     docs_tar = os.path.join(REPO_HOME, 'core', 'build', 'distributions', 'kafka_2.13-%s-site-docs.tgz' % gradle_version_override)
 
@@ -508,7 +508,7 @@ if not rc:
 apache_id = get_pref(prefs, 'apache_id', lambda: raw_input("Enter your apache username: "))
 
 jdk8_env = get_jdk(prefs, 8)
-
+jdk11_env = get_jdk(prefs, 11)
 
 def select_gpg_key():
     print("Here are the available GPG keys:")
@@ -597,7 +597,7 @@ cmd("Creating source archive", "git archive --format tar.gz --prefix kafka-%(rel
 
 cmd("Building artifacts", "./gradlew clean && ./gradlewAll releaseTarGz", cwd=kafka_dir, env=jdk8_env, shell=True)
 cmd("Copying artifacts", "cp %s/core/build/distributions/* %s" % (kafka_dir, artifacts_dir), shell=True)
-cmd("Building docs", "./gradlew aggregatedJavadoc", cwd=kafka_dir, env=jdk8_env)
+cmd("Building docs", "./gradlew clean aggregatedJavadoc", cwd=kafka_dir, env=jdk11_env)
 cmd("Copying docs", "cp -R %s/build/docs/javadoc %s" % (kafka_dir, artifacts_dir))
 
 for filename in os.listdir(artifacts_dir):

--- a/release.py
+++ b/release.py
@@ -207,8 +207,11 @@ def get_jdk(prefs, version):
     jdk_java_home = get_pref(prefs, 'jdk%d' % version, lambda: raw_input("Enter the path for JAVA_HOME for a JDK%d compiler (blank to use default JAVA_HOME): " % version))
     jdk_env = dict(os.environ) if jdk_java_home.strip() else None
     if jdk_env is not None: jdk_env['JAVA_HOME'] = jdk_java_home
-    if "1.%d.0" % version not in cmd_output("java -version", env=jdk_env):
-        fail("JDK %s is required" % version)
+    javaVersion = cmd_output("%s/bin/java -version" % jdk_java_home, env=jdk_env)
+    if version == 8 and "1.8.0" not in javaVersion:
+      fail("JDK 8 is required")
+    elif "%d.0" % version not in javaVersion:
+      fail("JDK %s is required" % version)
     return jdk_env
 
 def get_version(repo=REPO_HOME):
@@ -423,7 +426,7 @@ prefs = load_prefs()
 
 if not user_ok("""Requirements:
 1. Updated docs to reference the new release version where appropriate.
-2. JDK8 compilers and libraries
+2. JDK8 and JDK11 compilers and libraries
 3. Your Apache ID, already configured with SSH keys on id.apache.org and SSH keys available in this shell session
 4. All issues in the target release resolved with valid resolutions (if not, this script will report the problematic JIRAs)
 5. A GPG key used for signing the release. This key should have been added to public Apache servers and the KEYS file on the Kafka site


### PR DESCRIPTION
Java 11 generates html5 pages with search support, which provides a better user experience.

Fixed `get_jdk` bugs found during testing and updated `release.py` blurb to indicate that
both JDK 8 and JDK 11 are required to perform a release.

Tested by running `python2 release.py stage-docs`, which triggers the `aggregateJavadoc`
path without some of the undesired (for testing) release steps.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
