### PR TITLE
KAFKA-12555 - Log all reason for rolling a segment

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1982,7 +1982,7 @@ class Log(@volatile private var _dir: File,
     val maxOffsetInMessages = appendInfo.lastOffset
 
     if (segment.shouldRoll(RollParams(config, appendInfo, messagesSize, now))) {
-      debug(s"Rolling new log segment (log_size = ${segment.size}/${config.segmentSize}}, " +
+      debug(s"Rolling new log segment (log_size = ${segment.size}/${config.segmentSize}, " +
         s"offset_index_size = ${segment.offsetIndex.entries}/${segment.offsetIndex.maxEntries}, " +
         s"time_index_size = ${segment.timeIndex.entries}/${segment.timeIndex.maxEntries}, " +
         s"inactive_time_ms = ${segment.timeWaitedForRoll(now, maxTimestampInMessages)}/${config.segmentMs - segment.rollJitterMs}, " +

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1985,7 +1985,8 @@ class Log(@volatile private var _dir: File,
       debug(s"Rolling new log segment (log_size = ${segment.size}/${config.segmentSize}}, " +
         s"offset_index_size = ${segment.offsetIndex.entries}/${segment.offsetIndex.maxEntries}, " +
         s"time_index_size = ${segment.timeIndex.entries}/${segment.timeIndex.maxEntries}, " +
-        s"inactive_time_ms = ${segment.timeWaitedForRoll(now, maxTimestampInMessages)}/${config.segmentMs - segment.rollJitterMs}).")
+        s"inactive_time_ms = ${segment.timeWaitedForRoll(now, maxTimestampInMessages)}/${config.segmentMs - segment.rollJitterMs}, " +
+        s"offset_convertible_to_relative = ${segment.canConvertToRelativeOffset(appendInfo.lastOffset)}).")
 
       /*
         maxOffsetInMessages - Integer.MAX_VALUE is a heuristic value for the first offset in the set of messages.


### PR DESCRIPTION
The original ticket was to debug log the reason for rolling a new log segment.
based on LogSegment.shouldRoll, there are 5 conditions for rolling:

1. Segment exceeds max byte size
2. Segment exceeds time limit
3. Offset index is full
4. Timestamp index is full
5. The offsets can no longer be converted to relative offsets

And the first 4 were already trackable from the existing debug log message, but 5 was missing so I'm suggesting to add it in the existing one. 
There was also an extra `}`  that's a typo in the log string  that I've removed. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
