### PR TITLE
[KAFKA-12635] auto sync consumer offset 0 when translated offset larger than partition end offset

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -256,6 +256,17 @@ public class MirrorConnectorConfig extends AbstractConfig {
         props.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
         return props;
     }
+    
+    Map<String, Object> targetConsumerConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.putAll(originalsWithPrefix(TARGET_CLUSTER_PREFIX));
+        props.keySet().retainAll(MirrorClientConfig.CLIENT_CONFIG_DEF.names());
+        props.putAll(originalsWithPrefix(CONSUMER_CLIENT_PREFIX));
+        props.putAll(originalsWithPrefix(TARGET_PREFIX + CONSUMER_CLIENT_PREFIX));
+        props.put(ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.putIfAbsent(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return props;
+    }
 
     Map<String, String> taskConfigForTopicPartitions(List<TopicPartition> topicPartitions) {
         Map<String, String> props = originalsStrings();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-12635

This issue has been verified and reproduced by some users. Here are the reproduce steps:

1. Create a topic with 1 partition on the source cluster, with `retention.ms` set to something short like 10 seconds.
```./kafka-topics.sh --bootstrap-server $SOURCE --create --topic myTopic --config 'retention.ms=10000'```
2. Create a consumer that consumes from the topic
```./kafka-console-consumer.sh --bootstrap-server $SOURCE --group myConsumer --topic myTopic```
3. Send 100 messages to the topic. These should get consumed by the consumer. Offset for this consumer on source cluster should be 100.
```for i in $(seq 1 100); do echo $i; done | ./kafka-console-producer.sh --bootstrap-server $SOURCE --topic myTopic```
4. Wait until the retention policy deletes the records
5. Start MM2 with `source->target.sync.group.offsets.enabled = true`
6. Observe on the target cluster that log-end-offset is 0, offset is 100, and lag is -100.
```./kafka-consumer-groups.sh --bootstrap-server $TARGET --describe --group myConsumer```
