### PR TITLE
MINOR: diable RaftClusterTest first

### DIFF
--- a/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
@@ -22,14 +22,16 @@ import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{Admin, NewTopic}
 import org.apache.kafka.common.quota.{ClientQuotaAlteration, ClientQuotaEntity, ClientQuotaFilter, ClientQuotaFilterComponent}
 import org.apache.kafka.metadata.BrokerState
-import org.junit.jupiter.api.{Test, Timeout}
+import org.junit.jupiter.api.{Disabled, Test, Timeout}
 import org.junit.jupiter.api.Assertions._
-
 import java.util
 import java.util.Collections
+
 import scala.jdk.CollectionConverters._
 
-@Timeout(120000)
+// Should remove the "Disabled" tag after KAFKA-12677 got fixed
+@Disabled
+@Timeout(120)
 class RaftClusterTest {
 
   @Test

--- a/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
@@ -29,8 +29,6 @@ import java.util.Collections
 
 import scala.jdk.CollectionConverters._
 
-// Should remove the "Disabled" tag after KAFKA-12677 got fixed
-@Disabled
 @Timeout(120)
 class RaftClusterTest {
 
@@ -73,6 +71,7 @@ class RaftClusterTest {
     }
   }
 
+  @Disabled
   @Test
   def testCreateClusterAndCreateListDeleteTopic(): Unit = {
     val cluster = new KafkaClusterTestKit.Builder(
@@ -131,6 +130,7 @@ class RaftClusterTest {
     }
   }
 
+  @Disabled
   @Test
   def testCreateClusterAndCreateAndManyTopics(): Unit = {
     val cluster = new KafkaClusterTestKit.Builder(
@@ -174,6 +174,7 @@ class RaftClusterTest {
     }
   }
 
+  @Disabled
   @Test
   def testCreateClusterAndCreateAndManyTopicsWithManyPartitions(): Unit = {
     val cluster = new KafkaClusterTestKit.Builder(


### PR DESCRIPTION
Disable the flaky RaftClusterTest tests before the root cause KAFKA-12677 got fixed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
