### PR TITLE
MINOR: Jenkinsfile's `post` needs `agent` to be set

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,9 +273,8 @@ pipeline {
   }
   
   post {
-    agent { label 'ubuntu' }
     always {
-      script {
+      node('ubuntu') {
         step([$class: 'Mailer',
              notifyEveryUnstableBuild: true,
              recipients: "dev@kafka.apache.org",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,10 +275,12 @@ pipeline {
   post {
     always {
       node('ubuntu') {
-        step([$class: 'Mailer',
-             notifyEveryUnstableBuild: true,
-             recipients: "dev@kafka.apache.org",
-             sendToIndividuals: false])
+        if (!isChangeRequest(env)) {
+          step([$class: 'Mailer',
+               notifyEveryUnstableBuild: true,
+               recipients: "dev@kafka.apache.org",
+               sendToIndividuals: false])
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,12 +276,10 @@ pipeline {
     agent { label 'ubuntu' }
     always {
       script {
-        if (!isChangeRequest(env)) {
-          step([$class: 'Mailer',
-               notifyEveryUnstableBuild: true,
-               recipients: "dev@kafka.apache.org",
-               sendToIndividuals: false])
-        }
+        step([$class: 'Mailer',
+             notifyEveryUnstableBuild: true,
+             recipients: "dev@kafka.apache.org",
+             sendToIndividuals: false])
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,11 +275,13 @@ pipeline {
   post {
     always {
       node('ubuntu') {
-        if (!isChangeRequest(env)) {
-          step([$class: 'Mailer',
-               notifyEveryUnstableBuild: true,
-               recipients: "dev@kafka.apache.org",
-               sendToIndividuals: false])
+        script {
+          if (!isChangeRequest(env)) {
+            step([$class: 'Mailer',
+                 notifyEveryUnstableBuild: true,
+                 recipients: "dev@kafka.apache.org",
+                 sendToIndividuals: false])
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -273,6 +273,7 @@ pipeline {
   }
   
   post {
+    agent { label 'ubuntu' }
     always {
       script {
         if (!isChangeRequest(env)) {


### PR DESCRIPTION
The `node` block achieves that.

Tested that an email was sent to the mailing list for:
https://github.com/apache/kafka/pull/10479/commits/592a0c31d5dec5b2d33b6239f6243831b7cca361

Added back the condition not to send emails for PR builds after
such test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
