### PR TITLE
KAFKA-12611: Fix using random payload in ProducerPerformance incorrectly

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -123,10 +123,14 @@ public class ProducerPerformance {
             long transactionStartTime = 0;
             for (long i = 0; i < numRecords; i++) {
 
-                if (recordSize != null) {
+                if (payloadFilePath != null) {
+                    payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
+                } else if (recordSize != null) {
                     payload = new byte[recordSize];
                     for (int j = 0; j < payload.length; ++j)
                         payload[j] = (byte) (random.nextInt(26) + 65);
+                } else {
+                    throw new IllegalArgumentException("no payload File Path or record Size provided");
                 }
 
                 if (transactionsEnabled && currentTransactionSize == 0) {
@@ -134,9 +138,6 @@ public class ProducerPerformance {
                     transactionStartTime = System.currentTimeMillis();
                 }
 
-                if (payloadFilePath != null) {
-                    payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
-                }
                 record = new ProducerRecord<>(topicName, payload);
 
                 long sendStartMs = System.currentTimeMillis();

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -111,7 +111,7 @@ public class ProducerPerformance {
                 producer.initTransactions();
 
             /* setup perf test */
-            byte[] payload = null;
+            byte[] payload = new byte[recordSize];
             Random random = new Random(0);
             ProducerRecord<byte[], byte[]> record;
             Stats stats = new Stats(numRecords, 5000);
@@ -126,7 +126,6 @@ public class ProducerPerformance {
                 if (payloadFilePath != null) {
                     payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
                 } else if (recordSize != null) {
-                    payload = new byte[recordSize];
                     for (int j = 0; j < payload.length; ++j)
                         payload[j] = (byte) (random.nextInt(26) + 65);
                 } else {

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -111,7 +111,7 @@ public class ProducerPerformance {
                 producer.initTransactions();
 
             /* setup perf test */
-            byte[] payload = new byte[recordSize];
+            byte[] payload = null;
             Random random = new Random(0);
             ProducerRecord<byte[], byte[]> record;
             Stats stats = new Stats(numRecords, 5000);
@@ -126,6 +126,7 @@ public class ProducerPerformance {
                 if (payloadFilePath != null) {
                     payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
                 } else if (recordSize != null) {
+                    payload = new byte[recordSize];
                     for (int j = 0; j < payload.length; ++j)
                         payload[j] = (byte) (random.nextInt(26) + 65);
                 } else {

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -113,11 +113,6 @@ public class ProducerPerformance {
             /* setup perf test */
             byte[] payload = null;
             Random random = new Random(0);
-            if (recordSize != null) {
-                payload = new byte[recordSize];
-                for (int i = 0; i < payload.length; ++i)
-                    payload[i] = (byte) (random.nextInt(26) + 65);
-            }
             ProducerRecord<byte[], byte[]> record;
             Stats stats = new Stats(numRecords, 5000);
             long startMs = System.currentTimeMillis();
@@ -127,11 +122,17 @@ public class ProducerPerformance {
             int currentTransactionSize = 0;
             long transactionStartTime = 0;
             for (long i = 0; i < numRecords; i++) {
+
+                if (recordSize != null) {
+                    payload = new byte[recordSize];
+                    for (int j = 0; j < payload.length; ++j)
+                        payload[j] = (byte) (random.nextInt(26) + 65);
+                }
+
                 if (transactionsEnabled && currentTransactionSize == 0) {
                     producer.beginTransaction();
                     transactionStartTime = System.currentTimeMillis();
                 }
-
 
                 if (payloadFilePath != null) {
                     payload = payloadByteList.get(random.nextInt(payloadByteList.size()));

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -112,6 +112,9 @@ public class ProducerPerformance {
 
             /* setup perf test */
             byte[] payload = null;
+            if (recordSize != null) {
+                payload = new byte[recordSize];
+            }
             Random random = new Random(0);
             ProducerRecord<byte[], byte[]> record;
             Stats stats = new Stats(numRecords, 5000);
@@ -126,7 +129,6 @@ public class ProducerPerformance {
                 if (payloadFilePath != null) {
                     payload = payloadByteList.get(random.nextInt(payloadByteList.size()));
                 } else if (recordSize != null) {
-                    payload = new byte[recordSize];
                     for (int j = 0; j < payload.length; ++j)
                         payload[j] = (byte) (random.nextInt(26) + 65);
                 } else {


### PR DESCRIPTION
In ProducerPerformance, random payload always same. It has a great impact when use the compression.type option.

https://issues.apache.org/jira/browse/KAFKA-12611

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
