### PR TITLE
KAFKA-12313: Streamling windowed Deserialiser configs.

### DIFF
--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewTypedDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewTypedDemo.java
@@ -30,6 +30,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -177,9 +178,7 @@ public class PageViewTypedDemo {
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         props.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, JsonTimestampExtractor.class);
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, JSONSerde.class);
-        props.put(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS, JSONSerde.class);
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, JSONSerde.class);
-        props.put(StreamsConfig.DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS, JSONSerde.class);
         props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
 
@@ -223,7 +222,7 @@ public class PageViewTypedDemo {
             });
 
         // write to the result topic
-        regionCount.to("streams-pageviewstats-typed-output");
+        regionCount.to("streams-pageviewstats-typed-output", Produced.with(new JSONSerde<>(), new JSONSerde<>()));
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), props);
         final CountDownLatch latch = new CountDownLatch(1);

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -394,15 +394,22 @@ public class StreamsConfig extends AbstractConfig {
 
     /** {@code default.windowed.key.serde.inner} */
     @SuppressWarnings("WeakerAccess")
+    @Deprecated
     public static final String DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS = "default.windowed.key.serde.inner";
     private static final String DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS_DOC = "Default serializer / deserializer for the inner class of a windowed key. Must implement the " +
         "<code>org.apache.kafka.common.serialization.Serde</code> interface.";
 
     /** {@code default.windowed.value.serde.inner} */
     @SuppressWarnings("WeakerAccess")
+    @Deprecated
     public static final String DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS = "default.windowed.value.serde.inner";
     private static final String DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS_DOC = "Default serializer / deserializer for the inner class of a windowed value. Must implement the " +
         "<code>org.apache.kafka.common.serialization.Serde</code> interface.";
+
+    public static final String WINDOWED_INNER_CLASS_SERDE = "windowed.inner.class.serde";
+    private static final String WINDOWED_INNER_CLASS_SERDE_DOC = " Default serializer / deserializer for the inner class of a windowed record. Must implement the \" +\n" +
+        "        \"<code>org.apache.kafka.common.serialization.Serde</code> interface.. Note that setting this config in KafkaStreams application would result " +
+        "in an error as it is meant to be used only from Plain consumer client.";
 
     /** {@code default key.serde} */
     @SuppressWarnings("WeakerAccess")
@@ -663,16 +670,6 @@ public class StreamsConfig extends AbstractConfig {
                     Serdes.ByteArraySerde.class.getName(),
                     Importance.MEDIUM,
                     DEFAULT_VALUE_SERDE_CLASS_DOC)
-            .define(DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS,
-                    Type.CLASS,
-                    null,
-                    Importance.MEDIUM,
-                    DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS_DOC)
-            .define(DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS,
-                    Type.CLASS,
-                    null,
-                    Importance.MEDIUM,
-                    DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS_DOC)
             .define(MAX_TASK_IDLE_MS_CONFIG,
                     Type.LONG,
                     0L,
@@ -858,6 +855,11 @@ public class StreamsConfig extends AbstractConfig {
                        UPGRADE_FROM_23),
                     Importance.LOW,
                     UPGRADE_FROM_DOC)
+            .define(WINDOWED_INNER_CLASS_SERDE,
+                Type.STRING,
+                null,
+                Importance.LOW,
+                WINDOWED_INNER_CLASS_SERDE_DOC)
             .define(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG,
                     Type.LONG,
                     24 * 60 * 60 * 1000L,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedDeserializer.java
@@ -25,12 +25,6 @@ import org.apache.kafka.streams.state.internals.SessionKeySchema;
 
 import java.util.Map;
 
-/**
- *  The inner serde class can be specified by setting the property
- *  {@link StreamsConfig#DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS} or
- *  {@link StreamsConfig#DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS}
- *  if the no-arg constructor is called and hence it is not passed during initialization.
- */
 public class SessionWindowedDeserializer<T> implements Deserializer<Windowed<T>> {
 
     private Deserializer<T> inner;
@@ -45,16 +39,31 @@ public class SessionWindowedDeserializer<T> implements Deserializer<Windowed<T>>
     @SuppressWarnings("unchecked")
     @Override
     public void configure(final Map<String, ?> configs, final boolean isKey) {
-        if (inner == null) {
-            final String propertyName = isKey ? StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS : StreamsConfig.DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS;
-            final String value = (String) configs.get(propertyName);
+        final String windowedInnerClassSerdeConfig = (String) configs.get(StreamsConfig.WINDOWED_INNER_CLASS_SERDE);
+
+        Serde<T> windowInnerClassSerde = null;
+
+        if (windowedInnerClassSerdeConfig != null) {
             try {
-                inner = Serde.class.cast(Utils.newInstance(value, Serde.class)).deserializer();
-                inner.configure(configs, isKey);
+                windowInnerClassSerde = Utils.newInstance(windowedInnerClassSerdeConfig, Serde.class);
             } catch (final ClassNotFoundException e) {
-                throw new ConfigException(propertyName, value, "Serde class " + value + " could not be found.");
+                throw new ConfigException(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, windowedInnerClassSerdeConfig,
+                    "Serde class " + windowedInnerClassSerdeConfig + " could not be found.");
             }
         }
+
+        if (inner != null && windowedInnerClassSerdeConfig != null) {
+            if (!inner.getClass().getName().equals(windowInnerClassSerde.deserializer().getClass().getName())) {
+                throw new IllegalArgumentException("Inner class deserializer set using constructor "
+                    + "(" + inner.getClass().getName() + ")" +
+                    " is different from the one set in windowed.inner.class.serde config " +
+                    "(" + windowInnerClassSerde.deserializer().getClass().getName() + ").");
+            }
+        } else if (inner == null && windowedInnerClassSerdeConfig == null) {
+            throw new IllegalArgumentException("Inner class deserializer should be set either via constructor " +
+                "or via the windowed.inner.class.serde config");
+        } else if (inner == null)
+            inner = windowInnerClassSerde.deserializer();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedSerializer.java
@@ -26,12 +26,6 @@ import org.apache.kafka.streams.state.internals.SessionKeySchema;
 
 import java.util.Map;
 
-/**
- *  The inner serde class can be specified by setting the property
- *  {@link StreamsConfig#DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS} or
- *  {@link StreamsConfig#DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS}
- *  if the no-arg constructor is called and hence it is not passed during initialization.
- */
 public class SessionWindowedSerializer<T> implements WindowedSerializer<T> {
 
     private Serializer<T> inner;
@@ -46,16 +40,29 @@ public class SessionWindowedSerializer<T> implements WindowedSerializer<T> {
     @SuppressWarnings("unchecked")
     @Override
     public void configure(final Map<String, ?> configs, final boolean isKey) {
-        if (inner == null) {
-            final String propertyName = isKey ? StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS : StreamsConfig.DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS;
-            final String value = (String) configs.get(propertyName);
+        final String windowedInnerClassSerdeConfig = (String) configs.get(StreamsConfig.WINDOWED_INNER_CLASS_SERDE);
+        Serde<T> windowInnerClassSerde = null;
+        if (windowedInnerClassSerdeConfig != null) {
             try {
-                inner = (Utils.newInstance(value, Serde.class)).serializer();
-                inner.configure(configs, isKey);
+                windowInnerClassSerde = Utils.newInstance(windowedInnerClassSerdeConfig, Serde.class);
             } catch (final ClassNotFoundException e) {
-                throw new ConfigException(propertyName, value, "Serde class " + value + " could not be found.");
+                throw new ConfigException(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, windowedInnerClassSerdeConfig,
+                    "Serde class " + windowedInnerClassSerdeConfig + " could not be found.");
             }
         }
+
+        if (inner != null && windowedInnerClassSerdeConfig != null) {
+            if (!inner.getClass().getName().equals(windowInnerClassSerde.serializer().getClass().getName())) {
+                throw new IllegalArgumentException("Inner class serializer set using constructor "
+                    + "(" + inner.getClass().getName() + ")" +
+                    " is different from the one set in windowed.inner.class.serde config " +
+                    "(" + windowInnerClassSerde.serializer().getClass().getName() + ").");
+            }
+        } else if (inner == null && windowedInnerClassSerdeConfig == null) {
+            throw new IllegalArgumentException("Inner class serializer should be set either via constructor " +
+                "or via the windowed.inner.class.serde config");
+        } else if (inner == null)
+            inner = windowInnerClassSerde.serializer();
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializer.java
@@ -25,12 +25,6 @@ import org.apache.kafka.streams.state.internals.WindowKeySchema;
 
 import java.util.Map;
 
-/**
- *  The inner serde class can be specified by setting the property
- *  {@link StreamsConfig#DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS} or
- *  {@link StreamsConfig#DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS}
- *  if the no-arg constructor is called and hence it is not passed during initialization.
- */
 public class TimeWindowedDeserializer<T> implements Deserializer<Windowed<T>> {
 
     private Long windowSize;
@@ -76,16 +70,32 @@ public class TimeWindowedDeserializer<T> implements Deserializer<Windowed<T>> {
         } else {
             windowSize = windowSize == null ? configWindowSize : windowSize;
         }
-        if (inner == null) {
-            final String propertyName = isKey ? StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS : StreamsConfig.DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS;
-            final String value = (String) configs.get(propertyName);
+
+        final String windowedInnerClassSerdeConfig = (String) configs.get(StreamsConfig.WINDOWED_INNER_CLASS_SERDE);
+
+        Serde<T> windowInnerClassSerde = null;
+
+        if (windowedInnerClassSerdeConfig != null) {
             try {
-                inner = Serde.class.cast(Utils.newInstance(value, Serde.class)).deserializer();
-                inner.configure(configs, isKey);
+                windowInnerClassSerde = Utils.newInstance(windowedInnerClassSerdeConfig, Serde.class);
             } catch (final ClassNotFoundException e) {
-                throw new ConfigException(propertyName, value, "Serde class " + value + " could not be found.");
+                throw new ConfigException(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, windowedInnerClassSerdeConfig,
+                    "Serde class " + windowedInnerClassSerdeConfig + " could not be found.");
             }
         }
+
+        if (inner != null && windowedInnerClassSerdeConfig != null) {
+            if (!inner.getClass().getName().equals(windowInnerClassSerde.deserializer().getClass().getName())) {
+                throw new IllegalArgumentException("Inner class deserializer set using constructor "
+                    + "(" + inner.getClass().getName() + ")" +
+                    " is different from the one set in windowed.inner.class.serde config " +
+                    "(" + windowInnerClassSerde.deserializer().getClass().getName() + ").");
+            }
+        } else if (inner == null && windowedInnerClassSerdeConfig == null) {
+            throw new IllegalArgumentException("Inner class deserializer should be set either via  constructor " +
+                "or via the windowed.inner.class.serde config");
+        } else if (inner == null)
+            inner = windowInnerClassSerde.deserializer();
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -1058,8 +1058,8 @@ public class KStreamAggregationIntegrationTest {
         consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass().getName());
         consumerProperties.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, 500L);
         if (keyDeserializer instanceof TimeWindowedDeserializer || keyDeserializer instanceof SessionWindowedDeserializer) {
-            consumerProperties.setProperty(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS,
-                    Serdes.serdeFrom(innerClass).getClass().getName());
+            consumerProperties.setProperty(StreamsConfig.WINDOWED_INNER_CLASS_SERDE,
+                Serdes.serdeFrom(innerClass).getClass().getName());
         }
         return IntegrationTestUtils.waitUntilMinKeyValueWithTimestampRecordsReceived(
                 consumerProperties,
@@ -1081,7 +1081,7 @@ public class KStreamAggregationIntegrationTest {
         consumerProperties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer.getClass().getName());
         consumerProperties.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, 500L);
         if (keyDeserializer instanceof TimeWindowedDeserializer || keyDeserializer instanceof SessionWindowedDeserializer) {
-            consumerProperties.setProperty(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS,
+            consumerProperties.setProperty(StreamsConfig.WINDOWED_INNER_CLASS_SERDE,
                 Serdes.serdeFrom(innerClass).getClass().getName());
         }
         return IntegrationTestUtils.waitUntilMinKeyValueWithTimestampRecordsReceived(
@@ -1113,7 +1113,7 @@ public class KStreamAggregationIntegrationTest {
                 "--property", "key.deserializer=" + keyDeserializer.getClass().getName(),
                 "--property", "value.deserializer=" + valueDeserializer.getClass().getName(),
                 "--property", "key.separator=" + keySeparator,
-                "--property", "key.deserializer." + StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS + "=" + Serdes.serdeFrom(innerClass).getClass().getName(),
+                "--property", "key.deserializer." + StreamsConfig.WINDOWED_INNER_CLASS_SERDE + "=" + Serdes.serdeFrom(innerClass).getClass().getName(),
                 "--property", "key.deserializer.window.size.ms=500",
             };
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowedSerializerTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.streams.kstream;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.StreamsConfig;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -29,19 +29,14 @@ import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
 public class SessionWindowedSerializerTest {
-    private final SessionWindowedSerializer<?> sessionWindowedSerializer = new SessionWindowedSerializer<>();
+    private final SessionWindowedSerializer<?> sessionWindowedSerializer = new SessionWindowedSerializer<>(Serdes.String().serializer());
     private final Map<String, String> props = new HashMap<>();
 
-    @Before
-    public void setUp() {
-        props.put(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS, Serdes.StringSerde.class.getName());
-        props.put(StreamsConfig.DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS, Serdes.ByteArraySerde.class.getName());
-    }
-
     @Test
-    public void testWindowedKeySerializerNoArgConstructors() {
+    public void testSessionWindowedSerializerConstructor() {
         sessionWindowedSerializer.configure(props, true);
         final Serializer<?> inner = sessionWindowedSerializer.innerSerializer();
         assertNotNull("Inner serializer should be not null", inner);
@@ -49,10 +44,28 @@ public class SessionWindowedSerializerTest {
     }
 
     @Test
-    public void testWindowedValueSerializerNoArgConstructors() {
-        sessionWindowedSerializer.configure(props, false);
-        final Serializer<?> inner = sessionWindowedSerializer.innerSerializer();
-        assertNotNull("Inner serializer should be not null", inner);
-        assertTrue("Inner serializer type should be ByteArraySerializer", inner instanceof ByteArraySerializer);
+    public void shouldSetWindowedInnerClassSerialiserThroughConfig() {
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.ByteArraySerde.class.getName());
+        final SessionWindowedSerializer<?> serializer = new SessionWindowedSerializer<>();
+        serializer.configure(props, false);
+        assertTrue(serializer.innerSerializer() instanceof ByteArraySerializer);
+    }
+
+    @Test
+    public void shouldThrowErrorIfWindowInnerClassSerialiserIsNotSet() {
+        final SessionWindowedSerializer<?> serializer = new SessionWindowedSerializer<>();
+        assertThrows(IllegalArgumentException.class, () -> serializer.configure(props, false));
+    }
+
+    @Test
+    public void shouldThrowErrorIfSerialisersConflictInConstructorAndConfig() {
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.ByteArraySerde.class.getName());
+        assertThrows(IllegalArgumentException.class, () -> sessionWindowedSerializer.configure(props, false));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionWhenInvalidWindowInnerClassSerialiserSupplied() {
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, "some.non.existent.class");
+        assertThrows(ConfigException.class, () -> sessionWindowedSerializer.configure(props, false));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowedDeserializerTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.kafka.streams.kstream;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.streams.StreamsConfig;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -35,17 +35,11 @@ import static org.junit.Assert.assertTrue;
 
 public class TimeWindowedDeserializerTest {
     private final long windowSize = 5000000;
-    private final TimeWindowedDeserializer<?> timeWindowedDeserializer = new TimeWindowedDeserializer<>(null, windowSize);
+    private final TimeWindowedDeserializer<?> timeWindowedDeserializer = new TimeWindowedDeserializer<>(new StringDeserializer(), windowSize);
     private final Map<String, String> props = new HashMap<>();
 
-    @Before
-    public void setUp() {
-        props.put(StreamsConfig.DEFAULT_WINDOWED_KEY_SERDE_INNER_CLASS, Serdes.StringSerde.class.getName());
-        props.put(StreamsConfig.DEFAULT_WINDOWED_VALUE_SERDE_INNER_CLASS, Serdes.ByteArraySerde.class.getName());
-    }
-
     @Test
-    public void testWindowedKeyDeserializerNoArgConstructors() {
+    public void testTimeWindowedDeserializerConstructor() {
         timeWindowedDeserializer.configure(props, true);
         final Deserializer<?> inner = timeWindowedDeserializer.innerDeserializer();
         assertNotNull("Inner deserializer should be not null", inner);
@@ -54,20 +48,13 @@ public class TimeWindowedDeserializerTest {
     }
 
     @Test
-    public void testWindowedValueDeserializerNoArgConstructors() {
-        timeWindowedDeserializer.configure(props, false);
-        final Deserializer<?> inner = timeWindowedDeserializer.innerDeserializer();
-        assertNotNull("Inner deserializer should be not null", inner);
-        assertTrue("Inner deserializer type should be ByteArrayDeserializer", inner instanceof ByteArrayDeserializer);
-        assertThat(timeWindowedDeserializer.getWindowSize(), is(5000000L));
-    }
-
-    @Test
-    public void shouldSetWindowSizeThroughConfigs() {
+    public void shouldSetWindowSizeAndWindowedInnerDeserialiserThroughConfigs() {
         props.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, "500");
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.ByteArraySerde.class.getName());
         final TimeWindowedDeserializer<?> deserializer = new TimeWindowedDeserializer<>();
         deserializer.configure(props, false);
         assertThat(deserializer.getWindowSize(), is(500L));
+        assertTrue(deserializer.innerDeserializer() instanceof ByteArrayDeserializer);
     }
 
     @Test
@@ -78,7 +65,27 @@ public class TimeWindowedDeserializerTest {
 
     @Test
     public void shouldThrowErrorIfWindowSizeIsNotSet() {
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.ByteArraySerde.class.getName());
         final TimeWindowedDeserializer<?> deserializer = new TimeWindowedDeserializer<>();
         assertThrows(IllegalArgumentException.class, () -> deserializer.configure(props, false));
+    }
+
+    @Test
+    public void shouldThrowErrorIfWindowedInnerClassDeserialiserIsNotSet() {
+        props.put(StreamsConfig.WINDOW_SIZE_MS_CONFIG, "500");
+        final TimeWindowedDeserializer<?> deserializer = new TimeWindowedDeserializer<>();
+        assertThrows(IllegalArgumentException.class, () -> deserializer.configure(props, false));
+    }
+
+    @Test
+    public void shouldThrowErrorIfWindowedInnerClassDeserialisersConflictInConstructorAndConfig() {
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, Serdes.ByteArraySerde.class.getName());
+        assertThrows(IllegalArgumentException.class, () -> timeWindowedDeserializer.configure(props, false));
+    }
+
+    @Test
+    public void shouldThrowConfigExceptionWhenInvalidWindowedInnerClassDeserialiserSupplied() {
+        props.put(StreamsConfig.WINDOWED_INNER_CLASS_SERDE, "some.non.existent.class");
+        assertThrows(ConfigException.class, () -> timeWindowedDeserializer.configure(props, false));
     }
 }


### PR DESCRIPTION
This PR aims to streamline the configurations for WindowedDeserialisers. It deprecates default.windowed.key.serde.inner and default.windowed.value.serde.inner configs in StreamConfig and adds window.inner.class.deserialiser. Details described here: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177047930