### PR TITLE
MINOR: Stop using hamcrest in system tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -43,9 +43,6 @@ import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.ValueJoiner;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.StringDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,10 +65,6 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasKey;
 
 /**
  * This test builds on a basic relational data caricature:
@@ -806,7 +799,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             }
         }
 
-        public static <T> void assertThat(final AtomicBoolean pass,
+        /*public static <T> void assertThat(final AtomicBoolean pass,
                                           final StringBuilder failures,
                                           final String message,
                                           final T actual,
@@ -823,7 +816,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                 }
                 pass.set(false);
             }
-        }
+        }*/
 
         static boolean verifySync(final boolean logResults,
                                   final Map<Integer, Article> consumedArticles,
@@ -833,10 +826,10 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             final AtomicBoolean pass = new AtomicBoolean(true);
             final StringBuilder report = logResults ? new StringBuilder() : null;
 
-            assertThat(pass, report, "one article", consumedArticles.size(), greaterThan(0));
-            assertThat(pass, report, "one comment", consumedComments.size(), greaterThan(0));
+            //assertThat(pass, report, "one article", consumedArticles.size(), greaterThan(0));
+            //assertThat(pass, report, "one comment", consumedComments.size(), greaterThan(0));
 
-            assertThat(
+           /* assertThat(
                 pass,
                 report,
                 "article size",
@@ -849,79 +842,79 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                 "comment size",
                 consumedAugmentedComments.size(),
                 is(consumedComments.size())
-            );
+            );*/
 
             final Map<Integer, Long> commentCounts = new TreeMap<>();
 
             for (final RelationalSmokeTest.AugmentedComment augmentedComment : consumedAugmentedComments.values()) {
                 final int key = augmentedComment.getKey();
-                assertThat(pass,
+                /*assertThat(pass,
                            report,
                            "comment missing, but found in augmentedComment: " + key,
                            consumedComments,
-                           hasKey(key));
+                           hasKey(key));*/
 
                 final Comment comment = consumedComments.get(key);
                 if (comment != null) {
-                    assertThat(
+                    /*assertThat(
                         pass,
                         report,
                         "comment articleId [" + comment.getArticleId() + "] didn't match " +
                             "augmentedComment articleId [" + augmentedComment.getArticleId() + "]",
                         comment.getArticleId(),
                         is(augmentedComment.getArticleId())
-                    );
+                    );*/
                 }
                 commentCounts.put(augmentedComment.getArticleId(),
                                   commentCounts.getOrDefault(augmentedComment.getArticleId(), 0L) + 1);
 
-                assertThat(
+                /*assertThat(
                     pass,
                     report,
                     "augmentedArticle [" + augmentedComment.getArticleId() + "] " +
                         "missing for augmentedComment [" + augmentedComment.getKey() + "]",
                     consumedAugmentedArticles,
                     hasKey(augmentedComment.getArticleId())
-                );
+                );*/
                 final AugmentedArticle augmentedArticle = consumedAugmentedArticles.get(augmentedComment.getArticleId());
                 if (augmentedArticle != null) {
-                    assertThat(
+                   /* assertThat(
                         pass,
                         report,
                         "articlePrefix didn't match augmentedArticle: " + augmentedArticle.getText(),
                         augmentedArticle.getText(),
                         startsWith(augmentedComment.getArticlePrefix())
-                    );
+                    );*/
                 }
 
-                assertThat(
+                /*assertThat(
                     pass,
                     report,
                     "article " + augmentedComment.getArticleId() + " missing from consumedArticles",
                     consumedArticles,
                     hasKey(augmentedComment.getArticleId())
-                );
+                );*/
                 final Article article = consumedArticles.get(augmentedComment.getArticleId());
                 if (article != null) {
-                    assertThat(
+                   /* assertThat(
                         pass,
                         report,
                         "articlePrefix didn't match article: " + article.getText(),
                         article.getText(),
                         startsWith(augmentedComment.getArticlePrefix())
-                    );
+                    );*/
                 }
             }
 
 
             for (final RelationalSmokeTest.AugmentedArticle augmentedArticle : consumedAugmentedArticles.values()) {
-                assertThat(
+               /* assertThat(
                     pass,
                     report,
                     "article " + augmentedArticle.getKey() + " comment count mismatch",
                     augmentedArticle.getCommentCount(),
                     is(commentCounts.getOrDefault(augmentedArticle.getKey(), 0L))
-                );
+                );*/
             }
 
             if (logResults) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -138,10 +138,10 @@ public class RelationalSmokeTest extends SmokeTestUtil {
 
                 final ByteBuffer buffer =
                     ByteBuffer.allocate(length)
-                        .putInt(data.getKey())
-                        .putLong(data.getTimestamp())
-                        .putInt(serialText.length)
-                        .put(serialText);
+                              .putInt(data.getKey())
+                              .putLong(data.getTimestamp())
+                              .putInt(serialText.length)
+                              .put(serialText);
 
                 return Serdes.ByteBuffer().serializer().serialize(topic, buffer);
             }
@@ -228,11 +228,11 @@ public class RelationalSmokeTest extends SmokeTestUtil {
 
                 final ByteBuffer buffer =
                     ByteBuffer.allocate(length)
-                        .putInt(data.key)
-                        .putLong(data.timestamp)
-                        .putInt(serialText.length)
-                        .put(serialText)
-                        .putInt(data.articleId);
+                              .putInt(data.key)
+                              .putLong(data.timestamp)
+                              .putInt(serialText.length)
+                              .put(serialText)
+                              .putInt(data.articleId);
 
                 return Serdes.ByteBuffer().serializer().serialize(topic, buffer);
             }
@@ -464,8 +464,8 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                 final int length = serializedArticle.length + Long.BYTES;
                 final ByteBuffer buffer =
                     ByteBuffer.allocate(length)
-                        .put(serializedArticle)
-                        .putLong(data.getCommentCount());
+                              .put(serializedArticle)
+                              .putLong(data.getCommentCount());
                 return Serdes.ByteBuffer().serializer().serialize(topic, buffer);
             }
         }
@@ -540,9 +540,9 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                 final int length = serializedComment.length + Integer.BYTES + serializedPrefix.length;
                 final ByteBuffer buffer =
                     ByteBuffer.allocate(length)
-                        .put(serializedComment)
-                        .putInt(serializedPrefix.length)
-                        .put(serializedPrefix);
+                              .put(serializedComment)
+                              .putInt(serializedPrefix.length)
+                              .put(serializedPrefix);
                 return Serdes.ByteBuffer().serializer().serialize(topic, buffer);
             }
         }
@@ -607,22 +607,22 @@ public class RelationalSmokeTest extends SmokeTestUtil {
 
             final KTable<Integer, Long> commentCounts =
                 comments.groupBy((key, value) -> new KeyValue<>(value.getArticleId(), (short) 1),
-                    Grouped.with(Serdes.Integer(), Serdes.Short()))
-                    .count();
+                                 Grouped.with(Serdes.Integer(), Serdes.Short()))
+                        .count();
 
             articles
                 .leftJoin(commentCounts,
-                    AugmentedArticle.joiner(),
-                    Materialized.with(null, new AugmentedArticle.AugmentedArticleSerde()))
+                          AugmentedArticle.joiner(),
+                          Materialized.with(null, new AugmentedArticle.AugmentedArticleSerde()))
                 .toStream()
                 .to(ARTICLE_RESULT_SINK);
 
             comments.join(articles,
-                Comment::getArticleId,
-                AugmentedComment.joiner(),
-                Materialized.with(null, new AugmentedComment.AugmentedCommentSerde()))
-                .toStream()
-                .to(COMMENT_RESULT_SINK);
+                          Comment::getArticleId,
+                          AugmentedComment.joiner(),
+                          Materialized.with(null, new AugmentedComment.AugmentedCommentSerde()))
+                    .toStream()
+                    .to(COMMENT_RESULT_SINK);
 
             return streamsBuilder.build();
         }
@@ -799,25 +799,6 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             }
         }
 
-        /*public static <T> void assertThat(final AtomicBoolean pass,
-                                          final StringBuilder failures,
-                                          final String message,
-                                          final T actual,
-                                          final Matcher<? super T> matcher) {
-            if (!matcher.matches(actual)) {
-                if (failures != null) {
-                    final Description description = new StringDescription(failures);
-                    description.appendText("\n" + message)
-                               .appendText("\nExpected: ")
-                               .appendDescriptionOf(matcher)
-                               .appendText("\n     but: ");
-                    matcher.describeMismatch(actual, description);
-                    description.appendText("\n");
-                }
-                pass.set(false);
-            }
-        }*/
-
         public static void assertThat(final AtomicBoolean pass,
                                       final StringBuilder failures,
                                       final String message,
@@ -855,13 +836,19 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             assertThat(
                 pass,
                 report,
-                "Mismatched article size between augmented articles (size " + consumedAugmentedArticles.size() + ") and consumed articles (size " + consumedArticles.size() + ")",
+                "Mismatched article size between augmented articles (size "
+                        + consumedAugmentedArticles.size() +
+                        ") and consumed articles (size "
+                        + consumedArticles.size() + ")",
                 consumedAugmentedArticles.size() == consumedArticles.size()
             );
             assertThat(
                 pass,
                 report,
-                "Mismatched comments size between augmented comments (size " + consumedAugmentedComments.size() + ") and consumed comments (size " + consumedComments.size() + ")",
+                "Mismatched comments size between augmented comments (size "
+                        + consumedAugmentedComments.size() +
+                        ") and consumed comments (size " +
+                        consumedComments.size() + ")",
                 consumedAugmentedComments.size() == consumedComments.size()
             );
 
@@ -870,9 +857,9 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             for (final RelationalSmokeTest.AugmentedComment augmentedComment : consumedAugmentedComments.values()) {
                 final int key = augmentedComment.getKey();
                 assertThat(pass,
-                    report,
-                    "comment missing, but found in augmentedComment: " + key,
-                    consumedComments.containsKey(key)
+                        report,
+                        "comment missing, but found in augmentedComment: " + key,
+                        consumedComments.containsKey(key)
                 );
 
                 final Comment comment = consumedComments.get(key);
@@ -886,7 +873,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                     );
                 }
                 commentCounts.put(augmentedComment.getArticleId(),
-                    commentCounts.getOrDefault(augmentedComment.getArticleId(), 0L) + 1);
+                                      commentCounts.getOrDefault(augmentedComment.getArticleId(), 0L) + 1);
 
                 assertThat(
                     pass,
@@ -895,7 +882,8 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                         "missing for augmentedComment [" + augmentedComment.getKey() + "]",
                     consumedAugmentedArticles.containsKey(augmentedComment.getArticleId())
                 );
-                final AugmentedArticle augmentedArticle = consumedAugmentedArticles.get(augmentedComment.getArticleId());
+                final AugmentedArticle augmentedArticle =
+                        consumedAugmentedArticles.get(augmentedComment.getArticleId());
                 if (augmentedArticle != null) {
                     assertThat(
                         pass,
@@ -928,7 +916,8 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                     pass,
                     report,
                     "article " + augmentedArticle.getKey() + " comment count mismatch",
-                    augmentedArticle.getCommentCount() == commentCounts.getOrDefault(augmentedArticle.getKey(), 0L)
+                    augmentedArticle.getCommentCount()
+                            == commentCounts.getOrDefault(augmentedArticle.getKey(), 0L)
                 );
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -837,9 +837,9 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                 pass,
                 report,
                 "Mismatched article size between augmented articles (size "
-                        + consumedAugmentedArticles.size() +
-                        ") and consumed articles (size "
-                        + consumedArticles.size() + ")",
+                    + consumedAugmentedArticles.size() +
+                    ") and consumed articles (size "
+                    + consumedArticles.size() + ")",
                 consumedAugmentedArticles.size() == consumedArticles.size()
             );
             assertThat(
@@ -867,13 +867,14 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                     assertThat(
                         pass,
                         report,
-                        "comment articleId [" + comment.getArticleId() + "] didn't match " +
-                            "augmentedComment articleId [" + augmentedComment.getArticleId() + "]",
-                        comment.getArticleId() == augmentedComment.getArticleId()
+                        "comment missing, but found in augmentedComment: " + key,
+                        consumedComments.containsKey(key)
                     );
                 }
-                commentCounts.put(augmentedComment.getArticleId(),
-                                      commentCounts.getOrDefault(augmentedComment.getArticleId(), 0L) + 1);
+                commentCounts.put(
+                    augmentedComment.getArticleId(),
+                    commentCounts.getOrDefault(augmentedComment.getArticleId(), 0L) + 1
+                );
 
                 assertThat(
                     pass,
@@ -916,8 +917,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                     pass,
                     report,
                     "article " + augmentedArticle.getKey() + " comment count mismatch",
-                    augmentedArticle.getCommentCount()
-                            == commentCounts.getOrDefault(augmentedArticle.getKey(), 0L)
+                    augmentedArticle.getCommentCount() == commentCounts.getOrDefault(augmentedArticle.getKey(), 0L)
                 );
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -818,6 +818,24 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             }
         }*/
 
+        public static void assertThat(final AtomicBoolean pass,
+                                                     final StringBuilder failures,
+                                                     final String message,
+                                                     final boolean passed,
+                                                 final String expected) {
+            if (!passed) {
+                if (failures != null) {
+                    final StringBuffer description = new StringBuffer(failures);
+                    description.append("\n" + message)
+                            .append("\nExpected: ")
+                            .append(expected)
+                            .append("\n     but: ");
+                    description.append("\n");
+                }
+                pass.set(false);
+            }
+        }
+
         static boolean verifySync(final boolean logResults,
                                   final Map<Integer, Article> consumedArticles,
                                   final Map<Integer, Comment> consumedComments,
@@ -826,95 +844,95 @@ public class RelationalSmokeTest extends SmokeTestUtil {
             final AtomicBoolean pass = new AtomicBoolean(true);
             final StringBuilder report = logResults ? new StringBuilder() : null;
 
-            //assertThat(pass, report, "one article", consumedArticles.size(), greaterThan(0));
-            //assertThat(pass, report, "one comment", consumedComments.size(), greaterThan(0));
+            assertThat(pass, report, "one article", consumedArticles.size() > 0, "greater than 0");
+            assertThat(pass, report, "one comment", consumedComments.size() > 0, "greater than 0");
 
-           /* assertThat(
+           assertThat(
                 pass,
                 report,
                 "article size",
-                consumedAugmentedArticles.size(),
-                is(consumedArticles.size())
+                consumedAugmentedArticles.size() == consumedArticles.size(),
+                   "to have " + consumedArticles.size() + " articles"
             );
             assertThat(
                 pass,
                 report,
                 "comment size",
-                consumedAugmentedComments.size(),
-                is(consumedComments.size())
-            );*/
+                consumedAugmentedComments.size() == consumedComments.size(),
+                    "to have " + consumedComments.size() + " comments"
+            );
 
             final Map<Integer, Long> commentCounts = new TreeMap<>();
 
             for (final RelationalSmokeTest.AugmentedComment augmentedComment : consumedAugmentedComments.values()) {
                 final int key = augmentedComment.getKey();
-                /*assertThat(pass,
+                assertThat(pass,
                            report,
                            "comment missing, but found in augmentedComment: " + key,
-                           consumedComments,
-                           hasKey(key));*/
+                           consumedComments.containsKey(key),
+                           "to contain " + key);
 
                 final Comment comment = consumedComments.get(key);
                 if (comment != null) {
-                    /*assertThat(
+                    assertThat(
                         pass,
                         report,
                         "comment articleId [" + comment.getArticleId() + "] didn't match " +
                             "augmentedComment articleId [" + augmentedComment.getArticleId() + "]",
-                        comment.getArticleId(),
-                        is(augmentedComment.getArticleId())
-                    );*/
+                        comment.getArticleId() == augmentedComment.getArticleId(),
+                        "article id " + comment.getArticleId()
+                    );
                 }
                 commentCounts.put(augmentedComment.getArticleId(),
                                   commentCounts.getOrDefault(augmentedComment.getArticleId(), 0L) + 1);
 
-                /*assertThat(
+                assertThat(
                     pass,
                     report,
                     "augmentedArticle [" + augmentedComment.getArticleId() + "] " +
                         "missing for augmentedComment [" + augmentedComment.getKey() + "]",
-                    consumedAugmentedArticles,
-                    hasKey(augmentedComment.getArticleId())
-                );*/
+                    consumedAugmentedArticles.containsKey(augmentedComment.getArticleId()),
+                    "to have article " + augmentedComment.getArticleId()
+                );
                 final AugmentedArticle augmentedArticle = consumedAugmentedArticles.get(augmentedComment.getArticleId());
                 if (augmentedArticle != null) {
-                   /* assertThat(
+                    assertThat(
                         pass,
                         report,
                         "articlePrefix didn't match augmentedArticle: " + augmentedArticle.getText(),
-                        augmentedArticle.getText(),
-                        startsWith(augmentedComment.getArticlePrefix())
-                    );*/
+                        augmentedArticle.getText().startsWith(augmentedComment.getArticlePrefix()),
+                        "comment to start with " + augmentedComment.getArticlePrefix()
+                    );
                 }
 
-                /*assertThat(
+                assertThat(
                     pass,
                     report,
                     "article " + augmentedComment.getArticleId() + " missing from consumedArticles",
-                    consumedArticles,
-                    hasKey(augmentedComment.getArticleId())
-                );*/
+                    consumedArticles.containsKey(augmentedComment.getArticleId()),
+                    "to see article " + augmentedComment.getArticleId()
+                );
                 final Article article = consumedArticles.get(augmentedComment.getArticleId());
                 if (article != null) {
-                   /* assertThat(
+                    assertThat(
                         pass,
                         report,
                         "articlePrefix didn't match article: " + article.getText(),
-                        article.getText(),
-                        startsWith(augmentedComment.getArticlePrefix())
-                    );*/
+                        article.getText().startsWith(augmentedComment.getArticlePrefix()),
+                        "article to start with " + augmentedComment.getArticlePrefix()
+                    );
                 }
             }
 
 
             for (final RelationalSmokeTest.AugmentedArticle augmentedArticle : consumedAugmentedArticles.values()) {
-               /* assertThat(
+                assertThat(
                     pass,
                     report,
                     "article " + augmentedArticle.getKey() + " comment count mismatch",
-                    augmentedArticle.getCommentCount(),
-                    is(commentCounts.getOrDefault(augmentedArticle.getKey(), 0L))
-                );*/
+                    augmentedArticle.getCommentCount() == commentCounts.getOrDefault(augmentedArticle.getKey(), 0L),
+                    "comment count to be " + commentCounts.getOrDefault(augmentedArticle.getKey(), 0L)
+                );
             }
 
             if (logResults) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/RelationalSmokeTest.java
@@ -805,8 +805,7 @@ public class RelationalSmokeTest extends SmokeTestUtil {
                                       final boolean passed) {
             if (!passed) {
                 if (failures != null) {
-                    final StringBuffer description = new StringBuffer(failures);
-                    description.append("\n" + message);
+                    failures.append("\n").append(message);
                 }
                 pass.set(false);
             }


### PR DESCRIPTION
We currently use `hamcrest` imports to check the outputs of the `RelationalSmokeTest`, but with the new gradle updates, the proper hamcrest imports are no longer included in the test jar.

This is a bit of a workaround to remove the hamcrest usage so we can get system tests up and running again. Potential follow-up could be to update the way we create the test-jar to pull in the proper dependencies

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
