### PR TITLE
KAFKA-10231 fail bootstrap of Rest server if the host name in the adv…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -380,8 +380,6 @@ public class RestServer {
     /**
      * Parses the uri and throws a more definitive error
      * when the internal node to node communication can't happen due to an invalid host name.
-     *
-     * @return
      */
     private void validateUriHost(URI uri) {
         if (uri.getHost() == null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -381,15 +381,15 @@ public class RestServer {
      * Parses the uri and throws a more definitive error
      * when the internal node to node communication can't happen due to an invalid host name.
      */
-    private void validateUriHost(URI uri) {
+    void validateUriHost(URI uri) {
         if (uri.getHost() == null) {
             String host = Utils.getHost(uri.getAuthority());
-            String errorMsg = "Invalid host=" + host + ", in url=" + uri.toString();
+            String errorMsg = "Could not parse host from advertised URL=" + uri.toString();
             if (host != null) {
                 try {
                     IDN.toASCII(host, IDN.USE_STD3_ASCII_RULES);
                 } catch (IllegalArgumentException e) {
-                    errorMsg += ", doesn't conform to RFC 1123 specification, reason=" + e.getMessage();
+                    errorMsg += ", as it doesn't conform to RFC 1123 specification, reason=" + e.getMessage();
                     throw new ConnectException(errorMsg, e);
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -392,7 +392,7 @@ public class RestServer {
                 try {
                     IDN.toASCII(host, IDN.USE_STD3_ASCII_RULES);
                 } catch (IllegalArgumentException e) {
-                    errorMsg += ", as it doesn't conform to RFC 1123 specification:" + e.getMessage();
+                    errorMsg += ", as it doesn't conform to RFC 1123 specification: " + e.getMessage();
                     throw new ConnectException(errorMsg, e);
                 }
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -358,11 +358,10 @@ public class RestServer {
         ServerConnector serverConnector = findConnector(advertisedSecurityProtocol);
         builder.scheme(advertisedSecurityProtocol);
 
-        String advertisedHostname = config.getString(WorkerConfig.REST_ADVERTISED_HOST_NAME_CONFIG);
-        if (advertisedHostname != null && !advertisedHostname.isEmpty())
-            builder.host(advertisedHostname);
-        else if (serverConnector != null && serverConnector.getHost() != null && serverConnector.getHost().length() > 0)
-            builder.host(serverConnector.getHost());
+        String hostNameOverride = hostNameOverride(serverConnector);
+        if (hostNameOverride != null) {
+            builder.host(hostNameOverride);
+        }
 
         Integer advertisedPort = config.getInt(WorkerConfig.REST_ADVERTISED_PORT_CONFIG);
         if (advertisedPort != null)
@@ -371,26 +370,34 @@ public class RestServer {
             builder.port(serverConnector.getPort());
 
         URI uri = builder.build();
-        validateUriHost(uri);
+        maybeThrowInvalidHostNameException(uri, hostNameOverride);
         log.info("Advertised URI: {}", uri);
 
         return uri;
+    }
+
+    private String hostNameOverride(ServerConnector serverConnector) {
+        String advertisedHostname = config.getString(WorkerConfig.REST_ADVERTISED_HOST_NAME_CONFIG);
+        if (advertisedHostname != null && !advertisedHostname.isEmpty())
+            return advertisedHostname;
+        else if (serverConnector != null && serverConnector.getHost() != null && serverConnector.getHost().length() > 0)
+            return serverConnector.getHost();
+        return null;
     }
 
     /**
      * Parses the uri and throws a more definitive error
      * when the internal node to node communication can't happen due to an invalid host name.
      */
-    static void validateUriHost(URI uri) {
+    static void maybeThrowInvalidHostNameException(URI uri, String hostNameOverride) {
         //java URI parsing will fail silently returning null in the host if the host name contains invalid characters like _
         //this bubbles up later when the Herder tries to communicate on the advertised url and the current HttpClient fails with an ambiguous message
-        //we need to revisit this when we upgrade to a better HttpClient that can communicate with such host names or throws a better error message
         if (uri.getHost() == null) {
-            String errorMsg = "Could not parse host '"  + uri.toString() + "' from advertised URL";
-            String host = uri.getAuthority() != null ? Utils.getHost(uri.getAuthority()) : null;
-            if (host != null) {
+            String errorMsg = "Could not parse host from advertised URL: '"  + uri.toString() + "'";
+            if (hostNameOverride != null) {
+                //validate hostname using IDN class to see if it can bubble up the real cause and we can show the user a more detailed exception
                 try {
-                    IDN.toASCII(host, IDN.USE_STD3_ASCII_RULES);
+                    IDN.toASCII(hostNameOverride, IDN.USE_STD3_ASCII_RULES);
                 } catch (IllegalArgumentException e) {
                     errorMsg += ", as it doesn't conform to RFC 1123 specification: " + e.getMessage();
                     throw new ConnectException(errorMsg, e);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestServer.java
@@ -381,7 +381,7 @@ public class RestServer {
      * Parses the uri and throws a more definitive error
      * when the internal node to node communication can't happen due to an invalid host name.
      */
-    void validateUriHost(URI uri) {
+    static void validateUriHost(URI uri) {
         if (uri.getHost() == null) {
             String host = Utils.getHost(uri.getAuthority());
             String errorMsg = "Could not parse host from advertised URL=" + uri.toString();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -58,7 +58,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.connect.runtime.WorkerConfig.ADMIN_LISTENERS_CONFIG;
-import static org.apache.kafka.connect.runtime.rest.RestServer.validateUriHost;
+import static org.apache.kafka.connect.runtime.rest.RestServer.maybeThrowInvalidHostNameException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -190,22 +190,11 @@ public class RestServerTest {
     }
 
     @Test
-    public void testValidateUriHost() {
-        validateUriHost(URI.create("http://localhost:8080"));
-        validateUriHost(URI.create("http://172.217.2.110:80"));
-        validateUriHost(URI.create("http://[2607:f8b0:4006:818::2004]:80"));
-        validateUriHost(URI.create("http://kafka-connect-0.dev-2:8080"));
-    }
-
-    @Test
-    public void testValidateUriInvalidHost() {
-        ConnectException exception = assertThrows(ConnectException.class, () -> validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080")));
-        assertTrue(exception.getMessage().contains("RFC 1123"));
-        //invalid uri with / in the end
-        exception = assertThrows(ConnectException.class, () -> validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080/")));
+    public void testMaybeThrowInvalidHostNameException() {
+        ConnectException exception = assertThrows(ConnectException.class, () -> maybeThrowInvalidHostNameException(URI.create("http://kafka_connect-0.dev-2:8080"), "kafka_connect-0.dev-2"));
         assertTrue(exception.getMessage().contains("RFC 1123"));
 
-        exception = assertThrows(ConnectException.class, () -> validateUriHost(URI.create("http://:8080")));
+        exception = assertThrows(ConnectException.class, () -> maybeThrowInvalidHostNameException(URI.create("http://:8080"), null));
         assertTrue(exception.getMessage().contains("Could not parse host"));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.connect.runtime.WorkerConfig.ADMIN_LISTENERS_CONFIG;
+import static org.apache.kafka.connect.runtime.rest.RestServer.validateUriHost;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -190,31 +191,20 @@ public class RestServerTest {
 
     @Test
     public void testValidateUriHost() {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
-        DistributedConfig config = new DistributedConfig(configMap);
-
-        server = new RestServer(config);
-        server.validateUriHost(URI.create("http://localhost:8080"));
-        server.validateUriHost(URI.create("http://172.217.2.110:80"));
-        server.validateUriHost(URI.create("http://[2607:f8b0:4006:818::2004]:80"));
+        validateUriHost(URI.create("http://localhost:8080"));
+        validateUriHost(URI.create("http://172.217.2.110:80"));
+        validateUriHost(URI.create("http://[2607:f8b0:4006:818::2004]:80"));
     }
 
     @Test
     public void testValidateUriInvalidHost() {
-        Map<String, String> configMap = new HashMap<>(baseWorkerProps());
-        configMap.put(WorkerConfig.LISTENERS_CONFIG, "http://localhost:8080,https://localhost:8443");
-        DistributedConfig config = new DistributedConfig(configMap);
-
-        server = new RestServer(config);
-
-        ConnectException exception = assertThrows(ConnectException.class, () -> server.validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080")));
+        ConnectException exception = assertThrows(ConnectException.class, () -> validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080")));
         assertTrue(exception.getMessage().contains("RFC 1123"));
         //invalid uri with / in the end
-        exception = assertThrows(ConnectException.class, () -> server.validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080/")));
+        exception = assertThrows(ConnectException.class, () -> validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080/")));
         assertTrue(exception.getMessage().contains("RFC 1123"));
 
-        exception = assertThrows(ConnectException.class, () -> server.validateUriHost(URI.create("http://:8080")));
+        exception = assertThrows(ConnectException.class, () -> validateUriHost(URI.create("http://:8080")));
         assertTrue(exception.getMessage().contains("Could not parse host"));
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -191,6 +191,8 @@ public class RestServerTest {
 
     @Test
     public void testMaybeThrowInvalidHostNameException() {
+        maybeThrowInvalidHostNameException(URI.create("http://localhost:8080"), null);
+
         ConnectException exception = assertThrows(ConnectException.class, () -> maybeThrowInvalidHostNameException(URI.create("http://kafka_connect-0.dev-2:8080"), "kafka_connect-0.dev-2"));
         assertTrue(exception.getMessage().contains("RFC 1123"));
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -194,6 +194,7 @@ public class RestServerTest {
         validateUriHost(URI.create("http://localhost:8080"));
         validateUriHost(URI.create("http://172.217.2.110:80"));
         validateUriHost(URI.create("http://[2607:f8b0:4006:818::2004]:80"));
+        validateUriHost(URI.create("http://kafka-connect-0.dev-2:8080"));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/RestServerTest.java
@@ -210,6 +210,9 @@ public class RestServerTest {
 
         ConnectException exception = assertThrows(ConnectException.class, () -> server.validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080")));
         assertTrue(exception.getMessage().contains("RFC 1123"));
+        //invalid uri with / in the end
+        exception = assertThrows(ConnectException.class, () -> server.validateUriHost(URI.create("http://kafka_connect-0.dev-2:8080/")));
+        assertTrue(exception.getMessage().contains("RFC 1123"));
 
         exception = assertThrows(ConnectException.class, () -> server.validateUriHost(URI.create("http://:8080")));
         assertTrue(exception.getMessage().contains("Could not parse host"));


### PR DESCRIPTION
…ertised uri is invalid and other nodes can't reach it. Node names have rules about what characters they can have and maximum length like in RFC-1123. The node-node communication over REST API won't happen if this node's advertised URL to the cluster has an invalid host name, and the error message in logs isn't very helpful. 

This PR adds a new behavior by using the java IDN class to expose the detailed error message and fails the server bootstrap. 

@C0urante , @rhauch and @kkonstantine  please review

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
