### PR TITLE
KAFKA-12667: Fix incorrect error log on StateDirectory close

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -410,7 +410,7 @@ public class StateDirectory {
             }
 
             // all threads should be stopped and cleaned up by now, so none should remain holding a lock
-            if (locks.isEmpty()) {
+            if (!locks.isEmpty()) {
                 log.error("Some task directories still locked while closing state, this indicates unclean shutdown: {}", locks);
             }
             if (globalStateLock != null) {


### PR DESCRIPTION
This condition was fixed on the side in a PR against trunk, but unfortunately missed the ongoing 2.8.0, 2.7.1, and 2.6.2 releases. This is a quick hotfix we should merge once those releases are finally out the door, and backport to 2.7 at the least