### PR TITLE
KAFKA-12700: override toString method to show correct value in doc

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -523,6 +523,11 @@ public class WorkerConfig extends AbstractConfig {
                 }
             }
         }
+
+        @Override
+        public String toString() {
+            return "List of comma-separated URIs, ex: http://localhost:8080,https://localhost:8443.";
+        }
     }
 
     private static class ResponseHttpHeadersValidator implements ConfigDef.Validator {


### PR DESCRIPTION
We use customized validator here, but forgot to override the `toString` method to show correct value in doc.

before:
`Valid Values:  org.apache.kafka.connect.runtime.WorkerConfig$AdminListenersValidator@383534aa`
after:
`Valid Values:  List of comma-separated URIs, ex: http://localhost:8080,https://localhost:8443.`

![image](https://user-images.githubusercontent.com/43372967/115515020-48430a00-a2b7-11eb-947e-02b15473427e.png)


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
