### PR TITLE
MINOR: Support ExponentialBackoff without jitter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/ExponentialBackoff.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ExponentialBackoff.java
@@ -47,7 +47,8 @@ public class ExponentialBackoff {
         }
         double exp = Math.min(attempts, this.expMax);
         double term = initialInterval * Math.pow(multiplier, exp);
-        double randomFactor = ThreadLocalRandom.current().nextDouble(1 - jitter, 1 + jitter);
+        double randomFactor = jitter < Double.MIN_NORMAL ? 1.0 :
+            ThreadLocalRandom.current().nextDouble(1 - jitter, 1 + jitter);
         return (long) (randomFactor * term);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ExponentialBackoffTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ExponentialBackoffTest.java
@@ -45,4 +45,13 @@ public class ExponentialBackoffTest {
             }
         }
     }
+
+    @Test
+    public void testExponentialBackoffWithoutJitter() {
+        ExponentialBackoff exponentialBackoff = new ExponentialBackoff(100, 2, 400, 0.0);
+        assertEquals(100, exponentialBackoff.backoff(0));
+        assertEquals(200, exponentialBackoff.backoff(1));
+        assertEquals(400, exponentialBackoff.backoff(2));
+        assertEquals(400, exponentialBackoff.backoff(3));
+    }
 }


### PR DESCRIPTION
It is useful to allow ExponentialBackoff to be configured to work
without jitter, in order to make unit tests more repeatable.