### PR TITLE
KAFKA-8784: remove default close for RocksDBConfigSetter

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -94,6 +94,9 @@
 
     <h3><a id="streams_api_changes_300" href="#streams_api_changes_300">Streams API changes in 3.0.0</a></h3>
     <p>
+        We removed the default implementation of <code>RocksDBConfigSetter#close()</code>.
+    </p>
+    <p>
         We removed the following deprecated APIs:
     </p>
     <ul>

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -57,7 +57,5 @@ public interface RocksDBConfigSetter {
      * @param storeName     the name of the store being configured
      * @param options       the RocksDB options
      */
-    default void close(final String storeName, final Options options) {
-        LOG.warn("The default close will be removed in 3.0.0 -- you should overwrite it if you have implemented RocksDBConfigSetter");
-    }
+    void close(final String storeName, final Options options);
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockRocksDbConfigSetter.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockRocksDbConfigSetter.java
@@ -35,6 +35,5 @@ public class MockRocksDbConfigSetter implements RocksDBConfigSetter {
 
     @Override
     public void close(String storeName, Options options) {
-        LOG.warn("The default close was removed in 3.0.0 -- you should overwrite it if you have implemented RocksDBConfigSetter");
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockRocksDbConfigSetter.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockRocksDbConfigSetter.java
@@ -32,4 +32,9 @@ public class MockRocksDbConfigSetter implements RocksDBConfigSetter {
 
         configMap.putAll(configs);
     }
+
+    @Override
+    public void close(String storeName, Options options) {
+        LOG.warn("The default close was removed in 3.0.0 -- you should overwrite it if you have implemented RocksDBConfigSetter");
+    }
 }


### PR DESCRIPTION
remove default

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
