### PR TITLE
KAFKA-12548; Propagate record error messages to application

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -527,7 +527,12 @@ public class MockProducer<K, V> implements Producer<K, V> {
         }
 
         public void complete(RuntimeException e) {
-            result.set(e == null ? offset : -1L, RecordBatch.NO_TIMESTAMP, e);
+            if (e == null) {
+                result.set(offset, RecordBatch.NO_TIMESTAMP, null);
+            } else {
+                result.set(-1, RecordBatch.NO_TIMESTAMP, index -> e);
+            }
+
             if (callback != null) {
                 if (e == null)
                     callback.onCompletion(metadata, null);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -274,13 +274,14 @@ public final class ProducerBatch {
         for (int i = 0; i < thunks.size(); i++) {
             try {
                 Thunk thunk = thunks.get(i);
-                if (recordExceptions == null) {
-                    RecordMetadata metadata = thunk.future.value();
-                    if (thunk.callback != null)
+                if (thunk.callback != null) {
+                    if (recordExceptions == null) {
+                        RecordMetadata metadata = thunk.future.value();
                         thunk.callback.onCompletion(metadata, null);
-                } else if (thunk.callback != null) {
-                    RuntimeException exception = recordExceptions.apply(i);
-                    thunk.callback.onCompletion(null, exception);
+                    } else {
+                        RuntimeException exception = recordExceptions.apply(i);
+                        thunk.callback.onCompletion(null, exception);
+                    }
                 }
             } catch (Exception e) {
                 log.error("Error executing user-provided callback on message for topic-partition '{}'", topicPartition, e);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.clients.producer.internals;
 
 import org.apache.kafka.clients.producer.Callback;
-import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
@@ -32,6 +31,7 @@ import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.utils.ProducerIdAndEpoch;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +42,10 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
 import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
@@ -156,14 +158,43 @@ public final class ProducerBatch {
             throw new IllegalStateException("Batch has already been completed in final state " + finalState.get());
 
         log.trace("Aborting batch for partition {}", topicPartition, exception);
-        completeFutureAndFireCallbacks(ProduceResponse.INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, exception);
+        completeFutureAndFireCallbacks(ProduceResponse.INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, index -> exception);
     }
 
     /**
-     * Return `true` if {@link #done(long, long, RuntimeException)} has been invoked at least once, `false` otherwise.
+     * Check if the batch has been completed (either successfully or exceptionally).
+     * @return `true` if the batch has been completed, `false` otherwise.
      */
     public boolean isDone() {
         return finalState() != null;
+    }
+
+    /**
+     * Complete the batch successfully.
+     * @param baseOffset The base offset of the messages assigned by the server
+     * @param logAppendTime The log append time or -1 if CreateTime is being used
+     * @return true if the batch was completed as a result of this call, and false
+     *   if it had been completed previously
+     */
+    public boolean complete(long baseOffset, long logAppendTime) {
+        return done(baseOffset, logAppendTime, null, null);
+    }
+
+    /**
+     * Complete the batch exceptionally. The provided top-level exception will be used
+     * for each record future contained in the batch.
+     *
+     * @param topLevelException top-level partition error
+     * @param recordExceptionMap Record exception map keyed by batchIndex which overrides `topLevelException`
+     *                           for records present in the map
+     * @return true if the batch was completed as a result of this call, and false
+     *   if it had been completed previously
+     */
+    public boolean completeExceptionally(
+        RuntimeException topLevelException,
+        Map<Integer, RuntimeException> recordExceptionMap
+    ) {
+        return done(ProduceResponse.INVALID_OFFSET, RecordBatch.NO_TIMESTAMP, topLevelException, recordExceptionMap);
     }
 
     /**
@@ -181,20 +212,36 @@ public final class ProducerBatch {
      *
      * @param baseOffset The base offset of the messages assigned by the server
      * @param logAppendTime The log append time or -1 if CreateTime is being used
-     * @param exception The exception that occurred (or null if the request was successful)
+     * @param topLevelException The exception that occurred (or null if the request was successful)
+     * @param recordExceptionMap Record exception map keyed by batchIndex which overrides `topLevelException`
+     *                           for records present in the map
      * @return true if the batch was completed successfully and false if the batch was previously aborted
      */
-    public boolean done(long baseOffset, long logAppendTime, RuntimeException exception) {
-        final FinalState tryFinalState = (exception == null) ? FinalState.SUCCEEDED : FinalState.FAILED;
-
+    private boolean done(
+        long baseOffset,
+        long logAppendTime,
+        RuntimeException topLevelException,
+        Map<Integer, RuntimeException> recordExceptionMap
+    ) {
+        final FinalState tryFinalState = (topLevelException == null) ? FinalState.SUCCEEDED : FinalState.FAILED;
         if (tryFinalState == FinalState.SUCCEEDED) {
             log.trace("Successfully produced messages to {} with base offset {}.", topicPartition, baseOffset);
         } else {
-            log.trace("Failed to produce messages to {} with base offset {}.", topicPartition, baseOffset, exception);
+            log.trace("Failed to produce messages to {} with base offset {}.", topicPartition, baseOffset, topLevelException);
         }
 
         if (this.finalState.compareAndSet(null, tryFinalState)) {
-            completeFutureAndFireCallbacks(baseOffset, logAppendTime, exception);
+            Function<Integer, RuntimeException> recordExceptions = null;
+            if (topLevelException != null) {
+                recordExceptions = batchIndex -> {
+                    if (recordExceptionMap == null) {
+                        return topLevelException;
+                    } else {
+                        return recordExceptionMap.getOrDefault(batchIndex, topLevelException);
+                    }
+                };
+            }
+            completeFutureAndFireCallbacks(baseOffset, logAppendTime, recordExceptions);
             return true;
         }
 
@@ -215,20 +262,25 @@ public final class ProducerBatch {
         return false;
     }
 
-    private void completeFutureAndFireCallbacks(long baseOffset, long logAppendTime, RuntimeException exception) {
+    private void completeFutureAndFireCallbacks(
+        long baseOffset,
+        long logAppendTime,
+        Function<Integer, RuntimeException> recordExceptions
+    ) {
         // Set the future before invoking the callbacks as we rely on its state for the `onCompletion` call
-        produceFuture.set(baseOffset, logAppendTime, exception);
+        produceFuture.set(baseOffset, logAppendTime, recordExceptions);
 
         // execute callbacks
-        for (Thunk thunk : thunks) {
+        for (int i = 0; i < thunks.size(); i++) {
             try {
-                if (exception == null) {
+                Thunk thunk = thunks.get(i);
+                if (recordExceptions == null) {
                     RecordMetadata metadata = thunk.future.value();
                     if (thunk.callback != null)
                         thunk.callback.onCompletion(metadata, null);
-                } else {
-                    if (thunk.callback != null)
-                        thunk.callback.onCompletion(null, exception);
+                } else if (thunk.callback != null) {
+                    RuntimeException exception = recordExceptions.apply(i);
+                    thunk.callback.onCompletion(null, exception);
                 }
             } catch (Exception e) {
                 log.error("Error executing user-provided callback on message for topic-partition '{}'", topicPartition, e);
@@ -280,7 +332,7 @@ public final class ProducerBatch {
             batch.closeForRecordAppends();
         }
 
-        produceFuture.set(ProduceResponse.INVALID_OFFSET, NO_TIMESTAMP, new RecordBatchTooLargeException());
+        produceFuture.set(ProduceResponse.INVALID_OFFSET, NO_TIMESTAMP, index -> new RecordBatchTooLargeException());
         produceFuture.done();
 
         if (hasSequence()) {
@@ -420,8 +472,8 @@ public final class ProducerBatch {
      * Abort the record builder and reset the state of the underlying buffer. This is used prior to aborting
      * the batch with {@link #abort(RuntimeException)} and ensures that no record previously appended can be
      * read. This is used in scenarios where we want to ensure a batch ultimately gets aborted, but in which
-     * it is not safe to invoke the completion callbacks (e.g. because we are holding a lock,
-     * {@link RecordAccumulator#abortBatches()}).
+     * it is not safe to invoke the completion callbacks (e.g. because we are holding a lock, such as
+     * when aborting batches in {@link RecordAccumulator}).
      */
     public void abortRecordAppends() {
         recordsBuilder.abort();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -717,7 +717,13 @@ public class Sender implements Runnable {
                     errorMessage = response.error.message();
                 }
 
-                recordErrorMap.put(recordError.batchIndex, new InvalidRecordException(errorMessage));
+                // If the batch contained only a single record error, then we can unambiguously
+                // use the exception type corresponding to the partition-level error code.
+                if (response.recordErrors.size() == 1) {
+                    recordErrorMap.put(recordError.batchIndex, response.error.exception(errorMessage));
+                } else {
+                    recordErrorMap.put(recordError.batchIndex, new InvalidRecordException(errorMessage));
+                }
             }
 
             Function<Integer, RuntimeException> recordExceptions = batchIndex -> {

--- a/clients/src/main/resources/common/message/ProduceRequest.json
+++ b/clients/src/main/resources/common/message/ProduceRequest.json
@@ -41,7 +41,7 @@
     { "name": "Acks", "type": "int16", "versions": "0+",
       "about": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for only the leader and -1 for the full ISR." },
     { "name": "TimeoutMs", "type": "int32", "versions": "0+",
-      "about": "The timeout to await a response in miliseconds." },
+      "about": "The timeout to await a response in milliseconds." },
     { "name": "TopicData", "type": "[]TopicProduceData", "versions": "0+",
       "about": "Each topic to produce to.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName", "mapKey": true,

--- a/clients/src/main/resources/common/message/ProduceResponse.json
+++ b/clients/src/main/resources/common/message/ProduceResponse.json
@@ -53,10 +53,10 @@
           "about": "The log start offset." },
         { "name": "RecordErrors", "type": "[]BatchIndexAndErrorMessage", "versions": "8+", "ignorable": true,
           "about": "The batch indices of records that caused the batch to be dropped", "fields": [
-          { "name":  "BatchIndex", "type": "int32", "versions":  "8+",
-            "about":  "The batch index of the record that cause the batch to be dropped" },
+          { "name": "BatchIndex", "type": "int32", "versions":  "8+",
+            "about": "The batch index of the record that cause the batch to be dropped" },
           { "name": "BatchIndexErrorMessage", "type": "string", "default": "null", "versions": "8+", "nullableVersions": "8+",
-            "about":  "The error message of the record that caused the batch to be dropped"}
+            "about": "The error message of the record that caused the batch to be dropped"}
         ]},
         { "name":  "ErrorMessage", "type": "string", "default": "null", "versions": "8+", "nullableVersions": "8+", "ignorable":  true,
           "about":  "The global error message summarizing the common root cause of the records that caused the batch to be dropped"}

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
@@ -39,7 +39,7 @@ public class RecordSendTest {
 
     private final TopicPartition topicPartition = new TopicPartition("test", 0);
     private final long baseOffset = 45;
-    private final long relOffset = 5;
+    private final int relOffset = 5;
 
     /**
      * Test that waiting on a request that never completes times out
@@ -89,7 +89,12 @@ public class RecordSendTest {
             public void run() {
                 try {
                     sleep(timeout);
-                    request.set(baseOffset, RecordBatch.NO_TIMESTAMP, error);
+                    if (error == null) {
+                        request.set(baseOffset, RecordBatch.NO_TIMESTAMP, null);
+                    } else {
+                        request.set(-1L, RecordBatch.NO_TIMESTAMP, index -> error);
+                    }
+
                     request.done();
                 } catch (InterruptedException e) { }
             }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerBatchTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/ProducerBatchTest.java
@@ -29,11 +29,17 @@ import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V0;
@@ -43,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -50,7 +57,7 @@ public class ProducerBatchTest {
 
     private final long now = 1488748346917L;
 
-    private final MemoryRecordsBuilder memoryRecordsBuilder = MemoryRecords.builder(ByteBuffer.allocate(128),
+    private final MemoryRecordsBuilder memoryRecordsBuilder = MemoryRecords.builder(ByteBuffer.allocate(512),
             CompressionType.NONE, TimestampType.CREATE_TIME, 128);
 
     @Test
@@ -75,8 +82,8 @@ public class ProducerBatchTest {
         assertNull(callback.metadata);
 
         // subsequent completion should be ignored
-        assertFalse(batch.done(500L, 2342342341L, null));
-        assertFalse(batch.done(-1, -1, new KafkaException()));
+        assertFalse(batch.complete(500L, 2342342341L));
+        assertFalse(batch.completeExceptionally(new KafkaException(), Collections.emptyMap()));
         assertEquals(1, callback.invocations);
 
         assertTrue(future.isDone());
@@ -121,18 +128,11 @@ public class ProducerBatchTest {
         ProducerBatch batch = new ProducerBatch(new TopicPartition("topic", 1), memoryRecordsBuilder, now);
         MockCallback callback = new MockCallback();
         FutureRecordMetadata future = batch.tryAppend(now, null, new byte[10], Record.EMPTY_HEADERS, callback, now);
-        batch.done(500L, 10L, null);
+        batch.complete(500L, 10L);
         assertEquals(1, callback.invocations);
         assertNull(callback.exception);
         assertNotNull(callback.metadata);
-
-        try {
-            batch.done(1000L, 20L, null);
-            fail("Expected exception from done");
-        } catch (IllegalStateException e) {
-            // expected
-        }
-
+        assertThrows(IllegalStateException.class, () -> batch.complete(1000L, 20L));
         RecordMetadata recordMetadata = future.get();
         assertEquals(500L, recordMetadata.offset());
         assertEquals(10L, recordMetadata.timestamp());
@@ -264,6 +264,53 @@ public class ProducerBatchTest {
         memoryRecordsBuilder.closeForRecordAppends();
         assertFalse(memoryRecordsBuilder.hasRoomFor(now, null, new byte[10], Record.EMPTY_HEADERS));
         assertNull(batch.tryAppend(now + 1, null, new byte[10], Record.EMPTY_HEADERS, null, now + 1));
+    }
+
+    @Test
+    public void testCompleteExceptionallyWithRecordErrors() {
+        int recordCount = 5;
+        RuntimeException topLevelException = new RuntimeException();
+        Map<Integer, RuntimeException> recordExceptions = new HashMap<>();
+        recordExceptions.put(0, new RuntimeException());
+        recordExceptions.put(3, new RuntimeException());
+        testCompleteExceptionally(recordCount, topLevelException, recordExceptions);
+    }
+
+    @Test
+    public void testCompleteExceptionallyWithNullRecordErrors() {
+        int recordCount = 5;
+        RuntimeException topLevelException = new RuntimeException();
+        testCompleteExceptionally(recordCount, topLevelException, null);
+    }
+
+    private void testCompleteExceptionally(
+        int recordCount,
+        RuntimeException topLevelException,
+        Map<Integer, RuntimeException> recordExceptions
+    ) {
+        ProducerBatch batch = new ProducerBatch(
+            new TopicPartition("topic", 1),
+            memoryRecordsBuilder,
+            now
+        );
+
+        List<FutureRecordMetadata> futures = new ArrayList<>(recordCount);
+        for (int i = 0; i < recordCount; i++) {
+            futures.add(batch.tryAppend(now, null, new byte[10], Record.EMPTY_HEADERS, null, now));
+        }
+        assertEquals(recordCount, batch.recordCount);
+
+        batch.completeExceptionally(topLevelException, recordExceptions);
+        assertTrue(batch.isDone());
+
+        for (int i = 0; i < futures.size(); i++) {
+            FutureRecordMetadata future = futures.get(i);
+            RuntimeException caughtException = TestUtils.assertFutureThrows(future, RuntimeException.class);
+            RuntimeException expectedException = recordExceptions == null ?
+                topLevelException :
+                recordExceptions.getOrDefault(i, topLevelException);
+            assertEquals(expectedException, caughtException);
+        }
     }
 
     private static class MockCallback implements Callback {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -754,7 +754,7 @@ public class RecordAccumulatorTest {
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
         assertFalse(drained.isEmpty());
         assertFalse(drained.get(node1.id()).isEmpty());
-        drained.get(node1.id()).get(0).done(acked.get(), 100L, null);
+        drained.get(node1.id()).get(0).complete(acked.get(), 100L);
         assertEquals(1, acked.get(), "The first message should have been acked.");
         assertTrue(future1.isDone());
         assertEquals(0, future1.get().offset());
@@ -762,7 +762,7 @@ public class RecordAccumulatorTest {
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
         assertFalse(drained.isEmpty());
         assertFalse(drained.get(node1.id()).isEmpty());
-        drained.get(node1.id()).get(0).done(acked.get(), 100L, null);
+        drained.get(node1.id()).get(0).complete(acked.get(), 100L);
         assertEquals(2, acked.get(), "Both message should have been acked.");
         assertTrue(future2.isDone());
         assertEquals(1, future2.get().offset());
@@ -1010,7 +1010,7 @@ public class RecordAccumulatorTest {
                         // release the resource of the original big batch.
                         numSplit++;
                     } else {
-                        batch.done(0L, 0L, null);
+                        batch.complete(0L, 0L);
                     }
                     accum.deallocate(batch);
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -2472,7 +2472,8 @@ public class SenderTest {
 
         OffsetAndError offsetAndError = new OffsetAndError(-1L, Errors.INVALID_RECORD, Arrays.asList(
             new BatchIndexAndErrorMessage().setBatchIndex(0).setBatchIndexErrorMessage("0"),
-            new BatchIndexAndErrorMessage().setBatchIndex(2).setBatchIndexErrorMessage("2")
+            new BatchIndexAndErrorMessage().setBatchIndex(2).setBatchIndexErrorMessage("2"),
+            new BatchIndexAndErrorMessage().setBatchIndex(3)
         ));
 
         client.respond(produceResponse(Collections.singletonMap(tp0, offsetAndError)));
@@ -2482,12 +2483,16 @@ public class SenderTest {
             FutureRecordMetadata future = futureEntry.getValue();
             assertTrue(future.isDone());
 
-            InvalidRecordException exception = TestUtils.assertFutureThrows(future, InvalidRecordException.class);
+            KafkaException exception = TestUtils.assertFutureThrows(future, KafkaException.class);
             Integer index = futureEntry.getKey();
             if (index == 0 || index == 2) {
+                assertTrue(exception instanceof InvalidRecordException);
                 assertEquals(index.toString(), exception.getMessage());
-            } else {
+            } else if (index == 3) {
+                assertTrue(exception instanceof InvalidRecordException);
                 assertEquals(Errors.INVALID_RECORD.message(), exception.getMessage());
+            } else {
+                assertEquals(KafkaException.class, exception.getClass());
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
@@ -45,6 +46,8 @@ import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.EndTxnResponseData;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.ProduceResponseData.BatchIndexAndErrorMessage;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -87,6 +90,7 @@ import org.junit.jupiter.api.Timeout;
 import org.mockito.InOrder;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
@@ -2452,6 +2456,43 @@ public class SenderTest {
     }
 
     @Test
+    public void testRecordErrorPropagatedToApplication() throws InterruptedException {
+        int recordCount = 5;
+
+        setup();
+
+        Map<Integer, FutureRecordMetadata> futures = new HashMap<>(recordCount);
+        for (int i = 0; i < recordCount; i++) {
+            futures.put(i, appendToAccumulator(tp0));
+        }
+
+        sender.runOnce();  // send request
+        assertEquals(1, client.inFlightRequestCount());
+        assertEquals(1, sender.inFlightBatches(tp0).size());
+
+        OffsetAndError offsetAndError = new OffsetAndError(-1L, Errors.INVALID_RECORD, Arrays.asList(
+            new BatchIndexAndErrorMessage().setBatchIndex(0).setBatchIndexErrorMessage("0"),
+            new BatchIndexAndErrorMessage().setBatchIndex(2).setBatchIndexErrorMessage("2")
+        ));
+
+        client.respond(produceResponse(Collections.singletonMap(tp0, offsetAndError)));
+        sender.runOnce();
+
+        for (Map.Entry<Integer, FutureRecordMetadata> futureEntry : futures.entrySet()) {
+            FutureRecordMetadata future = futureEntry.getValue();
+            assertTrue(future.isDone());
+
+            InvalidRecordException exception = TestUtils.assertFutureThrows(future, InvalidRecordException.class);
+            Integer index = futureEntry.getKey();
+            if (index == 0 || index == 2) {
+                assertEquals(index.toString(), exception.getMessage());
+            } else {
+                assertEquals(Errors.INVALID_RECORD.message(), exception.getMessage());
+            }
+        }
+    }
+
+    @Test
     public void testWhenFirstBatchExpireNoSendSecondBatchIfGuaranteeOrder() throws InterruptedException {
         long deliveryTimeoutMs = 1500L;
         setupWithTransactionState(null, true, null);
@@ -2868,13 +2909,25 @@ public class SenderTest {
         };
     }
 
-    class OffsetAndError {
-        long offset;
-        Errors error;
-        OffsetAndError(long offset, Errors error) {
+    private static class OffsetAndError {
+        final long offset;
+        final Errors error;
+        final List<BatchIndexAndErrorMessage> recordErrors;
+
+        OffsetAndError(
+            long offset,
+            Errors error,
+            List<BatchIndexAndErrorMessage> recordErrors
+        ) {
             this.offset = offset;
             this.error = error;
+            this.recordErrors = recordErrors;
         }
+
+        OffsetAndError(long offset, Errors error) {
+            this(offset, error, Collections.emptyList());
+        }
+
     }
 
     private FutureRecordMetadata appendToAccumulator(TopicPartition tp) throws InterruptedException {
@@ -2894,16 +2947,29 @@ public class SenderTest {
         return new ProduceResponse(partResp, throttleTimeMs);
     }
 
-    @SuppressWarnings("deprecation")
     private ProduceResponse produceResponse(Map<TopicPartition, OffsetAndError> responses) {
-        Map<TopicPartition, ProduceResponse.PartitionResponse> partResponses = new LinkedHashMap<>();
-        for (Map.Entry<TopicPartition, OffsetAndError> entry : responses.entrySet()) {
-            ProduceResponse.PartitionResponse response = new ProduceResponse.PartitionResponse(entry.getValue().error,
-                    entry.getValue().offset, RecordBatch.NO_TIMESTAMP, -1);
-            partResponses.put(entry.getKey(), response);
-        }
-        return new ProduceResponse(partResponses);
+        ProduceResponseData data = new ProduceResponseData();
 
+        for (Map.Entry<TopicPartition, OffsetAndError> entry : responses.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            ProduceResponseData.TopicProduceResponse topicData = data.responses().find(topicPartition.topic());
+            if (topicData == null) {
+                topicData = new ProduceResponseData.TopicProduceResponse().setName(topicPartition.topic());
+                data.responses().add(topicData);
+            }
+
+            OffsetAndError offsetAndError = entry.getValue();
+            ProduceResponseData.PartitionProduceResponse partitionData =
+                new ProduceResponseData.PartitionProduceResponse()
+                    .setIndex(topicPartition.partition())
+                    .setBaseOffset(offsetAndError.offset)
+                    .setErrorCode(offsetAndError.error.code())
+                    .setRecordErrors(offsetAndError.recordErrors);
+
+            topicData.partitionResponses().add(partitionData);
+        }
+
+        return new ProduceResponse(data);
     }
     private ProduceResponse produceResponse(TopicPartition tp, long offset, Errors error, int throttleTimeMs) {
         return produceResponse(tp, offset, error, throttleTimeMs, -1L, null);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -595,7 +595,7 @@ public class TransactionManagerTest {
         long b1AppendTime = time.milliseconds();
         ProduceResponse.PartitionResponse b1Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        b1.done(500L, b1AppendTime, null);
+        b1.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(b1, b1Response);
 
         // We get an UNKNOWN_PRODUCER_ID, so bump the epoch and set sequence numbers back to 0
@@ -3084,12 +3084,12 @@ public class TransactionManagerTest {
         long b1AppendTime = time.milliseconds();
         ProduceResponse.PartitionResponse t0b1Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp0b1.done(500L, b1AppendTime, null);
+        tp0b1.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp0b1, t0b1Response);
 
         ProduceResponse.PartitionResponse t1b1Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp1b1.done(500L, b1AppendTime, null);
+        tp1b1.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b1, t1b1Response);
 
         // We bump the epoch and set sequence numbers back to 0
@@ -3134,7 +3134,7 @@ public class TransactionManagerTest {
         // After successfully retrying, there should be no in-flight batches for tp1 and the sequence should be 0
         t1b2Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp1b2.done(500L, b1AppendTime, null);
+        tp1b2.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b2, t1b2Response);
 
         transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
@@ -3149,7 +3149,7 @@ public class TransactionManagerTest {
 
         ProduceResponse.PartitionResponse t1b3Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp1b3.done(500L, b1AppendTime, null);
+        tp1b3.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b3, t1b3Response);
 
         transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
@@ -3208,12 +3208,12 @@ public class TransactionManagerTest {
         long b1AppendTime = time.milliseconds();
         ProduceResponse.PartitionResponse t0b1Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp0b1.done(500L, b1AppendTime, null);
+        tp0b1.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp0b1, t0b1Response);
 
         ProduceResponse.PartitionResponse t1b1Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp1b1.done(500L, b1AppendTime, null);
+        tp1b1.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b1, t1b1Response);
 
         // We bump the epoch and set sequence numbers back to 0
@@ -3258,7 +3258,7 @@ public class TransactionManagerTest {
         // After successfully retrying, there should be no in-flight batches for tp1 and the sequence should be 0
         t1b2Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp1b2.done(500L, b1AppendTime, null);
+        tp1b2.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b2, t1b2Response);
 
         transactionManager.maybeUpdateProducerIdAndEpoch(tp1);
@@ -3273,7 +3273,7 @@ public class TransactionManagerTest {
 
         ProduceResponse.PartitionResponse t1b3Response = new ProduceResponse.PartitionResponse(
                 Errors.NONE, 500L, b1AppendTime, 0L);
-        tp1b3.done(500L, b1AppendTime, null);
+        tp1b3.complete(500L, b1AppendTime);
         transactionManager.handleCompletedBatch(tp1b3, t1b3Response);
 
         assertFalse(transactionManager.hasInflightBatches(tp1));

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -100,7 +100,6 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
       val e = assertThrows(classOf[ExecutionException],
         () => producer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()).getCause
       assertTrue(e.isInstanceOf[InvalidTimestampException])
-      assertEquals("One or more records have been rejected due to invalid timestamp", e.getMessage)
     } finally {
       producer.close()
     }
@@ -111,7 +110,6 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
       val e = assertThrows(classOf[ExecutionException],
         () => compressedProducer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()).getCause
       assertTrue(e.isInstanceOf[InvalidTimestampException])
-      assertEquals("One or more records have been rejected due to invalid timestamp", e.getMessage)
     } finally {
       compressedProducer.close()
     }


### PR DESCRIPTION
KIP-467 added a field in the produce response to allow the broker to indicate which specific records failed validation. This patch adds the logic to propagate this message up to the application.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
