### PR TITLE
KAFKA-12557: Fix hanging KafkaAdminClientTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
@@ -116,8 +116,8 @@ public class AdminClientUnitTestEnv implements AutoCloseable {
     public void close() {
         // tell the admin client to close now
         this.adminClient.close(Duration.ZERO);
-        // block until it is really closed
-        this.adminClient.close();
+        // block for up to a minute until the internal threads shut down.
+        this.adminClient.close(Duration.ofMinutes(1));
     }
 
     static Map<String, Object> clientConfigs(String... overrides) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -113,6 +114,9 @@ public class AdminClientUnitTestEnv implements AutoCloseable {
 
     @Override
     public void close() {
+        // tell the admin client to close now
+        this.adminClient.close(Duration.ZERO);
+        // block until it is really closed
         this.adminClient.close();
     }
 


### PR DESCRIPTION
While running tests for https://github.com/apache/kafka/pull/10397, I got a test timeout under Java 8.

I ran it locally via `./gradlew clean -PscalaVersion=2.12 :clients:unitTest --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed -PignoreFailures=true -PmaxTestRetries=1 -PmaxTestRetryFailures=5` (copied from the Jenkins log) and was able to determine that the hanging test is:

org.apache.kafka.clients.admin.KafkaAdminClientTest#testClientSideTimeoutAfterFailureToReceiveResponse

It's odd, but it hangs most times on my branch, and I haven't seen it hang on trunk, despite the fact that my PR doesn't touch the client or core code at all.

Some debugging reveals that when the client is hanging, it's because the listTopics request is still sitting in its pendingRequests queue, and if I understand the test setup correctly, it would never be completed, since we will never advance time or queue up a metadata response for it.

I figure a reasonable blanket response to this is just to make sure that the test harness will close the admin client eagerly instead of lazily.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
