### PR TITLE
MINOR: update default for field in DeleteTopicsRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
@@ -44,12 +44,6 @@ public class DeleteTopicsRequest extends AbstractRequest {
         public DeleteTopicsRequest build(short version) {
             if (version >= 6 && !data.topicNames().isEmpty()) {
                 data.setTopics(groupByTopic(data.topicNames()));
-            } else if (version >= 6) {
-                for (DeleteTopicState topic : data.topics()) {
-                    if (topic.name() != null && topic.name().equals("")) {
-                        topic.setName(null);
-                    }
-                }
             }
             return new DeleteTopicsRequest(data, version);
         }

--- a/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+++ b/clients/src/main/resources/common/message/DeleteTopicsRequest.json
@@ -31,7 +31,7 @@
   "fields": [
     { "name": "Topics", "type": "[]DeleteTopicState", "versions": "6+", "about": "The name or topic ID of the topic",
       "fields": [
-        {"name": "Name", "type": "string", "versions": "6+", "nullableVersions": "6+", "entityType": "topicName", "about": "The topic name"},
+        {"name": "Name", "type": "string", "versions": "6+", "nullableVersions": "6+", "default": "null", "entityType": "topicName", "about": "The topic name"},
         {"name": "TopicId", "type": "uuid", "versions": "6+", "about": "The unique topic ID"}
     ]},
     { "name": "TopicNames", "type": "[]string", "versions": "0-5", "entityType": "topicName", "ignorable": true,


### PR DESCRIPTION
When using DeleteTopicsRequest with topic IDs, the topic name field should be null. Before, the code was programmatically assigning null, but it will be easier and less error prone to simply set that as the default. 

Tested using the previously created `DeleteTopicsRequestTest.java` file.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
