### PR TITLE
MINOR: update getMagic java doc

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -934,7 +934,7 @@ class GroupMetadataManager(brokerId: Int,
   }
 
   /**
-   * Check if the replica is local and return the message format version and timestamp
+   * Check if the replica is local and return the message format version
    *
    * @param   partition  Partition of GroupMetadataTopic
    * @return  Some(MessageFormatVersion) if replica is local, None otherwise


### PR DESCRIPTION
Saw this java doc error while tracing codes. We forgot to update it while updating the method before: https://github.com/apache/kafka/pull/2657/files#diff-d3539714f9c04947365bf02a4dac4183aaba88e70d83b455bcb80207339ddb96R665

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
