### PR TITLE
KAFKA-12586; Add `DescribeTransactions` Admin API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1509,6 +1509,27 @@ public interface Admin extends AutoCloseable {
     DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options);
 
     /**
+     * Describe the state of a set of transactionalIds. See
+     * {@link #describeTransactions(Collection, DescribeTransactionsOptions)} for more details.
+     *
+     * @param transactionalIds The set of transactionalIds to query
+     * @return The result
+     */
+    default DescribeTransactionsResult describeTransactions(Collection<String> transactionalIds) {
+        return describeTransactions(transactionalIds, new DescribeTransactionsOptions());
+    }
+
+    /**
+     * Describe the state of a set of transactionalIds from the respective transaction coordinators,
+     * which are dynamically discovered.
+     *
+     * @param transactionalIds The set of transactionalIds to query
+     * @param options Options to control the method behavior
+     * @return The result
+     */
+    DescribeTransactionsResult describeTransactions(Collection<String> transactionalIds, DescribeTransactionsOptions options);
+
+    /**
      * Get the metrics kept by the adminClient
      */
     Map<MetricName, ? extends Metric> metrics();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1509,10 +1509,10 @@ public interface Admin extends AutoCloseable {
     DescribeProducersResult describeProducers(Collection<TopicPartition> partitions, DescribeProducersOptions options);
 
     /**
-     * Describe the state of a set of transactionalIds. See
+     * Describe the state of a set of transactional IDs. See
      * {@link #describeTransactions(Collection, DescribeTransactionsOptions)} for more details.
      *
-     * @param transactionalIds The set of transactionalIds to query
+     * @param transactionalIds The set of transactional IDs to query
      * @return The result
      */
     default DescribeTransactionsResult describeTransactions(Collection<String> transactionalIds) {
@@ -1520,10 +1520,10 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
-     * Describe the state of a set of transactionalIds from the respective transaction coordinators,
+     * Describe the state of a set of transactional IDs from the respective transaction coordinators,
      * which are dynamically discovered.
      *
-     * @param transactionalIds The set of transactionalIds to query
+     * @param transactionalIds The set of transactional IDs to query
      * @param options Options to control the method behavior
      * @return The result
      */

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsOptions.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
+/**
+ * Options for {@link Admin#describeTransactions(Collection)}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeTransactionsOptions extends AbstractOptions<DescribeTransactionsOptions> {
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsResult.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.admin.internals.CoordinatorKey;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@InterfaceStability.Evolving
+public class DescribeTransactionsResult {
+    private final Map<CoordinatorKey, KafkaFutureImpl<TransactionDescription>> futures;
+
+    DescribeTransactionsResult(Map<CoordinatorKey, KafkaFutureImpl<TransactionDescription>> futures) {
+        this.futures = futures;
+    }
+
+    public KafkaFuture<TransactionDescription> transactionalIdResult(String transactionalId) {
+        CoordinatorKey key = buildKey(transactionalId);
+        KafkaFuture<TransactionDescription> future = futures.get(key);
+        if (future == null) {
+            throw new IllegalArgumentException("TransactionalId " +
+                "`" + transactionalId + "` was not included in the request");
+        }
+        return future;
+    }
+
+    private CoordinatorKey buildKey(String transactionalId) {
+        return new CoordinatorKey(transactionalId, FindCoordinatorRequest.CoordinatorType.TRANSACTION);
+    }
+
+    public KafkaFuture<Map<String, TransactionDescription>> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
+            .thenApply(nil -> {
+                Map<String, TransactionDescription> results = new HashMap<>(futures.size());
+                for (Map.Entry<CoordinatorKey, KafkaFutureImpl<TransactionDescription>> entry : futures.entrySet()) {
+                    try {
+                        results.put(entry.getKey().idValue, entry.getValue().get());
+                    } catch (InterruptedException | ExecutionException e) {
+                        // This should be unreachable, because allOf ensured that all the futures completed successfully.
+                        throw new RuntimeException(e);
+                    }
+                }
+                return results;
+            });
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -31,11 +31,12 @@ import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.OffsetSpec.TimestampSpec;
+import org.apache.kafka.clients.admin.internals.AdminApiDriver;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler;
 import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
-import org.apache.kafka.clients.admin.internals.AdminApiDriver;
 import org.apache.kafka.clients.admin.internals.ConsumerGroupOperationContext;
 import org.apache.kafka.clients.admin.internals.DescribeProducersHandler;
+import org.apache.kafka.clients.admin.internals.DescribeTransactionsHandler;
 import org.apache.kafka.clients.admin.internals.MetadataOperationContext;
 import org.apache.kafka.clients.consumer.ConsumerPartitionAssignor.Assignment;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -4733,6 +4734,15 @@ public class KafkaAdminClient extends AdminClient {
             logContext
         );
         return new DescribeProducersResult(invokeDriver(handler, options.timeoutMs));
+    }
+
+    @Override
+    public DescribeTransactionsResult describeTransactions(Collection<String> transactionalIds, DescribeTransactionsOptions options) {
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(
+            transactionalIds,
+            logContext
+        );
+        return new DescribeTransactionsResult(invokeDriver(handler, options.timeoutMs));
     }
 
     private <K, V> Map<K, KafkaFutureImpl<V>> invokeDriver(

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TransactionDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TransactionDescription.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+import java.util.Set;
+
+public class TransactionDescription {
+    private final int coordinatorId;
+    private final TransactionState state;
+    private final long producerId;
+    private final int producerEpoch;
+    private final long transactionTimeoutMs;
+    private final OptionalLong transactionStartTimeMs;
+    private final Set<TopicPartition> topicPartitions;
+
+    public TransactionDescription(
+        int coordinatorId,
+        TransactionState state,
+        long producerId,
+        int producerEpoch,
+        long transactionTimeoutMs,
+        OptionalLong transactionStartTimeMs,
+        Set<TopicPartition> topicPartitions
+    ) {
+        this.coordinatorId = coordinatorId;
+        this.state = state;
+        this.producerId = producerId;
+        this.producerEpoch = producerEpoch;
+        this.transactionTimeoutMs = transactionTimeoutMs;
+        this.transactionStartTimeMs = transactionStartTimeMs;
+        this.topicPartitions = topicPartitions;
+    }
+
+    public int coordinatorId() {
+        return coordinatorId;
+    }
+
+    public TransactionState state() {
+        return state;
+    }
+
+    public long producerId() {
+        return producerId;
+    }
+
+    public int producerEpoch() {
+        return producerEpoch;
+    }
+
+    public long transactionTimeoutMs() {
+        return transactionTimeoutMs;
+    }
+
+    public OptionalLong transactionStartTimeMs() {
+        return transactionStartTimeMs;
+    }
+
+    public Set<TopicPartition> topicPartitions() {
+        return topicPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionDescription that = (TransactionDescription) o;
+        return coordinatorId == that.coordinatorId &&
+            producerId == that.producerId &&
+            producerEpoch == that.producerEpoch &&
+            transactionTimeoutMs == that.transactionTimeoutMs &&
+            state == that.state &&
+            Objects.equals(transactionStartTimeMs, that.transactionStartTimeMs) &&
+            Objects.equals(topicPartitions, that.topicPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(coordinatorId, state, producerId, producerEpoch, transactionTimeoutMs, transactionStartTimeMs, topicPartitions);
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionDescription(" +
+            "coordinatorId=" + coordinatorId +
+            ", state=" + state +
+            ", producerId=" + producerId +
+            ", producerEpoch=" + producerEpoch +
+            ", transactionTimeoutMs=" + transactionTimeoutMs +
+            ", transactionStartTimeMs=" + transactionStartTimeMs +
+            ", topicPartitions=" + topicPartitions +
+            ')';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TransactionDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TransactionDescription.java
@@ -17,11 +17,13 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Objects;
 import java.util.OptionalLong;
 import java.util.Set;
 
+@InterfaceStability.Evolving
 public class TransactionDescription {
     private final int coordinatorId;
     private final TransactionState state;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TransactionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TransactionState.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import java.util.HashMap;
+
+public enum TransactionState {
+    ONGOING("Ongoing"),
+    PREPARE_ABORT("PrepareAbort"),
+    PREPARE_COMMIT("PrepareCommit"),
+    COMPLETE_ABORT("CompleteAbort"),
+    COMPLETE_COMMIT("CompleteCommit"),
+    EMPTY("Empty"),
+    PREPARE_EPOCH_FENCE("PrepareEpochFence"),
+    UNKNOWN("Unknown");
+
+    private final static HashMap<String, TransactionState> NAME_TO_ENUM;
+
+    static {
+        NAME_TO_ENUM = new HashMap<>();
+        for (TransactionState state : TransactionState.values()) {
+            NAME_TO_ENUM.put(state.name, state);
+        }
+    }
+
+    private final String name;
+
+    TransactionState(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public static TransactionState parse(String name) {
+        TransactionState state = NAME_TO_ENUM.get(name);
+        return state == null ? UNKNOWN : state;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TransactionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TransactionState.java
@@ -18,8 +18,10 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @InterfaceStability.Evolving
 public enum TransactionState {
@@ -32,14 +34,8 @@ public enum TransactionState {
     PREPARE_EPOCH_FENCE("PrepareEpochFence"),
     UNKNOWN("Unknown");
 
-    private final static Map<String, TransactionState> NAME_TO_ENUM;
-
-    static {
-        NAME_TO_ENUM = new HashMap<>();
-        for (TransactionState state : TransactionState.values()) {
-            NAME_TO_ENUM.put(state.name, state);
-        }
-    }
+    private final static Map<String, TransactionState> NAME_TO_ENUM = Arrays.stream(values())
+        .collect(Collectors.toMap(state -> state.name, Function.identity()));
 
     private final String name;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TransactionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TransactionState.java
@@ -16,8 +16,12 @@
  */
 package org.apache.kafka.clients.admin;
 
-import java.util.HashMap;
+import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@InterfaceStability.Evolving
 public enum TransactionState {
     ONGOING("Ongoing"),
     PREPARE_ABORT("PrepareAbort"),
@@ -28,7 +32,7 @@ public enum TransactionState {
     PREPARE_EPOCH_FENCE("PrepareEpochFence"),
     UNKNOWN("Unknown");
 
-    private final static HashMap<String, TransactionState> NAME_TO_ENUM;
+    private final static Map<String, TransactionState> NAME_TO_ENUM;
 
     static {
         NAME_TO_ENUM = new HashMap<>();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
@@ -58,7 +58,7 @@ public interface AdminApiHandler<K, V> {
      *
      * @return a builder for the request containing the given keys
      */
-    AbstractRequest.Builder<?> buildRequest(Integer brokerId, Set<K> keys);
+    AbstractRequest.Builder<?> buildRequest(int brokerId, Set<K> keys);
 
     /**
      * Callback that is invoked when a request returns successfully.
@@ -80,7 +80,7 @@ public interface AdminApiHandler<K, V> {
      *
      * @return result indicating key completion, failure, and unmapping
      */
-    ApiResult<K, V> handleResponse(Integer brokerId, Set<K> keys, AbstractResponse response);
+    ApiResult<K, V> handleResponse(int brokerId, Set<K> keys, AbstractResponse response);
 
     class Keys<K> {
         public final Map<K, Integer> staticKeys;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiLookupStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiLookupStrategy.java
@@ -23,6 +23,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+
 public interface AdminApiLookupStrategy<T> {
 
     /**
@@ -83,6 +86,19 @@ public interface AdminApiLookupStrategy<T> {
             this.failedKeys = Collections.unmodifiableMap(failedKeys);
             this.mappedKeys = Collections.unmodifiableMap(mappedKeys);
         }
+
+        static <K> LookupResult<K> empty() {
+            return new LookupResult<>(emptyMap(), emptyMap());
+        }
+
+        static <K> LookupResult<K> failed(K key, Throwable exception) {
+            return new LookupResult<>(singletonMap(key, exception), emptyMap());
+        }
+
+        static <K> LookupResult<K> mapped(K key, Integer brokerId) {
+            return new LookupResult<>(emptyMap(), singletonMap(key, brokerId));
+        }
+
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorKey.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+
+import java.util.Objects;
+
+public class CoordinatorKey {
+    public final String idValue;
+    public final FindCoordinatorRequest.CoordinatorType type;
+
+    public CoordinatorKey(String idValue, FindCoordinatorRequest.CoordinatorType type) {
+        this.idValue = idValue;
+        this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CoordinatorKey that = (CoordinatorKey) o;
+        return Objects.equals(idValue, that.idValue) &&
+            type == that.type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idValue, type);
+    }
+
+    @Override
+    public String toString() {
+        return "CoordinatorKey(" +
+            "idValue='" + idValue + '\'' +
+            ", type=" + type +
+            ')';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorKey.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorKey.java
@@ -24,7 +24,7 @@ public class CoordinatorKey {
     public final String idValue;
     public final FindCoordinatorRequest.CoordinatorType type;
 
-    public CoordinatorKey(String idValue, FindCoordinatorRequest.CoordinatorType type) {
+    private CoordinatorKey(String idValue, FindCoordinatorRequest.CoordinatorType type) {
         this.idValue = idValue;
         this.type = type;
     }
@@ -50,4 +50,13 @@ public class CoordinatorKey {
             ", type=" + type +
             ')';
     }
+
+    public static CoordinatorKey byGroupId(String groupId) {
+        return new CoordinatorKey(groupId, FindCoordinatorRequest.CoordinatorType.GROUP);
+    }
+
+    public static CoordinatorKey byTransactionalId(String transactionalId) {
+        return new CoordinatorKey(transactionalId, FindCoordinatorRequest.CoordinatorType.TRANSACTION);
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
+import org.apache.kafka.common.message.FindCoordinatorRequestData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class CoordinatorStrategy<V> implements AdminApiLookupStrategy<CoordinatorKey> {
+    private final Logger log;
+
+    public CoordinatorStrategy(
+        LogContext logContext
+    ) {
+        this.log = logContext.logger(CoordinatorStrategy.class);
+    }
+
+    @Override
+    public ApiRequestScope lookupScope(CoordinatorKey key) {
+        // The `FindCoordinator` API does not support batched lookups, so we use a
+        // separate lookup context for each coordinator key we need to lookup
+        return new LookupRequestScope(key);
+    }
+
+    @Override
+    public FindCoordinatorRequest.Builder buildRequest(Set<CoordinatorKey> keys) {
+        CoordinatorKey key = requireSingleton(keys);
+        return new FindCoordinatorRequest.Builder(
+            new FindCoordinatorRequestData()
+                .setKey(key.idValue)
+                .setKeyType(key.type.id())
+        );
+    }
+
+    @Override
+    public LookupResult<CoordinatorKey> handleResponse(
+        Set<CoordinatorKey> keys,
+        AbstractResponse abstractResponse
+    ) {
+        CoordinatorKey key = requireSingleton(keys);
+        FindCoordinatorResponse response = (FindCoordinatorResponse) abstractResponse;
+        Errors error = response.error();
+
+        switch (error) {
+            case NONE:
+                return LookupResult.mapped(key, response.data().nodeId());
+
+            case NOT_COORDINATOR:
+            case COORDINATOR_NOT_AVAILABLE:
+            case COORDINATOR_LOAD_IN_PROGRESS:
+                log.debug("FindCoordinator request for key {} returned topic-level error {}. Will retry",
+                    key, error);
+                return LookupResult.empty();
+
+            case GROUP_AUTHORIZATION_FAILED:
+                return LookupResult.failed(key, new GroupAuthorizationException("FindCoordinator request for groupId " +
+                    "`" + key + "` failed due to authorization failure", key.idValue));
+
+            case TRANSACTIONAL_ID_AUTHORIZATION_FAILED:
+                return LookupResult.failed(key, new TransactionalIdAuthorizationException("FindCoordinator request for " +
+                    "transactionalId `" + key + "` failed due to authorization failure"));
+
+            default:
+                return LookupResult.failed(key, error.exception("FindCoordinator request for key " +
+                    "`" + key + "` failed due to an unexpected error"));
+        }
+    }
+
+    private static CoordinatorKey requireSingleton(Set<CoordinatorKey> keys) {
+        if (keys.size() != 1) {
+            throw new IllegalArgumentException("Unexpected lookup key set");
+        }
+        return keys.iterator().next();
+    }
+
+    private static class LookupRequestScope implements ApiRequestScope {
+        final CoordinatorKey key;
+
+        private LookupRequestScope(CoordinatorKey key) {
+            this.key = key;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LookupRequestScope that = (LookupRequestScope) o;
+            return Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategy.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import java.util.Objects;
 import java.util.Set;
 
-public class CoordinatorStrategy<V> implements AdminApiLookupStrategy<CoordinatorKey> {
+public class CoordinatorStrategy implements AdminApiLookupStrategy<CoordinatorKey> {
     private final Logger log;
 
     public CoordinatorStrategy(
@@ -68,7 +68,6 @@ public class CoordinatorStrategy<V> implements AdminApiLookupStrategy<Coordinato
             case NONE:
                 return LookupResult.mapped(key, response.data().nodeId());
 
-            case NOT_COORDINATOR:
             case COORDINATOR_NOT_AVAILABLE:
             case COORDINATOR_LOAD_IN_PROGRESS:
                 log.debug("FindCoordinator request for key {} returned topic-level error {}. Will retry",

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
@@ -82,7 +82,7 @@ public class DescribeProducersHandler implements AdminApiHandler<TopicPartition,
 
     @Override
     public DescribeProducersRequest.Builder buildRequest(
-        Integer brokerId,
+        int brokerId,
         Set<TopicPartition> topicPartitions
     ) {
         DescribeProducersRequestData request = new DescribeProducersRequestData();
@@ -154,7 +154,7 @@ public class DescribeProducersHandler implements AdminApiHandler<TopicPartition,
 
     @Override
     public ApiResult<TopicPartition, PartitionProducerState> handleResponse(
-        Integer brokerId,
+        int brokerId,
         Set<TopicPartition> keys,
         AbstractResponse abstractResponse
     ) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
@@ -68,7 +68,7 @@ public class DescribeTransactionsHandler implements AdminApiHandler<CoordinatorK
 
     @Override
     public Keys<CoordinatorKey> initializeKeys() {
-        return Keys.dynamicMapped(keys, new CoordinatorStrategy<>(logContext));
+        return Keys.dynamicMapped(keys, new CoordinatorStrategy(logContext));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.TransactionDescription;
+import org.apache.kafka.clients.admin.TransactionState;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
+import org.apache.kafka.common.errors.TransactionalIdNotFoundException;
+import org.apache.kafka.common.message.DescribeTransactionsRequestData;
+import org.apache.kafka.common.message.DescribeTransactionsResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.DescribeTransactionsRequest;
+import org.apache.kafka.common.requests.DescribeTransactionsResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DescribeTransactionsHandler implements AdminApiHandler<CoordinatorKey, TransactionDescription> {
+    private final LogContext logContext;
+    private final Logger log;
+    private final Set<CoordinatorKey> keys;
+
+    public DescribeTransactionsHandler(
+        Collection<String> transactionalIds,
+        LogContext logContext
+    ) {
+        this.keys = buildKeySet(transactionalIds);
+        this.log = logContext.logger(DescribeTransactionsHandler.class);
+        this.logContext = logContext;
+    }
+
+    private static Set<CoordinatorKey> buildKeySet(Collection<String> transactionalIds) {
+        return transactionalIds.stream()
+            .map(DescribeTransactionsHandler::asCoordinatorKey)
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String apiName() {
+        return "describeTransactions";
+    }
+
+    @Override
+    public Keys<CoordinatorKey> initializeKeys() {
+        return Keys.dynamicMapped(keys, new CoordinatorStrategy<>(logContext));
+    }
+
+    @Override
+    public DescribeTransactionsRequest.Builder buildRequest(
+        Integer brokerId,
+        Set<CoordinatorKey> keys
+    ) {
+        DescribeTransactionsRequestData request = new DescribeTransactionsRequestData();
+        List<String> transactionalIds = keys.stream().map(key -> key.idValue).collect(Collectors.toList());
+        request.setTransactionalIds(transactionalIds);
+        return new DescribeTransactionsRequest.Builder(request);
+    }
+
+    @Override
+    public ApiResult<CoordinatorKey, TransactionDescription> handleResponse(
+        Integer brokerId,
+        Set<CoordinatorKey> keys,
+        AbstractResponse abstractResponse
+    ) {
+        DescribeTransactionsResponse response = (DescribeTransactionsResponse) abstractResponse;
+        Map<CoordinatorKey, TransactionDescription> completed = new HashMap<>();
+        Map<CoordinatorKey, Throwable> failed = new HashMap<>();
+        List<CoordinatorKey> unmapped = new ArrayList<>();
+
+        for (DescribeTransactionsResponseData.TransactionState transactionState : response.data().transactionStates()) {
+            CoordinatorKey transactionalIdKey = asCoordinatorKey(transactionState.transactionalId());
+            Errors error = Errors.forCode(transactionState.errorCode());
+
+            if (error != Errors.NONE) {
+                handleError(transactionalIdKey, error, failed, unmapped);
+                continue;
+            }
+
+            OptionalLong transactionStartTimeMs = transactionState.transactionStartTimeMs() < 0 ?
+                OptionalLong.empty() :
+                OptionalLong.of(transactionState.transactionStartTimeMs());
+
+            completed.put(transactionalIdKey, new TransactionDescription(
+                brokerId,
+                TransactionState.parse(transactionState.transactionState()),
+                transactionState.producerId(),
+                transactionState.producerEpoch(),
+                transactionState.transactionTimeoutMs(),
+                transactionStartTimeMs,
+                collectTopicPartitions(transactionState)
+            ));
+        }
+
+        return new ApiResult<>(completed, failed, unmapped);
+    }
+
+    private Set<TopicPartition> collectTopicPartitions(
+        DescribeTransactionsResponseData.TransactionState transactionState
+    ) {
+        Set<TopicPartition> res = new HashSet<>();
+        for (DescribeTransactionsResponseData.TopicData topicData : transactionState.topics()) {
+            String topic = topicData.topic();
+            for (Integer partitionId : topicData.partitions()) {
+                res.add(new TopicPartition(topic, partitionId));
+            }
+        }
+        return res;
+    }
+
+    public static CoordinatorKey asCoordinatorKey(String transactionalId) {
+        return new CoordinatorKey(transactionalId, FindCoordinatorRequest.CoordinatorType.TRANSACTION);
+    }
+
+    private void handleError(
+        CoordinatorKey transactionalIdKey,
+        Errors error,
+        Map<CoordinatorKey, Throwable> failed,
+        List<CoordinatorKey> unmapped
+    ) {
+        switch (error) {
+            case TRANSACTIONAL_ID_AUTHORIZATION_FAILED:
+                failed.put(transactionalIdKey, new TransactionalIdAuthorizationException(
+                    "DescribeTransactions request for transactionalId `" + transactionalIdKey.idValue + "` " +
+                        "failed due to authorization failure"));
+                break;
+
+            case TRANSACTIONAL_ID_NOT_FOUND:
+                failed.put(transactionalIdKey, new TransactionalIdNotFoundException(
+                    "DescribeTransactions request for transactionalId `" + transactionalIdKey.idValue + "` " +
+                        "failed because the ID could not be found"));
+                break;
+
+            case COORDINATOR_LOAD_IN_PROGRESS:
+                // If the coordinator is in the middle of loading, then we just need to retry
+                log.debug("DescribeTransactions request for transactionalId `{}` failed because the " +
+                        "coordinator is still in the process of loading state. Will retry",
+                    transactionalIdKey.idValue);
+                break;
+
+            case NOT_COORDINATOR:
+            case COORDINATOR_NOT_AVAILABLE:
+                // If the coordinator is unavailable or there was a coordinator change, then we unmap
+                // the key so that we retry the `FindCoordinator` request
+                unmapped.add(transactionalIdKey);
+                log.debug("DescribeTransactions request for transactionalId `{}` returned error {}. Will retry",
+                    transactionalIdKey.idValue, error);
+                break;
+
+            default:
+                failed.put(transactionalIdKey, error.exception("DescribeTransactions request for " +
+                    "transactionalId `" + transactionalIdKey.idValue + "` failed due to unexpected error"));
+        }
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/PartitionLeaderStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/PartitionLeaderStrategy.java
@@ -153,7 +153,6 @@ public class PartitionLeaderStrategy implements AdminApiLookupStrategy<TopicPart
                 continue;
             }
 
-
             for (MetadataResponseData.MetadataResponsePartition partitionMetadata : topicMetadata.partitions()) {
                 TopicPartition topicPartition = new TopicPartition(topic, partitionMetadata.partitionIndex());
                 Errors partitionError = Errors.forCode(partitionMetadata.errorCode());

--- a/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java
@@ -17,7 +17,10 @@
 
 package org.apache.kafka.common;
 
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * The consumer group state.
@@ -30,14 +33,8 @@ public enum ConsumerGroupState {
     DEAD("Dead"),
     EMPTY("Empty");
 
-    private final static HashMap<String, ConsumerGroupState> NAME_TO_ENUM;
-
-    static {
-        NAME_TO_ENUM = new HashMap<>();
-        for (ConsumerGroupState state : ConsumerGroupState.values()) {
-            NAME_TO_ENUM.put(state.name, state);
-        }
-    }
+    private final static Map<String, ConsumerGroupState> NAME_TO_ENUM = Arrays.stream(values())
+        .collect(Collectors.toMap(state -> state.name, Function.identity()));;
 
     private final String name;
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -909,6 +909,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public DescribeTransactionsResult describeTransactions(Collection<String> transactionalIds, DescribeTransactionsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public void close(Duration timeout) {}
 
     public synchronized void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
@@ -678,14 +678,14 @@ class AdminApiDriverTest {
         }
 
         @Override
-        public AbstractRequest.Builder<?> buildRequest(Integer brokerId, Set<K> keys) {
+        public AbstractRequest.Builder<?> buildRequest(int brokerId, Set<K> keys) {
             // The request is just a placeholder in these tests
             assertTrue(expectedRequests.containsKey(keys), "Unexpected fulfillment request for keys " + keys);
             return new MetadataRequest.Builder(Collections.emptyList(), false);
         }
 
         @Override
-        public ApiResult<K, V> handleResponse(Integer brokerId, Set<K> keys, AbstractResponse response) {
+        public ApiResult<K, V> handleResponse(int brokerId, Set<K> keys, AbstractResponse response) {
             return Optional.ofNullable(expectedRequests.get(keys)).orElseThrow(() ->
                 new AssertionError("Unexpected fulfillment request for keys " + keys)
             );

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
@@ -41,7 +41,7 @@ public class CoordinatorStrategyTest {
     public void testBuildLookupRequest() {
         CoordinatorStrategy strategy = new CoordinatorStrategy(new LogContext());
         FindCoordinatorRequest.Builder request = strategy.buildRequest(singleton(
-            new CoordinatorKey("foo", CoordinatorType.GROUP)));
+            CoordinatorKey.byGroupId("foo")));
         assertEquals("foo", request.data().key());
         assertEquals(CoordinatorType.GROUP, CoordinatorType.forId(request.data().keyType()));
     }
@@ -51,14 +51,14 @@ public class CoordinatorStrategyTest {
         CoordinatorStrategy strategy = new CoordinatorStrategy(new LogContext());
         assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(Collections.emptySet()));
 
-        CoordinatorKey group1 = new CoordinatorKey("foo", CoordinatorType.GROUP);
-        CoordinatorKey group2 = new CoordinatorKey("bar", CoordinatorType.GROUP);
+        CoordinatorKey group1 = CoordinatorKey.byGroupId("foo");
+        CoordinatorKey group2 = CoordinatorKey.byGroupId("bar");
         assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(mkSet(group1, group2)));
     }
 
     @Test
     public void testSuccessfulCoordinatorLookup() {
-        CoordinatorKey group = new CoordinatorKey("foo", CoordinatorType.GROUP);
+        CoordinatorKey group = CoordinatorKey.byGroupId("foo");
 
         FindCoordinatorResponseData responseData = new FindCoordinatorResponseData()
             .setErrorCode(Errors.NONE.code())
@@ -78,7 +78,7 @@ public class CoordinatorStrategyTest {
     }
 
     public void testRetriableCoordinatorLookup(Errors error) {
-        CoordinatorKey group = new CoordinatorKey("foo", CoordinatorType.GROUP);
+        CoordinatorKey group = CoordinatorKey.byGroupId("foo");
         FindCoordinatorResponseData responseData = new FindCoordinatorResponseData().setErrorCode(error.code());
         AdminApiLookupStrategy.LookupResult<CoordinatorKey> result = runLookup(group, responseData);
 
@@ -88,7 +88,7 @@ public class CoordinatorStrategyTest {
 
     @Test
     public void testFatalErrorLookupResponses() {
-        CoordinatorKey group = new CoordinatorKey("foo", CoordinatorType.TRANSACTION);
+        CoordinatorKey group = CoordinatorKey.byTransactionalId("foo");
         assertFatalLookup(group, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
         assertFatalLookup(group, Errors.UNKNOWN_SERVER_ERROR);
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
@@ -57,6 +57,21 @@ public class CoordinatorStrategyTest {
     }
 
     @Test
+    public void testHandleResponseRequiresOneKey() {
+        FindCoordinatorResponseData responseData = new FindCoordinatorResponseData().setErrorCode(Errors.NONE.code());
+        FindCoordinatorResponse response = new FindCoordinatorResponse(responseData);
+
+        CoordinatorStrategy strategy = new CoordinatorStrategy(new LogContext());
+        assertThrows(IllegalArgumentException.class, () ->
+            strategy.handleResponse(Collections.emptySet(), response));
+
+        CoordinatorKey group1 = CoordinatorKey.byGroupId("foo");
+        CoordinatorKey group2 = CoordinatorKey.byGroupId("bar");
+        assertThrows(IllegalArgumentException.class, () ->
+            strategy.handleResponse(mkSet(group1, group2), response));
+    }
+
+    @Test
     public void testSuccessfulCoordinatorLookup() {
         CoordinatorKey group = CoordinatorKey.byGroupId("foo");
 
@@ -77,7 +92,7 @@ public class CoordinatorStrategyTest {
         testRetriableCoordinatorLookup(Errors.COORDINATOR_NOT_AVAILABLE);
     }
 
-    public void testRetriableCoordinatorLookup(Errors error) {
+    private void testRetriableCoordinatorLookup(Errors error) {
         CoordinatorKey group = CoordinatorKey.byGroupId("foo");
         FindCoordinatorResponseData responseData = new FindCoordinatorResponseData().setErrorCode(error.code());
         AdminApiLookupStrategy.LookupResult<CoordinatorKey> result = runLookup(group, responseData);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType;
+import org.apache.kafka.common.requests.FindCoordinatorResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CoordinatorStrategyTest {
+
+    @Test
+    public void testBuildLookupRequest() {
+        CoordinatorStrategy<Object> strategy = new CoordinatorStrategy<>(new LogContext());
+        FindCoordinatorRequest.Builder request = strategy.buildRequest(singleton(
+            new CoordinatorKey("foo", CoordinatorType.GROUP)));
+        assertEquals("foo", request.data().key());
+        assertEquals(CoordinatorType.GROUP, CoordinatorType.forId(request.data().keyType()));
+    }
+
+    @Test
+    public void testBuildLookupRequestRequiresOneKey() {
+        CoordinatorStrategy<Object> strategy = new CoordinatorStrategy<>(new LogContext());
+        assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(Collections.emptySet()));
+
+        CoordinatorKey group1 = new CoordinatorKey("foo", CoordinatorType.GROUP);
+        CoordinatorKey group2 = new CoordinatorKey("bar", CoordinatorType.GROUP);
+        assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(mkSet(group1, group2)));
+    }
+
+    @Test
+    public void testSuccessfulCoordinatorLookup() {
+        CoordinatorKey group = new CoordinatorKey("foo", CoordinatorType.GROUP);
+
+        FindCoordinatorResponseData responseData = new FindCoordinatorResponseData()
+            .setErrorCode(Errors.NONE.code())
+            .setHost("localhost")
+            .setPort(9092)
+            .setNodeId(1);
+
+        AdminApiLookupStrategy.LookupResult<CoordinatorKey> result = runLookup(group, responseData);
+        assertEquals(singletonMap(group, 1), result.mappedKeys);
+        assertEquals(emptyMap(), result.failedKeys);
+    }
+
+    @Test
+    public void testRetriableCoordinatorLookup() {
+        testRetriableCoordinatorLookup(Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        testRetriableCoordinatorLookup(Errors.COORDINATOR_NOT_AVAILABLE);
+        testRetriableCoordinatorLookup(Errors.NOT_COORDINATOR);
+    }
+
+    public void testRetriableCoordinatorLookup(Errors error) {
+        CoordinatorKey group = new CoordinatorKey("foo", CoordinatorType.GROUP);
+        FindCoordinatorResponseData responseData = new FindCoordinatorResponseData().setErrorCode(error.code());
+        AdminApiLookupStrategy.LookupResult<CoordinatorKey> result = runLookup(group, responseData);
+
+        assertEquals(emptyMap(), result.failedKeys);
+        assertEquals(emptyMap(), result.mappedKeys);
+    }
+
+    @Test
+    public void testFatalErrorLookupResponses() {
+        CoordinatorKey group = new CoordinatorKey("foo", CoordinatorType.TRANSACTION);
+        assertFatalLookup(group, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
+        assertFatalLookup(group, Errors.UNKNOWN_SERVER_ERROR);
+
+        Throwable throwable = assertFatalLookup(group, Errors.GROUP_AUTHORIZATION_FAILED);
+        assertTrue(throwable instanceof GroupAuthorizationException);
+        GroupAuthorizationException exception = (GroupAuthorizationException) throwable;
+        assertEquals("foo", exception.groupId());
+    }
+
+    public Throwable assertFatalLookup(
+        CoordinatorKey key,
+        Errors error
+    ) {
+        FindCoordinatorResponseData responseData = new FindCoordinatorResponseData().setErrorCode(error.code());
+        AdminApiLookupStrategy.LookupResult<CoordinatorKey> result = runLookup(key, responseData);
+
+        assertEquals(emptyMap(), result.mappedKeys);
+        assertEquals(singleton(key), result.failedKeys.keySet());
+
+        Throwable throwable = result.failedKeys.get(key);
+        assertTrue(error.exception().getClass().isInstance(throwable));
+        return throwable;
+    }
+
+    private AdminApiLookupStrategy.LookupResult<CoordinatorKey> runLookup(
+        CoordinatorKey key,
+        FindCoordinatorResponseData responseData
+    ) {
+        CoordinatorStrategy<Object> strategy = new CoordinatorStrategy<>(new LogContext());
+        FindCoordinatorResponse response = new FindCoordinatorResponse(responseData);
+        return strategy.handleResponse(singleton(key), response);
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/CoordinatorStrategyTest.java
@@ -39,7 +39,7 @@ public class CoordinatorStrategyTest {
 
     @Test
     public void testBuildLookupRequest() {
-        CoordinatorStrategy<Object> strategy = new CoordinatorStrategy<>(new LogContext());
+        CoordinatorStrategy strategy = new CoordinatorStrategy(new LogContext());
         FindCoordinatorRequest.Builder request = strategy.buildRequest(singleton(
             new CoordinatorKey("foo", CoordinatorType.GROUP)));
         assertEquals("foo", request.data().key());
@@ -48,7 +48,7 @@ public class CoordinatorStrategyTest {
 
     @Test
     public void testBuildLookupRequestRequiresOneKey() {
-        CoordinatorStrategy<Object> strategy = new CoordinatorStrategy<>(new LogContext());
+        CoordinatorStrategy strategy = new CoordinatorStrategy(new LogContext());
         assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(Collections.emptySet()));
 
         CoordinatorKey group1 = new CoordinatorKey("foo", CoordinatorType.GROUP);
@@ -75,7 +75,6 @@ public class CoordinatorStrategyTest {
     public void testRetriableCoordinatorLookup() {
         testRetriableCoordinatorLookup(Errors.COORDINATOR_LOAD_IN_PROGRESS);
         testRetriableCoordinatorLookup(Errors.COORDINATOR_NOT_AVAILABLE);
-        testRetriableCoordinatorLookup(Errors.NOT_COORDINATOR);
     }
 
     public void testRetriableCoordinatorLookup(Errors error) {
@@ -118,7 +117,7 @@ public class CoordinatorStrategyTest {
         CoordinatorKey key,
         FindCoordinatorResponseData responseData
     ) {
-        CoordinatorStrategy<Object> strategy = new CoordinatorStrategy<>(new LogContext());
+        CoordinatorStrategy strategy = new CoordinatorStrategy(new LogContext());
         FindCoordinatorResponse response = new FindCoordinatorResponse(responseData);
         return strategy.handleResponse(singleton(key), response);
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.TransactionDescription;
+import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.DescribeTransactionsResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.DescribeTransactionsRequest;
+import org.apache.kafka.common.requests.DescribeTransactionsResponse;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DescribeTransactionsHandlerTest {
+    private final LogContext logContext = new LogContext();
+
+    @Test
+    public void testBuildRequest() {
+        String transactionalId1 = "foo";
+        String transactionalId2 = "bar";
+        String transactionalId3 = "baz";
+
+        Set<String> transactionalIds = mkSet(transactionalId1, transactionalId2, transactionalId3);
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(transactionalIds, logContext);
+
+        assertLookup(handler, transactionalIds);
+        assertLookup(handler, mkSet(transactionalId1));
+        assertLookup(handler, mkSet(transactionalId2, transactionalId3));
+    }
+
+    @Test
+    public void testHandleSuccessfulResponse() {
+        int brokerId = 1;
+        String transactionalId1 = "foo";
+        String transactionalId2 = "bar";
+
+        Set<String> transactionalIds = mkSet(transactionalId1, transactionalId2);
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(transactionalIds, logContext);
+
+        DescribeTransactionsResponseData.TransactionState transactionState1 =
+            sampleTransactionState1(transactionalId1);
+        DescribeTransactionsResponseData.TransactionState transactionState2 =
+            sampleTransactionState2(transactionalId2);
+
+        Set<CoordinatorKey> keys = coordinatorKeys(transactionalIds);
+        DescribeTransactionsResponse response = new DescribeTransactionsResponse(new DescribeTransactionsResponseData()
+            .setTransactionStates(asList(transactionState1, transactionState2)));
+
+        ApiResult<CoordinatorKey, TransactionDescription> result = handler.handleResponse(
+            brokerId, keys, response);
+
+        assertEquals(keys, result.completedKeys.keySet());
+        assertMatchingTransactionState(brokerId, transactionState1,
+            result.completedKeys.get(coordinatorKey(transactionalId1)));
+        assertMatchingTransactionState(brokerId, transactionState2,
+            result.completedKeys.get(coordinatorKey(transactionalId2)));
+    }
+
+    @Test
+    public void testHandleErrorResponse() {
+        String transactionalId = "foo";
+        Set<String> transactionalIds = mkSet(transactionalId);
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(transactionalIds, logContext);
+        assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
+        assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_NOT_FOUND);
+        assertFatalError(handler, transactionalId, Errors.UNKNOWN_SERVER_ERROR);
+        assertRetriableError(handler, transactionalId, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        assertUnmappedKey(handler, transactionalId, Errors.NOT_COORDINATOR);
+        assertUnmappedKey(handler, transactionalId, Errors.COORDINATOR_NOT_AVAILABLE);
+    }
+
+    private void assertFatalError(
+        DescribeTransactionsHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        CoordinatorKey key = coordinatorKey(transactionalId);
+        ApiResult<CoordinatorKey, TransactionDescription> result = handleResponseError(handler, transactionalId, error);
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(mkSet(key), result.failedKeys.keySet());
+
+        Throwable throwable = result.failedKeys.get(key);
+        assertTrue(error.exception().getClass().isInstance(throwable));
+    }
+
+    private void assertRetriableError(
+        DescribeTransactionsHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        ApiResult<CoordinatorKey, TransactionDescription> result = handleResponseError(handler, transactionalId, error);
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(emptyMap(), result.failedKeys);
+    }
+
+    private void assertUnmappedKey(
+        DescribeTransactionsHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        CoordinatorKey key = coordinatorKey(transactionalId);
+        ApiResult<CoordinatorKey, TransactionDescription> result = handleResponseError(handler, transactionalId, error);
+        assertEquals(emptyMap(), result.failedKeys);
+        assertEquals(singletonList(key), result.unmappedKeys);
+    }
+
+    private ApiResult<CoordinatorKey, TransactionDescription> handleResponseError(
+        DescribeTransactionsHandler handler,
+        String transactionalId,
+        Errors error
+    ) {
+        int brokerId = 1;
+
+        CoordinatorKey key = coordinatorKey(transactionalId);
+        Set<CoordinatorKey> keys = mkSet(key);
+
+        DescribeTransactionsResponseData.TransactionState transactionState = new DescribeTransactionsResponseData.TransactionState()
+            .setErrorCode(error.code())
+            .setTransactionalId(transactionalId);
+
+        DescribeTransactionsResponse response = new DescribeTransactionsResponse(new DescribeTransactionsResponseData()
+            .setTransactionStates(singletonList(transactionState)));
+
+        ApiResult<CoordinatorKey, TransactionDescription> result = handler.handleResponse(brokerId, keys, response);
+        assertEquals(emptyMap(), result.completedKeys);
+        return result;
+    }
+
+    private void assertLookup(
+        DescribeTransactionsHandler handler,
+        Set<String> transactionalIds
+    ) {
+        Set<CoordinatorKey> keys = coordinatorKeys(transactionalIds);
+        DescribeTransactionsRequest.Builder request = handler.buildRequest(1, keys);
+        assertEquals(transactionalIds, new HashSet<>(request.data.transactionalIds()));
+    }
+
+    private static CoordinatorKey coordinatorKey(String transactionalId) {
+        return new CoordinatorKey(transactionalId, FindCoordinatorRequest.CoordinatorType.TRANSACTION);
+    }
+
+    private static Set<CoordinatorKey> coordinatorKeys(Set<String> transactionalIds) {
+        return transactionalIds.stream()
+            .map(DescribeTransactionsHandlerTest::coordinatorKey)
+            .collect(Collectors.toSet());
+    }
+
+    private DescribeTransactionsResponseData.TransactionState sampleTransactionState1(
+        String transactionalId
+    ) {
+        return new DescribeTransactionsResponseData.TransactionState()
+            .setErrorCode(Errors.NONE.code())
+            .setTransactionState("Ongoing")
+            .setTransactionalId(transactionalId)
+            .setProducerId(12345L)
+            .setProducerEpoch((short) 15)
+            .setTransactionStartTimeMs(1599151791L)
+            .setTransactionTimeoutMs(10000)
+            .setTopics(new DescribeTransactionsResponseData.TopicDataCollection(asList(
+                new DescribeTransactionsResponseData.TopicData()
+                    .setTopic("foo")
+                    .setPartitions(asList(1, 3, 5)),
+                new DescribeTransactionsResponseData.TopicData()
+                    .setTopic("bar")
+                    .setPartitions(asList(1, 3, 5))
+            ).iterator()));
+    }
+
+    private DescribeTransactionsResponseData.TransactionState sampleTransactionState2(
+        String transactionalId
+    ) {
+        return new DescribeTransactionsResponseData.TransactionState()
+            .setErrorCode(Errors.NONE.code())
+            .setTransactionState("Empty")
+            .setTransactionalId(transactionalId)
+            .setProducerId(98765L)
+            .setProducerEpoch((short) 30)
+            .setTransactionStartTimeMs(-1);
+    }
+
+    private void assertMatchingTransactionState(
+        int expectedCoordinatorId,
+        DescribeTransactionsResponseData.TransactionState expected,
+        TransactionDescription actual
+    ) {
+        assertEquals(expectedCoordinatorId, actual.coordinatorId());
+        assertEquals(expected.producerId(), actual.producerId());
+        assertEquals(expected.producerEpoch(), actual.producerEpoch());
+        assertEquals(expected.transactionTimeoutMs(), actual.transactionTimeoutMs());
+        assertEquals(expected.transactionStartTimeMs(), actual.transactionStartTimeMs().orElse(-1));
+        assertEquals(collectTransactionPartitions(expected), actual.topicPartitions());
+    }
+
+    private Set<TopicPartition> collectTransactionPartitions(
+        DescribeTransactionsResponseData.TransactionState transactionState
+    ) {
+        Set<TopicPartition> topicPartitions = new HashSet<>();
+        for (DescribeTransactionsResponseData.TopicData topicData : transactionState.topics()) {
+            for (Integer partitionId : topicData.partitions()) {
+                topicPartitions.add(new TopicPartition(topicData.topic(), partitionId));
+            }
+        }
+        return topicPartitions;
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.message.DescribeTransactionsResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.DescribeTransactionsRequest;
 import org.apache.kafka.common.requests.DescribeTransactionsResponse;
-import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.junit.jupiter.api.Test;
 
@@ -79,9 +78,9 @@ public class DescribeTransactionsHandlerTest {
 
         assertEquals(keys, result.completedKeys.keySet());
         assertMatchingTransactionState(brokerId, transactionState1,
-            result.completedKeys.get(coordinatorKey(transactionalId1)));
+            result.completedKeys.get(CoordinatorKey.byTransactionalId(transactionalId1)));
         assertMatchingTransactionState(brokerId, transactionState2,
-            result.completedKeys.get(coordinatorKey(transactionalId2)));
+            result.completedKeys.get(CoordinatorKey.byTransactionalId(transactionalId2)));
     }
 
     @Test
@@ -102,7 +101,7 @@ public class DescribeTransactionsHandlerTest {
         String transactionalId,
         Errors error
     ) {
-        CoordinatorKey key = coordinatorKey(transactionalId);
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
         ApiResult<CoordinatorKey, TransactionDescription> result = handleResponseError(handler, transactionalId, error);
         assertEquals(emptyList(), result.unmappedKeys);
         assertEquals(mkSet(key), result.failedKeys.keySet());
@@ -126,7 +125,7 @@ public class DescribeTransactionsHandlerTest {
         String transactionalId,
         Errors error
     ) {
-        CoordinatorKey key = coordinatorKey(transactionalId);
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
         ApiResult<CoordinatorKey, TransactionDescription> result = handleResponseError(handler, transactionalId, error);
         assertEquals(emptyMap(), result.failedKeys);
         assertEquals(singletonList(key), result.unmappedKeys);
@@ -139,7 +138,7 @@ public class DescribeTransactionsHandlerTest {
     ) {
         int brokerId = 1;
 
-        CoordinatorKey key = coordinatorKey(transactionalId);
+        CoordinatorKey key = CoordinatorKey.byTransactionalId(transactionalId);
         Set<CoordinatorKey> keys = mkSet(key);
 
         DescribeTransactionsResponseData.TransactionState transactionState = new DescribeTransactionsResponseData.TransactionState()
@@ -163,13 +162,9 @@ public class DescribeTransactionsHandlerTest {
         assertEquals(transactionalIds, new HashSet<>(request.data.transactionalIds()));
     }
 
-    private static CoordinatorKey coordinatorKey(String transactionalId) {
-        return new CoordinatorKey(transactionalId, FindCoordinatorRequest.CoordinatorType.TRANSACTION);
-    }
-
     private static Set<CoordinatorKey> coordinatorKeys(Set<String> transactionalIds) {
         return transactionalIds.stream()
-            .map(DescribeTransactionsHandlerTest::coordinatorKey)
+            .map(CoordinatorKey::byTransactionalId)
             .collect(Collectors.toSet());
     }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -50,7 +50,8 @@ class TransactionCoordinatorTest {
   private val partitions = mutable.Set[TopicPartition](new TopicPartition("topic1", 0))
   private val scheduler = new MockScheduler(time)
 
-  val coordinator = new TransactionCoordinator(brokerId,
+  val coordinator = new TransactionCoordinator(
+    brokerId,
     TransactionConfig(),
     scheduler,
     () => pidGenerator,
@@ -1085,6 +1086,22 @@ class TransactionCoordinatorTest {
     val result = coordinator.handleDescribeTransactions("")
     assertEquals("", result.transactionalId)
     assertEquals(Errors.INVALID_REQUEST, Errors.forCode(result.errorCode))
+  }
+
+  @Test
+  def testDescribeTransactionsWithExpiringTransactionalId(): Unit = {
+    coordinator.startup(() => transactionStatePartitionCount, enableTransactionalIdExpiration = false)
+
+    val txnMetadata = new TransactionMetadata(transactionalId, producerId, producerId, producerEpoch,
+      RecordBatch.NO_PRODUCER_EPOCH, txnTimeoutMs, Dead, mutable.Set.empty, time.milliseconds(),
+      time.milliseconds())
+    EasyMock.expect(transactionManager.getTransactionState(EasyMock.eq(transactionalId)))
+      .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata))))
+    EasyMock.replay(transactionManager)
+
+    val result = coordinator.handleDescribeTransactions(transactionalId)
+    assertEquals(transactionalId, result.transactionalId)
+    assertEquals(Errors.TRANSACTIONAL_ID_NOT_FOUND, Errors.forCode(result.errorCode))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMetadataTest.scala
@@ -465,6 +465,12 @@ class TransactionMetadataTest {
     for (state <- TransactionState.AllStates) {
       assertEquals(state, TransactionState.fromId(state.id))
       assertEquals(Some(state), TransactionState.fromName(state.name))
+
+      if (state != Dead) {
+        val clientTransactionState = org.apache.kafka.clients.admin.TransactionState.parse(state.name)
+        assertEquals(state.name, clientTransactionState.toString)
+        assertNotEquals(org.apache.kafka.clients.admin.TransactionState.UNKNOWN, clientTransactionState)
+      }
     }
   }
 


### PR DESCRIPTION
This patch contains the `Admin` implementation of the `DescribeTransactions` APIs described in KIP-664: KIP-664: https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
