### PR TITLE
MINOR: Remove `setupGradle()` from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,14 +17,6 @@
  *
  */
 
-def setupGradle() {
-  // Delete gradle cache to workaround cache corruption bugs, see KAFKA-3167
-  dir('.gradle') {
-    deleteDir()
-  }
-  sh './gradlew -version'
-}
-
 def doValidation() {
   sh """
     ./gradlew -PscalaVersion=$SCALA_VERSION clean compileJava compileScala compileTestJava compileTestScala \
@@ -125,7 +117,6 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            setupGradle()
             doValidation()
             doTest(env)
             tryStreamsArchetype()
@@ -145,7 +136,6 @@ pipeline {
             SCALA_VERSION=2.13
           }
           steps {
-            setupGradle()
             doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 11'
@@ -165,7 +155,6 @@ pipeline {
             SCALA_VERSION=2.13
           }
           steps {
-            setupGradle()
             doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 15'
@@ -182,7 +171,6 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            setupGradle()
             doValidation()
             catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
               doTest(env, 'unitTest')
@@ -214,7 +202,6 @@ pipeline {
             SCALA_VERSION=2.13
           }
           steps {
-            setupGradle()
             doValidation()
             doTest(env)
             tryStreamsArchetype()
@@ -238,7 +225,6 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            setupGradle()
             doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 11'
@@ -262,7 +248,6 @@ pipeline {
             SCALA_VERSION=2.12
           }
           steps {
-            setupGradle()
             doValidation()
             doTest(env)
             echo 'Skipping Kafka Streams archetype test for Java 15'


### PR DESCRIPTION
We no longer need this since:

1. The PR and branch jobs are configured to `clean before checkout`.
2. The Gradle build outputs the gradle version on start-up.

The description of `clean before checkout` is:

> Clean up the workspace before every checkout by deleting all untracked files and directories, including those which are specified in .gitignore. It also resets all tracked files to their versioned state. This ensures that the workspace is in the same state as if you cloned and checked out in a brand-new empty directory, and ensures that your build is not affected by the files generated by the previous build.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
