### PR TITLE
KAFKA-12716; Add `Admin` API to abort transactions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionOptions.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+@InterfaceStability.Evolving
+public class AbortTransactionOptions extends AbstractOptions<AbortTransactionOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionResult.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@InterfaceStability.Evolving
+public class AbortTransactionResult {
+    private final Map<TopicPartition, KafkaFutureImpl<Void>> futures;
+
+    AbortTransactionResult(Map<TopicPartition, KafkaFutureImpl<Void>> futures) {
+        this.futures = futures;
+    }
+
+    public KafkaFuture<Void> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]))
+            .thenApply(nil -> {
+                for (Map.Entry<TopicPartition, KafkaFutureImpl<Void>> entry : futures.entrySet()) {
+                    try {
+                        KafkaFutureImpl<Void> future = entry.getValue();
+                        future.get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        // This should be unreachable, because allOf ensured that all the futures completed successfully.
+                        throw new KafkaException(e);
+                    }
+                }
+                return null;
+            });
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionSpec.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Objects;
+
+@InterfaceStability.Evolving
+public class AbortTransactionSpec {
+    private final TopicPartition topicPartition;
+    private final long producerId;
+    private final short producerEpoch;
+    private final int coordinatorEpoch;
+
+    public AbortTransactionSpec(
+        TopicPartition topicPartition,
+        long producerId,
+        short producerEpoch,
+        int coordinatorEpoch
+    ) {
+        this.topicPartition = topicPartition;
+        this.producerId = producerId;
+        this.producerEpoch = producerEpoch;
+        this.coordinatorEpoch = coordinatorEpoch;
+    }
+
+    public TopicPartition topicPartition() {
+        return topicPartition;
+    }
+
+    public long producerId() {
+        return producerId;
+    }
+
+    public short producerEpoch() {
+        return producerEpoch;
+    }
+
+    public int coordinatorEpoch() {
+        return coordinatorEpoch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbortTransactionSpec that = (AbortTransactionSpec) o;
+        return producerId == that.producerId &&
+            producerEpoch == that.producerEpoch &&
+            coordinatorEpoch == that.coordinatorEpoch &&
+            Objects.equals(topicPartition, that.topicPartition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicPartition, producerId, producerEpoch, coordinatorEpoch);
+    }
+
+    @Override
+    public String toString() {
+        return "AbortTransactionSpec(" +
+            "topicPartition=" + topicPartition +
+            ", producerId=" + producerId +
+            ", producerEpoch=" + producerEpoch +
+            ", coordinatorEpoch=" + coordinatorEpoch +
+            ')';
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1512,6 +1512,28 @@ public interface Admin extends AutoCloseable {
     DescribeTransactionsResult describeTransactions(Collection<String> transactionalIds, DescribeTransactionsOptions options);
 
     /**
+     * Forcefully abort a transaction which is open on a topic partition. See
+     * {@link #abortTransaction(AbortTransactionSpec, AbortTransactionOptions)} for more details.
+     *
+     * @param spec The transaction specification including topic partition and producer details
+     * @return The result
+     */
+    default AbortTransactionResult abortTransaction(AbortTransactionSpec spec) {
+        return abortTransaction(spec, new AbortTransactionOptions());
+    }
+
+    /**
+     * Forcefully abort a transaction which is open on a topic partition. This will
+     * send a `WriteTxnMarkers` request to the partition leader in order to abort the
+     * transaction. This requires administrative privileges.
+     *
+     * @param spec The transaction specification including topic partition and producer details
+     * @param options Options to control the method behavior (including filters)
+     * @return The result
+     */
+    AbortTransactionResult abortTransaction(AbortTransactionSpec spec, AbortTransactionOptions options);
+
+    /**
      * Get the metrics kept by the adminClient
      */
     Map<MetricName, ? extends Metric> metrics();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult.ReplicaLogDirInfo;
 import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
 import org.apache.kafka.clients.admin.OffsetSpec.TimestampSpec;
+import org.apache.kafka.clients.admin.internals.AbortTransactionHandler;
 import org.apache.kafka.clients.admin.internals.AdminApiDriver;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler;
 import org.apache.kafka.clients.admin.internals.AdminMetadataManager;
@@ -4743,6 +4744,15 @@ public class KafkaAdminClient extends AdminClient {
             logContext
         );
         return new DescribeTransactionsResult(invokeDriver(handler, options.timeoutMs));
+    }
+
+    @Override
+    public AbortTransactionResult abortTransaction(AbortTransactionSpec spec, AbortTransactionOptions options) {
+        AbortTransactionHandler handler = new AbortTransactionHandler(
+            spec,
+            logContext
+        );
+        return new AbortTransactionResult(invokeDriver(handler, options.timeoutMs));
     }
 
     private <K, V> Map<K, KafkaFutureImpl<V>> invokeDriver(

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
@@ -142,7 +142,7 @@ public class AbortTransactionHandler implements AdminApiHandler<TopicPartition, 
                 log.error("WriteTxnMarkers request for abort spec {} failed cluster authorization", abortSpec);
                 return ApiResult.failed(abortSpec.topicPartition(), new ClusterAuthorizationException(
                     "WriteTxnMarkers request with " + abortSpec + " failed due to cluster " +
-                        "authorization error."));
+                        "authorization error"));
 
             case INVALID_PRODUCER_EPOCH:
                 log.error("WriteTxnMarkers request for abort spec {} failed due to an invalid producer epoch",

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.AbortTransactionSpec;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.TransactionCoordinatorFencedException;
+import org.apache.kafka.common.message.WriteTxnMarkersRequestData;
+import org.apache.kafka.common.message.WriteTxnMarkersResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
+import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+
+public class AbortTransactionHandler implements AdminApiHandler<TopicPartition, Void> {
+    private final Logger log;
+    private final AbortTransactionSpec abortSpec;
+    private final PartitionLeaderStrategy lookupStrategy;
+
+    public AbortTransactionHandler(
+        AbortTransactionSpec abortSpec,
+        LogContext logContext
+    ) {
+        this.abortSpec = abortSpec;
+        this.log = logContext.logger(AbortTransactionHandler.class);
+        this.lookupStrategy = new PartitionLeaderStrategy(logContext);
+    }
+
+    @Override
+    public String apiName() {
+        return "abortTransaction";
+    }
+
+    @Override
+    public Keys<TopicPartition> initializeKeys() {
+        return Keys.dynamicMapped(
+            Collections.singleton(abortSpec.topicPartition()),
+            lookupStrategy
+        );
+    }
+
+    @Override
+    public WriteTxnMarkersRequest.Builder buildRequest(
+        int brokerId,
+        Set<TopicPartition> topicPartitions
+    ) {
+        validateTopicPartitions(topicPartitions);
+
+        WriteTxnMarkersRequestData.WritableTxnMarker marker = new WriteTxnMarkersRequestData.WritableTxnMarker()
+            .setCoordinatorEpoch(abortSpec.coordinatorEpoch())
+            .setProducerEpoch(abortSpec.producerEpoch())
+            .setProducerId(abortSpec.producerId())
+            .setTransactionResult(false);
+
+        marker.topics().add(new WriteTxnMarkersRequestData.WritableTxnMarkerTopic()
+            .setName(abortSpec.topicPartition().topic())
+            .setPartitionIndexes(singletonList(abortSpec.topicPartition().partition()))
+        );
+
+        WriteTxnMarkersRequestData request = new WriteTxnMarkersRequestData();
+        request.markers().add(marker);
+
+        return new WriteTxnMarkersRequest.Builder(request);
+    }
+
+    @Override
+    public ApiResult<TopicPartition, Void> handleResponse(
+        int brokerId,
+        Set<TopicPartition> topicPartitions,
+        AbstractResponse abstractResponse
+    ) {
+        validateTopicPartitions(topicPartitions);
+
+        WriteTxnMarkersResponse response = (WriteTxnMarkersResponse) abstractResponse;
+        List<WriteTxnMarkersResponseData.WritableTxnMarkerResult> markerResponses = response.data().markers();
+
+        if (markerResponses.size() != 1 || markerResponses.get(0).producerId() != abortSpec.producerId()) {
+            return ApiResult.failed(abortSpec.topicPartition(), new KafkaException("WriteTxnMarkers response " +
+                "included unexpected marker entries: " + markerResponses + "(expected to find exactly one " +
+                "entry with producerId " + abortSpec.producerId() + ")"));
+        }
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerResult markerResponse = markerResponses.get(0);
+        List<WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult> topicResponses = markerResponse.topics();
+
+        if (topicResponses.size() != 1 || !topicResponses.get(0).name().equals(abortSpec.topicPartition().topic())) {
+            return ApiResult.failed(abortSpec.topicPartition(), new KafkaException("WriteTxnMarkers response " +
+                "included unexpected topic entries: " + markerResponses + "(expected to find exactly one " +
+                "entry with topic partition " + abortSpec.topicPartition() + ")"));
+        }
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult topicResponse = topicResponses.get(0);
+        List<WriteTxnMarkersResponseData.WritableTxnMarkerPartitionResult> partitionResponses =
+            topicResponse.partitions();
+
+        if (partitionResponses.size() != 1 || partitionResponses.get(0).partitionIndex() != abortSpec.topicPartition().partition()) {
+            return ApiResult.failed(abortSpec.topicPartition(), new KafkaException("WriteTxnMarkers response " +
+                "included unexpected partition entries for topic " + abortSpec.topicPartition().topic() +
+                ": " + markerResponses + "(expected to find exactly one entry with partition " +
+                abortSpec.topicPartition().partition() + ")"));
+        }
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerPartitionResult partitionResponse = partitionResponses.get(0);
+        Errors error = Errors.forCode(partitionResponse.errorCode());
+
+        if (error != Errors.NONE) {
+            return handleError(error);
+        } else {
+            return ApiResult.completed(abortSpec.topicPartition(), null);
+        }
+    }
+
+    private ApiResult<TopicPartition, Void> handleError(Errors error) {
+        switch (error) {
+            case CLUSTER_AUTHORIZATION_FAILED:
+                log.error("WriteTxnMarkers request for abort spec {} failed cluster authorization", abortSpec);
+                return ApiResult.failed(abortSpec.topicPartition(), new ClusterAuthorizationException(
+                    "WriteTxnMarkers request with " + abortSpec + " failed due to cluster " +
+                        "authorization error."));
+
+            case INVALID_PRODUCER_EPOCH:
+                log.error("WriteTxnMarkers request for abort spec {} failed due to an invalid producer epoch",
+                    abortSpec);
+                return ApiResult.failed(abortSpec.topicPartition(), new InvalidProducerEpochException(
+                    "WriteTxnMarkers request with " + abortSpec + " failed due an invalid producer epoch"));
+
+            case TRANSACTION_COORDINATOR_FENCED:
+                log.error("WriteTxnMarkers request for abort spec {} failed because the coordinator epoch is fenced",
+                    abortSpec);
+                return ApiResult.failed(abortSpec.topicPartition(), new TransactionCoordinatorFencedException(
+                    "WriteTxnMarkers request with " + abortSpec + " failed since the provided " +
+                        "coordinator epoch " + abortSpec.coordinatorEpoch() + " has been fenced " +
+                        "by the active coordinator"));
+
+            case NOT_LEADER_OR_FOLLOWER:
+            case REPLICA_NOT_AVAILABLE:
+            case BROKER_NOT_AVAILABLE:
+            case UNKNOWN_TOPIC_OR_PARTITION:
+                log.debug("WriteTxnMarkers request for abort spec {} failed due to {}. Will retry after attempting to " +
+                        "find the leader again", abortSpec, error);
+                return ApiResult.unmapped(singletonList(abortSpec.topicPartition()));
+
+            default:
+                log.error("WriteTxnMarkers request for abort spec {} failed due to an unexpected error {}",
+                    abortSpec, error);
+                return ApiResult.failed(abortSpec.topicPartition(), error.exception(
+                    "WriteTxnMarkers request with " + abortSpec + " failed due to unexpected error: " + error.message()));
+        }
+    }
+
+    private void validateTopicPartitions(Set<TopicPartition> topicPartitions) {
+        if (!topicPartitions.equals(singleton(abortSpec.topicPartition()))) {
+            throw new IllegalArgumentException("Received unexpected topic partitions " + topicPartitions +
+                " (expected only " + singleton(abortSpec.topicPartition()) + ")");
+        }
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
@@ -135,5 +135,30 @@ public interface AdminApiHandler<K, V> {
             this.failedKeys = Collections.unmodifiableMap(failedKeys);
             this.unmappedKeys = Collections.unmodifiableList(unmappedKeys);
         }
+
+        public static <K, V> ApiResult<K, V> completed(K key, V value) {
+            return new ApiResult<>(
+                Collections.singletonMap(key, value),
+                Collections.emptyMap(),
+                Collections.emptyList()
+            );
+        }
+
+        public static <K, V> ApiResult<K, V> failed(K key, Throwable t) {
+            return new ApiResult<>(
+                Collections.emptyMap(),
+                Collections.singletonMap(key, t),
+                Collections.emptyList()
+            );
+        }
+
+        public static <K, V> ApiResult<K, V> unmapped(List<K> keys) {
+            return new ApiResult<>(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                keys
+            );
+        }
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
@@ -105,6 +105,11 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
 
         public final WriteTxnMarkersRequestData data;
 
+        public Builder(WriteTxnMarkersRequestData data) {
+            super(ApiKeys.WRITE_TXN_MARKERS);
+            this.data = data;
+        }
+
         public Builder(short version, final List<TxnMarkerEntry> markers) {
             super(ApiKeys.WRITE_TXN_MARKERS, version);
             List<WritableTxnMarker> dataMarkers = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -914,6 +914,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public AbortTransactionResult abortTransaction(AbortTransactionSpec spec, AbortTransactionOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public void close(Duration timeout) {}
 
     public synchronized void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandlerTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.AbortTransactionSpec;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.TransactionCoordinatorFencedException;
+import org.apache.kafka.common.message.WriteTxnMarkersRequestData;
+import org.apache.kafka.common.message.WriteTxnMarkersResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
+import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AbortTransactionHandlerTest {
+    private final LogContext logContext = new LogContext();
+    private final TopicPartition topicPartition = new TopicPartition("foo", 5);
+    private final AbortTransactionSpec abortSpec = new AbortTransactionSpec(
+        topicPartition, 12345L, (short) 15, 4321);
+
+    @Test
+    public void testInvalidBuildRequestCall() {
+        AbortTransactionHandler handler = new AbortTransactionHandler(abortSpec, logContext);
+        assertThrows(IllegalArgumentException.class, () -> handler.buildRequest(1,
+            emptySet()));
+        assertThrows(IllegalArgumentException.class, () -> handler.buildRequest(1,
+            mkSet(new TopicPartition("foo", 1))));
+        assertThrows(IllegalArgumentException.class, () -> handler.buildRequest(1,
+            mkSet(topicPartition, new TopicPartition("foo", 1))));
+    }
+
+    @Test
+    public void testValidBuildRequestCall() {
+        AbortTransactionHandler handler = new AbortTransactionHandler(abortSpec, logContext);
+        WriteTxnMarkersRequest.Builder request = handler.buildRequest(1, singleton(topicPartition));
+        assertEquals(1, request.data.markers().size());
+
+        WriteTxnMarkersRequestData.WritableTxnMarker markerRequest = request.data.markers().get(0);
+        assertEquals(abortSpec.producerId(), markerRequest.producerId());
+        assertEquals(abortSpec.producerEpoch(), markerRequest.producerEpoch());
+        assertEquals(abortSpec.coordinatorEpoch(), markerRequest.coordinatorEpoch());
+        assertEquals(1, markerRequest.topics().size());
+
+        WriteTxnMarkersRequestData.WritableTxnMarkerTopic topicRequest = markerRequest.topics().get(0);
+        assertEquals(abortSpec.topicPartition().topic(), topicRequest.name());
+        assertEquals(singletonList(abortSpec.topicPartition().partition()), topicRequest.partitionIndexes());
+    }
+
+    @Test
+    public void testInvalidHandleResponseCall() {
+        AbortTransactionHandler handler = new AbortTransactionHandler(abortSpec, logContext);
+        WriteTxnMarkersResponseData response = new WriteTxnMarkersResponseData();
+        assertThrows(IllegalArgumentException.class, () -> handler.handleResponse(1,
+            emptySet(), new WriteTxnMarkersResponse(response)));
+        assertThrows(IllegalArgumentException.class, () -> handler.handleResponse(1,
+            mkSet(new TopicPartition("foo", 1)), new WriteTxnMarkersResponse(response)));
+        assertThrows(IllegalArgumentException.class, () -> handler.handleResponse(1,
+            mkSet(topicPartition, new TopicPartition("foo", 1)), new WriteTxnMarkersResponse(response)));
+    }
+
+    @Test
+    public void testInvalidResponse() {
+        AbortTransactionHandler handler = new AbortTransactionHandler(abortSpec, logContext);
+
+        WriteTxnMarkersResponseData response = new WriteTxnMarkersResponseData();
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerResult markerResponse =
+            new WriteTxnMarkersResponseData.WritableTxnMarkerResult();
+        response.markers().add(markerResponse);
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        markerResponse.setProducerId(abortSpec.producerId());
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult topicResponse =
+            new WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult();
+        markerResponse.topics().add(topicResponse);
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        topicResponse.setName(abortSpec.topicPartition().topic());
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerPartitionResult partitionResponse =
+            new WriteTxnMarkersResponseData.WritableTxnMarkerPartitionResult();
+        topicResponse.partitions().add(partitionResponse);
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        partitionResponse.setPartitionIndex(abortSpec.topicPartition().partition());
+        topicResponse.setName(abortSpec.topicPartition().topic() + "random");
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+
+        topicResponse.setName(abortSpec.topicPartition().topic());
+        markerResponse.setProducerId(abortSpec.producerId() + 1);
+        assertFailed(KafkaException.class, topicPartition, handler.handleResponse(1, singleton(topicPartition),
+            new WriteTxnMarkersResponse(response)));
+    }
+
+    @Test
+    public void testSuccessfulResponse() {
+        assertCompleted(abortSpec.topicPartition(), handleWithError(abortSpec, Errors.NONE));
+    }
+
+    @Test
+    public void testRetriableErrors() {
+        assertUnmapped(abortSpec.topicPartition(), handleWithError(abortSpec, Errors.NOT_LEADER_OR_FOLLOWER));
+        assertUnmapped(abortSpec.topicPartition(), handleWithError(abortSpec, Errors.UNKNOWN_TOPIC_OR_PARTITION));
+        assertUnmapped(abortSpec.topicPartition(), handleWithError(abortSpec, Errors.REPLICA_NOT_AVAILABLE));
+        assertUnmapped(abortSpec.topicPartition(), handleWithError(abortSpec, Errors.BROKER_NOT_AVAILABLE));
+    }
+
+    @Test
+    public void testFatalErrors() {
+        assertFailed(ClusterAuthorizationException.class, abortSpec.topicPartition(),
+            handleWithError(abortSpec, Errors.CLUSTER_AUTHORIZATION_FAILED));
+        assertFailed(InvalidProducerEpochException.class, abortSpec.topicPartition(),
+            handleWithError(abortSpec, Errors.INVALID_PRODUCER_EPOCH));
+        assertFailed(TransactionCoordinatorFencedException.class, abortSpec.topicPartition(),
+            handleWithError(abortSpec, Errors.TRANSACTION_COORDINATOR_FENCED));
+    }
+
+    private AdminApiHandler.ApiResult<TopicPartition, Void> handleWithError(
+        AbortTransactionSpec abortSpec,
+        Errors error
+    ) {
+        AbortTransactionHandler handler = new AbortTransactionHandler(abortSpec, logContext);
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerPartitionResult partitionResponse =
+            new WriteTxnMarkersResponseData.WritableTxnMarkerPartitionResult()
+                .setPartitionIndex(abortSpec.topicPartition().partition())
+                .setErrorCode(error.code());
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult topicResponse =
+            new WriteTxnMarkersResponseData.WritableTxnMarkerTopicResult()
+                .setName(abortSpec.topicPartition().topic());
+        topicResponse.partitions().add(partitionResponse);
+
+        WriteTxnMarkersResponseData.WritableTxnMarkerResult markerResponse =
+            new WriteTxnMarkersResponseData.WritableTxnMarkerResult()
+                .setProducerId(abortSpec.producerId());
+        markerResponse.topics().add(topicResponse);
+
+        WriteTxnMarkersResponseData response = new WriteTxnMarkersResponseData();
+        response.markers().add(markerResponse);
+
+        return handler.handleResponse(1, singleton(abortSpec.topicPartition()),
+            new WriteTxnMarkersResponse(response));
+    }
+
+    private void assertUnmapped(
+        TopicPartition topicPartition,
+        AdminApiHandler.ApiResult<TopicPartition, Void> result
+    ) {
+        assertEquals(emptySet(), result.completedKeys.keySet());
+        assertEquals(emptySet(), result.failedKeys.keySet());
+        assertEquals(singletonList(topicPartition), result.unmappedKeys);
+    }
+
+    private void assertCompleted(
+        TopicPartition topicPartition,
+        AdminApiHandler.ApiResult<TopicPartition, Void> result
+    ) {
+        assertEquals(emptySet(), result.failedKeys.keySet());
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(singleton(topicPartition), result.completedKeys.keySet());
+        assertNull(result.completedKeys.get(topicPartition));
+    }
+
+    private void assertFailed(
+        Class<? extends Throwable> expectedExceptionType,
+        TopicPartition topicPartition,
+        AdminApiHandler.ApiResult<TopicPartition, Void> result
+    ) {
+        assertEquals(emptySet(), result.completedKeys.keySet());
+        assertEquals(emptyList(), result.unmappedKeys);
+        assertEquals(singleton(topicPartition), result.failedKeys.keySet());
+        assertTrue(expectedExceptionType.isInstance(result.failedKeys.get(topicPartition)));
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidProducerEpochException;
 import org.apache.kafka.common.errors.TransactionCoordinatorFencedException;
+import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.message.WriteTxnMarkersRequestData;
 import org.apache.kafka.common.message.WriteTxnMarkersResponseData;
 import org.apache.kafka.common.protocol.Errors;
@@ -152,6 +153,8 @@ public class AbortTransactionHandlerTest {
             handleWithError(abortSpec, Errors.INVALID_PRODUCER_EPOCH));
         assertFailed(TransactionCoordinatorFencedException.class, abortSpec.topicPartition(),
             handleWithError(abortSpec, Errors.TRANSACTION_COORDINATOR_FENCED));
+        assertFailed(UnknownServerException.class, abortSpec.topicPartition(),
+            handleWithError(abortSpec, Errors.UNKNOWN_SERVER_ERROR));
     }
 
     private AdminApiHandler.ApiResult<TopicPartition, Void> handleWithError(


### PR DESCRIPTION
This patch adds the Admin API to abort transactions from KIP-664: https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions. The `WriteTxnMarker` API needs to be sent to partition leaders, so we are able to reuse `PartitionLeaderStrategy`, which was introduced when support for `DescribeProducers` was added.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
