### PR TITLE
KAFKA-12605 - make GZIP decompression use BufferSupplier

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/compress/KafkaBufferedInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/KafkaBufferedInputStream.java
@@ -1,0 +1,486 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 1994, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.apache.kafka.common.compress;
+
+import org.apache.kafka.common.utils.BufferSupplier;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * this is a version of {@link java.io.BufferedInputStream} that has been modified
+ * to obtain its' buffer from a {@link org.apache.kafka.common.utils.BufferSupplier}
+ * (and also return said buffer when it's closed)
+ */
+public class KafkaBufferedInputStream extends FilterInputStream {
+
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+
+    //original code uses Unsafe here, for reasons that are not relevant to our use case.
+    //this achieves the same behaviour in a more compatible way.
+    private static final AtomicReferenceFieldUpdater<KafkaBufferedInputStream, byte[]> BUF_FIELD_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(KafkaBufferedInputStream.class, byte[].class, "buf");
+
+    /**
+     * the supplier providing buffer(s), and to which any buffers are returned
+     */
+    private final BufferSupplier bufferSupplier;
+    /**
+     * the actual buffer currently used, as returned by supplier.
+     */
+    private volatile ByteBuffer buffer;
+
+    /**
+     * The internal buffer array where the data is stored.
+     * Replacement not currently supported
+     */
+    /*
+     * We null this out with a CAS on close(), which is necessary since
+     * closes can be asynchronous. We use nullness of buf[] as primary
+     * indicator that this stream is closed. (The "in" field is also
+     * nulled out on close.)
+     */
+    protected volatile byte[] buf;
+
+    /**
+     * The index one greater than the index of the last valid byte in
+     * the buffer.
+     * This value is always
+     * in the range {@code 0} through {@code buf.length};
+     * elements {@code buf[0]} through {@code buf[count-1]}
+     * contain buffered input data obtained
+     * from the underlying  input stream.
+     */
+    protected int count;
+
+    /**
+     * The current position in the buffer. This is the index of the next
+     * character to be read from the {@code buf} array.
+     * <p>
+     * This value is always in the range {@code 0}
+     * through {@code count}. If it is less
+     * than {@code count}, then  {@code buf[pos]}
+     * is the next byte to be supplied as input;
+     * if it is equal to {@code count}, then
+     * the  next {@code read} or {@code skip}
+     * operation will require more bytes to be
+     * read from the contained  input stream.
+     *
+     * @see     KafkaBufferedInputStream#buf
+     */
+    protected int pos;
+
+    /**
+     * The value of the {@code pos} field at the time the last
+     * {@code mark} method was called.
+     * <p>
+     * This value is always
+     * in the range {@code -1} through {@code pos}.
+     * If there is no marked position in  the input
+     * stream, this field is {@code -1}. If
+     * there is a marked position in the input
+     * stream,  then {@code buf[markpos]}
+     * is the first byte to be supplied as input
+     * after a {@code reset} operation. If
+     * {@code markpos} is not {@code -1},
+     * then all bytes from positions {@code buf[markpos]}
+     * through  {@code buf[pos-1]} must remain
+     * in the buffer array (though they may be
+     * moved to  another place in the buffer array,
+     * with suitable adjustments to the values
+     * of {@code count},  {@code pos},
+     * and {@code markpos}); they may not
+     * be discarded unless and until the difference
+     * between {@code pos} and {@code markpos}
+     * exceeds {@code marklimit}.
+     *
+     * @see     KafkaBufferedInputStream#mark(int)
+     * @see     KafkaBufferedInputStream#pos
+     */
+    protected int markpos = -1;
+
+    /**
+     * The maximum read ahead allowed after a call to the
+     * {@code mark} method before subsequent calls to the
+     * {@code reset} method fail.
+     * Whenever the difference between {@code pos}
+     * and {@code markpos} exceeds {@code marklimit},
+     * then the  mark may be dropped by setting
+     * {@code markpos} to {@code -1}.
+     *
+     * @see     KafkaBufferedInputStream#mark(int)
+     * @see     KafkaBufferedInputStream#reset()
+     */
+    protected int marklimit;
+
+    /**
+     * Check to make sure that underlying input stream has not been
+     * nulled out due to close; if not return it;
+     */
+    private InputStream getInIfOpen() throws IOException {
+        InputStream input = in;
+        if (input == null)
+            throw new IOException("Stream closed");
+        return input;
+    }
+
+    /**
+     * Check to make sure that buffer has not been nulled out due to
+     * close; if not return it;
+     */
+    private byte[] getBufIfOpen() throws IOException {
+        byte[] buffer = buf;
+        if (buffer == null)
+            throw new IOException("Stream closed");
+        return buffer;
+    }
+
+    /**
+     * Creates a {@code BufferedInputStream}
+     * and saves its  argument, the input stream
+     * {@code in}, for later use. An internal
+     * buffer array is created and  stored in {@code buf}.
+     *
+     * @param   in   the underlying input stream.
+     */
+    public KafkaBufferedInputStream(InputStream in, BufferSupplier bufferSupplier) {
+        this(in, bufferSupplier, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Creates a {@code BufferedInputStream}
+     * with the specified buffer size,
+     * and saves its  argument, the input stream
+     * {@code in}, for later use.  An internal
+     * buffer array of length  {@code size}
+     * is created and stored in {@code buf}.
+     *
+     * @param   in     the underlying input stream.
+     * @param   size   the buffer size.
+     * @throws  IllegalArgumentException if {@code size <= 0}.
+     */
+    public KafkaBufferedInputStream(InputStream in, BufferSupplier bufferSupplier, int size) {
+        super(in);
+        if (size <= 0) {
+            throw new IllegalArgumentException("Buffer size <= 0");
+        }
+        this.bufferSupplier = bufferSupplier;
+        this.buffer = this.bufferSupplier.get(size);
+        this.buf = this.buffer.array(); //implicitly means off-heap buffers are not supported.
+    }
+
+    /**
+     * Fills the buffer with more data, taking into account
+     * shuffling and other tricks for dealing with marks.
+     * Assumes that it is being called by a synchronized method.
+     * This method also assumes that all data has already been read in,
+     * hence pos > count.
+     */
+    private void fill() throws IOException {
+        byte[] buffer = getBufIfOpen();
+        if (markpos < 0)
+            pos = 0;            /* no mark: throw away the buffer */
+        else if (pos >= buffer.length) { /* no room left in buffer */
+            if (markpos > 0) {  /* can throw away early part of the buffer */
+                int sz = pos - markpos;
+                System.arraycopy(buffer, markpos, buffer, 0, sz);
+                pos = sz;
+                markpos = 0;
+            } else if (buffer.length >= marklimit) {
+                markpos = -1;   /* buffer got too big, invalidate mark */
+                pos = 0;        /* drop buffer contents */
+            } else {            /* grow buffer */
+                //original code allocates a new, bigger buffer here. since our buffers
+                //originate from the supplier - which may or may not have more - we cant
+                //naively use the original implementation.
+                throw new UnsupportedOperationException("buffer re-allocation for mark() TBD?");
+            }
+        }
+        count = pos;
+        int n = getInIfOpen().read(buffer, pos, buffer.length - pos);
+        if (n > 0)
+            count = n + pos;
+    }
+
+    /**
+     * See
+     * the general contract of the {@code read}
+     * method of {@code InputStream}.
+     *
+     * @return     the next byte of data, or {@code -1} if the end of the
+     *             stream is reached.
+     * @throws     IOException  if this input stream has been closed by
+     *                          invoking its {@link #close()} method,
+     *                          or an I/O error occurs.
+     * @see        FilterInputStream#in
+     */
+    public synchronized int read() throws IOException {
+        if (pos >= count) {
+            fill();
+            if (pos >= count)
+                return -1;
+        }
+        return getBufIfOpen()[pos++] & 0xff;
+    }
+
+    /**
+     * Read characters into a portion of an array, reading from the underlying
+     * stream at most once if necessary.
+     */
+    private int read1(byte[] b, int off, int len) throws IOException {
+        int avail = count - pos;
+        if (avail <= 0) {
+            /* If the requested length is at least as large as the buffer, and
+               if there is no mark/reset activity, do not bother to copy the
+               bytes into the local buffer.  In this way buffered streams will
+               cascade harmlessly. */
+            if (len >= getBufIfOpen().length && markpos < 0) {
+                return getInIfOpen().read(b, off, len);
+            }
+            fill();
+            avail = count - pos;
+            if (avail <= 0) return -1;
+        }
+        int cnt = (avail < len) ? avail : len;
+        System.arraycopy(getBufIfOpen(), pos, b, off, cnt);
+        pos += cnt;
+        return cnt;
+    }
+
+    /**
+     * Reads bytes from this byte-input stream into the specified byte array,
+     * starting at the given offset.
+     *
+     * <p> This method implements the general contract of the corresponding
+     * <code>{@link InputStream#read(byte[], int, int) read}</code> method of
+     * the <code>{@link InputStream}</code> class.  As an additional
+     * convenience, it attempts to read as many bytes as possible by repeatedly
+     * invoking the {@code read} method of the underlying stream.  This
+     * iterated {@code read} continues until one of the following
+     * conditions becomes true: <ul>
+     *
+     *   <li> The specified number of bytes have been read,
+     *
+     *   <li> The {@code read} method of the underlying stream returns
+     *   {@code -1}, indicating end-of-file, or
+     *
+     *   <li> The {@code available} method of the underlying stream
+     *   returns zero, indicating that further input requests would block.
+     *
+     * </ul> If the first {@code read} on the underlying stream returns
+     * {@code -1} to indicate end-of-file then this method returns
+     * {@code -1}.  Otherwise this method returns the number of bytes
+     * actually read.
+     *
+     * <p> Subclasses of this class are encouraged, but not required, to
+     * attempt to read as many bytes as possible in the same fashion.
+     *
+     * @param      b     destination buffer.
+     * @param      off   offset at which to start storing bytes.
+     * @param      len   maximum number of bytes to read.
+     * @return     the number of bytes read, or {@code -1} if the end of
+     *             the stream has been reached.
+     * @throws     IOException  if this input stream has been closed by
+     *                          invoking its {@link #close()} method,
+     *                          or an I/O error occurs.
+     */
+    public synchronized int read(byte[] b, int off, int len) throws IOException {
+        getBufIfOpen(); // Check for closed stream
+        if ((off | len | (off + len) | (b.length - (off + len))) < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int n = 0;
+        for (;;) {
+            int nread = read1(b, off + n, len - n);
+            if (nread <= 0)
+                return (n == 0) ? nread : n;
+            n += nread;
+            if (n >= len)
+                return n;
+            // if not closed but no bytes available, return
+            InputStream input = in;
+            if (input != null && input.available() <= 0)
+                return n;
+        }
+    }
+
+    /**
+     * See the general contract of the {@code skip}
+     * method of {@code InputStream}.
+     *
+     * @throws IOException  if this input stream has been closed by
+     *                      invoking its {@link #close()} method,
+     *                      {@code in.skip(n)} throws an IOException,
+     *                      or an I/O error occurs.
+     */
+    public synchronized long skip(long n) throws IOException {
+        getBufIfOpen(); // Check for closed stream
+        if (n <= 0) {
+            return 0;
+        }
+        long avail = count - pos;
+
+        if (avail <= 0) {
+            // If no mark position set then don't keep in buffer
+            if (markpos < 0)
+                return getInIfOpen().skip(n);
+
+            // Fill in buffer to save bytes for reset
+            fill();
+            avail = count - pos;
+            if (avail <= 0)
+                return 0;
+        }
+
+        long skipped = (avail < n) ? avail : n;
+        pos += skipped;
+        return skipped;
+    }
+
+    /**
+     * Returns an estimate of the number of bytes that can be read (or
+     * skipped over) from this input stream without blocking by the next
+     * invocation of a method for this input stream. The next invocation might be
+     * the same thread or another thread.  A single read or skip of this
+     * many bytes will not block, but may read or skip fewer bytes.
+     * <p>
+     * This method returns the sum of the number of bytes remaining to be read in
+     * the buffer (<code>count&nbsp;- pos</code>) and the result of calling the
+     * {@link FilterInputStream#in in}.available().
+     *
+     * @return     an estimate of the number of bytes that can be read (or skipped
+     *             over) from this input stream without blocking.
+     * @throws     IOException  if this input stream has been closed by
+     *                          invoking its {@link #close()} method,
+     *                          or an I/O error occurs.
+     */
+    public synchronized int available() throws IOException {
+        int n = count - pos;
+        int avail = getInIfOpen().available();
+        return n > (Integer.MAX_VALUE - avail)
+                    ? Integer.MAX_VALUE
+                    : n + avail;
+    }
+
+    /**
+     * See the general contract of the {@code mark}
+     * method of {@code InputStream}.
+     *
+     * @param   readlimit   the maximum limit of bytes that can be read before
+     *                      the mark position becomes invalid.
+     * @see     KafkaBufferedInputStream#reset()
+     */
+    public synchronized void mark(int readlimit) {
+        marklimit = readlimit;
+        markpos = pos;
+    }
+
+    /**
+     * See the general contract of the {@code reset}
+     * method of {@code InputStream}.
+     * <p>
+     * If {@code markpos} is {@code -1}
+     * (no mark has been set or the mark has been
+     * invalidated), an {@code IOException}
+     * is thrown. Otherwise, {@code pos} is
+     * set equal to {@code markpos}.
+     *
+     * @throws     IOException  if this stream has not been marked or,
+     *                  if the mark has been invalidated, or the stream
+     *                  has been closed by invoking its {@link #close()}
+     *                  method, or an I/O error occurs.
+     * @see        KafkaBufferedInputStream#mark(int)
+     */
+    public synchronized void reset() throws IOException {
+        getBufIfOpen(); // Cause exception if closed
+        if (markpos < 0)
+            throw new IOException("Resetting to invalid mark");
+        pos = markpos;
+    }
+
+    /**
+     * Tests if this input stream supports the {@code mark}
+     * and {@code reset} methods. The {@code markSupported}
+     * method of {@code BufferedInputStream} returns
+     * {@code true}.
+     *
+     * @return  a {@code boolean} indicating if this stream type supports
+     *          the {@code mark} and {@code reset} methods.
+     * @see     InputStream#mark(int)
+     * @see     InputStream#reset()
+     */
+    public boolean markSupported() {
+        return true;
+    }
+
+    /**
+     * Closes this input stream and releases any system resources
+     * associated with the stream.
+     * Once the stream has been closed, further read(), available(), reset(),
+     * or skip() invocations will throw an IOException.
+     * Closing a previously closed stream has no effect.
+     *
+     * @throws     IOException  if an I/O error occurs.
+     */
+    public void close() throws IOException {
+        byte[] buffer;
+        while ((buffer = buf) != null) {
+            if (BUF_FIELD_UPDATER.compareAndSet(this, buffer, null)) {
+                this.bufferSupplier.release(this.buffer);
+                this.buffer = null; //this.buf has been nulled above
+                InputStream input = in;
+                in = null;
+                if (input != null)
+                    input.close();
+                return;
+            }
+            // Else retry in case a new buf was CASed in fill()
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/compress/KafkaGZIPInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/KafkaGZIPInputStream.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.compress;
+
+import org.apache.kafka.common.utils.BufferSupplier;
+
+import java.io.ByteArrayInputStream;
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.zip.CRC32;
+import java.util.zip.CheckedInputStream;
+import java.util.zip.Inflater;
+import java.util.zip.ZipException;
+
+/**
+ * this code is a modified version of {@link java.util.zip.GZIPInputStream} to allow for buffer reuse
+ * (via {@link org.apache.kafka.common.utils.BufferSupplier}
+ */
+public class KafkaGZIPInputStream extends KafkaInflaterInputStream {
+    /**
+     * CRC-32 for uncompressed data.
+     */
+    protected CRC32 crc = new CRC32();
+
+    /**
+     * Indicates end of input stream.
+     */
+    protected boolean eos;
+
+    private boolean closed = false;
+
+    /**
+     * Check to make sure that this stream has not been closed
+     */
+    private void ensureOpen() throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+    }
+
+    /**
+     * Creates a new input stream with the specified buffer size.
+     * @param in the input stream
+     * @param size the input buffer size
+     *
+     * @throws ZipException if a GZIP format error has occurred or the
+     *                         compression method used is unsupported
+     * @throws    IOException if an I/O error has occurred
+     * @throws    IllegalArgumentException if {@code size <= 0}
+     */
+    public KafkaGZIPInputStream(InputStream in, BufferSupplier bufferSupplier, int size) throws IOException {
+        super(in, new Inflater(true), bufferSupplier, size);
+        usesDefaultInflater = true;
+        readHeader(in);
+    }
+
+    /**
+     * Reads uncompressed data into an array of bytes. If {@code len} is not
+     * zero, the method will block until some input can be decompressed; otherwise,
+     * no bytes are read and {@code 0} is returned.
+     * @param buf the buffer into which the data is read
+     * @param off the start offset in the destination array {@code b}
+     * @param len the maximum number of bytes read
+     * @return  the actual number of bytes read, or -1 if the end of the
+     *          compressed input stream is reached
+     *
+     * @throws     NullPointerException If {@code buf} is {@code null}.
+     * @throws     IndexOutOfBoundsException If {@code off} is negative,
+     * {@code len} is negative, or {@code len} is greater than
+     * {@code buf.length - off}
+     * @throws    ZipException if the compressed input data is corrupt.
+     * @throws    IOException if an I/O error has occurred.
+     *
+     */
+    public int read(byte[] buf, int off, int len) throws IOException {
+        ensureOpen();
+        if (eos) {
+            return -1;
+        }
+        int n = super.read(buf, off, len);
+        if (n == -1) {
+            if (readTrailer())
+                eos = true;
+            else
+                return this.read(buf, off, len);
+        } else {
+            crc.update(buf, off, n);
+        }
+        return n;
+    }
+
+    /**
+     * Closes this input stream and releases any system resources associated
+     * with the stream.
+     * @throws    IOException if an I/O error has occurred
+     */
+    public void close() throws IOException {
+        if (!closed) {
+            super.close();
+            eos = true;
+            closed = true;
+        }
+    }
+
+    /**
+     * GZIP header magic number.
+     */
+    public static final int GZIP_MAGIC = 0x8b1f;
+
+    /*
+     * File header flags.
+     */
+    private static final int FTEXT      = 1;    // Extra text
+    private static final int FHCRC      = 2;    // Header CRC
+    private static final int FEXTRA     = 4;    // Extra field
+    private static final int FNAME      = 8;    // File name
+    private static final int FCOMMENT   = 16;   // File comment
+
+    /*
+     * Reads GZIP member header and returns the total byte number
+     * of this member header.
+     */
+    private int readHeader(InputStream input) throws IOException {
+        CheckedInputStream in = new CheckedInputStream(input, crc);
+        crc.reset();
+        // Check header magic
+        if (readUShort(in) != GZIP_MAGIC) {
+            throw new ZipException("Not in GZIP format");
+        }
+        // Check compression method
+        if (readUByte(in) != 8) {
+            throw new ZipException("Unsupported compression method");
+        }
+        // Read flags
+        int flg = readUByte(in);
+        // Skip MTIME, XFL, and OS fields
+        skipBytes(in, 6);
+        int n = 2 + 2 + 6;
+        // Skip optional extra field
+        if ((flg & FEXTRA) == FEXTRA) {
+            int m = readUShort(in);
+            skipBytes(in, m);
+            n += m + 2;
+        }
+        // Skip optional file name
+        if ((flg & FNAME) == FNAME) {
+            do {
+                n++;
+            } while (readUByte(in) != 0);
+        }
+        // Skip optional file comment
+        if ((flg & FCOMMENT) == FCOMMENT) {
+            do {
+                n++;
+            } while (readUByte(in) != 0);
+        }
+        // Check optional header CRC
+        if ((flg & FHCRC) == FHCRC) {
+            int v = (int) crc.getValue() & 0xffff;
+            if (readUShort(in) != v) {
+                throw new ZipException("Corrupt GZIP header");
+            }
+            n += 2;
+        }
+        crc.reset();
+        return n;
+    }
+
+    /*
+     * Reads GZIP member trailer and returns true if the eos
+     * reached, false if there are more (concatenated gzip
+     * data set)
+     */
+    private boolean readTrailer() throws IOException {
+        InputStream in = this.in;
+        int n = inf.getRemaining();
+        if (n > 0) {
+            in = new SequenceInputStream(
+                    new ByteArrayInputStream(buf, len - n, n),
+                    new FilterInputStream(in) {
+                        public void close() throws IOException {}
+                    });
+        }
+        // Uses left-to-right evaluation order
+        if ((readUInt(in) != crc.getValue()) ||
+                // rfc1952; ISIZE is the input size modulo 2^32
+                (readUInt(in) != (inf.getBytesWritten() & 0xffffffffL)))
+            throw new ZipException("Corrupt GZIP trailer");
+
+        // If there are more bytes available in "in" or
+        // the leftover in the "inf" is > 26 bytes:
+        // this.trailer(8) + next.header.min(10) + next.trailer(8)
+        // try concatenated case
+        if (this.in.available() > 0 || n > 26) {
+            int m = 8;                  // this.trailer
+            try {
+                m += readHeader(in);    // next.header
+            } catch (IOException ze) {
+                return true;  // ignore any malformed, do nothing
+            }
+            inf.reset();
+            if (n > m)
+                inf.setInput(buf, len - n + m, n - m);
+            return false;
+        }
+        return true;
+    }
+
+    /*
+     * Reads unsigned integer in Intel byte order.
+     */
+    private long readUInt(InputStream in) throws IOException {
+        long s = readUShort(in);
+        return ((long) readUShort(in) << 16) | s;
+    }
+
+    /*
+     * Reads unsigned short in Intel byte order.
+     */
+    private int readUShort(InputStream in) throws IOException {
+        int b = readUByte(in);
+        return (readUByte(in) << 8) | b;
+    }
+
+    /*
+     * Reads unsigned byte.
+     */
+    private int readUByte(InputStream in) throws IOException {
+        int b = in.read();
+        if (b == -1) {
+            throw new EOFException();
+        }
+        if (b < -1 || b > 255) {
+            // Report on this.in, not argument in; see read{Header, Trailer}.
+            throw new IOException(this.in.getClass().getName()
+                    + ".read() returned value out of range -1..255: " + b);
+        }
+        return b;
+    }
+
+    private byte[] tmpbuf = new byte[128];
+
+    /*
+     * Skips bytes of input data blocking until all bytes are skipped.
+     * Does not assume that the input stream is capable of seeking.
+     */
+    private void skipBytes(InputStream in, int n) throws IOException {
+        while (n > 0) {
+            int len = in.read(tmpbuf, 0, n < tmpbuf.length ? n : tmpbuf.length);
+            if (len == -1) {
+                throw new EOFException();
+            }
+            n -= len;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/compress/KafkaInflaterInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/compress/KafkaInflaterInputStream.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 1996, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.apache.kafka.common.compress;
+
+import org.apache.kafka.common.utils.BufferSupplier;
+
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
+import java.util.zip.ZipException;
+
+/**
+ * this is a modified {@link java.util.zip.InflaterInputStream} that gets
+ * it's internal buffer from a {@link BufferSupplier} and also returns the
+ * buffer when it's {@link #close()}ed
+ */
+public class KafkaInflaterInputStream extends FilterInputStream {
+    /**
+     * Decompressor for this stream.
+     */
+    protected Inflater inf;
+
+    /**
+     * Buffer Supplier for the decompression buffer
+     */
+    protected BufferSupplier bufferSupplier;
+
+    /**
+     * Actual Buffer originating from (and to be released back to) {@link #bufferSupplier}
+     */
+    protected ByteBuffer buffer;
+
+    /**
+     * Input buffer for decompression.
+     */
+    protected byte[] buf;
+
+    /**
+     * Length of input buffer.
+     */
+    protected int len;
+
+    private boolean closed = false;
+    // this flag is set to true after EOF has reached
+    private boolean reachEOF = false;
+
+    /**
+     * Check to make sure that this stream has not been closed
+     */
+    private void ensureOpen() throws IOException {
+        if (closed) {
+            throw new IOException("Stream closed");
+        }
+    }
+
+    /**
+     * Creates a new input stream with the specified decompressor and
+     * buffer size.
+     * @param in the input stream
+     * @param inf the decompressor ("inflater")
+     * @param size the input buffer size
+     * @throws    IllegalArgumentException if {@code size <= 0}
+     */
+    public KafkaInflaterInputStream(InputStream in, Inflater inf, BufferSupplier bufferSupplier, int size) {
+        super(in);
+        if (in == null || inf == null) {
+            throw new NullPointerException();
+        } else if (size <= 0) {
+            throw new IllegalArgumentException("buffer size <= 0");
+        }
+        this.inf = inf;
+        this.bufferSupplier = bufferSupplier;
+        this.buffer = this.bufferSupplier.get(size);
+        this.buf = buffer.array(); //implicitly we do not support off-heap buffers
+    }
+
+    /**
+     * Creates a new input stream with the specified decompressor and a
+     * default buffer size.
+     * @param in the input stream
+     * @param inf the decompressor ("inflater")
+     */
+    public KafkaInflaterInputStream(InputStream in, Inflater inf, BufferSupplier bufferSupplier) {
+        this(in, inf, bufferSupplier, 512);
+    }
+
+    boolean usesDefaultInflater = false;
+
+    /**
+     * Creates a new input stream with a default decompressor and buffer size.
+     * @param in the input stream
+     */
+    public KafkaInflaterInputStream(InputStream in, BufferSupplier bufferSupplier) {
+        this(in, new Inflater(), bufferSupplier);
+        usesDefaultInflater = true;
+    }
+
+    private final byte[] singleByteBuf = new byte[1];
+
+    /**
+     * Reads a byte of uncompressed data. This method will block until
+     * enough input is available for decompression.
+     * @return the byte read, or -1 if end of compressed input is reached
+     * @throws    IOException if an I/O error has occurred
+     */
+    public int read() throws IOException {
+        ensureOpen();
+        return read(singleByteBuf, 0, 1) == -1 ? -1 : Byte.toUnsignedInt(singleByteBuf[0]);
+    }
+
+    /**
+     * Reads uncompressed data into an array of bytes. If {@code len} is not
+     * zero, the method will block until some input can be decompressed; otherwise,
+     * no bytes are read and {@code 0} is returned.
+     * @param b the buffer into which the data is read
+     * @param off the start offset in the destination array {@code b}
+     * @param len the maximum number of bytes read
+     * @return the actual number of bytes read, or -1 if the end of the
+     *         compressed input is reached or a preset dictionary is needed
+     * @throws     NullPointerException If {@code b} is {@code null}.
+     * @throws     IndexOutOfBoundsException If {@code off} is negative,
+     * {@code len} is negative, or {@code len} is greater than
+     * {@code b.length - off}
+     * @throws ZipException if a ZIP format error has occurred
+     * @throws    IOException if an I/O error has occurred
+     */
+    public int read(byte[] b, int off, int len) throws IOException {
+        ensureOpen();
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (off < 0 || len < 0 || len > b.length - off) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        }
+        try {
+            int n;
+            while ((n = inf.inflate(b, off, len)) == 0) {
+                if (inf.finished() || inf.needsDictionary()) {
+                    reachEOF = true;
+                    return -1;
+                }
+                if (inf.needsInput()) {
+                    fill();
+                }
+            }
+            return n;
+        } catch (DataFormatException e) {
+            String s = e.getMessage();
+            throw new ZipException(s != null ? s : "Invalid ZLIB data format");
+        }
+    }
+
+    /**
+     * Returns 0 after EOF has been reached, otherwise always return 1.
+     * <p>
+     * Programs should not count on this method to return the actual number
+     * of bytes that could be read without blocking.
+     *
+     * @return     1 before EOF and 0 after EOF.
+     * @throws     IOException  if an I/O error occurs.
+     *
+     */
+    public int available() throws IOException {
+        ensureOpen();
+        if (reachEOF) {
+            return 0;
+        } else if (inf.finished()) {
+            // the end of the compressed data stream has been reached
+            reachEOF = true;
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+
+    private byte[] b = new byte[512];
+
+    /**
+     * Skips specified number of bytes of uncompressed data.
+     * @param n the number of bytes to skip
+     * @return the actual number of bytes skipped.
+     * @throws    IOException if an I/O error has occurred
+     * @throws    IllegalArgumentException if {@code n < 0}
+     */
+    public long skip(long n) throws IOException {
+        if (n < 0) {
+            throw new IllegalArgumentException("negative skip length");
+        }
+        ensureOpen();
+        int max = (int) Math.min(n, Integer.MAX_VALUE);
+        int total = 0;
+        while (total < max) {
+            int len = max - total;
+            if (len > b.length) {
+                len = b.length;
+            }
+            len = read(b, 0, len);
+            if (len == -1) {
+                reachEOF = true;
+                break;
+            }
+            total += len;
+        }
+        return total;
+    }
+
+    /**
+     * Closes this input stream and releases any system resources associated
+     * with the stream.
+     * @throws    IOException if an I/O error has occurred
+     */
+    public void close() throws IOException {
+        if (!closed) {
+            if (usesDefaultInflater)
+                inf.end();
+            bufferSupplier.release(buffer);
+            buffer = null;
+            buf = null;
+            in.close();
+            closed = true;
+        }
+    }
+
+    /**
+     * Fills input buffer with more data to decompress.
+     * @throws    IOException if an I/O error has occurred
+     */
+    protected void fill() throws IOException {
+        ensureOpen();
+        len = in.read(buf, 0, buf.length);
+        if (len == -1) {
+            throw new EOFException("Unexpected end of ZLIB input stream");
+        }
+        inf.setInput(buf, 0, len);
+    }
+
+    /**
+     * Tests if this input stream supports the {@code mark} and
+     * {@code reset} methods. The {@code markSupported}
+     * method of {@code InflaterInputStream} returns
+     * {@code false}.
+     *
+     * @return  a {@code boolean} indicating if this stream type supports
+     *          the {@code mark} and {@code reset} methods.
+     * @see     InputStream#mark(int)
+     * @see     InputStream#reset()
+     */
+    public boolean markSupported() {
+        return false;
+    }
+
+    /**
+     * Marks the current position in this input stream.
+     *
+     * <p> The {@code mark} method of {@code InflaterInputStream}
+     * does nothing.
+     *
+     * @param   readlimit   the maximum limit of bytes that can be read before
+     *                      the mark position becomes invalid.
+     * @see     InputStream#reset()
+     */
+    public synchronized void mark(int readlimit) {
+    }
+
+    /**
+     * Repositions this stream to the position at the time the
+     * {@code mark} method was last called on this input stream.
+     *
+     * <p> The method {@code reset} for class
+     * {@code InflaterInputStream} does nothing except throw an
+     * {@code IOException}.
+     *
+     * @throws     IOException  if this method is invoked.
+     * @see     InputStream#mark(int)
+     * @see     IOException
+     */
+    public synchronized void reset() throws IOException {
+        throw new IOException("mark/reset not supported");
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/CompressionType.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.compress.KafkaBufferedInputStream;
+import org.apache.kafka.common.compress.KafkaGZIPInputStream;
 import org.apache.kafka.common.compress.KafkaLZ4BlockInputStream;
 import org.apache.kafka.common.compress.KafkaLZ4BlockOutputStream;
 import org.apache.kafka.common.compress.SnappyFactory;
@@ -25,12 +27,10 @@ import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -69,8 +69,13 @@ public enum CompressionType {
                 // Set output buffer (uncompressed) to 16 KB (none by default) and input buffer (compressed) to
                 // 8 KB (0.5 KB by default) to ensure reasonable performance in cases where the caller reads a small
                 // number of bytes (potentially a single byte)
-                return new BufferedInputStream(new GZIPInputStream(new ByteBufferInputStream(buffer), 8 * 1024),
-                        16 * 1024);
+                return new KafkaBufferedInputStream(
+                        new KafkaGZIPInputStream(
+                                new ByteBufferInputStream(buffer), decompressionBufferSupplier, 8 * 1024
+                        ),
+                        decompressionBufferSupplier,
+                        16 * 1024
+                );
             } catch (Exception e) {
                 throw new KafkaException(e);
             }

--- a/clients/src/test/java/org/apache/kafka/common/compress/KafkaGzipTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/compress/KafkaGzipTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.compress;
+
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.ByteBufferInputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.opentest4j.AssertionFailedError;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.IdentityHashMap;
+import java.util.Random;
+import java.util.zip.GZIPOutputStream;
+
+@ExtendWith(KafkaGzipTest.class)
+public class KafkaGzipTest implements TestWatcher {
+
+    private long seed;
+
+    @BeforeEach
+    public void setup() {
+        seed = System.currentTimeMillis();
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        throw new AssertionError("seed was " + seed, cause);
+    }
+
+    @Test
+    public void testCompressibleInput() throws Exception {
+        Random random = new Random(seed);
+        byte[] payload = generateCompressibleBytes(random, 1, 24 * 1024);
+        byte[] compressedByVanilla = compressUsingJDK(payload);
+        byte[] decompressed = decompressUsingBufferSupplier(random, compressedByVanilla);
+        Assertions.assertArrayEquals(payload, decompressed, "decompressed contents differ from input");
+    }
+
+    /**
+     * generates a random compressible sequence of bytes of a random size (between bounds).
+     * sequence would be composed of subsequences, each subsequence would be composed of a
+     * single value repeated 1-10 times.
+     */
+    private static byte[] generateCompressibleBytes(Random random, int minSize, int maxSize) {
+        if (maxSize < minSize) {
+            throw new IllegalArgumentException();
+        }
+        int size = minSize + random.nextInt(maxSize - minSize);
+        byte[] output = new byte[size];
+        byte[] oneByte = new byte[1];
+        int remaining = size;
+        int position = 0;
+        while (remaining > 0) {
+            int sequenceSize = 1 + random.nextInt(10); //[1-10]
+            if (sequenceSize > remaining) {
+                sequenceSize = remaining;
+            }
+            random.nextBytes(oneByte);
+            for (int i = 0; i < sequenceSize; i++) {
+                output[position++] = oneByte[0];
+            }
+            remaining -= sequenceSize;
+        }
+        return output;
+    }
+
+    private static byte[] compressUsingJDK(byte[] payload) throws Exception {
+        try (
+                ByteArrayOutputStream baos = new ByteArrayOutputStream(payload.length);
+                GZIPOutputStream gos = new GZIPOutputStream(baos, 8 * 1024) //kafka default for gzip
+        ) {
+            gos.write(payload);
+            gos.flush();
+            gos.close();
+            baos.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    private static byte[] decompressUsingBufferSupplier(Random random, byte[] compressed) throws Exception {
+        try (ValidatingBufferSupplier supplier = new ValidatingBufferSupplier(random)) {
+            ByteBuffer compressedBuffer = ByteBuffer.wrap(compressed);
+            InputStream is = new KafkaBufferedInputStream(
+                    new KafkaGZIPInputStream(
+                            new ByteBufferInputStream(compressedBuffer), supplier, 8 * 1024
+                    ),
+                    supplier,
+                    16 * 1024
+            );
+            Assertions.assertEquals(2, supplier.numOutstandingBuffers());
+            ByteArrayOutputStream os = new ByteArrayOutputStream(compressed.length);
+            byte[] copyBuffer = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = is.read(copyBuffer)) >= 0) {
+                if (bytesRead > 0) {
+                    os.write(copyBuffer, 0, bytesRead);
+                }
+            }
+            is.close();
+            Assertions.assertEquals(0, supplier.numOutstandingBuffers());
+            os.flush();
+            return os.toByteArray();
+        }
+    }
+
+    private static class ValidatingBufferSupplier extends BufferSupplier {
+        private final IdentityHashMap<ByteBuffer, RuntimeException> buffersOutstanding = new IdentityHashMap<>();
+        private final Random random;
+        private volatile AssertionFailedError issue;
+
+        public ValidatingBufferSupplier(Random random) {
+            this.random = random;
+        }
+
+        @Override
+        public ByteBuffer get(int capacity) {
+            RuntimeException pointOfAllocation = new RuntimeException("this is where the buffer was requested");
+            int deliveredCapacity = capacity + random.nextInt(10 * capacity + 1); //1x-10x requested capacity, inclusive
+            ByteBuffer buffer = ByteBuffer.allocate(deliveredCapacity);
+            buffersOutstanding.put(buffer, pointOfAllocation);
+            return buffer;
+        }
+
+        @Override
+        public void release(ByteBuffer buffer) {
+            if (buffer == null) {
+                issue = new AssertionFailedError("null buffer released");
+                throw issue;
+            }
+            RuntimeException pointOfAllocation = buffersOutstanding.remove(buffer);
+            if (pointOfAllocation == null) {
+                issue = new AssertionFailedError("foreign buffer released");
+                throw issue;
+            }
+        }
+
+        public int numOutstandingBuffers() {
+            return buffersOutstanding.size();
+        }
+
+        @Override
+        public void close() {
+            if (issue != null) {
+                throw issue;
+            }
+            int leakedBuffers = buffersOutstanding.size();
+            if (leakedBuffers != 0) {
+                AssertionFailedError error = new AssertionFailedError(leakedBuffers + " buffers allocated yet never released");
+                buffersOutstanding.values().forEach(error::addSuppressed);
+                throw error;
+            }
+        }
+    }
+}

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -475,4 +475,11 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
         <Package name="org.apache.kafka.jmh.metadata.generated"/>
     </Match>
 
+    <Match>
+        <!-- Suppress a warning about array field volatility as it exists in the original code -->
+        <Class name="org.apache.kafka.common.compress.KafkaBufferedInputStream"/>
+        <Field name="buf"/>
+        <Bug pattern="VO_VOLATILE_REFERENCE_TO_ARRAY"/>
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
as laid out in https://issues.apache.org/jira/browse/KAFKA-12605 kafka consumers decoding gzip'ed payloads currently do not re-use memory buffers because the JDK classes used have no support for it.

this PR adds buffer reuse support to gzip decoding.

unfortunately, since the JDK classes involved are not properly extensible I've had to make copies of them. modification to these copies are kept minimal:

1. buffers now come from, and are returned to, suppliers
2. some use of Unsafe has been replaced with more portable code
3. minor changes required to comply with kafka's checkstyle
4. KafkaBufferedInputStream does not fully support the mark() operation as that may involve buffer re-allocation. I have not found any usage of mark() in kafka code though.

so far only decompression is supported. compression may be added later.

a (randomized) test has been added that I have run on my machine for several hours with no issues.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
