### PR TITLE
MINOR: Extend Predicate interface to allow combining and negation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Predicate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Predicate.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.streams.KeyValue;
 
+import java.util.Objects;
+
 /**
  * The {@code Predicate} interface represents a predicate (boolean-valued function) of a {@link KeyValue} pair.
  * This is a stateless record-by-record operation, i.e, {@link #test(Object, Object)} is invoked individually for each
@@ -41,4 +43,54 @@ public interface Predicate<K, V> {
      * @return {@code true} if the {@link KeyValue} pair satisfies the predicate&mdash;{@code false} otherwise
      */
     boolean test(final K key, final V value);
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical AND of this predicate and another.
+     * When evaluating the composed predicate, if this predicate is false, then the other predicate is not evaluated.
+     * Any exceptions thrown during evaluation of either predicate are relayed to the caller; if evaluation of this
+     * predicate throws an exception, the other predicate will not be evaluated.
+     * @param other a predicate that will be logically-ANDed with this predicate
+     * @return a composed predicate that represents the short-circuiting logical AND of this predicate and the other predicate
+     * @throws NullPointerException if other is null
+     */
+    default Predicate<K, V> and(Predicate<? super K, ? super V> other) {
+        Objects.requireNonNull(other);
+        return (k, v) -> this.test(k, v) && other.test(k, v);
+    }
+
+    /**
+     * Returns a predicate that represents the logical negation of this predicate.
+     * @return a predicate that represents the logical negation of this predicate
+     */
+    default Predicate<K, V> negate() {
+        return (k, v) -> !this.test(k, v);
+    }
+
+    /**
+     * Returns a composed predicate that represents a short-circuiting logical OR of this predicate and another. When
+     * evaluating the composed predicate, if this predicate is true, then the other predicate is not evaluated.
+     * Any exceptions thrown during evaluation of either predicate are relayed to the caller; if evaluation of this
+     * predicate throws an exception, the other predicate will not be evaluated.
+     * @param other a predicate that will be logically-ORed with this predicate
+     * @return a composed predicate that represents the short-circuiting logical OR of this predicate and the other predicate
+     * @throws NullPointerException if other is null
+     */
+    default Predicate<K, V> or(Predicate<? super K, ? super V> other) {
+        Objects.requireNonNull(other);
+        return (k, v) -> this.test(k, v) || other.test(k, v);
+    }
+
+    /**
+     * Returns a predicate that is the negation of the supplied predicate. This is accomplished by returning result
+     * of the calling target.negate().
+     * @param target predicate to negate
+     * @param <K> key type
+     * @param <V> value type
+     * @return a predicate that negates the results of the supplied predicate
+     * @throws NullPointerException if target is null
+     */
+    static <K, V> Predicate<K, V> not(Predicate<K, V> target) {
+        Objects.requireNonNull(target);
+        return target.negate();
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -761,7 +761,7 @@ public class QueryableStateIntegrationTest {
         final Predicate<String, Long> filterPredicate = (key, value) -> key.contains("kafka");
         final KTable<String, Long> t1 = builder.table(streamOne);
         final KTable<String, Long> t2 = t1.filter(filterPredicate, Materialized.as("queryFilter"));
-        t1.filterNot(filterPredicate, Materialized.as("queryFilterNot"));
+        t1.filter(filterPredicate.negate(), Materialized.as("queryFilterNot"));
         t2.toStream().to(outputTopic);
 
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamBranchTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamBranchTest.java
@@ -19,12 +19,12 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Predicate;
-import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.test.MockProcessor;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.StreamsTestUtils;
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -75,6 +76,44 @@ public class KStreamBranchTest {
         assertEquals(3, processors.get(0).processed().size());
         assertEquals(1, processors.get(1).processed().size());
         assertEquals(2, processors.get(2).processed().size());
+    }
+
+    @SuppressWarnings({"unchecked", "deprecation"})
+    @Test
+    public void testKStreamBranchWithComposedPredicate() {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final Predicate<Integer, String> isEven = (key, value) -> (key % 2) == 0;
+        final Predicate<Integer, String> isMultipleOfThree = (key, value) -> (key % 3) == 0;
+        final Predicate<Integer, String> isMultipleOfFour = (key, value) -> (key % 4) == 0;
+
+        final int[] expectedKeys = IntStream.range(1, 14).toArray();
+
+        final KStream<Integer, String> stream;
+        final KStream<Integer, String>[] branches;
+
+        stream = builder.stream(topicName, Consumed.with(Serdes.Integer(), Serdes.String()));
+        branches = stream.branch(isMultipleOfFour.and(isMultipleOfThree), isEven.and(isMultipleOfThree),
+            isMultipleOfFour.or(isMultipleOfThree));
+
+        assertEquals(3, branches.length);
+
+        final MockProcessorSupplier<Integer, String> supplier = new MockProcessorSupplier<>();
+        for (int i = 0; i < branches.length; i++) {
+            branches[i].process(supplier);
+        }
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final TestInputTopic<Integer, String> inputTopic = driver.createInputTopic(topicName, new IntegerSerializer(), new StringSerializer());
+            for (final int expectedKey : expectedKeys) {
+                inputTopic.pipeInput(expectedKey, "V" + expectedKey);
+            }
+        }
+
+        final List<MockProcessor<Integer, String>> processors = supplier.capturedProcessors(3);
+        assertEquals(1, processors.get(0).processed().size());
+        assertEquals(1, processors.get(1).processed().size());
+        assertEquals(4, processors.get(2).processed().size());
     }
 
     @SuppressWarnings({"unchecked", "deprecation"})


### PR DESCRIPTION
After this commit Predicate interface will be aligned as much as possible with the java.util.function.Predicate.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
