### PR TITLE
KAFKA-12344 Support SlidingWindows in the Scala API

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -17,7 +17,12 @@
 package org.apache.kafka.streams.scala
 package kstream
 
-import org.apache.kafka.streams.kstream.{SessionWindows, SlidingWindows, Window, Windows, CogroupedKStream => CogroupedKStreamJ}
+import org.apache.kafka.streams.kstream.{
+  SessionWindows,
+  SlidingWindows,
+  Window,
+  Windows,
+  CogroupedKStream => CogroupedKStreamJ}
 import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFromFunction, InitializerFromFunction}
 
 /**
@@ -83,13 +88,13 @@ class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
     new TimeWindowedCogroupedKStream(inner.windowedBy(windows))
 
   /**
-   * Create a new [[TimeWindowedCogroupedKStream]] instance that can be used to perform windowed aggregations.
+   * Create a new [[TimeWindowedCogroupedKStream]] instance that can be used to perform sliding windowed aggregations.
    *
    * @param windows the specification of the aggregation `SlidingWindows`
    * @return an instance of [[TimeWindowedCogroupedKStream]]
    * @see `org.apache.kafka.streams.kstream.CogroupedKStream#windowedBy`
    */
-  def windowedBy[W <: Window](windows: SlidingWindows): TimeWindowedCogroupedKStream[KIn, VOut] =
+  def windowedBy(windows: SlidingWindows): TimeWindowedCogroupedKStream[KIn, VOut] =
     new TimeWindowedCogroupedKStream(inner.windowedBy(windows))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.scala
 package kstream
 
-import org.apache.kafka.streams.kstream.{CogroupedKStream => CogroupedKStreamJ, SessionWindows, Window, Windows}
+import org.apache.kafka.streams.kstream.{SessionWindows, SlidingWindows, Window, Windows, CogroupedKStream => CogroupedKStreamJ}
 import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFromFunction, InitializerFromFunction}
 
 /**
@@ -80,6 +80,16 @@ class CogroupedKStream[KIn, VOut](val inner: CogroupedKStreamJ[KIn, VOut]) {
    * @see `org.apache.kafka.streams.kstream.CogroupedKStream#windowedBy`
    */
   def windowedBy[W <: Window](windows: Windows[W]): TimeWindowedCogroupedKStream[KIn, VOut] =
+    new TimeWindowedCogroupedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[TimeWindowedCogroupedKStream]] instance that can be used to perform windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `SlidingWindows`
+   * @return an instance of [[TimeWindowedCogroupedKStream]]
+   * @see `org.apache.kafka.streams.kstream.CogroupedKStream#windowedBy`
+   */
+  def windowedBy[W <: Window](windows: SlidingWindows): TimeWindowedCogroupedKStream[KIn, VOut] =
     new TimeWindowedCogroupedKStream(inner.windowedBy(windows))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/CogroupedKStream.scala
@@ -22,7 +22,8 @@ import org.apache.kafka.streams.kstream.{
   SlidingWindows,
   Window,
   Windows,
-  CogroupedKStream => CogroupedKStreamJ}
+  CogroupedKStream => CogroupedKStreamJ
+}
 import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFromFunction, InitializerFromFunction}
 
 /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
@@ -19,8 +19,20 @@ package kstream
 
 import org.apache.kafka.streams.kstream.internals.KTableImpl
 import org.apache.kafka.streams.scala.serialization.Serdes
-import org.apache.kafka.streams.kstream.{SessionWindows, SlidingWindows, Window, Windows, KGroupedStream => KGroupedStreamJ, KTable => KTableJ}
-import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFromFunction, InitializerFromFunction, ReducerFromFunction, ValueMapperFromFunction}
+import org.apache.kafka.streams.kstream.{
+  SessionWindows,
+  SlidingWindows,
+  Window,
+  Windows,
+  KGroupedStream => KGroupedStreamJ,
+  KTable => KTableJ
+}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
+  AggregatorFromFunction,
+  InitializerFromFunction,
+  ReducerFromFunction,
+  ValueMapperFromFunction
+}
 
 /**
  * Wraps the Java class KGroupedStream and delegates method calls to the underlying Java object.
@@ -145,13 +157,13 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
     new TimeWindowedKStream(inner.windowedBy(windows))
 
   /**
-   * Create a new [[TimeWindowedKStream]] instance that can be used to perform windowed aggregations.
+   * Create a new [[TimeWindowedKStream]] instance that can be used to perform sliding windowed aggregations.
    *
    * @param windows the specification of the aggregation `SlidingWindows`
    * @return an instance of [[TimeWindowedKStream]]
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
    */
-  def windowedBy[W <: Window](windows: SlidingWindows): TimeWindowedKStream[K, V] =
+  def windowedBy(windows: SlidingWindows): TimeWindowedKStream[K, V] =
     new TimeWindowedKStream(inner.windowedBy(windows))
 
   /**

--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KGroupedStream.scala
@@ -19,19 +19,8 @@ package kstream
 
 import org.apache.kafka.streams.kstream.internals.KTableImpl
 import org.apache.kafka.streams.scala.serialization.Serdes
-import org.apache.kafka.streams.kstream.{
-  SessionWindows,
-  Window,
-  Windows,
-  KGroupedStream => KGroupedStreamJ,
-  KTable => KTableJ
-}
-import org.apache.kafka.streams.scala.FunctionsCompatConversions.{
-  AggregatorFromFunction,
-  InitializerFromFunction,
-  ReducerFromFunction,
-  ValueMapperFromFunction
-}
+import org.apache.kafka.streams.kstream.{SessionWindows, SlidingWindows, Window, Windows, KGroupedStream => KGroupedStreamJ, KTable => KTableJ}
+import org.apache.kafka.streams.scala.FunctionsCompatConversions.{AggregatorFromFunction, InitializerFromFunction, ReducerFromFunction, ValueMapperFromFunction}
 
 /**
  * Wraps the Java class KGroupedStream and delegates method calls to the underlying Java object.
@@ -153,6 +142,16 @@ class KGroupedStream[K, V](val inner: KGroupedStreamJ[K, V]) {
    * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
    */
   def windowedBy[W <: Window](windows: Windows[W]): TimeWindowedKStream[K, V] =
+    new TimeWindowedKStream(inner.windowedBy(windows))
+
+  /**
+   * Create a new [[TimeWindowedKStream]] instance that can be used to perform windowed aggregations.
+   *
+   * @param windows the specification of the aggregation `SlidingWindows`
+   * @return an instance of [[TimeWindowedKStream]]
+   * @see `org.apache.kafka.streams.kstream.KGroupedStream#windowedBy`
+   */
+  def windowedBy[W <: Window](windows: SlidingWindows): TimeWindowedKStream[K, V] =
     new TimeWindowedKStream(inner.windowedBy(windows))
 
   /**

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -17,7 +17,13 @@
 package org.apache.kafka.streams.scala.kstream
 
 import org.apache.kafka.streams.kstream.Suppressed.BufferConfig
-import org.apache.kafka.streams.kstream.{Named, SessionWindows, SlidingWindows, TimeWindows, Windowed, Suppressed => JSuppressed}
+import org.apache.kafka.streams.kstream.{
+  Named,
+  SlidingWindows,
+  SessionWindows,
+  TimeWindows,
+  Windowed,
+  Suppressed => JSuppressed}
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.apache.kafka.streams.scala.utils.TestDriver
@@ -213,7 +219,7 @@ class KTableTest extends TestDriver {
   }
 
   @Test
-  def testCorrectlyGroupBySlidingWindow(): Unit = {
+  def testCorrectlyGroupByKeyWindowedBySlidingWindow(): Unit = {
     val builder = new StreamsBuilder()
     val sourceTopic = "source"
     val sinkTopic = "sink"

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -17,15 +17,16 @@
 package org.apache.kafka.streams.scala.kstream
 
 import org.apache.kafka.streams.kstream.Suppressed.BufferConfig
-import org.apache.kafka.streams.kstream.{Named, SessionWindows, TimeWindows, Windowed, Suppressed => JSuppressed}
+import org.apache.kafka.streams.kstream.{Named, SessionWindows, SlidingWindows, TimeWindows, Windowed, Suppressed => JSuppressed}
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.apache.kafka.streams.scala.utils.TestDriver
 import org.apache.kafka.streams.scala.{ByteArrayKeyValueStore, StreamsBuilder}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertNull, assertTrue}
 import org.junit.jupiter.api.Test
-
 import java.time.Duration
+import java.time.Duration.ofMillis
+
 import scala.jdk.CollectionConverters._
 
 class KTableTest extends TestDriver {
@@ -205,6 +206,44 @@ class KTableTest extends TestDriver {
       val record = testOutput.readKeyValue
       assertEquals("0:1000:1", record.key)
       assertEquals(3L, record.value)
+    }
+    assertTrue(testOutput.isEmpty)
+
+    testDriver.close()
+  }
+
+  @Test
+  def testCorrectlyGroupBySlidingWindow(): Unit = {
+    val builder = new StreamsBuilder()
+    val sourceTopic = "source"
+    val sinkTopic = "sink"
+    val window = SlidingWindows.withTimeDifferenceAndGrace(ofMillis(1000L), ofMillis(1000L))
+    val suppression = JSuppressed.untilWindowCloses(BufferConfig.unbounded())
+
+    val table: KTable[Windowed[String], Long] = builder
+      .stream[String, String](sourceTopic)
+      .groupByKey
+      .windowedBy(window)
+      .count()
+      .suppress(suppression)
+
+    table.toStream((k, _) => s"${k.window().start()}:${k.window().end()}:${k.key()}").to(sinkTopic)
+
+    val testDriver = createTestDriver(builder)
+    val testInput = testDriver.createInput[String, String](sourceTopic)
+    val testOutput = testDriver.createOutput[String, Long](sinkTopic)
+
+    {
+      // publish key=1 @ time 0 => count==1
+      testInput.pipeInput("1", "value1", 0L)
+      assertTrue(testOutput.isEmpty)
+    }
+    {
+      // move event time right past the grace period of the first window.
+      testInput.pipeInput("2", "value3", 5001L)
+      val record = testOutput.readKeyValue
+      assertEquals("0:1000:1", record.key)
+      assertEquals(1L, record.value)
     }
     assertTrue(testOutput.isEmpty)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KTableTest.scala
@@ -23,7 +23,8 @@ import org.apache.kafka.streams.kstream.{
   SessionWindows,
   TimeWindows,
   Windowed,
-  Suppressed => JSuppressed}
+  Suppressed => JSuppressed
+}
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.serialization.Serdes._
 import org.apache.kafka.streams.scala.utils.TestDriver


### PR DESCRIPTION
*Added windowedBy(SlidingWindows) method to  CogroupedKStream and KGroupedStream scala wrappers also added test for KGroupedStream windowedBy(SlidingWindows) method in KTaableTests*


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
