### PR TITLE
HOTFIX: delete removed WindowedStore.put() method

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
@@ -19,10 +19,6 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -44,7 +40,6 @@ public class RocksDBTimeOrderedWindowStore
     private final boolean retainDuplicates;
     private final long windowSize;
 
-    private InternalProcessorContext context;
     private int seqnum = 0;
 
     RocksDBTimeOrderedWindowStore(final SegmentedBytesStore bytesStore,
@@ -53,19 +48,6 @@ public class RocksDBTimeOrderedWindowStore
         super(bytesStore);
         this.retainDuplicates = retainDuplicates;
         this.windowSize = windowSize;
-    }
-
-    @Deprecated
-    @Override
-    public void init(final ProcessorContext context, final StateStore root) {
-        this.context = context instanceof InternalProcessorContext ? (InternalProcessorContext) context : null;
-        super.init(context, root);
-    }
-
-    @Override
-    public void init(final StateStoreContext context, final StateStore root) {
-        this.context = context instanceof InternalProcessorContext ? (InternalProcessorContext) context : null;
-        super.init(context, root);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimeOrderedWindowStore.java
@@ -68,12 +68,6 @@ public class RocksDBTimeOrderedWindowStore
         super.init(context, root);
     }
 
-    @Deprecated
-    @Override
-    public void put(final Bytes key, final byte[] value) {
-        put(key, value, context != null ? context.timestamp() : 0L);
-    }
-
     @Override
     public void put(final Bytes key, final byte[] value, final long timestamp) {
         // Skip if value is null and duplicates are allowed since this delete is a no-op


### PR DESCRIPTION
Merging https://github.com/apache/kafka/pull/10293 (that was not rebased) broke `trunk`.

Unresolved overlap with https://github.com/apache/kafka/pull/10331