### PR TITLE
KAFKA-12763 NoSuchElementException during checkpointLogStartOffsets

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -661,7 +661,7 @@ class LogManager(logDirs: Seq[File],
     try {
       logStartOffsetCheckpoints.get(logDir).foreach { checkpoint =>
         val logStartOffsets = logsToCheckpoint.collect {
-          case (tp, log) if log.logStartOffset > log.logSegments.head.baseOffset => tp -> log.logStartOffset
+          case (tp, log) if log.logSegments.headOption.exists(_.baseOffset < log.logStartOffset) => tp -> log.logStartOffset
         }
         checkpoint.write(logStartOffsets)
       }


### PR DESCRIPTION
The following exception shows that `log.logSegments` may be empty during `checkpointLogStartOffsets`.
`logSegments.headOption` should be used instead of `logSegments.head` to prevent this exception.

```json
{
  "class": "java.util.NoSuchElementException",
  "msg": null,
  "stack": [
    "java.util.concurrent.ConcurrentSkipListMap$ValueIterator.next(ConcurrentSkipListMap.java:2123)",
    "scala.collection.convert.JavaCollectionWrappers$JIteratorWrapper.next(JavaCollectionWrappers.scala:38)",
    "scala.collection.IterableOps.head(Iterable.scala:218)",
    "scala.collection.IterableOps.head$(Iterable.scala:218)",
    "scala.collection.AbstractIterable.head(Iterable.scala:920)",
    "kafka.log.LogManager$$anonfun$4.applyOrElse(LogManager.scala:640)",
    "kafka.log.LogManager$$anonfun$4.applyOrElse(LogManager.scala:639)",
    "scala.collection.Iterator$$anon$7.hasNext(Iterator.scala:516)",
    "scala.collection.mutable.Growable.addAll(Growable.scala:61)",
    "scala.collection.mutable.Growable.addAll$(Growable.scala:59)",
    "scala.collection.mutable.HashMap.addAll(HashMap.scala:111)",
    "scala.collection.mutable.HashMap$.from(HashMap.scala:549)",
    "scala.collection.mutable.HashMap$.from(HashMap.scala:542)",
    "scala.collection.MapFactory$Delegate.from(Factory.scala:425)",
    "scala.collection.MapOps.collect(Map.scala:283)",
    "scala.collection.MapOps.collect$(Map.scala:282)",
    "scala.collection.AbstractMap.collect(Map.scala:375)",
    "kafka.log.LogManager.$anonfun$checkpointLogStartOffsetsInDir$2(LogManager.scala:639)",
    "kafka.log.LogManager.$anonfun$checkpointLogStartOffsetsInDir$1(LogManager.scala:636)",
    "kafka.log.LogManager.checkpointLogStartOffsetsInDir(LogManager.scala:635)",
    "kafka.log.LogManager.$anonfun$checkpointLogStartOffsets$1(LogManager.scala:600)",
    "kafka.log.LogManager.$anonfun$checkpointLogStartOffsets$1$adapted(LogManager.scala:600)",
    "scala.collection.IterableOnceOps.foreach(IterableOnce.scala:553)",
    "scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:551)",
    "scala.collection.AbstractIterable.foreach(Iterable.scala:920)",
    "kafka.log.LogManager.checkpointLogStartOffsets(LogManager.scala:600)",
    "kafka.log.LogManager.$anonfun$startup$6(LogManager.scala:426)",
    "kafka.utils.KafkaScheduler.$anonfun$schedule$2(KafkaScheduler.scala:114)",
    "java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)",
    "java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)",
    "java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)",
    "java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)",
    "java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)",
    "java.lang.Thread.run(Thread.java:834)"
  ]
}
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
