### PR TITLE
KAFKA-12701: NPE in MetadataRequest when using topic IDs

### DIFF
--- a/clients/src/main/resources/common/message/MetadataRequest.json
+++ b/clients/src/main/resources/common/message/MetadataRequest.json
@@ -33,7 +33,8 @@
     //
     // Version 9 is the first flexible version.
     //
-    // Version 10 adds topicId.
+    // Version 10 adds topicId and allows name field to be null. However, this functionality was not implemented on the server.
+    // Versions 10 and 11 should not use the topicId field or set topic name to null.
     //
     // Version 11 deprecates IncludeClusterAuthorizedOperations field. This is now exposed
     // by the DescribeCluster API (KIP-700).

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -17,12 +17,13 @@
 
 package kafka.server
 
-import java.util.Optional
+import java.util.{Collections, Optional}
 
 import kafka.utils.TestUtils
 import org.apache.kafka.common.Uuid
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.common.internals.Topic
+import org.apache.kafka.common.message.MetadataRequestData
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
 import org.apache.kafka.metadata.BrokerState
@@ -232,6 +233,32 @@ class MetadataRequestTest extends AbstractMetadataRequestTest {
       assertNotEquals(Uuid.ZERO_UUID, topicMetadata.topicId())
       assertNotNull(topicMetadata.topicId())
     }
+  }
+
+  @Test
+  def testInvalidMetadataRequestReturnsError(): Unit = {
+    val replicaAssignment = Map(0 -> Seq(1, 2, 0))
+    val topic1 = "topic1"
+    val topic2 = "topic2"
+    createTopic(topic1, replicaAssignment)
+    createTopic(topic2, replicaAssignment)
+
+    // Construct invalid MetadataRequestTopics. We will send each one separately and ensure the error is thrown.
+    val topics = List(new MetadataRequestData.MetadataRequestTopic().setName(null).setTopicId(Uuid.randomUuid()),
+                      new MetadataRequestData.MetadataRequestTopic().setName(null),
+                      new MetadataRequestData.MetadataRequestTopic().setTopicId(Uuid.randomUuid()),
+                      new MetadataRequestData.MetadataRequestTopic().setName(topic1).setTopicId(Uuid.randomUuid()))
+
+    // if version is 10 or 11, the invalid topic metadata should return an error
+    val invalidVersions = Set(10, 11)
+    invalidVersions.foreach( version =>
+      topics.foreach(topic => {
+        val metadataRequestData = new MetadataRequestData().setTopics(Collections.singletonList(topic))
+        val resp = sendMetadataRequest(new MetadataRequest(metadataRequestData, version.toShort), Some(controllerSocketServer))
+        assertEquals(1, resp.topicMetadata.size)
+        assertEquals(1, resp.errorCounts().get(Errors.INVALID_REQUEST))
+      })
+    )
   }
 
   /**


### PR DESCRIPTION
This is the change for 2.8 that should be used in 2.8.1. We prevent handling MetadataRequests where the topic name is null (to prevent NPE) as well as prevent requests that set topic IDs since this functionality has not yet been implemented. 

Will cherry-pick these changes to trunk and bump the request/response version when we implement metadata requests using topic IDs.

Added tests to ensure the error is thrown.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
