### PR TITLE
MINOR: rename wrong topic id variable name and description

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -200,7 +200,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("partition")
       .ofType(classOf[java.lang.Integer])
-    val offsetOpt = parser.accepts("offset", "The offset id to consume from (a non-negative number), or 'earliest' which means from beginning, or 'latest' which means from end")
+    val offsetOpt = parser.accepts("offset", "The offset to consume from (a non-negative number), or 'earliest' which means from beginning, or 'latest' which means from end")
       .withRequiredArg
       .describedAs("consume offset")
       .ofType(classOf[String])

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -187,7 +187,7 @@ object ConsoleConsumer extends Logging {
   }
 
   class ConsumerConfig(args: Array[String]) extends CommandDefaultOptions(args) {
-    val topicIdOpt = parser.accepts("topic", "The topic id to consume on.")
+    val topicOpt = parser.accepts("topic", "The topic to consume on.")
       .withRequiredArg
       .describedAs("topic")
       .ofType(classOf[String])
@@ -209,7 +209,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("consumer_prop")
       .ofType(classOf[String])
-    val consumerConfigOpt = parser.accepts("consumer.config", s"Consumer config properties file. Note that ${consumerPropertyOpt} takes precedence over this config.")
+    val consumerConfigOpt = parser.accepts("consumer.config", s"Consumer config properties file. Note that $consumerPropertyOpt takes precedence over this config.")
       .withRequiredArg
       .describedAs("config file")
       .ofType(classOf[String])
@@ -306,23 +306,23 @@ object ConsoleConsumer extends Logging {
     val valueDeserializer = options.valueOf(valueDeserializerOpt)
     val formatter: MessageFormatter = messageFormatterClass.getDeclaredConstructor().newInstance().asInstanceOf[MessageFormatter]
 
-    if (keyDeserializer != null && !keyDeserializer.isEmpty) {
+    if (keyDeserializer != null && keyDeserializer.nonEmpty) {
       formatterArgs.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer)
     }
-    if (valueDeserializer != null && !valueDeserializer.isEmpty) {
+    if (valueDeserializer != null && valueDeserializer.nonEmpty) {
       formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer)
     }
 
     formatter.configure(formatterArgs.asScala.asJava)
 
-    val topicOrFilterOpt = List(topicIdOpt, whitelistOpt).filter(options.has)
+    val topicOrFilterOpt = List(topicOpt, whitelistOpt).filter(options.has)
     if (topicOrFilterOpt.size != 1)
       CommandLineUtils.printUsageAndDie(parser, "Exactly one of whitelist/topic is required.")
-    topicArg = options.valueOf(topicIdOpt)
+    topicArg = options.valueOf(topicOpt)
     whitelistArg = options.valueOf(whitelistOpt)
 
     if (partitionArg.isDefined) {
-      if (!options.has(topicIdOpt))
+      if (!options.has(topicOpt))
         CommandLineUtils.printUsageAndDie(parser, "The topic is required when partition is specified.")
       if (fromBeginning && options.has(offsetOpt))
         CommandLineUtils.printUsageAndDie(parser, "Options from-beginning and offset cannot be specified together.")


### PR DESCRIPTION
*More detailed description of your change*
![image](https://user-images.githubusercontent.com/26023240/116053055-d569d280-a6ac-11eb-84d1-3b6d8760214e.png)
1. The argument description "The topic id to produce messages to" is not right, currently we do not support topicId when producing messages, maybe 3.0.0.
2. also rename deprecaed `Class.newInstance` to `class.getDeclaredConstructor().newInstance()`

*Summary of testing strategy (including rationale)*
Test locally.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
