### PR TITLE
MINOR: Fix the negative time difference value from Log.scala

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1017,7 +1017,7 @@ class Log(@volatile private var _dir: File,
       }
       producerStateManager.updateMapEndOffset(lastOffset)
       producerStateManager.takeSnapshot()
-      info(s"Producer state recovery took ${producerStateLoadStart - segmentRecoveryStart}ms for snapshot load " +
+      info(s"Producer state recovery took ${segmentRecoveryStart - producerStateLoadStart}ms for snapshot load " +
         s"and ${time.milliseconds() - segmentRecoveryStart}ms for segment recovery from offset $lastOffset")
     }
   }


### PR DESCRIPTION
When I tested the kraft mode, I found that the time taken to load the snapshot in the startup log was negative.

[2021-04-18 00:19:37,377] INFO [Log partition=@metadata-0, dir=/tmp/kraft-combined-logs] Recovering unflushed segment 0 (kafka.log.Log)
[2021-04-18 00:19:37,382] INFO [Log partition=@metadata-0, dir=/tmp/kraft-combined-logs] Loading producer state till offset 0 with message format version 2 (kafka.log.Log)
[2021-04-18 00:19:37,389] INFO [Log partition=@metadata-0, dir=/tmp/kraft-combined-logs] Reloading from producer snapshot and rebuilding producer state from offset 0 (kafka.log.Log)
[2021-04-18 00:19:37,393] INFO [Log partition=@metadata-0, dir=/tmp/kraft-combined-logs] Producer state recovery took **-2ms** for snapshot load and 1ms for segment recovery from offset 0 (kafka.log.Log)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
