### PR TITLE
KAFKA-12571: Eliminate LeaderEpochFileCache constructor dependency on logEndOffset

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -581,7 +581,7 @@ class Log(@volatile private var _dir: File,
 
     def newLeaderEpochFileCache(): LeaderEpochFileCache = {
       val checkpointFile = new LeaderEpochCheckpointFile(leaderEpochFile, logDirFailureChannel)
-      new LeaderEpochFileCache(topicPartition, () => logEndOffset, checkpointFile)
+      new LeaderEpochFileCache(topicPartition, checkpointFile)
     }
 
     if (recordVersion.precedes(RecordVersion.V2)) {
@@ -1348,7 +1348,7 @@ class Log(@volatile private var _dir: File,
 
   def endOffsetForEpoch(leaderEpoch: Int): Option[OffsetAndEpoch] = {
     leaderEpochCache.flatMap { cache =>
-      val (foundEpoch, foundOffset) = cache.endOffsetFor(leaderEpoch)
+      val (foundEpoch, foundOffset) = cache.endOffsetFor(leaderEpoch, logEndOffset)
       if (foundOffset == UNDEFINED_EPOCH_OFFSET)
         None
       else

--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -36,10 +36,8 @@ import scala.jdk.CollectionConverters._
  *
  * @param topicPartition the associated topic partition
  * @param checkpoint the checkpoint file
- * @param logEndOffset function to fetch the current log end offset
  */
 class LeaderEpochFileCache(topicPartition: TopicPartition,
-                           logEndOffset: () => Long,
                            checkpoint: LeaderEpochCheckpoint) extends Logging {
   this.logIdent = s"[LeaderEpochCache $topicPartition] "
 
@@ -184,9 +182,10 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
     * so that the follower falls back to High Water Mark.
     *
     * @param requestedEpoch requested leader epoch
-    * @return found leader epoch and end offset
+    * @param logEndOffset the existing Log End Offset
+    * @return found leader epoch and end offset 
     */
-  def endOffsetFor(requestedEpoch: Int): (Int, Long) = {
+  def endOffsetFor(requestedEpoch: Int, logEndOffset: Long): (Int, Long) = {
     inReadLock(lock) {
       val epochAndOffset =
         if (requestedEpoch == UNDEFINED_EPOCH) {
@@ -198,7 +197,7 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
           // Followers should not have any reason to query for the end offset of the current epoch, but a consumer
           // might if it is verifying its committed offset following a group rebalance. In this case, we return
           // the current log end offset which makes the truncation check work as expected.
-          (requestedEpoch, logEndOffset())
+          (requestedEpoch, logEndOffset)
         } else {
           val higherEntry = epochs.higherEntry(requestedEpoch)
           if (higherEntry == null) {

--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -183,7 +183,7 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
     *
     * @param requestedEpoch requested leader epoch
     * @param logEndOffset the existing Log End Offset
-    * @return found leader epoch and end offset 
+    * @return found leader epoch and end offset  
     */
   def endOffsetFor(requestedEpoch: Int, logEndOffset: Long): (Int, Long) = {
     inReadLock(lock) {

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -389,7 +389,7 @@ class LogSegmentTest {
       override def read(): Seq[EpochEntry] = this.epochs
     }
 
-    val cache = new LeaderEpochFileCache(topicPartition, () => seg.readNextOffset, checkpoint)
+    val cache = new LeaderEpochFileCache(topicPartition, checkpoint)
     seg.append(largestOffset = 105L, largestTimestamp = RecordBatch.NO_TIMESTAMP,
       shallowOffsetOfMaxTimestamp = 104L, records = MemoryRecords.withRecords(104L, CompressionType.NONE, 0,
         new SimpleRecord("a".getBytes), new SimpleRecord("b".getBytes)))


### PR DESCRIPTION
This PR is a precursor to the recovery logic refactor work ([KAFKA-12553](https://issues.apache.org/jira/browse/KAFKA-12553)).

**Problems:**
For refactoring the recovery logic ([KAFKA-12553](https://issues.apache.org/jira/browse/KAFKA-12553)), we would like to [move the logic to initialize](https://github.com/apache/kafka/blob/d9bb2ef596343da9402bff4903b129cff1f7c22b/core/src/main/scala/kafka/log/Log.scala#L579) `LeaderEpochFileCache` out of the `Log` class and into a separate static function. In the future, once we successfully initialize `LeaderEpochFileCache` outside `Log`, we will be able pass it as a dependency into both the `Log` recovery module and `Log` class constructor. However, currently the `LeaderEpochFileCache` constructor takes a [dependency](https://github.com/apache/kafka/blob/d9bb2ef596343da9402bff4903b129cff1f7c22b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala#L42) on `logEndOffset` (via a callback), which poses the following problems:
1. Blocks the instantiation of `LeaderEpochFileCache` outside `Log` class. Because, outside `Log` the `logEndOffset` is unavailable to be passed into `LeaderEpochFileCache` constructor. As a result, this situation blocks the recovery logic ([KAFKA-12553](https://issues.apache.org/jira/browse/KAFKA-12553)) refactor work.
2. It turns out the `logEndOffset` dependency is used only in 1 of the `LeaderEpochFileCache` methods: `LeaderEpochFileCache.endOffsetFor`, and just for 1 particular case. Therefore, it is overkill to pass it in the constructor as a dependency. Also a callback is generally not a neat way to access dependencies and it poses code readability problems too.

**Solution:**
This PR modifies the code such that we only pass the `logEndOffset` as a parameter into `LeaderEpochFileCache.endOffsetFor` whenever the method is called, thus eliminating the constructor dependency. This will also unblock the recovery logic refactor work ([KAFKA-12553](https://issues.apache.org/jira/browse/KAFKA-12553)).

**Tests:**
I have modified the existing tests to suit the above refactor.