### PR TITLE
MINOR: Rename LogUtils class in tests to LogTestUtils

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -43,7 +43,7 @@ class LogSegmentTest {
   def createSegment(offset: Long,
                     indexIntervalBytes: Int = 10,
                     time: Time = Time.SYSTEM): LogSegment = {
-    val seg = LogUtils.createSegment(offset, logDir, indexIntervalBytes, time)
+    val seg = LogTestUtils.createSegment(offset, logDir, indexIntervalBytes, time)
     segments += seg
     seg
   }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
@@ -32,7 +32,7 @@ class LogSegmentsTest {
   private def createSegment(offset: Long,
                     indexIntervalBytes: Int = 10,
                     time: Time = Time.SYSTEM): LogSegment = {
-    LogUtils.createSegment(offset, logDir, indexIntervalBytes, time)
+    LogTestUtils.createSegment(offset, logDir, indexIntervalBytes, time)
   }
 
   private def assertEntry(segment: LogSegment, tested: java.util.Map.Entry[java.lang.Long, LogSegment]): Unit = {

--- a/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTestUtils.scala
@@ -22,7 +22,7 @@ import java.io.File
 import org.apache.kafka.common.record.FileRecords
 import org.apache.kafka.common.utils.Time
 
-object LogUtils {
+object LogTestUtils {
   /**
     *  Create a segment with the given base offset
     */


### PR DESCRIPTION
This PR is a precursor to the recovery logic refactor work (KAFKA-12553).

I've renamed the file: `core/src/test/scala/unit/kafka/log/LogUtils.scala` to `core/src/test/scala/unit/kafka/log/LogTestUtils.scala`. Also I've renamed the underlying lass from `LogUtils` to `LogTestUtils`. This is going to help avoid a naming conflict with a new file called `LogUtils.scala` that I plan to introduce in `core/src/main/scala/kafka/log/` as part of the recovery logic refactor. The new file will also contain a bunch of static functions.

**Tests:**
Relying on existing tests to catch regressions (if any) since this is a simple change.