### PR TITLE
MINOR: clean up some replication code

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
@@ -311,8 +311,16 @@ public class BrokersToIsrs {
         return new PartitionsOnReplicaIterator(topicMap, leadersOnly);
     }
 
-    PartitionsOnReplicaIterator noLeaderIterator() {
+    PartitionsOnReplicaIterator partitionsWithNoLeader() {
         return iterator(NO_LEADER, true);
+    }
+
+    PartitionsOnReplicaIterator partitionsLedByBroker(int brokerId) {
+        return iterator(brokerId, true);
+    }
+
+    PartitionsOnReplicaIterator partitionsWithBrokerInIsr(int brokerId) {
+        return iterator(brokerId, false);
     }
 
     boolean hasLeaderships(int brokerId) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ConfigurationControlManager.java
@@ -374,6 +374,10 @@ public class ConfigurationControlManager {
         configData.remove(new ConfigResource(Type.TOPIC, name));
     }
 
+    boolean uncleanLeaderElectionEnabledForTopic(String name) {
+        return false; // TODO: support configuring unclean leader election.
+    }
+
     class ConfigurationControlIterator implements Iterator<List<ApiMessageAndVersion>> {
         private final long epoch;
         private final Iterator<Entry<ConfigResource, TimelineHashMap<String, String>>> iterator;

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -825,7 +825,7 @@ public class ReplicationControlManager {
                 "No such partition as " + topic + "-" + partitionId);
         }
         int newLeader = bestLeader(partitionInfo.replicas, partitionInfo.isr, uncleanOk,
-                                   r -> clusterControl.unfenced(r));
+            r -> clusterControl.unfenced(r));
         if (newLeader == NO_LEADER) {
             // If we can't find any leader for the partition, return an error.
             return new ApiError(Errors.LEADER_NOT_AVAILABLE,

--- a/metadata/src/test/java/org/apache/kafka/controller/BrokersToIsrsTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/BrokersToIsrsTest.java
@@ -101,9 +101,9 @@ public class BrokersToIsrsTest {
         assertEquals(toSet(new TopicIdPartition(UUIDS[0], 2)),
             toSet(brokersToIsrs.iterator(3, true)));
         assertEquals(toSet(), toSet(brokersToIsrs.iterator(2, true)));
-        assertEquals(toSet(), toSet(brokersToIsrs.noLeaderIterator()));
+        assertEquals(toSet(), toSet(brokersToIsrs.partitionsWithNoLeader()));
         brokersToIsrs.update(UUIDS[0], 2, new int[]{1, 2, 3}, new int[]{1, 2, 3}, 3, -1);
         assertEquals(toSet(new TopicIdPartition(UUIDS[0], 2)),
-            toSet(brokersToIsrs.noLeaderIterator()));
+            toSet(brokersToIsrs.partitionsWithNoLeader()));
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -185,7 +185,7 @@ public class QuorumControllerTest {
                 topicPartitionFuture = active.appendReadEvent(
                     "debugGetPartition", () -> {
                         Iterator<TopicIdPartition> iterator = active.
-                            replicationControl().brokersToIsrs().noLeaderIterator();
+                            replicationControl().brokersToIsrs().partitionsWithNoLeader();
                         assertTrue(iterator.hasNext());
                         return iterator.next();
                     });

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -657,7 +657,7 @@ public class ReplicationControlManagerTest {
         assertTrue(ReplicationControlManager.electionWasClean(1, new int[] {1, 2}));
         assertFalse(ReplicationControlManager.electionWasClean(1, new int[] {0, 2}));
         assertFalse(ReplicationControlManager.electionWasClean(1, new int[] {}));
-        assertTrue(ReplicationControlManager.electionWasClean(3, new int[] {1,2,3,4,5,6}));
+        assertTrue(ReplicationControlManager.electionWasClean(3, new int[] {1, 2, 3, 4, 5, 6}));
     }
 
     @Test


### PR DESCRIPTION
Centralize leader and ISR changes in generateLeaderAndIsrUpdates.
Consolidate handleNodeDeactivated and handleNodeActivated into this
function.

Rename BrokersToIsrs#noLeaderIterator to BrokersToIsrs#partitionsWithNoLeader.
Create BrokersToIsrs#partitionsLedByBroker, BrokersToIsrs#partitionsWithBrokerInIsr

In ReplicationControlManagerTest, createTestTopic should be a member
function of ReplicationControlTestContext.  It should invoke
ReplicationControlTestContext#replay so that records are applied to all
parts of the test context.