### PR TITLE
KAFKA-12752: CVE-2021-28168 upgrade jersey to 2.34 or 3.02

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
   jetty: "9.4.39.v20210325",
-  jersey: "2.31",
+  jersey: "2.34",
   jline: "3.12.1",
   jmh: "1.27",
   hamcrest: "2.2",


### PR DESCRIPTION
[CVE-2021-28168](https://nvd.nist.gov/vuln/detail/CVE-2021-28168) in Jersey was fixed in [2.34](https://github.com/eclipse-ee4j/jersey/security/advisories/GHSA-c43q-5hpj-4crv).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
