### PR TITLE
KAFKA-12751: Reset AlterIsr in-flight state for duplicate update requests

### DIFF
--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1632,6 +1632,13 @@ class PartitionTest extends AbstractPartitionTest {
       case _ => fail("Expected a committed ISR following Zk expansion")
     }
 
+    // Verify duplicate request. In-flight state should be reset even though version hasn't changed.
+    doAnswer(_ => (true, 2))
+      .when(kafkaZkClient)
+      .conditionalUpdatePath(anyString(), any(), ArgumentMatchers.eq(2), any())
+    partition.expandIsr(follower3)
+    TestUtils.waitUntilTrue(() => !partition.isrState.isInflight, "Expected ISR state to be committed", 100)
+
     scheduler.shutdown()
   }
 


### PR DESCRIPTION
When processing AlterIsr request, KafkaController returns success without updating version if the requested LeaderAndIsr is the same as the persisted LeaderAndIsr: https://github.com/apache/kafka/blob/fe16912dfc59aa9f2379b904df89c9531cc9a2d5/core/src/main/scala/kafka/controller/KafkaController.scala#L2310

This PR ensures that we reset in-flight state in this case so that future updates are not blocked.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
