### PR TITLE
MINOR : Downgrade log level for safe catch

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -309,7 +309,7 @@ abstract class AbstractIndex(@volatile var file: File, val baseOffset: Long, val
   protected def safeForceUnmap(): Unit = {
     try forceUnmap()
     catch {
-      case t: Throwable => error(s"Error unmapping index $file", t)
+      case t: Throwable => warn(s"Error unmapping index $file", t)
     }
   }
 


### PR DESCRIPTION
Minor log level downgrade to avoid alarm on ERROR log for a safe catch that could be a WARN