### PR TITLE
KAFKA-12744: Breaking change dependency upgrade: "argparse4j" 0.7.0 -->> 0.9.0

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorMaker.java
@@ -275,7 +275,9 @@ public class MirrorMaker {
     }
 
     public static void main(String[] args) {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("connect-mirror-maker");
+        ArgumentParser parser = ArgumentParsers
+                .newFor("connect-mirror-maker")
+                .build();
         parser.description("MirrorMaker 2.0 driver");
         parser.addArgument("config").type(Arguments.fileType().verifyCanRead())
             .metavar("mm2.properties").required(true)

--- a/core/src/main/scala/kafka/tools/ClusterTool.scala
+++ b/core/src/main/scala/kafka/tools/ClusterTool.scala
@@ -32,7 +32,8 @@ object ClusterTool extends Logging {
   def main(args: Array[String]): Unit = {
     try {
       val parser = ArgumentParsers.
-        newArgumentParser("kafka-cluster").
+        newFor("kafka-cluster").
+        build().
         defaultHelp(true).
         description("The Kafka cluster tool.")
       val subparsers = parser.addSubparsers().dest("command")

--- a/core/src/main/scala/kafka/tools/StorageTool.scala
+++ b/core/src/main/scala/kafka/tools/StorageTool.scala
@@ -33,7 +33,8 @@ object StorageTool extends Logging {
   def main(args: Array[String]): Unit = {
     try {
       val parser = ArgumentParsers.
-        newArgumentParser("kafka-storage").
+        newFor("kafka-storage").
+        build().
         defaultHelp(true).
         description("The Kafka storage tool.")
       val subparsers = parser.addSubparsers().dest("command")

--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -330,7 +330,8 @@ public final class MessageGenerator {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("message-generator")
+            .newFor("message-generator")
+            .build()
             .defaultHelp(true)
             .description("The Kafka message generator");
         parser.addArgument("--package", "-p")

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -57,7 +57,7 @@ versions += [
   activation: "1.1.1",
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
-  argparse4j: "0.7.0",
+  argparse4j: "0.9.0",
   bcpkix: "1.66",
   checkstyle: "8.20",
   commonsCli: "1.4",

--- a/shell/src/main/java/org/apache/kafka/shell/Commands.java
+++ b/shell/src/main/java/org/apache/kafka/shell/Commands.java
@@ -23,7 +23,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
 import net.sourceforge.argparse4j.inf.Subparsers;
-import net.sourceforge.argparse4j.internal.HelpScreenException;
+import net.sourceforge.argparse4j.helper.HelpScreenException;
 import org.jline.reader.Candidate;
 
 import java.io.PrintWriter;
@@ -95,7 +95,7 @@ public final class Commands {
      * @param addShellCommands  True if we should include the shell-only commands.
      */
     public Commands(boolean addShellCommands) {
-        this.parser = ArgumentParsers.newArgumentParser("", false);
+        this.parser = ArgumentParsers.newFor("shell-commands").build();
         Subparsers subparsers = this.parser.addSubparsers().dest("command");
         for (Type type : TYPES.values()) {
             if (addShellCommands || !type.shellOnly()) {

--- a/shell/src/main/java/org/apache/kafka/shell/ManCommandHandler.java
+++ b/shell/src/main/java/org/apache/kafka/shell/ManCommandHandler.java
@@ -87,7 +87,7 @@ public final class ManCommandHandler implements Commands.Handler {
             writer.println("man: unknown command " + cmd +
                 ". Type help to get a list of commands.");
         } else {
-            ArgumentParser parser = ArgumentParsers.newArgumentParser(type.name(), false);
+            ArgumentParser parser = ArgumentParsers.newFor(type.name()).build();
             type.addArguments(parser);
             writer.printf("%s: %s%n%n", cmd, type.description());
             parser.printHelp(writer);

--- a/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
+++ b/shell/src/main/java/org/apache/kafka/shell/MetadataShell.java
@@ -133,7 +133,8 @@ public final class MetadataShell {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("metadata-tool")
+            .newFor("metadata-tool")
+            .build()
             .defaultHelp(true)
             .description("The Apache Kafka metadata tool");
         parser.addArgument("--snapshot", "-s")

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -104,7 +104,8 @@ public class ClientCompatibilityTest {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("client-compatibility-test")
+            .newFor("client-compatibility-test")
+            .build()
             .defaultHelp(true)
             .description("This tool is used to verify client compatibility guarantees.");
         parser.addArgument("--topic")

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -193,7 +193,8 @@ public class ProducerPerformance {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("producer-performance")
+                .newFor("producer-performance")
+                .build()
                 .defaultHelp(true)
                 .description("This tool is used to verify the producer performance.");
 

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -65,7 +65,8 @@ public class TransactionalMessageCopier {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("transactional-message-copier")
+                .newFor("transactional-message-copier")
+                .build()
                 .defaultHelp(true)
                 .description("This tool copies messages transactionally from an input partition to an output topic, " +
                         "committing the consumed offsets along with the output messages");

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -501,7 +501,8 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
 
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("verifiable-consumer")
+                .newFor("verifiable-consumer")
+                .build()
                 .defaultHelp(true)
                 .description("This tool consumes messages from a specific topic and emits consumer events (e.g. group rebalances, received messages, and offsets committed) as JSON objects to STDOUT.");
         MutuallyExclusiveGroup connectionGroup = parser.addMutuallyExclusiveGroup("Connection Group")

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableLog4jAppender.java
@@ -55,7 +55,8 @@ public class VerifiableLog4jAppender {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("verifiable-log4j-appender")
+            .newFor("verifiable-log4j-appender")
+            .build()
             .defaultHelp(true)
             .description("This tool produces increasing integers to the specified topic using KafkaLog4jAppender.");
 

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -109,7 +109,8 @@ public class VerifiableProducer implements AutoCloseable {
     /** Get the command-line argument parser. */
     private static ArgumentParser argParser() {
         ArgumentParser parser = ArgumentParsers
-                .newArgumentParser("verifiable-producer")
+                .newFor("verifiable-producer")
+                .build()
                 .defaultHelp(true)
                 .description("This tool produces increasing integers to the specified topic and prints JSON metadata to stdout on each \"send\" request, making externally visible which messages have been acked and which have not.");
 

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -203,7 +203,8 @@ public final class Agent {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("trogdor-agent")
+            .newFor("trogdor-agent")
+            .build()
             .defaultHelp(true)
             .description("The Trogdor fault injection agent");
         parser.addArgument("--agent.config", "-c")

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/agent/AgentClient.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/agent/AgentClient.java
@@ -199,7 +199,8 @@ public class AgentClient {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser rootParser = ArgumentParsers
-            .newArgumentParser("trogdor-agent-client")
+            .newFor("trogdor-agent-client")
+            .build()
             .defaultHelp(true)
             .description("The Trogdor agent client.");
         Subparsers subParsers = rootParser.addSubparsers().

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -131,7 +131,8 @@ public final class Coordinator {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser parser = ArgumentParsers
-            .newArgumentParser("trogdor-coordinator")
+            .newFor("trogdor-coordinator")
+            .build()
             .defaultHelp(true)
             .description("The Trogdor fault injection coordinator");
         parser.addArgument("--coordinator.config", "-c")

--- a/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/coordinator/CoordinatorClient.java
@@ -222,7 +222,8 @@ public class CoordinatorClient {
 
     public static void main(String[] args) throws Exception {
         ArgumentParser rootParser = ArgumentParsers
-            .newArgumentParser("trogdor-coordinator-client")
+            .newFor("trogdor-coordinator-client")
+            .build()
             .description("The Trogdor coordinator client.");
         Subparsers subParsers = rootParser.addSubparsers().
             dest("command");


### PR DESCRIPTION
Corresponding JIRA ticket: https://issues.apache.org/jira/browse/KAFKA-12744 

Migration guide: https://argparse4j.github.io/migration.html#to-0-8-0

Release notes:
 * https://github.com/argparse4j/argparse4j/releases/tag/argparse4j-0.8.0
 * https://github.com/argparse4j/argparse4j/releases/tag/argparse4j-0.8.1
 * https://github.com/argparse4j/argparse4j/releases/tag/argparse4j-0.9.0

Related to this PR: #10094 and this commit: https://github.com/apache/kafka/commit/690f72dd69d31589655c84d3cc1a6eec006bcab5

@cmccabe, @hachikuji, @mumrah and @soarez: it would be nice if you could spare some time and review this (especially these two classes):

```
shell/src/main/java/org/apache/kafka/shell/Commands.java
shell/src/main/java/org/apache/kafka/shell/ManCommandHandler.java
```

FYI also @ijuma 




