### PR TITLE
KAFKA-10816: Use root resource as readiness and health probe for Connect distributed mode

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -97,7 +97,7 @@ public class ConnectDistributed {
         String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
         log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
-        RestServer rest = new RestServer(config);
+        RestServer rest = new RestServer(config, kafkaClusterId);
         rest.initializeServer();
 
         URI advertisedUrl = rest.advertisedUrl();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -82,7 +82,7 @@ public class ConnectStandalone {
             String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
             log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
-            RestServer rest = new RestServer(config);
+            RestServer rest = new RestServer(config, kafkaClusterId);
             rest.initializeServer();
 
             URI advertisedUrl = rest.advertisedUrl();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -85,6 +85,7 @@ public class RestServer {
     private static final String PROTOCOL_HTTPS = "https";
 
     private final WorkerConfig config;
+    private final String kafkaClusterId;
     private ContextHandlerCollection handlers;
     private Server jettyServer;
 
@@ -93,8 +94,9 @@ public class RestServer {
     /**
      * Create a REST server for this herder using the specified configs.
      */
-    public RestServer(WorkerConfig config) {
+    public RestServer(WorkerConfig config, String kafkaClusterId) {
         this.config = config;
+        this.kafkaClusterId = kafkaClusterId;
 
         List<String> listeners = parseListeners();
         List<String> adminListeners = config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG);
@@ -457,9 +459,7 @@ public class RestServer {
             herderRequestTimeoutMs = Math.min(herderRequestTimeoutMs, rebalanceTimeoutMs.longValue());
         }
 
-        ConnectClusterDetails connectClusterDetails = new ConnectClusterDetailsImpl(
-            herder.kafkaClusterId()
-        );
+        ConnectClusterDetails connectClusterDetails = new ConnectClusterDetailsImpl(kafkaClusterId);
 
         ConnectRestExtensionContext connectRestExtensionContext =
             new ConnectRestExtensionContextImpl(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/BlockingConnectorTest.java
@@ -131,7 +131,7 @@ public class BlockingConnectorTest {
         // request timeout; otherwise, we may get an unexpected 500 with our first real REST request
         // if the worker is still getting on its feet.
         waitForCondition(
-            () -> connect.requestGet(connect.endpointForResource("connectors/nonexistent")).getStatus() == 404,
+            () -> connect.requestGet(connect.endpointForResource("")).getStatus() == 200,
             CONNECT_WORKER_STARTUP_TIMEOUT,
             "Worker did not complete startup in time"
         );

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -115,7 +115,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
         DistributedConfig config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertArrayEquals(new String[] {"http://localhost:8080", "https://localhost:8443"}, server.parseListeners().toArray());
 
         // Build listener from hostname and port
@@ -124,7 +124,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.REST_HOST_NAME_CONFIG, "my-hostname");
         configMap.put(WorkerConfig.REST_PORT_CONFIG, "8080");
         config = new DistributedConfig(configMap);
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertArrayEquals(new String[] {"http://my-hostname:8080"}, server.parseListeners().toArray());
     }
 
@@ -136,7 +136,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
         DistributedConfig config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertEquals("http://localhost:8080/", server.advertisedUrl().toString());
 
         // Advertised URI from listeners with protocol
@@ -145,7 +145,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "https");
         config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertEquals("https://localhost:8443/", server.advertisedUrl().toString());
 
         // Advertised URI from listeners with only SSL available
@@ -153,7 +153,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://localhost:8443");
         config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertEquals("https://localhost:8443/", server.advertisedUrl().toString());
 
         // Listener is overriden by advertised values
@@ -164,7 +164,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.REST_ADVERTISED_PORT_CONFIG, "10000");
         config = new DistributedConfig(configMap);
 
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertEquals("http://somehost:10000/", server.advertisedUrl().toString());
 
         // listener from hostname and port
@@ -173,7 +173,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.REST_HOST_NAME_CONFIG, "my-hostname");
         configMap.put(WorkerConfig.REST_PORT_CONFIG, "8080");
         config = new DistributedConfig(configMap);
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertEquals("http://my-hostname:8080/", server.advertisedUrl().toString());
 
         // correct listener is chosen when https listener is configured before http listener and advertised listener is http
@@ -181,7 +181,7 @@ public class RestServerTest {
         configMap.put(WorkerConfig.LISTENERS_CONFIG, "https://encrypted-localhost:42069,http://plaintext-localhost:4761");
         configMap.put(WorkerConfig.REST_ADVERTISED_LISTENER_CONFIG, "http");
         config = new DistributedConfig(configMap);
-        server = new RestServer(config);
+        server = new RestServer(config, KAFKA_CLUSTER_ID);
         Assert.assertEquals("http://plaintext-localhost:4761/", server.advertisedUrl().toString());
     }
 
@@ -190,7 +190,6 @@ public class RestServerTest {
         Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
             workerConfig,
@@ -198,7 +197,7 @@ public class RestServerTest {
             .andStubReturn(Collections.emptyList());
         PowerMock.replayAll();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -227,7 +226,6 @@ public class RestServerTest {
         workerProps.put(WorkerConfig.ACCESS_CONTROL_ALLOW_METHODS_CONFIG, method);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                                            workerConfig,
@@ -238,7 +236,7 @@ public class RestServerTest {
 
         PowerMock.replayAll();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         server.initializeServer();
         server.initializeResources(herder);
         HttpRequest request = new HttpGet("/connectors");
@@ -281,7 +279,6 @@ public class RestServerTest {
         workerProps.put("offset.storage.file.filename", "/tmp");
         WorkerConfig workerConfig = new StandaloneConfig(workerProps);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
             workerConfig,
@@ -291,7 +288,7 @@ public class RestServerTest {
 
         PowerMock.replayAll();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         server.initializeServer();
         server.initializeResources(herder);
         HttpRequest request = new HttpGet("/connectors");
@@ -307,7 +304,6 @@ public class RestServerTest {
         Map<String, String> configMap = new HashMap<>(baseWorkerProps());
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                 workerConfig,
@@ -318,7 +314,7 @@ public class RestServerTest {
         // create some loggers in the process
         LoggerFactory.getLogger("a.b.c.s.W");
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -344,7 +340,6 @@ public class RestServerTest {
 
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                 workerConfig,
@@ -358,7 +353,7 @@ public class RestServerTest {
         LoggerFactory.getLogger("a.b.c.p.Y");
         LoggerFactory.getLogger("a.b.c.p.Z");
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -380,7 +375,6 @@ public class RestServerTest {
 
         DistributedConfig workerConfig = new DistributedConfig(configMap);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                 workerConfig,
@@ -388,7 +382,7 @@ public class RestServerTest {
                 .andStubReturn(Collections.emptyList());
         PowerMock.replayAll();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         server.initializeServer();
         server.initializeResources(herder);
 
@@ -425,7 +419,6 @@ public class RestServerTest {
         workerProps.put(WorkerConfig.RESPONSE_HTTP_HEADERS_CONFIG, headerConfig);
         WorkerConfig workerConfig = new DistributedConfig(workerProps);
 
-        EasyMock.expect(herder.kafkaClusterId()).andReturn(KAFKA_CLUSTER_ID);
         EasyMock.expect(herder.plugins()).andStubReturn(plugins);
         EasyMock.expect(plugins.newPlugins(Collections.emptyList(),
                 workerConfig,
@@ -435,7 +428,7 @@ public class RestServerTest {
 
         PowerMock.replayAll();
 
-        server = new RestServer(workerConfig);
+        server = new RestServer(workerConfig, KAFKA_CLUSTER_ID);
         try {
             server.initializeServer();
             server.initializeResources(herder);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -24,7 +24,6 @@ import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ActiveTopicsInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
-import org.apache.kafka.connect.runtime.rest.entities.ServerInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -284,8 +283,8 @@ public class EmbeddedConnectCluster {
         return connectCluster.stream()
                 .filter(w -> {
                     try {
-                        mapper.readerFor(ServerInfo.class)
-                                .readValue(responseToString(requestGet(w.url().toString())));
+                        mapper.readerFor(new TypeReference<Collection<String>>() { })
+                                .readValue(responseToString(requestGet(w.url().toString() + "connectors")));
                         return true;
                     } catch (ConnectException | IOException e) {
                         // Worker failed to respond. Consider it's offline


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-10816)


To address KAFKA-10816, the root resource (`GET /`) is modified to go through the worker's herder tick thread. This causes all requests to that resource to either not complete or be met with a 404 response before the worker has finished startup and is ready to handle requests.

In addition to being made a viable readiness probe, the root resource is also made into a health probe for the worker. If the worker is having trouble reading to the end of the config topic or (re-)joining the Connect cluster, requests to the root resource will not return and will eventually be met with a 500 timeout response.

The hacky workaround used to check for worker readiness in the `BlockingConnectorTest` is modified to use the root resource instead. No other tests are touched; existing coverage should be sufficient to vet this change.
