### PR TITLE
MINOR: bump version to 2.6.3-SNAPSHOT in missing files

### DIFF
--- a/docs/js/templateData.js
+++ b/docs/js/templateData.js
@@ -19,6 +19,6 @@ limitations under the License.
 var context={
     "version": "26",
     "dotVersion": "2.6",
-    "fullDotVersion": "2.6.2-SNAPSHOT",
+    "fullDotVersion": "2.6.3-SNAPSHOT",
     "scalaVersion": "2.13"
 };

--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -70,7 +70,7 @@ TEMP_BRANCH_PREFIX = "PR_TOOL"
 
 DEV_BRANCH_NAME = "trunk"
 
-DEFAULT_FIX_VERSION = os.environ.get("DEFAULT_FIX_VERSION", "2.6.2-SNAPSHOT")
+DEFAULT_FIX_VERSION = os.environ.get("DEFAULT_FIX_VERSION", "2.6.3-SNAPSHOT")
 
 def get_json(url):
     try:


### PR DESCRIPTION
I was just editing something on the release process wiki and noticed that under the "Cut Branch" section, which it says to skip for bugfix releases, there's actually a list of files that it then says to update for both feature and bugfix releases. Luckily most of those files are actually covered later in the wiki, but two were not.

Also updated the release process wiki to clear this up for future RMs