### PR TITLE
MINOR Removed copying storage libraries specifically as the task already copies them.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1003,10 +1003,6 @@ project(':core') {
     from(project(':connect:mirror').configurations.runtimeClasspath) { into("libs/") }
     from(project(':connect:mirror-client').jar) { into("libs/") }
     from(project(':connect:mirror-client').configurations.runtimeClasspath) { into("libs/") }
-    from(project(':storage').jar) { into("libs/") }
-    from(project(':storage').configurations.runtimeClasspath) { into("libs/") }
-    from(project(':storage:api').jar) { into("libs/") }
-    from(project(':storage:api').configurations.runtimeClasspath) { into("libs/") }
     from(project(':streams').jar) { into("libs/") }
     from(project(':streams').configurations.runtimeClasspath) { into("libs/") }
     from(project(':streams:streams-scala').jar) { into("libs/") }


### PR DESCRIPTION
- Removed copying storage libraries specifically as the task already copies them as part of `configurations.runtimeClasspath` in `releaseTarGz`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
