### PR TITLE
KAFKA-12417: streams `copyDependentLibs` should not copy testRuntime configuration jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1667,11 +1667,6 @@ project(':streams') {
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
-    from (configurations.testRuntime) {
-      include('slf4j-log4j12*')
-      include('log4j*jar')
-      include('*hamcrest*')
-    }
     from (configurations.runtimeClasspath) {
       exclude('kafka-clients*')
     }


### PR DESCRIPTION
This also fixes a Gradle deprecation that unblocks the upgrade to Gradle 7.0.