### PR TITLE
MINOR: cleanup Jenkins workspace before build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,14 +120,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
-            skipDefaultCheckout(true)
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.12
           }
           steps {
-            cleanWs()
-            checkout scm
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             doTest(env)
@@ -143,14 +143,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
-            skipDefaultCheckout(true)
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
-            cleanWs()
-            checkout scm
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             doTest(env)
@@ -166,14 +166,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
-            skipDefaultCheckout(true)
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
-            cleanWs()
-            checkout scm
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             doTest(env)
@@ -186,11 +186,14 @@ pipeline {
           options {
             timeout(time: 2, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.12
           }
           steps {
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
@@ -218,11 +221,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             doTest(env)
@@ -242,11 +248,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.12
           }
           steps {
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             doTest(env)
@@ -266,11 +275,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true) // skip default checkout and checkout manually after workspace was cleaned
           }
           environment {
             SCALA_VERSION=2.12
           }
           steps {
+            cleanWs() // clean workspace
+            checkout scm // checkout explicitely
             setupGradle()
             doValidation()
             doTest(env)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,11 +120,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true)
           }
           environment {
             SCALA_VERSION=2.12
           }
           steps {
+            cleanWs()
+            checkout scm
             setupGradle()
             doValidation()
             doTest(env)
@@ -140,11 +143,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true)
           }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
+            cleanWs()
+            checkout scm
             setupGradle()
             doValidation()
             doTest(env)
@@ -160,11 +166,14 @@ pipeline {
           options {
             timeout(time: 8, unit: 'HOURS') 
             timestamps()
+            skipDefaultCheckout(true)
           }
           environment {
             SCALA_VERSION=2.13
           }
           steps {
+            cleanWs()
+            checkout scm
             setupGradle()
             doValidation()
             doTest(env)


### PR DESCRIPTION
Observed a failing build with
```
Failed to execute goal org.apache.maven.plugins:maven-archetype-plugin:3.2.0:generate (default-cli) on project standalone-pom: A Maven project already exists in the directory /home/jenkins/workspace/Kafka_kafka-pr_PR-10131/streams/quickstart/test-streams-archetype/streams.examples -> [Help 1]
```

We should clean the workspace before we start the build to avoid this issue. \cc @ijuma 

Using Workspace Cleanup: https://plugins.jenkins.io/ws-cleanup/ 