### PR TITLE
KAFKA-12265: Move the BatchAccumulator in KafkaRaftClient to LeaderState

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -641,12 +641,9 @@ public class MemoryRecords extends AbstractRecords {
         long initialOffset,
         long timestamp,
         int leaderEpoch,
+        ByteBuffer buffer,
         LeaderChangeMessage leaderChangeMessage
     ) {
-        // To avoid calling message toStruct multiple times, we supply a fixed message size
-        // for leader change, as it happens rare and the buffer could still grow if not sufficient in
-        // certain edge cases.
-        ByteBuffer buffer = ByteBuffer.allocate(256);
         writeLeaderChangeMessage(buffer, initialOffset, timestamp, leaderEpoch, leaderChangeMessage);
         buffer.flip();
         return MemoryRecords.readableRecords(buffer);

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsTest.java
@@ -494,10 +494,12 @@ public class MemoryRecordsTest {
             .setLeaderId(leaderId)
             .setVoters(Collections.singletonList(
                 new Voter().setVoterId(voterId)));
+        ByteBuffer buffer = ByteBuffer.allocate(256);
         MemoryRecords records = MemoryRecords.withLeaderChangeMessage(
             initialOffset,
             System.currentTimeMillis(),
             leaderEpoch,
+            buffer,
             leaderChangeMessage
         );
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2221,7 +2221,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     private Long append(int epoch, List<T> records, boolean isAtomic) {
         BatchAccumulator<T> accumulator;
         try {
-            accumulator =  (BatchAccumulator<T>) quorum.leaderStateOrThrow().accumulator();
+            accumulator = quorum.<T>leaderStateOrThrow().accumulator();
         } catch (IllegalStateException ise) {
             return Long.MAX_VALUE;
         }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1841,8 +1841,8 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         LeaderState<T> state,
         long currentTimeMs
     ) {
-        long timeUntilFlush = state.accumulator().timeUntilDrain(currentTimeMs);
-        if (timeUntilFlush <= 0) {
+        long timeUntilDrain = state.accumulator().timeUntilDrain(currentTimeMs);
+        if (timeUntilDrain <= 0) {
             List<BatchAccumulator.CompletedBatch<T>> batches = state.accumulator().drain();
             Iterator<BatchAccumulator.CompletedBatch<T>> iterator = batches.iterator();
 
@@ -1859,7 +1859,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
                 }
             }
         }
-        return timeUntilFlush;
+        return timeUntilDrain;
     }
 
     private long pollResigned(long currentTimeMs) throws IOException {

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -166,8 +166,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     private final List<ListenerContext> listenerContexts = new ArrayList<>();
     private final ConcurrentLinkedQueue<Listener<T>> pendingListeners = new ConcurrentLinkedQueue<>();
 
-    private volatile BatchAccumulator<T> accumulator;
-
     /**
      * Create a new instance.
      *
@@ -272,7 +270,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private void updateLeaderEndOffsetAndTimestamp(
-        LeaderState state,
+        LeaderState<T> state,
         long currentTimeMs
     ) {
         final LogOffsetMetadata endOffsetMetadata = log.endOffset();
@@ -285,7 +283,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private void onUpdateLeaderHighWatermark(
-        LeaderState state,
+        LeaderState<T> state,
         long currentTimeMs
     ) {
         state.highWatermark().ifPresent(highWatermark -> {
@@ -340,7 +338,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         }
     }
 
-    private void maybeFireHandleClaim(LeaderState state) {
+    private void maybeFireHandleClaim(LeaderState<T> state) {
         int leaderEpoch = state.epoch();
         long epochStartOffset = state.epochStartOffset();
         for (ListenerContext listenerContext : listenerContexts) {
@@ -395,24 +393,14 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         requestManager.resetAll();
     }
 
-    private void onBecomeLeader(long currentTimeMs) {
-        LeaderState state = quorum.leaderStateOrThrow();
+    private void onBecomeLeader(long currentTimeMs) throws IOException {
+        long endOffset = log.endOffset().offset;
 
-        log.initializeLeaderEpoch(quorum.epoch());
-
-        // The high watermark can only be advanced once we have written a record
-        // from the new leader's epoch. Hence we write a control message immediately
-        // to ensure there is no delay committing pending data.
-        appendLeaderChangeMessage(state, log.endOffset().offset, currentTimeMs);
-        updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
-
-        resetConnections();
-
-        kafkaRaftMetrics.maybeUpdateElectionLatency(currentTimeMs);
-
-        accumulator = new BatchAccumulator<>(
+        // Add 1 to the offset that the accumulator tracks since appendLeaderChangeMessage 
+        // will write a record from the new leader's epoch to advance the high watermark below
+        BatchAccumulator<T> accumulator = new BatchAccumulator<>(
             quorum.epoch(),
-            log.endOffset().offset,
+            endOffset + 1,
             raftConfig.appendLingerMs(),
             MAX_BATCH_SIZE_BYTES,
             memoryPool,
@@ -420,6 +408,20 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             CompressionType.NONE,
             serde
         );
+
+        LeaderState<T> state = quorum.transitionToLeader(endOffset, accumulator);
+
+        log.initializeLeaderEpoch(quorum.epoch());
+
+        // The high watermark can only be advanced once we have written a record
+        // from the new leader's epoch. Hence we write a control message immediately
+        // to ensure there is no delay committing pending data.
+        appendLeaderChangeMessage(state, endOffset, currentTimeMs);
+        updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
+
+        resetConnections();
+
+        kafkaRaftMetrics.maybeUpdateElectionLatency(currentTimeMs);
     }
 
     private static List<Voter> convertToVoters(Set<Integer> voterIds) {
@@ -428,7 +430,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             .collect(Collectors.toList());
     }
 
-    private void appendLeaderChangeMessage(LeaderState state, long baseOffset, long currentTimeMs) {
+    private void appendLeaderChangeMessage(LeaderState<T> state, long baseOffset, long currentTimeMs) {
         List<Voter> voters = convertToVoters(state.followers());
         List<Voter> grantingVoters = convertToVoters(state.grantingVoters());
 
@@ -451,7 +453,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         flushLeaderLog(state, currentTimeMs);
     }
 
-    private void flushLeaderLog(LeaderState state, long currentTimeMs) {
+    private void flushLeaderLog(LeaderState<T> state, long currentTimeMs) {
         // We update the end offset before flushing so that parked fetches can return sooner
         updateLeaderEndOffsetAndTimestamp(state, currentTimeMs);
         log.flush();
@@ -459,8 +461,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
     private boolean maybeTransitionToLeader(CandidateState state, long currentTimeMs) throws IOException {
         if (state.isVoteGranted()) {
-            long endOffset = log.endOffset().offset;
-            quorum.transitionToLeader(endOffset);
             onBecomeLeader(currentTimeMs);
             return true;
         } else {
@@ -479,11 +479,6 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     private void maybeResignLeadership() {
         if (quorum.isLeader()) {
             fireHandleResign(quorum.epoch());
-        }
-
-        if (accumulator != null) {
-            accumulator.close();
-            accumulator = null;
         }
     }
 
@@ -761,7 +756,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             return handled.get();
         } else if (partitionError == Errors.NONE) {
             if (quorum.isLeader()) {
-                LeaderState state = quorum.leaderStateOrThrow();
+                LeaderState<T> state = quorum.leaderStateOrThrow();
                 state.addAcknowledgementFrom(remoteNodeId);
             } else {
                 logger.debug("Ignoring BeginQuorumEpoch response {} since " +
@@ -1025,7 +1020,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
 
             long fetchOffset = request.fetchOffset();
             int lastFetchedEpoch = request.lastFetchedEpoch();
-            LeaderState state = quorum.leaderStateOrThrow();
+            LeaderState<T> state = quorum.leaderStateOrThrow();
             ValidOffsetAndEpoch validOffsetAndEpoch = log.validateOffsetAndEpoch(fetchOffset, lastFetchedEpoch);
 
             final Records records;
@@ -1180,7 +1175,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
             return DescribeQuorumRequest.getTopLevelErrorResponse(Errors.INVALID_REQUEST);
         }
 
-        LeaderState leaderState = quorum.leaderStateOrThrow();
+        LeaderState<T> leaderState = quorum.leaderStateOrThrow();
         return DescribeQuorumResponse.singletonResponse(log.topicPartition(),
             leaderState.localId(),
             leaderState.epoch(),
@@ -1847,7 +1842,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private void appendBatch(
-        LeaderState state,
+        LeaderState<T> state,
         BatchAccumulator.CompletedBatch<T> batch,
         long appendTimeMs
     ) {
@@ -1876,12 +1871,12 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private long maybeAppendBatches(
-        LeaderState state,
+        LeaderState<T> state,
         long currentTimeMs
     ) {
-        long timeUnitFlush = accumulator.timeUntilDrain(currentTimeMs);
+        long timeUnitFlush = state.accumulator().timeUntilDrain(currentTimeMs);
         if (timeUnitFlush <= 0) {
-            List<BatchAccumulator.CompletedBatch<T>> batches = accumulator.drain();
+            List<BatchAccumulator.CompletedBatch<T>> batches = state.accumulator().drain();
             Iterator<BatchAccumulator.CompletedBatch<T>> iterator = batches.iterator();
 
             try {
@@ -1925,7 +1920,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     private long pollLeader(long currentTimeMs) {
-        LeaderState state = quorum.leaderStateOrThrow();
+        LeaderState<T> state = quorum.leaderStateOrThrow();
         maybeFireHandleClaim(state);
 
         GracefulShutdown shutdown = this.shutdown.get();
@@ -2222,9 +2217,12 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         return append(epoch, records, true);
     }
 
+    @SuppressWarnings("unchecked")
     private Long append(int epoch, List<T> records, boolean isAtomic) {
-        BatchAccumulator<T> accumulator = this.accumulator;
-        if (accumulator == null) {
+        BatchAccumulator<T> accumulator;
+        try {
+            accumulator =  (BatchAccumulator<T>) quorum.leaderStateOrThrow().accumulator();
+        } catch (IllegalStateException ise) {
             return Long.MAX_VALUE;
         }
 
@@ -2235,6 +2233,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         } else {
             offset = accumulator.append(epoch, records);
         }
+        
 
         // Wakeup the network channel if either this is the first append
         // or the accumulator is ready to drain now. Checking for the first

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -1826,7 +1826,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
                     double elapsedTimePerRecord = (double) elapsedTime / batch.numRecords;
                     kafkaRaftMetrics.updateCommitLatency(elapsedTimePerRecord, appendTimeMs);
                     logger.debug("Completed commit of {} records at {}", batch.numRecords, offsetAndEpoch);
-                    maybeFireHandleCommit(batch.baseOffset, epoch, batch.records.get());
+                    batch.records.ifPresent(records -> maybeFireHandleCommit(batch.baseOffset, epoch, records));
                 }
             });
         } finally {

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -97,7 +97,7 @@ public class LeaderState<T> implements EpochState {
             .setGrantingVoters(grantingVoters);
         
         accumulator.appendLeaderChangeMessage(leaderChangeMessage, currentTimeMs);
-        accumulator.flush();
+        accumulator.forceDrain();
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -57,8 +58,8 @@ public class LeaderState<T> implements EpochState {
         long epochStartOffset,
         Set<Integer> voters,
         Set<Integer> grantingVoters,
-        LogContext logContext,
-        BatchAccumulator<T> accumulator
+        BatchAccumulator<T> accumulator,
+        LogContext logContext
     ) {
         this.localId = localId;
         this.epoch = epoch;
@@ -71,7 +72,7 @@ public class LeaderState<T> implements EpochState {
         }
         this.grantingVoters.addAll(grantingVoters);
         this.log = logContext.logger(LeaderState.class);
-        this.accumulator = accumulator;
+        this.accumulator = Objects.requireNonNull(accumulator, "accumulator must be non-null");
     }
 
     public BatchAccumulator<T> accumulator() {
@@ -341,9 +342,7 @@ public class LeaderState<T> implements EpochState {
 
     @Override
     public void close() {
-        if (accumulator != null) {
-            accumulator.close();
-        }
+        accumulator.close();
     }
 
 }

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -91,9 +91,6 @@ public class LeaderState<T> implements EpochState {
         List<Voter> voters = convertToVoters(voterStates.keySet());
         List<Voter> grantingVoters = convertToVoters(this.grantingVoters());
 
-        // Adding the leader to the voters as any voter always votes for itself.
-        //voters.add(new Voter().setVoterId(this.election().leaderId()));
-
         LeaderChangeMessage leaderChangeMessage = new LeaderChangeMessage()
             .setLeaderId(this.election().leaderId())
             .setVoters(voters)

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -452,8 +452,8 @@ public class QuorumState {
             epochStartOffset,
             voters,
             candidateState.grantingVoters(),
-            logContext,
-            accumulator
+            accumulator,
+            logContext
         );
         transitionTo(state);
         return state;

--- a/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/QuorumState.java
@@ -18,6 +18,7 @@ package org.apache.kafka.raft;
 
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -422,7 +423,7 @@ public class QuorumState {
         ));
     }
 
-    public void transitionToLeader(long epochStartOffset) throws IOException {
+    public <T> LeaderState<T> transitionToLeader(long epochStartOffset, BatchAccumulator<T> accumulator) throws IOException {
         if (isObserver()) {
             throw new IllegalStateException("Cannot transition to Leader since the local broker.id="  + localId +
                 " is not one of the voters " + voters);
@@ -445,14 +446,17 @@ public class QuorumState {
         // could address this problem by decoupling the local high watermark, but
         // we typically expect the state machine to be caught up anyway.
 
-        transitionTo(new LeaderState(
+        LeaderState<T> state = new LeaderState<>(
             localIdOrThrow(),
             epoch(),
             epochStartOffset,
             voters,
             candidateState.grantingVoters(),
-            logContext
-        ));
+            logContext,
+            accumulator
+        );
+        transitionTo(state);
+        return state;
     }
 
     private void transitionTo(EpochState state) throws IOException {
@@ -493,9 +497,10 @@ public class QuorumState {
         throw new IllegalStateException("Expected to be Unattached, but current state is " + state);
     }
 
-    public LeaderState leaderStateOrThrow() {
+    @SuppressWarnings("unchecked")
+    public <T> LeaderState<T> leaderStateOrThrow() {
         if (isLeader())
-            return (LeaderState) state;
+            return (LeaderState<T>) state;
         throw new IllegalStateException("Expected to be Leader, but current state is " + state);
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchAccumulator.java
@@ -196,7 +196,7 @@ public class BatchAccumulator<T> implements Closeable {
         MemoryRecords data = currentBatch.build();
         completed.add(new CompletedBatch<>(
             currentBatch.baseOffset(),
-            currentBatch.records(),
+            Optional.of(currentBatch.records()),
             data,
             memoryPool,
             currentBatch.initialBuffer()
@@ -216,7 +216,7 @@ public class BatchAccumulator<T> implements Closeable {
                     leaderChangeMessage);
             completed.add(new CompletedBatch<>(
                 nextOffset,
-                null,
+                Optional.empty(),
                 data,
                 memoryPool,
                 buffer
@@ -381,13 +381,13 @@ public class BatchAccumulator<T> implements Closeable {
 
         private CompletedBatch(
             long baseOffset,
-            List<T> records,
+            Optional<List<T>> records,
             MemoryRecords data,
             MemoryPool pool,
             ByteBuffer initialBuffer
         ) {
             this.baseOffset = baseOffset;
-            this.records = Optional.ofNullable(records);
+            this.records = records;
             this.data = data;
             this.pool = pool;
             this.initialBuffer = initialBuffer;

--- a/raft/src/main/java/org/apache/kafka/raft/internals/BatchBuilder.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/BatchBuilder.java
@@ -96,7 +96,7 @@ public class BatchBuilder<T> {
     }
 
     /**
-     * Append a record to this patch. The caller must first verify there is room for the batch
+     * Append a record to this batch. The caller must first verify there is room for the batch
      * using {@link #bytesNeeded(Collection, ObjectSerializationCache)}.
      *
      * @param record the record to append

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -299,7 +299,7 @@ public class KafkaRaftClientTest {
 
         Record record = batch.iterator().next();
         assertEquals(electionTimestamp, record.timestamp());
-        RaftClientTestContext.verifyLeaderChangeMessage(localId, Arrays.asList(otherNodeId, localId),
+        RaftClientTestContext.verifyLeaderChangeMessage(localId, Arrays.asList(localId, otherNodeId),
             Arrays.asList(otherNodeId, localId), record.key(), record.value());
     }
 
@@ -339,7 +339,7 @@ public class KafkaRaftClientTest {
 
         Record record = batch.iterator().next();
         assertEquals(electionTimestamp, record.timestamp());
-        RaftClientTestContext.verifyLeaderChangeMessage(localId, Arrays.asList(firstNodeId, secondNodeId, localId),
+        RaftClientTestContext.verifyLeaderChangeMessage(localId, Arrays.asList(localId, firstNodeId, secondNodeId),
             Arrays.asList(firstNodeId, localId), record.key(), record.value());
     }
 
@@ -475,8 +475,11 @@ public class KafkaRaftClientTest {
 
         MemoryPool memoryPool = Mockito.mock(MemoryPool.class);
         ByteBuffer buffer = ByteBuffer.allocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES);
+        ByteBuffer leaderBuffer = ByteBuffer.allocate(256);
         Mockito.when(memoryPool.tryAllocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES))
             .thenReturn(buffer);
+        Mockito.when(memoryPool.tryAllocate(256))
+            .thenReturn(leaderBuffer);
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
             .withAppendLingerMs(lingerMs)
@@ -504,8 +507,11 @@ public class KafkaRaftClientTest {
 
         MemoryPool memoryPool = Mockito.mock(MemoryPool.class);
         ByteBuffer buffer = ByteBuffer.allocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES);
+        ByteBuffer leaderBuffer = ByteBuffer.allocate(256);
         Mockito.when(memoryPool.tryAllocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES))
             .thenReturn(buffer);
+        Mockito.when(memoryPool.tryAllocate(256))
+            .thenReturn(leaderBuffer);
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
             .withAppendLingerMs(lingerMs)
@@ -534,8 +540,11 @@ public class KafkaRaftClientTest {
 
         MemoryPool memoryPool = Mockito.mock(MemoryPool.class);
         ByteBuffer buffer = ByteBuffer.allocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES);
+        ByteBuffer leaderBuffer = ByteBuffer.allocate(256);
         Mockito.when(memoryPool.tryAllocate(KafkaRaftClient.MAX_BATCH_SIZE_BYTES))
             .thenReturn(buffer);
+        Mockito.when(memoryPool.tryAllocate(256))
+            .thenReturn(leaderBuffer);
 
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters)
             .withAppendLingerMs(lingerMs)

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientTest.java
@@ -80,6 +80,7 @@ public class KafkaRaftClientTest {
             .withElectedLeader(initialEpoch, localId)
             .build();
 
+        context.pollUntil(() -> context.log.endOffset().offset == 1L);
         assertEquals(1L, context.log.endOffset().offset);
         assertEquals(initialEpoch + 1, context.log.lastFetchedEpoch());
         assertEquals(new LeaderAndEpoch(OptionalInt.of(localId), initialEpoch + 1),
@@ -280,7 +281,7 @@ public class KafkaRaftClientTest {
         context.deliverResponse(correlationId, otherNodeId, context.voteResponse(true, Optional.empty(), 1));
 
         // Become leader after receiving the vote
-        context.client.poll();
+        context.pollUntil(() -> context.log.endOffset().offset == 1L);
         context.assertElectedLeader(1, localId);
         long electionTimestamp = context.time.milliseconds();
 
@@ -320,7 +321,7 @@ public class KafkaRaftClientTest {
         context.deliverResponse(correlationId, firstNodeId, context.voteResponse(true, Optional.empty(), 1));
 
         // Become leader after receiving the vote
-        context.client.poll();
+        context.pollUntil(() -> context.log.endOffset().offset == 1L);
         context.assertElectedLeader(1, localId);
         long electionTimestamp = context.time.milliseconds();
 
@@ -1871,6 +1872,7 @@ public class KafkaRaftClientTest {
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, voters).build();
         long now = context.time.milliseconds();
 
+        context.pollUntil(() -> context.log.endOffset().offset == 1L);
         context.assertElectedLeader(1, localId);
 
         // We still write the leader change message
@@ -1957,6 +1959,7 @@ public class KafkaRaftClientTest {
         int epoch = 1;
         RaftClientTestContext context = new RaftClientTestContext.Builder(localId, Collections.singleton(localId))
             .build();
+        context.pollUntil(() -> context.log.endOffset().offset == 1L);
 
         assertNotNull(getMetric(context.metrics, "current-state"));
         assertNotNull(getMetric(context.metrics, "current-leader"));

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -148,20 +148,8 @@ public class LeaderStateTest<T> {
     public void testUpdateHighWatermarkQuorumSizeTwo() {
         int otherNodeId = 1;
         LeaderState<T> state = newLeaderState(mkSet(localId, otherNodeId), 10L);
-        assertFalse(state.updateLocalState(0, new LogOffsetMetadata(15L)));
-        assertEquals(Optional.empty(), state.highWatermark());
-        assertTrue(state.updateReplicaState(otherNodeId, 0, new LogOffsetMetadata(10L)));
-        assertEquals(emptySet(), state.nonAcknowledgingVoters());
-        assertEquals(Optional.of(new LogOffsetMetadata(10L)), state.highWatermark());
-        assertTrue(state.updateReplicaState(otherNodeId, 0, new LogOffsetMetadata(15L)));
-        assertEquals(Optional.of(new LogOffsetMetadata(15L)), state.highWatermark());
-    }
-
-    @Test
-    public void testHighWatermarkUnknownUntilStartOfLeaderEpoch() {
-        int otherNodeId = 1;
-        LeaderState<T> state = newLeaderState(mkSet(localId, otherNodeId), 15L);
-        assertFalse(state.updateLocalState(0, new LogOffsetMetadata(20L)));
+        assertFalse(state.updateLocalState(0, new LogOffsetMetadata(13L)));
+        assertEquals(singleton(otherNodeId), state.nonAcknowledgingVoters());
         assertEquals(Optional.empty(), state.highWatermark());
         assertFalse(state.updateReplicaState(otherNodeId, 0, new LogOffsetMetadata(10L)));
         assertEquals(emptySet(), state.nonAcknowledgingVoters());

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -19,12 +19,11 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.internals.BatchAccumulator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
@@ -43,15 +42,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LeaderStateTest<T> {
+public class LeaderStateTest {
     private final int localId = 0;
     private final int epoch = 5;
     private final LogContext logContext = new LogContext();
 
-    @SuppressWarnings("unchecked")
-    private final BatchAccumulator<T> accumulator = (BatchAccumulator<T>) Mockito.mock(BatchAccumulator.class);
+    private final BatchAccumulator<?> accumulator = Mockito.mock(BatchAccumulator.class);
 
-    private LeaderState<T> newLeaderState(
+    private LeaderState<?> newLeaderState(
         Set<Integer> voters,
         long epochStartOffset
     ) {
@@ -83,7 +81,7 @@ public class LeaderStateTest<T> {
     public void testFollowerAcknowledgement() {
         int node1 = 1;
         int node2 = 2;
-        LeaderState<T> state = newLeaderState(mkSet(localId, node1, node2), 0L);
+        LeaderState<?> state = newLeaderState(mkSet(localId, node1, node2), 0L);
         assertEquals(mkSet(node1, node2), state.nonAcknowledgingVoters());
         state.addAcknowledgementFrom(node1);
         assertEquals(singleton(node2), state.nonAcknowledgingVoters());
@@ -94,13 +92,13 @@ public class LeaderStateTest<T> {
     @Test
     public void testNonFollowerAcknowledgement() {
         int nonVoterId = 1;
-        LeaderState<T> state = newLeaderState(singleton(localId), 0L);
+        LeaderState<?> state = newLeaderState(singleton(localId), 0L);
         assertThrows(IllegalArgumentException.class, () -> state.addAcknowledgementFrom(nonVoterId));
     }
 
     @Test
     public void testUpdateHighWatermarkQuorumSizeOne() {
-        LeaderState<T> state = newLeaderState(singleton(localId), 15L);
+        LeaderState<?> state = newLeaderState(singleton(localId), 15L);
         assertEquals(Optional.empty(), state.highWatermark());
         assertFalse(state.updateLocalState(0, new LogOffsetMetadata(15L)));
         assertEquals(emptySet(), state.nonAcknowledgingVoters());
@@ -113,7 +111,7 @@ public class LeaderStateTest<T> {
 
     @Test
     public void testNonMonotonicLocalEndOffsetUpdate() {
-        LeaderState<T> state = newLeaderState(singleton(localId), 15L);
+        LeaderState<?> state = newLeaderState(singleton(localId), 15L);
         assertEquals(Optional.empty(), state.highWatermark());
         assertTrue(state.updateLocalState(0, new LogOffsetMetadata(16L)));
         assertEquals(Optional.of(new LogOffsetMetadata(16L)), state.highWatermark());
@@ -123,7 +121,7 @@ public class LeaderStateTest<T> {
 
     @Test
     public void testIdempotentEndOffsetUpdate() {
-        LeaderState<T> state = newLeaderState(singleton(localId), 15L);
+        LeaderState<?> state = newLeaderState(singleton(localId), 15L);
         assertEquals(Optional.empty(), state.highWatermark());
         assertTrue(state.updateLocalState(0, new LogOffsetMetadata(16L)));
         assertFalse(state.updateLocalState(0, new LogOffsetMetadata(16L)));
@@ -132,7 +130,7 @@ public class LeaderStateTest<T> {
 
     @Test
     public void testUpdateHighWatermarkMetadata() {
-        LeaderState<T> state = newLeaderState(singleton(localId), 15L);
+        LeaderState<?> state = newLeaderState(singleton(localId), 15L);
         assertEquals(Optional.empty(), state.highWatermark());
 
         LogOffsetMetadata initialHw = new LogOffsetMetadata(16L, Optional.of(new MockOffsetMetadata("bar")));
@@ -147,7 +145,7 @@ public class LeaderStateTest<T> {
     @Test
     public void testUpdateHighWatermarkQuorumSizeTwo() {
         int otherNodeId = 1;
-        LeaderState<T> state = newLeaderState(mkSet(localId, otherNodeId), 10L);
+        LeaderState<?> state = newLeaderState(mkSet(localId, otherNodeId), 10L);
         assertFalse(state.updateLocalState(0, new LogOffsetMetadata(13L)));
         assertEquals(singleton(otherNodeId), state.nonAcknowledgingVoters());
         assertEquals(Optional.empty(), state.highWatermark());
@@ -164,7 +162,7 @@ public class LeaderStateTest<T> {
     public void testUpdateHighWatermarkQuorumSizeThree() {
         int node1 = 1;
         int node2 = 2;
-        LeaderState<T> state = newLeaderState(mkSet(localId, node1, node2), 10L);
+        LeaderState<?> state = newLeaderState(mkSet(localId, node1, node2), 10L);
         assertFalse(state.updateLocalState(0, new LogOffsetMetadata(15L)));
         assertEquals(mkSet(node1, node2), state.nonAcknowledgingVoters());
         assertEquals(Optional.empty(), state.highWatermark());
@@ -188,7 +186,7 @@ public class LeaderStateTest<T> {
     public void testNonMonotonicHighWatermarkUpdate() {
         MockTime time = new MockTime();
         int node1 = 1;
-        LeaderState<T> state = newLeaderState(mkSet(localId, node1), 0L);
+        LeaderState<?> state = newLeaderState(mkSet(localId, node1), 0L);
         state.updateLocalState(time.milliseconds(), new LogOffsetMetadata(10L));
         state.updateReplicaState(node1, time.milliseconds(), new LogOffsetMetadata(10L));
         assertEquals(Optional.of(new LogOffsetMetadata(10L)), state.highWatermark());
@@ -207,7 +205,7 @@ public class LeaderStateTest<T> {
         long leaderStartOffset = 10L;
         long leaderEndOffset = 15L;
 
-        LeaderState<T> state = setUpLeaderAndFollowers(node1, node2, leaderStartOffset, leaderEndOffset);
+        LeaderState<?> state = setUpLeaderAndFollowers(node1, node2, leaderStartOffset, leaderEndOffset);
 
         // Leader should not be included; the follower with larger offset should be prioritized.
         assertEquals(Arrays.asList(node2, node1), state.nonLeaderVotersByDescendingFetchOffset());
@@ -220,7 +218,7 @@ public class LeaderStateTest<T> {
         long leaderStartOffset = 10L;
         long leaderEndOffset = 15L;
 
-        LeaderState<T> state = setUpLeaderAndFollowers(node1, node2, leaderStartOffset, leaderEndOffset);
+        LeaderState<?> state = setUpLeaderAndFollowers(node1, node2, leaderStartOffset, leaderEndOffset);
 
         assertEquals(mkMap(
             mkEntry(localId, leaderEndOffset),
@@ -229,11 +227,11 @@ public class LeaderStateTest<T> {
         ), state.getVoterEndOffsets());
     }
 
-    private LeaderState<T> setUpLeaderAndFollowers(int follower1,
+    private LeaderState<?> setUpLeaderAndFollowers(int follower1,
                                                 int follower2,
                                                 long leaderStartOffset,
                                                 long leaderEndOffset) {
-        LeaderState<T> state = newLeaderState(mkSet(localId, follower1, follower2), leaderStartOffset);
+        LeaderState<?> state = newLeaderState(mkSet(localId, follower1, follower2), leaderStartOffset);
         state.updateLocalState(0, new LogOffsetMetadata(leaderEndOffset));
         assertEquals(Optional.empty(), state.highWatermark());
         state.updateReplicaState(follower1, 0, new LogOffsetMetadata(leaderStartOffset));
@@ -246,7 +244,7 @@ public class LeaderStateTest<T> {
         int observerId = 10;
         long epochStartOffset = 10L;
 
-        LeaderState<T> state = newLeaderState(mkSet(localId), epochStartOffset);
+        LeaderState<?> state = newLeaderState(mkSet(localId), epochStartOffset);
         long timestamp = 20L;
         assertFalse(state.updateReplicaState(observerId, timestamp, new LogOffsetMetadata(epochStartOffset)));
 
@@ -258,7 +256,7 @@ public class LeaderStateTest<T> {
         int observerId = -1;
         long epochStartOffset = 10L;
 
-        LeaderState<T> state = newLeaderState(mkSet(localId), epochStartOffset);
+        LeaderState<?> state = newLeaderState(mkSet(localId), epochStartOffset);
         assertFalse(state.updateReplicaState(observerId, 0, new LogOffsetMetadata(epochStartOffset)));
 
         assertEquals(Collections.emptyMap(), state.getObserverStates(10));
@@ -269,7 +267,7 @@ public class LeaderStateTest<T> {
         MockTime time = new MockTime();
         int observerId = 10;
         long epochStartOffset = 10L;
-        LeaderState<T> state = newLeaderState(mkSet(localId), epochStartOffset);
+        LeaderState<?> state = newLeaderState(mkSet(localId), epochStartOffset);
 
         state.updateReplicaState(observerId, time.milliseconds(), new LogOffsetMetadata(epochStartOffset));
         assertEquals(singleton(observerId), state.getObserverStates(time.milliseconds()).keySet());
@@ -281,7 +279,7 @@ public class LeaderStateTest<T> {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testGrantVote(boolean isLogUpToDate) {
-        LeaderState<T> state = newLeaderState(Utils.mkSet(1, 2, 3), 1);
+        LeaderState<?> state = newLeaderState(Utils.mkSet(1, 2, 3), 1);
 
         assertFalse(state.canGrantVote(1, isLogUpToDate));
         assertFalse(state.canGrantVote(2, isLogUpToDate));

--- a/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/LeaderStateTest.java
@@ -228,9 +228,9 @@ public class LeaderStateTest {
     }
 
     private LeaderState<?> setUpLeaderAndFollowers(int follower1,
-                                                int follower2,
-                                                long leaderStartOffset,
-                                                long leaderEndOffset) {
+                                                   int follower2,
+                                                   long leaderStartOffset,
+                                                   long leaderEndOffset) {
         LeaderState<?> state = newLeaderState(mkSet(localId, follower1, follower2), leaderStartOffset);
         state.updateLocalState(0, new LogOffsetMetadata(leaderEndOffset));
         assertEquals(Optional.empty(), state.highWatermark());

--- a/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/MockLogTest.java
@@ -235,8 +235,9 @@ public class MockLogTest {
         final long initialOffset = 0;
         final int currentEpoch = 3;
         LeaderChangeMessage messageData =  new LeaderChangeMessage().setLeaderId(0);
+        ByteBuffer buffer = ByteBuffer.allocate(256);
         log.appendAsLeader(
-            MemoryRecords.withLeaderChangeMessage(initialOffset, 0L, 2, messageData),
+            MemoryRecords.withLeaderChangeMessage(initialOffset, 0L, 2, buffer, messageData),
             currentEpoch
         );
 

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -269,7 +269,7 @@ public class QuorumStateTest {
         assertTrue(state.isCandidate());
         assertEquals(1, state.epoch());
 
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         LeaderState leaderState = state.leaderStateOrThrow();
         assertTrue(state.isLeader());
         assertEquals(1, leaderState.epoch());
@@ -284,10 +284,10 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
         assertFalse(state.candidateStateOrThrow().isVoteGranted());
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
         assertTrue(state.candidateStateOrThrow().isVoteGranted());
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         assertTrue(state.isLeader());
     }
 
@@ -359,11 +359,11 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
 
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
     }
@@ -376,7 +376,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
 
@@ -397,7 +397,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
 
@@ -415,7 +415,7 @@ public class QuorumStateTest {
 
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         state.transitionToFollower(5, otherNodeId);
 
         assertEquals(5, state.epoch());
@@ -431,7 +431,7 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         state.transitionToUnattached(5);
         assertEquals(5, state.epoch());
         assertEquals(OptionalInt.empty(), state.leaderId());
@@ -446,7 +446,7 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         state.transitionToVoted(5, otherNodeId);
 
         assertEquals(5, state.epoch());
@@ -465,7 +465,7 @@ public class QuorumStateTest {
         state.transitionToUnattached(5);
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         assertThrows(IllegalStateException.class, () -> state.transitionToUnattached(4));
         assertThrows(IllegalStateException.class, () -> state.transitionToVoted(4, otherNodeId));
         assertThrows(IllegalStateException.class, () -> state.transitionToFollower(4, otherNodeId));
@@ -492,7 +492,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         assertTrue(state.isUnattached());
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
         assertThrows(IllegalStateException.class, () -> state.transitionToResigned(Collections.emptyList()));
     }
 
@@ -626,7 +626,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToVoted(5, node1);
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0, null));
         assertThrows(IllegalStateException.class, () -> state.transitionToResigned(Collections.emptyList()));
     }
 
@@ -780,7 +780,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToFollower(8, node2);
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0, null));
         assertThrows(IllegalStateException.class, () -> state.transitionToResigned(Collections.emptyList()));
     }
 
@@ -900,7 +900,7 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         assertTrue(state.isObserver());
         assertThrows(IllegalStateException.class, state::transitionToCandidate);
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
         assertThrows(IllegalStateException.class, () -> state.transitionToVoted(5, otherNodeId));
     }
 
@@ -982,7 +982,7 @@ public class QuorumStateTest {
         assertFalse(state.hasRemoteLeader());
 
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L);
+        state.transitionToLeader(0L, null);
         assertFalse(state.hasRemoteLeader());
 
         state.transitionToUnattached(state.epoch() + 1);
@@ -1022,7 +1022,7 @@ public class QuorumStateTest {
         candidateState.recordGrantedVote(otherNodeId);
         assertTrue(candidateState.isVoteGranted());
 
-        state.transitionToLeader(10L);
+        state.transitionToLeader(10L, null);
         assertEquals(Optional.empty(), state.highWatermark());
     }
 
@@ -1036,7 +1036,7 @@ public class QuorumStateTest {
 
         assertThrows(IllegalStateException.class, state::transitionToCandidate);
         assertThrows(IllegalStateException.class, () -> state.transitionToVoted(1, 1));
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
 
         state.transitionToFollower(1, 1);
         assertTrue(state.isFollower());

--- a/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/QuorumStateTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.raft;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.raft.internals.BatchAccumulator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -44,6 +45,8 @@ public class QuorumStateTest {
     private final int electionTimeoutMs = 5000;
     private final int fetchTimeoutMs = 10000;
     private final Random random = Mockito.spy(new Random(1));
+
+    private BatchAccumulator<?> accumulator = Mockito.mock(BatchAccumulator.class);
 
     private QuorumState buildQuorumState(Set<Integer> voters) {
         return buildQuorumState(OptionalInt.of(localId), voters);
@@ -269,7 +272,7 @@ public class QuorumStateTest {
         assertTrue(state.isCandidate());
         assertEquals(1, state.epoch());
 
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         LeaderState leaderState = state.leaderStateOrThrow();
         assertTrue(state.isLeader());
         assertEquals(1, leaderState.epoch());
@@ -284,10 +287,10 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
         assertFalse(state.candidateStateOrThrow().isVoteGranted());
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, accumulator));
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
         assertTrue(state.candidateStateOrThrow().isVoteGranted());
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         assertTrue(state.isLeader());
     }
 
@@ -359,11 +362,11 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
 
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, accumulator));
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
     }
@@ -376,7 +379,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
 
@@ -397,7 +400,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         assertTrue(state.isLeader());
         assertEquals(1, state.epoch());
 
@@ -415,7 +418,7 @@ public class QuorumStateTest {
 
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         state.transitionToFollower(5, otherNodeId);
 
         assertEquals(5, state.epoch());
@@ -431,7 +434,7 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         state.transitionToUnattached(5);
         assertEquals(5, state.epoch());
         assertEquals(OptionalInt.empty(), state.leaderId());
@@ -446,7 +449,7 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         state.transitionToVoted(5, otherNodeId);
 
         assertEquals(5, state.epoch());
@@ -465,7 +468,7 @@ public class QuorumStateTest {
         state.transitionToUnattached(5);
         state.transitionToCandidate();
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         assertThrows(IllegalStateException.class, () -> state.transitionToUnattached(4));
         assertThrows(IllegalStateException.class, () -> state.transitionToVoted(4, otherNodeId));
         assertThrows(IllegalStateException.class, () -> state.transitionToFollower(4, otherNodeId));
@@ -492,7 +495,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         assertTrue(state.isUnattached());
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, accumulator));
         assertThrows(IllegalStateException.class, () -> state.transitionToResigned(Collections.emptyList()));
     }
 
@@ -626,7 +629,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToVoted(5, node1);
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0, accumulator));
         assertThrows(IllegalStateException.class, () -> state.transitionToResigned(Collections.emptyList()));
     }
 
@@ -780,7 +783,7 @@ public class QuorumStateTest {
         QuorumState state = initializeEmptyState(voters);
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         state.transitionToFollower(8, node2);
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0, accumulator));
         assertThrows(IllegalStateException.class, () -> state.transitionToResigned(Collections.emptyList()));
     }
 
@@ -900,7 +903,7 @@ public class QuorumStateTest {
         state.initialize(new OffsetAndEpoch(0L, logEndEpoch));
         assertTrue(state.isObserver());
         assertThrows(IllegalStateException.class, state::transitionToCandidate);
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, accumulator));
         assertThrows(IllegalStateException.class, () -> state.transitionToVoted(5, otherNodeId));
     }
 
@@ -982,7 +985,7 @@ public class QuorumStateTest {
         assertFalse(state.hasRemoteLeader());
 
         state.candidateStateOrThrow().recordGrantedVote(otherNodeId);
-        state.transitionToLeader(0L, null);
+        state.transitionToLeader(0L, accumulator);
         assertFalse(state.hasRemoteLeader());
 
         state.transitionToUnattached(state.epoch() + 1);
@@ -1022,7 +1025,7 @@ public class QuorumStateTest {
         candidateState.recordGrantedVote(otherNodeId);
         assertTrue(candidateState.isVoteGranted());
 
-        state.transitionToLeader(10L, null);
+        state.transitionToLeader(10L, accumulator);
         assertEquals(Optional.empty(), state.highWatermark());
     }
 
@@ -1036,7 +1039,7 @@ public class QuorumStateTest {
 
         assertThrows(IllegalStateException.class, state::transitionToCandidate);
         assertThrows(IllegalStateException.class, () -> state.transitionToVoted(1, 1));
-        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, null));
+        assertThrows(IllegalStateException.class, () -> state.transitionToLeader(0L, accumulator));
 
         state.transitionToFollower(1, 1);
         assertTrue(state.isFollower());

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -202,7 +202,7 @@ class BatchAccumulatorTest {
             assertEquals(Long.MAX_VALUE - time.milliseconds(), acc.timeUntilDrain(time.milliseconds()));
 
             BatchAccumulator.CompletedBatch<String> batch = batches.get(0);
-            assertEquals(records, batch.records);
+            assertEquals(records, batch.records.get());
             assertEquals(baseOffset, batch.baseOffset);
         });
     }

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -121,12 +121,9 @@ class BatchAccumulatorTest {
             assertEquals(baseOffset + 7, appender.call(acc, leaderEpoch, records.subList(6, 8)));
             assertEquals(baseOffset + 8, appender.call(acc, leaderEpoch, records.subList(8, 9)));
 
-            // Check that a drain is needed
-            time.sleep(lingerMs);
-            assertTrue(acc.needsDrain(time.milliseconds()));
-
-            // Force a drain and check that the drain status is `FINISHED`
+            assertFalse(acc.needsDrain(time.milliseconds()));
             acc.forceDrain();
+            assertTrue(acc.needsDrain(time.milliseconds()));
             assertEquals(0, acc.timeUntilDrain(time.milliseconds()));
            
             // Drain completed batches
@@ -171,12 +168,12 @@ class BatchAccumulatorTest {
             assertEquals(baseOffset + 7, appender.call(acc, leaderEpoch, records.subList(6, 8)));
             assertEquals(baseOffset + 8, appender.call(acc, leaderEpoch, records.subList(8, 9)));
 
-            // Check that a drain is needed
-            time.sleep(lingerMs);
-            assertTrue(acc.needsDrain(time.milliseconds()));
+            assertFalse(acc.needsDrain(time.milliseconds()));
            
             // Append a leader change message
             acc.appendLeaderChangeMessage(new LeaderChangeMessage(), time.milliseconds());
+
+            assertTrue(acc.needsDrain(time.milliseconds()));
 
             // Test that drain status is FINISHED
             assertEquals(0, acc.timeUntilDrain(time.milliseconds()));
@@ -484,7 +481,6 @@ class BatchAccumulatorTest {
             completedBatch.data.batches().forEach(recordBatch -> {
                 assertEquals(leaderEpoch, recordBatch.partitionLeaderEpoch()); });
         });
-        acc.close();
     }
 
     int recordSizeInBytes(String record, int numberOfRecords) {

--- a/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/BatchAccumulatorTest.java
@@ -85,6 +85,7 @@ class BatchAccumulatorTest {
         );
 
         acc.appendLeaderChangeMessage(new LeaderChangeMessage(), time.milliseconds());
+        assertTrue(acc.needsDrain(time.milliseconds()));
 
         List<BatchAccumulator.CompletedBatch<String>> batches = acc.drain();
         assertEquals(1, batches.size());

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -92,7 +92,7 @@ public class KafkaRaftMetricsTest {
         assertEquals((double) -1L, getMetric(metrics, "high-watermark").metricValue());
 
         state.candidateStateOrThrow().recordGrantedVote(1);
-        state.transitionToLeader(2L);
+        state.transitionToLeader(2L, null);
         assertEquals("leader", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) localId, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) localId, getMetric(metrics, "current-vote").metricValue());

--- a/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/KafkaRaftMetricsTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.raft.OffsetAndEpoch;
 import org.apache.kafka.raft.QuorumState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -49,6 +50,8 @@ public class KafkaRaftMetricsTest {
     private final Metrics metrics = new Metrics(time);
     private final Random random = new Random(1);
     private KafkaRaftMetrics raftMetrics;
+
+    private BatchAccumulator<?> accumulator = Mockito.mock(BatchAccumulator.class);
 
     @AfterEach
     public void tearDown() {
@@ -92,7 +95,7 @@ public class KafkaRaftMetricsTest {
         assertEquals((double) -1L, getMetric(metrics, "high-watermark").metricValue());
 
         state.candidateStateOrThrow().recordGrantedVote(1);
-        state.transitionToLeader(2L, null);
+        state.transitionToLeader(2L, accumulator);
         assertEquals("leader", getMetric(metrics, "current-state").metricValue());
         assertEquals((double) localId, getMetric(metrics, "current-leader").metricValue());
         assertEquals((double) localId, getMetric(metrics, "current-vote").metricValue());


### PR DESCRIPTION
The KafkaRaftClient has a field for the BatchAccumulator that is only used and set when it is the leader. In other cases, leader specific information was stored in LeaderState. In a recent change EpochState, which LeaderState implements, was changed to be a Closable. QuorumState makes sure to always close the previous state before transitioning to the next state. This redesign was used to move the BatchAccumulator to the LeaderState and simplify some of the handling in KafkaRaftClient.

https://issues.apache.org/jira/browse/KAFKA-12265