### PR TITLE
KAFKA-12543: Change RawSnapshotReader ownership model

### DIFF
--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -320,7 +320,7 @@ final class KafkaMetadataLog private (
    * Forget the snapshots earlier than a given snapshot id and return the associated
    * snapshot readers.
    *
-   * This method assumes that the lock for `snapshots` is ready held.
+   * This method assumes that the lock for `snapshots` is already held.
    */
   @nowarn("cat=deprecation") // Needed for TreeMap.until
   private def forgetSnapshotsBefore(
@@ -333,8 +333,8 @@ final class KafkaMetadataLog private (
   }
 
   /**
-   * Rename the given snapshots on the log directory. Asynchronously, close and delete the given
-   * snapshots.
+   * Rename the given snapshots on the log directory. Asynchronously, close and delete the
+   * given snapshots after some delay.
    */
   private def removeSnapshots(
     expiredSnapshots: mutable.TreeMap[OffsetAndEpoch, Option[FileRawSnapshotReader]]
@@ -444,7 +444,7 @@ object KafkaMetadataLog {
   private def deleteSnapshotFiles(
     logDir: Path,
     expiredSnapshots: mutable.TreeMap[OffsetAndEpoch, Option[FileRawSnapshotReader]]
-  )(): Unit = {
+  ): () => Unit = () => {
     expiredSnapshots.foreach { case (snapshotId, snapshotReader) =>
       snapshotReader.foreach(_.close())
       Snapshots.deleteIfExists(logDir, snapshotId)

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -163,8 +163,10 @@ final class KafkaMetadataLog private (
   override def truncateToLatestSnapshot(): Boolean = {
     val latestEpoch = log.latestEpoch.getOrElse(0)
     val (truncated, forgottenSnapshots) = latestSnapshotId().asScala match {
-      case Some(snapshotId) if (snapshotId.epoch > latestEpoch ||
-        (snapshotId.epoch == latestEpoch && snapshotId.offset > endOffset().offset)) =>
+      case Some(snapshotId) if (
+          snapshotId.epoch > latestEpoch ||
+          (snapshotId.epoch == latestEpoch && snapshotId.offset > endOffset().offset)
+        ) =>
         // Truncate the log fully if the latest snapshot is greater than the log end offset
         log.truncateFullyAndStartAt(snapshotId.offset)
 

--- a/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/raft/KafkaMetadataLogTest.scala
@@ -99,9 +99,7 @@ final class KafkaMetadataLogTest {
       snapshot.freeze()
     }
 
-    TestUtils.resource(log.readSnapshot(snapshotId).get()) { snapshot =>
-      assertEquals(0, snapshot.sizeInBytes())
-    }
+    assertEquals(0, log.readSnapshot(snapshotId).get().sizeInBytes())
   }
 
   @Test

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1245,51 +1245,50 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             );
         }
 
-        try (RawSnapshotReader snapshot = snapshotOpt.get()) {
-            long snapshotSize = snapshot.sizeInBytes();
-            if (partitionSnapshot.position() < 0 || partitionSnapshot.position() >= snapshotSize) {
-                return FetchSnapshotResponse.singleton(
-                    log.topicPartition(),
-                    responsePartitionSnapshot -> addQuorumLeader(responsePartitionSnapshot)
-                        .setErrorCode(Errors.POSITION_OUT_OF_RANGE.code())
-                );
-            }
-
-            if (partitionSnapshot.position() > Integer.MAX_VALUE) {
-                throw new IllegalStateException(
-                    String.format(
-                        "Trying to fetch a snapshot with size (%s) and a position (%s) larger than %s",
-                        snapshotSize,
-                        partitionSnapshot.position(),
-                        Integer.MAX_VALUE
-                    )
-                );
-            }
-
-            int maxSnapshotSize;
-            try {
-                maxSnapshotSize = Math.toIntExact(snapshotSize);
-            } catch (ArithmeticException e) {
-                maxSnapshotSize = Integer.MAX_VALUE;
-            }
-
-            UnalignedRecords records = snapshot.slice(partitionSnapshot.position(), Math.min(data.maxBytes(), maxSnapshotSize));
-
+        RawSnapshotReader snapshot = snapshotOpt.get();
+        long snapshotSize = snapshot.sizeInBytes();
+        if (partitionSnapshot.position() < 0 || partitionSnapshot.position() >= snapshotSize) {
             return FetchSnapshotResponse.singleton(
                 log.topicPartition(),
-                responsePartitionSnapshot -> {
-                    addQuorumLeader(responsePartitionSnapshot)
-                        .snapshotId()
-                        .setEndOffset(snapshotId.offset)
-                        .setEpoch(snapshotId.epoch);
-
-                    return responsePartitionSnapshot
-                        .setSize(snapshotSize)
-                        .setPosition(partitionSnapshot.position())
-                        .setUnalignedRecords(records);
-                }
+                responsePartitionSnapshot -> addQuorumLeader(responsePartitionSnapshot)
+                    .setErrorCode(Errors.POSITION_OUT_OF_RANGE.code())
             );
         }
+
+        if (partitionSnapshot.position() > Integer.MAX_VALUE) {
+            throw new IllegalStateException(
+                String.format(
+                    "Trying to fetch a snapshot with size (%s) and a position (%s) larger than %s",
+                    snapshotSize,
+                    partitionSnapshot.position(),
+                    Integer.MAX_VALUE
+                )
+            );
+        }
+
+        int maxSnapshotSize;
+        try {
+            maxSnapshotSize = Math.toIntExact(snapshotSize);
+        } catch (ArithmeticException e) {
+            maxSnapshotSize = Integer.MAX_VALUE;
+        }
+
+        UnalignedRecords records = snapshot.slice(partitionSnapshot.position(), Math.min(data.maxBytes(), maxSnapshotSize));
+
+        return FetchSnapshotResponse.singleton(
+            log.topicPartition(),
+            responsePartitionSnapshot -> {
+                addQuorumLeader(responsePartitionSnapshot)
+                    .snapshotId()
+                    .setEndOffset(snapshotId.offset)
+                    .setEpoch(snapshotId.epoch);
+
+                return responsePartitionSnapshot
+                    .setSize(snapshotSize)
+                    .setPosition(partitionSnapshot.position())
+                    .setUnalignedRecords(records);
+            }
+        );
     }
 
     private boolean handleFetchSnapshotResponse(

--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotReader.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.record.UnalignedRecords;
 import org.apache.kafka.raft.OffsetAndEpoch;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 
 public final class FileRawSnapshotReader implements RawSnapshotReader, AutoCloseable {
@@ -58,7 +59,14 @@ public final class FileRawSnapshotReader implements RawSnapshotReader, AutoClose
         try {
             fileRecords.close();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(
+                String.format(
+                    "Unable to close snapshot reader %s at %s",
+                    snapshotId,
+                    fileRecords.file
+                ),
+                e
+            );
         }
     }
 

--- a/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/FileRawSnapshotReader.java
@@ -24,7 +24,7 @@ import org.apache.kafka.raft.OffsetAndEpoch;
 import java.io.IOException;
 import java.nio.file.Path;
 
-public final class FileRawSnapshotReader implements RawSnapshotReader {
+public final class FileRawSnapshotReader implements RawSnapshotReader, AutoCloseable {
     private final FileRecords fileRecords;
     private final OffsetAndEpoch snapshotId;
 
@@ -54,8 +54,12 @@ public final class FileRawSnapshotReader implements RawSnapshotReader {
     }
 
     @Override
-    public void close() throws IOException {
-        fileRecords.close();
+    public void close() {
+        try {
+            fileRecords.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/raft/src/main/java/org/apache/kafka/snapshot/RawSnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/RawSnapshotReader.java
@@ -20,12 +20,10 @@ import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.record.UnalignedRecords;
 import org.apache.kafka.raft.OffsetAndEpoch;
 
-import java.io.Closeable;
-
 /**
  * Interface for reading snapshots as a sequence of records.
  */
-public interface RawSnapshotReader extends Closeable {
+public interface RawSnapshotReader {
     /**
      * Returns the end offset and epoch for the snapshot.
      */

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.text.NumberFormat;
 import java.util.Optional;
 
@@ -50,10 +51,6 @@ public final class Snapshots {
         return logDir;
     }
 
-    public static Path snapshotPath(Path logDir, OffsetAndEpoch snapshotId) {
-        return snapshotDir(logDir).resolve(filenameFromSnapshotId(snapshotId) + SUFFIX);
-    }
-
     static String filenameFromSnapshotId(OffsetAndEpoch snapshotId) {
         return String.format("%s-%s", OFFSET_FORMATTER.format(snapshotId.offset), EPOCH_FORMATTER.format(snapshotId.epoch));
     }
@@ -62,8 +59,12 @@ public final class Snapshots {
         return source.resolveSibling(filenameFromSnapshotId(snapshotId) + SUFFIX);
     }
 
-    public static Path deleteRename(Path source, OffsetAndEpoch snapshotId) {
+    static Path deleteRename(Path source, OffsetAndEpoch snapshotId) {
         return source.resolveSibling(filenameFromSnapshotId(snapshotId) + DELETE_SUFFIX);
+    }
+
+    public static Path snapshotPath(Path logDir, OffsetAndEpoch snapshotId) {
+        return snapshotDir(logDir).resolve(filenameFromSnapshotId(snapshotId) + SUFFIX);
     }
 
     public static Path createTempFile(Path logDir, OffsetAndEpoch snapshotId) throws IOException {
@@ -104,18 +105,29 @@ public final class Snapshots {
     }
 
     /**
-     * Delete the snapshot from the filesystem, the caller may firstly rename snapshot file to
-     * ${file}.deleted, so we try to delete the file as well as the renamed file if exists.
+     * Delete the snapshot from the filesystem.
      */
-    public static boolean deleteSnapshotIfExists(Path logDir, OffsetAndEpoch snapshotId) {
-        Path immutablePath = Snapshots.snapshotPath(logDir, snapshotId);
-        Path deletingPath = Snapshots.deleteRename(immutablePath, snapshotId);
+    public static boolean deleteIfExists(Path logDir, OffsetAndEpoch snapshotId) {
+        Path immutablePath = snapshotPath(logDir, snapshotId);
+        Path deletedPath = deleteRename(immutablePath, snapshotId);
         try {
-            return Files.deleteIfExists(immutablePath) | Files.deleteIfExists(deletingPath);
+            return Files.deleteIfExists(immutablePath) | Files.deleteIfExists(deletedPath);
         } catch (IOException e) {
-            log.error("Error deleting snapshot file " + deletingPath, e);
+            log.error("Error deleting snapshot files {} and {}", immutablePath, deletedPath, e);
             return false;
         }
     }
 
+    /**
+     * Mark a snapshot for deletion by renaming with the deleted suffix
+     */
+    public static void markForDelete(Path logDir, OffsetAndEpoch snapshotId) {
+        Path immutablePath = snapshotPath(logDir, snapshotId);
+        Path deletedPath = deleteRename(immutablePath, snapshotId);
+        try {
+            Files.move(immutablePath, deletedPath, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            log.error("Error renaming snapshot file from {} to {}", immutablePath, deletedPath, e);
+        }
+    }
 }

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
@@ -127,7 +128,14 @@ public final class Snapshots {
         try {
             Utils.atomicMoveWithFallback(immutablePath, deletedPath, false);
         } catch (IOException e) {
-            log.error("Error renaming snapshot file from {} to {}", immutablePath, deletedPath, e);
+            throw new UncheckedIOException(
+                String.format(
+                    "Error renaming snapshot file from %s to %s",
+                    immutablePath,
+                    deletedPath
+                ),
+                e
+            );
         }
     }
 }

--- a/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/Snapshots.java
@@ -17,13 +17,13 @@
 package org.apache.kafka.snapshot;
 
 import org.apache.kafka.raft.OffsetAndEpoch;
+import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.text.NumberFormat;
 import java.util.Optional;
 
@@ -125,7 +125,7 @@ public final class Snapshots {
         Path immutablePath = snapshotPath(logDir, snapshotId);
         Path deletedPath = deleteRename(immutablePath, snapshotId);
         try {
-            Files.move(immutablePath, deletedPath, StandardCopyOption.ATOMIC_MOVE);
+            Utils.atomicMoveWithFallback(immutablePath, deletedPath, false);
         } catch (IOException e) {
             log.error("Error renaming snapshot file from {} to {}", immutablePath, deletedPath, e);
         }

--- a/raft/src/test/java/org/apache/kafka/raft/MockLog.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLog.java
@@ -709,8 +709,5 @@ public class MockLog implements ReplicatedLog {
         public Records records() {
             return data;
         }
-
-        @Override
-        public void close() {}
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -441,9 +441,8 @@ public class MockLogTest {
             snapshot.freeze();
         }
 
-        try (RawSnapshotReader snapshot = log.readSnapshot(snapshotId).get()) {
-            assertEquals(0, snapshot.sizeInBytes());
-        }
+        RawSnapshotReader snapshot = log.readSnapshot(snapshotId).get();
+        assertEquals(0, snapshot.sizeInBytes());
     }
 
     @Test

--- a/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
+++ b/raft/src/test/java/org/apache/kafka/snapshot/SnapshotsTest.java
@@ -118,7 +118,7 @@ final public class SnapshotsTest {
                 // rename snapshot before deleting
                 Utils.atomicMoveWithFallback(snapshotPath, Snapshots.deleteRename(snapshotPath, snapshotId), false);
 
-            assertTrue(Snapshots.deleteSnapshotIfExists(logDirPath, snapshot.snapshotId()));
+            assertTrue(Snapshots.deleteIfExists(logDirPath, snapshot.snapshotId()));
             assertFalse(Files.exists(snapshotPath));
             assertFalse(Files.exists(Snapshots.deleteRename(snapshotPath, snapshotId)));
         }


### PR DESCRIPTION
Kafka networking layer doesn't close `FileRecords` and assumes that they are already open when sending them over a channel. To support this pattern this commit changes the ownership model for `FileRawSnapshotReader` so that they are owned by `KafkaMetadataLog`. This includes:

1. Changing `KafkaMetadataLog`'s `snapshotIds` form a `Set[OffsetAndEpoch]` to a `TreeMap[OffsetAndEpoch, Option[FileRawSnapshotReader]]`. This map contains all of the known snapshots. The value will be `Some` if a snapshot reader has been opened in the past.

2. Split and change the functionality in `KafkaMetadataLog::removeSnapshotFilesBefore` so that a) `forgetSnapshotsBefore` removes any snapshot less that the given snapshot id from `snapshots`; b) `removeSnapshots` deletes the enumerated snapshots from `forgetSnapshotsBefore`.

3. Change the interface `RawSnapshotReader` to not extend `Closeable` since only `KafkaMetadataLog` is responsible for closing snapshots. `FileRawSnapshotReader` implements `AutoCloseable`.

4. Fixed the implementation of `handleFetchSnapshotRequest` in `KafkaRaftClient` so that `RawSnapshotReader` and the associated `FileRecords` are not close before sending to the network layer.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
