### PR TITLE
KAFKA-12734: LazyTimeIndex & LazyOffsetIndex may cause niobufferoverflow when skip activeSegment sanityCheck

### DIFF
--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -106,17 +106,19 @@ object LogLoader extends Logging {
       loadSegmentFiles(params)
     })
 
-    try params.segments.lastSegment.get.activeSegmentSanityCheck
-    catch {
-      case _: NoSuchFileException =>
-        error(s"${params.logIdentifier} Could not find offset index file corresponding to log file" +
-          s" ${params.segments.lastSegment.get.log.file.getAbsolutePath}, recovering segment and rebuilding index files...")
-        recoverSegment(params.segments.lastSegment.get, params)
-      case e: CorruptIndexException =>
-        warn(s"${params.logIdentifier} Found a corrupted index file corresponding to log file" +
-          s" ${params.segments.lastSegment.get.log.file.getAbsolutePath} due to ${e.getMessage}}, recovering segment and" +
-          " rebuilding index files...")
-        recoverSegment(params.segments.lastSegment.get, params)
+    if (params.segments.nonEmpty) {
+      try params.segments.lastSegment.get.activeSegmentSanityCheck
+      catch {
+        case _: NoSuchFileException =>
+          error(s"${params.logIdentifier} Could not find offset index file corresponding to log file" +
+            s" ${params.segments.lastSegment.get.log.file.getAbsolutePath}, recovering segment and rebuilding index files...")
+          recoverSegment(params.segments.lastSegment.get, params)
+        case e: CorruptIndexException =>
+          warn(s"${params.logIdentifier} Found a corrupted index file corresponding to log file" +
+            s" ${params.segments.lastSegment.get.log.file.getAbsolutePath} due to ${e.getMessage}}, recovering segment and" +
+            " rebuilding index files...")
+          recoverSegment(params.segments.lastSegment.get, params)
+      }
     }
 
     completeSwapOperations(swapFiles, params)

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -93,6 +93,15 @@ class LogSegment private[log] (val log: FileRecords,
     else throw new NoSuchFileException(s"Offset index file ${lazyOffsetIndex.file.getAbsolutePath} does not exist")
   }
 
+  def activeSegmentSanityCheck: Unit = {
+    if (offsetIndex.file.exists) {
+      offsetIndex.sanityCheck()
+      timeIndex.sanityCheck()
+      txnIndex.sanityCheck()
+    }
+    else throw new NoSuchFileException(s"Offset index file ${offsetIndex.file.getAbsolutePath} does not exist")
+  }
+
   private var created = time.milliseconds
 
   /* the number of bytes since we last added an entry in the offset index */


### PR DESCRIPTION
The detailed stack information is linked to this jiraId [KAFKA-12734](https://issues.apache.org/jira/browse/KAFKA-12734)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
