### PR TITLE
KAFKA-10493: Drop out-of-order KTable records (WIP)

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -122,6 +122,13 @@
         <li>Connect-json: As of Kafka Streams no longer has a compile time dependency on "connect:json" module (<a href="https://issues.apache.org/jira/browse/KAFKA-5146">KAFKA-5146</a>).
             Projects that were relying on this transitive dependency will have to explicitly declare it.</li>
     </ul>
+    <p>
+      We improved the semantics of <code>StreamsBuilder.table()</code> and <code>KStream.toTable()</code> operators:
+      both operator now follow <em>timestamp order</em>, in contrast to <em>offset order</em> as previously.
+      This change implies that all out-of-order records will now be dropped by default.
+      If you want to keep the old semantics, you can use a custom timestamp extractor that returns the
+      current <code>partitionTime</code> for out-of-order records instead of their event timestamp.
+    </p>
     
     <h3><a id="streams_api_changes_280" href="#streams_api_changes_280">Streams API changes in 2.8.0</a></h3>
     <p>

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -902,6 +902,16 @@ public class StreamsConfig extends AbstractConfig {
 
         // This is settable in the main Streams config, but it's a private API for testing
         public static final String ASSIGNMENT_LISTENER = "__assignment.listener__";
+
+        // if users run into issues with the new semantics, we should first propose that they
+        // use a custom TimestampExtractor that returns:
+        //
+        //  long extract(ConsumerRecord<Object, Object> record, long partitionTime) {
+        //    return Math.max(record.timestamp, partitionTime);
+        // }
+        //
+        // this internal config should be the last resort if the timestamp extractor trick does not work
+        public static final String ENABLE_KTABLE_OUT_OF_ORDER_HANDLING = "__enable.ktable.out.of.order.handling__";
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -128,7 +128,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         final String tableSourceName = named
             .orElseGenerateWithPrefix(this, KTableImpl.SOURCE_NAME);
 
-        final KTableSource<K, V> tableSource = new KTableSource<>(materialized.storeName(), materialized.queryableStoreName());
+        final KTableSource<K, V> tableSource = new KTableSource<>(materialized.storeName(), materialized.queryableStoreName(), false);
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, tableSourceName);
 
         final TableSourceNode<K, V> tableSourceNode = TableSourceNode.<K, V>tableSourceNodeBuilder()
@@ -170,7 +170,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
         // enforce store name as queryable name to always materialize global table stores
         final String storeName = materialized.storeName();
-        final KTableSource<K, V> tableSource = new KTableSource<>(storeName, storeName);
+        final KTableSource<K, V> tableSource = new KTableSource<>(storeName, storeName, true);
 
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, processorName);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -750,7 +750,8 @@ public class KStreamImpl<K, V> extends AbstractStream<K, V> implements KStream<K
 
         final KTableSource<K, V> tableSource = new KTableSource<>(
             materializedInternal.storeName(),
-            materializedInternal.queryableStoreName()
+            materializedInternal.queryableStoreName(),
+            false
         );
         final ProcessorParameters<K, V, ?, ?> processorParameters = new ProcessorParameters<>(tableSource, name);
         final GraphNode tableNode = new StreamToTableNode<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -1146,7 +1146,8 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
 
         final KTableSource<K, VR> resultProcessorSupplier = new KTableSource<>(
             materializedInternal.storeName(),
-            materializedInternal.queryableStoreName()
+            materializedInternal.queryableStoreName(),
+            false
         );
 
         final StoreBuilder<TimestampedKeyValueStore<K, VR>> resultStore =

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/CogroupedKStreamImplTest.java
@@ -1235,10 +1235,10 @@ public class CogroupedKStreamImplTest {
 
             assertTrue(testOutputTopic.isEmpty());
 
-            testInputTopic3.pipeInput("k1", "C", 0L);
+            testInputTopic3.pipeInput("k1", "C", 8L);
             testInputTopic3.pipeInput("k2", "D", 10L);
 
-            assertOutputKeyValueTimestamp(testOutputTopic, "k1", "A+C", 5L);
+            assertOutputKeyValueTimestamp(testOutputTopic, "k1", "A+C", 8L);
             assertOutputKeyValueTimestamp(testOutputTopic, "k2", "B+D", 10L);
             assertTrue(testOutputTopic.isEmpty());
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -2494,19 +2494,20 @@ public class KStreamImplTest {
                 driver.createOutputTopic(output, Serdes.String().deserializer(), Serdes.String().deserializer());
 
             inputTopic.pipeInput("A", "01", 5L);
-            inputTopic.pipeInput("B", "02", 100L);
-            inputTopic.pipeInput("C", "03", 0L);
-            inputTopic.pipeInput("D", "04", 0L);
-            inputTopic.pipeInput("A", "05", 10L);
-            inputTopic.pipeInput("A", "06", 8L);
+            inputTopic.pipeInput("B", "02", 10L);
+            inputTopic.pipeInput("C", "03", 20L);
+            inputTopic.pipeInput("D", "04", 30L);
+            inputTopic.pipeInput("D", "05", 20L); // dropped
+            inputTopic.pipeInput("A", "05", 40L);
+            inputTopic.pipeInput("A", "06", 50L);
 
             final List<TestRecord<String, String>> outputExpectRecords = new ArrayList<>();
             outputExpectRecords.add(new TestRecord<>("A", "01", Instant.ofEpochMilli(5L)));
-            outputExpectRecords.add(new TestRecord<>("B", "02", Instant.ofEpochMilli(100L)));
-            outputExpectRecords.add(new TestRecord<>("C", "03", Instant.ofEpochMilli(0L)));
-            outputExpectRecords.add(new TestRecord<>("D", "04", Instant.ofEpochMilli(0L)));
-            outputExpectRecords.add(new TestRecord<>("A", "05", Instant.ofEpochMilli(10L)));
-            outputExpectRecords.add(new TestRecord<>("A", "06", Instant.ofEpochMilli(8L)));
+            outputExpectRecords.add(new TestRecord<>("B", "02", Instant.ofEpochMilli(10L)));
+            outputExpectRecords.add(new TestRecord<>("C", "03", Instant.ofEpochMilli(20L)));
+            outputExpectRecords.add(new TestRecord<>("D", "04", Instant.ofEpochMilli(30L)));
+            outputExpectRecords.add(new TestRecord<>("A", "05", Instant.ofEpochMilli(40L)));
+            outputExpectRecords.add(new TestRecord<>("A", "06", Instant.ofEpochMilli(50L)));
 
             assertEquals(outputTopic.readRecordsToList(), outputExpectRecords);
         }
@@ -2603,19 +2604,20 @@ public class KStreamImplTest {
                 driver.createOutputTopic(output, Serdes.Integer().deserializer(), Serdes.String().deserializer());
 
             inputTopic.pipeInput("A", "01", 5L);
-            inputTopic.pipeInput("B", "02", 100L);
-            inputTopic.pipeInput("C", "03", 0L);
-            inputTopic.pipeInput("D", "04", 0L);
-            inputTopic.pipeInput("A", "05", 10L);
-            inputTopic.pipeInput("A", "06", 8L);
+            inputTopic.pipeInput("B", "02", 10L);
+            inputTopic.pipeInput("C", "03", 20L);
+            inputTopic.pipeInput("D", "04", 30L);
+            inputTopic.pipeInput("D", "05", 20L); // dropped
+            inputTopic.pipeInput("A", "05", 40L);
+            inputTopic.pipeInput("A", "06", 50L);
 
             final List<TestRecord<Integer, String>> outputExpectRecords = new ArrayList<>();
             outputExpectRecords.add(new TestRecord<>(0, "01", Instant.ofEpochMilli(5L)));
-            outputExpectRecords.add(new TestRecord<>(1, "02", Instant.ofEpochMilli(100L)));
-            outputExpectRecords.add(new TestRecord<>(2, "03", Instant.ofEpochMilli(0L)));
-            outputExpectRecords.add(new TestRecord<>(3, "04", Instant.ofEpochMilli(0L)));
-            outputExpectRecords.add(new TestRecord<>(0, "05", Instant.ofEpochMilli(10L)));
-            outputExpectRecords.add(new TestRecord<>(0, "06", Instant.ofEpochMilli(8L)));
+            outputExpectRecords.add(new TestRecord<>(1, "02", Instant.ofEpochMilli(10L)));
+            outputExpectRecords.add(new TestRecord<>(2, "03", Instant.ofEpochMilli(20L)));
+            outputExpectRecords.add(new TestRecord<>(3, "04", Instant.ofEpochMilli(30L)));
+            outputExpectRecords.add(new TestRecord<>(0, "05", Instant.ofEpochMilli(40L)));
+            outputExpectRecords.add(new TestRecord<>(0, "06", Instant.ofEpochMilli(50L)));
 
             assertEquals(outputTopic.readRecordsToList(), outputExpectRecords);
         }
@@ -2951,19 +2953,20 @@ public class KStreamImplTest {
                 driver.createOutputTopic(output, Serdes.String().deserializer(), Serdes.Long().deserializer());
 
             inputTopic.pipeInput("A", "green", 10L);
-            inputTopic.pipeInput("B", "green", 9L);
+            inputTopic.pipeInput("B", "green", 9L); // dropped
+            inputTopic.pipeInput("B", "green", 11L);
             inputTopic.pipeInput("A", "blue", 12L);
             inputTopic.pipeInput("C", "yellow", 15L);
-            inputTopic.pipeInput("D", "green", 11L);
+            inputTopic.pipeInput("D", "green", 16L);
 
             assertEquals(
                 asList(
                     new TestRecord<>("green", 1L, Instant.ofEpochMilli(10)),
-                    new TestRecord<>("green", 2L, Instant.ofEpochMilli(10)),
+                    new TestRecord<>("green", 2L, Instant.ofEpochMilli(11)),
                     new TestRecord<>("green", 1L, Instant.ofEpochMilli(12)),
                     new TestRecord<>("blue", 1L, Instant.ofEpochMilli(12)),
                     new TestRecord<>("yellow", 1L, Instant.ofEpochMilli(15)),
-                    new TestRecord<>("green", 2L, Instant.ofEpochMilli(12))),
+                    new TestRecord<>("green", 2L, Instant.ofEpochMilli(16))),
                 outputTopic.readRecordsToList());
         }
     }
@@ -3017,10 +3020,11 @@ public class KStreamImplTest {
             final KeyValueStore<String, Integer> store = driver.getKeyValueStore(storeName);
 
             inputTopic.pipeInput("A", "green", 10L);
-            inputTopic.pipeInput("B", "green", 9L);
+            inputTopic.pipeInput("B", "green", 11L);
+            inputTopic.pipeInput("B", "blue", 9L); // dropped
             inputTopic.pipeInput("A", "blue", 12L);
             inputTopic.pipeInput("C", "yellow", 15L);
-            inputTopic.pipeInput("D", "green", 11L);
+            inputTopic.pipeInput("D", "green", 16L);
 
             final Map<String, Integer> expectedStore = new HashMap<>();
             expectedStore.putIfAbsent("A", 1);
@@ -3033,10 +3037,10 @@ public class KStreamImplTest {
             assertEquals(
                 asList(
                     new TestRecord<>("A", 6, Instant.ofEpochMilli(10)),
-                    new TestRecord<>("B", 6, Instant.ofEpochMilli(9)),
+                    new TestRecord<>("B", 6, Instant.ofEpochMilli(11)),
                     new TestRecord<>("A", 1, Instant.ofEpochMilli(12)),
                     new TestRecord<>("C", 24, Instant.ofEpochMilli(15)),
-                    new TestRecord<>("D", 6, Instant.ofEpochMilli(11))),
+                    new TestRecord<>("D", 6, Instant.ofEpochMilli(16))),
                 outputTopic.readRecordsToList());
 
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
@@ -85,25 +85,35 @@ public class KStreamKTableLeftJoinTest {
         driver.close();
     }
 
-    private void pushToStream(final int messageCount, final String valuePrefix) {
+    private void pushToStream(final int messageCount,
+                              final String valuePrefix,
+                              final long startTimestampMs) {
         for (int i = 0; i < messageCount; i++) {
-            inputStreamTopic.pipeInput(expectedKeys[i], valuePrefix + expectedKeys[i], i);
+            inputStreamTopic.pipeInput(
+                expectedKeys[i],
+                valuePrefix + expectedKeys[i],
+                startTimestampMs + i
+            );
         }
     }
 
-    private void pushToTable(final int messageCount, final String valuePrefix) {
+    private void pushToTable(final int messageCount,
+                             final String valuePrefix,
+                             final long startTimestampMs) {
         final Random r = new Random(System.currentTimeMillis());
         for (int i = 0; i < messageCount; i++) {
             inputTableTopic.pipeInput(
                 expectedKeys[i],
                 valuePrefix + expectedKeys[i],
-                r.nextInt(Integer.MAX_VALUE));
+                startTimestampMs + i
+            );
         }
     }
 
-    private void pushNullValueToTable(final int messageCount) {
+    private void pushNullValueToTable(final int messageCount,
+                                      final long startTimestampMs) {
         for (int i = 0; i < messageCount; i++) {
-            inputTableTopic.pipeInput(expectedKeys[i], null);
+            inputTableTopic.pipeInput(expectedKeys[i], null, startTimestampMs + i);
         }
     }
 
@@ -119,83 +129,97 @@ public class KStreamKTableLeftJoinTest {
     @Test
     public void shouldJoinWithEmptyTableOnStreamUpdates() {
         // push two items to the primary stream. the table is empty
-        pushToStream(2, "X");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+null", 0),
-                new KeyValueTimestamp<>(1, "X1+null", 1));
+        pushToStream(2, "X", 0L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "X0+null", 0L),
+            new KeyValueTimestamp<>(1, "X1+null", 1L)
+        );
     }
 
     @Test
     public void shouldNotJoinOnTableUpdates() {
         // push two items to the primary stream. the table is empty
-        pushToStream(2, "X");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+null", 0),
-                new KeyValueTimestamp<>(1, "X1+null", 1));
+        pushToStream(2, "X", 0L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "X0+null", 0L),
+            new KeyValueTimestamp<>(1, "X1+null", 1L)
+        );
 
         // push two items to the table. this should not produce any item.
-        pushToTable(2, "Y");
+        pushToTable(2, "Y", 10L);
         processor.checkAndClearProcessResult(EMPTY);
 
         // push all four items to the primary stream. this should produce four items.
-        pushToStream(4, "X");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+Y0", 0),
-                new KeyValueTimestamp<>(1, "X1+Y1", 1),
-                new KeyValueTimestamp<>(2, "X2+null", 2),
-                new KeyValueTimestamp<>(3, "X3+null", 3));
+        pushToStream(4, "X", 20L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "X0+Y0", 20L),
+            new KeyValueTimestamp<>(1, "X1+Y1", 21L),
+            new KeyValueTimestamp<>(2, "X2+null", 22L),
+            new KeyValueTimestamp<>(3, "X3+null", 23L)
+        );
 
         // push all items to the table. this should not produce any item
-        pushToTable(4, "YY");
+        pushToTable(4, "YY", 30L);
         processor.checkAndClearProcessResult(EMPTY);
 
         // push all four items to the primary stream. this should produce four items.
-        pushToStream(4, "X");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+YY0", 0),
-                new KeyValueTimestamp<>(1, "X1+YY1", 1),
-                new KeyValueTimestamp<>(2, "X2+YY2", 2),
-                new KeyValueTimestamp<>(3, "X3+YY3", 3));
+        pushToStream(4, "X", 40L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "X0+YY0", 40L),
+            new KeyValueTimestamp<>(1, "X1+YY1", 41L),
+            new KeyValueTimestamp<>(2, "X2+YY2", 42L),
+            new KeyValueTimestamp<>(3, "X3+YY3", 43L)
+        );
 
         // push all items to the table. this should not produce any item
-        pushToTable(4, "YYY");
+        pushToTable(4, "YYY", 50L);
         processor.checkAndClearProcessResult(EMPTY);
     }
 
     @Test
     public void shouldJoinRegardlessIfMatchFoundOnStreamUpdates() {
         // push two items to the table. this should not produce any item.
-        pushToTable(2, "Y");
+        pushToTable(2, "Y", 0L);
         processor.checkAndClearProcessResult(EMPTY);
 
         // push all four items to the primary stream. this should produce four items.
-        pushToStream(4, "X");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+Y0", 0),
-                new KeyValueTimestamp<>(1, "X1+Y1", 1),
-                new KeyValueTimestamp<>(2, "X2+null", 2),
-                new KeyValueTimestamp<>(3, "X3+null", 3));
+        pushToStream(4, "X", 10L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "X0+Y0", 10L),
+            new KeyValueTimestamp<>(1, "X1+Y1", 11L),
+            new KeyValueTimestamp<>(2, "X2+null", 12L),
+            new KeyValueTimestamp<>(3, "X3+null", 13L)
+        );
 
     }
 
     @Test
     public void shouldClearTableEntryOnNullValueUpdates() {
         // push all four items to the table. this should not produce any item.
-        pushToTable(4, "Y");
+        pushToTable(4, "Y", 0L);
         processor.checkAndClearProcessResult(EMPTY);
 
         // push all four items to the primary stream. this should produce four items.
-        pushToStream(4, "X");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "X0+Y0", 0),
-                new KeyValueTimestamp<>(1, "X1+Y1", 1),
-                new KeyValueTimestamp<>(2, "X2+Y2", 2),
-                new KeyValueTimestamp<>(3, "X3+Y3", 3));
+        pushToStream(4, "X", 10L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "X0+Y0", 10L),
+            new KeyValueTimestamp<>(1, "X1+Y1", 11L),
+            new KeyValueTimestamp<>(2, "X2+Y2", 12L),
+            new KeyValueTimestamp<>(3, "X3+Y3", 13L)
+        );
 
         // push two items with null to the table as deletes. this should not produce any item.
-        pushNullValueToTable(2);
+        pushNullValueToTable(2, 20L);
         processor.checkAndClearProcessResult(EMPTY);
 
         // push all four items to the primary stream. this should produce four items.
-        pushToStream(4, "XX");
-        processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "XX0+null", 0),
-                new KeyValueTimestamp<>(1, "XX1+null", 1),
-                new KeyValueTimestamp<>(2, "XX2+Y2", 2),
-                new KeyValueTimestamp<>(3, "XX3+Y3", 3));
+        pushToStream(4, "XX", 30L);
+        processor.checkAndClearProcessResult(
+            new KeyValueTimestamp<>(0, "XX0+null", 30L),
+            new KeyValueTimestamp<>(1, "XX1+null", 31L),
+            new KeyValueTimestamp<>(2, "XX2+Y2", 32L),
+            new KeyValueTimestamp<>(3, "XX3+Y3", 33L)
+        );
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
@@ -213,7 +213,6 @@ public class KTableSourceTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
-        @SuppressWarnings("unchecked")
         final KTableImpl<String, String, String> table1 =
             (KTableImpl<String, String, String>) builder.table(topic1, stringConsumed, Materialized.as("store"));
 
@@ -270,7 +269,6 @@ public class KTableSourceTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
-        @SuppressWarnings("unchecked")
         final KTableImpl<String, String, String> table1 =
             (KTableImpl<String, String, String>) builder.table(topic1, stringConsumed);
 
@@ -323,7 +321,6 @@ public class KTableSourceTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic1 = "topic1";
 
-        @SuppressWarnings("unchecked")
         final KTableImpl<String, String, String> table1 =
             (KTableImpl<String, String, String>) builder.table(topic1, stringConsumed);
         table1.enableSendingOldValues(true);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/TableSourceNodeTest.java
@@ -67,7 +67,7 @@ public class TableSourceNodeTest {
             .withMaterializedInternal(new MaterializedInternal<>(Materialized.as(STORE_NAME)))
             .withConsumedInternal(new ConsumedInternal<>(Consumed.as("node-name")))
             .withProcessorParameters(
-                new ProcessorParameters<>(new KTableSource<>(STORE_NAME, STORE_NAME), null))
+                new ProcessorParameters<>(new KTableSource<>(STORE_NAME, STORE_NAME, false), null))
             .build();
         tableSourceNode.reuseSourceTopicForChangeLog(shouldReuseSourceTopicForChangelog);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -96,7 +96,7 @@ public class GlobalStreamThreadTest {
             null,
             GLOBAL_STORE_TOPIC_NAME,
             "processorName",
-            () -> ProcessorAdapter.adapt(new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME).get()));
+            () -> ProcessorAdapter.adapt(new KTableSource<>(GLOBAL_STORE_NAME, GLOBAL_STORE_NAME, true).get()));
 
         baseDirectoryName = TestUtils.tempDirectory().getAbsolutePath();
         final HashMap<String, Object> properties = new HashMap<>();


### PR DESCRIPTION
WIP PR (did not update all test yet).

The proposal is to be _strict_ and use `context.streamTime()` to drop out-of-order records. The advantage is, that we can drop out-of-order records even if there is no table state store.

Call for review @guozhangwang @ableegoldman @vvcephei @cadonna @spena 