### PR TITLE
KAFKA-12756: Update Zookeeper to 3.6.3 or higher

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,7 @@ versions += [
   snappy: "1.1.8.1",
   spotbugs: "4.2.2",
   zinc: "1.3.5",
-  zookeeper: "3.5.9",
+  zookeeper: "3.6.3",
   zstd: "1.4.9-1"
 ]
 libs += [


### PR DESCRIPTION
[CVE-2021-21409](https://nvd.nist.gov/vuln/detail/CVE-2021-21409) in Zookeeper was fixed in [3.6.3](https://zookeeper.apache.org/doc/r3.6.3/releasenotes.html).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
