### PR TITLE
KAFKA-5761: support ByteBuffer as value in ProducerRecord and avoid redundant serialization when it's used

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Time;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -505,7 +506,9 @@ public class MockProducer<K, V> implements Producer<K, V> {
             return partition;
         }
         byte[] keyBytes = keySerializer.serialize(topic, record.headers(), record.key());
-        byte[] valueBytes = valueSerializer.serialize(topic, record.headers(), record.value());
+        byte[] valueBytes = record.value() instanceof ByteBuffer ? KafkaProducer.EMPTY_BYTE_ARRAY :
+            valueSerializer.serialize(topic, record.headers(), record.value());
+
         return this.partitioner.partition(topic, record.key(), keyBytes, record.value(), valueBytes, cluster);
     }
 


### PR DESCRIPTION
Allows to use pooled byte buffer implementations to serialize record value before calling KafkaProducer.send and reclaim the buffer afterwards, thus reducing unnecessary allocations and GC pressure

Is a new take on https://cwiki.apache.org/confluence/display/KAFKA/KIP-646+Serializer+API+should+support+ByteBuffer