### PR TITLE
MINOR: system test spelling/pydoc/dead code fixes

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -199,29 +199,33 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         :param int num_nodes: the number of nodes in the service.  There are 4 possibilities:
             1) Zookeeper quorum:
                 The number of brokers is defined by this parameter.
+                The broker.id values will be 1..num_nodes.
             2) Co-located Raft quorum:
                 The number of nodes having a broker role is defined by this parameter.
+                The node.id values will be 1..num_nodes
                 The number of nodes having a controller role will by default be 1, 3, or 5 depending on num_nodes
                 (1 if num_nodes < 3, otherwise 3 if num_nodes < 5, otherwise 5).  This calculation
                 can be overridden via controller_num_nodes_override, which must be between 1 and num_nodes,
                 inclusive, when non-zero.  Here are some possibilities:
                 num_nodes = 1:
-                    node 0: broker.roles=broker+controller
+                    broker having node.id=1: broker.roles=broker+controller
                 num_nodes = 2:
-                    node 0: broker.roles=broker+controller
-                    node 1: broker.roles=broker
+                    broker having node.id=1: broker.roles=broker+controller
+                    broker having node.id=2: broker.roles=broker
                 num_nodes = 3:
-                    node 0: broker.roles=broker+controller
-                    node 1: broker.roles=broker+controller
-                    node 2: broker.roles=broker+controller
+                    broker having node.id=1: broker.roles=broker+controller
+                    broker having node.id=2: broker.roles=broker+controller
+                    broker having node.id=3: broker.roles=broker+controller
                 num_nodes = 3, controller_num_nodes_override = 1
-                    node 0: broker.roles=broker+controller
-                    node 1: broker.roles=broker
-                    node 2: broker.roles=broker
+                    broker having node.id=1: broker.roles=broker+controller
+                    broker having node.id=2: broker.roles=broker
+                    broker having node.id=3: broker.roles=broker
             3) Remote Raft quorum when instantiating the broker service:
                 The number of nodes, all of which will have broker.roles=broker, is defined by this parameter.
+                The node.id values will be 1..num_nodes
             4) Remote Raft quorum when instantiating the controller service:
                 The number of nodes, all of which will have broker.roles=controller, is defined by this parameter.
+                The node.id values will be 3001..(3000 + num_nodes)
                 The value passed in is determined by the broker service when that is instantiated, and it uses the
                 same algorithm as described above: 1, 3, or 5 unless controller_num_nodes_override is provided.
         :param ZookeeperService zk:

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -187,7 +187,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                  interbroker_security_protocol=SecurityConfig.PLAINTEXT,
                  client_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI, interbroker_sasl_mechanism=SecurityConfig.SASL_MECHANISM_GSSAPI,
                  authorizer_class_name=None, topics=None, version=DEV_BRANCH, jmx_object_names=None,
-                 jmx_attributes=None, zk_connect_timeout=18000, zk_session_timeout=18000, server_prop_overides=None, zk_chroot=None,
+                 jmx_attributes=None, zk_connect_timeout=18000, zk_session_timeout=18000, server_prop_overrides=None, zk_chroot=None,
                  zk_client_secure=False,
                  listener_security_config=ListenerSecurityConfig(), per_node_server_prop_overrides=None,
                  extra_kafka_opts="", tls_version=None,
@@ -237,13 +237,14 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         :param jmx_attributes:
         :param int zk_connect_timeout:
         :param int zk_session_timeout:
-        :param dict server_prop_overides: overrides for kafka.properties file
+        :param list[list] server_prop_overrides: overrides for kafka.properties file
+            e.g: [["config1", "true"], ["config2", "1000"]]
         :param str zk_chroot:
         :param bool zk_client_secure: connect to Zookeeper over secure client port (TLS) when True
         :param ListenerSecurityConfig listener_security_config: listener config to use
-        :param dict per_node_server_prop_overrides: overrides for kafka.properties file keyed by 0-based node number
+        :param dict per_node_server_prop_overrides: overrides for kafka.properties file keyed by 1-based node number
+            e.g: {1: [["config1", "true"], ["config2", "1000"]], 2: [["config1", "false"], ["config2", "0"]]}
         :param str extra_kafka_opts: jvm args to add to KAFKA_OPTS variable
-        :param str tls_version: TLS version to use
         :param KafkaService remote_kafka: process.roles=controller for this cluster when not None; ignored when using ZooKeeper
         :param int controller_num_nodes_override: the number of nodes to use in the cluster, instead of 5, 3, or 1 based on num_nodes, if positive, not using ZooKeeper, and remote_kafka is not None; ignored otherwise
 
@@ -314,10 +315,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.minikdc = None
         self.authorizer_class_name = authorizer_class_name
         self.zk_set_acl = False
-        if server_prop_overides is None:
-            self.server_prop_overides = []
+        if server_prop_overrides is None:
+            self.server_prop_overrides = []
         else:
-            self.server_prop_overides = server_prop_overides
+            self.server_prop_overrides = server_prop_overrides
         if per_node_server_prop_overrides is None:
             self.per_node_server_prop_overrides = {}
         else:
@@ -560,12 +561,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         if self.quorum_info.using_zk:
             self.logger.info("Waiting for brokers to register at ZK")
 
-            retries = 30
             expected_broker_ids = set(self.nodes)
-            wait_until(lambda: {node for node in self.nodes if self.is_registered(node)} == expected_broker_ids, 30, 1)
-
-            if retries == 0:
-                raise RuntimeError("Kafka servers didn't register at ZK within 30 seconds")
+            wait_until(lambda: {node for node in self.nodes if self.is_registered(node)} == expected_broker_ids,
+                       timeout_sec=30, backoff_sec=1, err_msg="Kafka servers didn't register at ZK within 30 seconds")
 
         # Create topics if necessary
         if self.topics is not None:
@@ -634,7 +632,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
             else:
                 override_configs[config_property.ZOOKEEPER_SSL_CLIENT_ENABLE] = 'false'
 
-        for prop in self.server_prop_overides:
+        for prop in self.server_prop_overrides:
             override_configs[prop[0]] = prop[1]
 
         for prop in self.per_node_server_prop_overrides.get(self.idx(node), []):

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -84,7 +84,7 @@ class ConnectDistributedTest(Test):
         self.kafka = KafkaService(self.test_context, self.num_brokers, self.zk,
                                   security_protocol=security_protocol, interbroker_security_protocol=security_protocol,
                                   topics=self.topics, version=broker_version,
-                                  server_prop_overides=[["auto.create.topics.enable", str(auto_create_topics)]])
+                                  server_prop_overrides=[["auto.create.topics.enable", str(auto_create_topics)]])
         if timestamp_type is not None:
             for node in self.kafka.nodes:
                 node.config[config_property.MESSAGE_TIMESTAMP_TYPE] = timestamp_type

--- a/tests/kafkatest/tests/core/delegation_token_test.py
+++ b/tests/kafkatest/tests/core/delegation_token_test.py
@@ -37,7 +37,7 @@ class DelegationTokenTest(Test):
         self.zk = ZookeeperService(test_context, num_nodes=1)
         self.kafka = KafkaService(self.test_context, num_nodes=1, zk=self.zk, zk_chroot="/kafka",
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}},
-                                  server_prop_overides=[
+                                  server_prop_overrides=[
                                       [config_property.DELEGATION_TOKEN_MAX_LIFETIME_MS, "604800000"],
                                       [config_property.DELEGATION_TOKEN_EXPIRY_TIME_MS, "86400000"],
                                       [config_property.DELEGATION_TOKEN_SECRET_KEY, "test12345"],

--- a/tests/kafkatest/tests/core/fetch_from_follower_test.py
+++ b/tests/kafkatest/tests/core/fetch_from_follower_test.py
@@ -47,7 +47,7 @@ class FetchFromFollowerTest(ProduceConsumeValidateTest):
                                           "replication-factor": 3,
                                           "configs": {"min.insync.replicas": 1}},
                                   },
-                                  server_prop_overides=[
+                                  server_prop_overrides=[
                                       ["replica.selector.class", self.RACK_AWARE_REPLICA_SELECTOR]
                                   ],
                                   per_node_server_prop_overrides={

--- a/tests/kafkatest/tests/core/log_dir_failure_test.py
+++ b/tests/kafkatest/tests/core/log_dir_failure_test.py
@@ -72,7 +72,7 @@ class LogDirFailureTest(ProduceConsumeValidateTest):
                                   },
                                   # Set log.roll.ms to 3 seconds so that broker will detect disk error sooner when it creates log segment
                                   # Otherwise broker will still be able to read/write the log file even if the log directory is inaccessible.
-                                  server_prop_overides=[
+                                  server_prop_overrides=[
                                       [config_property.OFFSETS_TOPIC_NUM_PARTITIONS, "1"],
                                       [config_property.LOG_FLUSH_INTERVAL_MESSAGE, "5"],
                                       [config_property.REPLICA_HIGHWATERMARK_CHECKPOINT_INTERVAL_MS, "60000"],

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -47,7 +47,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         # reassignment for upto one replica per partition, which is not
         # desirable for this test in particular.
         self.kafka = KafkaService(test_context, num_nodes=4, zk=self.zk,
-                                  server_prop_overides=[
+                                  server_prop_overrides=[
                                       [config_property.LOG_ROLL_TIME_MS, "5000"],
                                       [config_property.LOG_RETENTION_CHECK_INTERVAL_MS, "5000"]
                                   ],

--- a/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
@@ -48,7 +48,7 @@ class StreamsBrokerCompatibility(Test):
                                       self.input: {'partitions': 1, 'replication-factor': 1},
                                       self.output: {'partitions': 1, 'replication-factor': 1}
                                   },
-                                  server_prop_overides=[
+                                  server_prop_overrides=[
                                       ["transaction.state.log.replication.factor", "1"],
                                       ["transaction.state.log.min.isr", "1"]
                                   ])

--- a/tests/kafkatest/tests/tools/log_compaction_test.py
+++ b/tests/kafkatest/tests/tools/log_compaction_test.py
@@ -49,7 +49,7 @@ class LogCompactionTest(Test):
             zk = self.zk,
             security_protocol=security_protocol,
             interbroker_security_protocol=interbroker_security_protocol,
-            server_prop_overides=[
+            server_prop_overrides=[
                 [config_property.LOG_SEGMENT_BYTES, LogCompactionTest.LOG_SEGMENT_BYTES],
             ],
             controller_num_nodes_override=self.num_zk)


### PR DESCRIPTION
Fixes some pydoc, corrects spelling, and removes dead code in system tests.

Renames `server_prop_overides` to `server_prop_overrides` to correct spelling.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
