### PR TITLE
MINOR: fix package name in core test

### DIFF
--- a/core/src/test/scala/integration/kafka/api/TransactionsWithMaxInFlightOneTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsWithMaxInFlightOneTest.scala
@@ -15,7 +15,7 @@
   * limitations under the License.
   */
 
-package integration.kafka.api
+package kafka.api
 
 import java.util.Properties
 
@@ -25,8 +25,8 @@ import kafka.utils.TestUtils
 import kafka.utils.TestUtils.consumeRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
 import scala.collection.Seq
 import scala.collection.mutable.Buffer
@@ -70,7 +70,7 @@ class TransactionsWithMaxInFlightOneTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testTransactionalProducerSingleBrokerMaxInFlightOne() = {
+  def testTransactionalProducerSingleBrokerMaxInFlightOne(): Unit = {
     // We want to test with one broker to verify multiple requests queued on a connection
     assertEquals(1, servers.size)
 

--- a/core/src/test/scala/integration/kafka/server/IntegrationTestUtils.scala
+++ b/core/src/test/scala/integration/kafka/server/IntegrationTestUtils.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package integration.kafka.server
+package kafka.server
 
 import kafka.network.SocketServer
 import kafka.utils.{NotNothing, TestUtils}

--- a/core/src/test/scala/kafka/tools/DefaultMessageFormatterTest.scala
+++ b/core/src/test/scala/kafka/tools/DefaultMessageFormatterTest.scala
@@ -15,12 +15,12 @@
   * limitations under the License.
   */
 
-package unit.kafka.tools
+package kafka.tools
 
 import java.io.{ByteArrayOutputStream, Closeable, PrintStream}
 import java.nio.charset.StandardCharsets
 import java.util
-import kafka.tools.DefaultMessageFormatter
+
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.header.internals.{RecordHeader, RecordHeaders}
@@ -35,7 +35,6 @@ import scala.jdk.CollectionConverters._
 
 class DefaultMessageFormatterTest {
   import DefaultMessageFormatterTest._
-
 
   @ParameterizedTest
   @MethodSource(Array("parameters"))
@@ -142,7 +141,7 @@ object DefaultMessageFormatterTest {
         Map("print.key" -> "true",
             "print.headers" -> "true",
             "print.value" -> "true",
-            "key.deserializer" -> "unit.kafka.tools.UpperCaseDeserializer"),
+            "key.deserializer" -> "kafka.tools.UpperCaseDeserializer"),
         "h1:v1,h2:v2\tSOMEKEY\tsomeValue\n"),
       Arguments.of(
         "print value with custom deserializer",
@@ -150,7 +149,7 @@ object DefaultMessageFormatterTest {
         Map("print.key" -> "true",
             "print.headers" -> "true",
             "print.value" -> "true",
-            "value.deserializer" -> "unit.kafka.tools.UpperCaseDeserializer"),
+            "value.deserializer" -> "kafka.tools.UpperCaseDeserializer"),
         "h1:v1,h2:v2\tsomeKey\tSOMEVALUE\n"),
       Arguments.of(
         "print headers with custom deserializer",
@@ -158,7 +157,7 @@ object DefaultMessageFormatterTest {
         Map("print.key" -> "true",
             "print.headers" -> "true",
             "print.value" -> "true",
-            "headers.deserializer" -> "unit.kafka.tools.UpperCaseDeserializer"),
+            "headers.deserializer" -> "kafka.tools.UpperCaseDeserializer"),
         "h1:V1,h2:V2\tsomeKey\tsomeValue\n"),
       Arguments.of(
         "print key and value",

--- a/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerContextTest.scala
@@ -15,19 +15,15 @@
   * limitations under the License.
   */
 
-package unit.kafka.controller
+package kafka.controller
 
 import kafka.api.LeaderAndIsr
 import kafka.cluster.{Broker, EndPoint}
-import kafka.controller.LeaderIsrAndControllerEpoch
-import kafka.controller.{ControllerContext, ReplicaAssignment}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.security.auth.SecurityProtocol
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Assertions.assertFalse
 
 
 class ControllerContextTest {

--- a/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractApiVersionsRequestTest.scala
@@ -18,7 +18,6 @@ package kafka.server
 
 import java.util.Properties
 
-import integration.kafka.server.IntegrationTestUtils
 import kafka.test.ClusterInstance
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion

--- a/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ClientQuotasRequestTest.scala
@@ -17,10 +17,14 @@
 
 package kafka.server
 
-import integration.kafka.server.IntegrationTestUtils
-import kafka.test.ClusterInstance
-
 import java.net.InetAddress
+import java.util
+import java.util.concurrent.{ExecutionException, TimeUnit}
+
+import kafka.test.ClusterInstance
+import kafka.test.annotation.{ClusterTest, ClusterTestDefaults, Type}
+import kafka.test.junit.ClusterTestExtensions
+import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{ScramCredentialInfo, ScramMechanism, UserScramCredentialUpsertion}
 import org.apache.kafka.common.config.internals.QuotaConfigs
 import org.apache.kafka.common.errors.{InvalidRequestException, UnsupportedVersionException}
@@ -29,12 +33,6 @@ import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, 
 import org.apache.kafka.common.requests.{AlterClientQuotasRequest, AlterClientQuotasResponse, DescribeClientQuotasRequest, DescribeClientQuotasResponse}
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.extension.ExtendWith
-
-import java.util
-import java.util.concurrent.{ExecutionException, TimeUnit}
-import kafka.utils.TestUtils
-import kafka.test.annotation.{ClusterTest, ClusterTestDefaults, Type}
-import kafka.test.junit.ClusterTestExtensions
 
 import scala.jdk.CollectionConverters._
 
@@ -597,7 +595,7 @@ class ClientQuotasRequestTest(cluster: ClusterInstance) {
     sendAlterClientQuotasRequest(entries, validateOnly).complete(response)
     val result = response.asScala
     assertEquals(request.size, result.size)
-    request.foreach(e => assertTrue(result.get(e._1).isDefined))
+    request.foreach(e => assertTrue(result.contains(e._1)))
     result
   }
 

--- a/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
@@ -16,22 +16,21 @@
   */
 package kafka.server
 
-import integration.kafka.server.IntegrationTestUtils
-
 import java.net.Socket
 import java.util.Collections
+
 import kafka.api.{KafkaSasl, SaslSetup}
+import kafka.test.annotation.{ClusterTest, Type}
+import kafka.test.junit.ClusterTestExtensions
+import kafka.test.{ClusterConfig, ClusterInstance}
 import kafka.utils.JaasTestUtils
 import org.apache.kafka.common.message.SaslHandshakeRequestData
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse, SaslHandshakeRequest, SaslHandshakeResponse}
-import kafka.test.annotation.{ClusterTest, Type}
-import kafka.test.junit.ClusterTestExtensions
-import kafka.test.{ClusterConfig, ClusterInstance}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.{AfterEach, BeforeEach}
 
 import scala.jdk.CollectionConverters._
 


### PR DESCRIPTION
*More detailed description of your change*
Change package name of `IntegrationTestUtils` ,`TransactionsWithMaxInFlightOneTest`, `ControllerContextTest` and `DefaultMessageFormatterTest` to `kafka.server` since we set the package name to `kafka.xxx` in all other classes.

*Summary of testing strategy (including rationale)*
QA

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
