### PR TITLE
KAFKA-12583: Upgrade netty to 4.1.62.Final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -100,7 +100,7 @@ versions += [
   mavenArtifact: "3.6.3",
   metrics: "2.2.0",
   mockito: "3.6.0",
-  netty: "4.1.59.Final",
+  netty: "4.1.62.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
   rocksDB: "5.18.4",


### PR DESCRIPTION
[This security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-21295) was found in netty-codec-http2, but caused by netty itself and [fixed in 4.1.60.Final](https://github.com/netty/netty/security/advisories/GHSA-wm47-8v5p-wjpj). So, upgrade the netty version from 4.1.59.Final to 4.1.62.Final.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
