### PR TITLE
KAFKA-12736: KafkaProducer.flush holds onto completed ProducerBatch(s) until flush completes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.producer.internals;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /*
  * A thread-safe helper class to hold batches that haven't been acknowledged yet (including those
@@ -53,9 +54,7 @@ class IncompleteBatches {
 
     public Iterable<ProduceRequestResult> requestResults() {
         synchronized (incomplete) {
-            ArrayList<ProduceRequestResult> results = new ArrayList<>(this.incomplete.size());
-            this.incomplete.forEach(incomplete -> results.add(incomplete.produceFuture));
-            return results;
+            return incomplete.stream().map(batch -> batch.produceFuture).collect(Collectors.toList());
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/IncompleteBatches.java
@@ -51,6 +51,14 @@ class IncompleteBatches {
         }
     }
 
+    public Iterable<ProduceRequestResult> requestResults() {
+        synchronized (incomplete) {
+            ArrayList<ProduceRequestResult> results = new ArrayList<>(this.incomplete.size());
+            this.incomplete.forEach(incomplete -> results.add(incomplete.produceFuture));
+            return results;
+        }
+    }
+
     public boolean isEmpty() {
         synchronized (incomplete) {
             return incomplete.isEmpty();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -710,9 +710,10 @@ public final class RecordAccumulator {
      */
     public void awaitFlushCompletion() throws InterruptedException {
         try {
-            // Obtain a copy of all of the incomplete ProduceRequestResult(s) the time of the flush.
+            // Obtain a copy of all of the incomplete ProduceRequestResult(s) at the time of the flush.
             // We must be careful not to hold a reference to the ProduceBatch(s) so that garbage
             // collection can occur on the contents.
+            // The sender will remove ProducerBatch(s) from the original incomplete collection.
             for (ProduceRequestResult result : this.incomplete.requestResults())
                 result.await();
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -710,8 +710,11 @@ public final class RecordAccumulator {
      */
     public void awaitFlushCompletion() throws InterruptedException {
         try {
-            for (ProducerBatch batch : this.incomplete.copyAll())
-                batch.produceFuture.await();
+            // Make a copy of of the request results at the time the flush is called.
+            // We avoid making a copy of the full incomplete batch collections to allow
+            // garbage collection.
+            for (ProduceRequestResult result : this.incomplete.requestResults())
+                result.await();
         } finally {
             this.flushesInProgress.decrementAndGet();
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -710,9 +710,9 @@ public final class RecordAccumulator {
      */
     public void awaitFlushCompletion() throws InterruptedException {
         try {
-            // Make a copy of of the request results at the time the flush is called.
-            // We avoid making a copy of the full incomplete batch collections to allow
-            // garbage collection.
+            // Obtain a copy of all of the incomplete ProduceRequestResult(s) the time of the flush.
+            // We must be careful not to hold a reference to the ProduceBatch(s) so that garbage
+            // collection can occur on the contents.
             for (ProduceRequestResult result : this.incomplete.requestResults())
                 result.await();
         } finally {


### PR DESCRIPTION
When flush is called a copy of incomplete batches is made. This
means that the full ProducerBatch(s) are held in memory until the flush
has completed. For batches where the existing memory pool is used this
is not as wasteful as the memory will be returned to the pool,
but for non pool memory it can only be GC'd after the flush has
completed. Rather than use copyAll we can make a new array with only the
produceFuture(s) and await on those.