### PR TITLE
KAFKA-12672: Added config for raft testing server

### DIFF
--- a/raft/README.md
+++ b/raft/README.md
@@ -16,6 +16,7 @@ Create 3 separate KRaft quorum properties as the following:
     
     node.id=1
     listeners=PLAINTEXT://localhost:9092
+    controller.listener.names=PLAINTEXT
     controller.quorum.voters=1@localhost:9092,2@localhost:9093,3@localhost:9094
     log.dirs=/tmp/kraft-logs-1
     EOF
@@ -24,6 +25,7 @@ Create 3 separate KRaft quorum properties as the following:
     
     node.id=2
     listeners=PLAINTEXT://localhost:9093
+    controller.listener.names=PLAINTEXT
     controller.quorum.voters=1@localhost:9092,2@localhost:9093,3@localhost:9094
     log.dirs=/tmp/kraft-logs-2
     EOF
@@ -32,6 +34,7 @@ Create 3 separate KRaft quorum properties as the following:
     
     node.id=3
     listeners=PLAINTEXT://localhost:9094
+    controller.listener.names=PLAINTEXT
     controller.quorum.voters=1@localhost:9092,2@localhost:9093,3@localhost:9094
     log.dirs=/tmp/kraft-logs-3
     EOF

--- a/raft/config/kraft.properties
+++ b/raft/config/kraft.properties
@@ -15,5 +15,6 @@
 
 node.id=0
 listeners=PLAINTEXT://localhost:9092
+controller.listener.names=PLAINTEXT
 controller.quorum.voters=0@localhost:9092
 log.dirs=/tmp/kraft-logs


### PR DESCRIPTION
Adding a property to the `raft/config/kraft.properties` for running the raft test server in development.

For testing I ran `./bin/test-kraft-server-start.sh --config config/kraft.properties` and validated the test server started running with a throughput test.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
