### PR TITLE
KAFKA-12670: support unclean.leader.election.enable in KRaft mode

### DIFF
--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -475,4 +475,9 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Package name="org.apache.kafka.jmh.metadata.generated"/>
     </Match>
 
+    <Match>
+        <!-- Suppress warnings related to returning null for a Boolean -->
+        <Class name="org.apache.kafka.controller.ElectionStrategizer"/>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
+    </Match>
 </FindBugsFilter>

--- a/metadata/src/main/java/org/apache/kafka/controller/ElectionStrategizer.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ElectionStrategizer.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.apache.kafka.common.config.TopicConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+
+class ElectionStrategizer {
+    private static final Logger log = LoggerFactory.getLogger(ElectionStrategizer.class);
+
+    private final int nodeId;
+    private Boolean nodeUncleanConfig = null;
+    private Boolean clusterUncleanConfig = null;
+    private Function<String, String> topicUncleanConfigAccessor = __ -> "false";
+    private Map<String, String> topicUncleanOverrides = new HashMap<>();
+
+    ElectionStrategizer(int nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    ElectionStrategizer setNodeUncleanConfig(String nodeUncleanConfig) {
+        this.nodeUncleanConfig = parseBoolean("node", nodeUncleanConfig);
+        return this;
+    }
+
+    ElectionStrategizer setClusterUncleanConfig(String clusterUncleanConfig) {
+        this.clusterUncleanConfig = parseBoolean("cluster", clusterUncleanConfig);
+        return this;
+    }
+
+    ElectionStrategizer setTopicUncleanConfigAccessor(
+            Function<String, String> topicUncleanConfigAccessor) {
+        this.topicUncleanConfigAccessor = topicUncleanConfigAccessor;
+        return this;
+    }
+
+    ElectionStrategizer setTopicUncleanOverride(String topicName, String value) {
+        this.topicUncleanOverrides.put(topicName, value);
+        return this;
+    }
+
+    boolean shouldBeUnclean(String topicName) {
+        Boolean topicConfig = (topicUncleanOverrides.containsKey(topicName)) ?
+            parseBoolean("topic", topicUncleanOverrides.get(topicName)) :
+            parseBoolean("topic", topicUncleanConfigAccessor.apply(topicName));
+        if (topicConfig != null) return topicConfig.booleanValue();
+        if (nodeUncleanConfig != null) return nodeUncleanConfig.booleanValue();
+        if (clusterUncleanConfig != null) return clusterUncleanConfig.booleanValue();
+        return false;
+    }
+
+    // VisibleForTesting
+    Boolean parseBoolean(String what, String value) {
+        if (value == null) return null;
+        if (value.equalsIgnoreCase("true")) return true;
+        if (value.equalsIgnoreCase("false")) return false;
+        if (value.trim().isEmpty()) return null;
+        log.warn("Invalid value for {} config {} on node {}: '{}'. Expected true or false.",
+            what, TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, nodeId, value);
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ElectionStrategizer)) return false;
+        ElectionStrategizer other = (ElectionStrategizer) o;
+        return Objects.equals(other.nodeUncleanConfig, nodeUncleanConfig) &&
+            Objects.equals(other.clusterUncleanConfig, clusterUncleanConfig) &&
+            other.topicUncleanConfigAccessor.equals(topicUncleanConfigAccessor) &&
+            other.topicUncleanOverrides.equals(topicUncleanOverrides);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodeUncleanConfig,
+            clusterUncleanConfig,
+            topicUncleanConfigAccessor,
+            topicUncleanOverrides);
+    }
+
+    @Override
+    public String toString() {
+        return "ElectionStrategizer(nodeUncleanConfig=" + nodeUncleanConfig +
+            ", clusterUncleanConfig=" + clusterUncleanConfig +
+            ", topicUncleanConfigAccessor=" + topicUncleanConfigAccessor +
+            ", topicUncleanOverrides=" + topicUncleanOverrides + ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -915,7 +915,7 @@ public final class QuorumController implements Controller {
         this.controllerMetrics = controllerMetrics;
         this.snapshotRegistry = new SnapshotRegistry(logContext);
         this.purgatory = new ControllerPurgatory();
-        this.configurationControl = new ConfigurationControlManager(logContext,
+        this.configurationControl = new ConfigurationControlManager(logContext, nodeId,
             snapshotRegistry, configDefs);
         this.clientQuotaControlManager = new ClientQuotaControlManager(snapshotRegistry);
         this.clusterControl = new ClusterControlManager(logContext, time,

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -1014,7 +1014,7 @@ public final class QuorumController implements Controller {
         boolean validateOnly) {
         return appendWriteEvent("incrementalAlterConfigs", () -> {
             ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.incrementalAlterConfigs(configChanges);
+                replicationControl.incrementalAlterConfigs(configChanges);
             if (validateOnly) {
                 return result.withoutRecords();
             } else {
@@ -1031,7 +1031,7 @@ public final class QuorumController implements Controller {
         }
         return appendWriteEvent("legacyAlterConfigs", () -> {
             ControllerResult<Map<ConfigResource, ApiError>> result =
-                configurationControl.legacyAlterConfigs(newConfigs);
+                replicationControl.legacyAlterConfigs(newConfigs);
             if (validateOnly) {
                 return result.withoutRecords();
             } else {

--- a/metadata/src/main/java/org/apache/kafka/controller/Replicas.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Replicas.java
@@ -44,6 +44,18 @@ public class Replicas {
     }
 
     /**
+     * Convert an array of integers to a list of ints and append a final element.
+     *
+     * @param array         The input array.
+     * @return              The output list.
+     */
+    public static List<Integer> toList(int[] array, int last) {
+        List<Integer> list = toList(array);
+        list.add(last);
+        return list;
+    }
+
+    /**
      * Convert a list of integers to an array of ints.
      *
      * @param list          The input list.

--- a/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
@@ -43,7 +43,6 @@ import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
 import static org.apache.kafka.common.config.ConfigResource.Type.BROKER_LOGGER;
 import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.config.ConfigResource.Type.UNKNOWN;
-import static org.apache.kafka.common.config.TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -245,33 +244,5 @@ public class ConfigurationControlManagerTest {
             ),
             manager.legacyAlterConfigs(toMap(entry(MYTOPIC, toMap(entry("def", "901")))))
         );
-    }
-
-    @Test
-    public void testShouldUseUncleanLeaderElection() throws Exception {
-        SnapshotRegistry snapshotRegistry = new SnapshotRegistry(new LogContext());
-        ConfigurationControlManager manager =
-            new ConfigurationControlManager(new LogContext(), 0, snapshotRegistry, CONFIGS);
-        ControllerResult<Map<ConfigResource, ApiError>> result = manager.incrementalAlterConfigs(
-            toMap(entry(BROKER0, toMap(
-                    entry(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, entry(SET, "true")))),
-                entry(MYTOPIC, toMap(
-                    entry(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, entry(SET, "false"))))));
-        Map<ConfigResource, ApiError> expectedResponse = new HashMap<>();
-        expectedResponse.put(BROKER0, ApiError.NONE);
-        expectedResponse.put(MYTOPIC, ApiError.NONE);
-        assertEquals(expectedResponse, result.response());
-        ControllerTestUtils.replayAll(manager, result.records());
-        assertTrue(manager.shouldUseUncleanLeaderElection(MYTOPIC.name()));
-        assertTrue(manager.shouldUseUncleanLeaderElection("quux"));
-        ControllerResult<Map<ConfigResource, ApiError>> result2 = manager.incrementalAlterConfigs(
-            toMap(entry(BROKER0, toMap(
-                entry(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, entry(DELETE, null)))),
-                entry(MYTOPIC, toMap(
-                    entry(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, entry(SET, "true"))))));
-        ControllerTestUtils.replayAll(manager, result2.records());
-        assertEquals(expectedResponse, result2.response());
-        assertTrue(manager.shouldUseUncleanLeaderElection(MYTOPIC.name()));
-        assertFalse(manager.shouldUseUncleanLeaderElection("quux"));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ElectionStrategizerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ElectionStrategizerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@Timeout(value = 40)
+public class ElectionStrategizerTest {
+    private final static Logger log = LoggerFactory.getLogger(ElectionStrategizerTest.class);
+
+    private static ElectionStrategizer createElectionStrategizer() {
+        return new ElectionStrategizer(0).
+            setTopicUncleanConfigAccessor(n -> {
+                if (n.startsWith("unclean_")) {
+                    return "true";
+                } else if (n.startsWith("clean_")) {
+                    return "false";
+                } else {
+                    return null;
+                }
+            }).
+            setNodeUncleanConfig(null).
+            setClusterUncleanConfig("true");
+    }
+
+    @Test
+    public void testShouldBeUnclean() {
+        ElectionStrategizer strategizer = createElectionStrategizer();
+        assertTrue(strategizer.shouldBeUnclean("unclean_foo"));
+        assertFalse(strategizer.shouldBeUnclean("clean_foo"));
+        assertTrue(strategizer.shouldBeUnclean("foo"));
+        strategizer.setNodeUncleanConfig("false");
+        assertFalse(strategizer.shouldBeUnclean("foo"));
+    }
+
+    @Test
+    public void testTopicUncleanOverride() {
+        ElectionStrategizer strategizer = createElectionStrategizer();
+        strategizer.setTopicUncleanOverride("unclean_foo", "false");
+        strategizer.setTopicUncleanOverride("clean_bar", "true");
+        assertFalse(strategizer.shouldBeUnclean("unclean_foo"));
+        assertTrue(strategizer.shouldBeUnclean("clean_bar"));
+    }
+
+    @Test
+    public void testParseBoolean() {
+        ElectionStrategizer strategizer = createElectionStrategizer();
+        assertFalse(strategizer.parseBoolean("testParseBoolean", "false"));
+        assertFalse(strategizer.parseBoolean("testParseBoolean", "FALSE"));
+        assertTrue(strategizer.parseBoolean("testParseBoolean", "true"));
+        assertTrue(strategizer.parseBoolean("testParseBoolean", "TRUE"));
+        assertNull(strategizer.parseBoolean("testParseBoolean", ""));
+        assertNull(strategizer.parseBoolean("testParseBoolean", " "));
+        assertNull(strategizer.parseBoolean("testParseBoolean", null));
+        assertNull(strategizer.parseBoolean("testParseBoolean", "foo"));
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicasTest.java
@@ -35,6 +35,8 @@ public class ReplicasTest {
         assertEquals(Arrays.asList(1, 2, 3, 4), Replicas.toList(new int[] {1, 2, 3, 4}));
         assertEquals(Arrays.asList(), Replicas.toList(Replicas.NONE));
         assertEquals(Arrays.asList(2), Replicas.toList(new int[] {2}));
+        assertEquals(Arrays.asList(2, 3), Replicas.toList(new int[] {2}, 3));
+        assertEquals(Arrays.asList(3), Replicas.toList(new int[] {}, 3));
     }
 
     @Test

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -30,10 +30,13 @@ import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartiti
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignment;
+import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableReplicaAssignmentCollection;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCollection;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult;
+import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.TopicRecord;
@@ -61,6 +64,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
+import static org.apache.kafka.common.config.TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG;
 import static org.apache.kafka.common.protocol.Errors.INVALID_PARTITIONS;
 import static org.apache.kafka.common.protocol.Errors.INVALID_REPLICA_ASSIGNMENT;
 import static org.apache.kafka.common.protocol.Errors.INVALID_TOPIC_EXCEPTION;
@@ -88,7 +93,7 @@ public class ReplicationControlManagerTest {
             logContext, time, snapshotRegistry, 1000,
             new SimpleReplicaPlacementPolicy(random));
         final ConfigurationControlManager configurationControl = new ConfigurationControlManager(
-            new LogContext(), snapshotRegistry, Collections.emptyMap());
+            new LogContext(), 0, snapshotRegistry, Collections.emptyMap());
         final ReplicationControlManager replicationControl = new ReplicationControlManager(snapshotRegistry,
             new LogContext(),
             (short) 3,
@@ -433,7 +438,7 @@ public class ReplicationControlManagerTest {
         CreateTopicsRequestData.CreateableTopicConfigCollection requestConfigs
     ) {
         Map<String, String> configs = ctx.configurationControl.getConfigs(
-            new ConfigResource(ConfigResource.Type.TOPIC, topic));
+            new ConfigResource(TOPIC, topic));
         assertEquals(requestConfigs.size(), configs.size());
         for (CreateTopicsRequestData.CreateableTopicConfig requestConfig : requestConfigs) {
             String value = configs.get(requestConfig.name());
@@ -446,7 +451,7 @@ public class ReplicationControlManagerTest {
         String topic
     ) {
         Map<String, String> configs = ctx.configurationControl.getConfigs(
-            new ConfigResource(ConfigResource.Type.TOPIC, topic));
+            new ConfigResource(TOPIC, topic));
         assertEquals(Collections.emptyMap(), configs);
     }
 
@@ -651,5 +656,83 @@ public class ReplicationControlManagerTest {
                 "3 replica(s).", assertThrows(InvalidReplicaAssignmentException.class, () ->
                     ctx.replicationControl.validateManualPartitionAssignment(Arrays.asList(1, 2),
                         OptionalInt.of(3))).getMessage());
+    }
+
+    @Test
+    public void testHandleNodeDeactivationAndReActivation() throws Exception {
+        // Create a two-node cluster with two topics.  One will have unclean leader
+        // election enabled, and the other will not.
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        ctx.configurationControl.replay(new ConfigRecord().setResourceName("foo").
+            setResourceType(TOPIC.id()).
+            setName(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG).
+            setValue("true"));
+        registerBroker(0, ctx);
+        unfenceBroker(0, ctx);
+        registerBroker(1, ctx);
+        unfenceBroker(1, ctx);
+        CreateTopicsRequestData createTopicsRequest = new CreateTopicsRequestData();
+        createTopicsRequest.topics().add(new CreatableTopic().setName("foo").
+            setNumPartitions(-1).
+            setReplicationFactor((short) -1).
+            setAssignments(new CreatableReplicaAssignmentCollection(Arrays.asList(
+                new CreatableReplicaAssignment().setBrokerIds(Arrays.asList(0, 1))).
+                iterator())));
+        createTopicsRequest.topics().add(new CreatableTopic().setName("bar").
+            setNumPartitions(-1).
+            setReplicationFactor((short) -1).
+            setAssignments(new CreatableReplicaAssignmentCollection(Arrays.asList(
+                new CreatableReplicaAssignment().setBrokerIds(Arrays.asList(0, 1))).
+                iterator())));
+        ControllerResult<CreateTopicsResponseData> createTopicsResult =
+            ctx.replicationControl.createTopics(createTopicsRequest);
+        assertEquals((short) 0,
+            createTopicsResult.response().topics().find("foo").errorCode());
+        assertEquals((short) 0,
+            createTopicsResult.response().topics().find("bar").errorCode());
+        ControllerTestUtils.replayAll(ctx.replicationControl, createTopicsResult.records());
+        Uuid fooId = createTopicsResult.response().topics().find("foo").topicId();
+        Uuid barId = createTopicsResult.response().topics().find("bar").topicId();
+        // Deactivate node 0.  This will remove it from the ISR and from the leadership
+        // of both topics.
+        List<ApiMessageAndVersion> deactivationRecords = new ArrayList<>();
+        ctx.replicationControl.handleNodeDeactivated(0, deactivationRecords);
+        assertEquals(new HashSet<>(Arrays.asList(
+            new ApiMessageAndVersion(new PartitionChangeRecord().
+                setPartitionId(0).
+                setTopicId(fooId).
+                setIsr(Arrays.asList(1)).
+                setLeader(1), (short) 0),
+            new ApiMessageAndVersion(new PartitionChangeRecord().
+                setPartitionId(0).
+                setTopicId(barId).
+                setIsr(Arrays.asList(1)).
+                setLeader(1), (short) 0))), new HashSet<>(deactivationRecords));
+        ControllerTestUtils.replayAll(ctx.replicationControl, deactivationRecords);
+        List<ApiMessageAndVersion> deactivationRecords2 = new ArrayList<>();
+        // Deactivate node 1.  This time, the ISR will not be changed (we never let the
+        // ISR become empty).  However, the topic will now be leaderless (leader = -1).
+        ctx.replicationControl.handleNodeDeactivated(1, deactivationRecords2);
+        assertEquals(new HashSet<>(Arrays.asList(
+            new ApiMessageAndVersion(new PartitionChangeRecord().
+                setPartitionId(0).
+                setTopicId(fooId).
+                setLeader(-1), (short) 0),
+            new ApiMessageAndVersion(new PartitionChangeRecord().
+                setPartitionId(0).
+                setTopicId(barId).
+                setLeader(-1), (short) 0))), new HashSet<>(deactivationRecords2));
+        ControllerTestUtils.replayAll(ctx.replicationControl, deactivationRecords2);
+        // Activate node 0.  It is not in the ISR.  Topic foo will make it the leader
+        // anyway, since unclean leader election is enabled for that topic.  Topic bar
+        // will be unaffected.
+        List<ApiMessageAndVersion> activationRecords = new ArrayList<>();
+        ctx.replicationControl.handleNodeActivated(0, activationRecords);
+        assertEquals(new HashSet<>(Arrays.asList(
+            new ApiMessageAndVersion(new PartitionChangeRecord().
+                setPartitionId(0).
+                setTopicId(fooId).
+                setIsr(Arrays.asList(1, 0)).
+                setLeader(0), (short) 0))), new HashSet<>(activationRecords));
     }
 }


### PR DESCRIPTION
Support node-level and topic-level unclean.leader.election.enable
in the KRaft controller.