### PR TITLE
KAFKA-806: Index may not always observe log.index.interval.bytes

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -586,4 +586,18 @@ class LogSegmentTest {
     Utils.delete(tempDir)
   }
 
+  @Test
+  def testIndexObserveLogIndexIntervalBytes(): Unit = {
+    val seg = createSegment(0)
+    seg.append(100, RecordBatch.NO_TIMESTAMP, -1L, records(100, "100"))
+    assertEquals(0, seg.offsetIndex.entries)
+    seg.append(200, RecordBatch.NO_TIMESTAMP, -1L, records(200, "200"))
+    assertEquals(1, seg.offsetIndex.entries)
+
+    seg.offsetIndex.reset()
+    assertEquals(0, seg.offsetIndex.entries)
+
+    seg.append(300, RecordBatch.NO_TIMESTAMP, -1L, records(300, "300"))
+    assertEquals(2, seg.offsetIndex.entries)
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-806

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
