### PR TITLE
KAFKA-12283: disable flaky testMultipleWorkersRejoining to stabilize build

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/RebalanceSourceConnectorsIntegrationTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -268,6 +269,8 @@ public class RebalanceSourceConnectorsIntegrationTest {
                 WORKER_SETUP_DURATION_MS, "Connect and tasks are imbalanced between the workers.");
     }
 
+    // should enable it after KAFKA-12495 fixed
+    @Ignore
     @Test
     public void testMultipleWorkersRejoining() throws Exception {
         // create test topic


### PR DESCRIPTION
Will address the root cause in this PR: https://github.com/apache/kafka/pull/10367, and added this test back in that PR, too.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
