### PR TITLE
KAFKA-9988: Suppress uncaught exceptions in log messages during Connect task shutdown

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -185,15 +185,13 @@ abstract class WorkerTask implements Runnable {
 
             execute();
         } catch (Throwable t) {
-            if (!stopping && !cancelled) {
+            if (cancelled) {
+                log.warn("{} After being scheduled for shutdown, the orphan task threw an uncaught exception. A newer instance of this task might be already running", this, t);
+            } else if (stopping) {
+                log.warn("{} After being scheduled for shutdown, task threw an uncaught exception.", this, t);
+            } else {
                 log.error("{} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted", this, t);
                 throw t;
-            } else {
-                if (cancelled) {
-                    log.warn("{} After being scheduled for shutdown, the orphan task threw an uncaught exception. A newer instance of this task might be already running", this, t);
-                } else {
-                    log.warn("{} After being scheduled for shutdown, task threw an uncaught exception.", this, t);
-                }
             }
         } finally {
             doClose();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -185,8 +185,16 @@ abstract class WorkerTask implements Runnable {
 
             execute();
         } catch (Throwable t) {
-            log.error("{} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted", this, t);
-            throw t;
+            if (!stopping && !cancelled) {
+                log.error("{} Task threw an uncaught and unrecoverable exception. Task is being killed and will not recover until manually restarted", this, t);
+                throw t;
+            } else {
+                if (cancelled) {
+                    log.warn("{} After being scheduled for shutdown, the orphan task threw an uncaught exception. A newer instance of this task might be already running", this, t);
+                } else {
+                    log.warn("{} After being scheduled for shutdown, task threw an uncaught exception.", this, t);
+                }
+            }
         } finally {
             doClose();
         }


### PR DESCRIPTION
Uncaught exceptions logged during task stop were misleading because the task is already on its way of being shutdown.

The suppression of exception causes a change in behavior as the caller method now calls `statusListener.onShutdown` instead of `statusListener.onFailure` which is the right behavior. A new test was added to test the right behavior for uncaught exception during shutdown and existing test was modified to test uncaught exception during normal execution

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
