### PR TITLE
MINOR: Move envelop body request serialize code to RequestContext

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -125,6 +125,26 @@ public class RequestContext implements AuthorizableRequestContext {
         return body.serializeWithHeader(header.toResponseHeader(), apiVersion());
     }
 
+    /**
+     * Serialize a request into a {@link ByteBuffer}. This is used when the request
+     * will be encapsulated in an {@link EnvelopeRequest}. The buffer will contain
+     * both the serialized {@link RequestHeader} as well as the bytes from the request.
+     * There is no `size` prefix unlike the output from {@link AbstractRequest#toSend(RequestHeader)}}.
+     *
+     * Note that envelope requests are only used when we want to forward a client request
+     * to the controller on behalf of the client.
+     */
+    public ByteBuffer buildRequestEnvelopePayload(AbstractRequest body) {
+        // Borrow client information such as client id and correlation id from the original request,
+        // in order to correlate the envelop request with the original client request.
+        RequestHeader requestHeader = new RequestHeader(
+            body.apiKey(),
+            body.version(),
+            clientId(),
+            correlationId());
+        return body.serializeWithHeader(requestHeader);
+    }
+
     private boolean isUnsupportedApiVersionsRequest() {
         return header.apiKey() == API_VERSIONS && !API_VERSIONS.isVersionSupported(header.apiVersion());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1028,7 +1028,31 @@ public class RequestResponseTest {
     }
 
     @Test
-    public void testSerializeWithHeader() {
+    public void testSerializeResponseWithHeader() {
+        CreateTopicsResponseData.CreatableTopicResultCollection collection =
+            new CreateTopicsResponseData.CreatableTopicResultCollection();
+        collection.add(new CreateTopicsResponseData.CreatableTopicResult()
+            .setTopicConfigErrorCode(Errors.CLUSTER_AUTHORIZATION_FAILED.code())
+            .setNumPartitions(5));
+
+        CreateTopicsResponse createTopicsResponse = new CreateTopicsResponse(
+            new CreateTopicsResponseData()
+                .setThrottleTimeMs(10)
+                .setTopics(collection));
+
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS,
+            ApiKeys.CREATE_TOPICS.latestVersion(), "client", 2);
+        ByteBuffer serializedResponse = createTopicsResponse.serializeWithHeader(
+            requestHeader.toResponseHeader(), requestHeader.apiVersion());
+
+        AbstractResponse parsedRequest = AbstractResponse.parseResponse(
+            serializedResponse, requestHeader);
+
+        assertEquals(createTopicsResponse.data(), parsedRequest.data());
+    }
+
+    @Test
+    public void testSerializeRequestWithHeader() {
         CreatableTopicCollection topicsToCreate = new CreatableTopicCollection(1);
         topicsToCreate.add(new CreatableTopic()
                                .setName("topic")

--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsRequestData.{CreatableTopic, CreateableTopicConfig, CreateableTopicConfigCollection}
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
-import org.apache.kafka.common.requests.{ApiError, CreateTopicsRequest, RequestContext, RequestHeader}
+import org.apache.kafka.common.requests.{ApiError, CreateTopicsRequest, RequestContext}
 
 import scala.collection.{Map, Seq, Set, mutable}
 import scala.jdk.CollectionConverters._
@@ -196,14 +196,8 @@ class DefaultAutoTopicCreationManager(
             nodeApiVersions.latestUsableVersion(ApiKeys.CREATE_TOPICS)
         }
 
-      // Borrow client information such as client id and correlation id from the original request,
-      // in order to correlate the create request with the original metadata request.
-      val requestHeader = new RequestHeader(ApiKeys.CREATE_TOPICS,
-        requestVersion,
-        context.clientId,
-        context.correlationId)
       ForwardingManager.buildEnvelopeRequest(context,
-        createTopicsRequest.build(requestVersion).serializeWithHeader(requestHeader))
+        context.buildRequestEnvelopePayload(createTopicsRequest.build(requestVersion)))
     }.getOrElse(createTopicsRequest)
 
     channelManager.sendRequest(request, requestCompletionHandler)


### PR DESCRIPTION
*More detailed description of your change*
Move envelop request body serialize code to `RequestContext `, see https://github.com/apache/kafka/pull/10142#discussion_r606613914

*Summary of testing strategy (including rationale)*
Unit test for the new method and `request.serializeWithHeader`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
