### PR TITLE
HOTFIX: remove unimplemented SPILL_TO_DISK buffer full strategy

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferFullStrategy.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferFullStrategy.java
@@ -18,6 +18,5 @@ package org.apache.kafka.streams.kstream.internals.suppress;
 
 public enum BufferFullStrategy {
     EMIT,
-    SPILL_TO_DISK,
     SHUT_DOWN
 }


### PR DESCRIPTION
We haven't yet found the time to implement spill-to-disk for the suppression buffer, so we should remove the  `SPILL_TO_DISK` enum to avoid confusion. Technically this enum is in an internal package, and a user would have to be invoking the `StrictBufferConfigImpl` constructor (which is also internal) to have reason to access this enum at all. But users don't always know/notice/care that APIs are internal, or they may just be browsing the source code, so we may as well remove this source of confusion. It's always kind of confusing to see this as a dev.

At the moment if a user does choose this strategy, an UnsupportedOperationException claiming that this is a bug will be thrown when the buffer is full, so it's not like anything too bad would happen...it's just awkward.