### PR TITLE
MINOR: Bump Jersey deps to 2.34 due to CVE-2021-28168

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
   jetty: "9.4.39.v20210325",
-  jersey: "2.31",
+  jersey: "2.34",
   jline: "3.12.1",
   jmh: "1.27",
   hamcrest: "2.2",


### PR DESCRIPTION
The version of the Eclipse Jersey library brought as dependences,
2.31, has a known vulnerability, CVE-2021-28168 (https://github.com/advisories/GHSA-c43q-5hpj-4crv).

This replaces it with 2.34, which is fully compatible with
2.31, except for bugs and vulnerabilities.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
