### PR TITLE
KAFKA-12487: Add support for cooperative consumer protocol with sink connectors

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -670,6 +670,7 @@ class WorkerSinkTask extends WorkerTask {
                 workerErrantRecordReporter.cancelFutures(topicPartitions);
                 log.trace("Cancelled all reported errors for {}", topicPartitions);
             }
+            topicPartitions.forEach(currentOffsets::remove);
         }
         updatePartitionCount();
     }
@@ -776,8 +777,6 @@ class WorkerSinkTask extends WorkerTask {
 
             if (partitions.isEmpty())
                 return;
-
-            partitions.forEach(currentOffsets::remove);
 
             try {
                 closePartitions(partitions, lost);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporter.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporter.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.errors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.Header;
@@ -31,13 +32,17 @@ import org.apache.kafka.connect.storage.HeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.LinkedList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 public class WorkerErrantRecordReporter implements ErrantRecordReporter {
 
@@ -49,7 +54,7 @@ public class WorkerErrantRecordReporter implements ErrantRecordReporter {
     private final HeaderConverter headerConverter;
 
     // Visible for testing
-    protected final LinkedList<Future<Void>> futures;
+    protected final Map<TopicPartition, Future<Void>> futures;
 
     public WorkerErrantRecordReporter(
         RetryWithToleranceOperator retryWithToleranceOperator,
@@ -61,7 +66,7 @@ public class WorkerErrantRecordReporter implements ErrantRecordReporter {
         this.keyConverter = keyConverter;
         this.valueConverter = valueConverter;
         this.headerConverter = headerConverter;
-        this.futures = new LinkedList<>();
+        this.futures = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -103,26 +108,47 @@ public class WorkerErrantRecordReporter implements ErrantRecordReporter {
         Future<Void> future = retryWithToleranceOperator.executeFailed(Stage.TASK_PUT, SinkTask.class, consumerRecord, error);
 
         if (!future.isDone()) {
-            futures.add(future);
+            futures.put(new TopicPartition(consumerRecord.topic(), consumerRecord.partition()), future);
         }
         return future;
     }
 
     /**
-     * Gets all futures returned by the sink records sent to Kafka by the errant
-     * record reporter. This function is intended to be used to block on all the errant record
-     * futures.
+     * Awaits the completion of all error reports for a given set of topic partitions
+     * @param topicPartitions the topic partitions to await reporter completion for
      */
-    public void awaitAllFutures() {
-        Future<?> future;
-        while ((future = futures.poll()) != null) {
+    public void awaitFutures(Collection<TopicPartition> topicPartitions) {
+        futuresFor(topicPartitions).forEach(future -> {
             try {
                 future.get();
             } catch (InterruptedException | ExecutionException e) {
-                log.error("Encountered an error while awaiting an errant record future's completion.");
+                log.error("Encountered an error while awaiting an errant record future's completion.", e);
                 throw new ConnectException(e);
             }
-        }
+        });
+    }
+
+    /**
+     * Cancels all active error reports for a given set of topic partitions
+     * @param topicPartitions the topic partitions to cancel reporting for
+     */
+    public void cancelFutures(Collection<TopicPartition> topicPartitions) {
+        futuresFor(topicPartitions).forEach(future -> {
+            try {
+                future.cancel(true);
+            } catch (Exception e) {
+                log.error("Encountered an error while cancelling an errant record future", e);
+                // No need to throw the exception here; it's enough to log an error message
+            }
+        });
+    }
+
+    // Removes and returns all futures for the given topic partitions from the set of currently-active futures
+    private Collection<Future<Void>> futuresFor(Collection<TopicPartition> topicPartitions) {
+        return topicPartitions.stream()
+                .map(futures::remove)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrantRecordSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrantRecordSinkConnector.java
@@ -53,7 +53,7 @@ public class ErrantRecordSinkConnector extends MonitorableSinkConnector {
                 TopicPartition tp = cachedTopicPartitions
                     .computeIfAbsent(rec.topic(), v -> new HashMap<>())
                     .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));
-                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0L) + 1);
+                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0) + 1);
                 reporter.report(rec, new Throwable());
             }
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ErrorHandlingIntegrationTest.java
@@ -261,7 +261,7 @@ public class ErrorHandlingIntegrationTest {
         try {
             ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
             return info != null && info.tasks().size() == NUM_TASKS
-                    && connectorHandle.taskHandle(TASK_ID).partitionsAssigned() == 1;
+                    && connectorHandle.taskHandle(TASK_ID).numPartitionsAssigned() == 1;
         }  catch (Exception e) {
             // Log the exception and return that the partitions were not assigned
             log.error("Could not check connector state info.", e);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ExampleConnectIntegrationTest.java
@@ -236,7 +236,7 @@ public class ExampleConnectIntegrationTest {
         try {
             ConnectorStateInfo info = connect.connectorStatus(CONNECTOR_NAME);
             return info != null && info.tasks().size() == NUM_TASKS
-                    && connectorHandle.tasks().stream().allMatch(th -> th.partitionsAssigned() == 1);
+                    && connectorHandle.tasks().stream().allMatch(th -> th.numPartitionsAssigned() == 1);
         } catch (Exception e) {
             // Log the exception and return that the partitions were not assigned
             log.error("Could not check connector state info.", e);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSinkConnector.java
@@ -29,10 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A sink connector that is used in Apache Kafka integration tests to verify the behavior of the
@@ -91,12 +89,10 @@ public class MonitorableSinkConnector extends TestSinkConnector {
         private String connectorName;
         private String taskId;
         TaskHandle taskHandle;
-        Set<TopicPartition> assignments;
-        Map<TopicPartition, Long> committedOffsets;
+        Map<TopicPartition, Integer> committedOffsets;
         Map<String, Map<Integer, TopicPartition>> cachedTopicPartitions;
 
         public MonitorableSinkTask() {
-            this.assignments = new HashSet<>();
             this.committedOffsets = new HashMap<>();
             this.cachedTopicPartitions = new HashMap<>();
         }
@@ -117,9 +113,15 @@ public class MonitorableSinkConnector extends TestSinkConnector {
 
         @Override
         public void open(Collection<TopicPartition> partitions) {
-            log.debug("Opening {} partitions", partitions.size());
-            assignments.addAll(partitions);
-            taskHandle.partitionsAssigned(partitions.size());
+            log.debug("Opening partitions {}", partitions);
+            taskHandle.partitionsAssigned(partitions);
+        }
+
+        @Override
+        public void close(Collection<TopicPartition> partitions) {
+            log.debug("Closing partitions {}", partitions);
+            taskHandle.partitionsRevoked(partitions);
+            partitions.forEach(committedOffsets::remove);
         }
 
         @Override
@@ -129,26 +131,22 @@ public class MonitorableSinkConnector extends TestSinkConnector {
                 TopicPartition tp = cachedTopicPartitions
                         .computeIfAbsent(rec.topic(), v -> new HashMap<>())
                         .computeIfAbsent(rec.kafkaPartition(), v -> new TopicPartition(rec.topic(), rec.kafkaPartition()));
-                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0L) + 1);
+                committedOffsets.put(tp, committedOffsets.getOrDefault(tp, 0) + 1);
                 log.trace("Task {} obtained record (key='{}' value='{}')", taskId, rec.key(), rec.value());
             }
         }
 
         @Override
         public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
-            for (TopicPartition tp : assignments) {
-                Long recordsSinceLastCommit = committedOffsets.get(tp);
-                if (recordsSinceLastCommit == null) {
-                    log.warn("preCommit was called with topic-partition {} that is not included "
-                            + "in the assignments of this task {}", tp, assignments);
-                } else {
-                    taskHandle.commit(recordsSinceLastCommit.intValue());
-                    log.error("Forwarding to framework request to commit additional {} for {}",
-                            recordsSinceLastCommit, tp);
-                    taskHandle.commit((int) (long) recordsSinceLastCommit);
-                    committedOffsets.put(tp, 0L);
+            taskHandle.partitionsCommitted(offsets.keySet());
+            offsets.forEach((tp, offset) -> {
+                int recordsSinceLastCommit = committedOffsets.getOrDefault(tp, 0);
+                if (recordsSinceLastCommit != 0) {
+                    taskHandle.commit(recordsSinceLastCommit);
+                    log.debug("Forwarding to framework request to commit {} records for {}", recordsSinceLastCommit, tp);
+                    committedOffsets.put(tp, 0);
                 }
-            }
+            });
             return offsets;
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/SinkConnectorsIntegrationTest.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
+import org.apache.kafka.clients.consumer.RoundRobinAssignor;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.test.TestUtils.waitForCondition;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test for sink connectors
+ */
+@Category(IntegrationTest.class)
+public class SinkConnectorsIntegrationTest {
+
+    private static final int NUM_TASKS = 1;
+    private static final int NUM_WORKERS = 1;
+    private static final String CONNECTOR_NAME = "connect-integration-test-sink";
+    private static final long TASK_CONSUME_TIMEOUT_MS = 10_000L;
+
+    private EmbeddedConnectCluster connect;
+
+    @Before
+    public void setup() throws Exception {
+        Map<String, String> workerProps = new HashMap<>();
+        // permit all Kafka client overrides; required for testing different consumer partition assignment strategies
+        workerProps.put(CONNECTOR_CLIENT_POLICY_CLASS_CONFIG, "All");
+
+        // setup Kafka broker properties
+        Properties brokerProps = new Properties();
+        brokerProps.put("auto.create.topics.enable", "false");
+        brokerProps.put("delete.topic.enable", "true");
+
+        // build a Connect cluster backed by Kafka and Zk
+        connect = new EmbeddedConnectCluster.Builder()
+                .name("connect-cluster")
+                .numWorkers(NUM_WORKERS)
+                .workerProps(workerProps)
+                .brokerProps(brokerProps)
+                .build();
+        connect.start();
+        connect.assertions().assertAtLeastNumWorkersAreUp(NUM_WORKERS, "Initial group of workers did not start in time.");
+    }
+
+    @After
+    public void close() {
+        // delete connector handle
+        RuntimeHandles.get().deleteConnector(CONNECTOR_NAME);
+
+        // stop all Connect, Kafka and Zk threads.
+        connect.stop();
+    }
+
+    @Test
+    public void testEagerConsumerPartitionAssignment() throws Exception {
+        final String topic1 = "topic1", topic2 = "topic2", topic3 = "topic3";
+        final TopicPartition tp1 = new TopicPartition(topic1, 0), tp2 = new TopicPartition(topic2, 0), tp3 = new TopicPartition(topic3, 0);
+        final Collection<String> topics = Arrays.asList(topic1, topic2, topic3);
+
+        Map<String, String> connectorProps = baseSinkConnectorProps(String.join(",", topics));
+        // Need an eager assignor here; round robin is as good as any
+        connectorProps.put(
+            CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+            RoundRobinAssignor.class.getName());
+        // After deleting a topic, offset commits will fail for it; reduce the timeout here so that the test doesn't take forever to proceed past that point
+        connectorProps.put(
+            CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + DEFAULT_API_TIMEOUT_MS_CONFIG,
+            "5000");
+
+        final Set<String> consumedRecordValues = new HashSet<>();
+        Consumer<SinkRecord> onPut = record -> assertTrue("Task received duplicate record from Connect", consumedRecordValues.add(Objects.toString(record.value())));
+        ConnectorHandle connector = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
+        TaskHandle task = connector.taskHandle(CONNECTOR_NAME + "-0", onPut);
+
+        connect.configureConnector(CONNECTOR_NAME, connectorProps);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS, "Connector tasks did not start in time.");
+
+        // None of the topics has been created yet; the task shouldn't be assigned any partitions
+        assertEquals(0, task.numPartitionsAssigned());
+
+        Set<String> expectedRecordValues = new HashSet<>();
+        Set<TopicPartition> expectedAssignment = new HashSet<>();
+
+        connect.kafka().createTopic(topic1, 1);
+        expectedAssignment.add(tp1);
+        connect.kafka().produce(topic1, "t1v1");
+        expectedRecordValues.add("t1v1");
+
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Task did not receive records in time");
+        assertEquals(1, task.timesAssigned(tp1));
+        assertEquals(0, task.timesRevoked(tp1));
+        assertEquals(expectedAssignment, task.assignment());
+
+        connect.kafka().createTopic(topic2, 1);
+        expectedAssignment.add(tp2);
+        connect.kafka().produce(topic2, "t2v1");
+        expectedRecordValues.add("t2v1");
+        connect.kafka().produce(topic2, "t1v2");
+        expectedRecordValues.add("t1v2");
+
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Task did not receive records in time");
+        assertEquals(2, task.timesAssigned(tp1));
+        assertEquals(1, task.timesRevoked(tp1));
+        assertEquals(1, task.timesCommitted(tp1));
+        assertEquals(1, task.timesAssigned(tp2));
+        assertEquals(0, task.timesRevoked(tp2));
+        assertEquals(expectedAssignment, task.assignment());
+
+        connect.kafka().createTopic(topic3, 1);
+        expectedAssignment.add(tp3);
+        connect.kafka().produce(topic3, "t3v1");
+        expectedRecordValues.add("t3v1");
+        connect.kafka().produce(topic2, "t2v2");
+        expectedRecordValues.add("t2v2");
+        connect.kafka().produce(topic2, "t1v3");
+        expectedRecordValues.add("t1v3");
+
+        expectedAssignment.add(tp3);
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Task did not receive records in time");
+        assertEquals(3, task.timesAssigned(tp1));
+        assertEquals(2, task.timesRevoked(tp1));
+        assertEquals(2, task.timesCommitted(tp1));
+        assertEquals(2, task.timesAssigned(tp2));
+        assertEquals(1, task.timesRevoked(tp2));
+        assertEquals(1, task.timesCommitted(tp2));
+        assertEquals(1, task.timesAssigned(tp3));
+        assertEquals(0, task.timesRevoked(tp3));
+        assertEquals(expectedAssignment, task.assignment());
+
+        connect.kafka().deleteTopic(topic1);
+        expectedAssignment.remove(tp1);
+        connect.kafka().produce(topic3, "t3v2");
+        expectedRecordValues.add("t3v2");
+        connect.kafka().produce(topic2, "t2v3");
+        expectedRecordValues.add("t2v3");
+
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues) && expectedAssignment.equals(task.assignment()),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Timed out while waiting for task to receive records and updated topic partition assignment");
+        assertEquals(3, task.timesAssigned(tp1));
+        assertEquals(3, task.timesRevoked(tp1));
+        assertEquals(3, task.timesCommitted(tp1));
+        assertEquals(3, task.timesAssigned(tp2));
+        assertEquals(2, task.timesRevoked(tp2));
+        assertEquals(2, task.timesCommitted(tp2));
+        assertEquals(2, task.timesAssigned(tp3));
+        assertEquals(1, task.timesRevoked(tp3));
+        assertEquals(1, task.timesCommitted(tp3));
+    }
+
+    @Test
+    public void testCooperativeConsumerPartitionAssignment() throws Exception {
+        final String topic1 = "topic1", topic2 = "topic2", topic3 = "topic3";
+        final TopicPartition tp1 = new TopicPartition(topic1, 0), tp2 = new TopicPartition(topic2, 0), tp3 = new TopicPartition(topic3, 0);
+        final Collection<String> topics = Arrays.asList(topic1, topic2, topic3);
+
+        Map<String, String> connectorProps = baseSinkConnectorProps(String.join(",", topics));
+        // Need an eager assignor here; round robin is as good as any
+        connectorProps.put(
+                CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+                CooperativeStickyAssignor.class.getName());
+        // After deleting a topic, offset commits will fail for it; reduce the timeout here so that the test doesn't take forever to proceed past that point
+        connectorProps.put(
+                CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + DEFAULT_API_TIMEOUT_MS_CONFIG,
+                "5000");
+
+        final Set<String> consumedRecordValues = new HashSet<>();
+        Consumer<SinkRecord> onPut = record -> assertTrue("Task received duplicate record from Connect", consumedRecordValues.add(Objects.toString(record.value())));
+        ConnectorHandle connector = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
+        TaskHandle task = connector.taskHandle(CONNECTOR_NAME + "-0", onPut);
+
+        connect.configureConnector(CONNECTOR_NAME, connectorProps);
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS, "Connector tasks did not start in time.");
+
+        // None of the topics has been created yet; the task shouldn't be assigned any partitions
+        assertEquals(0, task.numPartitionsAssigned());
+
+        Set<String> expectedRecordValues = new HashSet<>();
+        Set<TopicPartition> expectedAssignment = new HashSet<>();
+
+        connect.kafka().createTopic(topic1, 1);
+        expectedAssignment.add(tp1);
+        connect.kafka().produce(topic1, "t1v1");
+        expectedRecordValues.add("t1v1");
+
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Task did not receive records in time");
+        assertEquals(1, task.timesAssigned(tp1));
+        assertEquals(0, task.timesRevoked(tp1));
+        assertEquals(expectedAssignment, task.assignment());
+
+        connect.kafka().createTopic(topic2, 1);
+        expectedAssignment.add(tp2);
+        connect.kafka().produce(topic2, "t2v1");
+        expectedRecordValues.add("t2v1");
+        connect.kafka().produce(topic2, "t1v2");
+        expectedRecordValues.add("t1v2");
+
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Task did not receive records in time");
+        assertEquals(1, task.timesAssigned(tp1));
+        assertEquals(0, task.timesRevoked(tp1));
+        assertEquals(0, task.timesCommitted(tp1));
+        assertEquals(1, task.timesAssigned(tp2));
+        assertEquals(0, task.timesRevoked(tp2));
+        assertEquals(expectedAssignment, task.assignment());
+
+        connect.kafka().createTopic(topic3, 1);
+        expectedAssignment.add(tp3);
+        connect.kafka().produce(topic3, "t3v1");
+        expectedRecordValues.add("t3v1");
+        connect.kafka().produce(topic2, "t2v2");
+        expectedRecordValues.add("t2v2");
+        connect.kafka().produce(topic2, "t1v3");
+        expectedRecordValues.add("t1v3");
+
+        expectedAssignment.add(tp3);
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Task did not receive records in time");
+        assertEquals(1, task.timesAssigned(tp1));
+        assertEquals(0, task.timesRevoked(tp1));
+        assertEquals(0, task.timesCommitted(tp1));
+        assertEquals(1, task.timesAssigned(tp2));
+        assertEquals(0, task.timesRevoked(tp2));
+        assertEquals(0, task.timesCommitted(tp2));
+        assertEquals(1, task.timesAssigned(tp3));
+        assertEquals(0, task.timesRevoked(tp3));
+        assertEquals(expectedAssignment, task.assignment());
+
+        connect.kafka().deleteTopic(topic1);
+        expectedAssignment.remove(tp1);
+        connect.kafka().produce(topic3, "t3v2");
+        expectedRecordValues.add("t3v2");
+        connect.kafka().produce(topic2, "t2v3");
+        expectedRecordValues.add("t2v3");
+
+        waitForCondition(
+            () -> expectedRecordValues.equals(consumedRecordValues) && expectedAssignment.equals(task.assignment()),
+            TASK_CONSUME_TIMEOUT_MS,
+            "Timed out while waiting for task to receive records and updated topic partition assignment");
+        assertEquals(1, task.timesAssigned(tp1));
+        assertEquals(1, task.timesRevoked(tp1));
+        assertEquals(1, task.timesCommitted(tp1));
+        assertEquals(1, task.timesAssigned(tp2));
+        assertEquals(0, task.timesRevoked(tp2));
+        assertEquals(0, task.timesCommitted(tp2));
+        assertEquals(1, task.timesAssigned(tp3));
+        assertEquals(0, task.timesRevoked(tp3));
+        assertEquals(0, task.timesCommitted(tp3));
+    }
+
+    private Map<String, String> baseSinkConnectorProps(String topics) {
+        Map<String, String> props = new HashMap<>();
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSinkConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
+        props.put(TOPICS_CONFIG, topics);
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        return props;
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
@@ -16,15 +16,19 @@
  */
 package org.apache.kafka.connect.integration;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
@@ -37,7 +41,7 @@ public class TaskHandle {
 
     private final String taskId;
     private final ConnectorHandle connectorHandle;
-    private final AtomicInteger partitionsAssigned = new AtomicInteger(0);
+    private final ConcurrentMap<TopicPartition, PartitionHistory> partitions = new ConcurrentHashMap<>();
     private final StartAndStopCounter startAndStopCounter = new StartAndStopCounter();
     private final Consumer<SinkRecord> consumer;
 
@@ -124,19 +128,74 @@ public class TaskHandle {
     }
 
     /**
-     * Set the number of partitions assigned to this task.
+     * Adds a set of partitions to the (sink) task's assignment
      *
-     * @param numPartitions number of partitions
+     * @param partitions the newly-assigned partitions
      */
-    public void partitionsAssigned(int numPartitions) {
-        partitionsAssigned.set(numPartitions);
+    public void partitionsAssigned(Collection<TopicPartition> partitions) {
+        partitions.forEach(partition -> this.partitions.computeIfAbsent(partition, PartitionHistory::new).assigned());
     }
 
     /**
-     * @return the number of topic partitions assigned to this task.
+     * Removes a set of partitions to the (sink) task's assignment
+     *
+     * @param partitions the newly-revoked partitions
      */
-    public int partitionsAssigned() {
-        return partitionsAssigned.get();
+    public void partitionsRevoked(Collection<TopicPartition> partitions) {
+        partitions.forEach(partition -> this.partitions.computeIfAbsent(partition, PartitionHistory::new).revoked());
+    }
+
+    /**
+     * Records offset commits for a (sink) task's partitions
+     *
+     * @param partitions the committed partitions
+     */
+    public void partitionsCommitted(Collection<TopicPartition> partitions) {
+        partitions.forEach(partition -> this.partitions.computeIfAbsent(partition, PartitionHistory::new).committed());
+    }
+
+    /**
+     * @return the complete set of partitions currently assigned to this (sink) task
+     */
+    public Collection<TopicPartition> assignment() {
+        return partitions.values().stream()
+                .filter(PartitionHistory::isAssigned)
+                .map(PartitionHistory::topicPartition)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * @return the number of topic partitions assigned to this (sink) task.
+     */
+    public int numPartitionsAssigned() {
+        return assignment().size();
+    }
+
+    /**
+     * Returns the number of times the partition has been assigned to this (sink) task.
+     * @param partition the partition
+     * @return the number of times it has been assigned; may be 0 if never assigned
+     */
+    public int timesAssigned(TopicPartition partition) {
+        return partitions.computeIfAbsent(partition, PartitionHistory::new).timesAssigned();
+    }
+
+    /**
+     * Returns the number of times the partition has been revoked from this (sink) task.
+     * @param partition the partition
+     * @return the number of times it has been revoked; may be 0 if never revoked
+     */
+    public int timesRevoked(TopicPartition partition) {
+        return partitions.computeIfAbsent(partition, PartitionHistory::new).timesRevoked();
+    }
+
+    /**
+     * Returns the number of times the framework has committed offsets for this partition
+     * @param partition the partition
+     * @return the number of times it has been committed; may be 0 if never committed
+     */
+    public int timesCommitted(TopicPartition partition) {
+        return partitions.computeIfAbsent(partition, PartitionHistory::new).timesCommitted();
     }
 
     /**
@@ -252,5 +311,51 @@ public class TaskHandle {
         return "Handle{" +
                 "taskId='" + taskId + '\'' +
                 '}';
+    }
+
+    private static class PartitionHistory {
+        private final TopicPartition topicPartition;
+        private boolean assigned = false;
+        private int timesAssigned = 0;
+        private int timesRevoked = 0;
+        private int timesCommitted = 0;
+
+        public PartitionHistory(TopicPartition topicPartition) {
+            this.topicPartition = topicPartition;
+        }
+
+        public void assigned() {
+            timesAssigned++;
+            assigned = true;
+        }
+
+        public void revoked() {
+            timesRevoked++;
+            assigned = false;
+        }
+
+        public void committed() {
+            timesCommitted++;
+        }
+
+        public TopicPartition topicPartition() {
+            return topicPartition;
+        }
+
+        public boolean isAssigned() {
+            return assigned;
+        }
+
+        public int timesAssigned() {
+            return timesAssigned;
+        }
+
+        public int timesRevoked() {
+            return timesRevoked;
+        }
+
+        public int timesCommitted() {
+            return timesCommitted;
+        }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TransformationIntegrationTest.java
@@ -236,7 +236,7 @@ public class TransformationIntegrationTest {
         props.put(PREDICATES_CONFIG + ".barPredicate.type", RecordIsTombstone.class.getSimpleName());
 
         // expect only half the records to be consumed by the connector
-        connectorHandle.expectedCommits(numRecords);
+        connectorHandle.expectedCommits(numRecords / 2);
         connectorHandle.expectedRecords(numRecords / 2);
 
         // start a sink connector

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -83,7 +83,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
@@ -433,6 +435,85 @@ public class WorkerSinkTaskTest {
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("batch-size-max", 1.0);
         assertTaskMetricValue("batch-size-avg", 0.5);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testPollRedeliveryWithConsumerRebalance() throws Exception {
+        createTask(initialState);
+
+        expectInitializeTask();
+        expectTaskGetTopic(true);
+        expectPollInitialAssignment();
+
+        // If a retriable exception is thrown, we should redeliver the same batch, pausing the consumer in the meantime
+        expectConsumerPoll(1);
+        expectConversionAndTransformation(1);
+        sinkTask.put(EasyMock.anyObject());
+        EasyMock.expectLastCall().andThrow(new RetriableException("retry"));
+        // Pause
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
+        consumer.pause(INITIAL_ASSIGNMENT);
+        PowerMock.expectLastCall();
+
+        // Empty consumer poll (all partitions are paused) with rebalance; one new partition is assigned
+        EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
+            () -> {
+                rebalanceListener.getValue().onPartitionsRevoked(Collections.emptySet());
+                rebalanceListener.getValue().onPartitionsAssigned(Collections.singleton(TOPIC_PARTITION3));
+                return ConsumerRecords.empty();
+            });
+        Set<TopicPartition> newAssignment = new HashSet<>(Arrays.asList(TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3));
+        EasyMock.expect(consumer.assignment()).andReturn(newAssignment).times(3);
+        EasyMock.expect(consumer.position(TOPIC_PARTITION3)).andReturn(FIRST_OFFSET);
+        sinkTask.open(Collections.singleton(TOPIC_PARTITION3));
+        EasyMock.expectLastCall();
+        // All partitions are re-paused in order to pause any newly-assigned partitions so that redelivery efforts can continue
+        consumer.pause(newAssignment);
+        EasyMock.expectLastCall();
+        sinkTask.put(EasyMock.anyObject());
+        EasyMock.expectLastCall().andThrow(new RetriableException("retry"));
+
+        // Next delivery attempt fails again
+        expectConsumerPoll(0);
+        sinkTask.put(EasyMock.anyObject());
+        EasyMock.expectLastCall().andThrow(new RetriableException("retry"));
+
+        // Non-empty consumer poll; all initially-assigned partitions are revoked in rebalance, and new partitions are allowed to resume
+        ConsumerRecord<byte[], byte[]> newRecord = new ConsumerRecord<>(TOPIC, PARTITION3, FIRST_OFFSET, RAW_KEY, RAW_VALUE);
+        EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
+            () -> {
+                rebalanceListener.getValue().onPartitionsRevoked(INITIAL_ASSIGNMENT);
+                rebalanceListener.getValue().onPartitionsAssigned(Collections.emptyList());
+                return new ConsumerRecords<>(Collections.singletonMap(TOPIC_PARTITION3, Collections.singletonList(newRecord)));
+            });
+        newAssignment = Collections.singleton(TOPIC_PARTITION3);
+        EasyMock.expect(consumer.assignment()).andReturn(new HashSet<>(newAssignment)).times(3);
+        final Map<TopicPartition, OffsetAndMetadata> offsets = INITIAL_ASSIGNMENT.stream()
+                .collect(Collectors.toMap(Function.identity(), tp -> new OffsetAndMetadata(FIRST_OFFSET)));
+        sinkTask.preCommit(offsets);
+        EasyMock.expectLastCall().andReturn(offsets);
+        sinkTask.close(INITIAL_ASSIGNMENT);
+        EasyMock.expectLastCall();
+        // All partitions are resumed, as all previously paused-for-redelivery partitions were revoked
+        newAssignment.forEach(tp -> {
+            consumer.resume(Collections.singleton(tp));
+            EasyMock.expectLastCall();
+        });
+        expectConversionAndTransformation(1);
+        sinkTask.put(EasyMock.anyObject());
+        EasyMock.expectLastCall();
+
+        PowerMock.replayAll();
+
+        workerTask.initialize(TASK_CONFIG);
+        workerTask.initializeAndStart();
+        workerTask.iteration();
+        workerTask.iteration();
+        workerTask.iteration();
+        workerTask.iteration();
+        workerTask.iteration();
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -639,7 +639,7 @@ public class WorkerSinkTaskTest {
                 rebalanceListener.getValue().onPartitionsAssigned(Collections.singleton(TOPIC_PARTITION));
                 return ConsumerRecords.empty();
             });
-        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(3);
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(4);
         sinkTask.close(Collections.singleton(TOPIC_PARTITION3));
         EasyMock.expectLastCall();
         EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(FIRST_OFFSET);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -117,6 +117,9 @@ public class WorkerSinkTaskTest {
     private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition(TOPIC, PARTITION2);
     private static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(TOPIC, PARTITION3);
 
+    private static final Set<TopicPartition> INITIAL_ASSIGNMENT =
+        new HashSet<>(Arrays.asList(TOPIC_PARTITION, TOPIC_PARTITION2));
+
     private static final Map<String, String> TASK_PROPS = new HashMap<>();
     static {
         TASK_PROPS.put(SinkConnector.TOPICS_CONFIG, TOPIC);
@@ -199,9 +202,8 @@ public class WorkerSinkTaskTest {
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
 
-        Set<TopicPartition> partitions = new HashSet<>(asList(TOPIC_PARTITION, TOPIC_PARTITION2));
-        EasyMock.expect(consumer.assignment()).andReturn(partitions);
-        consumer.pause(partitions);
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
+        consumer.pause(INITIAL_ASSIGNMENT);
         PowerMock.expectLastCall();
 
         PowerMock.replayAll();
@@ -233,14 +235,12 @@ public class WorkerSinkTaskTest {
         sinkTask.put(EasyMock.anyObject());
         EasyMock.expectLastCall();
 
-        Set<TopicPartition> partitions = new HashSet<>(asList(TOPIC_PARTITION, TOPIC_PARTITION2));
-
         // Pause
         statusListener.onPause(taskId);
         EasyMock.expectLastCall();
         expectConsumerWakeup();
-        EasyMock.expect(consumer.assignment()).andReturn(partitions);
-        consumer.pause(partitions);
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
+        consumer.pause(INITIAL_ASSIGNMENT);
         PowerMock.expectLastCall();
 
         // Offset commit as requested when pausing; No records returned by consumer.poll()
@@ -254,11 +254,11 @@ public class WorkerSinkTaskTest {
         statusListener.onResume(taskId);
         EasyMock.expectLastCall();
         expectConsumerWakeup();
-        EasyMock.expect(consumer.assignment()).andReturn(new HashSet<>(asList(TOPIC_PARTITION, TOPIC_PARTITION2)));
-        consumer.resume(singleton(TOPIC_PARTITION));
-        PowerMock.expectLastCall();
-        consumer.resume(singleton(TOPIC_PARTITION2));
-        PowerMock.expectLastCall();
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
+        INITIAL_ASSIGNMENT.forEach(tp -> {
+            consumer.resume(Collections.singleton(tp));
+            PowerMock.expectLastCall();
+        });
 
         expectConsumerPoll(1);
         expectConversionAndTransformation(1);
@@ -338,11 +338,12 @@ public class WorkerSinkTaskTest {
         sinkTask.stop();
         PowerMock.expectLastCall();
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
         // WorkerSinkTask::close
         consumer.close();
         PowerMock.expectLastCall().andAnswer(() -> {
             rebalanceListener.getValue().onPartitionsRevoked(
-                asList(TOPIC_PARTITION, TOPIC_PARTITION2)
+                INITIAL_ASSIGNMENT
             );
             return null;
         });
@@ -377,9 +378,8 @@ public class WorkerSinkTaskTest {
         sinkTask.put(EasyMock.capture(records));
         EasyMock.expectLastCall().andThrow(new RetriableException("retry"));
         // Pause
-        HashSet<TopicPartition> partitions = new HashSet<>(asList(TOPIC_PARTITION, TOPIC_PARTITION2));
-        EasyMock.expect(consumer.assignment()).andReturn(partitions);
-        consumer.pause(partitions);
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
+        consumer.pause(INITIAL_ASSIGNMENT);
         PowerMock.expectLastCall();
 
         // Retry delivery should succeed
@@ -387,11 +387,11 @@ public class WorkerSinkTaskTest {
         sinkTask.put(EasyMock.capture(records));
         EasyMock.expectLastCall();
         // And unpause
-        EasyMock.expect(consumer.assignment()).andReturn(partitions);
-        consumer.resume(singleton(TOPIC_PARTITION));
-        PowerMock.expectLastCall();
-        consumer.resume(singleton(TOPIC_PARTITION2));
-        PowerMock.expectLastCall();
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
+        INITIAL_ASSIGNMENT.forEach(tp -> {
+            consumer.resume(singleton(tp));
+            PowerMock.expectLastCall();
+        });
 
         PowerMock.replayAll();
 
@@ -433,6 +433,32 @@ public class WorkerSinkTaskTest {
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("batch-size-max", 1.0);
         assertTaskMetricValue("batch-size-avg", 0.5);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testErrorInRebalancePartitionLoss() throws Exception {
+        RuntimeException exception = new RuntimeException("Revocation error");
+
+        createTask(initialState);
+
+        expectInitializeTask();
+        expectTaskGetTopic(true);
+        expectPollInitialAssignment();
+        expectRebalanceLossError(exception);
+
+        PowerMock.replayAll();
+
+        workerTask.initialize(TASK_CONFIG);
+        workerTask.initializeAndStart();
+        workerTask.iteration();
+        try {
+            workerTask.iteration();
+            fail("Poll should have raised the rebalance exception");
+        } catch (RuntimeException e) {
+            assertEquals(exception, e);
+        }
 
         PowerMock.verifyAll();
     }
@@ -490,6 +516,74 @@ public class WorkerSinkTaskTest {
     }
 
     @Test
+    public void testPartialRevocationAndAssignment() throws Exception {
+        createTask(initialState);
+
+        expectInitializeTask();
+        expectTaskGetTopic(true);
+        expectPollInitialAssignment();
+
+        EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
+            () -> {
+                rebalanceListener.getValue().onPartitionsRevoked(Collections.singleton(TOPIC_PARTITION));
+                rebalanceListener.getValue().onPartitionsAssigned(Collections.emptySet());
+                return ConsumerRecords.empty();
+            });
+        EasyMock.expect(consumer.assignment()).andReturn(Collections.singleton(TOPIC_PARTITION)).times(2);
+        final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET));
+        sinkTask.preCommit(offsets);
+        EasyMock.expectLastCall().andReturn(offsets);
+        sinkTask.close(Collections.singleton(TOPIC_PARTITION));
+        EasyMock.expectLastCall();
+        sinkTask.put(Collections.emptyList());
+        EasyMock.expectLastCall();
+
+        EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
+            () -> {
+                rebalanceListener.getValue().onPartitionsRevoked(Collections.emptySet());
+                rebalanceListener.getValue().onPartitionsAssigned(Collections.singleton(TOPIC_PARTITION3));
+                return ConsumerRecords.empty();
+            });
+        EasyMock.expect(consumer.assignment()).andReturn(new HashSet<>(Arrays.asList(TOPIC_PARTITION2, TOPIC_PARTITION3))).times(2);
+        EasyMock.expect(consumer.position(TOPIC_PARTITION3)).andReturn(FIRST_OFFSET);
+        sinkTask.open(Collections.singleton(TOPIC_PARTITION3));
+        EasyMock.expectLastCall();
+        sinkTask.put(Collections.emptyList());
+        EasyMock.expectLastCall();
+
+        EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
+            () -> {
+                rebalanceListener.getValue().onPartitionsLost(Collections.singleton(TOPIC_PARTITION3));
+                rebalanceListener.getValue().onPartitionsAssigned(Collections.singleton(TOPIC_PARTITION));
+                return ConsumerRecords.empty();
+            });
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(3);
+        sinkTask.close(Collections.singleton(TOPIC_PARTITION3));
+        EasyMock.expectLastCall();
+        EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(FIRST_OFFSET);
+        sinkTask.open(Collections.singleton(TOPIC_PARTITION));
+        EasyMock.expectLastCall();
+        sinkTask.put(Collections.emptyList());
+        EasyMock.expectLastCall();
+
+        PowerMock.replayAll();
+
+        workerTask.initialize(TASK_CONFIG);
+        workerTask.initializeAndStart();
+        // First iteration--first call to poll, first consumer assignment
+        workerTask.iteration();
+        // Second iteration--second call to poll, partial consumer revocation
+        workerTask.iteration();
+        // Third iteration--third call to poll, partial consumer assignment
+        workerTask.iteration();
+        // Fourth iteration--fourth call to poll, one partition lost; can't commit offsets for it, one new partition assigned
+        workerTask.iteration();
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
     public void testWakeupInCommitSyncCausesRetry() throws Exception {
         createTask(initialState);
 
@@ -501,8 +595,6 @@ public class WorkerSinkTaskTest {
         expectConversionAndTransformation(1);
         sinkTask.put(EasyMock.anyObject());
         EasyMock.expectLastCall();
-
-        final List<TopicPartition> partitions = asList(TOPIC_PARTITION, TOPIC_PARTITION2);
 
         final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         offsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 1));
@@ -518,29 +610,26 @@ public class WorkerSinkTaskTest {
         consumer.commitSync(EasyMock.<Map<TopicPartition, OffsetAndMetadata>>anyObject());
         EasyMock.expectLastCall();
 
-        sinkTask.close(new HashSet<>(partitions));
+        sinkTask.close(INITIAL_ASSIGNMENT);
         EasyMock.expectLastCall();
 
-        EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(FIRST_OFFSET);
-        EasyMock.expect(consumer.position(TOPIC_PARTITION2)).andReturn(FIRST_OFFSET);
+        INITIAL_ASSIGNMENT.forEach(tp -> EasyMock.expect(consumer.position(tp)).andReturn(FIRST_OFFSET));
 
-        sinkTask.open(partitions);
+        sinkTask.open(INITIAL_ASSIGNMENT);
         EasyMock.expectLastCall();
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(5);
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
             () -> {
-                rebalanceListener.getValue().onPartitionsRevoked(partitions);
-                rebalanceListener.getValue().onPartitionsAssigned(partitions);
+                rebalanceListener.getValue().onPartitionsRevoked(INITIAL_ASSIGNMENT);
+                rebalanceListener.getValue().onPartitionsAssigned(INITIAL_ASSIGNMENT);
                 return ConsumerRecords.empty();
             });
 
-        EasyMock.expect(consumer.assignment()).andReturn(new HashSet<>(partitions));
-
-        consumer.resume(Collections.singleton(TOPIC_PARTITION));
-        EasyMock.expectLastCall();
-
-        consumer.resume(Collections.singleton(TOPIC_PARTITION2));
-        EasyMock.expectLastCall();
+        INITIAL_ASSIGNMENT.forEach(tp -> {
+            consumer.resume(Collections.singleton(tp));
+            EasyMock.expectLastCall();
+        });
 
         statusListener.onResume(taskId);
         EasyMock.expectLastCall();
@@ -604,6 +693,8 @@ public class WorkerSinkTaskTest {
         sinkTask.put(EasyMock.eq(Collections.emptyList()));
         EasyMock.expectLastCall();
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(1);
+
         final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
         offsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 1));
         offsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
@@ -649,6 +740,8 @@ public class WorkerSinkTaskTest {
         offsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
         sinkTask.preCommit(offsets);
         EasyMock.expectLastCall().andReturn(offsets);
+
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
 
         final Capture<OffsetCommitCallback> callback = EasyMock.newCapture();
         consumer.commitAsync(EasyMock.eq(offsets), EasyMock.capture(callback));
@@ -770,7 +863,7 @@ public class WorkerSinkTaskTest {
         sinkTask.preCommit(workerCurrentOffsets);
         EasyMock.expectLastCall().andReturn(taskOffsets);
         // Expect extra invalid topic partition to be filtered, which causes the consumer assignment to be logged
-        EasyMock.expect(consumer.assignment()).andReturn(workerCurrentOffsets.keySet());
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
         final Capture<OffsetCommitCallback> callback = EasyMock.newCapture();
         consumer.commitAsync(EasyMock.eq(committableOffsets), EasyMock.capture(callback));
         EasyMock.expectLastCall().andAnswer(() -> {
@@ -823,6 +916,8 @@ public class WorkerSinkTaskTest {
         workerCurrentOffsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 1));
         workerCurrentOffsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
+
         // iter 3
         sinkTask.preCommit(workerCurrentOffsets);
         EasyMock.expectLastCall().andReturn(workerStartingOffsets);
@@ -873,6 +968,8 @@ public class WorkerSinkTaskTest {
         final Map<TopicPartition, OffsetAndMetadata> workerCurrentOffsets = new HashMap<>();
         workerCurrentOffsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 1));
         workerCurrentOffsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
+
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
 
         // iter 3 - note that we return the current offset to indicate they should be committed
         sinkTask.preCommit(workerCurrentOffsets);
@@ -947,6 +1044,8 @@ public class WorkerSinkTaskTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
 
+        expectPollInitialAssignment();
+
         // Put one message through the task to get some offsets to commit
         expectConsumerPoll(1);
         expectConversionAndTransformation(1);
@@ -989,6 +1088,8 @@ public class WorkerSinkTaskTest {
         createTask(initialState);
         expectInitializeTask();
         expectTaskGetTopic(true);
+
+        expectPollInitialAssignment();
 
         // Put one message through the task to get some offsets to commit
         expectConsumerPoll(1);
@@ -1052,7 +1153,7 @@ public class WorkerSinkTaskTest {
         workerCurrentOffsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 1));
         workerCurrentOffsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
 
-        final List<TopicPartition> originalPartitions = asList(TOPIC_PARTITION, TOPIC_PARTITION2);
+        final List<TopicPartition> originalPartitions = new ArrayList<>(INITIAL_ASSIGNMENT);
         final List<TopicPartition> rebalancedPartitions = asList(TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3);
         final Map<TopicPartition, OffsetAndMetadata> rebalanceOffsets = new HashMap<>();
         rebalanceOffsets.put(TOPIC_PARTITION, workerCurrentOffsets.get(TOPIC_PARTITION));
@@ -1063,6 +1164,8 @@ public class WorkerSinkTaskTest {
         postRebalanceCurrentOffsets.put(TOPIC_PARTITION, new OffsetAndMetadata(FIRST_OFFSET + 3));
         postRebalanceCurrentOffsets.put(TOPIC_PARTITION2, new OffsetAndMetadata(FIRST_OFFSET));
         postRebalanceCurrentOffsets.put(TOPIC_PARTITION3, new OffsetAndMetadata(FIRST_OFFSET + 2));
+
+        EasyMock.expect(consumer.assignment()).andReturn(new HashSet<>(originalPartitions)).times(2);
 
         // iter 3 - note that we return the current offset to indicate they should be committed
         sinkTask.preCommit(workerCurrentOffsets);
@@ -1126,7 +1229,7 @@ public class WorkerSinkTaskTest {
         EasyMock.expectLastCall().andReturn(workerCurrentOffsets);
         sinkTask.put(EasyMock.anyObject());
         EasyMock.expectLastCall();
-        sinkTask.close(workerCurrentOffsets.keySet());
+        sinkTask.close(new ArrayList<>(workerCurrentOffsets.keySet()));
         EasyMock.expectLastCall();
         consumer.commitSync(workerCurrentOffsets);
         EasyMock.expectLastCall();
@@ -1138,9 +1241,10 @@ public class WorkerSinkTaskTest {
         EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(offsetTp1);
         EasyMock.expect(consumer.position(TOPIC_PARTITION2)).andReturn(offsetTp2);
         EasyMock.expect(consumer.position(TOPIC_PARTITION3)).andReturn(offsetTp3);
+        EasyMock.expect(consumer.assignment()).andReturn(new HashSet<>(rebalancedPartitions)).times(6);
 
         // onPartitionsAssigned - step 2
-        sinkTask.open(rebalancedPartitions);
+        sinkTask.open(EasyMock.eq(rebalancedPartitions));
         EasyMock.expectLastCall();
 
         // onPartitionsAssigned - step 3 rewind
@@ -1259,6 +1363,8 @@ public class WorkerSinkTaskTest {
         sinkTask.preCommit(offsets);
         EasyMock.expectLastCall().andReturn(offsets);
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
+
         final Capture<OffsetCommitCallback> callback = EasyMock.newCapture();
         consumer.commitAsync(EasyMock.eq(offsets), EasyMock.capture(callback));
         EasyMock.expectLastCall().andAnswer(() -> {
@@ -1371,9 +1477,8 @@ public class WorkerSinkTaskTest {
 
         expectPollInitialAssignment();
 
-        Set<TopicPartition> partitions = new HashSet<>(asList(TOPIC_PARTITION, TOPIC_PARTITION2));
-        EasyMock.expect(consumer.assignment()).andReturn(partitions);
-        consumer.pause(partitions);
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT);
+        consumer.pause(INITIAL_ASSIGNMENT);
         PowerMock.expectLastCall();
 
         PowerMock.replayAll();
@@ -1538,10 +1643,19 @@ public class WorkerSinkTaskTest {
         PowerMock.expectLastCall();
     }
 
-    private void expectRebalanceRevocationError(RuntimeException e) {
-        final List<TopicPartition> partitions = asList(TOPIC_PARTITION, TOPIC_PARTITION2);
+    private void expectRebalanceLossError(RuntimeException e) {
+        sinkTask.close(new HashSet<>(INITIAL_ASSIGNMENT));
+        EasyMock.expectLastCall().andThrow(e);
 
-        sinkTask.close(new HashSet<>(partitions));
+        EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
+            () -> {
+                rebalanceListener.getValue().onPartitionsLost(INITIAL_ASSIGNMENT);
+                return ConsumerRecords.empty();
+            });
+    }
+
+    private void expectRebalanceRevocationError(RuntimeException e) {
+        sinkTask.close(new HashSet<>(INITIAL_ASSIGNMENT));
         EasyMock.expectLastCall().andThrow(e);
 
         sinkTask.preCommit(EasyMock.anyObject());
@@ -1549,15 +1663,13 @@ public class WorkerSinkTaskTest {
 
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
             () -> {
-                rebalanceListener.getValue().onPartitionsRevoked(partitions);
+                rebalanceListener.getValue().onPartitionsRevoked(INITIAL_ASSIGNMENT);
                 return ConsumerRecords.empty();
             });
     }
 
     private void expectRebalanceAssignmentError(RuntimeException e) {
-        final List<TopicPartition> partitions = asList(TOPIC_PARTITION, TOPIC_PARTITION2);
-
-        sinkTask.close(new HashSet<>(partitions));
+        sinkTask.close(INITIAL_ASSIGNMENT);
         EasyMock.expectLastCall();
 
         sinkTask.preCommit(EasyMock.anyObject());
@@ -1566,29 +1678,29 @@ public class WorkerSinkTaskTest {
         EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(FIRST_OFFSET);
         EasyMock.expect(consumer.position(TOPIC_PARTITION2)).andReturn(FIRST_OFFSET);
 
-        sinkTask.open(partitions);
+        sinkTask.open(INITIAL_ASSIGNMENT);
         EasyMock.expectLastCall().andThrow(e);
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(3);
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(
             () -> {
-                rebalanceListener.getValue().onPartitionsRevoked(partitions);
-                rebalanceListener.getValue().onPartitionsAssigned(partitions);
+                rebalanceListener.getValue().onPartitionsRevoked(INITIAL_ASSIGNMENT);
+                rebalanceListener.getValue().onPartitionsAssigned(INITIAL_ASSIGNMENT);
                 return ConsumerRecords.empty();
             });
     }
 
     private void expectPollInitialAssignment() {
-        final List<TopicPartition> partitions = asList(TOPIC_PARTITION, TOPIC_PARTITION2);
-
-        sinkTask.open(partitions);
+        sinkTask.open(INITIAL_ASSIGNMENT);
         EasyMock.expectLastCall();
 
+        EasyMock.expect(consumer.assignment()).andReturn(INITIAL_ASSIGNMENT).times(2);
+
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(() -> {
-            rebalanceListener.getValue().onPartitionsAssigned(partitions);
+            rebalanceListener.getValue().onPartitionsAssigned(INITIAL_ASSIGNMENT);
             return ConsumerRecords.empty();
         });
-        EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(FIRST_OFFSET);
-        EasyMock.expect(consumer.position(TOPIC_PARTITION2)).andReturn(FIRST_OFFSET);
+        INITIAL_ASSIGNMENT.forEach(tp -> EasyMock.expect(consumer.position(tp)).andReturn(FIRST_OFFSET));
 
         sinkTask.put(Collections.emptyList());
         EasyMock.expectLastCall();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -65,6 +65,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -92,6 +93,8 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
     private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition(TOPIC, PARTITION2);
     private static final TopicPartition TOPIC_PARTITION3 = new TopicPartition(TOPIC, PARTITION3);
     private static final TopicPartition UNASSIGNED_TOPIC_PARTITION = new TopicPartition(TOPIC, 200);
+    private static final Set<TopicPartition> INITIAL_ASSIGNMENT = new HashSet<>(Arrays.asList(
+            TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3));
 
     private static final Map<String, String> TASK_PROPS = new HashMap<>();
     private static final long TIMESTAMP = 42L;
@@ -202,6 +205,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
+        expectConsumerAssignment(INITIAL_ASSIGNMENT).times(2);
 
         // Make each poll() take the offset commit interval
         Capture<Collection<SinkRecord>> capturedRecords
@@ -236,6 +240,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
+        expectConsumerAssignment(INITIAL_ASSIGNMENT);
 
         Capture<Collection<SinkRecord>> capturedRecords = expectPolls(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_DEFAULT);
         expectOffsetCommit(1L, new RuntimeException(), null, 0, true);
@@ -276,6 +281,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
+        expectConsumerAssignment(INITIAL_ASSIGNMENT).times(3);
         Capture<Collection<SinkRecord>> capturedRecords = expectPolls(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_DEFAULT);
         expectOffsetCommit(1L, null, null, 0, true);
         expectOffsetCommit(2L, new RuntimeException(), null, 0, true);
@@ -315,6 +321,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
+        expectConsumerAssignment(INITIAL_ASSIGNMENT).times(2);
 
         Capture<Collection<SinkRecord>> capturedRecords
                 = expectPolls(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_DEFAULT);
@@ -347,6 +354,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
+        expectConsumerAssignment(INITIAL_ASSIGNMENT).times(2);
 
         // Cut down amount of time to pass in each poll so we trigger exactly 1 offset commit
         Capture<Collection<SinkRecord>> capturedRecords
@@ -483,6 +491,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         expectInitializeTask();
         expectTaskGetTopic(true);
         expectPollInitialAssignment();
+        expectConsumerAssignment(INITIAL_ASSIGNMENT).times(2);
 
         expectRebalanceDuringPoll().andAnswer(() -> {
             Map<TopicPartition, Long> offsets = sinkTaskContext.getValue().offsets();
@@ -515,13 +524,13 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
     }
 
     private void expectPollInitialAssignment() throws Exception {
-        final List<TopicPartition> partitions = Arrays.asList(TOPIC_PARTITION, TOPIC_PARTITION2, TOPIC_PARTITION3);
+        expectConsumerAssignment(INITIAL_ASSIGNMENT).times(2);
 
-        sinkTask.open(partitions);
+        sinkTask.open(INITIAL_ASSIGNMENT);
         EasyMock.expectLastCall();
 
         EasyMock.expect(consumer.poll(Duration.ofMillis(EasyMock.anyLong()))).andAnswer(() -> {
-            rebalanceListener.getValue().onPartitionsAssigned(partitions);
+            rebalanceListener.getValue().onPartitionsAssigned(INITIAL_ASSIGNMENT);
             return ConsumerRecords.empty();
         });
         EasyMock.expect(consumer.position(TOPIC_PARTITION)).andReturn(FIRST_OFFSET);
@@ -530,6 +539,10 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
 
         sinkTask.put(Collections.emptyList());
         EasyMock.expectLastCall();
+    }
+
+    private IExpectationSetters<Set<TopicPartition>> expectConsumerAssignment(Set<TopicPartition> assignment) {
+        return EasyMock.expect(consumer.assignment()).andReturn(assignment);
     }
 
     private void expectStopTask() throws Exception {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporterTest.java
@@ -30,6 +30,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertFalse;
@@ -71,7 +72,7 @@ public class WorkerErrantRecordReporterTest {
         for (int i = 0; i < 4; i++) {
             TopicPartition topicPartition = new TopicPartition("topic", i);
             topicPartitions.add(topicPartition);
-            reporter.futures.put(topicPartition, CompletableFuture.completedFuture(null));
+            reporter.futures.put(topicPartition, Collections.singletonList(CompletableFuture.completedFuture(null)));
         }
         assertFalse(reporter.futures.isEmpty());
         reporter.awaitFutures(topicPartitions);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/WorkerErrantRecordReporterTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.connect.runtime.errors;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
@@ -27,6 +28,8 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertFalse;
@@ -62,13 +65,16 @@ public class WorkerErrantRecordReporterTest {
     }
 
     @Test
-    public void testGetAllFutures() {
+    public void testGetFutures() {
+        Collection<TopicPartition> topicPartitions = new ArrayList<>();
         assertTrue(reporter.futures.isEmpty());
         for (int i = 0; i < 4; i++) {
-            reporter.futures.add(CompletableFuture.completedFuture(null));
+            TopicPartition topicPartition = new TopicPartition("topic", i);
+            topicPartitions.add(topicPartition);
+            reporter.futures.put(topicPartition, CompletableFuture.completedFuture(null));
         }
         assertFalse(reporter.futures.isEmpty());
-        reporter.awaitAllFutures();
+        reporter.awaitFutures(topicPartitions);
         assertTrue(reporter.futures.isEmpty());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedKafkaCluster.java
@@ -366,6 +366,19 @@ public class EmbeddedKafkaCluster {
         }
     }
 
+    /**
+     * Delete a Kafka topic.
+     *
+     * @param topic the topic to delete; may not be null
+     */
+    public void deleteTopic(String topic) {
+        try (final Admin adminClient = createAdminClient()) {
+            adminClient.deleteTopics(Collections.singleton(topic)).all().get();
+        } catch (final InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void produce(String topic, String value) {
         produce(topic, null, null, value);
     }


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-12487)

Currently, the `WorkerSinkTask`'s consumer rebalance listener (and related logic) is hardcoded to assume eager rebalancing, which means that all partitions are revoked any time a rebalance occurs and then the set of partitions included in `onPartitionsAssigned` is assumed to be the complete assignment for the task. Not only does this cause failures when the cooperative consumer protocol is used, it fails to take advantage of the benefits provided by that protocol.

These changes alter framework logic to not only not break when the cooperative consumer protocol is used for a sink connector, but to reap the benefits of it as well, by not revoking partitions unnecessarily from tasks just to reopen them immediately after the rebalance has completed.

This change will be necessary in order to support [KIP-726](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=177048248), which currently proposes that the default consumer partition assignor be changed to the `CooperativeStickyAssignor`.

Two integration tests are added to verify sink task behavior with both eager and cooperative consumer protocols, and new and existing unit tests are adopted as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
