### PR TITLE
KAFKA-12603: Add benchmarks for handleFetchRequest and FetchContext

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -274,4 +274,8 @@
               files="KafkaEventQueue.java"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
             files="metadata[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
+
+    <!-- jmh-benchmarks -->
+   <suppress checks="(ClassFanOutComplexity|ClassDataAbstractionCoupling)"
+             files="KafkaApisFetchBenchmark.java"/>
 </suppressions>

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/KafkaApisFetchBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/KafkaApisFetchBenchmark.java
@@ -175,6 +175,11 @@ public class KafkaApisFetchBenchmark {
                         Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
 
         scheduler.startup();
+        for (int topicIdx = 0; topicIdx < topicCount; topicIdx++) {
+            String topicName = Uuid.randomUuid().toString();
+            topics.add(topicName);
+            topicIds.put(topicName, Uuid.randomUuid());
+        }
         initializeMetadataCache();
         replicaManager = createReplicaManager();
         kafkaApis = createKafkaApis();
@@ -193,12 +198,6 @@ public class KafkaApisFetchBenchmark {
                 return new Properties();
             }
         };
-
-        for (int topicIdx = 0; topicIdx < topicCount; topicIdx++) {
-            String topicName = Uuid.randomUuid().toString();
-            topics.add(topicName);
-            topicIds.put(topicName, Uuid.randomUuid());
-        }
         ReplicaManager replicaManager = new ReplicaManager(
                 brokerProperties,
                 metrics,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/KafkaApisFetchBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/KafkaApisFetchBenchmark.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.common;
+
+import kafka.controller.KafkaController;
+import kafka.coordinator.group.GroupCoordinator;
+import kafka.coordinator.transaction.TransactionCoordinator;
+import kafka.log.CleanerConfig;
+import kafka.log.LogConfig;
+import kafka.log.LogManager;
+import kafka.network.RequestChannel;
+import kafka.server.AlterIsrManager;
+import kafka.server.AutoTopicCreationManager;
+import kafka.server.BrokerTopicStats;
+import kafka.server.ClientQuotaManager;
+import kafka.server.ClientQuotaManagerConfig;
+import kafka.server.ClientRequestQuotaManager;
+import kafka.server.ControllerMutationQuotaManager;
+import kafka.server.FetchManager;
+import kafka.server.FetchSessionCache;
+import kafka.server.KafkaApis;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaConfig$;
+import kafka.server.LogDirFailureChannel;
+import kafka.server.MetadataCache;
+import kafka.server.QuotaFactory;
+import kafka.server.QuotaType;
+import kafka.server.ReplicaManager;
+import kafka.server.ReplicationQuotaManager;
+import kafka.server.SimpleApiVersionManager;
+import kafka.server.ZkAdminManager;
+import kafka.server.ZkMetadataCache;
+import kafka.server.ZkSupport;
+import kafka.server.metadata.CachedConfigRepository;
+import kafka.utils.KafkaScheduler;
+import kafka.utils.MockTime;
+import kafka.utils.TestUtils;
+import kafka.zk.KafkaZkClient;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.memory.MemoryPool;
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.message.UpdateMetadataRequestData;
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ClientInformation;
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.LeaderAndIsrRequest;
+import org.apache.kafka.common.requests.UpdateMetadataRequest;
+import org.apache.kafka.common.requests.RequestContext;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
+import org.mockito.Mockito;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import scala.Option;
+import scala.collection.JavaConverters;
+import scala.compat.java8.OptionConverters;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+
+public class KafkaApisFetchBenchmark {
+    @Param({"10", "20", "100"})
+    private int topicCount;
+    @Param({"10", "20", "50"})
+    private int partitionCount;
+
+
+    private final int brokerId = 1;
+    private MockTime time = new MockTime();
+    private List<ApiKeys> keys = Arrays.asList(ApiKeys.FETCH, ApiKeys.LEADER_AND_ISR);
+    @SuppressWarnings("deprecation")
+    private RequestChannel.Metrics requestChannelMetrics = new RequestChannel.Metrics(JavaConverters.collectionAsScalaIterable(keys));
+    private RequestChannel requestChannel = new RequestChannel(20, "", time, requestChannelMetrics);
+
+    private GroupCoordinator groupCoordinator = Mockito.mock(GroupCoordinator.class);
+    private ZkAdminManager adminManager = Mockito.mock(ZkAdminManager.class);
+    private TransactionCoordinator transactionCoordinator = Mockito.mock(TransactionCoordinator.class);
+    private KafkaController kafkaController = Mockito.mock(KafkaController.class);
+    private AutoTopicCreationManager autoTopicCreationManager = Mockito.mock(AutoTopicCreationManager.class);
+    private KafkaZkClient kafkaZkClient = Mockito.mock(KafkaZkClient.class);
+    private Metrics metrics = new Metrics();
+    private ZkMetadataCache metadataCache = MetadataCache.zkMetadataCache(brokerId);
+
+    private ClientQuotaManager clientQuotaManager = new ClientQuotaManager(new ClientQuotaManagerConfig(Long.MAX_VALUE, 11, 1),
+            metrics, QuotaType.Fetch$.MODULE$, time, "", Option.empty());
+    private ClientRequestQuotaManager clientRequestQuotaManager = new ClientRequestQuotaManager(new ClientQuotaManagerConfig(Long.MAX_VALUE, 11, 1),
+            metrics, time, "", Option.empty());
+    private ControllerMutationQuotaManager controllerMutationQuotaManager = Mockito.mock(ControllerMutationQuotaManager.class);
+    private ReplicationQuotaManager replicaQuotaManager = Mockito.mock(ReplicationQuotaManager.class);
+    private QuotaFactory.QuotaManagers quotaManagers = new QuotaFactory.QuotaManagers(clientQuotaManager,
+            clientQuotaManager, clientRequestQuotaManager, controllerMutationQuotaManager, replicaQuotaManager,
+            replicaQuotaManager, replicaQuotaManager, Option.empty());
+
+    private FetchManager fetchManager =  new FetchManager(time, new FetchSessionCache(1000, 120000));
+    private BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
+    private KafkaPrincipal principal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "test-user");
+    private final CachedConfigRepository configRepository = new CachedConfigRepository();
+    private KafkaScheduler scheduler =  new KafkaScheduler(1, "scheduler-thread", true);
+    private AlterIsrManager alterIsrManager = TestUtils.createAlterIsrManager();
+    private KafkaConfig brokerProperties =  KafkaConfig.fromProps(TestUtils.createBrokerConfig(
+            0, TestUtils.MockZkConnect(), true, true, 9092, Option.empty(), Option.empty(),
+            Option.empty(), true, false, 0, false, 0, false, 0, Option.empty(), 1, true, 1,
+            (short) 1));
+    private LogDirFailureChannel failureChannel = new LogDirFailureChannel(brokerProperties.logDirs().size());
+    private List<String> topics = new ArrayList<>();
+    private Map<String, Uuid> topicIds = new HashMap<>();
+
+    private LogManager logManager;
+    private ReplicaManager replicaManager;
+    private KafkaApis kafkaApis;
+    private RequestChannel.Request request;
+
+    @SuppressWarnings("deprecation")
+    @Setup(Level.Trial)
+    public void setup() {
+        final List<File> files =
+                JavaConverters.seqAsJavaList(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
+        logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
+                LogConfig.apply(), configRepository, CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
+                        1024 * 1024, 32 * 1024 * 1024,
+                        Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
+
+        scheduler.startup();
+        initializeMetadataCache();
+        replicaManager = createReplicaManager();
+        kafkaApis = createKafkaApis();
+
+        // Put LISR data into ReplicaManager
+        kafkaApis.handleLeaderAndIsrRequest(buildLeaderAndIsrRequest());
+        request = buildFetchRequest();
+
+    }
+
+    private ReplicaManager createReplicaManager() {
+        final BrokerTopicStats brokerTopicStats = new BrokerTopicStats();
+        KafkaZkClient zkClient = new KafkaZkClient(null, false, Time.SYSTEM) {
+            @Override
+            public Properties getEntityConfigs(String rootEntityType, String sanitizedEntityName) {
+                return new Properties();
+            }
+        };
+
+        for (int topicIdx = 0; topicIdx < topicCount; topicIdx++) {
+            String topicName = Uuid.randomUuid().toString();
+            topics.add(topicName);
+            topicIds.put(topicName, Uuid.randomUuid());
+        }
+        ReplicaManager replicaManager = new ReplicaManager(
+                brokerProperties,
+                metrics,
+                time,
+                OptionConverters.toScala(Optional.of(zkClient)),
+                scheduler,
+                logManager,
+                new AtomicBoolean(false),
+                quotaManagers,
+                brokerTopicStats,
+                metadataCache,
+                failureChannel,
+                alterIsrManager,
+                configRepository,
+                Option.empty());
+        replicaManager.startup();
+        replicaManager.checkpointHighWatermarks();
+        return replicaManager;
+    }
+
+    private KafkaApis createKafkaApis() {
+        Properties kafkaProps =  new Properties();
+        kafkaProps.put(KafkaConfig$.MODULE$.ZkConnectProp(), "zk");
+        kafkaProps.put(KafkaConfig$.MODULE$.BrokerIdProp(), brokerId + "");
+        return new KafkaApis(requestChannel,
+                new ZkSupport(adminManager, kafkaController, kafkaZkClient, Option.empty(), metadataCache),
+                replicaManager,
+                groupCoordinator,
+                transactionCoordinator,
+                autoTopicCreationManager,
+                brokerId,
+                new KafkaConfig(kafkaProps),
+                configRepository,
+                metadataCache,
+                metrics,
+                Option.empty(),
+                quotaManagers,
+                fetchManager,
+                brokerTopicStats,
+                "clusterId",
+                new SystemTime(),
+                null,
+                new SimpleApiVersionManager(ApiMessageType.ListenerType.ZK_BROKER));
+    }
+
+    private void initializeMetadataCache() {
+        List<UpdateMetadataRequestData.UpdateMetadataBroker> liveBrokers = new LinkedList<>();
+        List<UpdateMetadataRequestData.UpdateMetadataPartitionState> partitionStates = new LinkedList<>();
+
+        IntStream.range(0, 5).forEach(brokerId -> liveBrokers.add(
+                new UpdateMetadataRequestData.UpdateMetadataBroker().setId(brokerId)
+                        .setEndpoints(endpoints(brokerId))
+                        .setRack("rack1")));
+
+        topics.forEach(topicName -> {
+
+            IntStream.range(0, partitionCount).forEach(partitionId -> {
+                partitionStates.add(
+                        new UpdateMetadataRequestData.UpdateMetadataPartitionState().setTopicName(topicName)
+                                .setPartitionIndex(partitionId)
+                                .setControllerEpoch(1)
+                                .setLeader(partitionCount % 5)
+                                .setLeaderEpoch(0)
+                                .setIsr(Arrays.asList(0, 1, 3))
+                                .setZkVersion(1)
+                                .setReplicas(Arrays.asList(0, 1, 3)));
+            });
+        });
+
+        UpdateMetadataRequest updateMetadataRequest = new UpdateMetadataRequest.Builder(
+                ApiKeys.UPDATE_METADATA.latestVersion(),
+                1, 1, 1,
+                partitionStates, liveBrokers, topicIds).build();
+        metadataCache.updateMetadata(100, updateMetadataRequest);
+    }
+
+    private List<UpdateMetadataRequestData.UpdateMetadataEndpoint> endpoints(final int brokerId) {
+        return Collections.singletonList(
+                new UpdateMetadataRequestData.UpdateMetadataEndpoint()
+                        .setHost("host_" + brokerId)
+                        .setPort(9092)
+                        .setSecurityProtocol(SecurityProtocol.PLAINTEXT.id)
+                        .setListener(ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT).value()));
+    }
+
+
+    private RequestChannel.Request buildLeaderAndIsrRequest() {
+        List<LeaderAndIsrPartitionState> partitionStates = new LinkedList<>();
+        List<Node> liveLeaders = new LinkedList<>();
+        Map<String, Uuid> topicIds = new HashMap<>();
+
+
+        IntStream.range(0, 5).forEach(brokerId -> liveLeaders.add(
+                new Node(brokerId, "host_" + brokerId, 9092, "rack1")));
+
+        topics.forEach(topicName -> {
+
+            IntStream.range(0, partitionCount).forEach(partitionId -> {
+                partitionStates.add(
+                        new LeaderAndIsrPartitionState().setTopicName(topicName)
+                                .setPartitionIndex(partitionId)
+                                .setControllerEpoch(1)
+                                .setLeader(partitionCount % 5)
+                                .setLeaderEpoch(0)
+                                .setIsr(Arrays.asList(0, 1, 3))
+                                .setZkVersion(1)
+                                .setReplicas(Arrays.asList(0, 1, 3)));
+            });
+        });
+
+        LeaderAndIsrRequest leaderAndIsrRequest = new LeaderAndIsrRequest.Builder(
+                ApiKeys.LEADER_AND_ISR.latestVersion(),
+                1, 1, 1,
+                partitionStates, topicIds, liveLeaders).build();
+        RequestHeader header = new RequestHeader(leaderAndIsrRequest.apiKey(), leaderAndIsrRequest.version(), "", 0);
+        ByteBuffer bodyBuffer = leaderAndIsrRequest.serialize();
+
+        RequestContext context = new RequestContext(header, "1", null, principal,
+                ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+                SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
+        return new RequestChannel.Request(1, context, 0, MemoryPool.NONE, bodyBuffer, requestChannelMetrics, Option.empty());
+    }
+
+    private RequestChannel.Request buildFetchRequest() {
+        Map<TopicPartition, FetchRequest.PartitionData> fetchData = new HashMap<>();
+        topics.forEach(topic -> {
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(
+                        0, 0, 4096, Optional.empty());
+                fetchData.put(new TopicPartition(topic, partitionId), partitionData);
+            }
+        });
+        FetchRequest fetchRequest = new FetchRequest.Builder(ApiKeys.FETCH.latestVersion(), ApiKeys.FETCH.latestVersion(),
+                -1, 0, 0, fetchData).build();
+        RequestHeader header = new RequestHeader(ApiKeys.FETCH, ApiKeys.FETCH.latestVersion(), "jmh-benchmark", 100);
+        ByteBuffer bodyBuffer = fetchRequest.serialize();
+
+        RequestContext context = new RequestContext(header, "1", null, principal,
+                ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
+                SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, false);
+        return new RequestChannel.Request(1, context, 0, MemoryPool.NONE, bodyBuffer, requestChannelMetrics, Option.empty());
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        kafkaApis.close();
+        metrics.close();
+        replicaManager.shutdown(false);
+        scheduler.shutdown();
+        quotaManagers.shutdown();
+    }
+
+    @Benchmark
+    public void testHandleFetchRequest() {
+        kafkaApis.handleFetchRequest(request);
+    }
+
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/FullFetchContextBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/FullFetchContextBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.fetchsession;
+
+import kafka.server.FetchContext;
+import kafka.server.FetchManager;
+import kafka.server.FetchSessionCache;
+import kafka.utils.MockTime;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.requests.FetchMetadata;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+
+public class FullFetchContextBenchmark {
+    @Param({"10", "20", "100"})
+    private int topicCount;
+    @Param({"10", "20", "50"})
+    private int partitionCount;
+
+    private MockTime time = new MockTime();
+    private FetchManager fetchManager =  new FetchManager(time, new FetchSessionCache(1000, 120000));
+    private FetchContext fullFetchContext;
+    private Map<TopicPartition, FetchRequest.PartitionData> fullReqData;
+    private LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> fullRespData;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        // FullFetchContext setup
+        List<TopicPartition> topics = new ArrayList<>();
+        IntStream.range(0, topicCount).forEach(topicNum -> {
+            String topicName = "topic" + topicNum;
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                topics.add(new TopicPartition(topicName, partitionId));
+            }
+        });
+        fullReqData = new HashMap<>();
+        fullRespData = new LinkedHashMap<>();
+        topics.forEach(tp -> {
+            FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(0,
+                    0, 4096, Optional.empty());
+            fullReqData.put(tp, partitionData);
+
+            FetchResponseData.PartitionData respPartitionData = new FetchResponseData.PartitionData()
+                    .setPartitionIndex(tp.partition())
+                    .setLastStableOffset(0)
+                    .setHighWatermark(0)
+                    .setLogStartOffset(0);
+            fullRespData.put(tp, respPartitionData);
+        });
+
+        fullFetchContext = fetchManager.newContext(FetchMetadata.INITIAL, fullReqData, Collections.emptyList(), false);
+    }
+
+    @Benchmark
+    public void newFullContext() {
+        fetchManager.newContext(FetchMetadata.INITIAL, fullReqData, Collections.emptyList(), false);
+    }
+
+    @Benchmark
+    public void updateAndGenerateResponseDataForFullContext() {
+        fullFetchContext.updateAndGenerateResponseData(fullRespData);
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/IncrementalFetchContextBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetchsession/IncrementalFetchContextBenchmark.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.fetchsession;
+
+import kafka.server.FetchContext;
+import kafka.server.FetchManager;
+import kafka.server.FetchSessionCache;
+import kafka.utils.MockTime;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.requests.FetchMetadata;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+
+public class IncrementalFetchContextBenchmark {
+    @Param({"10", "20", "100"})
+    private int topicCount;
+    @Param({"10", "20", "50"})
+    private int partitionCount;
+    @Param({"5", "10", "50"})
+    private int toForgetPercentage;
+
+    private MockTime time = new MockTime();
+    private FetchManager fetchManager =  new FetchManager(time, new FetchSessionCache(1000, 120000));
+    private FetchContext incrementalFetchContext;
+    private Map<TopicPartition, FetchRequest.PartitionData> incrementalReqData;
+    private List<TopicPartition> toForget;
+    private FetchMetadata incrementalMetadata;
+    private LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> incrementalRespData;
+
+
+    @Setup(Level.Trial)
+    public void setup() {
+        // FullFetchContext setup
+        List<TopicPartition> topics = new ArrayList<>();
+        IntStream.range(0, topicCount).forEach(topicNum -> {
+            String topicName = "topic" + topicNum;
+            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+                topics.add(new TopicPartition(topicName, partitionId));
+            }
+        });
+        Map<TopicPartition, FetchRequest.PartitionData> fullReqData = new HashMap<>();
+        LinkedHashMap<TopicPartition, FetchResponseData.PartitionData> fullRespData = new LinkedHashMap<>();
+        topics.forEach(tp -> {
+            FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(0,
+                    0, 4096, Optional.empty());
+            fullReqData.put(tp, partitionData);
+
+            FetchResponseData.PartitionData respPartitionData = new FetchResponseData.PartitionData()
+                    .setPartitionIndex(tp.partition())
+                    .setLastStableOffset(0)
+                    .setHighWatermark(0)
+                    .setLogStartOffset(0);
+            fullRespData.put(tp, respPartitionData);
+        });
+
+        FetchContext fullFetchContext = fetchManager.newContext(FetchMetadata.INITIAL, fullReqData, Collections.emptyList(), false);
+        FetchResponse fullResponse = fullFetchContext.updateAndGenerateResponseData(fullRespData);
+
+        // IncrementalFetchContext setup
+        // Let's add a fraction of the current topicPartitions to the session. Say, 1/10.
+        List<TopicPartition> incrementalTopics = new ArrayList<>();
+        IntStream.range(0, topicCount).forEach(topicNum -> {
+            String topicName = "incrementalTopic" + topicNum;
+            for (int partitionId = 0; partitionId < partitionCount; partitionId += 10) {
+                incrementalTopics.add(new TopicPartition(topicName, partitionId));
+            }
+        });
+        incrementalReqData = new HashMap<>();
+        incrementalRespData = new LinkedHashMap<>();
+        incrementalTopics.forEach(tp -> {
+            FetchRequest.PartitionData partitionData = new FetchRequest.PartitionData(
+                    0, 0, 4096, Optional.empty());
+            incrementalReqData.put(tp, partitionData);
+
+            FetchResponseData.PartitionData respPartitionData = new FetchResponseData.PartitionData()
+                    .setPartitionIndex(tp.partition())
+                    .setLastStableOffset(0)
+                    .setHighWatermark(0)
+                    .setLogStartOffset(0);
+            incrementalRespData.put(tp, respPartitionData);
+        });
+        // Add responses from session
+        incrementalRespData.putAll(fullRespData);
+
+        // Add some topicPartitions toForget
+        toForget = new ArrayList<>();
+        IntStream.range(0, topics.size()).forEach(tpNum -> {
+            if (tpNum % (100 / toForgetPercentage) == 0) {
+                toForget.add(topics.get(tpNum));
+                incrementalRespData.remove(topics.get(tpNum));
+            }
+        });
+
+        incrementalMetadata = new FetchMetadata(fullResponse.sessionId(), 1);
+        incrementalFetchContext = fetchManager.newContext(incrementalMetadata, incrementalReqData, toForget, false);
+
+    }
+
+    @Benchmark
+    public void newIncrementalContext() {
+        fetchManager.newContext(incrementalMetadata, incrementalReqData, toForget, false);
+
+    }
+
+    @Benchmark
+    public void updateAndGenerateResponseDataForIncrementalContext() {
+        incrementalFetchContext.updateAndGenerateResponseData(incrementalRespData);
+
+    }
+}


### PR DESCRIPTION
Added benchmarks to help test https://github.com/apache/kafka/pull/9944.
These benchmarks can be used to compare the handleFetchRequest path, FullFetchContext and IncrementalFetchContext.
Results below and flame graphs attached:
[FetchApiBench.zip](https://github.com/apache/kafka/files/6250489/FetchApiBench.zip)
[full fetch context.zip](https://github.com/apache/kafka/files/6245147/full.fetch.context.zip)
[incremental.zip](https://github.com/apache/kafka/files/6255229/incremental.zip)



KafkaApisFetchBenchmark:
```
KafkaApisFetchBenchmark.testHandleFetchRequest                       10            10  avgt   15    106580.752 ±   8069.373  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       10            20  avgt   15    202546.131 ±   7748.566  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       10           100  avgt   15   1287241.258 ±  57127.925  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       20            10  avgt   15    210566.535 ±   8284.169  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       20            20  avgt   15    485464.773 ±  22446.261  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       20           100  avgt   15   3311306.969 ± 294758.904  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       50            10  avgt   15    560291.055 ±  28779.937  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       50            20  avgt   15   1373390.613 ± 208724.875  ns/op
KafkaApisFetchBenchmark.testHandleFetchRequest                       50           100  avgt   15  12345590.790 ± 443485.022  ns/op
```

FullFetchContextBenchmark:
```
Benchmark                                                                     (partitionCount)  (topicCount)  Mode  Cnt            Score           Error  Units
FullFetchContextBenchmark.newFullContext                                                    10            10  avgt   15            9.400 ±         0.642  ns/op
FullFetchContextBenchmark.newFullContext                                                    10            20  avgt   15            9.163 ±         0.177  ns/op
FullFetchContextBenchmark.newFullContext                                                    10           100  avgt   15            9.014 ±         0.281  ns/op
FullFetchContextBenchmark.newFullContext                                                    20            10  avgt   15            8.935 ±         0.334  ns/op
FullFetchContextBenchmark.newFullContext                                                    20            20  avgt   15            8.769 ±         0.102  ns/op
FullFetchContextBenchmark.newFullContext                                                    20           100  avgt   15            8.729 ±         0.291  ns/op
FullFetchContextBenchmark.newFullContext                                                    50            10  avgt   15            9.032 ±         0.447  ns/op
FullFetchContextBenchmark.newFullContext                                                    50            20  avgt   15            9.074 ±         0.422  ns/op
FullFetchContextBenchmark.newFullContext                                                    50           100  avgt   15            9.122 ±         0.283  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       10            10  avgt   15          920.954 ±        12.131  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       10            20  avgt   15         1825.846 ±        26.501  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       10           100  avgt   15    271718890.632 ±  12225638.258  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       20            10  avgt   15         2282.090 ±        98.191  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       20            20  avgt   15         4424.841 ±       159.225  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       20           100  avgt   15   2496876236.183 ±  87972780.491  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       50            10  avgt   15         5646.134 ±       457.860  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       50            20  avgt   15        10576.038 ±       173.532  ns/op
FullFetchContextBenchmark.updateAndGenerateResponseDataForFullContext                       50           100  avgt   15  52923741093.333 ± 302811682.429  ns/op
```

IncrementalFetchContextBenchmark
```
Benchmark                                                                                   (partitionCount)  (toForgetPercentage)  (topicCount)  Mode  Cnt        Score       Error  Units
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                     5            10  avgt   10       24.198 ±     0.862  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                     5            20  avgt   10       19.128 ±     0.137  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                     5            50  avgt   10       19.138 ±     0.115  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                    10            10  avgt   10       23.959 ±     0.565  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                    10            20  avgt   10       19.161 ±     0.266  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                    10            50  avgt   10       19.357 ±     1.049  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                    50            10  avgt   10       23.626 ±     0.207  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                    50            20  avgt   10       19.045 ±     0.121  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       10                    50            50  avgt   10       18.986 ±     0.130  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                     5            10  avgt   10       18.991 ±     0.126  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                     5            20  avgt   10       18.969 ±     0.141  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                     5            50  avgt   10       19.446 ±     1.025  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                    10            10  avgt   10       20.460 ±     2.441  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                    10            20  avgt   10       19.000 ±     0.092  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                    10            50  avgt   10       19.009 ±     0.161  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                    50            10  avgt   10       19.555 ±     0.393  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                    50            20  avgt   10       19.112 ±     0.093  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       20                    50            50  avgt   10       18.868 ±     0.159  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                     5            10  avgt   10       19.047 ±     0.130  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                     5            20  avgt   10       19.021 ±     0.150  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                     5            50  avgt   10       22.758 ±     0.440  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                    10            10  avgt   10       19.026 ±     0.147  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                    10            20  avgt   10       19.001 ±     0.120  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                    10            50  avgt   10       23.185 ±     0.133  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                    50            10  avgt   10       19.040 ±     0.141  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                    50            20  avgt   10       19.059 ±     0.156  ns/op
IncrementalFetchContextBenchmark.updateAndGenerateResponseDataForIncrementalContext                       50                    50            50  avgt   10       23.380 ±     0.686  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                     5            10  avgt   10      739.484 ±     9.827  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                     5            20  avgt   10      754.875 ±    11.633  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                     5            50  avgt   10   147673.425 ±   620.465  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                    10            10  avgt   10      804.706 ±     5.787  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                    10            20  avgt   10      677.133 ±    22.897  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                    10            50  avgt   10   137332.596 ±  1397.904  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                    50            10  avgt   10      946.258 ±     5.860  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                    50            20  avgt   10     2742.098 ±    16.485  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            10                    50            50  avgt   10    45436.163 ±  1060.107  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                     5            10  avgt   10      682.163 ±    28.272  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                     5            20  avgt   10     3092.904 ±    23.698  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                     5            50  avgt   10    10471.081 ±   113.056  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                    10            10  avgt   10      747.679 ±    10.476  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                    10            20  avgt   10     3365.438 ±    50.438  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                    10            50  avgt   10   117471.422 ±   885.095  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                    50            10  avgt   10     1223.101 ±    10.043  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                    50            20  avgt   10     3352.377 ±    45.685  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            20                    50            50  avgt   10    46741.668 ±  3626.344  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                     5            10  avgt   10     1367.241 ±    30.799  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                     5            20  avgt   10     3994.033 ±    65.925  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                     5            50  avgt   10  1236542.020 ± 10982.921  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                    10            10  avgt   10     1480.727 ±    16.649  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                    10            20  avgt   10     4440.147 ±    39.263  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                    10            50  avgt   10  1714720.865 ± 14837.272  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                    50            10  avgt   10     2847.598 ±    27.665  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                    50            20  avgt   10     6220.523 ±    74.483  ns/op
IncrementalFetchContextBenchmark.updateSession                                                            50                    50            50  avgt   10   146124.265 ±  1667.414  ns/op
```