### PR TITLE
KAFKA-12614: Use Jenkinsfile for trunk and release branch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,12 +33,17 @@ def doValidation() {
   '''
 }
 
+def retryFlagsString(jobConfig) {
+    if (jobConfig.isPrJob) " -PmaxTestRetries=1 -PmaxTestRetryFailures=5"
+    else ""
+}
+
 def doTest(target = "unitTest integrationTest") {
   sh """
     ./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
         --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed \
-        -PignoreFailures=true -PmaxParallelForks=2 -PmaxTestRetries=1 -PmaxTestRetryFailures=5
-  """
+        -PignoreFailures=true -PmaxParallelForks=2
+  """ + retryFlagsString(config)
   junit '**/build/test-results/**/TEST-*.xml'
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,11 +26,11 @@ def setupGradle() {
 }
 
 def doValidation() {
-  sh '''
+  sh """
     ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
         spotlessScalaCheck checkstyleMain checkstyleTest spotbugsMain rat \
         --profile --no-daemon --continue -PxmlSpotBugsReport=true
-  '''
+  """
 }
 
 def retryFlagsString(jobConfig) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,10 @@ pipeline {
         // the `when` clause.
         
         stage('JDK 8 and Scala 2.13') {
-          when { not { changeRequest() } }
+          when {
+            not { changeRequest() }
+            beforeAgent true
+          }
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_1.8_latest'
@@ -217,7 +220,10 @@ pipeline {
         }
 
         stage('JDK 11 and Scala 2.12') {
-          when { not { changeRequest() } }
+          when {
+            not { changeRequest() }
+            beforeAgent true
+          }
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_11_latest'
@@ -238,7 +244,10 @@ pipeline {
         }
 
         stage('JDK 15 and Scala 2.12') {
-          when { not { changeRequest() } }
+          when {
+            not { changeRequest() }
+            beforeAgent true
+          }
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_15_latest'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ def doValidation() {
 }
 
 def isChangeRequest(env) {
-  if (env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty())
+  env.CHANGE_ID != null && !env.CHANGE_ID.isEmpty()
 }
 
 def retryFlagsString(env) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -271,12 +271,15 @@ pipeline {
   }
   
   post {
-    when { not { changeRequest() } }
     always {
-      step([$class: 'Mailer',
-           notifyEveryUnstableBuild: true,
-           recipients: "dev@kafka.apache.org",
-           sendToIndividuals: false])
+      script {
+        if (!config.isPrJob) {
+          step([$class: 'Mailer',
+               notifyEveryUnstableBuild: true,
+               recipients: "dev@kafka.apache.org",
+               sendToIndividuals: false])
+        }
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,9 @@ def tryStreamsArchetype() {
 
 pipeline {
   agent none
+  options {
+    disableConcurrentBuilds()
+  }
   stages {
     stage('Build') {
       parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,9 +100,11 @@ def tryStreamsArchetype() {
 
 pipeline {
   agent none
+  
   options {
     disableConcurrentBuilds()
   }
+  
   stages {
     stage('Build') {
       parallel {
@@ -256,6 +258,16 @@ pipeline {
           }
         }
       }
+    }
+  }
+  
+  post {
+    when { not { changeRequest() } }
+    always {
+      step([$class: 'Mailer',
+           notifyEveryUnstableBuild: true,
+           recipients: "dev@kafka.apache.org",
+           sendToIndividuals: false])
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,8 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
-        stage('JDK 8') {
+
+        stage('JDK 8 and Scala 2.12') {
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_1.8_latest'
@@ -124,7 +125,7 @@ pipeline {
           }
         }
 
-        stage('JDK 11') {
+        stage('JDK 11 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_11_latest'
@@ -143,8 +144,8 @@ pipeline {
             echo 'Skipping Kafka Streams archetype test for Java 11'
           }
         }
-       
-        stage('JDK 15') {
+
+        stage('JDK 15 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_15_latest'
@@ -180,6 +181,72 @@ pipeline {
               doTest('unitTest')
             }
             echo 'Skipping Kafka Streams archetype test for ARM build'
+          }
+        }
+        
+        // To avoid excessive Jenkins resource usage, we run a subset of builds
+        // at the PR stage. The rest are executed after changes are pushed to
+        // trunk and/or release branches.
+        if (!jobConfig.isPrJob) {
+          stage('JDK 8 and Scala 2.13') {
+            agent { label 'ubuntu' }
+            tools {
+              jdk 'jdk_1.8_latest'
+              maven 'maven_3_latest'
+            }
+            options {
+              timeout(time: 8, unit: 'HOURS') 
+              timestamps()
+            }
+            environment {
+              SCALA_VERSION=2.13
+            }
+            steps {
+              setupGradle()
+              doValidation()
+              doTest()
+              tryStreamsArchetype()
+            }
+          }
+
+          stage('JDK 11 and Scala 2.12') {
+            agent { label 'ubuntu' }
+            tools {
+              jdk 'jdk_11_latest'
+            }
+            options {
+              timeout(time: 8, unit: 'HOURS') 
+              timestamps()
+            }
+            environment {
+              SCALA_VERSION=2.12
+            }
+            steps {
+              setupGradle()
+              doValidation()
+              doTest()
+              echo 'Skipping Kafka Streams archetype test for Java 11'
+            }
+          }
+          
+          stage('JDK 15 and Scala 2.12') {
+            agent { label 'ubuntu' }
+            tools {
+              jdk 'jdk_15_latest'
+            }
+            options {
+              timeout(time: 8, unit: 'HOURS') 
+              timestamps()
+            }
+            environment {
+              SCALA_VERSION=2.12
+            }
+            steps {
+              setupGradle()
+              doValidation()
+              doTest()
+              echo 'Skipping Kafka Streams archetype test for Java 15'
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ pipeline {
         // the `when` clause.
         
         stage('JDK 8 and Scala 2.13') {
-          when { !changeRequest() }
+          when { not { changeRequest() } }
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_1.8_latest'
@@ -212,7 +212,7 @@ pipeline {
         }
 
         stage('JDK 11 and Scala 2.12') {
-          when { !changeRequest() }
+          when { not { changeRequest() } }
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_11_latest'
@@ -233,7 +233,7 @@ pipeline {
         }
 
         stage('JDK 15 and Scala 2.12') {
-          when { !changeRequest() }
+          when { not { changeRequest() } }
           agent { label 'ubuntu' }
           tools {
             jdk 'jdk_15_latest'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,9 @@ def retryFlagsString(env) {
 }
 
 def doTest(env, target = "unitTest integrationTest") {
-  sh """
-    ./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
-        --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed \
-        -PignoreFailures=true -PmaxParallelForks=2
-  """ + retryFlagsString(env)
+  sh """./gradlew -PscalaVersion=$SCALA_VERSION ${target} \
+      --profile --no-daemon --continue -PtestLoggingEvents=started,passed,skipped,failed \
+      -PignoreFailures=true -PmaxParallelForks=2""" + retryFlagsString(env)
   junit '**/build/test-results/**/TEST-*.xml'
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -277,7 +277,7 @@ pipeline {
   post {
     always {
       script {
-        if (!isChangeRequest(env) {
+        if (!isChangeRequest(env)) {
           step([$class: 'Mailer',
                notifyEveryUnstableBuild: true,
                recipients: "dev@kafka.apache.org",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,69 +184,72 @@ pipeline {
           }
         }
         
-        // To avoid excessive Jenkins resource usage, we run a subset of builds
-        // at the PR stage. The rest are executed after changes are pushed to
-        // trunk and/or release branches.
-        if (!jobConfig.isPrJob) {
-          stage('JDK 8 and Scala 2.13') {
-            agent { label 'ubuntu' }
-            tools {
-              jdk 'jdk_1.8_latest'
-              maven 'maven_3_latest'
-            }
-            options {
-              timeout(time: 8, unit: 'HOURS') 
-              timestamps()
-            }
-            environment {
-              SCALA_VERSION=2.13
-            }
-            steps {
-              setupGradle()
-              doValidation()
-              doTest()
-              tryStreamsArchetype()
-            }
+        // To avoid excessive Jenkins resource usage, we only run the stages
+        // above at the PR stage. The ones below are executed after changes
+        // are pushed to trunk and/or release branches. We achieve this via
+        // the `when` clause.
+        
+        stage('JDK 8 and Scala 2.13') {
+          when { !changeRequest() }
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_1.8_latest'
+            maven 'maven_3_latest'
           }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            setupGradle()
+            doValidation()
+            doTest()
+            tryStreamsArchetype()
+          }
+        }
 
-          stage('JDK 11 and Scala 2.12') {
-            agent { label 'ubuntu' }
-            tools {
-              jdk 'jdk_11_latest'
-            }
-            options {
-              timeout(time: 8, unit: 'HOURS') 
-              timestamps()
-            }
-            environment {
-              SCALA_VERSION=2.12
-            }
-            steps {
-              setupGradle()
-              doValidation()
-              doTest()
-              echo 'Skipping Kafka Streams archetype test for Java 11'
-            }
+        stage('JDK 11 and Scala 2.12') {
+          when { !changeRequest() }
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_11_latest'
           }
-          
-          stage('JDK 15 and Scala 2.12') {
-            agent { label 'ubuntu' }
-            tools {
-              jdk 'jdk_15_latest'
-            }
-            options {
-              timeout(time: 8, unit: 'HOURS') 
-              timestamps()
-            }
-            environment {
-              SCALA_VERSION=2.12
-            }
-            steps {
-              setupGradle()
-              doValidation()
-              doTest()
-              echo 'Skipping Kafka Streams archetype test for Java 15'
-            }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.12
+          }
+          steps {
+            setupGradle()
+            doValidation()
+            doTest()
+            echo 'Skipping Kafka Streams archetype test for Java 11'
+          }
+        }
+
+        stage('JDK 15 and Scala 2.12') {
+          when { !changeRequest() }
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_15_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.12
+          }
+          steps {
+            setupGradle()
+            doValidation()
+            doTest()
+            echo 'Skipping Kafka Streams archetype test for Java 15'
           }
         }
       }

--- a/release.py
+++ b/release.py
@@ -731,7 +731,7 @@ https://kafka.apache.org/%(docs_version)s/documentation.html
 https://kafka.apache.org/%(docs_version)s/protocol.html
 
 * Successful Jenkins builds for the %(dev_branch)s branch:
-Unit/integration tests: https://builds.apache.org/job/kafka-%(dev_branch)s-jdk8/<BUILD NUMBER>/
+Unit/integration tests: https://ci-builds.apache.org/job/Kafka/job/kafka/job/%(dev_branch)s/<BUILD NUMBER>/
 System tests: https://jenkins.confluent.io/job/system-test-kafka/job/%(dev_branch)s/<BUILD_NUMBER>/
 
 /**************************************


### PR DESCRIPTION
* Run all JDK/Scala version combinations for trunk/release branch builds.
* Only retry failures in PR builds for now (we can remove this distinction if/when
we report flaky failures as described in KAFKA-12216).
* Disable concurrent builds
* Send email to dev list on build failure
* Use triple double quotes in `doValidation` since we use string interpolation
for `SCALA_VERSION`.
* Update release.py to output new `Unit/integration tests` Jenkins link

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
