### PR TITLE
KAFKA-10357: Use validate and setup during internal topics creation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/MisconfiguredInternalTopicException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/MisconfiguredInternalTopicException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.errors;
+
+public class MisconfiguredInternalTopicException extends StreamsException {
+
+    private final static long serialVersionUID = 1L;
+
+    public MisconfiguredInternalTopicException(final String message) {
+        super(message);
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogTopics.java
@@ -18,14 +18,20 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.errors.MisconfiguredInternalTopicException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopicManager.ValidationResult;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
 import org.slf4j.Logger;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -34,13 +40,13 @@ import static org.apache.kafka.streams.processor.internals.assignment.StreamsAss
 public class ChangelogTopics {
 
     private final InternalTopicManager internalTopicManager;
-    private final Map<Integer, TopicsInfo> topicGroups;
-    private final Map<Integer, Set<TaskId>> tasksForTopicGroup;
+    private final ValidationResult validationResult;
+    private final Map<String, InternalTopicConfig> changelogTopicConfigs;
     private final Map<TaskId, Set<TopicPartition>> changelogPartitionsForStatefulTask = new HashMap<>();
     private final Map<TaskId, Set<TopicPartition>> preExistingChangelogPartitionsForTask = new HashMap<>();
     private final Set<TopicPartition> preExistingNonSourceTopicBasedChangelogPartitions = new HashSet<>();
     private final Set<String> sourceTopicBasedChangelogTopics = new HashSet<>();
-    private final Set<TopicPartition> preExsitingSourceTopicBasedChangelogPartitions = new HashSet<>();
+    private final Set<TopicPartition> preExistingSourceTopicBasedChangelogPartitions = new HashSet<>();
     private final Logger log;
 
     public ChangelogTopics(final InternalTopicManager internalTopicManager,
@@ -48,67 +54,48 @@ public class ChangelogTopics {
                            final Map<Integer, Set<TaskId>> tasksForTopicGroup,
                            final String logPrefix) {
         this.internalTopicManager = internalTopicManager;
-        this.topicGroups = topicGroups;
-        this.tasksForTopicGroup = tasksForTopicGroup;
         final LogContext logContext = new LogContext(logPrefix);
         log = logContext.logger(getClass());
+        changelogTopicConfigs = computeChangelogTopicConfig(topicGroups, tasksForTopicGroup);
+        validationResult = internalTopicManager.validate(changelogTopicConfigs);
     }
 
     public void setup() {
-        // add tasks to state change log topic subscribers
-        final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
-        for (final Map.Entry<Integer, TopicsInfo> entry : topicGroups.entrySet()) {
-            final int topicGroupId = entry.getKey();
-            final TopicsInfo topicsInfo = entry.getValue();
-
-            final Set<TaskId> topicGroupTasks = tasksForTopicGroup.get(topicGroupId);
-            if (topicGroupTasks == null) {
-                log.debug("No tasks found for topic group {}", topicGroupId);
-                continue;
-            } else if (topicsInfo.stateChangelogTopics.isEmpty()) {
-                continue;
-            }
-
-            for (final TaskId task : topicGroupTasks) {
-                final Set<TopicPartition> changelogTopicPartitions = topicsInfo.stateChangelogTopics
-                    .keySet()
-                    .stream()
-                    .map(topic -> new TopicPartition(topic, task.partition))
-                    .collect(Collectors.toSet());
-                changelogPartitionsForStatefulTask.put(task, changelogTopicPartitions);
-            }
-
-            for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
-                // the expected number of partitions is the max value of TaskId.partition + 1
-                int numPartitions = UNKNOWN;
-                for (final TaskId task : topicGroupTasks) {
-                    if (numPartitions < task.partition + 1) {
-                        numPartitions = task.partition + 1;
-                    }
-                }
-                topicConfig.setNumberOfPartitions(numPartitions);
-                changelogTopicMetadata.put(topicConfig.name(), topicConfig);
-            }
-            sourceTopicBasedChangelogTopics.addAll(topicsInfo.sourceTopicChangelogs());
+        if (!validationResult.misconfigurationsForTopics().isEmpty()) {
+            throw new MisconfiguredInternalTopicException(Utils.join(misconfigured().values().stream()
+                .flatMap(Collection::stream).collect(Collectors.toList()), Utils.NL)
+            );
         }
 
-        final Set<String> newlyCreatedChangelogTopics = internalTopicManager.makeReady(changelogTopicMetadata);
-        log.debug("Created state changelog topics {} from the parsed topology.", changelogTopicMetadata.values());
+        final Set<String> missingTopics = validationResult.missingTopics();
+        final Map<String, InternalTopicConfig> changelogsToCreate = changelogTopicConfigs.entrySet().stream()
+            .filter(entry -> missingTopics.contains(entry.getKey()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        internalTopicManager.setup(changelogsToCreate);
+        log.info("Created state changelog topics {} from the parsed topology.", changelogsToCreate.values());
 
         for (final Map.Entry<TaskId, Set<TopicPartition>> entry : changelogPartitionsForStatefulTask.entrySet()) {
             final TaskId taskId = entry.getKey();
             final Set<TopicPartition> topicPartitions = entry.getValue();
             for (final TopicPartition topicPartition : topicPartitions) {
-                if (!newlyCreatedChangelogTopics.contains(topicPartition.topic())) {
+                if (!missingTopics.contains(topicPartition.topic())) {
                     preExistingChangelogPartitionsForTask.computeIfAbsent(taskId, task -> new HashSet<>()).add(topicPartition);
                     if (!sourceTopicBasedChangelogTopics.contains(topicPartition.topic())) {
                         preExistingNonSourceTopicBasedChangelogPartitions.add(topicPartition);
                     } else {
-                        preExsitingSourceTopicBasedChangelogPartitions.add(topicPartition);
+                        preExistingSourceTopicBasedChangelogPartitions.add(topicPartition);
                     }
                 }
             }
         }
+    }
+
+    public Set<String> missing() {
+        return validationResult.missingTopics();
+    }
+
+    public Map<String, List<String>> misconfigured() {
+        return validationResult.misconfigurationsForTopics();
     }
 
     public Set<TopicPartition> preExistingNonSourceTopicBasedPartitions() {
@@ -123,10 +110,48 @@ public class ChangelogTopics {
     }
 
     public Set<TopicPartition> preExistingSourceTopicBasedPartitions() {
-        return Collections.unmodifiableSet(preExsitingSourceTopicBasedChangelogPartitions);
+        return Collections.unmodifiableSet(preExistingSourceTopicBasedChangelogPartitions);
     }
 
     public Set<TaskId> statefulTaskIds() {
         return Collections.unmodifiableSet(changelogPartitionsForStatefulTask.keySet());
+    }
+
+    private Map<String, InternalTopicConfig> computeChangelogTopicConfig(final Map<Integer, TopicsInfo> topicGroups,
+                                                                         final Map<Integer, Set<TaskId>> tasksForTopicGroup) {
+        final Map<String, InternalTopicConfig> changelogTopicMetadata = new HashMap<>();
+        for (final Map.Entry<Integer, TopicsInfo> entry : topicGroups.entrySet()) {
+            final int topicGroupId = entry.getKey();
+            final TopicsInfo topicsInfo = entry.getValue();
+
+            final Set<TaskId> topicGroupTasks = tasksForTopicGroup.get(topicGroupId);
+            if (topicGroupTasks == null) {
+                log.debug("No tasks found for topic group {}", topicGroupId);
+                continue;
+            } else if (topicsInfo.stateChangelogTopics.isEmpty()) {
+                continue;
+            }
+            for (final TaskId task : topicGroupTasks) {
+                final Set<TopicPartition> changelogTopicPartitions = topicsInfo.stateChangelogTopics
+                    .keySet()
+                    .stream()
+                    .map(topic -> new TopicPartition(topic, task.partition))
+                    .collect(Collectors.toSet());
+                changelogPartitionsForStatefulTask.put(task, changelogTopicPartitions);
+            }
+            for (final InternalTopicConfig topicConfig : topicsInfo.nonSourceChangelogTopics()) {
+                // the expected number of partitions is the max value of TaskId.partition + 1
+                int numPartitions = UNKNOWN;
+                for (final TaskId task : topicGroupTasks) {
+                    if (numPartitions < task.partition + 1) {
+                        numPartitions = task.partition + 1;
+                    }
+                }
+                topicConfig.setNumberOfPartitions(numPartitions);
+                changelogTopicMetadata.put(topicConfig.name(), topicConfig);
+            }
+            sourceTopicBasedChangelogTopics.addAll(topicsInfo.sourceTopicChangelogs());
+        }
+        return changelogTopicMetadata;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/HighAvailabilityTaskAssignorIntegrationTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
@@ -51,6 +52,7 @@ import org.junit.rules.TestName;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -119,7 +121,16 @@ public class HighAvailabilityTaskAssignorIntegrationTest {
             new TopicPartition(storeChangelog, 1)
         );
 
-        IntegrationTestUtils.cleanStateBeforeTest(CLUSTER, 2, inputTopic, storeChangelog);
+        IntegrationTestUtils.cleanStateBeforeTest(
+            CLUSTER,
+            2,
+            mkMap(
+                mkEntry(inputTopic, Collections.emptyMap()),
+                mkEntry(storeChangelog, mkMap(
+                    mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT))
+                )
+            )
+        );
 
         final ReentrantLock assignmentLock = new ReentrantLock();
         final AtomicInteger assignmentsCompleted = new AtomicInteger(0);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
@@ -77,6 +78,8 @@ import org.junit.rules.TestName;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
 import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.startApplicationAndWaitUntilRunning;
@@ -206,7 +209,12 @@ public class RestoreIntegrationTest {
     @Test
     public void shouldRestoreStateFromChangelogTopic() throws Exception {
         final String changelog = appId + "-store-changelog";
-        CLUSTER.createTopic(changelog, 2, 1);
+        CLUSTER.createTopic(
+            changelog,
+            2,
+            1,
+            mkMap(mkEntry(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT))
+        );
 
         final AtomicInteger numReceived = new AtomicInteger(0);
         final StreamsBuilder builder = new StreamsBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -181,6 +181,19 @@ public class IntegrationTestUtils {
         }
     }
 
+    public static void cleanStateBeforeTest(final EmbeddedKafkaCluster cluster,
+                                            final int partitionCount,
+                                            final Map<String, Map<String, String>> topics) {
+        try {
+            cluster.deleteAllTopicsAndWait(DEFAULT_TIMEOUT);
+            for (final Map.Entry<String, Map<String, String>> topic : topics.entrySet()) {
+                cluster.createTopic(topic.getKey(), partitionCount, 1, topic.getValue());
+            }
+        } catch (final InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static void quietlyCleanStateAfterTest(final EmbeddedKafkaCluster cluster, final KafkaStreams driver) {
         try {
             driver.cleanUp();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -17,7 +17,9 @@
 package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.errors.MisconfiguredInternalTopicException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.InternalTopicManager.ValidationResult;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
 import org.junit.Test;
 
@@ -32,8 +34,10 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class ChangelogTopicsTest {
 
@@ -41,17 +45,21 @@ public class ChangelogTopicsTest {
     private static final String SINK_TOPIC_NAME = "sink";
     private static final String REPARTITION_TOPIC_NAME = "repartition";
     private static final String CHANGELOG_TOPIC_NAME1 = "changelog1";
-    private static final Map<String, String> TOPIC_CONFIG = Collections.singletonMap("config1", "val1");
+    private static final String CHANGELOG_TOPIC_NAME2 = "changelog2";
+    private static final Map<String, String> TOPIC_CONFIG1 = Collections.singletonMap("config1", "val1");
+    private static final Map<String, String> TOPIC_CONFIG2 = Collections.singletonMap("config2", "val2");
     private static final RepartitionTopicConfig REPARTITION_TOPIC_CONFIG =
-        new RepartitionTopicConfig(REPARTITION_TOPIC_NAME, TOPIC_CONFIG);
-    private static final UnwindowedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG =
-        new UnwindowedChangelogTopicConfig(CHANGELOG_TOPIC_NAME1, TOPIC_CONFIG);
+        new RepartitionTopicConfig(REPARTITION_TOPIC_NAME, TOPIC_CONFIG1);
+    private static final UnwindowedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG1 =
+        new UnwindowedChangelogTopicConfig(CHANGELOG_TOPIC_NAME1, TOPIC_CONFIG1);
+    private static final UnwindowedChangelogTopicConfig CHANGELOG_TOPIC_CONFIG2 =
+        new UnwindowedChangelogTopicConfig(CHANGELOG_TOPIC_NAME2, TOPIC_CONFIG2);
 
     private static final TopicsInfo TOPICS_INFO1 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
-        mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
+        mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1))
     );
     private static final TopicsInfo TOPICS_INFO2 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
@@ -63,13 +71,22 @@ public class ChangelogTopicsTest {
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
-        mkMap(mkEntry(SOURCE_TOPIC_NAME, CHANGELOG_TOPIC_CONFIG))
+        mkMap(mkEntry(SOURCE_TOPIC_NAME, CHANGELOG_TOPIC_CONFIG1))
     );
     private static final TopicsInfo TOPICS_INFO4 = new TopicsInfo(
         mkSet(SINK_TOPIC_NAME),
         mkSet(SOURCE_TOPIC_NAME),
         mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
-        mkMap(mkEntry(SOURCE_TOPIC_NAME, null), mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))
+        mkMap(mkEntry(SOURCE_TOPIC_NAME, null), mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1))
+    );
+    private static final TopicsInfo TOPICS_INFO5 = new TopicsInfo(
+        mkSet(SINK_TOPIC_NAME),
+        mkSet(SOURCE_TOPIC_NAME),
+        mkMap(mkEntry(REPARTITION_TOPIC_NAME, REPARTITION_TOPIC_CONFIG)),
+        mkMap(
+            mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1),
+            mkEntry(CHANGELOG_TOPIC_NAME2, CHANGELOG_TOPIC_CONFIG2)
+        )
     );
     private static final TaskId TASK_0_0 = new TaskId(0, 0);
     private static final TaskId TASK_0_1 = new TaskId(0, 1);
@@ -79,7 +96,10 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldNotContainChangelogsForStatelessTasks() {
-        expect(internalTopicManager.makeReady(Collections.emptyMap())).andStubReturn(Collections.emptySet());
+        final ValidationResult validationResult = new ValidationResult();
+        final Map<String, InternalTopicConfig> changelogsToValidateAndSetup = Collections.emptyMap();
+        expect(internalTopicManager.validate(changelogsToValidateAndSetup)).andReturn(validationResult);
+        internalTopicManager.setup(changelogsToValidateAndSetup);
         final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO2));
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
         replay(internalTopicManager);
@@ -98,8 +118,13 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldNotContainAnyPreExistingChangelogsIfChangelogIsNewlyCreated() {
-        expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
-            .andStubReturn(mkSet(CHANGELOG_TOPIC_NAME1));
+        final ValidationResult validationResult = new ValidationResult();
+        validationResult.addMissingTopic(CHANGELOG_TOPIC_NAME1);
+        final Map<String, InternalTopicConfig> changelogsToValidateAndSetup = mkMap(
+            mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1)
+        );
+        expect(internalTopicManager.validate(changelogsToValidateAndSetup)).andReturn(validationResult);
+        internalTopicManager.setup(changelogsToValidateAndSetup);
         final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO1));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
@@ -110,7 +135,7 @@ public class ChangelogTopicsTest {
         changelogTopics.setup();
 
         verify(internalTopicManager);
-        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertThat(CHANGELOG_TOPIC_CONFIG1.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(Collections.emptySet()));
         assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(Collections.emptySet()));
@@ -119,9 +144,51 @@ public class ChangelogTopicsTest {
     }
 
     @Test
+    public void shouldSetupOnlyMissingChangelogs() {
+        final ValidationResult validationResult = new ValidationResult();
+        validationResult.addMissingTopic(CHANGELOG_TOPIC_NAME1);
+        final Map<String, InternalTopicConfig> changelogsToValidate = mkMap(
+            mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1),
+            mkEntry(CHANGELOG_TOPIC_NAME2, CHANGELOG_TOPIC_CONFIG2)
+        );
+        final Map<String, InternalTopicConfig> changelogsToSetup = mkMap(
+            mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1)
+        );
+        expect(internalTopicManager.validate(changelogsToValidate)).andReturn(validationResult);
+        internalTopicManager.setup(changelogsToSetup);
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO5));
+        final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+                new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        changelogTopics.setup();
+
+        verify(internalTopicManager);
+        assertThat(CHANGELOG_TOPIC_CONFIG1.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertThat(CHANGELOG_TOPIC_CONFIG2.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        final TopicPartition changelogPartition10 = new TopicPartition(CHANGELOG_TOPIC_NAME2, 0);
+        final TopicPartition changelogPartition11 = new TopicPartition(CHANGELOG_TOPIC_NAME2, 1);
+        final TopicPartition changelogPartition12 = new TopicPartition(CHANGELOG_TOPIC_NAME2, 2);
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_0), is(mkSet(changelogPartition10)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_1), is(mkSet(changelogPartition11)));
+        assertThat(changelogTopics.preExistingPartitionsFor(TASK_0_2), is(mkSet(changelogPartition12)));
+        assertThat(changelogTopics.preExistingSourceTopicBasedPartitions(), is(Collections.emptySet()));
+        assertThat(
+            changelogTopics.preExistingNonSourceTopicBasedPartitions(),
+            is(mkSet(changelogPartition10, changelogPartition11, changelogPartition12))
+        );
+    }
+
+    @Test
     public void shouldOnlyContainPreExistingNonSourceBasedChangelogs() {
-        expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
-            .andStubReturn(Collections.emptySet());
+        final ValidationResult validationResult = new ValidationResult();
+        final Map<String, InternalTopicConfig> changelogsToValidate = mkMap(
+            mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1)
+        );
+        expect(internalTopicManager.validate(changelogsToValidate)).andReturn(validationResult);
+        internalTopicManager.setup(Collections.emptyMap());
         final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO1));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
@@ -132,7 +199,7 @@ public class ChangelogTopicsTest {
         changelogTopics.setup();
 
         verify(internalTopicManager);
-        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertThat(CHANGELOG_TOPIC_CONFIG1.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
         final TopicPartition changelogPartition0 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 0);
         final TopicPartition changelogPartition1 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 1);
         final TopicPartition changelogPartition2 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 2);
@@ -148,7 +215,10 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldOnlyContainPreExistingSourceBasedChangelogs() {
-        expect(internalTopicManager.makeReady(Collections.emptyMap())).andStubReturn(Collections.emptySet());
+        final ValidationResult validationResult = new ValidationResult();
+        final Map<String, InternalTopicConfig> changelogsToValidateAndSetup = Collections.emptyMap();
+        expect(internalTopicManager.validate(changelogsToValidateAndSetup)).andReturn(validationResult);
+        internalTopicManager.setup(changelogsToValidateAndSetup);
         final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO3));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
@@ -174,8 +244,12 @@ public class ChangelogTopicsTest {
 
     @Test
     public void shouldContainBothTypesOfPreExistingChangelogs() {
-        expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
-            .andStubReturn(Collections.emptySet());
+        final ValidationResult validationResult = new ValidationResult();
+        final Map<String, InternalTopicConfig> changelogsToValidate = mkMap(
+            mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1)
+        );
+        expect(internalTopicManager.validate(changelogsToValidate)).andReturn(validationResult);
+        internalTopicManager.setup(Collections.emptyMap());
         final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO4));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
         final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
@@ -186,7 +260,7 @@ public class ChangelogTopicsTest {
         changelogTopics.setup();
 
         verify(internalTopicManager);
-        assertThat(CHANGELOG_TOPIC_CONFIG.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
+        assertThat(CHANGELOG_TOPIC_CONFIG1.numberOfPartitions().orElse(Integer.MIN_VALUE), is(3));
         final TopicPartition changelogPartition0 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 0);
         final TopicPartition changelogPartition1 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 1);
         final TopicPartition changelogPartition2 = new TopicPartition(CHANGELOG_TOPIC_NAME1, 2);
@@ -204,5 +278,35 @@ public class ChangelogTopicsTest {
             changelogTopics.preExistingNonSourceTopicBasedPartitions(),
             is(mkSet(changelogPartition0, changelogPartition1, changelogPartition2))
         );
+    }
+
+    @Test
+    public void shouldThrowMisconfiguredInternalTopicExceptionIfMisconfigurationsExistsDuringSetup() {
+        final ValidationResult validationResult = new ValidationResult();
+        final String misconfiguration1 = "misconfiguration1";
+        final String misconfiguration2 = "misconfiguration2";
+        validationResult.addMisconfiguration(CHANGELOG_TOPIC_NAME1, misconfiguration1);
+        validationResult.addMisconfiguration(CHANGELOG_TOPIC_NAME2, misconfiguration2);
+        expect(internalTopicManager.validate(
+            mkMap(
+                mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG1),
+                mkEntry(CHANGELOG_TOPIC_NAME2, CHANGELOG_TOPIC_CONFIG2)
+            ))
+        ).andReturn(validationResult);
+        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO5));
+        final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
+        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        replay(internalTopicManager);
+
+        final ChangelogTopics changelogTopics =
+            new ChangelogTopics(internalTopicManager, topicGroups, tasksForTopicGroup, "[test] ");
+        final MisconfiguredInternalTopicException misconfiguredInternalTopicException = assertThrows(
+            MisconfiguredInternalTopicException.class,
+            changelogTopics::setup
+        );
+
+        final String message = misconfiguredInternalTopicException.getMessage();
+        assertThat(message, containsString(misconfiguration1));
+        assertThat(message, containsString(misconfiguration2));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignorTest.java
@@ -1175,7 +1175,7 @@ public class StreamsPartitionAssignorTest {
             false
         ) {
             @Override
-            public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) {
+            public void setup(final Map<String, InternalTopicConfig> topics) {
                 throw new TimeoutException("KABOOM!");
             }
         };
@@ -1208,9 +1208,9 @@ public class StreamsPartitionAssignorTest {
             false
         ) {
             @Override
-            public Set<String> makeReady(final Map<String, InternalTopicConfig> topics) {
+            public void setup(final Map<String, InternalTopicConfig> topics) {
                 if (topics.isEmpty()) {
-                    return emptySet();
+                    return;
                 }
                 throw new TimeoutException("KABOOM!");
             }


### PR DESCRIPTION
For KIP-698, we introduce new setup and validation methods for
internal topics. This PR uses the newly added methods and removes
the old methods.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
