### PR TITLE
KAFKA-12754: Improve endOffsets for TaskMetadata

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
@@ -60,14 +60,23 @@ public class TaskMetadata {
         return topicPartitions;
     }
 
+    /**
+     * This function will return a map of TopicPartitions and the highest committed offset seen so far
+     */
     public Map<TopicPartition, Long> committedOffsets() {
         return committedOffsets;
     }
 
+    /**
+     * This function will return a map of TopicPartitions and the highest offset seen so far in the Topic
+     */
     public Map<TopicPartition, Long> endOffsets() {
         return endOffsets;
     }
 
+    /**
+     * This function will return the time task idling started, if the task is not currently idling it will return empty
+     */
     public Optional<Long> timeCurrentIdlingStarted() {
         return timeCurrentIdlingStarted;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -14,13 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.kafka.streams.processor.internals;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -34,6 +28,11 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * A StandbyTask

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -14,7 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.kafka.streams.processor.internals;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -28,11 +34,6 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * A StandbyTask
@@ -299,6 +300,11 @@ public class StandbyTask extends AbstractTask implements Task {
 
     @Override
     public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
+
+    }
+
+    @Override
+    public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
 
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -298,16 +298,6 @@ public class StandbyTask extends AbstractTask implements Task {
     }
 
     @Override
-    public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
-
-    }
-
-    @Override
-    public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
-
-    }
-
-    @Override
     public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
         throw new IllegalStateException("Attempted to add records to task " + id() + " for invalid input partition " + partition);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -198,6 +198,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         stateMgr.registerGlobalStateStores(topology.globalStateStores());
         this.committedOffsets = new HashMap<>();
         this.highWatermark = new HashMap<>();
+        for (final TopicPartition topicPartition: inputPartitions) {
+            this.committedOffsets.put(topicPartition, -1L);
+            this.highWatermark.put(topicPartition, -1L);
+        }
         this.timeCurrentIdlingStarted = Optional.empty();
     }
 
@@ -1173,7 +1177,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
 
     @Override
     public Map<TopicPartition, Long> highWaterMark() {
-        highWatermark.putAll(recordCollector.offsets());
         return Collections.unmodifiableMap(highWatermark);
     }
 
@@ -1191,6 +1194,11 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
     @Override
     public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
         committedOffsets.put(topicPartition, offset);
+    }
+
+    @Override
+    public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
+        highWatermark.put(topicPartition, offset);
     }
 
     public boolean hasRecordsQueued() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -196,13 +196,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         );
 
         stateMgr.registerGlobalStateStores(topology.globalStateStores());
-        this.committedOffsets = new HashMap<>();
-        this.highWatermark = new HashMap<>();
+        committedOffsets = new HashMap<>();
+        highWatermark = new HashMap<>();
         for (final TopicPartition topicPartition: inputPartitions) {
-            this.committedOffsets.put(topicPartition, -1L);
-            this.highWatermark.put(topicPartition, -1L);
+            committedOffsets.put(topicPartition, -1L);
+            highWatermark.put(topicPartition, -1L);
         }
-        this.timeCurrentIdlingStarted = Optional.empty();
+        timeCurrentIdlingStarted = Optional.empty();
     }
 
     // create queues for each assigned partition and associate them
@@ -1191,12 +1191,10 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         return timeCurrentIdlingStarted;
     }
 
-    @Override
     public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
         committedOffsets.put(topicPartition, offset);
     }
 
-    @Override
     public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
         highWatermark.put(topicPartition, offset);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -903,16 +903,13 @@ public class StreamThread extends Thread {
 
         final int numRecords = records.count();
 
-        final Map<TopicPartition, Long> offsets = new HashMap<>();
         for (final TopicPartition topicPartition: records.partitions()) {
             records
                 .records(topicPartition)
                 .stream()
                 .max(Comparator.comparing(ConsumerRecord::offset))
-                .ifPresent(t -> offsets.put(topicPartition, t.offset()));
+                .ifPresent(t -> taskManager.updateTaskEndMetadata(topicPartition, t.offset()));
         }
-
-        taskManager.updateTaskEndMetadata(offsets);
 
         log.debug("Main Consumer poll completed in {} ms and fetched {} records", pollLatency, numRecords);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -54,7 +54,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.common.KafkaException;
@@ -52,6 +53,8 @@ import org.slf4j.Logger;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -899,6 +902,17 @@ public class StreamThread extends Thread {
         final long pollLatency = advanceNowAndComputeLatency();
 
         final int numRecords = records.count();
+
+        final Map<TopicPartition, Long> offsets = new HashMap<>();
+        for (final TopicPartition topicPartition: records.partitions()) {
+            records
+                .records(topicPartition)
+                .stream()
+                .max(Comparator.comparing(ConsumerRecord::offset))
+                .ifPresent(t -> offsets.put(topicPartition, t.offset()));
+        }
+
+        taskManager.updateTaskEndMetadata(offsets);
 
         log.debug("Main Consumer poll completed in {} ms and fetched {} records", pollLatency, numRecords);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -248,16 +248,4 @@ public interface Task {
      * @return This returns the time the task started idling. If it is not idling it returns empty.
      */
     Optional<Long> timeCurrentIdlingStarted();
-
-    /**
-     * Update the committed offsets in the Task
-     * @param topicPartition
-     * @param offset
-     */
-    void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset);
-
-    /**
-     * Update the end offsets in the Task with the latest consumer lag
-     */
-    void updateEndOffsets(final TopicPartition topicPartition, final Long offset);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -255,4 +255,9 @@ public interface Task {
      * @param offset
      */
     void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset);
+
+    /**
+     * Update the end offsets in the Task with the latest consumer lag
+     */
+    void updateEndOffsets(final TopicPartition topicPartition, final Long offset);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -1162,12 +1162,10 @@ public class TaskManager {
         }
     }
 
-    public void updateTaskEndMetadata(final Map<TopicPartition, Long> offsets) {
+    public void updateTaskEndMetadata(final TopicPartition topicPartition, final Long offset) {
         for (final Task task: tasks.activeTasks()) {
-            for (final TopicPartition topicPartition: task.inputPartitions()) {
-                if (offsets.containsKey(topicPartition)) {
-                    task.updateEndOffsets(topicPartition, offsets.get(topicPartition));
-                }
+            if (task.inputPartitions().contains(topicPartition)) {
+                task.updateEndOffsets(topicPartition, offset);
             }
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -119,17 +119,17 @@ public class TaskMetadataIntegrationTest {
             final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);
 
             produceMessages(0L, inputTopic, "test");
-            TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+            TestUtils.waitForCondition(() -> !process.get(), "The record was not processed");
             TestUtils.waitForCondition(() -> taskMetadata.committedOffsets().get(topicPartition) == 1L, "the record was processed");
             process.set(true);
 
             produceMessages(0L, inputTopic, "test1");
-            TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+            TestUtils.waitForCondition(() -> !process.get(), "The record was not processed");
             TestUtils.waitForCondition(() -> taskMetadata.committedOffsets().get(topicPartition) == 2L, "the record was processed");
             process.set(true);
 
             produceMessages(0L, inputTopic, "test1");
-            TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+            TestUtils.waitForCondition(() -> !process.get(), "The record was not processed");
             TestUtils.waitForCondition(() -> taskMetadata.committedOffsets().get(topicPartition) == 3L, "the record was processed");
         } catch (final Exception e) {
             e.printStackTrace();
@@ -147,7 +147,7 @@ public class TaskMetadataIntegrationTest {
 
             for (int i = 0; i < 10; i++) {
                 produceMessages(0L, inputTopic, "test");
-                TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+                TestUtils.waitForCondition(() -> !process.get(), "The record was not processed");
                 process.set(true);
             }
             assertThat(taskMetadata.endOffsets().get(topicPartition), equalTo(9L));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -105,7 +105,7 @@ public class TaskMetadataIntegrationTest {
                         mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
                         mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
                         mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
-                        mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10L)
+                        mkEntry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1L)
                 )
         );
     }
@@ -120,7 +120,7 @@ public class TaskMetadataIntegrationTest {
 
             produceMessages(0L, inputTopic, "test");
             TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
-            assertThat(taskMetadata.committedOffsets().get(topicPartition), equalTo(1L));
+            TestUtils.waitForCondition(() -> taskMetadata.committedOffsets().get(topicPartition) == 1L, "the record was processed");
             process.set(true);
 
             produceMessages(0L, inputTopic, "test1");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.TaskMetadata;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkObjectProperties;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.purgeLocalStreamsState;
+import static org.apache.kafka.streams.integration.utils.IntegrationTestUtils.safeUniqueTestName;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Category(IntegrationTest.class)
+public class TaskMetadataIntegrationTest {
+
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1, new Properties(), 0L, 0L);
+
+    @BeforeClass
+    public static void startCluster() throws IOException {
+        CLUSTER.start();
+    }
+
+    @AfterClass
+    public static void closeCluster() {
+        CLUSTER.stop();
+    }
+    public static final Duration DEFAULT_DURATION = Duration.ofSeconds(30);
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private String inputTopic;
+    private static StreamsBuilder builder;
+    private static Properties properties;
+    private static String appId = "";
+    private AtomicBoolean process;
+    private AtomicBoolean commit;
+
+    @Before
+    public void setup() {
+        final String testId = safeUniqueTestName(getClass(), testName);
+        appId = "appId_" + testId;
+        inputTopic = "input" + testId;
+        IntegrationTestUtils.cleanStateBeforeTest(CLUSTER, inputTopic);
+
+        builder  = new StreamsBuilder();
+
+        process = new AtomicBoolean(true);
+        commit = new AtomicBoolean(true);
+
+        final KStream<String, String> stream = builder.stream(inputTopic);
+        stream.process(PauseProcessor::new);
+
+        properties  = mkObjectProperties(
+                mkMap(
+                        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers()),
+                        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, appId),
+                        mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath()),
+                        mkEntry(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 2),
+                        mkEntry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class),
+                        mkEntry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class)
+                )
+        );
+    }
+
+    @Test
+    public void shouldReportCorrectCommittedOffsetInformation() {
+        try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(Collections.singletonList(kafkaStreams), DEFAULT_DURATION);
+            final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
+            assertThat(taskMetadata.committedOffsets().size(), equalTo(1));
+            final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);
+
+            produceMessages(0L, inputTopic, "test");
+            TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+            assertThat(taskMetadata.committedOffsets().get(topicPartition), equalTo(1L));
+            process.set(true);
+
+            produceMessages(0L, inputTopic, "test1");
+            TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+            TestUtils.waitForCondition(() -> taskMetadata.committedOffsets().get(topicPartition) == 2L, "the record was processed");
+
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void shouldReportCorrectEndOffsetInformation() {
+        try (final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), properties)) {
+            IntegrationTestUtils.startApplicationAndWaitUntilRunning(Collections.singletonList(kafkaStreams), DEFAULT_DURATION);
+            final TaskMetadata taskMetadata = getTaskMetadata(kafkaStreams);
+            assertThat(taskMetadata.endOffsets().size(), equalTo(1));
+            final TopicPartition topicPartition = new TopicPartition(inputTopic, 0);
+            commit.set(false);
+
+            for (int i = 0; i < 100; i++) {
+                produceMessages(0L, inputTopic, "test");
+                TestUtils.waitForCondition(() -> !process.get(), "the record was processed");
+                process.set(true);
+            }
+            assertThat(taskMetadata.committedOffsets().get(topicPartition), equalTo(-1L));
+            assertThat(taskMetadata.endOffsets().get(topicPartition), equalTo(99L));
+
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private TaskMetadata getTaskMetadata(final KafkaStreams kafkaStreams) {
+        final List<TaskMetadata> taskMetadataList = kafkaStreams.localThreadsMetadata().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList());
+        assertThat("only one task", taskMetadataList.size() == 1);
+        return taskMetadataList.get(0);
+    }
+
+    @After
+    public void teardown() throws IOException {
+        purgeLocalStreamsState(properties);
+    }
+
+    private void produceMessages(final long timestamp, final String streamOneInput, final String msg) {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+                streamOneInput,
+                Collections.singletonList(new KeyValue<>("1", msg)),
+                TestUtils.producerConfig(
+                        CLUSTER.bootstrapServers(),
+                        StringSerializer.class,
+                        StringSerializer.class,
+                        new Properties()),
+                timestamp);
+    }
+
+    private class PauseProcessor extends AbstractProcessor<String, String> {
+        @Override
+        public void process(final String key, final String value) {
+            while (!process.get()) {
+                try {
+                    wait(100);
+                } catch (final InterruptedException e) {
+
+                }
+            }
+            context().forward(key, value);
+            if (commit.get()) {
+                context().commit();
+            }
+            process.set(false);
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -78,14 +78,14 @@ public class TaskMetadataIntegrationTest {
     private String inputTopic;
     private static StreamsBuilder builder;
     private static Properties properties;
-    private static String appId = "";
+    private static String appId = "TaskMetadataTest_";
     private AtomicBoolean process;
     private AtomicBoolean commit;
 
     @Before
     public void setup() {
         final String testId = safeUniqueTestName(getClass(), testName);
-        appId = "appId_" + testId;
+        appId = appId + testId;
         inputTopic = "input" + testId;
         IntegrationTestUtils.cleanStateBeforeTest(CLUSTER, inputTopic);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1388,7 +1388,7 @@ public class StreamTaskTest {
             getConsumerRecordWithOffsetAsTimestamp(partition2, 45)
         ));
 
-        assertThat("Map was not empty", task.highWaterMark().containsKey(partition1)
+        assertThat("Map did not contain the partitions", task.highWaterMark().containsKey(partition1)
                 && task.highWaterMark().containsKey(partition2));
         assertThrows(StreamsException.class, () -> task.process(0L));
     }
@@ -1445,7 +1445,7 @@ public class StreamTaskTest {
         EasyMock.reset(recordCollector);
         EasyMock.expect(recordCollector.offsets()).andReturn(emptyMap());
         EasyMock.replay(recordCollector);
-        assertThat("Map was empty", task.highWaterMark().containsKey(partition1));
+        assertThat("Map did not contain the partition", task.highWaterMark().containsKey(partition1));
     }
 
     @Test
@@ -1473,7 +1473,7 @@ public class StreamTaskTest {
         task.postCommit(false);   // should not checkpoint
 
         EasyMock.verify(stateManager, recordCollector);
-        assertThat("Map was not empty", task.highWaterMark().size() == 2);
+        assertThat("Map was empty", task.highWaterMark().size() == 2);
     }
 
     @Test
@@ -1503,7 +1503,7 @@ public class StreamTaskTest {
         task.postCommit(false);
 
         EasyMock.verify(recordCollector);
-        assertThat("Map was not empty", task.highWaterMark().size() == 2);
+        assertThat("Map was empty", task.highWaterMark().size() == 2);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -1388,7 +1388,8 @@ public class StreamTaskTest {
             getConsumerRecordWithOffsetAsTimestamp(partition2, 45)
         ));
 
-        assertThat("Map was not empty", task.highWaterMark().isEmpty());
+        assertThat("Map was not empty", task.highWaterMark().containsKey(partition1)
+                && task.highWaterMark().containsKey(partition2));
         assertThrows(StreamsException.class, () -> task.process(0L));
     }
 
@@ -1444,7 +1445,7 @@ public class StreamTaskTest {
         EasyMock.reset(recordCollector);
         EasyMock.expect(recordCollector.offsets()).andReturn(emptyMap());
         EasyMock.replay(recordCollector);
-        assertThat("Map was not empty", task.highWaterMark().isEmpty());
+        assertThat("Map was empty", task.highWaterMark().containsKey(partition1));
     }
 
     @Test
@@ -1472,7 +1473,7 @@ public class StreamTaskTest {
         task.postCommit(false);   // should not checkpoint
 
         EasyMock.verify(stateManager, recordCollector);
-        assertThat("Map was not empty", task.highWaterMark().containsValue(offset));
+        assertThat("Map was not empty", task.highWaterMark().size() == 2);
     }
 
     @Test
@@ -1502,7 +1503,7 @@ public class StreamTaskTest {
         task.postCommit(false);
 
         EasyMock.verify(recordCollector);
-        assertThat("Map was not empty", task.highWaterMark().containsValue(offset));
+        assertThat("Map was not empty", task.highWaterMark().size() == 2);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -69,7 +69,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -3464,16 +3463,6 @@ public class TaskManagerTest {
         @Override
         public Optional<Long> timeCurrentIdlingStarted() {
             return Optional.empty();
-        }
-
-        @Override
-        public void updateCommittedOffsets(final TopicPartition topicPartition, final Long offset) {
-            Objects.requireNonNull(topicPartition);
-            assertThat("It must be from an owned topic", inputPartitions.contains(topicPartition));
-        }
-
-        @Override
-        public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -3473,6 +3473,10 @@ public class TaskManagerTest {
         }
 
         @Override
+        public void updateEndOffsets(final TopicPartition topicPartition, final Long offset) {
+        }
+
+        @Override
         public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
             if (isActive()) {
                 final Deque<ConsumerRecord<byte[], byte[]>> partitionQueue =


### PR DESCRIPTION
Improve endOffsets for TaskMetadata also add an int test for TaskMetadata offset collections

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
