### PR TITLE
KAFKA-10847: Add new RocksDBPrefixRangeIterator class

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Bytes.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Bytes.java
@@ -16,9 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
-import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Comparator;
 
 /**
  * Utility class that handles immutable byte arrays.
@@ -94,7 +92,7 @@ public class Bytes implements Comparable<Bytes> {
 
     @Override
     public int compareTo(Bytes that) {
-        return BYTES_LEXICO_COMPARATOR.compare(this.bytes, that.bytes);
+        return BytesComparators.BYTES_LEXICO_COMPARATOR.compare(this.bytes, that.bytes);
     }
 
     @Override
@@ -163,48 +161,6 @@ public class Bytes implements Comparable<Bytes> {
             return wrap(ret);
         } else {
             throw new IndexOutOfBoundsException();
-        }
-    }
-
-    /**
-     * A byte array comparator based on lexicograpic ordering.
-     */
-    public final static ByteArrayComparator BYTES_LEXICO_COMPARATOR = new LexicographicByteArrayComparator();
-
-    public interface ByteArrayComparator extends Comparator<byte[]>, Serializable {
-
-        int compare(final byte[] buffer1, int offset1, int length1,
-                    final byte[] buffer2, int offset2, int length2);
-    }
-
-    private static class LexicographicByteArrayComparator implements ByteArrayComparator {
-
-        @Override
-        public int compare(byte[] buffer1, byte[] buffer2) {
-            return compare(buffer1, 0, buffer1.length, buffer2, 0, buffer2.length);
-        }
-
-        public int compare(final byte[] buffer1, int offset1, int length1,
-                           final byte[] buffer2, int offset2, int length2) {
-
-            // short circuit equal case
-            if (buffer1 == buffer2 &&
-                    offset1 == offset2 &&
-                    length1 == length2) {
-                return 0;
-            }
-
-            // similar to Arrays.compare() but considers offset and length
-            int end1 = offset1 + length1;
-            int end2 = offset2 + length2;
-            for (int i = offset1, j = offset2; i < end1 && j < end2; i++, j++) {
-                int a = buffer1[i] & 0xff;
-                int b = buffer2[j] & 0xff;
-                if (a != b) {
-                    return a - b;
-                }
-            }
-            return length1 - length2;
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/BytesComparators.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/BytesComparators.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+public final class BytesComparators {
+    public interface ByteArrayComparator extends Comparator<byte[]>, Serializable {
+        int compare(final byte[] buffer1, int offset1, int length1,
+                    final byte[] buffer2, int offset2, int length2);
+    }
+
+    /**
+     * A byte array comparator based on lexicograpic ordering.
+     */
+    public final static ByteArrayComparator BYTES_LEXICO_COMPARATOR = new LexicographicByteArrayComparator();
+
+    /**
+     * A byte array comparator used on lexicographc ordering, but only comparing prefixes.
+     * i.e. 0001     == 00010003   (only first 4 bytes are compared)
+     *      00010003 == 0001       (only first 4 bytes are compared)
+     */
+    public final static ByteArrayComparator PREFIX_BYTES_LEXICO_COMPARATOR = new LexicographicPrefixByteArrayComparator();
+
+    private static class LexicographicByteArrayComparator implements ByteArrayComparator {
+
+        @Override
+        public int compare(byte[] buffer1, byte[] buffer2) {
+            return compare(buffer1, 0, buffer1.length, buffer2, 0, buffer2.length);
+        }
+
+        public int compare(final byte[] buffer1, int offset1, int length1,
+                           final byte[] buffer2, int offset2, int length2) {
+
+            // short circuit equal case
+            if (buffer1 == buffer2 &&
+                offset1 == offset2 &&
+                length1 == length2) {
+                return 0;
+            }
+
+            // similar to Arrays.compare() but considers offset and length
+            int end1 = offset1 + length1;
+            int end2 = offset2 + length2;
+            for (int i = offset1, j = offset2; i < end1 && j < end2; i++, j++) {
+                int a = buffer1[i] & 0xff;
+                int b = buffer2[j] & 0xff;
+                if (a != b) {
+                    return a - b;
+                }
+            }
+            return length1 - length2;
+        }
+    }
+
+    private static class LexicographicPrefixByteArrayComparator extends LexicographicByteArrayComparator {
+        public int compare(final byte[] buffer1, int offset1, int length1,
+                           final byte[] buffer2, int offset2, int length2) {
+            // short circuit equal case
+            if (buffer1 == buffer2 &&
+                offset1 == offset2 &&
+                length1 == length2) {
+                return 0;
+            }
+
+            // similar to Arrays.compare() but considers offset and length
+            int end1 = offset1 + length1;
+            int end2 = offset2 + length2;
+            for (int i = offset1, j = offset2; i < end1 && j < end2; i++, j++) {
+                int a = buffer1[i] & 0xff;
+                int b = buffer2[j] & 0xff;
+                if (a != b) {
+                    return a - b;
+                }
+            }
+
+            // If above comparison passed, then both prefixes are equals
+            return 0;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBPrefixRangeIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBPrefixRangeIterator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.BytesComparators;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.rocksdb.RocksIterator;
+import java.util.Set;
+
+public class RocksDBPrefixRangeIterator extends RocksDBRangeIterator {
+    RocksDBPrefixRangeIterator(final String storeName,
+                               final RocksIterator iter,
+                               final Set<KeyValueIterator<Bytes, byte[]>> openIterators,
+                               final Bytes from,
+                               final Bytes to,
+                               final boolean forward,
+                               final boolean toInclusive) {
+        super(storeName,
+            iter,
+            openIterators,
+            from,
+            to,
+            forward,
+            toInclusive,
+            BytesComparators.PREFIX_BYTES_LEXICO_COMPARATOR);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBRangeIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBRangeIterator.java
@@ -17,18 +17,20 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.BytesComparators;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.rocksdb.RocksIterator;
 
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.Set;
 
 class RocksDBRangeIterator extends RocksDbIterator {
     // RocksDB's JNI interface does not expose getters/setters that allow the
     // comparator to be pluggable, and the default is lexicographic, so it's
     // safe to just force lexicographic comparator here for now.
-    private final Comparator<byte[]> comparator = Bytes.BYTES_LEXICO_COMPARATOR;
+    private final Comparator<byte[]> comparator;
     private final byte[] rawLastKey;
     private final boolean forward;
     private final boolean toInclusive;
@@ -40,9 +42,28 @@ class RocksDBRangeIterator extends RocksDbIterator {
                          final Bytes to,
                          final boolean forward,
                          final boolean toInclusive) {
+        this(storeName,
+            iter,
+            openIterators,
+            from,
+            to,
+            forward,
+            toInclusive,
+            BytesComparators.BYTES_LEXICO_COMPARATOR);
+    }
+
+    RocksDBRangeIterator(final String storeName,
+                         final RocksIterator iter,
+                         final Set<KeyValueIterator<Bytes, byte[]>> openIterators,
+                         final Bytes from,
+                         final Bytes to,
+                         final boolean forward,
+                         final boolean toInclusive,
+                         final Comparator<byte[]> comparator) {
         super(storeName, iter, openIterators, forward);
         this.forward = forward;
         this.toInclusive = toInclusive;
+        this.comparator = Objects.requireNonNull(comparator, "comparator");
         if (forward) {
             iter.seek(from.get());
             rawLastKey = to.get();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/SegmentedCacheFunction.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.BytesComparators;
 import org.apache.kafka.streams.state.internals.SegmentedBytesStore.KeySchema;
 
 import java.nio.ByteBuffer;
@@ -77,7 +78,7 @@ class SegmentedCacheFunction implements CacheFunction {
         if (segmentCompare == 0) {
             final byte[] cacheKeyBytes = cacheKey.get();
             final byte[] storeKeyBytes = storeKey.get();
-            return Bytes.BYTES_LEXICO_COMPARATOR.compare(
+            return BytesComparators.BYTES_LEXICO_COMPARATOR.compare(
                 cacheKeyBytes, SEGMENT_ID_BYTES, cacheKeyBytes.length - SEGMENT_ID_BYTES,
                 storeKeyBytes, 0, storeKeyBytes.length
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBPrefixRangeIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBPrefixRangeIteratorTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.Test;
+import org.rocksdb.RocksIterator;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class RocksDBPrefixRangeIteratorTest {
+    private final String storeName = "store";
+    private final String key1 = "a";
+    private final String key2 = "b";
+
+    private final byte[] prefix1 = new byte[]{0x1};
+    private final byte[] prefix2 = new byte[]{0x2};
+
+    private final String value = "value";
+    private final byte[] valueBytes = value.getBytes();
+
+    private final Bytes prefix1Key1Bytes = Bytes.wrap(concat(prefix1, key1.getBytes()));
+    private final Bytes prefix1Key2Bytes = Bytes.wrap(concat(prefix1, key2.getBytes()));
+    private final Bytes prefix2Key1Bytes = Bytes.wrap(concat(prefix2, key1.getBytes()));
+    private final Bytes prefix2Key2Bytes = Bytes.wrap(concat(prefix2, key2.getBytes()));
+
+    private final Bytes prefix1Bytes = Bytes.wrap(prefix1);
+    private final Bytes prefix2Bytes = Bytes.wrap(prefix2);
+
+    private byte[] concat(final byte[] a, final byte[] b) {
+        final ByteBuffer concatArrays = ByteBuffer.allocate(a.length + b.length);
+        concatArrays.put(a);
+        concatArrays.put(b);
+        return concatArrays.array();
+    }
+
+
+    @Test
+    public void shouldReturnAllKeysInThePrefixRangeInForwardDirection() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seek(prefix1);
+        expect(rocksIterator.isValid())
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(false);
+        expect(rocksIterator.key())
+            .andReturn(prefix1Key1Bytes.get())
+            .andReturn(prefix1Key2Bytes.get())
+            .andReturn(prefix2Key1Bytes.get())
+            .andReturn(prefix2Key2Bytes.get());
+        expect(rocksIterator.value()).andReturn(valueBytes).times(4);
+        rocksIterator.next();
+        expectLastCall().times(4);
+        replay(rocksIterator);
+
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            prefix2Bytes,
+            true,
+            true
+        );
+
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldReturnAllKeysInThePrefixRangeReverseDirection() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seekForPrev(prefix2);
+        expect(rocksIterator.isValid())
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(false);
+        expect(rocksIterator.key())
+            .andReturn(prefix2Key2Bytes.get())
+            .andReturn(prefix2Key1Bytes.get())
+            .andReturn(prefix1Key2Bytes.get())
+            .andReturn(prefix1Key1Bytes.get());
+        expect(rocksIterator.value()).andReturn(valueBytes).times(4);
+        rocksIterator.prev();
+        expectLastCall().times(4);
+        replay(rocksIterator);
+
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            prefix2Bytes,
+            false,
+            true
+        );
+
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldReturnAllKeysWhenLastPrefixKeyIsGreaterThanLargestKeyInStateStoreInForwardDirection() {
+        final Bytes toBytes = Bytes.increment(prefix2Bytes);
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seek(prefix1Bytes.get());
+        expect(rocksIterator.isValid())
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(false);
+        expect(rocksIterator.key())
+            .andReturn(prefix1Key1Bytes.get())
+            .andReturn(prefix1Key2Bytes.get())
+            .andReturn(prefix2Key1Bytes.get())
+            .andReturn(prefix2Key2Bytes.get());
+        expect(rocksIterator.value()).andReturn(valueBytes).times(4);
+        rocksIterator.next();
+        expectLastCall().times(4);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            toBytes,
+            true,
+            true
+        );
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldReturnNoKeysWhenLastPrefixKeyIsSmallerThanSmallestKeyInStateStoreForwardDirection() {
+        // key range in state store: [c-f]
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seek(prefix1Bytes.get());
+        expect(rocksIterator.isValid()).andReturn(false);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            prefix2Bytes,
+            true,
+            true
+        );
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+
+    @Test
+    public void shouldReturnNoKeysWhenLastPrefixKeyIsLargerThanLargestKeyInStateStoreReverseDirection() {
+        // key range in state store: [c-f]
+        final byte[] fromPrefix = new byte[]{0x1};
+        final byte[] toPrefix = new byte[]{0x2};
+        final  Bytes fromBytes = Bytes.wrap(fromPrefix);
+        final  Bytes toBytes = Bytes.wrap(toPrefix);
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seekForPrev(toBytes.get());
+        expect(rocksIterator.isValid())
+            .andReturn(false);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            fromBytes,
+            toBytes,
+            false,
+            true
+        );
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldReturnAllKeysInPartiallyOverlappingPrefixRangeInForwardDirection() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seek(prefix1Bytes.get());
+        expect(rocksIterator.isValid())
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(false);
+        expect(rocksIterator.key())
+            .andReturn(prefix2Key1Bytes.get())
+            .andReturn(prefix2Key2Bytes.get());
+        expect(rocksIterator.value()).andReturn(valueBytes).times(2);
+        rocksIterator.next();
+        expectLastCall().times(2);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            prefix2Bytes,
+            true,
+            true
+        );
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key2Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldReturnAllKeysInPartiallyOverlappingPrefixRangeInReverseDirection() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        final byte[] toPrefix = new byte[]{0x3};
+        final Bytes toBytes = Bytes.wrap(toPrefix);
+        rocksIterator.seekForPrev(toBytes.get());
+        expect(rocksIterator.isValid())
+            .andReturn(true)
+            .andReturn(true)
+            .andReturn(false);
+        expect(rocksIterator.key())
+            .andReturn(prefix2Key1Bytes.get())
+            .andReturn(prefix1Key1Bytes.get());
+        expect(rocksIterator.value()).andReturn(valueBytes).times(2);
+        rocksIterator.prev();
+        expectLastCall().times(2);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            toBytes,
+            false,
+            true
+        );
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix2Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldCloseIterator() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seek(prefix1Bytes.get());
+        rocksIterator.close();
+        expectLastCall().times(1);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            prefix2Bytes,
+            true,
+            true
+        );
+        rocksDBPrefixRangeIterator.close();
+        verify(rocksIterator);
+    }
+
+    @Test
+    public void shouldExcludeEndOfRange() {
+        final RocksIterator rocksIterator = mock(RocksIterator.class);
+        rocksIterator.seek(prefix1Bytes.get());
+        expect(rocksIterator.isValid())
+            .andReturn(true)
+            .andReturn(true);
+        expect(rocksIterator.key())
+            .andReturn(prefix1Key1Bytes.get())
+            .andReturn(prefix2Key1Bytes.get());
+        expect(rocksIterator.value()).andReturn(valueBytes).times(2);
+        rocksIterator.next();
+        expectLastCall().times(2);
+        replay(rocksIterator);
+        final RocksDBPrefixRangeIterator rocksDBPrefixRangeIterator = new RocksDBPrefixRangeIterator(
+            storeName,
+            rocksIterator,
+            Collections.emptySet(),
+            prefix1Bytes,
+            prefix2Bytes,
+            true,
+            false
+        );
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(true));
+        assertThat(rocksDBPrefixRangeIterator.next().key, is(prefix1Key1Bytes));
+        assertThat(rocksDBPrefixRangeIterator.hasNext(), is(false));
+        verify(rocksIterator);
+    }
+}


### PR DESCRIPTION
This iterator is similar to `RocksDBRangeIterator` except that compares key prefixes during each iteration instead of the full record key. This iterator will be used by the time-ordered window store from the PR https://github.com/apache/kafka/pull/10331.
This iterator is more efficient when doing range queries.

The `RocksDBPrefixRangeIterator` uses a new bytes lexico comparator that compares two bytes by their prefixes only.
i.e.
```
comparator.compare(0001, 0001000F); // smallest key prefix is 4 bytes, so 0001 == 0001
comparator.compare(0001000F, 0001); // smallest key prefix is 4 bytes, so 0001 == 0001
comparator.compare(0002000F, 0001); // smallest key prefix is 4 bytes, so 0002 > 0001
comparator.compare(0001000F, 0002); // smallest key prefix is 4 bytes, so 0001 < 0002
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
