### PR TITLE
MINOR: move topic configuration defaults

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -17,6 +17,11 @@
 
 package org.apache.kafka.common.config;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+
 /**
  * <p>Keys that can be used to configure a topic. These keys are useful when creating or reconfiguring a
  * topic using the AdminClient.
@@ -29,25 +34,30 @@ package org.apache.kafka.common.config;
 // Eventually this should replace LogConfig.scala.
 public class TopicConfig {
     public static final String SEGMENT_BYTES_CONFIG = "segment.bytes";
+    public static final int SEGMENT_BYTES_DEFAULT = 1 * 1024 * 1024 * 1024;
     public static final String SEGMENT_BYTES_DOC = "This configuration controls the segment file size for " +
         "the log. Retention and cleaning is always done a file at a time so a larger segment size means " +
         "fewer files but less granular control over retention.";
 
     public static final String SEGMENT_MS_CONFIG = "segment.ms";
+    public static final long SEGMENT_MS_DEFAULT = TimeUnit.DAYS.toMillis(7);
     public static final String SEGMENT_MS_DOC = "This configuration controls the period of time after " +
         "which Kafka will force the log to roll even if the segment file isn't full to ensure that retention " +
         "can delete or compact old data.";
 
     public static final String SEGMENT_JITTER_MS_CONFIG = "segment.jitter.ms";
+    public static final long SEGMENT_JITTER_MS_DEFAULT = 0;
     public static final String SEGMENT_JITTER_MS_DOC = "The maximum random jitter subtracted from the scheduled " +
         "segment roll time to avoid thundering herds of segment rolling";
 
     public static final String SEGMENT_INDEX_BYTES_CONFIG = "segment.index.bytes";
+    public static final int SEGMENT_INDEX_BYTES_DEFAULT = 10 * 1024 * 1024;
     public static final String SEGMENT_INDEX_BYTES_DOC = "This configuration controls the size of the index that " +
         "maps offsets to file positions. We preallocate this index file and shrink it only after log " +
         "rolls. You generally should not need to change this setting.";
 
     public static final String FLUSH_MESSAGES_INTERVAL_CONFIG = "flush.messages";
+    public static final long FLUSH_MESSAGES_INTERVAL_DEFAULT = Long.MAX_VALUE;
     public static final String FLUSH_MESSAGES_INTERVAL_DOC = "This setting allows specifying an interval at " +
         "which we will force an fsync of data written to the log. For example if this was set to 1 " +
         "we would fsync after every message; if it were 5 we would fsync after every five messages. " +
@@ -56,6 +66,7 @@ public class TopicConfig {
         "be overridden on a per-topic basis (see <a href=\"#topicconfigs\">the per-topic configuration section</a>).";
 
     public static final String FLUSH_MS_CONFIG = "flush.ms";
+    public static final long FLUSH_MS_DEFAULT = Long.MAX_VALUE;
     public static final String FLUSH_MS_DOC = "This setting allows specifying a time interval at which we will " +
         "force an fsync of data written to the log. For example if this was set to 1000 " +
         "we would fsync after 1000 ms had passed. In general we recommend you not set " +
@@ -63,6 +74,7 @@ public class TopicConfig {
         "flush capabilities as it is more efficient.";
 
     public static final String RETENTION_BYTES_CONFIG = "retention.bytes";
+    public static final long RETENTION_BYTES_DEFAULT = -1L;
     public static final String RETENTION_BYTES_DOC = "This configuration controls the maximum size a partition " +
         "(which consists of log segments) can grow to before we will discard old log segments to free up space if we " +
         "are using the \"delete\" retention policy. By default there is no size limit only a time limit. " +
@@ -70,12 +82,14 @@ public class TopicConfig {
         "the topic retention in bytes.";
 
     public static final String RETENTION_MS_CONFIG = "retention.ms";
+    public static final long RETENTION_MS_DEFAULT = TimeUnit.DAYS.toMillis(7);
     public static final String RETENTION_MS_DOC = "This configuration controls the maximum time we will retain a " +
         "log before we will discard old log segments to free up space if we are using the " +
         "\"delete\" retention policy. This represents an SLA on how soon consumers must read " +
         "their data. If set to -1, no time limit is applied.";
 
     public static final String MAX_MESSAGE_BYTES_CONFIG = "max.message.bytes";
+    public static final int MAX_MESSAGE_BYTES_DEFAULT = 1024 * 1024 + 12;
     public static final String MAX_MESSAGE_BYTES_DOC =
         "The largest record batch size allowed by Kafka (after compression if compression is enabled). " +
         "If this is increased and there are consumers older than 0.10.2, the consumers' fetch " +
@@ -85,16 +99,19 @@ public class TopicConfig {
         "limit only applies to a single record in that case.";
 
     public static final String INDEX_INTERVAL_BYTES_CONFIG = "index.interval.bytes";
-    public static final String INDEX_INTERVAL_BYTES_DOCS = "This setting controls how frequently " +
+    public static final int INDEX_INTERVAL_BYTES_DEFAULT = 4096;
+    public static final String INDEX_INTERVAL_BYTES_DOC = "This setting controls how frequently " +
         "Kafka adds an index entry to its offset index. The default setting ensures that we index a " +
         "message roughly every 4096 bytes. More indexing allows reads to jump closer to the exact " +
         "position in the log but makes the index larger. You probably don't need to change this.";
 
     public static final String FILE_DELETE_DELAY_MS_CONFIG = "file.delete.delay.ms";
+    public static final long FILE_DELETE_DELAY_MS_DEFAULT = TimeUnit.MINUTES.toMillis(1);
     public static final String FILE_DELETE_DELAY_MS_DOC = "The time to wait before deleting a file from the " +
         "filesystem";
 
     public static final String DELETE_RETENTION_MS_CONFIG = "delete.retention.ms";
+    public static final long DELETE_RETENTION_MS_DEFAULT = TimeUnit.DAYS.toMillis(1);
     public static final String DELETE_RETENTION_MS_DOC = "The amount of time to retain delete tombstone markers " +
         "for <a href=\"#compaction\">log compacted</a> topics. This setting also gives a bound " +
         "on the time in which a consumer must complete a read if they begin from offset 0 " +
@@ -102,14 +119,17 @@ public class TopicConfig {
         "tombstones may be collected before they complete their scan).";
 
     public static final String MIN_COMPACTION_LAG_MS_CONFIG = "min.compaction.lag.ms";
+    public static final long MIN_COMPACTION_LAG_MS_DEFAULT = 0L;
     public static final String MIN_COMPACTION_LAG_MS_DOC = "The minimum time a message will remain " +
         "uncompacted in the log. Only applicable for logs that are being compacted.";
 
     public static final String MAX_COMPACTION_LAG_MS_CONFIG = "max.compaction.lag.ms";
+    public static final long MAX_COMPACTION_LAG_MS_DEFAULT = Long.MAX_VALUE;
     public static final String MAX_COMPACTION_LAG_MS_DOC = "The maximum time a message will remain " +
         "ineligible for compaction in the log. Only applicable for logs that are being compacted.";
 
     public static final String MIN_CLEANABLE_DIRTY_RATIO_CONFIG = "min.cleanable.dirty.ratio";
+    public static final double MIN_CLEANABLE_DIRTY_RATIO_DEFAULT = 0.5d;
     public static final String MIN_CLEANABLE_DIRTY_RATIO_DOC = "This configuration controls how frequently " +
         "the log compactor will attempt to clean the log (assuming <a href=\"#compaction\">log " +
         "compaction</a> is enabled). By default we will avoid cleaning a log where more than " +
@@ -125,6 +145,7 @@ public class TopicConfig {
     public static final String CLEANUP_POLICY_CONFIG = "cleanup.policy";
     public static final String CLEANUP_POLICY_COMPACT = "compact";
     public static final String CLEANUP_POLICY_DELETE = "delete";
+    public static final String CLEANUP_POLICY_DEFAULT = CLEANUP_POLICY_DELETE;
     public static final String CLEANUP_POLICY_DOC = "A string that is either \"" + CLEANUP_POLICY_DELETE +
         "\" or \"" + CLEANUP_POLICY_COMPACT + "\" or both. This string designates the retention policy to use on " +
         "old log segments. The default policy (\"delete\") will discard old segments when their retention " +
@@ -132,11 +153,13 @@ public class TopicConfig {
         "compaction</a> on the topic.";
 
     public static final String UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG = "unclean.leader.election.enable";
+    public static final boolean UNCLEAN_LEADER_ELECTION_ENABLE_DEFAULT = false;
     public static final String UNCLEAN_LEADER_ELECTION_ENABLE_DOC = "Indicates whether to enable replicas " +
         "not in the ISR set to be elected as leader as a last resort, even though doing so may result in data " +
         "loss.";
 
     public static final String MIN_IN_SYNC_REPLICAS_CONFIG = "min.insync.replicas";
+    public static final int MIN_IN_SYNC_REPLICAS_DEFAULT = 1;
     public static final String MIN_IN_SYNC_REPLICAS_DOC = "When a producer sets acks to \"all\" (or \"-1\"), " +
         "this configuration specifies the minimum number of replicas that must acknowledge " +
         "a write for the write to be considered successful. If this minimum cannot be met, " +
@@ -148,12 +171,14 @@ public class TopicConfig {
         "if a majority of replicas do not receive a write.";
 
     public static final String COMPRESSION_TYPE_CONFIG = "compression.type";
+    public static final String COMPRESSION_TYPE_DEFAULT = "producer";
     public static final String COMPRESSION_TYPE_DOC = "Specify the final compression type for a given topic. " +
         "This configuration accepts the standard compression codecs ('gzip', 'snappy', 'lz4', 'zstd'). It additionally " +
         "accepts 'uncompressed' which is equivalent to no compression; and 'producer' which means retain the " +
         "original compression codec set by the producer.";
 
     public static final String PREALLOCATE_CONFIG = "preallocate";
+    public static final boolean PREALLOCATE_DEFAULT = false;
     public static final String PREALLOCATE_DOC = "True if we should preallocate the file on disk when " +
         "creating a new log segment.";
 
@@ -166,19 +191,36 @@ public class TopicConfig {
         "they will receive messages with a format that they don't understand.";
 
     public static final String MESSAGE_TIMESTAMP_TYPE_CONFIG = "message.timestamp.type";
+    public static final String MESSAGE_TIMESTAMP_TYPE_DEFAULT = "CreateTime";
     public static final String MESSAGE_TIMESTAMP_TYPE_DOC = "Define whether the timestamp in the message is " +
         "message create time or log append time. The value should be either `CreateTime` or `LogAppendTime`";
 
     public static final String MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_CONFIG = "message.timestamp.difference.max.ms";
+    public static final long MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DEFAULT = Long.MAX_VALUE;
     public static final String MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DOC = "The maximum difference allowed between " +
         "the timestamp when a broker receives a message and the timestamp specified in the message. If " +
         "message.timestamp.type=CreateTime, a message will be rejected if the difference in timestamp " +
         "exceeds this threshold. This configuration is ignored if message.timestamp.type=LogAppendTime.";
 
     public static final String MESSAGE_DOWNCONVERSION_ENABLE_CONFIG = "message.downconversion.enable";
+    public static final boolean MESSAGE_DOWNCONVERSION_ENABLE_DEFAULT = true;
     public static final String MESSAGE_DOWNCONVERSION_ENABLE_DOC = "This configuration controls whether " +
         "down-conversion of message formats is enabled to satisfy consume requests. When set to <code>false</code>, " +
         "broker will not perform down-conversion for consumers expecting an older message format. The broker responds " +
         "with <code>UNSUPPORTED_VERSION</code> error for consume requests from such older clients. This configuration" +
         "does not apply to any message format conversion that might be required for replication to followers.";
+
+    public static final String LEADER_REPLICATION_THROTTLED_REPLICAS = "leader.replication.throttled.replicas";
+    public static final Collection<String> LEADER_REPLICATION_THROTTLED_REPLICAS_DEFAULT = Collections.emptyList();
+    public static final String LEADER_REPLICATION_THROTTLED_REPLICAS_DOC = "A list of replicas for which log " +
+        "replication should be throttled on the leader side. The list should describe a set of replicas in the form " +
+        "[PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle " +
+        "all replicas for this topic.";
+
+    public static final String FOLLOW_REPLICATION_THROTTLED_REPLICAS = "follower.replication.throttled.replicas";
+    public static final Collection<String> FOLLOWER_REPLICATION_THROTTLED_REPLICAS_DEFAULT = Collections.emptyList();
+    public static final String FOLLOWER_REPLICATION_THROTTLED_REPLICAS_DOC = "A list of replicas for which log " +
+        "replication should be throttled on the follower side. The list should describe a set of replicas in the form " +
+        "[PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle " +
+        "all replicas for this topic.";
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/Records.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/Records.java
@@ -46,6 +46,7 @@ public interface Records extends TransferableRecords {
     int OFFSET_LENGTH = 8;
     int SIZE_OFFSET = OFFSET_OFFSET + OFFSET_LENGTH;
     int SIZE_LENGTH = 4;
+    // If the log overhead increases, please consider increasing TopicConfig.MAX_MESSAGE_BYTES_DEFAULT.
     int LOG_OVERHEAD = SIZE_OFFSET + SIZE_LENGTH;
 
     // the magic offset is at the same offset for all current message formats, but the 4 bytes

--- a/clients/src/main/java/org/apache/kafka/common/utils/ConfigUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ConfigUtils.java
@@ -28,6 +28,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 public class ConfigUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ConfigUtils.class);
@@ -112,5 +115,28 @@ public class ConfigUtils {
         });
 
         return newConfigs;
+    }
+
+    /**
+     * Convert a 64-bit number of milliseconds into a 32-bit number of hours.
+     *
+     * @param milliseconds  The number of milliseconds. There must not be any remainder
+     *                      when converting this into hours.
+     * @return              The number of hours as an integer.
+     */
+    public static int millisecondsToHours(long milliseconds) {
+        if (milliseconds < 0) {
+            throw new RuntimeException("Invalid number of milliseconds " + milliseconds +
+                ". The number of milliseconds must be non-negative.");
+        }
+        long hours = MILLISECONDS.toHours(milliseconds);
+        if (milliseconds != HOURS.toMillis(hours)) {
+            throw new RuntimeException("The given number of milliseconds " + milliseconds +
+                " does not divide cleanly into a number of hours.");
+        } else if (hours > Integer.MAX_VALUE) {
+            throw new RuntimeException("Invalid number of hours " + hours + ". The " +
+                "number of hours must be representable in an integer.");
+        }
+        return (int) hours;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/ConfigUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ConfigUtilsTest.java
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConfigUtilsTest {
 
@@ -139,5 +141,19 @@ public class ConfigUtilsTest {
         assertEquals("derp", newConfig.get("foo.bar"));
         assertNull(newConfig.get("foo.bar.deprecated"));
         assertNull(newConfig.get("foo.bar.even.more.deprecated"));
+    }
+
+    @Test
+    public void testMillisecondsToHours() {
+        assertEquals(5, ConfigUtils.millisecondsToHours(5 * 60 * 60 * 1000));
+        assertEquals("Invalid number of milliseconds -1. The number of milliseconds " +
+            "must be non-negative.", assertThrows(RuntimeException.class,
+                () -> ConfigUtils.millisecondsToHours(-1)).getMessage());
+        assertEquals("The given number of milliseconds 18000001 does not divide cleanly into " +
+            "a number of hours.", assertThrows(RuntimeException.class,
+                () -> ConfigUtils.millisecondsToHours(1 + 5 * 60 * 60 * 1000)).getMessage());
+        assertEquals("Invalid number of hours 2147483648. The number of hours must be " +
+            "representable in an integer.", assertThrows(RuntimeException.class,
+                () -> ConfigUtils.millisecondsToHours(7730941132800000L)).getMessage());
     }
 }

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -17,7 +17,7 @@
 
 package kafka.log
 
-import java.util.{Collections, Locale, Properties}
+import java.util.{Locale, Properties}
 
 import scala.jdk.CollectionConverters._
 import kafka.api.{ApiVersion, ApiVersionValidator}
@@ -33,33 +33,32 @@ import scala.collection.{Map, mutable}
 import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList, Validator}
 
 object Defaults {
-  val SegmentSize = kafka.server.Defaults.LogSegmentBytes
-  val SegmentMs = kafka.server.Defaults.LogRollHours * 60 * 60 * 1000L
-  val SegmentJitterMs = kafka.server.Defaults.LogRollJitterHours * 60 * 60 * 1000L
-  val FlushInterval = kafka.server.Defaults.LogFlushIntervalMessages
-  val FlushMs = kafka.server.Defaults.LogFlushSchedulerIntervalMs
-  val RetentionSize = kafka.server.Defaults.LogRetentionBytes
-  val RetentionMs = kafka.server.Defaults.LogRetentionHours * 60 * 60 * 1000L
-  val MaxMessageSize = kafka.server.Defaults.MessageMaxBytes
-  val MaxIndexSize = kafka.server.Defaults.LogIndexSizeMaxBytes
-  val IndexInterval = kafka.server.Defaults.LogIndexIntervalBytes
-  val FileDeleteDelayMs = kafka.server.Defaults.LogDeleteDelayMs
-  val DeleteRetentionMs = kafka.server.Defaults.LogCleanerDeleteRetentionMs
-  val MinCompactionLagMs = kafka.server.Defaults.LogCleanerMinCompactionLagMs
-  val MaxCompactionLagMs = kafka.server.Defaults.LogCleanerMaxCompactionLagMs
-  val MinCleanableDirtyRatio = kafka.server.Defaults.LogCleanerMinCleanRatio
-  val CleanupPolicy = kafka.server.Defaults.LogCleanupPolicy
-  val UncleanLeaderElectionEnable = kafka.server.Defaults.UncleanLeaderElectionEnable
-  val MinInSyncReplicas = kafka.server.Defaults.MinInSyncReplicas
-  val CompressionType = kafka.server.Defaults.CompressionType
-  val PreAllocateEnable = kafka.server.Defaults.LogPreAllocateEnable
+  val SegmentSize = TopicConfig.SEGMENT_BYTES_DEFAULT
+  val SegmentMs = TopicConfig.SEGMENT_MS_DEFAULT
+  val SegmentJitterMs = TopicConfig.SEGMENT_JITTER_MS_DEFAULT
+  val FlushInterval = TopicConfig.FLUSH_MESSAGES_INTERVAL_DEFAULT
+  val FlushMs = TopicConfig.FLUSH_MESSAGES_INTERVAL_DEFAULT
+  val RetentionSize = TopicConfig.RETENTION_BYTES_DEFAULT
+  val RetentionMs = TopicConfig.RETENTION_MS_DEFAULT
+  val MaxMessageSize = TopicConfig.MAX_MESSAGE_BYTES_DEFAULT
+  val MaxIndexSize = TopicConfig.SEGMENT_INDEX_BYTES_DEFAULT
+  val IndexInterval = TopicConfig.INDEX_INTERVAL_BYTES_DEFAULT
+  val FileDeleteDelayMs = TopicConfig.FILE_DELETE_DELAY_MS_DEFAULT
+  val DeleteRetentionMs = TopicConfig.DELETE_RETENTION_MS_DEFAULT
+  val MinCompactionLagMs = TopicConfig.MIN_COMPACTION_LAG_MS_DEFAULT
+  val MaxCompactionLagMs = TopicConfig.MAX_COMPACTION_LAG_MS_DEFAULT
+  val MinCleanableDirtyRatio = TopicConfig.MIN_CLEANABLE_DIRTY_RATIO_DEFAULT
+  val CleanupPolicy = TopicConfig.CLEANUP_POLICY_DEFAULT
+  val UncleanLeaderElectionEnable = TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_DEFAULT
+  val MinInSyncReplicas = TopicConfig.MIN_IN_SYNC_REPLICAS_DEFAULT
+  val CompressionType = TopicConfig.COMPRESSION_TYPE_DEFAULT
+  val PreAllocateEnable = TopicConfig.PREALLOCATE_DEFAULT
   val MessageFormatVersion = kafka.server.Defaults.LogMessageFormatVersion
-  val MessageTimestampType = kafka.server.Defaults.LogMessageTimestampType
-  val MessageTimestampDifferenceMaxMs = kafka.server.Defaults.LogMessageTimestampDifferenceMaxMs
-  val LeaderReplicationThrottledReplicas = Collections.emptyList[String]()
-  val FollowerReplicationThrottledReplicas = Collections.emptyList[String]()
-  val MaxIdMapSnapshots = kafka.server.Defaults.MaxIdMapSnapshots
-  val MessageDownConversionEnable = kafka.server.Defaults.MessageDownConversionEnable
+  val MessageTimestampType = TopicConfig.MESSAGE_TIMESTAMP_TYPE_DEFAULT
+  val MessageTimestampDifferenceMaxMs = TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DEFAULT
+  val LeaderReplicationThrottledReplicas = TopicConfig.LEADER_REPLICATION_THROTTLED_REPLICAS_DEFAULT
+  val FollowerReplicationThrottledReplicas = TopicConfig.FOLLOWER_REPLICATION_THROTTLED_REPLICAS_DEFAULT
+  val MessageDownConversionEnable = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DEFAULT
 }
 
 case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] = Set.empty)
@@ -158,7 +157,7 @@ object LogConfig {
   val RetentionSizeDoc = TopicConfig.RETENTION_BYTES_DOC
   val RetentionMsDoc = TopicConfig.RETENTION_MS_DOC
   val MaxMessageSizeDoc = TopicConfig.MAX_MESSAGE_BYTES_DOC
-  val IndexIntervalDoc = TopicConfig.INDEX_INTERVAL_BYTES_DOCS
+  val IndexIntervalDoc = TopicConfig.INDEX_INTERVAL_BYTES_DOC
   val FileDeleteDelayMsDoc = TopicConfig.FILE_DELETE_DELAY_MS_DOC
   val DeleteRetentionMsDoc = TopicConfig.DELETE_RETENTION_MS_DOC
   val MinCompactionLagMsDoc = TopicConfig.MIN_COMPACTION_LAG_MS_DOC

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -38,9 +38,9 @@ import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.config.types.Password
 import org.apache.kafka.common.metrics.Sensor
 import org.apache.kafka.common.network.ListenerName
-import org.apache.kafka.common.record.{LegacyRecord, Records, TimestampType}
+import org.apache.kafka.common.record.{LegacyRecord, TimestampType}
 import org.apache.kafka.common.security.auth.SecurityProtocol
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{ConfigUtils, Utils}
 import org.apache.kafka.raft.RaftConfig
 import org.apache.kafka.server.authorizer.Authorizer
 import org.apache.zookeeper.client.ZKClientConfig
@@ -64,7 +64,7 @@ object Defaults {
   val BrokerIdGenerationEnable = true
   val MaxReservedBrokerId = 1000
   val BrokerId = -1
-  val MessageMaxBytes = 1024 * 1024 + Records.LOG_OVERHEAD
+  val MessageMaxBytes = TopicConfig.MAX_MESSAGE_BYTES_DEFAULT
   val NumNetworkThreads = 3
   val NumIoThreads = 8
   val BackgroundThreads = 10
@@ -104,43 +104,43 @@ object Defaults {
   /** ********* Log Configuration ***********/
   val NumPartitions = 1
   val LogDir = "/tmp/kafka-logs"
-  val LogSegmentBytes = 1 * 1024 * 1024 * 1024
-  val LogRollHours = 24 * 7
-  val LogRollJitterHours = 0
-  val LogRetentionHours = 24 * 7
+  val LogSegmentBytes = TopicConfig.SEGMENT_BYTES_DEFAULT
+  val LogRollHours = ConfigUtils.millisecondsToHours(TopicConfig.SEGMENT_MS_DEFAULT)
+  val LogRollJitterHours = ConfigUtils.millisecondsToHours(TopicConfig.SEGMENT_JITTER_MS_DEFAULT)
+  val LogRetentionHours = ConfigUtils.millisecondsToHours(TopicConfig.RETENTION_MS_DEFAULT)
 
-  val LogRetentionBytes = -1L
+  val LogRetentionBytes = TopicConfig.RETENTION_BYTES_DEFAULT
   val LogCleanupIntervalMs = 5 * 60 * 1000L
-  val Delete = "delete"
-  val Compact = "compact"
-  val LogCleanupPolicy = Delete
+  val Delete = TopicConfig.CLEANUP_POLICY_DELETE
+  val Compact = TopicConfig.CLEANUP_POLICY_COMPACT
+  val LogCleanupPolicy = TopicConfig.CLEANUP_POLICY_DEFAULT
   val LogCleanerThreads = 1
   val LogCleanerIoMaxBytesPerSecond = Double.MaxValue
   val LogCleanerDedupeBufferSize = 128 * 1024 * 1024L
   val LogCleanerIoBufferSize = 512 * 1024
   val LogCleanerDedupeBufferLoadFactor = 0.9d
   val LogCleanerBackoffMs = 15 * 1000
-  val LogCleanerMinCleanRatio = 0.5d
+  val LogCleanerMinCleanRatio = TopicConfig.MIN_CLEANABLE_DIRTY_RATIO_DEFAULT
   val LogCleanerEnable = true
-  val LogCleanerDeleteRetentionMs = 24 * 60 * 60 * 1000L
-  val LogCleanerMinCompactionLagMs = 0L
-  val LogCleanerMaxCompactionLagMs = Long.MaxValue
-  val LogIndexSizeMaxBytes = 10 * 1024 * 1024
-  val LogIndexIntervalBytes = 4096
-  val LogFlushIntervalMessages = Long.MaxValue
-  val LogDeleteDelayMs = 60000
-  val LogFlushSchedulerIntervalMs = Long.MaxValue
+  val LogCleanerDeleteRetentionMs = TopicConfig.DELETE_RETENTION_MS_DEFAULT
+  val LogCleanerMinCompactionLagMs = TopicConfig.MIN_COMPACTION_LAG_MS_DEFAULT
+  val LogCleanerMaxCompactionLagMs = TopicConfig.MAX_COMPACTION_LAG_MS_DEFAULT
+  val LogIndexSizeMaxBytes = TopicConfig.SEGMENT_INDEX_BYTES_DEFAULT
+  val LogIndexIntervalBytes = TopicConfig.INDEX_INTERVAL_BYTES_DEFAULT
+  val LogFlushIntervalMessages = TopicConfig.FLUSH_MESSAGES_INTERVAL_DEFAULT
+  val LogDeleteDelayMs = TopicConfig.FILE_DELETE_DELAY_MS_DEFAULT
+  val LogFlushSchedulerIntervalMs = TopicConfig.FLUSH_MESSAGES_INTERVAL_DEFAULT
   val LogFlushOffsetCheckpointIntervalMs = 60000
   val LogFlushStartOffsetCheckpointIntervalMs = 60000
-  val LogPreAllocateEnable = false
+  val LogPreAllocateEnable = TopicConfig.PREALLOCATE_DEFAULT
   // lazy val as `InterBrokerProtocolVersion` is defined later
   lazy val LogMessageFormatVersion = InterBrokerProtocolVersion
-  val LogMessageTimestampType = "CreateTime"
-  val LogMessageTimestampDifferenceMaxMs = Long.MaxValue
+  val LogMessageTimestampType = TopicConfig.MESSAGE_TIMESTAMP_TYPE_DEFAULT
+  val LogMessageTimestampDifferenceMaxMs = TopicConfig.MESSAGE_TIMESTAMP_DIFFERENCE_MAX_MS_DEFAULT
   val NumRecoveryThreadsPerDataDir = 1
   val AutoCreateTopicsEnable = true
-  val MinInSyncReplicas = 1
-  val MessageDownConversionEnable = true
+  val MinInSyncReplicas = TopicConfig.MIN_IN_SYNC_REPLICAS_DEFAULT
+  val MessageDownConversionEnable = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DEFAULT
 
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMs = RequestTimeoutMs
@@ -162,7 +162,7 @@ object Defaults {
   val AutoLeaderRebalanceEnable = true
   val LeaderImbalancePerBrokerPercentage = 10
   val LeaderImbalanceCheckIntervalSeconds = 300
-  val UncleanLeaderElectionEnable = false
+  val UncleanLeaderElectionEnable = TopicConfig.UNCLEAN_LEADER_ELECTION_ENABLE_DEFAULT
   val InterBrokerSecurityProtocol = SecurityProtocol.PLAINTEXT.toString
   val InterBrokerProtocolVersion = ApiVersion.latestVersion.toString
 
@@ -219,7 +219,7 @@ object Defaults {
 
   val DeleteTopicEnable = true
 
-  val CompressionType = "producer"
+  val CompressionType = TopicConfig.COMPRESSION_TYPE_DEFAULT
 
   val MaxIdMapSnapshots = 2
   /** ********* Kafka Metrics Configuration ***********/


### PR DESCRIPTION
Add default values for the configurations to TopicConfig.java.  Eventually we want to move
all of the log configurations into TopicConfig.java, and this is a good step along the way.