### PR TITLE
KAFKA-8605 log an error message when we detect multiple copies of sam…

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -165,10 +165,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     //visible for testing
     PluginDesc<?> usedPluginDesc(String name) {
         SortedMap<PluginDesc<?>, ClassLoader> inner = pluginLoaders.get(name);
-        if (inner == null) {
-            return null;
-        }
-        return usedPluginDesc(inner);
+        return inner == null ? null : usedPluginDesc(inner);
     }
 
     private PluginDesc<?> usedPluginDesc(SortedMap<PluginDesc<?>, ClassLoader> inner) {
@@ -233,7 +230,9 @@ public class DelegatingClassLoader extends URLClassLoader {
             PluginDesc<?> usedPluginDesc = usedPluginDesc(pluginClassName);
             List<PluginDesc<?>> ignoredPlugins = new ArrayList<>(e.getValue());
             ignoredPlugins.remove(usedPluginDesc);
-            log.error("Detected multiple plugins contain '{}'; using {} and ignoring {}", pluginClassName, usedPluginDesc, ignoredPlugins);
+            log.error("Detected multiple plugins contain '{}'; using plugin {} and ignoring {} plugins ({}). "
+                            + "Check the installation and remove duplicate plugins from all workers.",
+                    pluginClassName, usedPluginDesc, ignoredPlugins.size(), ignoredPlugins);
             return pluginClassName;
         }).collect(Collectors.toSet());
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -231,7 +231,7 @@ public class DelegatingClassLoader extends URLClassLoader {
             List<PluginDesc<?>> ignoredPlugins = new ArrayList<>(e.getValue());
             ignoredPlugins.remove(usedPluginDesc);
             log.warn("Detected multiple plugins contain '{}'; using plugin {} and ignoring {} plugins ({}). "
-                            + "Check the installation on all workers and if possible remove all but one of these duplicated plugins.",
+                    + "Check the installation on all workers and if possible remove all but one of these duplicated plugins.",
                     pluginClassName, usedPluginDesc, ignoredPlugins.size(), ignoredPlugins);
             return pluginClassName;
         }).collect(Collectors.toSet());

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -192,6 +192,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         );
     }
 
+    //visible for testing
     <T> void addPlugins(Collection<PluginDesc<T>> plugins, ClassLoader loader) {
         for (PluginDesc<T> plugin : plugins) {
             String pluginClassName = plugin.className();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -157,7 +157,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         if (inner == null) {
             return null;
         }
-        ClassLoader pluginLoader = inner.get(inner.lastKey());
+        ClassLoader pluginLoader = inner.get(pluginDescInUse(inner));
         return pluginLoader instanceof PluginClassLoader
                ? (PluginClassLoader) pluginLoader
                : null;
@@ -169,10 +169,14 @@ public class DelegatingClassLoader extends URLClassLoader {
         if (inner == null) {
             return null;
         }
+        return pluginDescInUse(inner);
+    }
+
+    private PluginDesc<?> pluginDescInUse(SortedMap<PluginDesc<?>, ClassLoader> inner) {
         return inner.lastKey();
     }
 
-    public ClassLoader connectorLoader(Connector connector) {
+        public ClassLoader connectorLoader(Connector connector) {
         return connectorLoader(connector.getClass().getName());
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -207,14 +207,11 @@ public class DelegatingClassLoader extends URLClassLoader {
     <T> void addPlugins(Collection<PluginDesc<T>> plugins, ClassLoader loader) {
         for (PluginDesc<T> plugin : plugins) {
             String pluginClassName = plugin.className();
-            SortedMap<PluginDesc<?>, ClassLoader> inner = pluginLoaders.get(pluginClassName);
-            if (inner == null) {
-                inner = new TreeMap<>();
-                pluginLoaders.put(pluginClassName, inner);
+            if (!pluginLoaders.containsKey(pluginClassName)) {
                 // TODO: once versioning is enabled this line should be moved outside this if branch
                 log.info("Added plugin '{}'", pluginClassName);
             }
-            inner.put(plugin, loader);
+            pluginLoaders.computeIfAbsent(pluginClassName, n -> new TreeMap<>()).put(plugin, loader);
             allAddedPlugins.computeIfAbsent(pluginClassName, n -> new ArrayList<>()).add(plugin);
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -230,8 +230,8 @@ public class DelegatingClassLoader extends URLClassLoader {
             PluginDesc<?> usedPluginDesc = usedPluginDesc(pluginClassName);
             List<PluginDesc<?>> ignoredPlugins = new ArrayList<>(e.getValue());
             ignoredPlugins.remove(usedPluginDesc);
-            log.error("Detected multiple plugins contain '{}'; using plugin {} and ignoring {} plugins ({}). "
-                            + "Check the installation and remove duplicate plugins from all workers.",
+            log.warn("Detected multiple plugins contain '{}'; using plugin {} and ignoring {} plugins ({}). "
+                            + "Check the installation on all workers and if possible remove all but one of these duplicated plugins.",
                     pluginClassName, usedPluginDesc, ignoredPlugins.size(), ignoredPlugins);
             return pluginClassName;
         }).collect(Collectors.toSet());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoaderTest.java
@@ -175,7 +175,7 @@ public class DelegatingClassLoaderTest {
         delegatingClassLoader.addPlugins(Arrays.asList(connectorDesc2), ClassLoader.getSystemClassLoader());
         String pluginClassName = klass.getName();
         assertTrue(delegatingClassLoader.reportPluginConflicts().contains(pluginClassName));
-        assertEquals(delegatingClassLoader.pluginDescInUse(pluginClassName), connectorDesc1);
+        assertEquals(delegatingClassLoader.usedPluginDesc(pluginClassName), connectorDesc1);
 
         PluginDesc<Connector> connectorDesc3 = new PluginDesc<>(
                 klass,
@@ -184,6 +184,6 @@ public class DelegatingClassLoaderTest {
         );
         delegatingClassLoader.addPlugins(Arrays.asList(connectorDesc3), ClassLoader.getSystemClassLoader());
         assertTrue(delegatingClassLoader.reportPluginConflicts().contains(pluginClassName));
-        assertEquals(delegatingClassLoader.pluginDescInUse(pluginClassName), connectorDesc3);
+        assertEquals(delegatingClassLoader.usedPluginDesc(pluginClassName), connectorDesc3);
     }
 }


### PR DESCRIPTION
…e plugin class in the plugin paths

*A plugin like a converter or connector can exist multiple times in the plugin-path and the user may not realize that one of those copies will be used. The copy that will be used really depends on the operating system and how the filesystem gives us the jar listing, therefore we need to log an error message so the user is aware of this conflict and can remove the offending copy*
 
@rhauch @gharris1727 @C0urante  please review 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
