### PR TITLE
KAFKA-12572: Add import ordering checkstyle rule and configure an automatic formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,20 +207,6 @@ You can run checkstyle using:
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
-As of present, the auto-formatting configuration is work in progress. Auto-formatting is automatically invoked for the modules listed below when the 'checkstyleMain' or 'checkstyleTest' task is run.
-
-- (No modules specified yet)
-
-You can also run auto-formatting independently for a single module listed above, like:
-
-    ./gradlew :core:spotlessApply   # auto-format *.java files in core module, without running checkstyleMain or checkstyleTest.
-
-If you are using an IDE, you can use a plugin that provides real-time automatic formatting. For detailed information, refer to the following links:
-
-- [Eclipse](https://checkstyle.org/eclipse-cs)
-- [Intellij](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea)
-- [Vscode](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle)
-
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.
 You can run spotbugs using:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Please note for this to work you should create/update user maven settings (typic
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                            https://maven.apache.org/xsd/settings-1.0.0.xsd">
-    ...                           
+    ...
     <servers>
        ...
        <server>
@@ -206,6 +206,20 @@ You can run checkstyle using:
 
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
+
+As of present, the auto-formatting configuration is working in progress. Auto-formatting is automatically invoked for the modules listed below when the 'checkstyleMain' or 'checkstyleTest' task is run.
+
+- (No modules specified yet)
+
+You can also run auto-formatting independently for a single module listed above, like:
+
+    ./gradlew :core:spotlessApply   # auto-format *.java files in core module, without running checkstyleMain or checkstyleTest.
+
+If you are using an IDE, you can use a plugin that provides real-time automatic formatting. For detailed information, refer to the following links:
+
+- [Eclipse](https://checkstyle.org/eclipse-cs)
+- [Intellij](https://plugins.jetbrains.com/plugin/1065-checkstyle-idea)
+- [Vscode](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle)
 
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ You can run checkstyle using:
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
 
-As of present, the auto-formatting configuration is working in progress. Auto-formatting is automatically invoked for the modules listed below when the 'checkstyleMain' or 'checkstyleTest' task is run.
+As of present, the auto-formatting configuration is work in progress. Auto-formatting is automatically invoked for the modules listed below when the 'checkstyleMain' or 'checkstyleTest' task is run.
 
 - (No modules specified yet)
 

--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,7 @@ subprojects {
   apply plugin: 'checkstyle'
   apply plugin: "com.github.spotbugs"
   apply plugin: 'org.gradle.test-retry'
+  apply plugin: 'com.diffplug.spotless'
 
   // We use the shadow plugin for the jmh-benchmarks module and the `-all` jar can get pretty large, so
   // don't publish it
@@ -611,6 +612,26 @@ subprojects {
     }
   }
 
+  spotless {
+    java {
+      importOrder('kafka', 'org.apache.kafka', 'com', 'net', 'org', 'java', 'javax', '', '\\#')
+
+      // auto-format specified modules only; the list of auto-format modules will be updated incrementally.
+      if ([].contains(project.name)) {
+        target 'src/**/*.java'
+      } else {
+        target = project.files([])
+      }
+
+      eclipse('4.13.0').configFile("$rootDir/eclipse-formatter.xml")
+      indentWithSpaces()
+      trimTrailingWhitespace()
+      removeUnusedImports()
+
+      licenseHeaderFile file("$rootDir/checkstyle/java.header")
+    }
+  }
+
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = checkstyleConfigProperties("import-control.xml")
@@ -621,6 +642,9 @@ subprojects {
     group = 'Verification'
     description = 'Run checkstyle on all main Java sources'
   }
+
+  checkstyleMain.dependsOn('spotlessApply')
+  checkstyleTest.dependsOn('spotlessApply')
 
   configure(checkstyleTest) {
     group = 'Verification'

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -34,6 +34,13 @@
     <module name="UnusedImports">
       <property name="processJavadoc" value="true" />
     </module>
+    <module name="ImportOrder">
+      <property name="groups" value="kafka,org.apache.kafka,com,net,org,java,javax"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+      <property name="option" value="bottom"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
+    </module>
     <module name="RedundantImport"/>
     <module name="IllegalImport" />
     <module name="EqualsHashCode"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -281,6 +281,10 @@
     <suppress checks="(ImportOrder|AvoidStarImport)"
               files="tools[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
+    <!-- Trogdor -->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="trogdor[\\/]src[\\/](main|test)[\\/].+.java$"/>
+
     <!-- Shell -->
     <suppress checks="CyclomaticComplexity"
               files="(GlobComponent).java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -326,9 +326,9 @@
 
     <!-- Storage -->
     <suppress checks="(ImportOrder|AvoidStarImport)"
-              files="storage[\\/]src[\\/](main|test)[\\/].+.java$"/>
+              files="storage[\\/]api[\\/]src[\\/](main|test)[\\/].+.java$"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
-              files="storage[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+              files="storage[\\/]api[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
     <suppress checks="(CyclomaticComplexity|ParameterNumber)"
               files="(RemoteLogManagerConfig).java"/>
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -19,9 +19,15 @@
               files="(FieldSpec|MessageDataGenerator).java"/>
     <suppress id="dontUseSystemExit"
               files="MessageGenerator.java"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="generator[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="generator[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
-    <!-- core -->
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
+    <!-- Core -->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="core[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
               files="core[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
     <suppress checks="NPathComplexity" files="ClusterTestExtensions.java"/>
 
@@ -81,8 +87,10 @@
     <suppress checks="(UnnecessaryParentheses|BooleanExpressionComplexity|CyclomaticComplexity|WhitespaceAfter|LocalVariableName)"
               files="Murmur3.java"/>
 
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
-            files="clients[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="clients[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
+              files="clients[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <suppress checks="NPathComplexity"
             files="MessageTest.java|OffsetFetchRequest.java"/>
@@ -135,7 +143,12 @@
     <suppress checks="NPathComplexity"
               files="(DistributedHerder|RestClient|RestServer|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask|TopicAdmin).java"/>
 
-    <!-- connect tests-->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="connect.+[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="connect.+[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+
+    <!-- Connect tests-->
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DistributedHerder|KafkaBasedLog|WorkerSourceTaskWithTopicCreation|WorkerSourceTask)Test.java"/>
 
@@ -149,6 +162,10 @@
 
     <suppress checks="JavaNCSS"
               files="DistributedHerderTest.java"/>
+
+    <!-- Server-common -->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="server-common[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
     <!-- Streams -->
     <suppress checks="ClassFanOutComplexity"
@@ -182,13 +199,12 @@
     <suppress checks="FinalLocalVariable"
               files="^(?!.*[\\/]org[\\/]apache[\\/]kafka[\\/]streams[\\/].*$)"/>
 
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="streams[\\/]src[\\/](main|test)[\\/].+.java$"/>
+
     <!-- Generated code -->
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
               files="streams[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
-              files="raft[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
-              files="storage[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
     <suppress checks="ImportControl" files="FetchResponseData.java"/>
     <suppress checks="ImportControl" files="RecordsSerdeTest.java"/>
@@ -226,10 +242,18 @@
               files="TopologyTestDriver.java"/>
     <suppress checks="ClassDataAbstractionCoupling"
               files="TopologyTestDriver.java"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="streams[\\/]test-utils[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
     <!-- Streams examples -->
     <suppress id="dontUseSystemExit"
               files="PageViewTypedDemo.java|PipeDemo.java|TemperatureDemo.java|WordCountDemo.java|WordCountProcessorDemo.java|WordCountTransformerDemo.java"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="examples[\\/]src[\\/](main|test)[\\/].+.java$"/>
+
+    <!-- Jmh-benchmarks -->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="jmh-benchmarks[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
     <!-- Tools -->
     <suppress checks="ClassDataAbstractionCoupling"
@@ -254,10 +278,14 @@
               files="VerifiableConsumer.java"/>
     <suppress id="dontUseSystemExit"
               files="VerifiableProducer.java"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="tools[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
     <!-- Shell -->
     <suppress checks="CyclomaticComplexity"
               files="(GlobComponent).java"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="shell[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
     <!-- Log4J-Appender -->
     <suppress checks="CyclomaticComplexity"
@@ -267,8 +295,10 @@
               files="KafkaLog4jAppender.java"/>
     <suppress checks="JavaNCSS"
               files="RequestResponseTest.java"/>
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="log4j-appender[\\/]src[\\/](main|test)[\\/].+.java$"/>
 
-    <!-- metadata -->
+    <!-- Metadata -->
     <suppress checks="ClassDataAbstractionCoupling"
               files="(QuorumControllerTest|ReplicationControlManager|ReplicationControlManagerTest).java"/>
     <suppress checks="ClassFanOutComplexity"
@@ -279,15 +309,26 @@
               files="(ClientQuotasImage|ReplicationControlManager).java"/>
     <suppress checks="NPathComplexity"
               files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager).java"/>
-    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="metadata[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
             files="metadata[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 
+    <!-- Raft -->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="raft[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
+              files="raft[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+
     <!-- Storage -->
+    <suppress checks="(ImportOrder|AvoidStarImport)"
+              files="storage[\\/]src[\\/](main|test)[\\/].+.java$"/>
+    <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|FinalLocalVariable|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|ImportOrder|AvoidStarImport)"
+              files="storage[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
     <suppress checks="(CyclomaticComplexity|ParameterNumber)"
               files="(RemoteLogManagerConfig).java"/>
 
     <!-- benchmarks -->
     <suppress checks="ClassDataAbstractionCoupling"
               files="(ReplicaFetcherThreadBenchmark).java"/>
-
 </suppressions>

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="1">
+<profile kind="CodeFormatterProfile" name="ApacheKafka" version="1">
+    <!-- Import ordering -->
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+
+    <!-- Line -->
+    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+
+    <!-- Brace -->
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+
+    <!-- Indentation -->
+    <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
+    <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+
+    <!-- Tabs -->
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+    <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+
+    <!-- Alignment -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="18"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="18"/>
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="82"/>
+
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+
+    <!-- Wrapping -->
+    <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.wrap_prefer_two_fragments" value="false"/>
+
+    <!-- No trailing spaces -->
+    <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+
+    <!-- Add a blank line at the end of the class -->
+    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="1"/>
+</profile>
+</profiles>

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -53,5 +53,8 @@
 
     <!-- No trailing spaces -->
     <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+
+    <!-- No blank line at the end of the class -->
+    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
 </profile>
 </profiles>

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -1,10 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
 <profiles version="1">
 <profile kind="CodeFormatterProfile" name="ApacheKafka" version="1">
     <!-- Import ordering -->
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+
+    <!-- Line -->
+    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="200"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="200"/>
 
     <!-- Disable comment formatting -->
     <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -6,21 +6,10 @@
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
     <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
 
-    <!-- Line -->
-    <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="120"/>
-    <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
-
-    <!-- Brace -->
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+    <!-- Disable comment formatting -->
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="false"/>
+    <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="false"/>
 
     <!-- Indentation -->
     <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
@@ -33,10 +22,9 @@
     <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
 
     <!-- Alignment -->
+    <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="18"/>
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="18"/>
-    <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="82"/>
-
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
 
     <!-- Wrapping -->

--- a/eclipse-formatter.xml
+++ b/eclipse-formatter.xml
@@ -35,7 +35,6 @@
     <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
     <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="1"/>
     <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="1"/>
-    <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
 
     <!-- Tabs -->
     <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
@@ -46,6 +45,7 @@
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="18"/>
     <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="18"/>
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+    <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
 
     <!-- Wrapping -->
     <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
@@ -53,8 +53,5 @@
 
     <!-- No trailing spaces -->
     <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
-
-    <!-- Add a blank line at the end of the class -->
-    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="1"/>
 </profile>
 </profiles>


### PR DESCRIPTION
This PR is a part of [KAFKA-10787](https://issues.apache.org/jira/browse/KAFKA-10787) umbrella task, replacing the previous implementation [here](https://github.com/apache/kafka/pull/8404/). **In short, this PR provides automatic import ordering and checking configurations, which will be a foundation of actual code formatting tasks later.** Here are some backgrounds.

When I first started [KAFKA-10787](https://issues.apache.org/jira/browse/KAFKA-10787), I thought it is a trivial one and can be resolved with only one PR. But it is entirely wrong.

1. It modifies hundreds of files; it is not only hard to review but also, every time it has some code conflict with the trunk branch.
2. As @mjsax already pointed out, the previous implementation omits the essential way of solving this problem - **automatic import formatter**. Since it includes the checkstyle rules only, it shows error messages for the import ordering violation and that's it.

For the reasons above, it is almost impossible to resolve this issue with one commit or PR.

So, I restarted this feature from scratch. First of all, I changed the approach like following:

1. Take an incremental approach, i.e., enlarge the import ordering rules applied area gradually. (In other words, narrow down the exception area to the import ordering rules, step by step.)
2. By adopting automatic code formatter, make the build tool to apply the import order automatically.

This approach has the advantages like:

1. We can apply the import order step by step; it is feasible to review and greatly reduces the possibility of code conflict.
2. The dev team doesn't have to care about the formatting anymore; the build tool automatically take cares of it.

With this scheme, we can expand the scope of auto-formatting and checkstyle incrementally.

In turn, I converted [KAFKA-10787](https://issues.apache.org/jira/browse/KAFKA-10787) into an umbrella one. As the first subtask, this PR do the following:

1. Define the import ordering rule in checkstyle: `kafka`, `org.apache.kafka`, `com`, `net`, `org`, `java`, `javax` and static imports. It is identical to [what we discussed in the dev mailing list](https://lists.apache.org/thread.html/rf6f49c845a3d48efe8a91916c8fbaddb76da17742eef06798fc5b24d%40%3Cdev.kafka.apache.org%3E), except each package is grouped independely. (e.g., `kafka` and `org.apache.kafka` are regarded as independent groups.)
2. Add an eclipse formatter file, which includes:
    - Minimal formatting rules that follow current checkstyle rules.
    - `ImportOrder` rule for the newly introduced import ordering rule.
3. **Add a spotless configuration to reformat the subset of modules automatically.**

Here are some reasons for the decisions I made:

1. Why choose eclipse formatter?

    As all of you know, Apache Kafka is using gradle as its build tool. To automatically apply the import ordering rule with gradle, we have to use [spotless](https://github.com/diffplug/spotless), which supports two formatters - google formatter and eclipse formatter.
    
    If we choose google formatter, it changes not only import ordering but also the other aspects of code, like an indentation. To minimize non-import ordering modifications, I choose eclipse formatter, which supports a custom formatter configuration.

    As you can see here, the formatter defines a minimal rules for out code only.

2. The original proposal consists of 3 groups: `kafka`/`org.apache.kafka`, `com`/`org`/`net`, `java`/`javax`, and static imports. Why are those packages separated into independent groups?

    It's simple - the spotless automatic formatter doesn't allow packages with different prefixes into one group. So I separated them.

**\* Updated (June 10th 2021): The `core` module is excluded from the PR, and it now only focuses on providing auto-formatting configurations.**

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
