### PR TITLE
MINOR: Remove unused Utils.delete

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -810,18 +810,6 @@ public final class Utils {
      * @param rootFile The root file at which to begin deleting
      */
     public static void delete(final File rootFile) throws IOException {
-        delete(rootFile, Collections.emptyList());
-    }
-
-    /**
-     * Recursively delete the subfiles (if any exist) of the passed in root file that are not included
-     * in the list to keep
-     *
-     * @param rootFile The root file at which to begin deleting
-     * @param filesToKeep The subfiles to keep (note that if a subfile is to be kept, so are all its parent
-     *                    files in its pat)h; if empty we would also delete the root file
-     */
-    public static void delete(final File rootFile, final List<File> filesToKeep) throws IOException {
         if (rootFile == null)
             return;
         Files.walkFileTree(rootFile.toPath(), new SimpleFileVisitor<Path>() {
@@ -835,9 +823,7 @@ public final class Utils {
 
             @Override
             public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
-                if (!filesToKeep.contains(path.toFile())) {
-                    Files.delete(path);
-                }
+                Files.delete(path);
                 return FileVisitResult.CONTINUE;
             }
 
@@ -848,15 +834,7 @@ public final class Utils {
                     throw exc;
                 }
 
-                if (rootFile.toPath().equals(path)) {
-                    // only delete the parent directory if there's nothing to keep
-                    if (filesToKeep.isEmpty()) {
-                        Files.delete(path);
-                    }
-                } else if (!filesToKeep.contains(path.toFile())) {
-                    Files.delete(path);
-                }
-
+                Files.delete(path);
                 return FileVisitResult.CONTINUE;
             }
         });

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -389,9 +389,9 @@ public class StateDirectoryTest {
         assertEquals(mkSet(taskDir1), Arrays.stream(
             directory.listNonEmptyTaskDirectories()).collect(Collectors.toSet()));
 
-        Utils.delete(taskDir1, Collections.singletonList(new File(taskDir1, LOCK_FILE_NAME)));
+        Utils.delete(taskDir1);
 
-        assertEquals(mkSet(taskDir1, taskDir2), Arrays.stream(
+        assertEquals(mkSet(taskDir2), Arrays.stream(
             directory.listAllTaskDirectories()).collect(Collectors.toSet()));
         assertEquals(Collections.emptySet(), Arrays.stream(
             directory.listNonEmptyTaskDirectories()).collect(Collectors.toSet()));


### PR DESCRIPTION
The function was only used to walk around a Windows "feature", and now is no longer used.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
