### PR TITLE
MINOR: Remove redudant test files and close LogSegment after test

### DIFF
--- a/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
@@ -18,10 +18,11 @@ package kafka.log
 
 import java.io.File
 
+import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.utils.Time
+import org.apache.kafka.common.utils.{Time, Utils}
 import org.junit.jupiter.api.Assertions._
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
 class LogSegmentsTest {
 
@@ -35,6 +36,16 @@ class LogSegmentsTest {
     LogTestUtils.createSegment(offset, logDir, indexIntervalBytes, time)
   }
 
+  @BeforeEach
+  def setup(): Unit = {
+    logDir = TestUtils.tempDir()
+  }
+
+  @AfterEach
+  def teardown(): Unit = {
+    Utils.delete(logDir)
+  }
+
   private def assertEntry(segment: LogSegment, tested: java.util.Map.Entry[java.lang.Long, LogSegment]): Unit = {
     assertEquals(segment.baseOffset, tested.getKey())
     assertEquals(segment, tested.getValue())
@@ -43,6 +54,7 @@ class LogSegmentsTest {
   @Test
   def testBasicOperations(): Unit = {
     val segments = new LogSegments(topicPartition)
+
     assertTrue(segments.isEmpty)
     assertFalse(segments.nonEmpty)
 
@@ -89,11 +101,14 @@ class LogSegmentsTest {
     assertFalse(segments.nonEmpty)
     assertEquals(0, segments.numberOfSegments)
     assertFalse(segments.contains(offset1))
+
+    segments.close()
   }
 
   @Test
   def testSegmentAccess(): Unit = {
     val segments = new LogSegments(topicPartition)
+
     val offset1 = 1
     val seg1 = createSegment(offset1)
     val offset2 = 2
@@ -130,11 +145,13 @@ class LogSegmentsTest {
     assertEquals(Seq(), segments.values(4, 4).toSeq)
     assertEquals(Seq(seg4), segments.values(4, 5).toSeq)
 
+    segments.close()
   }
 
   @Test
   def testClosestMatchOperations(): Unit = {
     val segments = new LogSegments(topicPartition)
+
     val seg1 = createSegment(1)
     val seg2 = createSegment(3)
     val seg3 = createSegment(5)
@@ -159,5 +176,7 @@ class LogSegmentsTest {
     assertEntry(seg3, segments.higherEntry(4).get)
     assertEquals(Some(seg4), segments.higherSegment(5))
     assertEntry(seg4, segments.higherEntry(5).get)
+
+    segments.close()
   }
 }

--- a/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentsTest.scala
@@ -54,7 +54,6 @@ class LogSegmentsTest {
   @Test
   def testBasicOperations(): Unit = {
     val segments = new LogSegments(topicPartition)
-
     assertTrue(segments.isEmpty)
     assertFalse(segments.nonEmpty)
 


### PR DESCRIPTION
*More detailed description of your change*
![image](https://user-images.githubusercontent.com/26023240/115959686-01b41080-a540-11eb-88b6-a7c668ddfa38.png)

1. `LogSegmentsTest` will create some redundant files, we should remove them after the test.
2. We also need to close LogSegment after the test.

*Summary of testing strategy (including rationale)*
Test locally, will not generate any redundant files.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
