### PR TITLE
KAFKA-12655: CVE-2021-28165 - Upgrade jetty to 9.4.39

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -69,7 +69,7 @@ versions += [
   jacksonDatabind: "2.10.5.1",
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
-  jetty: "9.4.38.v20210224",
+  jetty: "9.4.39.v20210325",
   jersey: "2.31",
   jline: "3.12.1",
   jmh: "1.27",


### PR DESCRIPTION
[Jetty 9.4.39.v20210325](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.39.v20210325) resolves following security vulnerabilities.

- [CVE-2021-28165](https://nvd.nist.gov/vuln/detail/CVE-2021-28165) (described in the issue)
- [CVE-2021-28164](https://nvd.nist.gov/vuln/detail/CVE-2021-28164)
- [CVE-2021-28163](https://nvd.nist.gov/vuln/detail/CVE-2021-28163)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
