### PR TITLE
KAFKA-12573; Remove deprecated `Metric#value`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Metric.java
+++ b/clients/src/main/java/org/apache/kafka/common/Metric.java
@@ -27,14 +27,6 @@ public interface Metric {
     MetricName metricName();
 
     /**
-     * The value of the metric as double if the metric is measurable and `0.0` otherwise.
-     *
-     * @deprecated As of 1.0.0, use {@link #metricValue()} instead. This will be removed in a future major release.
-     */
-    @Deprecated
-    double value();
-
-    /**
      * The value of the metric, which may be measurable or a non-measurable gauge
      */
     Object metricValue();

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -49,15 +49,6 @@ public final class KafkaMetric implements Metric {
         return this.metricName;
     }
 
-    /**
-     * See {@link Metric#value()} for the details on why this is deprecated.
-     */
-    @Override
-    @Deprecated
-    public double value() {
-        return measurableValue(time.milliseconds());
-    }
-
     @Override
     public Object metricValue() {
         long now = time.milliseconds();

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -952,14 +952,4 @@ public class MetricsTest {
             return sensor;
         }
     }
-
-    /**
-     * This test is to verify the deprecated {@link Metric#value()} method.
-     * @deprecated This will be removed in a future major release.
-     */
-    @Deprecated
-    @Test
-    public void testDeprecatedMetricValueMethod() {
-        verifyStats(KafkaMetric::value);
-    }
 }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -27,6 +27,7 @@
         or updating the application not to use internal classes.</li>
     <li>The Streams API removed all deprecated APIs that were deprecated in version 2.5.0 or earlier.
         For a complete list of removed APIs compare the detailed Kafka Streams upgrade notes.</li>
+    <li>The deprecated <code>Metric#value()</code> method was removed (<a href="https://issues.apache.org/jira/browse/KAFKA-12573">KAFKA-12573</a>).</li>
 </ul>
 
 <h5><a id="upgrade_280_notable" href="#upgrade_280_notable">Notable changes in 2.8.0</a></h5>


### PR DESCRIPTION
The `Metric#value` method was deprecated in AK 1.0. It makes sense to remove it in AK 3.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
