### PR TITLE
MINOR: fix some bugs in ControllerApis.scala

### DIFF
--- a/core/src/main/scala/kafka/server/ControllerApis.scala
+++ b/core/src/main/scala/kafka/server/ControllerApis.scala
@@ -19,6 +19,7 @@ package kafka.server
 
 import java.util
 import java.util.Collections
+import java.util.Map.Entry
 import java.util.concurrent.{CompletableFuture, ExecutionException}
 
 import kafka.network.RequestChannel
@@ -27,16 +28,17 @@ import kafka.server.QuotaFactory.QuotaManagers
 import kafka.utils.Logging
 import org.apache.kafka.clients.admin.AlterConfigOp
 import org.apache.kafka.common.Uuid.ZERO_UUID
-import org.apache.kafka.common.{Node, Uuid}
 import org.apache.kafka.common.acl.AclOperation.{ALTER, ALTER_CONFIGS, CLUSTER_ACTION, CREATE, DELETE, DESCRIBE}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{ApiException, ClusterAuthorizationException, InvalidRequestException, TopicDeletionDisabledException}
 import org.apache.kafka.common.internals.FatalExitError
+import org.apache.kafka.common.message.AlterConfigsResponseData.{AlterConfigsResourceResponse => OldAlterConfigsResourceResponse}
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic
 import org.apache.kafka.common.message.CreatePartitionsResponseData.CreatePartitionsTopicResult
 import org.apache.kafka.common.message.CreateTopicsRequestData
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult
 import org.apache.kafka.common.message.DeleteTopicsResponseData.{DeletableTopicResult, DeletableTopicResultCollection}
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse
 import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseBroker
 import org.apache.kafka.common.message._
 import org.apache.kafka.common.protocol.Errors._
@@ -46,6 +48,7 @@ import org.apache.kafka.common.resource.Resource
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType.{CLUSTER, TOPIC}
 import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.{Node, Uuid}
 import org.apache.kafka.controller.Controller
 import org.apache.kafka.metadata.{ApiMessageAndVersion, BrokerHeartbeatReply, BrokerRegistrationReply, VersionRange}
 import org.apache.kafka.server.authorizer.Authorizer
@@ -79,6 +82,7 @@ class ControllerApis(val requestChannel: RequestChannel,
         case ApiKeys.CREATE_TOPICS => handleCreateTopics(request)
         case ApiKeys.DELETE_TOPICS => handleDeleteTopics(request)
         case ApiKeys.API_VERSIONS => handleApiVersionsRequest(request)
+        case ApiKeys.ALTER_CONFIGS => handleLegacyAlterConfigs(request)
         case ApiKeys.VOTE => handleVote(request)
         case ApiKeys.BEGIN_QUORUM_EPOCH => handleBeginQuorumEpoch(request)
         case ApiKeys.END_QUORUM_EPOCH => handleEndQuorumEpoch(request)
@@ -89,6 +93,8 @@ class ControllerApis(val requestChannel: RequestChannel,
         case ApiKeys.UNREGISTER_BROKER => handleUnregisterBroker(request)
         case ApiKeys.ALTER_CLIENT_QUOTAS => handleAlterClientQuotas(request)
         case ApiKeys.INCREMENTAL_ALTER_CONFIGS => handleIncrementalAlterConfigs(request)
+        case ApiKeys.ALTER_PARTITION_REASSIGNMENTS => handleAlterPartitionReassignments(request)
+        case ApiKeys.LIST_PARTITION_REASSIGNMENTS => handleListPartitionReassignments(request)
         case ApiKeys.ENVELOPE => handleEnvelopeRequest(request)
         case ApiKeys.SASL_HANDSHAKE => handleSaslHandshakeRequest(request)
         case ApiKeys.SASL_AUTHENTICATE => handleSaslAuthenticateRequest(request)
@@ -112,18 +118,18 @@ class ControllerApis(val requestChannel: RequestChannel,
   }
 
   def handleSaslHandshakeRequest(request: RequestChannel.Request): Unit = {
-    val responseData = new SaslHandshakeResponseData().setErrorCode(Errors.ILLEGAL_SASL_STATE.code)
+    val responseData = new SaslHandshakeResponseData().setErrorCode(ILLEGAL_SASL_STATE.code)
     requestHelper.sendResponseMaybeThrottle(request, _ => new SaslHandshakeResponse(responseData))
   }
 
   def handleSaslAuthenticateRequest(request: RequestChannel.Request): Unit = {
     val responseData = new SaslAuthenticateResponseData()
-      .setErrorCode(Errors.ILLEGAL_SASL_STATE.code)
+      .setErrorCode(ILLEGAL_SASL_STATE.code)
       .setErrorMessage("SaslAuthenticate request received after successful authentication")
     requestHelper.sendResponseMaybeThrottle(request, _ => new SaslAuthenticateResponse(responseData))
   }
 
-  private def handleFetch(request: RequestChannel.Request): Unit = {
+  def handleFetch(request: RequestChannel.Request): Unit = {
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     handleRaftRequest(request, response => new FetchResponse(response.asInstanceOf[FetchResponseData]))
   }
@@ -140,7 +146,7 @@ class ControllerApis(val requestChannel: RequestChannel,
           .setPort(node.port)
           .setRack(node.rack))
       }
-      metadataResponseData.setClusterId(metaProperties.clusterId.toString)
+      metadataResponseData.setClusterId(metaProperties.clusterId)
       if (controller.isActive) {
         metadataResponseData.setControllerId(config.nodeId)
       } else {
@@ -164,16 +170,23 @@ class ControllerApis(val requestChannel: RequestChannel,
   }
 
   def handleDeleteTopics(request: RequestChannel.Request): Unit = {
-    val responses = deleteTopics(request.body[DeleteTopicsRequest].data,
+    val deleteTopicsRequest = request.body[DeleteTopicsRequest]
+    val future = deleteTopics(deleteTopicsRequest.data,
       request.context.apiVersion,
       authHelper.authorize(request.context, DELETE, CLUSTER, CLUSTER_NAME),
       names => authHelper.filterByAuthorized(request.context, DESCRIBE, TOPIC, names)(n => n),
       names => authHelper.filterByAuthorized(request.context, DELETE, TOPIC, names)(n => n))
-    requestHelper.sendResponseMaybeThrottle(request, throttleTimeMs => {
-      val responseData = new DeleteTopicsResponseData().
-        setResponses(new DeletableTopicResultCollection(responses.iterator)).
-        setThrottleTimeMs(throttleTimeMs)
-      new DeleteTopicsResponse(responseData)
+    future.whenComplete((results, exception) => {
+      requestHelper.sendResponseMaybeThrottle(request, throttleTimeMs => {
+        if (exception != null) {
+          deleteTopicsRequest.getErrorResponse(throttleTimeMs, exception)
+        } else {
+          val responseData = new DeleteTopicsResponseData().
+            setResponses(new DeletableTopicResultCollection(results.iterator)).
+            setThrottleTimeMs(throttleTimeMs)
+          new DeleteTopicsResponse(responseData)
+        }
+      })
     })
   }
 
@@ -181,7 +194,8 @@ class ControllerApis(val requestChannel: RequestChannel,
                    apiVersion: Int,
                    hasClusterAuth: Boolean,
                    getDescribableTopics: Iterable[String] => Set[String],
-                   getDeletableTopics: Iterable[String] => Set[String]): util.List[DeletableTopicResult] = {
+                   getDeletableTopics: Iterable[String] => Set[String])
+                   : CompletableFuture[util.List[DeletableTopicResult]] = {
     // Check if topic deletion is enabled at all.
     if (!config.deleteTopicEnable) {
       if (apiVersion < 3) {
@@ -242,87 +256,99 @@ class ControllerApis(val requestChannel: RequestChannel,
     val toAuthenticate = new util.HashSet[String]
     toAuthenticate.addAll(providedNames)
     val idToName = new util.HashMap[Uuid, String]
-    controller.findTopicNames(providedIds).get().forEach { (id, nameOrError) =>
-      if (nameOrError.isError) {
-        appendResponse(null, id, nameOrError.error())
-      } else {
-        toAuthenticate.add(nameOrError.result())
-        idToName.put(id, nameOrError.result())
-      }
-    }
-    // Get the list of deletable topics (those we can delete) and the list of describeable
-    // topics.  If a topic can't be deleted or described, we have to act like it doesn't
-    // exist, even when it does.
-    val topicsToAuthenticate = toAuthenticate.asScala
-    val (describeable, deletable) = if (hasClusterAuth) {
-      (topicsToAuthenticate.toSet, topicsToAuthenticate.toSet)
-    } else {
-      (getDescribableTopics(topicsToAuthenticate), getDeletableTopics(topicsToAuthenticate))
-    }
-    // For each topic that was provided by ID, check if authentication failed.
-    // If so, remove it from the idToName map and create an error response for it.
-    val iterator = idToName.entrySet().iterator()
-    while (iterator.hasNext) {
-      val entry = iterator.next()
-      val id = entry.getKey
-      val name = entry.getValue
-      if (!deletable.contains(name)) {
-        if (describeable.contains(name)) {
-          appendResponse(name, id, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+    controller.findTopicNames(providedIds).thenCompose(topicNames => {
+      topicNames.forEach { (id, nameOrError) =>
+        if (nameOrError.isError) {
+          appendResponse(null, id, nameOrError.error())
         } else {
-          appendResponse(null, id, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+          toAuthenticate.add(nameOrError.result())
+          idToName.put(id, nameOrError.result())
         }
-        iterator.remove()
       }
-    }
-    // For each topic that was provided by name, check if authentication failed.
-    // If so, create an error response for it.  Otherwise, add it to the idToName map.
-    controller.findTopicIds(providedNames).get().forEach { (name, idOrError) =>
-      if (!describeable.contains(name)) {
-        appendResponse(name, ZERO_UUID, new ApiError(TOPIC_AUTHORIZATION_FAILED))
-      } else if (idOrError.isError) {
-        appendResponse(name, ZERO_UUID, idOrError.error)
-      } else if (deletable.contains(name)) {
-        val id = idOrError.result()
-        if (duplicateProvidedIds.contains(id) || idToName.put(id, name) != null) {
-          // This is kind of a weird case: what if we supply topic ID X and also a name
-          // that maps to ID X?  In that case, _if authorization succeeds_, we end up
-          // here.  If authorization doesn't succeed, we refrain from commenting on the
-          // situation since it would reveal topic ID mappings.
-          duplicateProvidedIds.add(id)
-          idToName.remove(id)
-          appendResponse(name, id, new ApiError(INVALID_REQUEST,
-            "The provided topic name maps to an ID that was already supplied."))
-        }
+      // Get the list of deletable topics (those we can delete) and the list of describeable
+      // topics.
+      val topicsToAuthenticate = toAuthenticate.asScala
+      val (describeable, deletable) = if (hasClusterAuth) {
+        (topicsToAuthenticate.toSet, topicsToAuthenticate.toSet)
       } else {
-        appendResponse(name, ZERO_UUID, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+        (getDescribableTopics(topicsToAuthenticate), getDeletableTopics(topicsToAuthenticate))
       }
-    }
-    // Finally, the idToName map contains all the topics that we are authorized to delete.
-    // Perform the deletion and create responses for each one.
-    val idToError = controller.deleteTopics(idToName.keySet).get()
-    idToError.forEach { (id, error) =>
-        appendResponse(idToName.get(id), id, error)
-    }
-    // Shuffle the responses so that users can not use patterns in their positions to
-    // distinguish between absent topics and topics we are not permitted to see.
-    Collections.shuffle(responses)
-    responses
+      // For each topic that was provided by ID, check if authentication failed.
+      // If so, remove it from the idToName map and create an error response for it.
+      val iterator = idToName.entrySet().iterator()
+      while (iterator.hasNext) {
+        val entry = iterator.next()
+        val id = entry.getKey
+        val name = entry.getValue
+        if (!deletable.contains(name)) {
+          if (describeable.contains(name)) {
+            appendResponse(name, id, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+          } else {
+            appendResponse(null, id, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+          }
+          iterator.remove()
+        }
+      }
+      // For each topic that was provided by name, check if authentication failed.
+      // If so, create an error response for it. Otherwise, add it to the idToName map.
+      controller.findTopicIds(providedNames).thenCompose(topicIds => {
+        topicIds.forEach { (name, idOrError) =>
+          if (!describeable.contains(name)) {
+            appendResponse(name, ZERO_UUID, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+          } else if (idOrError.isError) {
+            appendResponse(name, ZERO_UUID, idOrError.error)
+          } else if (deletable.contains(name)) {
+            val id = idOrError.result()
+            if (duplicateProvidedIds.contains(id) || idToName.put(id, name) != null) {
+              // This is kind of a weird case: what if we supply topic ID X and also a name
+              // that maps to ID X?  In that case, _if authorization succeeds_, we end up
+              // here.  If authorization doesn't succeed, we refrain from commenting on the
+              // situation since it would reveal topic ID mappings.
+              duplicateProvidedIds.add(id)
+              idToName.remove(id)
+              appendResponse(name, id, new ApiError(INVALID_REQUEST,
+                "The provided topic name maps to an ID that was already supplied."))
+            }
+          } else {
+            appendResponse(name, ZERO_UUID, new ApiError(TOPIC_AUTHORIZATION_FAILED))
+          }
+        }
+        // Finally, the idToName map contains all the topics that we are authorized to delete.
+        // Perform the deletion and create responses for each one.
+        controller.deleteTopics(idToName.keySet).thenApply(idToError => {
+          idToError.forEach { (id, error) =>
+            appendResponse(idToName.get(id), id, error)
+          }
+          // Shuffle the responses so that users can not use patterns in their positions to
+          // distinguish between absent topics and topics we are not permitted to see.
+          Collections.shuffle(responses)
+          responses
+        })
+      })
+    })
   }
 
   def handleCreateTopics(request: RequestChannel.Request): Unit = {
-    val responseData = createTopics(request.body[CreateTopicsRequest].data(),
+    val createTopicsRequest = request.body[CreateTopicsRequest]
+    val future = createTopics(createTopicsRequest.data(),
         authHelper.authorize(request.context, CREATE, CLUSTER, CLUSTER_NAME),
         names => authHelper.filterByAuthorized(request.context, CREATE, TOPIC, names)(identity))
-    requestHelper.sendResponseMaybeThrottle(request, throttleTimeMs => {
-      responseData.setThrottleTimeMs(throttleTimeMs)
-      new CreateTopicsResponse(responseData)
+    future.whenComplete((result, exception) => {
+      requestHelper.sendResponseMaybeThrottle(request, throttleTimeMs => {
+        if (exception != null) {
+          createTopicsRequest.getErrorResponse(throttleTimeMs, exception)
+        } else {
+          result.setThrottleTimeMs(throttleTimeMs)
+          new CreateTopicsResponse(result)
+        }
+      })
     })
   }
 
   def createTopics(request: CreateTopicsRequestData,
                    hasClusterAuth: Boolean,
-                   getCreatableTopics: Iterable[String] => Set[String]): CreateTopicsResponseData = {
+                   getCreatableTopics: Iterable[String] => Set[String])
+                   : CompletableFuture[CreateTopicsResponseData] = {
     val topicNames = new util.HashSet[String]()
     val duplicateTopicNames = new util.HashSet[String]()
     request.topics().forEach { topicData =>
@@ -347,21 +373,22 @@ class ControllerApis(val requestChannel: RequestChannel,
         iterator.remove()
       }
     }
-    val response = controller.createTopics(effectiveRequest).get()
-    duplicateTopicNames.forEach { name =>
-      response.topics().add(new CreatableTopicResult().
-        setName(name).
-        setErrorCode(INVALID_REQUEST.code()).
-        setErrorMessage("Found multiple entries for this topic."))
-    }
-    topicNames.forEach { name =>
-      if (!authorizedTopicNames.contains(name)) {
+    controller.createTopics(effectiveRequest).thenApply(response => {
+      duplicateTopicNames.forEach { name =>
         response.topics().add(new CreatableTopicResult().
           setName(name).
-          setErrorCode(TOPIC_AUTHORIZATION_FAILED.code()))
+          setErrorCode(INVALID_REQUEST.code).
+          setErrorMessage("Duplicate topic name."))
       }
-    }
-    response
+      topicNames.forEach { name =>
+        if (!authorizedTopicNames.contains(name)) {
+          response.topics().add(new CreatableTopicResult().
+            setName(name).
+            setErrorCode(TOPIC_AUTHORIZATION_FAILED.code))
+        }
+      }
+      response
+    })
   }
 
   def handleApiVersionsRequest(request: RequestChannel.Request): Unit = {
@@ -374,7 +401,7 @@ class ControllerApis(val requestChannel: RequestChannel,
     def createResponseCallback(requestThrottleMs: Int): ApiVersionsResponse = {
       val apiVersionRequest = request.body[ApiVersionsRequest]
       if (apiVersionRequest.hasUnsupportedRequestVersion) {
-        apiVersionRequest.getErrorResponse(requestThrottleMs, Errors.UNSUPPORTED_VERSION.exception)
+        apiVersionRequest.getErrorResponse(requestThrottleMs, UNSUPPORTED_VERSION.exception)
       } else if (!apiVersionRequest.isValid) {
         apiVersionRequest.getErrorResponse(requestThrottleMs, INVALID_REQUEST.exception)
       } else {
@@ -384,29 +411,106 @@ class ControllerApis(val requestChannel: RequestChannel,
     requestHelper.sendResponseMaybeThrottle(request, createResponseCallback)
   }
 
-  private def handleVote(request: RequestChannel.Request): Unit = {
+  def authorizeAlterResource(requestContext: RequestContext,
+                             resource: ConfigResource): ApiError = {
+    resource.`type` match {
+      case ConfigResource.Type.BROKER =>
+        if (authHelper.authorize(requestContext, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)) {
+          new ApiError(NONE)
+        } else {
+          new ApiError(CLUSTER_AUTHORIZATION_FAILED)
+        }
+      case ConfigResource.Type.TOPIC =>
+        if (authHelper.authorize(requestContext, ALTER_CONFIGS, TOPIC, resource.name)) {
+          new ApiError(NONE)
+        } else {
+          new ApiError(TOPIC_AUTHORIZATION_FAILED)
+        }
+      case rt => new ApiError(INVALID_REQUEST, s"Unexpected resource type $rt.")
+    }
+  }
+
+  def handleLegacyAlterConfigs(request: RequestChannel.Request): Unit = {
+    val response = new AlterConfigsResponseData()
+    val alterConfigsRequest = request.body[AlterConfigsRequest]
+    val duplicateResources = new util.HashSet[ConfigResource]
+    val configChanges = new util.HashMap[ConfigResource, util.Map[String, String]]()
+    alterConfigsRequest.data.resources.forEach { resource =>
+      val configResource = new ConfigResource(
+        ConfigResource.Type.forId(resource.resourceType), resource.resourceName())
+      if (configResource.`type`().equals(ConfigResource.Type.UNKNOWN)) {
+        response.responses().add(new OldAlterConfigsResourceResponse().
+          setErrorCode(UNSUPPORTED_VERSION.code()).
+          setErrorMessage("Unknown resource type " + resource.resourceType() + ".").
+          setResourceName(resource.resourceName()).
+          setResourceType(resource.resourceType()))
+      } else if (!duplicateResources.contains(configResource)) {
+        val configs = new util.HashMap[String, String]()
+        resource.configs().forEach(config => configs.put(config.name(), config.value()))
+        if (configChanges.put(configResource, configs) != null) {
+          duplicateResources.add(configResource)
+          configChanges.remove(configResource)
+          response.responses().add(new OldAlterConfigsResourceResponse().
+            setErrorCode(INVALID_REQUEST.code()).
+            setErrorMessage("Duplicate resource.").
+            setResourceName(resource.resourceName()).
+            setResourceType(resource.resourceType()))
+        }
+      }
+    }
+    val iterator = configChanges.keySet().iterator()
+    while (iterator.hasNext) {
+      val resource = iterator.next()
+      val apiError = authorizeAlterResource(request.context, resource)
+      if (apiError.isFailure) {
+        response.responses().add(new OldAlterConfigsResourceResponse().
+          setErrorCode(apiError.error().code()).
+          setErrorMessage(apiError.message()).
+          setResourceName(resource.name()).
+          setResourceType(resource.`type`().id()))
+        iterator.remove()
+      }
+    }
+    controller.legacyAlterConfigs(configChanges, alterConfigsRequest.data.validateOnly)
+      .whenComplete((controllerResults, exception) => {
+        if (exception != null) {
+          requestHelper.handleError(request, exception)
+        } else {
+          controllerResults.entrySet().forEach(entry => response.responses().add(
+            new OldAlterConfigsResourceResponse().
+              setErrorCode(entry.getValue.error().code()).
+              setErrorMessage(entry.getValue.message()).
+              setResourceName(entry.getKey.name()).
+              setResourceType(entry.getKey.`type`().id())))
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new AlterConfigsResponse(response.setThrottleTimeMs(throttleMs)))
+        }
+      })
+  }
+
+  def handleVote(request: RequestChannel.Request): Unit = {
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     handleRaftRequest(request, response => new VoteResponse(response.asInstanceOf[VoteResponseData]))
   }
 
-  private def handleBeginQuorumEpoch(request: RequestChannel.Request): Unit = {
+  def handleBeginQuorumEpoch(request: RequestChannel.Request): Unit = {
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     handleRaftRequest(request, response => new BeginQuorumEpochResponse(response.asInstanceOf[BeginQuorumEpochResponseData]))
   }
 
-  private def handleEndQuorumEpoch(request: RequestChannel.Request): Unit = {
+  def handleEndQuorumEpoch(request: RequestChannel.Request): Unit = {
     authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     handleRaftRequest(request, response => new EndQuorumEpochResponse(response.asInstanceOf[EndQuorumEpochResponseData]))
   }
 
-  private def handleDescribeQuorum(request: RequestChannel.Request): Unit = {
+  def handleDescribeQuorum(request: RequestChannel.Request): Unit = {
     authHelper.authorizeClusterOperation(request, DESCRIBE)
     handleRaftRequest(request, response => new DescribeQuorumResponse(response.asInstanceOf[DescribeQuorumResponseData]))
   }
 
   def handleAlterIsrRequest(request: RequestChannel.Request): Unit = {
-    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val alterIsrRequest = request.body[AlterIsrRequest]
+    authHelper.authorizeClusterOperation(request, CLUSTER_ACTION)
     val future = controller.alterIsr(alterIsrRequest.data)
     future.whenComplete((result, exception) => {
       val response = if (exception != null) {
@@ -433,7 +537,7 @@ class ControllerApis(val requestChannel: RequestChannel,
         } else {
           new BrokerHeartbeatResponse(new BrokerHeartbeatResponseData().
             setThrottleTimeMs(requestThrottleMs).
-            setErrorCode(Errors.NONE.code).
+            setErrorCode(NONE.code).
             setIsCaughtUp(reply.isCaughtUp).
             setIsFenced(reply.isFenced).
             setShouldShutDown(reply.shouldShutDown))
@@ -476,11 +580,11 @@ class ControllerApis(val requestChannel: RequestChannel,
         if (e != null) {
           new BrokerRegistrationResponse(new BrokerRegistrationResponseData().
             setThrottleTimeMs(requestThrottleMs).
-            setErrorCode(Errors.forException(e).code()))
+            setErrorCode(Errors.forException(e).code))
         } else {
           new BrokerRegistrationResponse(new BrokerRegistrationResponseData().
             setThrottleTimeMs(requestThrottleMs).
-            setErrorCode(Errors.NONE.code).
+            setErrorCode(NONE.code).
             setBrokerEpoch(reply.epoch))
         }
       }
@@ -506,8 +610,7 @@ class ControllerApis(val requestChannel: RequestChannel,
 
   def handleAlterClientQuotas(request: RequestChannel.Request): Unit = {
     val quotaRequest = request.body[AlterClientQuotasRequest]
-    authHelper.authorize(request.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)
-
+    authHelper.authorizeClusterOperation(request, ALTER_CONFIGS)
     controller.alterClientQuotas(quotaRequest.entries, quotaRequest.validateOnly)
       .whenComplete((results, exception) => {
         if (exception != null) {
@@ -520,25 +623,63 @@ class ControllerApis(val requestChannel: RequestChannel,
   }
 
   def handleIncrementalAlterConfigs(request: RequestChannel.Request): Unit = {
+    val response = new IncrementalAlterConfigsResponseData()
     val alterConfigsRequest = request.body[IncrementalAlterConfigsRequest]
-    authHelper.authorize(request.context, ALTER_CONFIGS, CLUSTER, CLUSTER_NAME)
-    val configChanges = new util.HashMap[ConfigResource, util.Map[String, util.Map.Entry[AlterConfigOp.OpType, String]]]()
+    val duplicateResources = new util.HashSet[ConfigResource]
+    val configChanges = new util.HashMap[ConfigResource,
+      util.Map[String, Entry[AlterConfigOp.OpType, String]]]()
     alterConfigsRequest.data.resources.forEach { resource =>
-      val configResource = new ConfigResource(ConfigResource.Type.forId(resource.resourceType), resource.resourceName())
-      val altersByName = new util.HashMap[String, util.Map.Entry[AlterConfigOp.OpType, String]]()
-      resource.configs.forEach { config =>
-        altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
-          AlterConfigOp.OpType.forId(config.configOperation), config.value))
+      val configResource = new ConfigResource(
+        ConfigResource.Type.forId(resource.resourceType), resource.resourceName())
+      if (configResource.`type`().equals(ConfigResource.Type.UNKNOWN)) {
+        response.responses().add(new AlterConfigsResourceResponse().
+          setErrorCode(UNSUPPORTED_VERSION.code()).
+          setErrorMessage("Unknown resource type " + resource.resourceType() + ".").
+          setResourceName(resource.resourceName()).
+          setResourceType(resource.resourceType()))
+      } else if (!duplicateResources.contains(configResource)) {
+        val altersByName = new util.HashMap[String, Entry[AlterConfigOp.OpType, String]]()
+        resource.configs.forEach { config =>
+          altersByName.put(config.name, new util.AbstractMap.SimpleEntry[AlterConfigOp.OpType, String](
+            AlterConfigOp.OpType.forId(config.configOperation), config.value))
+        }
+        if (configChanges.put(configResource, altersByName) != null) {
+          duplicateResources.add(configResource)
+          configChanges.remove(configResource)
+          response.responses().add(new AlterConfigsResourceResponse().
+            setErrorCode(INVALID_REQUEST.code()).
+            setErrorMessage("Duplicate resource.").
+            setResourceName(resource.resourceName()).
+            setResourceType(resource.resourceType()))
+        }
       }
-      configChanges.put(configResource, altersByName)
+    }
+    val iterator = configChanges.keySet().iterator()
+    while (iterator.hasNext) {
+      val resource = iterator.next()
+      val apiError = authorizeAlterResource(request.context, resource)
+      if (apiError.isFailure) {
+        response.responses().add(new AlterConfigsResourceResponse().
+          setErrorCode(apiError.error().code()).
+          setErrorMessage(apiError.message()).
+          setResourceName(resource.name()).
+          setResourceType(resource.`type`().id()))
+        iterator.remove()
+      }
     }
     controller.incrementalAlterConfigs(configChanges, alterConfigsRequest.data.validateOnly)
-      .whenComplete((results, exception) => {
+      .whenComplete((controllerResults, exception) => {
         if (exception != null) {
           requestHelper.handleError(request, exception)
         } else {
-          requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
-            new IncrementalAlterConfigsResponse(requestThrottleMs, results))
+          controllerResults.entrySet().forEach(entry => response.responses().add(
+            new AlterConfigsResourceResponse().
+              setErrorCode(entry.getValue.error().code()).
+              setErrorMessage(entry.getValue.message()).
+              setResourceName(entry.getKey.name()).
+              setResourceType(entry.getKey.`type`().id())))
+          requestHelper.sendResponseMaybeThrottle(request, throttleMs =>
+            new IncrementalAlterConfigsResponse(response.setThrottleTimeMs(throttleMs)))
         }
       })
   }
@@ -577,7 +718,7 @@ class ControllerApis(val requestChannel: RequestChannel,
     duplicateTopicNames.forEach { topicName =>
       responses.add(new CreatePartitionsTopicResult().
         setName(topicName).
-        setErrorCode(INVALID_REQUEST.code()).
+        setErrorCode(INVALID_REQUEST.code).
         setErrorMessage("Duplicate topic name."))
         topicNames.remove(topicName)
     }
@@ -595,12 +736,28 @@ class ControllerApis(val requestChannel: RequestChannel,
       } else {
         responses.add(new CreatePartitionsTopicResult().
           setName(topicName).
-          setErrorCode(TOPIC_AUTHORIZATION_FAILED.code()))
+          setErrorCode(TOPIC_AUTHORIZATION_FAILED.code))
       }
     }
     controller.createPartitions(topics).thenApply { results =>
       results.forEach(response => responses.add(response))
       responses
     }
+  }
+
+  def handleAlterPartitionReassignments(request: RequestChannel.Request): Unit = {
+    val alterRequest = request.body[AlterPartitionReassignmentsRequest]
+    authHelper.authorizeClusterOperation(request, ALTER)
+    val response = controller.alterPartitionReassignments(alterRequest.data()).get()
+    requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+      new AlterPartitionReassignmentsResponse(response))
+  }
+
+  def handleListPartitionReassignments(request: RequestChannel.Request): Unit = {
+    val listRequest = request.body[ListPartitionReassignmentsRequest]
+    authHelper.authorizeClusterOperation(request, DESCRIBE)
+    val response = controller.listPartitionReassignments(listRequest.data()).get()
+    requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs =>
+      new ListPartitionReassignmentsResponse(response))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControllerApisTest.scala
@@ -27,9 +27,11 @@ import kafka.raft.RaftManager
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.test.MockController
 import kafka.utils.MockTime
+import org.apache.kafka.clients.admin.AlterConfigOp
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.Uuid.ZERO_UUID
-import org.apache.kafka.common.errors.{InvalidRequestException, NotControllerException, TopicDeletionDisabledException}
+import org.apache.kafka.common.config.{ConfigResource, TopicConfig}
+import org.apache.kafka.common.errors._
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.message.ApiMessageType.ListenerType
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic
@@ -40,7 +42,14 @@ import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopicCol
 import org.apache.kafka.common.message.CreateTopicsResponseData.CreatableTopicResult
 import org.apache.kafka.common.message.DeleteTopicsRequestData.DeleteTopicState
 import org.apache.kafka.common.message.DeleteTopicsResponseData.DeletableTopicResult
-import org.apache.kafka.common.message.{BrokerRegistrationRequestData, CreatePartitionsRequestData, DeleteTopicsRequestData}
+import org.apache.kafka.common.message._
+import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.{AlterConfigsResourceCollection, AlterableConfig, AlterableConfigCollection, AlterConfigsResource}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterConfigsResourceCollection => OldAlterConfigsResourceCollection}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterConfigsResource => OldAlterConfigsResource}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterableConfigCollection => OldAlterableConfigCollection}
+import org.apache.kafka.common.message.AlterConfigsRequestData.{AlterableConfig => OldAlterableConfig}
+import org.apache.kafka.common.message.AlterConfigsResponseData.{AlterConfigsResourceResponse => OldAlterConfigsResourceResponse}
+import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData.AlterConfigsResourceResponse
 import org.apache.kafka.common.network.{ClientInformation, ListenerName}
 import org.apache.kafka.common.protocol.Errors._
 import org.apache.kafka.common.protocol.ApiKeys
@@ -123,6 +132,139 @@ class ControllerApisTest {
       requestChannelMetrics)
   }
 
+  def createDenyAllAuthorizer(): Authorizer = {
+    val authorizer = mock(classOf[Authorizer])
+    mock(classOf[Authorizer])
+    when(authorizer.authorize(
+      any(classOf[AuthorizableRequestContext]),
+      any(classOf[java.util.List[Action]])
+    )).thenReturn(
+      java.util.Collections.singletonList(AuthorizationResult.DENIED)
+    )
+    authorizer
+  }
+
+  @Test
+  def testUnauthorizedFetch(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleFetch(buildRequest(new FetchRequest(new FetchRequestData(), 12))))
+  }
+
+  @Test
+  def testUnauthorizedVote(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleVote(buildRequest(new VoteRequest.Builder(new VoteRequestData()).build(0))))
+  }
+
+  @Test
+  def testHandleLegacyAlterConfigsErrors(): Unit = {
+    val requestData = new AlterConfigsRequestData().setResources(
+      new OldAlterConfigsResourceCollection(util.Arrays.asList(
+        new OldAlterConfigsResource().
+          setResourceName("1").
+          setResourceType(ConfigResource.Type.BROKER.id()).
+          setConfigs(new OldAlterableConfigCollection(util.Arrays.asList(new OldAlterableConfig().
+            setName(KafkaConfig.LogCleanerBackoffMsProp).
+            setValue("100000")).iterator())),
+        new OldAlterConfigsResource().
+          setResourceName("2").
+          setResourceType(ConfigResource.Type.BROKER.id()).
+          setConfigs(new OldAlterableConfigCollection(util.Arrays.asList(new OldAlterableConfig().
+            setName(KafkaConfig.LogCleanerBackoffMsProp).
+            setValue("100000")).iterator())),
+        new OldAlterConfigsResource().
+          setResourceName("2").
+          setResourceType(ConfigResource.Type.BROKER.id()).
+          setConfigs(new OldAlterableConfigCollection(util.Arrays.asList(new OldAlterableConfig().
+            setName(KafkaConfig.LogCleanerBackoffMsProp).
+            setValue("100000")).iterator())),
+        new OldAlterConfigsResource().
+          setResourceName("baz").
+          setResourceType(123.toByte).
+          setConfigs(new OldAlterableConfigCollection(util.Arrays.asList(new OldAlterableConfig().
+            setName("foo").
+            setValue("bar")).iterator())),
+        ).iterator()))
+    val request = buildRequest(new AlterConfigsRequest(requestData, 0))
+    createControllerApis(Some(createDenyAllAuthorizer()),
+      new MockController.Builder().build()).handleLegacyAlterConfigs(request)
+    val capturedResponse: ArgumentCaptor[AbstractResponse] =
+      ArgumentCaptor.forClass(classOf[AbstractResponse])
+    verify(requestChannel).sendResponse(
+      ArgumentMatchers.eq(request),
+      capturedResponse.capture(),
+      ArgumentMatchers.eq(None))
+    assertNotNull(capturedResponse.getValue)
+    val response = capturedResponse.getValue.asInstanceOf[AlterConfigsResponse]
+    assertEquals(Set(
+      new OldAlterConfigsResourceResponse().
+        setErrorCode(INVALID_REQUEST.code()).
+        setErrorMessage("Duplicate resource.").
+        setResourceName("2").
+        setResourceType(ConfigResource.Type.BROKER.id()),
+      new OldAlterConfigsResourceResponse().
+        setErrorCode(UNSUPPORTED_VERSION.code()).
+        setErrorMessage("Unknown resource type 123.").
+        setResourceName("baz").
+        setResourceType(123.toByte),
+      new OldAlterConfigsResourceResponse().
+        setErrorCode(CLUSTER_AUTHORIZATION_FAILED.code()).
+        setErrorMessage("Cluster authorization failed.").
+        setResourceName("1").
+        setResourceType(ConfigResource.Type.BROKER.id())),
+      response.data().responses().asScala.toSet)
+  }
+
+  @Test
+  def testUnauthorizedBeginQuorumEpoch(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleBeginQuorumEpoch(buildRequest(new BeginQuorumEpochRequest.Builder(
+          new BeginQuorumEpochRequestData()).build(0))))
+  }
+
+  @Test
+  def testUnauthorizedEndQuorumEpoch(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleEndQuorumEpoch(buildRequest(new EndQuorumEpochRequest.Builder(
+          new EndQuorumEpochRequestData()).build(0))))
+  }
+
+  @Test
+  def testUnauthorizedDescribeQuorum(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleDescribeQuorum(buildRequest(new DescribeQuorumRequest.Builder(
+          new DescribeQuorumRequestData()).build(0))))
+  }
+
+  @Test
+  def testUnauthorizedHandleAlterIsrRequest(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleAlterIsrRequest(buildRequest(new AlterIsrRequest.Builder(
+          new AlterIsrRequestData()).build(0))))
+  }
+
+  @Test
+  def testUnauthorizedHandleBrokerHeartBeatRequest(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleBrokerHeartBeatRequest(buildRequest(new BrokerHeartbeatRequest.Builder(
+          new BrokerHeartbeatRequestData()).build(0))))
+  }
+
+  @Test
+  def testUnauthorizedHandleUnregisterBroker(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleUnregisterBroker(buildRequest(new UnregisterBrokerRequest.Builder(
+          new UnregisterBrokerRequestData()).build(0))))
+  }
+
   @Test
   def testUnauthorizedBrokerRegistration(): Unit = {
     val brokerRegistrationRequest = new BrokerRegistrationRequest.Builder(
@@ -134,15 +276,7 @@ class ControllerApisTest {
     val request = buildRequest(brokerRegistrationRequest)
     val capturedResponse: ArgumentCaptor[AbstractResponse] = ArgumentCaptor.forClass(classOf[AbstractResponse])
 
-    val authorizer = mock(classOf[Authorizer])
-    when(authorizer.authorize(
-      any(classOf[AuthorizableRequestContext]),
-      any(classOf[java.util.List[Action]])
-    )).thenReturn(
-      java.util.Collections.singletonList(AuthorizationResult.DENIED)
-    )
-
-    createControllerApis(Some(authorizer), mock(classOf[Controller])).handle(request)
+    createControllerApis(Some(createDenyAllAuthorizer()), mock(classOf[Controller])).handle(request)
     verify(requestChannel).sendResponse(
       ArgumentMatchers.eq(request),
       capturedResponse.capture(),
@@ -153,6 +287,136 @@ class ControllerApisTest {
     val brokerRegistrationResponse = capturedResponse.getValue.asInstanceOf[BrokerRegistrationResponse]
     assertEquals(Map(CLUSTER_AUTHORIZATION_FAILED -> 1),
       brokerRegistrationResponse.errorCounts().asScala)
+  }
+
+  @Test
+  def testUnauthorizedHandleAlterClientQuotas(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleAlterClientQuotas(buildRequest(new AlterClientQuotasRequest(
+          new AlterClientQuotasRequestData(), 0))))
+  }
+
+  @Test
+  def testUnauthorizedHandleIncrementalAlterConfigs(): Unit = {
+    val requestData = new IncrementalAlterConfigsRequestData().setResources(
+      new AlterConfigsResourceCollection(
+        util.Arrays.asList(new AlterConfigsResource().
+          setResourceName("1").
+          setResourceType(ConfigResource.Type.BROKER.id()).
+          setConfigs(new AlterableConfigCollection(util.Arrays.asList(new AlterableConfig().
+            setName(KafkaConfig.LogCleanerBackoffMsProp).
+            setValue("100000").
+            setConfigOperation(AlterConfigOp.OpType.SET.id())).iterator())),
+        new AlterConfigsResource().
+          setResourceName("foo").
+          setResourceType(ConfigResource.Type.TOPIC.id()).
+          setConfigs(new AlterableConfigCollection(util.Arrays.asList(new AlterableConfig().
+            setName(TopicConfig.FLUSH_MS_CONFIG).
+            setValue("1000").
+            setConfigOperation(AlterConfigOp.OpType.SET.id())).iterator())),
+        ).iterator()))
+    val request = buildRequest(new IncrementalAlterConfigsRequest.Builder(requestData).build(0))
+    createControllerApis(Some(createDenyAllAuthorizer()),
+      new MockController.Builder().build()).handleIncrementalAlterConfigs(request)
+    val capturedResponse: ArgumentCaptor[AbstractResponse] =
+      ArgumentCaptor.forClass(classOf[AbstractResponse])
+    verify(requestChannel).sendResponse(
+      ArgumentMatchers.eq(request),
+      capturedResponse.capture(),
+      ArgumentMatchers.eq(None))
+    assertNotNull(capturedResponse.getValue)
+    val response = capturedResponse.getValue.asInstanceOf[IncrementalAlterConfigsResponse]
+    assertEquals(Set(new AlterConfigsResourceResponse().
+        setErrorCode(CLUSTER_AUTHORIZATION_FAILED.code()).
+        setErrorMessage(CLUSTER_AUTHORIZATION_FAILED.message()).
+        setResourceName("1").
+        setResourceType(ConfigResource.Type.BROKER.id()),
+      new AlterConfigsResourceResponse().
+        setErrorCode(TOPIC_AUTHORIZATION_FAILED.code()).
+        setErrorMessage(TOPIC_AUTHORIZATION_FAILED.message()).
+        setResourceName("foo").
+        setResourceType(ConfigResource.Type.TOPIC.id())),
+      response.data().responses().asScala.toSet)
+  }
+
+  @Test
+  def testInvalidIncrementalAlterConfigsResources(): Unit = {
+    val requestData = new IncrementalAlterConfigsRequestData().setResources(
+      new AlterConfigsResourceCollection(util.Arrays.asList(
+        new AlterConfigsResource().
+          setResourceName("1").
+          setResourceType(ConfigResource.Type.BROKER_LOGGER.id()).
+          setConfigs(new AlterableConfigCollection(util.Arrays.asList(new AlterableConfig().
+            setName("kafka.server.KafkaConfig").
+            setValue("TRACE").
+            setConfigOperation(AlterConfigOp.OpType.SET.id())).iterator())),
+        new AlterConfigsResource().
+          setResourceName("3").
+          setResourceType(ConfigResource.Type.BROKER.id()).
+          setConfigs(new AlterableConfigCollection(util.Arrays.asList(new AlterableConfig().
+            setName(KafkaConfig.LogCleanerBackoffMsProp).
+            setValue("100000").
+            setConfigOperation(AlterConfigOp.OpType.SET.id())).iterator())),
+        new AlterConfigsResource().
+          setResourceName("3").
+          setResourceType(ConfigResource.Type.BROKER.id()).
+          setConfigs(new AlterableConfigCollection(util.Arrays.asList(new AlterableConfig().
+            setName(KafkaConfig.LogCleanerBackoffMsProp).
+            setValue("100000").
+            setConfigOperation(AlterConfigOp.OpType.SET.id())).iterator())),
+        new AlterConfigsResource().
+          setResourceName("foo").
+          setResourceType(124.toByte).
+          setConfigs(new AlterableConfigCollection(util.Arrays.asList(new AlterableConfig().
+            setName("foo").
+            setValue("bar").
+            setConfigOperation(AlterConfigOp.OpType.SET.id())).iterator())),
+        ).iterator()))
+    val request = buildRequest(new IncrementalAlterConfigsRequest.Builder(requestData).build(0))
+    createControllerApis(Some(createDenyAllAuthorizer()),
+      new MockController.Builder().build()).handleIncrementalAlterConfigs(request)
+    val capturedResponse: ArgumentCaptor[AbstractResponse] =
+      ArgumentCaptor.forClass(classOf[AbstractResponse])
+    verify(requestChannel).sendResponse(
+      ArgumentMatchers.eq(request),
+      capturedResponse.capture(),
+      ArgumentMatchers.eq(None))
+    assertNotNull(capturedResponse.getValue)
+    val response = capturedResponse.getValue.asInstanceOf[IncrementalAlterConfigsResponse]
+    assertEquals(Set(
+      new AlterConfigsResourceResponse().
+        setErrorCode(INVALID_REQUEST.code()).
+        setErrorMessage("Unexpected resource type BROKER_LOGGER.").
+        setResourceName("1").
+        setResourceType(ConfigResource.Type.BROKER_LOGGER.id()),
+      new AlterConfigsResourceResponse().
+        setErrorCode(INVALID_REQUEST.code()).
+        setErrorMessage("Duplicate resource.").
+        setResourceName("3").
+        setResourceType(ConfigResource.Type.BROKER.id()),
+      new AlterConfigsResourceResponse().
+        setErrorCode(UNSUPPORTED_VERSION.code()).
+        setErrorMessage("Unknown resource type 124.").
+        setResourceName("foo").
+        setResourceType(124.toByte)),
+      response.data().responses().asScala.toSet)
+  }
+
+  @Test
+  def testUnauthorizedHandleAlterPartitionReassignments(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+        handleAlterPartitionReassignments(buildRequest(new AlterPartitionReassignmentsRequest.Builder(
+            new AlterPartitionReassignmentsRequestData()).build())))
+  }
+
+  @Test
+  def testUnauthorizedHandleListPartitionReassignments(): Unit = {
+    assertThrows(classOf[ClusterAuthorizationException], () => createControllerApis(
+      Some(createDenyAllAuthorizer()), new MockController.Builder().build()).
+      handleListPartitionReassignments(buildRequest(new ListPartitionReassignmentsRequest.Builder(
+        new ListPartitionReassignmentsRequestData()).build())))
   }
 
   @Test
@@ -170,10 +434,10 @@ class ControllerApisTest {
     ).iterator()))
     val expectedResponse = Set(new CreatableTopicResult().setName("foo").
         setErrorCode(INVALID_REQUEST.code()).
-        setErrorMessage("Found multiple entries for this topic."),
+        setErrorMessage("Duplicate topic name."),
       new CreatableTopicResult().setName("bar").
         setErrorCode(INVALID_REQUEST.code()).
-        setErrorMessage("Found multiple entries for this topic."),
+        setErrorMessage("Duplicate topic name."),
       new CreatableTopicResult().setName("baz").
         setErrorCode(NONE.code()).
         setTopicId(new Uuid(0L, 1L)),
@@ -181,7 +445,7 @@ class ControllerApisTest {
         setErrorCode(TOPIC_AUTHORIZATION_FAILED.code()))
     assertEquals(expectedResponse, controllerApis.createTopics(request,
       false,
-      _ => Set("baz")).topics().asScala.toSet)
+      _ => Set("baz")).get().topics().asScala.toSet)
   }
 
   @Test
@@ -202,7 +466,7 @@ class ControllerApisTest {
       ApiKeys.DELETE_TOPICS.latestVersion().toInt,
       true,
       _ => Set.empty,
-      _ => Set.empty).asScala.toSet)
+      _ => Set.empty).get().asScala.toSet)
   }
 
   @Test
@@ -228,7 +492,7 @@ class ControllerApisTest {
       ApiKeys.DELETE_TOPICS.latestVersion().toInt,
       true,
       _ => Set.empty,
-      _ => Set.empty).asScala.toSet)
+      _ => Set.empty).get().asScala.toSet)
   }
 
   @Test
@@ -270,7 +534,7 @@ class ControllerApisTest {
       ApiKeys.DELETE_TOPICS.latestVersion().toInt,
       false,
       names => names.toSet,
-      names => names.toSet).asScala.toSet)
+      names => names.toSet).get().asScala.toSet)
   }
 
   @Test
@@ -306,7 +570,7 @@ class ControllerApisTest {
       ApiKeys.DELETE_TOPICS.latestVersion().toInt,
       false,
       _ => Set("foo", "baz"),
-      _ => Set.empty).asScala.toSet)
+      _ => Set.empty).get().asScala.toSet)
   }
 
   @Test
@@ -331,7 +595,7 @@ class ControllerApisTest {
       ApiKeys.DELETE_TOPICS.latestVersion().toInt,
       false,
       _ => Set("foo"),
-      _ => Set.empty).asScala.toSet)
+      _ => Set.empty).get().asScala.toSet)
   }
 
   @Test
@@ -350,7 +614,7 @@ class ControllerApisTest {
         ApiKeys.DELETE_TOPICS.latestVersion().toInt,
         false,
         _ => Set("foo", "bar"),
-        _ => Set("foo", "bar"))).getCause.getClass)
+        _ => Set("foo", "bar")).get()).getCause.getClass)
   }
 
   @Test

--- a/metadata/src/main/java/org/apache/kafka/controller/Controller.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/Controller.java
@@ -22,6 +22,8 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.AlterIsrRequestData;
 import org.apache.kafka.common.message.AlterIsrResponseData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
@@ -30,6 +32,8 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
+import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.requests.ApiError;
@@ -137,6 +141,26 @@ public interface Controller extends AutoCloseable {
     CompletableFuture<Map<ConfigResource, ApiError>> incrementalAlterConfigs(
         Map<ConfigResource, Map<String, Map.Entry<AlterConfigOp.OpType, String>>> configChanges,
         boolean validateOnly);
+
+    /**
+     * Start or stop some partition reassignments.
+     *
+     * @param request       The alter partition reassignments request.
+     *
+     * @return              A future yielding the results.
+     */
+    CompletableFuture<AlterPartitionReassignmentsResponseData>
+        alterPartitionReassignments(AlterPartitionReassignmentsRequestData request);
+
+    /**
+     * List ongoing partition reassignments.
+     *
+     * @param request       The list partition reassignments request.
+     *
+     * @return              A future yielding the results.
+     */
+    CompletableFuture<ListPartitionReassignmentsResponseData>
+        listPartitionReassignments(ListPartitionReassignmentsRequestData request);
 
     /**
      * Perform some configuration changes using the legacy API.

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -41,6 +41,8 @@ import org.apache.kafka.common.errors.NotControllerException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.AlterIsrRequestData;
 import org.apache.kafka.common.message.AlterIsrResponseData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData;
 import org.apache.kafka.common.message.BrokerHeartbeatRequestData;
 import org.apache.kafka.common.message.BrokerRegistrationRequestData;
 import org.apache.kafka.common.message.CreatePartitionsRequestData.CreatePartitionsTopic;
@@ -49,6 +51,8 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
 import org.apache.kafka.common.message.ElectLeadersResponseData;
+import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
+import org.apache.kafka.common.message.ListPartitionReassignmentsResponseData;
 import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.metadata.FenceBrokerRecord;
@@ -1021,6 +1025,22 @@ public final class QuorumController implements Controller {
                 return result;
             }
         });
+    }
+
+    @Override
+    public CompletableFuture<AlterPartitionReassignmentsResponseData>
+            alterPartitionReassignments(AlterPartitionReassignmentsRequestData request) {
+        CompletableFuture<AlterPartitionReassignmentsResponseData> future = new CompletableFuture<>();
+        future.completeExceptionally(new UnsupportedOperationException());
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<ListPartitionReassignmentsResponseData>
+            listPartitionReassignments(ListPartitionReassignmentsRequestData request) {
+        CompletableFuture<ListPartitionReassignmentsResponseData> future = new CompletableFuture<>();
+        future.completeExceptionally(new UnsupportedOperationException());
+        return future;
     }
 
     @Override


### PR DESCRIPTION
Fix some cases where ControllerApis was blocking on the controller
thread.  This should not be necessary, since the controller thread can
just interface directly with the network threads.

alterClientQuotas and incrementalAlterConfigs were not doing
authorization correctly in ControllerApis.scala.  Since the previous
release of KRaft did not support authorizers, this bug is not as severe
as it could have been, but it still needs to be fixed.  This PR also
adds unit tests to verify that all of the controller operations return
authorization failures when appropriate.  Fix how duplicate
configuration resources are handled.

Add support for the ALTER_CONFIGS API, and stub functions for
cluster reassignment, as specified in KIP-631.

Additionally, this PR fixes a comment in ControllerApis#deleteTopics
that no longer reflects what the code is doing when we don't have
"describe" permission.