### PR TITLE
KAFKA-12651: Register Connect REST extensions before bringing up REST resources

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -227,14 +227,17 @@ public class RestServer {
         ResourceConfig resourceConfig = new ResourceConfig();
         resourceConfig.register(new JacksonJsonProvider());
 
+        // Make sure to register REST extensions first as they may be used to secure the REST API.
+        // If other resources (such as the /connectors resource) are registered first, they will be
+        // unsecured until/unless REST extension registration completes.
+        registerRestExtensions(herder, resourceConfig);
+
         resourceConfig.register(new RootResource(herder));
         resourceConfig.register(new ConnectorsResource(herder, config));
         resourceConfig.register(new ConnectorPluginsResource(herder));
 
         resourceConfig.register(ConnectExceptionMapper.class);
         resourceConfig.property(ServerProperties.WADL_FEATURE_DISABLE, true);
-
-        registerRestExtensions(herder, resourceConfig);
 
         List<String> adminListeners = config.getList(WorkerConfig.ADMIN_LISTENERS_CONFIG);
         ResourceConfig adminResourceConfig;


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-12651)

Copied from the Jira ticket:

> Connect currently registers custom REST extensions after REST resources. This can be problematic in security-conscious environments where REST extensions are used to lock down access to the Connect REST API, as it creates a window of opportunity for unauthenticated access to the REST API between the time the worker's REST resources are brought up and when its REST extensions are registered.

This change aims to address that vulnerability by registering REST extensions before REST resources.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
