### PR TITLE
Kafka producer Partitioner add canAbortOnNewBatch

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -948,7 +948,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 transactionManager.failIfNotReadyForSend();
             }
             RecordAccumulator.RecordAppendResult result = accumulator.append(tp, timestamp, serializedKey,
-                    serializedValue, headers, interceptCallback, remainingWaitMs, true, nowMs);
+                    serializedValue, headers, interceptCallback, remainingWaitMs, partitioner.canAbortOnNewBatch(record.partition(), serializedKey), nowMs);
 
             if (result.abortForNewBatch) {
                 int prevPartition = partition;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Partitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Partitioner.java
@@ -54,4 +54,13 @@ public interface Partitioner extends Configurable, Closeable {
      */
     default public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
     }
+
+    /**
+     * We can abort on new batch if record partition and key is null
+     * @param recordPartition The partition to which the record should be sent
+     * @param keyBytes The serialized key to partition on( or null if no key)
+     */
+    default public boolean canAbortOnNewBatch(Integer recordPartition, byte[] keyBytes) {
+        return recordPartition == null && keyBytes == null;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RoundRobinPartitioner.java
@@ -73,4 +73,8 @@ public class RoundRobinPartitioner implements Partitioner {
 
     public void close() {}
 
+    @Override
+    public boolean canAbortOnNewBatch(Integer recordPartition, byte[] keyBytes) {
+        return false;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/UniformStickyPartitioner.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/UniformStickyPartitioner.java
@@ -62,4 +62,9 @@ public class UniformStickyPartitioner implements Partitioner {
     public void onNewBatch(String topic, Cluster cluster, int prevPartition) {
         stickyPartitionCache.nextPartition(topic, cluster, prevPartition);
     }
+
+    @Override
+    public boolean canAbortOnNewBatch(Integer recordPartition, byte[] keyBytes) {
+        return recordPartition == null;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -205,7 +205,7 @@ public final class RecordAccumulator {
             // we don't have an in-progress record batch try to allocate a new batch
             if (abortOnNewBatch) {
                 // Return a result that will cause another call to append.
-                return new RecordAppendResult(null, false, false, true);
+                return RecordAppendResult.ABORT_ON_NEW_BATCH_RESULT;
             }
 
             byte maxUsableMagic = apiVersions.maxUsableProduceMagic();
@@ -806,6 +806,7 @@ public final class RecordAccumulator {
      * Metadata about a record just appended to the record accumulator
      */
     public final static class RecordAppendResult {
+        public static final RecordAppendResult ABORT_ON_NEW_BATCH_RESULT = new RecordAppendResult(null, false, false, true);
         public final FutureRecordMetadata future;
         public final boolean batchIsFull;
         public final boolean newBatchCreated;


### PR DESCRIPTION
Partitioner add canAbortOnNewBatch method to reduce unnecessary abort new batch