### PR TITLE
[WIP]MINOR: add abstract keywords to util classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/RecordsUtil.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordsUtil.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-public class RecordsUtil {
+public abstract class RecordsUtil {
     /**
      * Down convert batches to the provided message format version. The first offset parameter is only relevant in the
      * conversion from uncompressed v2 or higher to v1 or lower. The reason is that uncompressed records in v0 and v1

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/SchemaUtil.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/util/SchemaUtil.java
@@ -21,7 +21,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 
 import java.util.Map;
 
-public class SchemaUtil {
+public abstract class SchemaUtil {
 
     public static SchemaBuilder copySchemaBasics(Schema source) {
         return copySchemaBasics(source, new SchemaBuilder(source.type()));

--- a/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftUtil.java
@@ -35,7 +35,7 @@ import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 
-public class RaftUtil {
+public abstract class RaftUtil {
 
     public static ApiMessage errorResponse(ApiKeys apiKey, Errors error) {
         switch (apiKey) {


### PR DESCRIPTION
I think that Util classes are intended for using the static method without instantiating the class.
So in order to be clear, I add abstract keywords to some Util classes which have no private constructor.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
