### PR TITLE
KAFKA-8897: Upgrade RocksDB to 6.19.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -103,7 +103,7 @@ versions += [
   netty: "4.1.62.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
-  rocksDB: "6.16.4",
+  rocksDB: "6.19.3",
   scalaCollectionCompat: "2.3.0",
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.1",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -103,7 +103,7 @@ versions += [
   netty: "4.1.62.Final",
   powermock: "2.0.9",
   reflections: "0.9.12",
-  rocksDB: "5.18.4",
+  rocksDB: "6.16.4",
   scalaCollectionCompat: "2.3.0",
   scalafmt: "1.5.1",
   scalaJava8Compat : "0.9.1",

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -374,7 +374,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
 
     @Override
     public void close() {
-        if (globalStores.isEmpty()) {
+        if (globalStateStores.isEmpty() && globalStores.isEmpty()) {
             return;
         }
         final StringBuilder closeFailed = new StringBuilder();
@@ -396,6 +396,21 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                 log.info("Skipping to close non-initialized store {}", entry.getKey());
             }
         }
+        for (final StateStore store : globalStateStores) {
+            if (store.isOpen()) {
+                try {
+                    store.close();
+                } catch (final RuntimeException e) {
+                    log.error("Failed to close global state store {}", store.name(), e);
+                    closeFailed.append("Failed to close global state store:")
+                            .append(store.name())
+                            .append(". Reason: ")
+                            .append(e)
+                            .append("\n");
+                }
+            }
+        }
+
         if (closeFailed.length() > 0) {
             throw new ProcessorStateException("Exceptions caught during close of 1 or more global state globalStores\n" + closeFailed);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStore.java
@@ -44,16 +44,16 @@ public class ChangeLoggingKeyValueBytesStore
     @Override
     public void init(final ProcessorContext context,
                      final StateStore root) {
-        super.init(context, root);
         this.context = asInternalProcessorContext(context);
+        super.init(context, root);
         maybeSetEvictionListener();
     }
 
     @Override
     public void init(final StateStoreContext context,
                      final StateStore root) {
-        super.init(context, root);
         this.context = asInternalProcessorContext(context);
+        super.init(context, root);
         maybeSetEvictionListener();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSessionBytesStore.java
@@ -44,14 +44,14 @@ class ChangeLoggingSessionBytesStore
     @Deprecated
     @Override
     public void init(final ProcessorContext context, final StateStore root) {
-        super.init(context, root);
         this.context = asInternalProcessorContext(context);
+        super.init(context, root);
     }
 
     @Override
     public void init(final StateStoreContext context, final StateStore root) {
-        super.init(context, root);
         this.context = asInternalProcessorContext(context);
+        super.init(context, root);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -133,7 +133,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]>, BatchWritingS
         tableConfig.setBlockSize(BLOCK_SIZE);
 
         filter = new BloomFilter();
-        tableConfig.setFilter(filter);
+        tableConfig.setFilterPolicy(filter);
 
         userSpecifiedOptions.optimizeFiltersForHits();
         userSpecifiedOptions.setTableFormatConfig(tableConfig);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBTimestampedStore.java
@@ -75,7 +75,7 @@ public class RocksDBTimestampedStore extends RocksDBStore implements Timestamped
             db = RocksDB.open(dbOptions, dbDir.getAbsolutePath(), columnFamilyDescriptors, columnFamilies);
             setDbAccessor(columnFamilies.get(0), columnFamilies.get(1));
         } catch (final RocksDBException e) {
-            if ("Column family not found: : keyValueWithTimestamp".equals(e.getMessage())) {
+            if ("Column family not found: keyValueWithTimestamp".equals(e.getMessage())) {
                 try {
                     db = RocksDB.open(dbOptions, dbDir.getAbsolutePath(), columnFamilyDescriptors.subList(0, 1), columnFamilies);
                     columnFamilies.add(db.createColumnFamily(columnFamilyDescriptors.get(1)));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -242,6 +242,7 @@ public class KStreamKTableJoinTest {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
 
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamKTableJoin.class)) {
+            driver.close();
             driver = new TopologyTestDriver(builder.build(), props);
             final TestInputTopic<Integer, String> inputTopic =
                 driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());
@@ -272,7 +273,7 @@ public class KStreamKTableJoinTest {
 
     private void shouldLogAndMeterWhenSkippingNullLeftValue(final String builtInMetricsVersion) {
         props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_0100_TO_24);
-
+        driver.close();
         driver = new TopologyTestDriver(builder.build(), props);
         final TestInputTopic<Integer, String> inputTopic =
             driver.createInputTopic(streamTopic, new IntegerSerializer(), new StringSerializer());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -386,7 +386,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     private void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final String builtInMetricsVersion) {
-        setup(builtInMetricsVersion, true);
+        setup(builtInMetricsVersion, false);
         context.setRecordContext(
             new ProcessorRecordContext(-1, -2, -3, "topic", null)
         );

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -34,7 +34,6 @@ import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.To;
-import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.ToInternal;
@@ -52,7 +51,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -91,22 +89,23 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private final Processor<String, String> processor = sessionAggregator.get();
     private SessionStore<String, Long> sessionStore;
     private InternalMockProcessorContext context;
-    private Metrics metrics;
+    private final Metrics metrics = new Metrics();
 
     @Before
-    public void initializeStore() {
-        final File stateDir = TestUtils.tempDirectory();
-        metrics = new Metrics();
-        final MockStreamsMetrics metrics = new MockStreamsMetrics(KStreamSessionWindowAggregateProcessorTest.this.metrics);
+    public void setup() {
+        setup(StreamsConfig.METRICS_LATEST, true);
+    }
 
+    private void setup(final String builtInMetricsVersion, final boolean enableCache) {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "test", builtInMetricsVersion, new MockTime());
         context = new InternalMockProcessorContext(
-            stateDir,
+            TestUtils.tempDirectory(),
             Serdes.String(),
             Serdes.String(),
-            metrics,
+            streamsMetrics,
             new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
             MockRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 100000, metrics),
+            new ThreadCache(new LogContext("testCache "), 100000, streamsMetrics),
             Time.SYSTEM
         ) {
             @SuppressWarnings("unchecked")
@@ -116,8 +115,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
                 results.add(new KeyValueTimestamp<>((Windowed<String>) key, (Change<Long>) value, toInternal.timestamp()));
             }
         };
+        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, context.taskId().toString(), streamsMetrics);
 
-        initStore(true);
+        initStore(enableCache);
         processor.init(context);
     }
 
@@ -133,6 +133,9 @@ public class KStreamSessionWindowAggregateProcessorTest {
             storeBuilder.withCachingEnabled();
         }
 
+        if (sessionStore != null) {
+            sessionStore.close();
+        }
         sessionStore = storeBuilder.build();
         sessionStore.init((StateStoreContext) context, sessionStore);
     }
@@ -383,8 +386,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     private void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetrics(final String builtInMetricsVersion) {
-        final InternalMockProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
-        processor.init(context);
+        setup(builtInMetricsVersion, true);
         context.setRecordContext(
             new ProcessorRecordContext(-1, -2, -3, "topic", null)
         );
@@ -424,7 +426,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     private void shouldLogAndMeterWhenSkippingLateRecordWithZeroGrace(final String builtInMetricsVersion) {
-        final InternalMockProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
+        setup(builtInMetricsVersion, false);
         final Processor<String, String> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.with(ofMillis(10L)).grace(ofMillis(0L)),
             STORE_NAME,
@@ -432,7 +434,6 @@ public class KStreamSessionWindowAggregateProcessorTest {
             aggregator,
             sessionMerger
         ).get();
-        initStore(false);
         processor.init(context);
 
         // dummy record to establish stream time = 0
@@ -522,7 +523,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     }
 
     private void shouldLogAndMeterWhenSkippingLateRecordWithNonzeroGrace(final String builtInMetricsVersion) {
-        final InternalMockProcessorContext context = createInternalMockProcessorContext(builtInMetricsVersion);
+        setup(builtInMetricsVersion, false);
         final Processor<String, String> processor = new KStreamSessionWindowAggregate<>(
             SessionWindows.with(ofMillis(10L)).grace(ofMillis(1L)),
             STORE_NAME,
@@ -530,7 +531,6 @@ public class KStreamSessionWindowAggregateProcessorTest {
             aggregator,
             sessionMerger
         ).get();
-        initStore(false);
         processor.init(context);
 
         try (final LogCaptureAppender appender =
@@ -615,36 +615,5 @@ public class KStreamSessionWindowAggregateProcessorTest {
         assertThat(
             (Double) metrics.metrics().get(dropRate).metricValue(),
             greaterThan(0.0));
-    }
-
-    private InternalMockProcessorContext createInternalMockProcessorContext(final String builtInMetricsVersion) {
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "test", builtInMetricsVersion, new MockTime());
-        final InternalMockProcessorContext context = new InternalMockProcessorContext(
-            TestUtils.tempDirectory(),
-            Serdes.String(),
-            Serdes.String(),
-            streamsMetrics,
-            new StreamsConfig(StreamsTestUtils.getStreamsConfig()),
-            MockRecordCollector::new,
-            new ThreadCache(new LogContext("testCache "), 100000, streamsMetrics),
-            Time.SYSTEM
-        ) {
-            @SuppressWarnings("unchecked")
-            @Override
-            public void forward(final Object key, final Object value, final To to) {
-                toInternal.update(to);
-                results.add(new KeyValueTimestamp<>((Windowed<String>) key, (Change<Long>) value, toInternal.timestamp()));
-            }
-        };
-        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, context.taskId().toString(), streamsMetrics);
-        final StoreBuilder<SessionStore<String, Long>> storeBuilder =
-            Stores.sessionStoreBuilder(
-                Stores.persistentSessionStore(STORE_NAME, ofMillis(GAP_MS * 3)),
-                Serdes.String(),
-                Serdes.Long())
-                .withLoggingDisabled();
-        final SessionStore<String, Long> sessionStore = storeBuilder.build();
-        sessionStore.init((StateStoreContext) context, sessionStore);
-        return context;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -50,6 +50,7 @@ import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.St
 import static org.apache.kafka.streams.processor.internals.GlobalStreamThread.State.RUNNING;
 import static org.apache.kafka.streams.processor.internals.testutil.ConsumerRecordUtil.record;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
@@ -119,26 +120,30 @@ public class GlobalStreamThreadTest {
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnStartupIfThereIsAStreamsException() {
+    public void shouldThrowStreamsExceptionOnStartupIfThereIsAStreamsException() throws Exception {
         // should throw as the MockConsumer hasn't been configured and there are no
         // partitions available
+        final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
         try {
             globalStreamThread.start();
             fail("Should have thrown StreamsException if start up failed");
         } catch (final StreamsException e) {
             // ok
         }
+        globalStreamThread.join();
+        assertThat(globalStore.isOpen(), is(false));
         assertFalse(globalStreamThread.stillRunning());
     }
 
     @Test
-    public void shouldThrowStreamsExceptionOnStartupIfExceptionOccurred() {
+    public void shouldThrowStreamsExceptionOnStartupIfExceptionOccurred() throws Exception {
         final MockConsumer<byte[], byte[]> mockConsumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST) {
             @Override
             public List<PartitionInfo> partitionsFor(final String topic) {
                 throw new RuntimeException("KABOOM!");
             }
         };
+        final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
         globalStreamThread = new GlobalStreamThread(
             builder.buildGlobalStateTopology(),
             config,
@@ -159,14 +164,19 @@ public class GlobalStreamThreadTest {
             assertThat(e.getCause(), instanceOf(RuntimeException.class));
             assertThat(e.getCause().getMessage(), equalTo("KABOOM!"));
         }
+        globalStreamThread.join();
+        assertThat(globalStore.isOpen(), is(false));
         assertFalse(globalStreamThread.stillRunning());
     }
 
     @Test
-    public void shouldBeRunningAfterSuccessfulStart() {
+    public void shouldBeRunningAfterSuccessfulStart() throws Exception {
         initializeConsumer();
         startAndSwallowError();
         assertTrue(globalStreamThread.stillRunning());
+
+        globalStreamThread.shutdown();
+        globalStreamThread.join();
     }
 
     @Test(timeout = 30000)
@@ -187,16 +197,6 @@ public class GlobalStreamThreadTest {
         globalStreamThread.shutdown();
         globalStreamThread.join();
         assertFalse(globalStore.isOpen());
-    }
-
-    @Test
-    public void shouldTransitionToDeadOnClose() throws Exception {
-        initializeConsumer();
-        startAndSwallowError();
-        globalStreamThread.shutdown();
-        globalStreamThread.join();
-
-        assertEquals(GlobalStreamThread.State.DEAD, globalStreamThread.state());
     }
 
     @Test
@@ -225,6 +225,7 @@ public class GlobalStreamThreadTest {
 
     @Test
     public void shouldDieOnInvalidOffsetExceptionDuringStartup() throws Exception {
+        final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
         initializeConsumer();
         mockConsumer.setPollException(new InvalidOffsetException("Try Again!") {
             @Override
@@ -240,12 +241,15 @@ public class GlobalStreamThreadTest {
             10 * 1000,
             "GlobalStreamThread should have died."
         );
+        globalStreamThread.join();
 
+        assertThat(globalStore.isOpen(), is(false));
         assertFalse(new File(baseDirectoryName + File.separator + "testAppId" + File.separator + "global").exists());
     }
 
     @Test
     public void shouldDieOnInvalidOffsetExceptionWhileRunning() throws Exception {
+        final StateStore globalStore = builder.globalStateStores().get(GLOBAL_STORE_NAME);
         initializeConsumer();
         startAndSwallowError();
 
@@ -274,7 +278,9 @@ public class GlobalStreamThreadTest {
             10 * 1000,
             "GlobalStreamThread should have died."
         );
+        globalStreamThread.join();
 
+        assertThat(globalStore.isOpen(), is(false));
         assertFalse(new File(baseDirectoryName + File.separator + "testAppId" + File.separator + "global").exists());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1535,6 +1535,7 @@ public class StreamThreadTest {
         assertThat(processed.get(), is(false));
         thread.runOnce();
         assertThat(processed.get(), is(true));
+        thread.taskManager().shutdown(true);
     }
 
     @Test
@@ -1736,6 +1737,8 @@ public class StreamThreadTest {
         assertEquals(StreamThread.State.RUNNING.name(), threadMetadata.threadState());
         assertTrue(threadMetadata.standbyTasks().contains(new TaskMetadata(task1.toString(), Utils.mkSet(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
         assertTrue(threadMetadata.activeTasks().isEmpty());
+
+        thread.taskManager().shutdown(true);
     }
 
     @SuppressWarnings("unchecked")
@@ -1816,6 +1819,8 @@ public class StreamThreadTest {
 
         assertEquals(10L, store1.approximateNumEntries());
         assertEquals(4L, store2.approximateNumEntries());
+
+        thread.taskManager().shutdown(true);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -209,6 +209,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             ),
             results
         );
+
+        segments.close();
     }
 
     @Test
@@ -237,6 +239,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             ),
             results
         );
+
+        segments.close();
     }
 
     @Test
@@ -265,6 +269,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
             ),
             results
         );
+
+        segments.close();
     }
 
     @Test
@@ -299,6 +305,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
                 )
             )
         );
+
+        segments.close();
     }
 
     @Test
@@ -329,6 +337,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
                 )
             )
         );
+
+        segments.close();
     }
 
     @Test
@@ -470,6 +480,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         }
         assertEquals(1.0, dropTotal.metricValue());
         assertNotEquals(0.0, dropRate.metricValue());
+
+        bytesStore.close();
     }
 
     private Set<String> segmentDirs() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -370,6 +370,7 @@ public abstract class AbstractSessionBytesStoreTest {
 
     @Test
     public void shouldFetchExactKeys() {
+        sessionStore.close();
         sessionStore = buildSessionStore(0x7a00000000000000L, Serdes.String(), Serdes.Long());
         sessionStore.init((StateStoreContext) context, sessionStore);
 
@@ -407,6 +408,7 @@ public abstract class AbstractSessionBytesStoreTest {
 
     @Test
     public void shouldBackwardFetchExactKeys() {
+        sessionStore.close();
         sessionStore = buildSessionStore(0x7a00000000000000L, Serdes.String(), Serdes.Long());
         sessionStore.init((StateStoreContext) context, sessionStore);
 
@@ -469,6 +471,8 @@ public abstract class AbstractSessionBytesStoreTest {
         assertThat(valuesToSet(sessionStore.findSessions(key2, 0L, Long.MAX_VALUE)), equalTo(expectedKey2));
         final Set<String> expectedKey3 = new HashSet<>(asList("3", "6", "9"));
         assertThat(valuesToSet(sessionStore.findSessions(key3, 0L, Long.MAX_VALUE)), equalTo(expectedKey3));
+
+        sessionStore.close();
     }
 
     @Test
@@ -498,6 +502,8 @@ public abstract class AbstractSessionBytesStoreTest {
         assertThat(valuesToSet(sessionStore.backwardFindSessions(key2, 0L, Long.MAX_VALUE)), equalTo(expectedKey2));
         final Set<String> expectedKey3 = new HashSet<>(asList("3", "6", "9"));
         assertThat(valuesToSet(sessionStore.backwardFindSessions(key3, 0L, Long.MAX_VALUE)), equalTo(expectedKey3));
+
+        sessionStore.close();
     }
 
     @Test
@@ -681,6 +687,8 @@ public abstract class AbstractSessionBytesStoreTest {
         }
         assertEquals(1.0, dropTotal.metricValue());
         assertNotEquals(0.0, dropRate.metricValue());
+
+        sessionStore.close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -783,6 +783,7 @@ public abstract class AbstractWindowBytesStoreTest {
 
     @Test
     public void testPutSameKeyTimestamp() {
+        windowStore.close();
         windowStore = buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, true, Serdes.Integer(), Serdes.String());
         windowStore.init((StateStoreContext) context, windowStore);
 
@@ -899,6 +900,7 @@ public abstract class AbstractWindowBytesStoreTest {
                 windowedPair("aa", "0004", 1, windowSize)
             )))
         );
+        windowStore.close();
     }
 
     @Test
@@ -978,6 +980,8 @@ public abstract class AbstractWindowBytesStoreTest {
             valuesToSet(windowStore.fetch(key3, ofEpochMilli(0), ofEpochMilli(Long.MAX_VALUE))),
             equalTo(expectedKey3)
         );
+
+        windowStore.close();
     }
 
     @Test
@@ -1101,6 +1105,8 @@ public abstract class AbstractWindowBytesStoreTest {
         }
         assertEquals(1.0, dropTotal.metricValue());
         assertNotEquals(0.0, dropRate.metricValue());
+
+        windowStore.close();
     }
 
     @Test
@@ -1168,6 +1174,7 @@ public abstract class AbstractWindowBytesStoreTest {
 
     @Test
     public void testFetchDuplicates() {
+        windowStore.close();
         windowStore = buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, true, Serdes.Integer(), Serdes.String());
         windowStore.init((StateStoreContext) context, windowStore);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentSessionStoreTest.java
@@ -201,6 +201,7 @@ public class CachingPersistentSessionStoreTest {
     }
 
     private void setUpCloseTests() {
+        underlyingStore.close();
         underlyingStore = EasyMock.createNiceMock(SessionStore.class);
         EasyMock.expect(underlyingStore.name()).andStubReturn("store-name");
         EasyMock.expect(underlyingStore.isOpen()).andStubReturn(true);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingPersistentWindowStoreTest.java
@@ -196,7 +196,6 @@ public class CachingPersistentWindowStoreTest {
                 }
             }, "store-name");
 
-        final String bootstrapServers = "localhost:9092";
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
@@ -231,6 +230,8 @@ public class CachingPersistentWindowStoreTest {
         for (int i = 0; i < 5; i++) {
             inputTopic.pipeInput(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         }
+
+        driver.close();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/KeyValueSegmentTest.java
@@ -75,6 +75,8 @@ public class KeyValueSegmentTest {
         segment.destroy();
         assertFalse(new File(directoryPath + File.separator + "window", "segment").exists());
         assertTrue(new File(directoryPath, "window").exists());
+
+        segment.close();
     }
 
     @Test
@@ -89,6 +91,8 @@ public class KeyValueSegmentTest {
         assertThat(segment, not(equalTo(segmentDifferentId)));
         assertThat(segment, not(equalTo(null)));
         assertThat(segment, not(equalTo("anyName")));
+
+        segment.close();
     }
 
     @Test
@@ -102,6 +106,8 @@ public class KeyValueSegmentTest {
         assertTrue(set.add(segment));
         assertFalse(set.add(segmentSameId));
         assertTrue(set.add(segmentDifferentId));
+
+        segment.close();
     }
 
     @Test
@@ -117,5 +123,9 @@ public class KeyValueSegmentTest {
         assertThat(segment3.compareTo(segment1), equalTo(-1));
         assertThat(segment2.compareTo(segment3), equalTo(1));
         assertThat(segment3.compareTo(segment2), equalTo(-1));
+
+        segment1.close();
+        segment2.close();
+        segment3.close();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -855,7 +855,7 @@ public class RocksDBStoreTest {
             tableConfig.setBlockSize(4096L);
             if (enableBloomFilters) {
                 filter = new BloomFilter();
-                tableConfig.setFilter(filter);
+                tableConfig.setFilterPolicy(filter);
                 options.optimizeFiltersForHits();
                 bloomFiltersSet = true;
             } else {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -372,7 +372,7 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
 
     @Test
     public void testSegmentMaintenance() {
-
+        windowStore.close();
         windowStore = buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, true, Serdes.Integer(),
             Serdes.String());
         windowStore.init((StateStoreContext) context, windowStore);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/TimestampedSegmentTest.java
@@ -75,6 +75,8 @@ public class TimestampedSegmentTest {
         segment.destroy();
         assertFalse(new File(directoryPath + File.separator + "window", "segment").exists());
         assertTrue(new File(directoryPath, "window").exists());
+
+        segment.close();
     }
 
     @Test
@@ -90,6 +92,10 @@ public class TimestampedSegmentTest {
         assertThat(segment, not(equalTo(segmentDifferentId)));
         assertThat(segment, not(equalTo(null)));
         assertThat(segment, not(equalTo("anyName")));
+
+        segment.close();
+        segmentSameId.close();
+        segmentDifferentId.close();
     }
 
     @Test
@@ -104,6 +110,10 @@ public class TimestampedSegmentTest {
         assertTrue(set.add(segment));
         assertFalse(set.add(segmentSameId));
         assertTrue(set.add(segmentDifferentId));
+
+        segment.close();
+        segmentSameId.close();
+        segmentDifferentId.close();
     }
 
     @Test
@@ -119,5 +129,9 @@ public class TimestampedSegmentTest {
         assertThat(segment3.compareTo(segment1), equalTo(-1));
         assertThat(segment2.compareTo(segment3), equalTo(1));
         assertThat(segment3.compareTo(segment2), equalTo(-1));
+
+        segment1.close();
+        segment2.close();
+        segment3.close();
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/wordcount/WindowedWordCountProcessorTest.java
@@ -84,6 +84,8 @@ public class WindowedWordCountProcessorTest {
         );
 
         assertThat(capturedForwards, is(expected));
+
+        store.close();
     }
 
     @Test
@@ -138,6 +140,8 @@ public class WindowedWordCountProcessorTest {
             );
 
             assertThat(capturedForwards, is(expected));
+
+            store.close();
         } finally {
             Utils.delete(stateDir);
         }


### PR DESCRIPTION
This PR upgrades RocksDB to 6.19.3. After the upgrade the Gradle build exited with code 134 due to SIGABRT signals ("Pure virtual function called!") coming from the C++ part of RocksDB. This error was caused by RocksDB state stores not properly closed in Streams' code. This PR adds the missing closings and updates the RocksDB option adapter.  

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
