### PR TITLE
KAFKA-12684: Fix noop set is incorrectly replaced with succeeded set from LeaderElectionCommand

### DIFF
--- a/core/src/main/scala/kafka/admin/LeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/LeaderElectionCommand.scala
@@ -166,7 +166,7 @@ object LeaderElectionCommand extends Logging {
     }
 
     if (noop.nonEmpty) {
-      val partitions = succeeded.mkString(", ")
+      val partitions = noop.mkString(", ")
       println(s"Valid replica already elected for partitions $partitions")
     }
 


### PR DESCRIPTION
When using the kafka-election-tool for preferred replica election, if there are partitions in the elected list that are in the preferred replica, the list of partitions already in the preferred replica will be replaced by the successfully elected partition list.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
