### PR TITLE
KAFKA-12709; Add Admin API for `ListTransactions`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbortTransactionOptions.java
@@ -20,4 +20,12 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 @InterfaceStability.Evolving
 public class AbortTransactionOptions extends AbstractOptions<AbortTransactionOptions> {
+
+    @Override
+    public String toString() {
+        return "AbortTransactionOptions(" +
+            "timeoutMs=" + timeoutMs +
+            ')';
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1534,6 +1534,28 @@ public interface Admin extends AutoCloseable {
     AbortTransactionResult abortTransaction(AbortTransactionSpec spec, AbortTransactionOptions options);
 
     /**
+     * List active transactions in the cluster. See
+     * {@link #listTransactions(ListTransactionsOptions)} for more details.
+     *
+     * @return The result
+     */
+    default ListTransactionsResult listTransactions() {
+        return listTransactions(new ListTransactionsOptions());
+    }
+
+    /**
+     * List active transactions in the cluster. This will query all potential transaction
+     * coordinators in the cluster and collect the state of all transactionalIds. Users
+     * should typically attempt to reduce the size of the result set using
+     * {@link ListTransactionsOptions#filterProducerIds(Set)} or
+     * {@link ListTransactionsOptions#filterStates(Set)}
+     *
+     * @param options Options to control the method behavior (including filters)
+     * @return The result
+     */
+    ListTransactionsResult listTransactions(ListTransactionsOptions options);
+
+    /**
      * Get the metrics kept by the adminClient
      */
     Map<MetricName, ? extends Metric> metrics();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -1545,10 +1545,10 @@ public interface Admin extends AutoCloseable {
 
     /**
      * List active transactions in the cluster. This will query all potential transaction
-     * coordinators in the cluster and collect the state of all transactionalIds. Users
+     * coordinators in the cluster and collect the state of all transactions. Users
      * should typically attempt to reduce the size of the result set using
-     * {@link ListTransactionsOptions#filterProducerIds(Set)} or
-     * {@link ListTransactionsOptions#filterStates(Set)}
+     * {@link ListTransactionsOptions#filterProducerIds(Collection)} or
+     * {@link ListTransactionsOptions#filterStates(Collection)}
      *
      * @param options Options to control the method behavior (including filters)
      * @return The result

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeProducersResult.java
@@ -71,6 +71,13 @@ public class DescribeProducersResult {
         public List<ProducerState> activeProducers() {
             return activeProducers;
         }
+
+        @Override
+        public String toString() {
+            return "PartitionProducerState(" +
+                "activeProducers=" + activeProducers +
+                ')';
+        }
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTransactionsOptions.java
@@ -28,4 +28,11 @@ import java.util.Collection;
 @InterfaceStability.Evolving
 public class DescribeTransactionsOptions extends AbstractOptions<DescribeTransactionsOptions> {
 
+    @Override
+    public String toString() {
+        return "DescribeTransactionsOptions(" +
+            "timeoutMs=" + timeoutMs +
+            ')';
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsOptions.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Options for {@link Admin#listTransactions()}.
+ *
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListTransactionsOptions extends AbstractOptions<ListTransactionsOptions> {
+    private Set<TransactionState> filteredStates = Collections.emptySet();
+    private Set<Long> filteredProducerIds = Collections.emptySet();
+
+    public ListTransactionsOptions filterStates(Collection<TransactionState> states) {
+        this.filteredStates = new HashSet<>(states);
+        return this;
+    }
+
+    public ListTransactionsOptions filterProducerIds(Collection<Long> producerIdFilters) {
+        this.filteredProducerIds = new HashSet<>(producerIdFilters);
+        return this;
+    }
+
+    /**
+     * Returns the list of States that are requested or empty if no states have been specified
+     */
+    public Set<TransactionState> filteredStates() {
+        return filteredStates;
+    }
+
+    public Set<Long> filteredProducerIds() {
+        return filteredProducerIds;
+    }
+
+    @Override
+    public String toString() {
+        return "ListTransactionsOptions(" +
+            "filteredStates=" + filteredStates +
+            ", filteredProducerIds=" + filteredProducerIds +
+            ", timeoutMs=" + timeoutMs +
+            ')';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsOptions.java
@@ -34,23 +34,48 @@ public class ListTransactionsOptions extends AbstractOptions<ListTransactionsOpt
     private Set<TransactionState> filteredStates = Collections.emptySet();
     private Set<Long> filteredProducerIds = Collections.emptySet();
 
+    /**
+     * Filter only the transactions that are in a specific set of states. If no filter
+     * is specified or if the passed set of states is empty, then transactions in all
+     * states will be returned.
+     *
+     * @param states the set of states to filter by
+     * @return this object
+     */
     public ListTransactionsOptions filterStates(Collection<TransactionState> states) {
         this.filteredStates = new HashSet<>(states);
         return this;
     }
 
+    /**
+     * Filter only the transactions from producers in a specific set of producerIds.
+     * If no filter is specified or if the passed collection of producerIds is empty,
+     * then the transactions of all producerIds will be returned.
+     *
+     * @param producerIdFilters the set of producerIds to filter by
+     * @return this object
+     */
     public ListTransactionsOptions filterProducerIds(Collection<Long> producerIdFilters) {
         this.filteredProducerIds = new HashSet<>(producerIdFilters);
         return this;
     }
 
     /**
-     * Returns the list of States that are requested or empty if no states have been specified
+     * Returns the set of states to be filtered or empty if no states have been specified.
+     *
+     * @return the current set of filtered states (empty means that no states are filtered and all
+     *         all transactions will be returned)
      */
     public Set<TransactionState> filteredStates() {
         return filteredStates;
     }
 
+    /**
+     * Returns the set of producerIds that are being filtered or empty if none have been specified.
+     *
+     * @return the current set of filtered states (empty means that no producerIds are filtered and
+     *         all transactions will be returned)
+     */
     public Set<Long> filteredProducerIds() {
         return filteredProducerIds;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsResult.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The result of the {@link Admin#listTransactions()} call.
+ * <p>
+ * The API of this class is evolving, see {@link Admin} for details.
+ */
+@InterfaceStability.Evolving
+public class ListTransactionsResult {
+    private final KafkaFutureImpl<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future;
+
+    ListTransactionsResult(KafkaFutureImpl<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future) {
+        this.future = future;
+    }
+
+    public KafkaFuture<Collection<TransactionListing>> all() {
+        return allByBrokerId().thenApply(map -> {
+            List<TransactionListing> allListings = new ArrayList<>();
+            for (Collection<TransactionListing> listings : map.values()) {
+                allListings.addAll(listings);
+            }
+            return allListings;
+        });
+    }
+
+    public KafkaFuture<Set<Integer>> brokerIds() {
+        return future.thenApply(map -> new HashSet<>(map.keySet()));
+    }
+
+    public KafkaFuture<Map<Integer, Collection<TransactionListing>>> allByBrokerId() {
+        KafkaFutureImpl<Map<Integer, Collection<TransactionListing>>> allFuture = new KafkaFutureImpl<>();
+        Map<Integer, Collection<TransactionListing>> allListingsMap = new HashMap<>();
+
+        future.whenComplete((map, topLevelException) -> {
+            if (topLevelException != null) {
+                allFuture.completeExceptionally(topLevelException);
+                return;
+            }
+
+            Set<Integer> remainingResponses = new HashSet<>(map.keySet());
+            for (Map.Entry<Integer, KafkaFutureImpl<Collection<TransactionListing>>> entry : map.entrySet()) {
+                Integer brokerId = entry.getKey();
+                KafkaFutureImpl<Collection<TransactionListing>> future = entry.getValue();
+                future.whenComplete((listings, brokerException) -> {
+
+                    if (brokerException != null) {
+                        allFuture.completeExceptionally(brokerException);
+                    } else if (!allFuture.isDone()) {
+                        allListingsMap.put(brokerId, listings);
+                        remainingResponses.remove(brokerId);
+
+                        if (remainingResponses.isEmpty()) {
+                            allFuture.complete(allListingsMap);
+                        }
+                    }
+                });
+            }
+        });
+
+        return allFuture;
+    }
+
+    public KafkaFuture<Collection<TransactionListing>> byBrokerId(Integer brokerId) {
+        KafkaFutureImpl<Collection<TransactionListing>> resultFuture = new KafkaFutureImpl<>();
+        future.whenComplete((map, exception) -> {
+            if (exception != null) {
+                resultFuture.completeExceptionally(exception);
+            } else {
+                KafkaFutureImpl<Collection<TransactionListing>> brokerFuture = map.get(brokerId);
+                if (brokerFuture == null) {
+                    resultFuture.completeExceptionally(new KafkaException("ListTransactions result " +
+                        "did not include listings from broker " + brokerId + ". The included listings " +
+                        "were from brokers " + map.keySet()));
+                } else {
+                    brokerFuture.whenComplete((listings, brokerException) -> {
+                        if (brokerException != null) {
+                            resultFuture.completeExceptionally(brokerException);
+                        } else {
+                            resultFuture.complete(listings);
+                        }
+                    });
+                }
+            }
+        });
+        return resultFuture;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTransactionsResult.java
@@ -67,11 +67,8 @@ public class ListTransactionsResult {
             }
 
             Set<Integer> remainingResponses = new HashSet<>(map.keySet());
-            for (Map.Entry<Integer, KafkaFutureImpl<Collection<TransactionListing>>> entry : map.entrySet()) {
-                Integer brokerId = entry.getKey();
-                KafkaFutureImpl<Collection<TransactionListing>> future = entry.getValue();
+            map.forEach((brokerId, future) -> {
                 future.whenComplete((listings, brokerException) -> {
-
                     if (brokerException != null) {
                         allFuture.completeExceptionally(brokerException);
                     } else if (!allFuture.isDone()) {
@@ -83,7 +80,7 @@ public class ListTransactionsResult {
                         }
                     }
                 });
-            }
+            });
         });
 
         return allFuture;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TransactionListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TransactionListing.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Objects;
+
+@InterfaceStability.Evolving
+public class TransactionListing {
+    private final String transactionalId;
+    private final long producerId;
+    private final TransactionState transactionState;
+
+    public TransactionListing(
+        String transactionalId,
+        long producerId,
+        TransactionState transactionState
+    ) {
+        this.transactionalId = transactionalId;
+        this.producerId = producerId;
+        this.transactionState = transactionState;
+    }
+
+    public String transactionalId() {
+        return transactionalId;
+    }
+
+    public long producerId() {
+        return producerId;
+    }
+
+    public TransactionState state() {
+        return transactionState;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionListing that = (TransactionListing) o;
+        return producerId == that.producerId &&
+            Objects.equals(transactionalId, that.transactionalId) &&
+            transactionState == that.transactionState;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transactionalId, producerId, transactionState);
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionListing(" +
+            "transactionalId='" + transactionalId + '\'' +
+            ", producerId=" + producerId +
+            ", transactionState=" + transactionState +
+            ')';
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AbortTransactionHandler.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -52,17 +51,20 @@ public class AbortTransactionHandler implements AdminApiHandler<TopicPartition, 
         this.lookupStrategy = new PartitionLeaderStrategy(logContext);
     }
 
+    public static AdminApiFuture.SimpleAdminApiFuture<TopicPartition, Void> newFuture(
+        Set<TopicPartition> topicPartitions
+    ) {
+        return AdminApiFuture.forKeys(topicPartitions);
+    }
+
     @Override
     public String apiName() {
         return "abortTransaction";
     }
 
     @Override
-    public Keys<TopicPartition> initializeKeys() {
-        return Keys.dynamicMapped(
-            Collections.singleton(abortSpec.topicPartition()),
-            lookupStrategy
-        );
+    public AdminApiLookupStrategy<TopicPartition> lookupStrategy() {
+        return lookupStrategy;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiFuture.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public interface AdminApiFuture<K, V> {
+
+    /**
+     * The initial set of lookup keys. Although this will usually match the fulfillment
+     * keys, it does not necessarily have to. For example, in the case of
+     * {@link AllBrokersStrategy.AllBrokersFuture},
+     * we use the lookup phase in order to discover the set of keys that will be searched
+     * during the fulfillment phase.
+     *
+     * @return non-empty set of initial lookup keys
+     */
+    Set<K> lookupKeys();
+
+    /**
+     * Complete the futures associated with the given keys.
+     *
+     * @param values the completed keys with their respective values
+     */
+    void complete(Map<K, V> values);
+
+    /**
+     * Invoked when lookup of a set of keys succeeds.
+     *
+     * @param brokerIdMapping the discovered mapping from key to the respective brokerId that will
+     *                        handle the fulfillment request
+     */
+    default void completeLookup(Map<K, Integer> brokerIdMapping) {
+    }
+
+    /**
+     * Invoked when lookup fails with a fatal error on a set of keys.
+     *
+     * @param lookupErrors the set of keys that failed lookup with their respective errors
+     */
+    default void completeLookupExceptionally(Map<K, Throwable> lookupErrors) {
+        completeExceptionally(lookupErrors);
+    }
+
+    /**
+     * Complete the futures associated with the given keys exceptionally.
+     *
+     * @param errors the failed keys with their respective errors
+     */
+    void completeExceptionally(Map<K, Throwable> errors);
+
+    static <K, V> SimpleAdminApiFuture<K, V> forKeys(Set<K> keys) {
+        return new SimpleAdminApiFuture<>(keys);
+    }
+
+    /**
+     * This class can be used when the set of keys is known ahead of time.
+     */
+    class SimpleAdminApiFuture<K, V> implements AdminApiFuture<K, V> {
+        private final Map<K, KafkaFutureImpl<V>> futures;
+
+        public SimpleAdminApiFuture(Set<K> keys) {
+            this.futures = keys.stream().collect(Collectors.toMap(
+                Function.identity(),
+                k -> new KafkaFutureImpl<>()
+            ));
+        }
+
+        @Override
+        public Set<K> lookupKeys() {
+            return futures.keySet();
+        }
+
+        @Override
+        public void complete(Map<K, V> values) {
+            values.forEach(this::complete);
+        }
+
+        private void complete(K key, V value) {
+            futureOrThrow(key).complete(value);
+        }
+
+        @Override
+        public void completeExceptionally(Map<K, Throwable> errors) {
+            errors.forEach(this::completeExceptionally);
+        }
+
+        private void completeExceptionally(K key, Throwable t) {
+            futureOrThrow(key).completeExceptionally(t);
+        }
+
+        private KafkaFutureImpl<V> futureOrThrow(K key) {
+            KafkaFutureImpl<V> future = futures.get(key);
+            if (future == null) {
+                throw new IllegalArgumentException("Attempt to complete future for " + key +
+                    ", which was not requested");
+            } else {
+                return future;
+            }
+        }
+
+        public Map<K, KafkaFutureImpl<V>> all() {
+            return futures;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiHandler.java
@@ -18,15 +18,11 @@ package org.apache.kafka.clients.admin.internals;
 
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
-import org.apache.kafka.common.utils.Utils;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
 
 public interface AdminApiHandler<K, V> {
 
@@ -34,19 +30,6 @@ public interface AdminApiHandler<K, V> {
      * Get a user-friendly name for the API this handler is implementing.
      */
     String apiName();
-
-    /**
-     * Initialize the set of keys required to handle this API and how the driver
-     * should map them to the broker that will handle the request for these keys.
-     *
-     * Two mapping types are supported:
-     *
-     * - Static mapping: when the brokerId is known ahead of time
-     * - Dynamic mapping: when the brokerId must be discovered dynamically
-     *
-     * @return the key mappings
-     */
-    Keys<K> initializeKeys();
 
     /**
      * Build the request. The set of keys are derived by {@link AdminApiDriver}
@@ -82,44 +65,13 @@ public interface AdminApiHandler<K, V> {
      */
     ApiResult<K, V> handleResponse(int brokerId, Set<K> keys, AbstractResponse response);
 
-    class Keys<K> {
-        public final Map<K, Integer> staticKeys;
-        public final Set<K> dynamicKeys;
-        public final AdminApiLookupStrategy<K> lookupStrategy;
-
-        public Keys(
-            Map<K, Integer> staticKeys,
-            Set<K> dynamicKeys,
-            AdminApiLookupStrategy<K> lookupStrategy
-        ) {
-            this.staticKeys = requireNonNull(staticKeys);
-            this.dynamicKeys = requireNonNull(dynamicKeys);
-            this.lookupStrategy = lookupStrategy;
-
-            Set<K> staticAndDynamicKeys = Utils.intersection(HashSet::new, staticKeys.keySet(), dynamicKeys);
-            if (!staticAndDynamicKeys.isEmpty()) {
-                throw new IllegalArgumentException("The following keys were configured both as dynamically " +
-                    "and statically mapped: " + staticAndDynamicKeys);
-            }
-
-            if (!dynamicKeys.isEmpty()) {
-                requireNonNull(lookupStrategy);
-            }
-        }
-
-        public static <K> Keys<K> staticMapped(
-            Map<K, Integer> staticKeys
-        ) {
-            return new Keys<>(staticKeys, Collections.emptySet(), null);
-        }
-
-        public static <K> Keys<K> dynamicMapped(
-            Set<K> dynamicKeys,
-            AdminApiLookupStrategy<K> lookupStrategy
-        ) {
-            return new Keys<>(Collections.emptyMap(), dynamicKeys, lookupStrategy);
-        }
-    }
+    /**
+     * Get the lookup strategy that is responsible for finding the brokerId
+     * which will handle each respective key.
+     *
+     * @return non-null lookup strategy
+     */
+    AdminApiLookupStrategy<K> lookupStrategy();
 
     class ApiResult<K, V> {
         public final Map<K, V> completedKeys;
@@ -157,6 +109,14 @@ public interface AdminApiHandler<K, V> {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 keys
+            );
+        }
+
+        public static <K, V> ApiResult<K, V> empty() {
+            return new ApiResult<>(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Collections.emptyList()
             );
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiLookupStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminApiLookupStrategy.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,6 +39,11 @@ public interface AdminApiLookupStrategy<T> {
      * On the other hand, `FindCoordinator` requests only support lookup of a
      * single key. This can be supported by returning a different scope object
      * for each lookup key.
+     *
+     * Note that if the {@link ApiRequestScope#destinationBrokerId()} maps to
+     * a specific brokerId, then lookup will be skipped. See the use of
+     * {@link StaticBrokerStrategy} in {@link DescribeProducersHandler} for
+     * an example of this usage.
      *
      * @param key the lookup key
      *
@@ -76,13 +82,31 @@ public interface AdminApiLookupStrategy<T> {
     LookupResult<T> handleResponse(Set<T> keys, AbstractResponse response);
 
     class LookupResult<K> {
+        // This is the set of keys that have been completed by the lookup phase itself.
+        // The driver will not attempt lookup or fulfillment for completed keys.
+        public final List<K> completedKeys;
+
+        // This is the set of keys that have been mapped to a specific broker for
+        // fulfillment of the API request.
         public final Map<K, Integer> mappedKeys;
+
+        // This is the set of keys that have encountered a fatal error during the lookup
+        // phase. The driver will not attempt lookup or fulfillment for failed keys.
         public final Map<K, Throwable> failedKeys;
 
         public LookupResult(
             Map<K, Throwable> failedKeys,
             Map<K, Integer> mappedKeys
         ) {
+            this(Collections.emptyList(), failedKeys, mappedKeys);
+        }
+
+        public LookupResult(
+            List<K> completedKeys,
+            Map<K, Throwable> failedKeys,
+            Map<K, Integer> mappedKeys
+        ) {
+            this.completedKeys = Collections.unmodifiableList(completedKeys);
             this.failedKeys = Collections.unmodifiableMap(failedKeys);
             this.mappedKeys = Collections.unmodifiableMap(mappedKeys);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  * service thread (which also uses the NetworkClient).
  */
 public class AdminMetadataManager {
-    private Logger log;
+    private final Logger log;
 
     /**
      * The minimum amount of time that we should wait between subsequent

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategy.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * This class is used for use cases which require requests to be sent to all
+ * brokers in the cluster.
+ *
+ * This is a slightly degenerate case of a lookup strategy in the sense that
+ * the broker IDs are used as both the keys and values. Also, unlike
+ * {@link CoordinatorStrategy} and {@link PartitionLeaderStrategy}, we do not
+ * know the set of keys ahead of time: we require the initial lookup in order
+ * to discover what the broker IDs are. This is represented with a more complex
+ * type {@code Future<Map<Integer, Future<V>>} in the admin API result type.
+ * For example, see {@link org.apache.kafka.clients.admin.ListTransactionsResult}.
+ */
+public class AllBrokersStrategy implements AdminApiLookupStrategy<AllBrokersStrategy.BrokerKey> {
+    public static final BrokerKey ANY_BROKER = new BrokerKey(OptionalInt.empty());
+    public static final Set<BrokerKey> LOOKUP_KEYS = Collections.singleton(ANY_BROKER);
+    private static final ApiRequestScope SINGLE_REQUEST_SCOPE = new ApiRequestScope() {
+    };
+
+    private final Logger log;
+
+    public AllBrokersStrategy(
+        LogContext logContext
+    ) {
+        this.log = logContext.logger(AllBrokersStrategy.class);
+    }
+
+    @Override
+    public ApiRequestScope lookupScope(BrokerKey key) {
+        return SINGLE_REQUEST_SCOPE;
+    }
+
+    @Override
+    public MetadataRequest.Builder buildRequest(Set<BrokerKey> keys) {
+        validateLookupKeys(keys);
+        // Send empty `Metadata` request. We are only interested in the brokers from the response
+        return new MetadataRequest.Builder(new MetadataRequestData());
+    }
+
+    @Override
+    public LookupResult<BrokerKey> handleResponse(Set<BrokerKey> keys, AbstractResponse abstractResponse) {
+        validateLookupKeys(keys);
+
+        MetadataResponse response = (MetadataResponse) abstractResponse;
+        MetadataResponseData.MetadataResponseBrokerCollection brokers = response.data().brokers();
+
+        if (brokers.isEmpty()) {
+            log.debug("Metadata response contained no brokers. Will backoff and retry");
+            return LookupResult.empty();
+        } else {
+            log.debug("Discovered all brokers {} to send requests to", brokers);
+        }
+
+        Map<BrokerKey, Integer> brokerKeys = brokers.stream().collect(Collectors.toMap(
+            broker -> new BrokerKey(OptionalInt.of(broker.nodeId())),
+            MetadataResponseData.MetadataResponseBroker::nodeId
+        ));
+
+        return new LookupResult<>(
+            Collections.singletonList(ANY_BROKER),
+            Collections.emptyMap(),
+            brokerKeys
+        );
+    }
+
+    private void validateLookupKeys(Set<BrokerKey> keys) {
+        if (keys.size() != 1) {
+            throw new IllegalArgumentException("Unexpected key set " + keys);
+        }
+        BrokerKey key = keys.iterator().next();
+        if (key != ANY_BROKER) {
+            throw new IllegalArgumentException("Unexpected key set " + keys);
+        }
+    }
+
+    public static class BrokerKey {
+        public final OptionalInt brokerId;
+
+        public BrokerKey(OptionalInt brokerId) {
+            this.brokerId = brokerId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            BrokerKey that = (BrokerKey) o;
+            return Objects.equals(brokerId, that.brokerId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(brokerId);
+        }
+
+        @Override
+        public String toString() {
+            return "BrokerKey(" +
+                "brokerId=" + brokerId +
+                ')';
+        }
+    }
+
+    public static class AllBrokersFuture<V> implements AdminApiFuture<BrokerKey, V> {
+        private final KafkaFutureImpl<Map<Integer, KafkaFutureImpl<V>>> future = new KafkaFutureImpl<>();
+        private final Map<Integer, KafkaFutureImpl<V>> brokerFutures = new HashMap<>();
+
+        @Override
+        public Set<BrokerKey> lookupKeys() {
+            return LOOKUP_KEYS;
+        }
+
+        @Override
+        public void completeLookup(Map<BrokerKey, Integer> brokerMapping) {
+            brokerMapping.forEach((brokerKey, brokerId) -> {
+                if (brokerId != brokerKey.brokerId.orElse(-1)) {
+                    throw new IllegalArgumentException("Invalid lookup mapping " + brokerKey + " -> " + brokerId);
+                }
+                brokerFutures.put(brokerId, new KafkaFutureImpl<>());
+            });
+            future.complete(brokerFutures);
+        }
+
+        @Override
+        public void completeLookupExceptionally(Map<BrokerKey, Throwable> lookupErrors) {
+            if (!LOOKUP_KEYS.equals(lookupErrors.keySet())) {
+                throw new IllegalArgumentException("Unexpected keys among lookup errors: " + lookupErrors);
+            }
+            future.completeExceptionally(lookupErrors.get(ANY_BROKER));
+        }
+
+        @Override
+        public void complete(Map<BrokerKey, V> values) {
+            values.forEach(this::complete);
+        }
+
+        private void complete(AllBrokersStrategy.BrokerKey key, V value) {
+            if (key == ANY_BROKER) {
+                throw new IllegalArgumentException("Invalid attempt to complete with lookup key sentinel");
+            } else {
+                futureOrThrow(key).complete(value);
+            }
+        }
+
+        @Override
+        public void completeExceptionally(Map<BrokerKey, Throwable> errors) {
+            errors.forEach(this::completeExceptionally);
+        }
+
+        private void completeExceptionally(AllBrokersStrategy.BrokerKey key, Throwable t) {
+            if (key == ANY_BROKER) {
+                future.completeExceptionally(t);
+            } else {
+                futureOrThrow(key).completeExceptionally(t);
+            }
+        }
+
+        public KafkaFutureImpl<Map<Integer, KafkaFutureImpl<V>>> all() {
+            return future;
+        }
+
+        private KafkaFutureImpl<V> futureOrThrow(BrokerKey key) {
+            if (!key.brokerId.isPresent()) {
+                throw new IllegalArgumentException("Attempt to complete with invalid key " + key);
+            } else {
+                int brokerId = key.brokerId.getAsInt();
+                KafkaFutureImpl<V> future = brokerFutures.get(brokerId);
+                if (future == null) {
+                    throw new IllegalArgumentException("Attempt to complete with unknown broker id " + brokerId);
+                } else {
+                    return future;
+                }
+            }
+        }
+
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategy.java
@@ -99,11 +99,11 @@ public class AllBrokersStrategy implements AdminApiLookupStrategy<AllBrokersStra
 
     private void validateLookupKeys(Set<BrokerKey> keys) {
         if (keys.size() != 1) {
-            throw new IllegalArgumentException("Unexpected key set " + keys);
+            throw new IllegalArgumentException("Unexpected key set: " + keys);
         }
         BrokerKey key = keys.iterator().next();
         if (key != ANY_BROKER) {
-            throw new IllegalArgumentException("Unexpected key set " + keys);
+            throw new IllegalArgumentException("Unexpected key set: " + keys);
         }
     }
 
@@ -195,12 +195,12 @@ public class AllBrokersStrategy implements AdminApiLookupStrategy<AllBrokersStra
 
         private KafkaFutureImpl<V> futureOrThrow(BrokerKey key) {
             if (!key.brokerId.isPresent()) {
-                throw new IllegalArgumentException("Attempt to complete with invalid key " + key);
+                throw new IllegalArgumentException("Attempt to complete with invalid key: " + key);
             } else {
                 int brokerId = key.brokerId.getAsInt();
                 KafkaFutureImpl<V> future = brokerFutures.get(brokerId);
                 if (future == null) {
-                    throw new IllegalArgumentException("Attempt to complete with unknown broker id " + brokerId);
+                    throw new IllegalArgumentException("Attempt to complete with unknown broker id: " + brokerId);
                 } else {
                     return future;
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ApiRequestScope.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ApiRequestScope.java
@@ -33,7 +33,11 @@ public interface ApiRequestScope {
      * Get the target broker ID that a request is intended for or
      * empty if the request can be sent to any broker.
      *
-     * @return optional broker id
+     * Note that if the destination broker ID is present in the
+     * {@link ApiRequestScope} returned by {@link AdminApiLookupStrategy#lookupScope(Object)},
+     * then no lookup will be attempted.
+     *
+     * @return optional broker ID
      */
     default OptionalInt destinationBrokerId() {
         return OptionalInt.empty();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeProducersHandler.java
@@ -31,12 +31,13 @@ import org.apache.kafka.common.requests.DescribeProducersRequest;
 import org.apache.kafka.common.requests.DescribeProducersResponse;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -45,20 +46,28 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DescribeProducersHandler implements AdminApiHandler<TopicPartition, PartitionProducerState> {
-    private final LogContext logContext;
     private final Logger log;
     private final DescribeProducersOptions options;
-    private final Set<TopicPartition> topicPartitions;
+    private final AdminApiLookupStrategy<TopicPartition> lookupStrategy;
 
     public DescribeProducersHandler(
-        Set<TopicPartition> topicPartitions,
         DescribeProducersOptions options,
         LogContext logContext
     ) {
-        this.topicPartitions = Collections.unmodifiableSet(topicPartitions);
         this.options = options;
         this.log = logContext.logger(DescribeProducersHandler.class);
-        this.logContext = logContext;
+
+        if (options.brokerId().isPresent()) {
+            this.lookupStrategy = new StaticBrokerStrategy<>(options.brokerId().getAsInt());
+        } else {
+            this.lookupStrategy = new PartitionLeaderStrategy(logContext);
+        }
+    }
+
+    public static AdminApiFuture.SimpleAdminApiFuture<TopicPartition, PartitionProducerState> newFuture(
+        Collection<TopicPartition> topicPartitions
+    ) {
+        return AdminApiFuture.forKeys(new HashSet<>(topicPartitions));
     }
 
     @Override
@@ -67,17 +76,8 @@ public class DescribeProducersHandler implements AdminApiHandler<TopicPartition,
     }
 
     @Override
-    public Keys<TopicPartition> initializeKeys() {
-        if (options.brokerId().isPresent()) {
-            // If the options indicate a specific broker, then we can skip the lookup step
-            int destinationBrokerId = options.brokerId().getAsInt();
-            Map<TopicPartition, Integer> staticMappedPartitions =
-                Utils.initializeMap(topicPartitions, () -> destinationBrokerId);
-            return Keys.staticMapped(staticMappedPartitions);
-        } else {
-            PartitionLeaderStrategy lookupStrategy = new PartitionLeaderStrategy(logContext);
-            return Keys.dynamicMapped(topicPartitions, lookupStrategy);
-        }
+    public AdminApiLookupStrategy<TopicPartition> lookupStrategy() {
+        return lookupStrategy;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandler.java
@@ -42,17 +42,20 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DescribeTransactionsHandler implements AdminApiHandler<CoordinatorKey, TransactionDescription> {
-    private final LogContext logContext;
     private final Logger log;
-    private final Set<CoordinatorKey> keys;
+    private final AdminApiLookupStrategy<CoordinatorKey> lookupStrategy;
 
     public DescribeTransactionsHandler(
-        Collection<String> transactionalIds,
         LogContext logContext
     ) {
-        this.keys = buildKeySet(transactionalIds);
         this.log = logContext.logger(DescribeTransactionsHandler.class);
-        this.logContext = logContext;
+        this.lookupStrategy = new CoordinatorStrategy(logContext);
+    }
+
+    public static AdminApiFuture.SimpleAdminApiFuture<CoordinatorKey, TransactionDescription> newFuture(
+        Collection<String> transactionalIds
+    ) {
+        return AdminApiFuture.forKeys(buildKeySet(transactionalIds));
     }
 
     private static Set<CoordinatorKey> buildKeySet(Collection<String> transactionalIds) {
@@ -67,8 +70,8 @@ public class DescribeTransactionsHandler implements AdminApiHandler<CoordinatorK
     }
 
     @Override
-    public Keys<CoordinatorKey> initializeKeys() {
-        return Keys.dynamicMapped(keys, new CoordinatorStrategy(logContext));
+    public AdminApiLookupStrategy<CoordinatorKey> lookupStrategy() {
+        return lookupStrategy;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.ListTransactionsOptions;
+import org.apache.kafka.clients.admin.TransactionListing;
+import org.apache.kafka.clients.admin.TransactionState;
+import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
+import org.apache.kafka.common.message.ListTransactionsRequestData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.ListTransactionsRequest;
+import org.apache.kafka.common.requests.ListTransactionsResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ListTransactionsHandler implements AdminApiHandler<AllBrokersStrategy.BrokerKey, Collection<TransactionListing>> {
+    private final Logger log;
+    private final ListTransactionsOptions options;
+    private final AllBrokersStrategy lookupStrategy;
+
+    public ListTransactionsHandler(
+        ListTransactionsOptions options,
+        LogContext logContext
+    ) {
+        this.options = options;
+        this.log = logContext.logger(ListTransactionsHandler.class);
+        this.lookupStrategy = new AllBrokersStrategy(logContext);
+    }
+
+    public static AllBrokersStrategy.AllBrokersFuture<Collection<TransactionListing>> newFuture() {
+        return new AllBrokersStrategy.AllBrokersFuture<>();
+    }
+
+    @Override
+    public String apiName() {
+        return "listTransactions";
+    }
+
+    @Override
+    public AdminApiLookupStrategy<AllBrokersStrategy.BrokerKey> lookupStrategy() {
+        return lookupStrategy;
+    }
+
+    @Override
+    public ListTransactionsRequest.Builder buildRequest(
+        int brokerId,
+        Set<AllBrokersStrategy.BrokerKey> keys
+    ) {
+        ListTransactionsRequestData request = new ListTransactionsRequestData();
+        request.setProducerIdFilters(new ArrayList<>(options.filteredProducerIds()));
+        request.setStateFilters(options.filteredStates().stream()
+            .map(TransactionState::toString)
+            .collect(Collectors.toList()));
+        return new ListTransactionsRequest.Builder(request);
+    }
+
+    @Override
+    public ApiResult<AllBrokersStrategy.BrokerKey, Collection<TransactionListing>> handleResponse(
+        int brokerId,
+        Set<AllBrokersStrategy.BrokerKey> keys,
+        AbstractResponse abstractResponse
+    ) {
+        AllBrokersStrategy.BrokerKey key = requireSingleton(keys, brokerId);
+
+        ListTransactionsResponse response = (ListTransactionsResponse) abstractResponse;
+        Errors error = Errors.forCode(response.data().errorCode());
+
+        if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS) {
+            log.debug("The `ListTransactions` request sent to broker {} failed because the " +
+                "coordinator is still loading state. Will try again after backing off", brokerId);
+            return ApiResult.empty();
+        } else if (error == Errors.COORDINATOR_NOT_AVAILABLE) {
+            log.debug("The `ListTransactions` request sent to broker {} failed because the " +
+                "coordinator is shutting down", brokerId);
+            return ApiResult.failed(key, new CoordinatorNotAvailableException("ListTransactions " +
+                "request sent to broker " + brokerId + " failed because the coordinator is shutting down"));
+        } else if (error != Errors.NONE) {
+            log.error("The `ListTransactions` request sent to broker {} failed because of an " +
+                "unexpected error {}", brokerId, error);
+            return ApiResult.failed(key, error.exception("ListTransactions request " +
+                "sent to broker " + brokerId + " failed with an unexpected exception"));
+        } else {
+            List<TransactionListing> listings = response.data().transactionStates().stream()
+                .map(transactionState -> new TransactionListing(
+                    transactionState.transactionalId(),
+                    transactionState.producerId(),
+                    TransactionState.parse(transactionState.transactionState())))
+                .collect(Collectors.toList());
+            return ApiResult.completed(key, listings);
+        }
+    }
+
+    private AllBrokersStrategy.BrokerKey requireSingleton(
+        Set<AllBrokersStrategy.BrokerKey> keys,
+        int brokerId
+    ) {
+        if (keys.size() != 1) {
+            throw new IllegalArgumentException("Unexpected key set" + keys);
+        }
+
+        AllBrokersStrategy.BrokerKey key = keys.iterator().next();
+        if (!key.brokerId.isPresent() || key.brokerId.getAsInt() != brokerId) {
+            throw new IllegalArgumentException("Unexpected broker key" + key);
+        }
+
+        return key;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandler.java
@@ -116,12 +116,12 @@ public class ListTransactionsHandler implements AdminApiHandler<AllBrokersStrate
         int brokerId
     ) {
         if (keys.size() != 1) {
-            throw new IllegalArgumentException("Unexpected key set" + keys);
+            throw new IllegalArgumentException("Unexpected key set: " + keys);
         }
 
         AllBrokersStrategy.BrokerKey key = keys.iterator().next();
         if (!key.brokerId.isPresent() || key.brokerId.getAsInt() != brokerId) {
-            throw new IllegalArgumentException("Unexpected broker key" + key);
+            throw new IllegalArgumentException("Unexpected broker key: " + key);
         }
 
         return key;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/StaticBrokerStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/StaticBrokerStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+
+import java.util.OptionalInt;
+import java.util.Set;
+
+/**
+ * This lookup strategy is used when we already know the destination broker ID
+ * and we have no need for an explicit lookup. By setting {@link ApiRequestScope#destinationBrokerId()}
+ * in the returned value for {@link #lookupScope(Object)}, the driver will
+ * skip the lookup.
+ */
+public class StaticBrokerStrategy<K> implements AdminApiLookupStrategy<K> {
+    private final SingleBrokerScope scope;
+
+    public StaticBrokerStrategy(int brokerId) {
+        this.scope = new SingleBrokerScope(brokerId);
+    }
+
+    @Override
+    public ApiRequestScope lookupScope(K key) {
+        return scope;
+    }
+
+    @Override
+    public AbstractRequest.Builder<?> buildRequest(Set<K> keys) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LookupResult<K> handleResponse(Set<K> keys, AbstractResponse response) {
+        throw new UnsupportedOperationException();
+    }
+
+    private static class SingleBrokerScope implements ApiRequestScope {
+        private final int brokerId;
+
+        private SingleBrokerScope(int brokerId) {
+            this.brokerId = brokerId;
+        }
+
+        @Override
+        public OptionalInt destinationBrokerId() {
+            return OptionalInt.of(brokerId);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ListTransactionsResultTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ListTransactionsResultTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.Utils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.kafka.test.TestUtils.assertFutureThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ListTransactionsResultTest {
+    private final KafkaFutureImpl<Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>>> future =
+        new KafkaFutureImpl<>();
+    private final ListTransactionsResult result = new ListTransactionsResult(future);
+
+    @Test
+    public void testAllFuturesFailIfLookupFails() {
+        future.completeExceptionally(new KafkaException());
+        assertFutureThrows(result.all(), KafkaException.class);
+        assertFutureThrows(result.allByBrokerId(), KafkaException.class);
+        assertFutureThrows(result.byBrokerId(0), KafkaException.class);
+        assertFutureThrows(result.brokerIds(), KafkaException.class);
+    }
+
+    @Test
+    public void testAllFuturesSucceed() throws Exception {
+        KafkaFutureImpl<Collection<TransactionListing>> future1 = new KafkaFutureImpl<>();
+        KafkaFutureImpl<Collection<TransactionListing>> future2 = new KafkaFutureImpl<>();
+
+        Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>> brokerFutures = new HashMap<>();
+        brokerFutures.put(1, future1);
+        brokerFutures.put(2, future2);
+
+        future.complete(brokerFutures);
+
+        List<TransactionListing> broker1Listings = asList(
+            new TransactionListing("foo", 12345L, TransactionState.ONGOING),
+            new TransactionListing("bar", 98765L, TransactionState.PREPARE_ABORT)
+        );
+        future1.complete(broker1Listings);
+
+        List<TransactionListing> broker2Listings = singletonList(
+            new TransactionListing("baz", 13579L, TransactionState.COMPLETE_COMMIT)
+        );
+        future2.complete(broker2Listings);
+
+        assertEquals(Utils.mkSet(1, 2), result.brokerIds().get());
+        assertEquals(broker1Listings, result.byBrokerId(1).get());
+        assertEquals(broker2Listings, result.byBrokerId(2).get());
+        assertEquals(broker1Listings, result.allByBrokerId().get().get(1));
+        assertEquals(broker2Listings, result.allByBrokerId().get().get(2));
+
+        Set<TransactionListing> allExpected = new HashSet<>();
+        allExpected.addAll(broker1Listings);
+        allExpected.addAll(broker2Listings);
+
+        assertEquals(allExpected, new HashSet<>(result.all().get()));
+    }
+
+    @Test
+    public void testPartialFailure() throws Exception {
+        KafkaFutureImpl<Collection<TransactionListing>> future1 = new KafkaFutureImpl<>();
+        KafkaFutureImpl<Collection<TransactionListing>> future2 = new KafkaFutureImpl<>();
+
+        Map<Integer, KafkaFutureImpl<Collection<TransactionListing>>> brokerFutures = new HashMap<>();
+        brokerFutures.put(1, future1);
+        brokerFutures.put(2, future2);
+
+        future.complete(brokerFutures);
+
+        List<TransactionListing> broker1Listings = asList(
+            new TransactionListing("foo", 12345L, TransactionState.ONGOING),
+            new TransactionListing("bar", 98765L, TransactionState.PREPARE_ABORT)
+        );
+        future1.complete(broker1Listings);
+        future2.completeExceptionally(new KafkaException());
+
+        // Ensure that the future for broker 1 completes successfully
+        assertEquals(Utils.mkSet(1, 2), result.brokerIds().get());
+        assertEquals(broker1Listings, result.byBrokerId(1).get());
+
+        // Everything else should fail
+        assertFutureThrows(result.all(), KafkaException.class);
+        assertFutureThrows(result.allByBrokerId(), KafkaException.class);
+        assertFutureThrows(result.byBrokerId(2), KafkaException.class);
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -919,6 +919,11 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
+    public ListTransactionsResult listTransactions(ListTransactionsOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
     synchronized public void close(Duration timeout) {}
 
     public synchronized void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AdminApiDriverTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients.admin.internals;
 
 import org.apache.kafka.clients.admin.internals.AdminApiDriver.RequestSpec;
 import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
-import org.apache.kafka.clients.admin.internals.AdminApiHandler.Keys;
 import org.apache.kafka.clients.admin.internals.AdminApiLookupStrategy.LookupResult;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.UnknownServerException;
@@ -38,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -57,11 +57,10 @@ class AdminApiDriverTest {
 
     @Test
     public void testCoalescedLookup() {
-        MockRequestScope scope = new MockRequestScope(OptionalInt.empty());
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", scope,
-            "bar", scope
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1",
+            "bar", "c1"
+        ));
 
         Map<Set<String>, LookupResult<String>> lookupRequests = map(
             mkSet("foo", "bar"), mapped("foo", 1, "bar", 2)
@@ -81,10 +80,10 @@ class AdminApiDriverTest {
 
     @Test
     public void testCoalescedFulfillment() {
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", new MockRequestScope(OptionalInt.empty()),
-            "bar", new MockRequestScope(OptionalInt.of(1))
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1",
+            "bar", "c2"
+        ));
 
         Map<Set<String>, LookupResult<String>> lookupRequests = map(
             mkSet("foo"), mapped("foo", 1),
@@ -104,10 +103,10 @@ class AdminApiDriverTest {
 
     @Test
     public void testKeyLookupFailure() {
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", new MockRequestScope(OptionalInt.empty()),
-            "bar", new MockRequestScope(OptionalInt.of(1))
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1",
+            "bar", "c2"
+        ));
 
         Map<Set<String>, LookupResult<String>> lookupRequests = map(
             mkSet("foo"), failedLookup("foo", new UnknownServerException()),
@@ -127,10 +126,10 @@ class AdminApiDriverTest {
 
     @Test
     public void testKeyLookupRetry() {
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", new MockRequestScope(OptionalInt.empty()),
-            "bar", new MockRequestScope(OptionalInt.of(1))
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1",
+            "bar", "c2"
+        ));
 
         Map<Set<String>, LookupResult<String>> lookupRequests = map(
             mkSet("foo"), emptyLookup(),
@@ -160,11 +159,11 @@ class AdminApiDriverTest {
 
     @Test
     public void testStaticMapping() {
-        TestContext ctx = new TestContext(Keys.staticMapped(map(
+        TestContext ctx = TestContext.staticMapped(map(
             "foo", 0,
             "bar", 1,
             "baz", 1
-        )));
+        ));
 
         Map<Set<String>, ApiResult<String, Long>> fulfillmentResults = map(
             mkSet("foo"), completed("foo", 15L),
@@ -178,11 +177,11 @@ class AdminApiDriverTest {
 
     @Test
     public void testFulfillmentFailure() {
-        TestContext ctx = new TestContext(Keys.staticMapped(map(
+        TestContext ctx = TestContext.staticMapped(map(
             "foo", 0,
             "bar", 1,
             "baz", 1
-        )));
+        ));
 
         Map<Set<String>, ApiResult<String, Long>> fulfillmentResults = map(
             mkSet("foo"), failed("foo", new UnknownServerException()),
@@ -196,11 +195,11 @@ class AdminApiDriverTest {
 
     @Test
     public void testFulfillmentRetry() {
-        TestContext ctx = new TestContext(Keys.staticMapped(map(
+        TestContext ctx = TestContext.staticMapped(map(
             "foo", 0,
             "bar", 1,
             "baz", 1
-        )));
+        ));
 
         Map<Set<String>, ApiResult<String, Long>> fulfillmentResults = map(
             mkSet("foo"), completed("foo", 15L),
@@ -220,10 +219,10 @@ class AdminApiDriverTest {
 
     @Test
     public void testFulfillmentUnmapping() {
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", new MockRequestScope(OptionalInt.empty()),
-            "bar", new MockRequestScope(OptionalInt.of(1))
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1",
+            "bar", "c2"
+        ));
 
         Map<Set<String>, LookupResult<String>> lookupRequests = map(
             mkSet("foo"), mapped("foo", 0),
@@ -256,11 +255,10 @@ class AdminApiDriverTest {
 
     @Test
     public void testRecoalescedLookup() {
-        MockRequestScope scope = new MockRequestScope(OptionalInt.empty());
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", scope,
-            "bar", scope
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1",
+            "bar", "c1"
+        ));
 
         Map<Set<String>, LookupResult<String>> lookupRequests = map(
             mkSet("foo", "bar"), mapped("foo", 1, "bar", 2)
@@ -292,9 +290,9 @@ class AdminApiDriverTest {
 
     @Test
     public void testRetryLookupAfterDisconnect() {
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", new MockRequestScope(OptionalInt.empty())
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1"
+        ));
 
         int initialLeaderId = 1;
 
@@ -303,7 +301,7 @@ class AdminApiDriverTest {
         );
 
         ctx.poll(initialLookup, emptyMap());
-        assertMappedKey(ctx.driver, "foo", initialLeaderId);
+        assertMappedKey(ctx, "foo", initialLeaderId);
 
         ctx.handler.expectRequest(mkSet("foo"), completed("foo", 15L));
 
@@ -314,7 +312,7 @@ class AdminApiDriverTest {
         assertEquals(OptionalInt.of(initialLeaderId), requestSpec.scope.destinationBrokerId());
 
         ctx.driver.onFailure(ctx.time.milliseconds(), requestSpec, new DisconnectException());
-        assertUnmappedKey(ctx.driver, "foo");
+        assertUnmappedKey(ctx, "foo");
 
         int retryLeaderId = 2;
 
@@ -329,19 +327,18 @@ class AdminApiDriverTest {
 
     @Test
     public void testCoalescedStaticAndDynamicFulfillment() {
-        Map<String, MockRequestScope> dynamicLookupScopes = map(
-            "foo", new MockRequestScope(OptionalInt.empty())
+        Map<String, String> dynamicMapping = map(
+            "foo", "c1"
         );
 
         Map<String, Integer> staticMapping = map(
             "bar", 1
         );
 
-        TestContext ctx = new TestContext(new Keys<>(
+        TestContext ctx = new TestContext(
             staticMapping,
-            dynamicLookupScopes.keySet(),
-            new MockLookupStrategy<>(dynamicLookupScopes)
-        ));
+            dynamicMapping
+        );
 
         // Initially we expect a lookup for the dynamic key and a
         // fulfillment request for the static key
@@ -400,9 +397,9 @@ class AdminApiDriverTest {
 
     @Test
     public void testLookupRetryBookkeeping() {
-        TestContext ctx = new TestContext(dynamicMapped(map(
-            "foo", new MockRequestScope(OptionalInt.empty())
-        )));
+        TestContext ctx = TestContext.dynamicMapped(map(
+            "foo", "c1"
+        ));
 
         LookupResult<String> emptyLookup = emptyLookup();
         ctx.lookupStrategy().expectLookup(mkSet("foo"), emptyLookup);
@@ -425,7 +422,7 @@ class AdminApiDriverTest {
 
     @Test
     public void testFulfillmentRetryBookkeeping() {
-        TestContext ctx = new TestContext(Keys.staticMapped(map("foo", 0)));
+        TestContext ctx = TestContext.staticMapped(map("foo", 0));
 
         ApiResult<String, Long> emptyFulfillment = emptyFulfillment();
         ctx.handler.expectRequest(mkSet("foo"), emptyFulfillment);
@@ -447,41 +444,41 @@ class AdminApiDriverTest {
     }
 
     private static void assertMappedKey(
-        AdminApiDriver<String, Long> driver,
+        TestContext context,
         String key,
         Integer expectedBrokerId
     )  {
-        OptionalInt brokerIdOpt = driver.keyToBrokerId(key);
+        OptionalInt brokerIdOpt = context.driver.keyToBrokerId(key);
         assertEquals(OptionalInt.of(expectedBrokerId), brokerIdOpt);
     }
 
     private static void assertUnmappedKey(
-        AdminApiDriver<String, Long> driver,
+        TestContext context,
         String key
     ) {
-        OptionalInt brokerIdOpt = driver.keyToBrokerId(key);
+        OptionalInt brokerIdOpt = context.driver.keyToBrokerId(key);
         assertEquals(OptionalInt.empty(), brokerIdOpt);
-        KafkaFutureImpl<Long> future = driver.futures().get(key);
+        KafkaFutureImpl<Long> future = context.future.all().get(key);
         assertFalse(future.isDone());
     }
 
     private static void assertFailedKey(
-        AdminApiDriver<String, Long> driver,
+        TestContext context,
         String key,
         Throwable expectedException
     ) {
-        KafkaFutureImpl<Long> future = driver.futures().get(key);
+        KafkaFutureImpl<Long> future = context.future.all().get(key);
         assertTrue(future.isCompletedExceptionally());
         Throwable exception = assertThrows(ExecutionException.class, future::get);
         assertEquals(expectedException, exception.getCause());
     }
 
     private static void assertCompletedKey(
-        AdminApiDriver<String, Long> driver,
+        TestContext context,
         String key,
         Long expected
     ) {
-        KafkaFutureImpl<Long> future = driver.futures().get(key);
+        KafkaFutureImpl<Long> future = context.future.all().get(key);
         assertTrue(future.isDone());
         try {
             assertEquals(expected, future.get());
@@ -492,40 +489,84 @@ class AdminApiDriverTest {
 
     private static class MockRequestScope implements ApiRequestScope {
         private final OptionalInt destinationBrokerId;
+        private final String id;
 
-        private MockRequestScope(OptionalInt destinationBrokerId) {
+        private MockRequestScope(
+            OptionalInt destinationBrokerId,
+            String id
+        ) {
             this.destinationBrokerId = destinationBrokerId;
+            this.id = id;
         }
 
         @Override
         public OptionalInt destinationBrokerId() {
             return destinationBrokerId;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MockRequestScope that = (MockRequestScope) o;
+            return Objects.equals(destinationBrokerId, that.destinationBrokerId) &&
+                Objects.equals(id, that.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(destinationBrokerId, id);
+        }
     }
 
     private static class TestContext {
         private final MockTime time = new MockTime();
-        private final Keys<String> keys;
         private final MockAdminApiHandler<String, Long> handler;
         private final AdminApiDriver<String, Long> driver;
+        private final AdminApiFuture.SimpleAdminApiFuture<String, Long> future;
 
-        public TestContext(Keys<String> keys) {
-            this.keys = keys;
-            this.handler = new MockAdminApiHandler<>(keys);
+        public TestContext(
+            Map<String, Integer> staticKeys,
+            Map<String, String> dynamicKeys
+        ) {
+            Map<String, MockRequestScope> lookupScopes = new HashMap<>();
+            staticKeys.forEach((key, brokerId) -> {
+                MockRequestScope scope = new MockRequestScope(OptionalInt.of(brokerId), null);
+                lookupScopes.put(key, scope);
+            });
+
+            dynamicKeys.forEach((key, context) -> {
+                MockRequestScope scope = new MockRequestScope(OptionalInt.empty(), context);
+                lookupScopes.put(key, scope);
+            });
+
+            MockLookupStrategy<String> lookupStrategy = new MockLookupStrategy<>(lookupScopes);
+            this.handler = new MockAdminApiHandler<>(lookupStrategy);
+            this.future = AdminApiFuture.forKeys(lookupStrategy.lookupScopes.keySet());
+
             this.driver = new AdminApiDriver<>(
                 handler,
+                future,
                 time.milliseconds() + API_TIMEOUT_MS,
                 RETRY_BACKOFF_MS,
                 new LogContext()
             );
 
-            keys.staticKeys.forEach((key, brokerId) -> {
-                assertMappedKey(driver, key, brokerId);
+            staticKeys.forEach((key, brokerId) -> {
+                assertMappedKey(this, key, brokerId);
             });
 
-            keys.dynamicKeys.forEach(key -> {
-                assertUnmappedKey(driver, key);
+            dynamicKeys.keySet().forEach(key -> {
+                assertUnmappedKey(this, key);
             });
+        }
+
+        public static TestContext staticMapped(Map<String, Integer> staticKeys) {
+            return new TestContext(staticKeys, Collections.emptyMap());
+        }
+
+        public static TestContext dynamicMapped(Map<String, String> dynamicKeys) {
+            return new TestContext(Collections.emptyMap(), dynamicKeys);
         }
 
         private void assertLookupResponse(
@@ -533,7 +574,7 @@ class AdminApiDriverTest {
             LookupResult<String> result
         ) {
             requestSpec.keys.forEach(key -> {
-                assertUnmappedKey(driver, key);
+                assertUnmappedKey(this, key);
             });
 
             // The response is just a placeholder. The result is all we are interested in
@@ -542,11 +583,11 @@ class AdminApiDriverTest {
             driver.onResponse(time.milliseconds(), requestSpec, response);
 
             result.mappedKeys.forEach((key, brokerId) -> {
-                assertMappedKey(driver, key, brokerId);
+                assertMappedKey(this, key, brokerId);
             });
 
             result.failedKeys.forEach((key, exception) -> {
-                assertFailedKey(driver, key, exception);
+                assertFailedKey(this, key, exception);
             });
         }
 
@@ -558,7 +599,7 @@ class AdminApiDriverTest {
                 new AssertionError("Fulfillment requests must specify a target brokerId"));
 
             requestSpec.keys.forEach(key -> {
-                assertMappedKey(driver, key, brokerId);
+                assertMappedKey(this, key, brokerId);
             });
 
             // The response is just a placeholder. The result is all we are interested in
@@ -568,23 +609,20 @@ class AdminApiDriverTest {
             driver.onResponse(time.milliseconds(), requestSpec, response);
 
             result.unmappedKeys.forEach(key -> {
-                assertUnmappedKey(driver, key);
+                assertUnmappedKey(this, key);
             });
 
             result.failedKeys.forEach((key, exception) -> {
-                assertFailedKey(driver, key, exception);
+                assertFailedKey(this, key, exception);
             });
 
             result.completedKeys.forEach((key, value) -> {
-                assertCompletedKey(driver, key, value);
+                assertCompletedKey(this, key, value);
             });
         }
 
         private MockLookupStrategy<String> lookupStrategy() {
-            if (keys.dynamicKeys.isEmpty()) {
-                throw new IllegalStateException("Unexpected lookup when no dynamic mapping is defined");
-            }
-            return (MockLookupStrategy<String>) keys.lookupStrategy;
+            return handler.lookupStrategy;
         }
 
         public void poll(
@@ -656,11 +694,11 @@ class AdminApiDriverTest {
     }
 
     private static class MockAdminApiHandler<K, V> implements AdminApiHandler<K, V> {
-        private final Keys<K> keyMappings;
         private final Map<Set<K>, ApiResult<K, V>> expectedRequests = new HashMap<>();
+        private final MockLookupStrategy<K> lookupStrategy;
 
-        private MockAdminApiHandler(Keys<K> keyMappings) {
-            this.keyMappings = keyMappings;
+        private MockAdminApiHandler(MockLookupStrategy<K> lookupStrategy) {
+            this.lookupStrategy = lookupStrategy;
         }
 
         @Override
@@ -669,8 +707,8 @@ class AdminApiDriverTest {
         }
 
         @Override
-        public Keys<K> initializeKeys() {
-            return keyMappings;
+        public AdminApiLookupStrategy<K> lookupStrategy() {
+            return lookupStrategy;
         }
 
         public void expectRequest(Set<K> keys, ApiResult<K, V> result) {
@@ -713,11 +751,6 @@ class AdminApiDriverTest {
         map.put(k2, v2);
         map.put(k3, v3);
         return map;
-    }
-
-    private static Keys<String> dynamicMapped(Map<String, MockRequestScope> lookupScopes) {
-        MockLookupStrategy<String> strategy = new MockLookupStrategy<>(lookupScopes);
-        return Keys.dynamicMapped(lookupScopes.keySet(), strategy);
     }
 
     private static ApiResult<String, Long> completed(String key, Long value) {

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategyIntegrationTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategyIntegrationTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AllBrokersStrategyIntegrationTest {
+    private static final long TIMEOUT_MS = 5000;
+    private static final long RETRY_BACKOFF_MS = 100;
+
+    private final LogContext logContext = new LogContext();
+    private final MockTime time = new MockTime();
+
+    private AdminApiDriver<AllBrokersStrategy.BrokerKey, Integer> buildDriver(
+        AllBrokersStrategy.AllBrokersFuture<Integer> result
+    ) {
+        return new AdminApiDriver<>(
+            new MockApiHandler(),
+            result,
+            time.milliseconds() + TIMEOUT_MS,
+            RETRY_BACKOFF_MS,
+            logContext
+        );
+    }
+
+    @Test
+    public void testFatalLookupError() {
+        AllBrokersStrategy.AllBrokersFuture<Integer> result = new AllBrokersStrategy.AllBrokersFuture<>();
+        AdminApiDriver<AllBrokersStrategy.BrokerKey, Integer> driver = buildDriver(result);
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> requestSpecs = driver.poll();
+        assertEquals(1, requestSpecs.size());
+
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> spec = requestSpecs.get(0);
+        assertEquals(AllBrokersStrategy.LOOKUP_KEYS, spec.keys);
+
+        driver.onFailure(time.milliseconds(), spec, new UnknownServerException());
+        assertTrue(result.all().isDone());
+        TestUtils.assertFutureThrows(result.all(), UnknownServerException.class);
+        assertEquals(Collections.emptyList(), driver.poll());
+    }
+
+    @Test
+    public void testRetryLookupAfterDisconnect() {
+        AllBrokersStrategy.AllBrokersFuture<Integer> result = new AllBrokersStrategy.AllBrokersFuture<>();
+        AdminApiDriver<AllBrokersStrategy.BrokerKey, Integer> driver = buildDriver(result);
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> requestSpecs = driver.poll();
+        assertEquals(1, requestSpecs.size());
+
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> spec = requestSpecs.get(0);
+        assertEquals(AllBrokersStrategy.LOOKUP_KEYS, spec.keys);
+
+        driver.onFailure(time.milliseconds(), spec, new DisconnectException());
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> retrySpecs = driver.poll();
+        assertEquals(1, retrySpecs.size());
+
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> retrySpec = retrySpecs.get(0);
+        assertEquals(AllBrokersStrategy.LOOKUP_KEYS, retrySpec.keys);
+        assertEquals(time.milliseconds() + RETRY_BACKOFF_MS, retrySpec.nextAllowedTryMs);
+        assertEquals(Collections.emptyList(), driver.poll());
+    }
+
+    @Test
+    public void testMultiBrokerCompletion() throws Exception {
+        AllBrokersStrategy.AllBrokersFuture<Integer> result = new AllBrokersStrategy.AllBrokersFuture<>();
+        AdminApiDriver<AllBrokersStrategy.BrokerKey, Integer> driver = buildDriver(result);
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> lookupSpecs = driver.poll();
+        assertEquals(1, lookupSpecs.size());
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> lookupSpec = lookupSpecs.get(0);
+
+        Set<Integer> brokerIds = Utils.mkSet(1, 2);
+        driver.onResponse(time.milliseconds(), lookupSpec, responseWithBrokers(brokerIds));
+        assertTrue(result.all().isDone());
+
+        Map<Integer, KafkaFutureImpl<Integer>> brokerFutures = result.all().get();
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> requestSpecs = driver.poll();
+        assertEquals(2, requestSpecs.size());
+
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> requestSpec1 = requestSpecs.get(0);
+        assertTrue(requestSpec1.scope.destinationBrokerId().isPresent());
+        int brokerId1 = requestSpec1.scope.destinationBrokerId().getAsInt();
+        assertTrue(brokerIds.contains(brokerId1));
+
+        driver.onResponse(time.milliseconds(), requestSpec1, null);
+        KafkaFutureImpl<Integer> future1 = brokerFutures.get(brokerId1);
+        assertTrue(future1.isDone());
+
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> requestSpec2 = requestSpecs.get(1);
+        assertTrue(requestSpec2.scope.destinationBrokerId().isPresent());
+        int brokerId2 = requestSpec2.scope.destinationBrokerId().getAsInt();
+        assertNotEquals(brokerId1, brokerId2);
+        assertTrue(brokerIds.contains(brokerId2));
+
+        driver.onResponse(time.milliseconds(), requestSpec2, null);
+        KafkaFutureImpl<Integer> future2 = brokerFutures.get(brokerId2);
+        assertTrue(future2.isDone());
+        assertEquals(Collections.emptyList(), driver.poll());
+    }
+
+    @Test
+    public void testRetryFulfillmentAfterDisconnect() throws Exception {
+        AllBrokersStrategy.AllBrokersFuture<Integer> result = new AllBrokersStrategy.AllBrokersFuture<>();
+        AdminApiDriver<AllBrokersStrategy.BrokerKey, Integer> driver = buildDriver(result);
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> lookupSpecs = driver.poll();
+        assertEquals(1, lookupSpecs.size());
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> lookupSpec = lookupSpecs.get(0);
+
+        int brokerId = 1;
+        driver.onResponse(time.milliseconds(), lookupSpec, responseWithBrokers(Collections.singleton(brokerId)));
+        assertTrue(result.all().isDone());
+
+        Map<Integer, KafkaFutureImpl<Integer>> brokerFutures = result.all().get();
+        KafkaFutureImpl<Integer> future = brokerFutures.get(brokerId);
+        assertFalse(future.isDone());
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> requestSpecs = driver.poll();
+        assertEquals(1, requestSpecs.size());
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> requestSpec = requestSpecs.get(0);
+
+        driver.onFailure(time.milliseconds(), requestSpec, new DisconnectException());
+        assertFalse(future.isDone());
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> retrySpecs = driver.poll();
+        assertEquals(1, retrySpecs.size());
+
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> retrySpec = retrySpecs.get(0);
+        assertEquals(time.milliseconds() + RETRY_BACKOFF_MS, retrySpec.nextAllowedTryMs);
+        assertEquals(OptionalInt.of(brokerId), retrySpec.scope.destinationBrokerId());
+
+        driver.onResponse(time.milliseconds(), retrySpec, null);
+        assertTrue(future.isDone());
+        assertEquals(brokerId, future.get());
+        assertEquals(Collections.emptyList(), driver.poll());
+    }
+
+    @Test
+    public void testFatalFulfillmentError() throws Exception {
+        AllBrokersStrategy.AllBrokersFuture<Integer> result = new AllBrokersStrategy.AllBrokersFuture<>();
+        AdminApiDriver<AllBrokersStrategy.BrokerKey, Integer> driver = buildDriver(result);
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> lookupSpecs = driver.poll();
+        assertEquals(1, lookupSpecs.size());
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> lookupSpec = lookupSpecs.get(0);
+
+        int brokerId = 1;
+        driver.onResponse(time.milliseconds(), lookupSpec, responseWithBrokers(Collections.singleton(brokerId)));
+        assertTrue(result.all().isDone());
+
+        Map<Integer, KafkaFutureImpl<Integer>> brokerFutures = result.all().get();
+        KafkaFutureImpl<Integer> future = brokerFutures.get(brokerId);
+        assertFalse(future.isDone());
+
+        List<AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey>> requestSpecs = driver.poll();
+        assertEquals(1, requestSpecs.size());
+        AdminApiDriver.RequestSpec<AllBrokersStrategy.BrokerKey> requestSpec = requestSpecs.get(0);
+
+        driver.onFailure(time.milliseconds(), requestSpec, new UnknownServerException());
+        assertTrue(future.isDone());
+        TestUtils.assertFutureThrows(future, UnknownServerException.class);
+        assertEquals(Collections.emptyList(), driver.poll());
+    }
+
+    private MetadataResponse responseWithBrokers(Set<Integer> brokerIds) {
+        MetadataResponseData response = new MetadataResponseData();
+        for (Integer brokerId : brokerIds) {
+            response.brokers().add(new MetadataResponseData.MetadataResponseBroker()
+                .setNodeId(brokerId)
+                .setHost("host" + brokerId)
+                .setPort(9092)
+            );
+        }
+        return new MetadataResponse(response, ApiKeys.METADATA.latestVersion());
+    }
+
+    private class MockApiHandler implements AdminApiHandler<AllBrokersStrategy.BrokerKey, Integer> {
+        private final AllBrokersStrategy allBrokersStrategy = new AllBrokersStrategy(logContext);
+
+        @Override
+        public String apiName() {
+            return "mock-api";
+        }
+
+        @Override
+        public AbstractRequest.Builder<?> buildRequest(
+            int brokerId,
+            Set<AllBrokersStrategy.BrokerKey> keys
+        ) {
+            return new MetadataRequest.Builder(new MetadataRequestData());
+        }
+
+        @Override
+        public ApiResult<AllBrokersStrategy.BrokerKey, Integer> handleResponse(
+            int brokerId,
+            Set<AllBrokersStrategy.BrokerKey> keys,
+            AbstractResponse response
+        ) {
+            return ApiResult.completed(keys.iterator().next(), brokerId);
+        }
+
+        @Override
+        public AdminApiLookupStrategy<AllBrokersStrategy.BrokerKey> lookupStrategy() {
+            return allBrokersStrategy;
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategyTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/AllBrokersStrategyTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AllBrokersStrategyTest {
+    private final LogContext logContext = new LogContext();
+
+    @Test
+    public void testBuildRequest() {
+        AllBrokersStrategy strategy = new AllBrokersStrategy(logContext);
+        MetadataRequest.Builder builder = strategy.buildRequest(AllBrokersStrategy.LOOKUP_KEYS);
+        assertEquals(Collections.emptyList(), builder.topics());
+    }
+
+    @Test
+    public void testBuildRequestWithInvalidLookupKeys() {
+        AllBrokersStrategy strategy = new AllBrokersStrategy(logContext);
+        AllBrokersStrategy.BrokerKey key1 = new AllBrokersStrategy.BrokerKey(OptionalInt.empty());
+        AllBrokersStrategy.BrokerKey key2 = new AllBrokersStrategy.BrokerKey(OptionalInt.of(1));
+        assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(mkSet(key1)));
+        assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(mkSet(key2)));
+        assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(mkSet(key1, key2)));
+
+        Set<AllBrokersStrategy.BrokerKey> keys = new HashSet<>(AllBrokersStrategy.LOOKUP_KEYS);
+        keys.add(key2);
+        assertThrows(IllegalArgumentException.class, () -> strategy.buildRequest(keys));
+    }
+
+    @Test
+    public void testHandleResponse() {
+        AllBrokersStrategy strategy = new AllBrokersStrategy(logContext);
+
+        MetadataResponseData response = new MetadataResponseData();
+        response.brokers().add(new MetadataResponseData.MetadataResponseBroker()
+            .setNodeId(1)
+            .setHost("host1")
+            .setPort(9092)
+        );
+        response.brokers().add(new MetadataResponseData.MetadataResponseBroker()
+            .setNodeId(2)
+            .setHost("host2")
+            .setPort(9092)
+        );
+
+        AdminApiLookupStrategy.LookupResult<AllBrokersStrategy.BrokerKey> lookupResult = strategy.handleResponse(
+            AllBrokersStrategy.LOOKUP_KEYS,
+            new MetadataResponse(response, ApiKeys.METADATA.latestVersion())
+        );
+
+        assertEquals(Collections.emptyMap(), lookupResult.failedKeys);
+
+        Set<AllBrokersStrategy.BrokerKey> expectedMappedKeys = mkSet(
+            new AllBrokersStrategy.BrokerKey(OptionalInt.of(1)),
+            new AllBrokersStrategy.BrokerKey(OptionalInt.of(2))
+        );
+
+        assertEquals(expectedMappedKeys, lookupResult.mappedKeys.keySet());
+        lookupResult.mappedKeys.forEach((brokerKey, brokerId) -> {
+            assertEquals(OptionalInt.of(brokerId), brokerKey.brokerId);
+        });
+    }
+
+    @Test
+    public void testHandleResponseWithNoBrokers() {
+        AllBrokersStrategy strategy = new AllBrokersStrategy(logContext);
+
+        MetadataResponseData response = new MetadataResponseData();
+
+        AdminApiLookupStrategy.LookupResult<AllBrokersStrategy.BrokerKey> lookupResult = strategy.handleResponse(
+            AllBrokersStrategy.LOOKUP_KEYS,
+            new MetadataResponse(response, ApiKeys.METADATA.latestVersion())
+        );
+
+        assertEquals(Collections.emptyMap(), lookupResult.failedKeys);
+        assertEquals(Collections.emptyMap(), lookupResult.mappedKeys);
+    }
+
+    @Test
+    public void testHandleResponseWithInvalidLookupKeys() {
+        AllBrokersStrategy strategy = new AllBrokersStrategy(logContext);
+        AllBrokersStrategy.BrokerKey key1 = new AllBrokersStrategy.BrokerKey(OptionalInt.empty());
+        AllBrokersStrategy.BrokerKey key2 = new AllBrokersStrategy.BrokerKey(OptionalInt.of(1));
+        MetadataResponse response = new MetadataResponse(new MetadataResponseData(), ApiKeys.METADATA.latestVersion());
+
+        assertThrows(IllegalArgumentException.class, () -> strategy.handleResponse(mkSet(key1), response));
+        assertThrows(IllegalArgumentException.class, () -> strategy.handleResponse(mkSet(key2), response));
+        assertThrows(IllegalArgumentException.class, () -> strategy.handleResponse(mkSet(key1, key2), response));
+
+        Set<AllBrokersStrategy.BrokerKey> keys = new HashSet<>(AllBrokersStrategy.LOOKUP_KEYS);
+        keys.add(key2);
+        assertThrows(IllegalArgumentException.class, () -> strategy.handleResponse(keys, response));
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/DescribeTransactionsHandlerTest.java
@@ -48,7 +48,7 @@ public class DescribeTransactionsHandlerTest {
         String transactionalId3 = "baz";
 
         Set<String> transactionalIds = mkSet(transactionalId1, transactionalId2, transactionalId3);
-        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(transactionalIds, logContext);
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(logContext);
 
         assertLookup(handler, transactionalIds);
         assertLookup(handler, mkSet(transactionalId1));
@@ -62,7 +62,7 @@ public class DescribeTransactionsHandlerTest {
         String transactionalId2 = "bar";
 
         Set<String> transactionalIds = mkSet(transactionalId1, transactionalId2);
-        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(transactionalIds, logContext);
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(logContext);
 
         DescribeTransactionsResponseData.TransactionState transactionState1 =
             sampleTransactionState1(transactionalId1);
@@ -86,8 +86,7 @@ public class DescribeTransactionsHandlerTest {
     @Test
     public void testHandleErrorResponse() {
         String transactionalId = "foo";
-        Set<String> transactionalIds = mkSet(transactionalId);
-        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(transactionalIds, logContext);
+        DescribeTransactionsHandler handler = new DescribeTransactionsHandler(logContext);
         assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED);
         assertFatalError(handler, transactionalId, Errors.TRANSACTIONAL_ID_NOT_FOUND);
         assertFatalError(handler, transactionalId, Errors.UNKNOWN_SERVER_ERROR);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListTransactionsHandlerTest.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin.internals;
+
+import org.apache.kafka.clients.admin.ListTransactionsOptions;
+import org.apache.kafka.clients.admin.TransactionListing;
+import org.apache.kafka.clients.admin.TransactionState;
+import org.apache.kafka.clients.admin.internals.AdminApiHandler.ApiResult;
+import org.apache.kafka.clients.admin.internals.AllBrokersStrategy.BrokerKey;
+import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ListTransactionsRequest;
+import org.apache.kafka.common.requests.ListTransactionsResponse;
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ListTransactionsHandlerTest {
+    private final LogContext logContext = new LogContext();
+
+    @Test
+    public void testBuildRequestWithoutFilters() {
+        int brokerId = 1;
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        ListTransactionsOptions options = new ListTransactionsOptions();
+        ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
+        ListTransactionsRequest request = handler.buildRequest(brokerId, singleton(brokerKey)).build();
+        assertEquals(Collections.emptyList(), request.data().producerIdFilters());
+        assertEquals(Collections.emptyList(), request.data().stateFilters());
+    }
+
+    @Test
+    public void testBuildRequestWithFilteredProducerId() {
+        int brokerId = 1;
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        long filteredProducerId = 23423L;
+        ListTransactionsOptions options = new ListTransactionsOptions()
+            .filterProducerIds(singleton(filteredProducerId));
+        ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
+        ListTransactionsRequest request = handler.buildRequest(brokerId, singleton(brokerKey)).build();
+        assertEquals(Collections.singletonList(filteredProducerId), request.data().producerIdFilters());
+        assertEquals(Collections.emptyList(), request.data().stateFilters());
+    }
+
+    @Test
+    public void testBuildRequestWithFilteredState() {
+        int brokerId = 1;
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        TransactionState filteredState = TransactionState.ONGOING;
+        ListTransactionsOptions options = new ListTransactionsOptions()
+            .filterStates(singleton(filteredState));
+        ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
+        ListTransactionsRequest request = handler.buildRequest(brokerId, singleton(brokerKey)).build();
+        assertEquals(Collections.singletonList(filteredState.toString()), request.data().stateFilters());
+        assertEquals(Collections.emptyList(), request.data().producerIdFilters());
+    }
+
+    @Test
+    public void testHandleSuccessfulResponse() {
+        int brokerId = 1;
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        ListTransactionsOptions options = new ListTransactionsOptions();
+        ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
+        ListTransactionsResponse response = sampleListTransactionsResponse1();
+        ApiResult<BrokerKey, Collection<TransactionListing>> result = handler.handleResponse(
+            brokerId, singleton(brokerKey), response);
+        assertEquals(singleton(brokerKey), result.completedKeys.keySet());
+        assertExpectedTransactions(response.data().transactionStates(), result.completedKeys.get(brokerKey));
+    }
+
+    @Test
+    public void testCoordinatorLoadingErrorIsRetriable() {
+        int brokerId = 1;
+        ApiResult<BrokerKey, Collection<TransactionListing>> result =
+            handleResponseWithError(brokerId, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        assertEquals(Collections.emptyMap(), result.completedKeys);
+        assertEquals(Collections.emptyMap(), result.failedKeys);
+        assertEquals(Collections.emptyList(), result.unmappedKeys);
+    }
+
+    @Test
+    public void testHandleResponseWithFatalErrors() {
+        assertFatalError(Errors.COORDINATOR_NOT_AVAILABLE);
+        assertFatalError(Errors.UNKNOWN_SERVER_ERROR);
+    }
+
+    private void assertFatalError(
+        Errors error
+    ) {
+        int brokerId = 1;
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        ApiResult<BrokerKey, Collection<TransactionListing>> result = handleResponseWithError(brokerId, error);
+        assertEquals(Collections.emptyMap(), result.completedKeys);
+        assertEquals(Collections.emptyList(), result.unmappedKeys);
+        assertEquals(Collections.singleton(brokerKey), result.failedKeys.keySet());
+        Throwable throwable = result.failedKeys.get(brokerKey);
+        assertEquals(error, Errors.forException(throwable));
+    }
+
+    private ApiResult<BrokerKey, Collection<TransactionListing>> handleResponseWithError(
+        int brokerId,
+        Errors error
+    ) {
+        BrokerKey brokerKey = new BrokerKey(OptionalInt.of(brokerId));
+        ListTransactionsOptions options = new ListTransactionsOptions();
+        ListTransactionsHandler handler = new ListTransactionsHandler(options, logContext);
+
+        ListTransactionsResponse response = new ListTransactionsResponse(
+            new ListTransactionsResponseData().setErrorCode(error.code())
+        );
+        return handler.handleResponse(brokerId, singleton(brokerKey), response);
+    }
+
+    private ListTransactionsResponse sampleListTransactionsResponse1() {
+        return new ListTransactionsResponse(
+            new ListTransactionsResponseData()
+                .setErrorCode(Errors.NONE.code())
+                .setTransactionStates(asList(
+                    new ListTransactionsResponseData.TransactionState()
+                        .setTransactionalId("foo")
+                        .setProducerId(12345L)
+                        .setTransactionState("Ongoing"),
+                    new ListTransactionsResponseData.TransactionState()
+                        .setTransactionalId("bar")
+                        .setProducerId(98765L)
+                        .setTransactionState("PrepareAbort")
+            ))
+        );
+    }
+
+    private void assertExpectedTransactions(
+        List<ListTransactionsResponseData.TransactionState> expected,
+        Collection<TransactionListing> actual
+    ) {
+        assertEquals(expected.size(), actual.size());
+
+        Map<String, ListTransactionsResponseData.TransactionState> expectedMap = expected.stream().collect(Collectors.toMap(
+            ListTransactionsResponseData.TransactionState::transactionalId,
+            Function.identity()
+        ));
+
+        for (TransactionListing actualListing : actual) {
+            ListTransactionsResponseData.TransactionState expectedState =
+                expectedMap.get(actualListing.transactionalId());
+            assertNotNull(expectedState);
+            assertExpectedTransactionState(expectedState, actualListing);
+        }
+    }
+
+    private void assertExpectedTransactionState(
+        ListTransactionsResponseData.TransactionState expected,
+        TransactionListing actual
+    ) {
+        assertEquals(expected.transactionalId(), actual.transactionalId());
+        assertEquals(expected.producerId(), actual.producerId());
+        assertEquals(expected.transactionState(), actual.state().toString());
+    }
+
+}


### PR DESCRIPTION
This patch adds `Admin` support for the `listTransactions` API, which was added by [KIP-664](https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions). Similar to `listConsumerGroups`, the new `listTransactions` API is intended to be sent to all brokers. This did not fit very well with the new `AdminApiDriver` that was used for the other KIP-664 APIs, so I had to refactor a bit. The way I ultimately handled it is to treat the brokerId as the key that needs to be mapped. Unlike with the other cases, the set of brokerIds is not known ahead of time and has to be discovered through a `Metadata` lookup (just as with `listConsumerGroups`). Because the future associated with `ListTransactionsResult` is more complex, I ended up externalizing future completion in a new `AdminApiFuture` object which is passed to `AdminApiDriver` during construction.

One minor change that is also worth calling out is the removal of `AdminApiHandler.Keys`. This was previously used to indicate the sets of statically and dynamically mapped keys. Instead, I now handle this with a new `StaticBrokerStrategy`. The static scope is indicated by returning an `ApiRequestScope` object which has a specific destination broker set.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
