### PR TITLE
MINOR: Remove unthrown exceptions, fix typo, etc.

### DIFF
--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/SourceAndTarget.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/SourceAndTarget.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.connect.mirror;
 
-/** Directional pair of clustes, where source is replicated to target. */
+/** Directional pair of clusters, where source is replicated to target. */
 public class SourceAndTarget {
     private String source;
     private String target;

--- a/connect/mirror-client/src/test/java/org/apache/kafka/connect/mirror/MirrorClientTest.java
+++ b/connect/mirror-client/src/test/java/org/apache/kafka/connect/mirror/MirrorClientTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Arrays;
-import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +52,7 @@ public class MirrorClientTest {
     }
 
     @Test
-    public void testIsHeartbeatTopic() throws InterruptedException, TimeoutException {
+    public void testIsHeartbeatTopic() {
         MirrorClient client = new FakeMirrorClient();
         assertTrue(client.isHeartbeatTopic("heartbeats"));
         assertTrue(client.isHeartbeatTopic("source1.heartbeats"));
@@ -65,7 +64,7 @@ public class MirrorClientTest {
     }
 
     @Test
-    public void testIsCheckpointTopic() throws InterruptedException, TimeoutException {
+    public void testIsCheckpointTopic() {
         MirrorClient client = new FakeMirrorClient();
         assertTrue(client.isCheckpointTopic("source1.checkpoints.internal"));
         assertFalse(client.isCheckpointTopic("checkpoints.internal"));
@@ -76,7 +75,7 @@ public class MirrorClientTest {
     }
 
     @Test
-    public void countHopsForTopicTest() throws InterruptedException, TimeoutException {
+    public void countHopsForTopicTest() {
         MirrorClient client = new FakeMirrorClient();
         assertEquals(-1, client.countHopsForTopic("topic", "source"));
         assertEquals(-1, client.countHopsForTopic("source", "source"));
@@ -90,7 +89,7 @@ public class MirrorClientTest {
     }
 
     @Test
-    public void heartbeatTopicsTest() throws InterruptedException, TimeoutException {
+    public void heartbeatTopicsTest() throws InterruptedException {
         MirrorClient client = new FakeMirrorClient(Arrays.asList("topic1", "topic2", "heartbeats",
             "source1.heartbeats", "source2.source1.heartbeats", "source3.heartbeats"));
         Set<String> heartbeatTopics = client.heartbeatTopics();
@@ -99,7 +98,7 @@ public class MirrorClientTest {
     }
 
     @Test
-    public void checkpointsTopicsTest() throws InterruptedException, TimeoutException {
+    public void checkpointsTopicsTest() throws InterruptedException {
         MirrorClient client = new FakeMirrorClient(Arrays.asList("topic1", "topic2", "checkpoints.internal",
             "source1.checkpoints.internal", "source2.source1.checkpoints.internal", "source3.checkpoints.internal"));
         Set<String> checkpointTopics = client.checkpointTopics();
@@ -108,7 +107,7 @@ public class MirrorClientTest {
     }
 
     @Test
-    public void replicationHopsTest() throws InterruptedException, TimeoutException {
+    public void replicationHopsTest() throws InterruptedException {
         MirrorClient client = new FakeMirrorClient(Arrays.asList("topic1", "topic2", "heartbeats",
             "source1.heartbeats", "source1.source2.heartbeats", "source3.heartbeats"));
         assertEquals(1, client.replicationHops("source1"));

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatTask.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorHeartbeatTask.java
@@ -47,7 +47,7 @@ public class MirrorHeartbeatTask extends SourceTask {
     }
 
     @Override
-    public void commit() throws InterruptedException {
+    public void commit() {
         // nop
     }
 

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -409,8 +409,7 @@ public class MirrorSourceConnector extends SourceConnector {
 
     @SuppressWarnings("deprecation")
     // use deprecated alterConfigs API for broker compatibility back to 0.11.0
-    private void updateTopicConfigs(Map<String, Config> topicConfigs)
-            throws InterruptedException, ExecutionException {
+    private void updateTopicConfigs(Map<String, Config> topicConfigs) {
         Map<ConfigResource, Config> configs = topicConfigs.entrySet().stream()
             .collect(Collectors.toMap(x ->
                 new ConfigResource(ConfigResource.Type.TOPIC, x.getKey()), Entry::getValue));
@@ -422,8 +421,7 @@ public class MirrorSourceConnector extends SourceConnector {
         }));
     }
 
-    private void updateTopicAcls(List<AclBinding> bindings)
-            throws InterruptedException, ExecutionException {
+    private void updateTopicAcls(List<AclBinding> bindings) {
         log.trace("Syncing {} topic ACL bindings.", bindings.size());
         targetAdminClient.createAcls(bindings).values().forEach((k, v) -> v.whenComplete((x, e) -> {
             if (e != null) {


### PR DESCRIPTION
1. Fix typo: clustes → clusters
2. Remove unused class: `RemoteClusterUtils`
3. Remove unthrown Exceptions: `MirrorClientTest`, `MirrorHeartbeatTask`, and `MirrorSourceConnector`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
