### PR TITLE
MINOR: Update jacoco to 0.8.7 for JDK 16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ See [Test Retry Gradle Plugin](https://github.com/gradle/test-retry-gradle-plugi
 ### Generating test coverage reports ###
 Generate coverage reports for the whole project:
 
-    ./gradlew reportCoverage -PenableTestCoverage=true
+    ./gradlew reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false
 
 Generate coverage for a single module, i.e.: 
 
-    ./gradlew clients:reportCoverage -PenableTestCoverage=true
+    ./gradlew clients:reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false
     
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,7 +67,7 @@ versions += [
   easymock: "4.3",
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
-  jacoco: "0.8.6",
+  jacoco: "0.8.7",
   javassist: "3.27.0-GA",
   jetty: "9.4.39.v20210325",
   jersey: "2.34",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -67,7 +67,7 @@ versions += [
   easymock: "4.3",
   jackson: "2.10.5",
   jacksonDatabind: "2.10.5.1",
-  jacoco: "0.8.5",
+  jacoco: "0.8.6",
   javassist: "3.27.0-GA",
   jetty: "9.4.39.v20210325",
   jersey: "2.34",


### PR DESCRIPTION
Details:
* https://github.com/jacoco/jacoco/releases/tag/v0.8.6
* https://github.com/jacoco/jacoco/releases/tag/v0.8.7

Ran `./gradlew clients:reportCoverage -PenableTestCoverage=true -Dorg.gradle.parallel=false`
successfully with Java 15 (see https://github.com/gradle/gradle/issues/15730 and
https://github.com/scoverage/gradle-scoverage/issues/150 for the reason why 
`-Dorg.gradle.parallel=false` is required).

Also updated `README.md` to include `-Dorg.gradle.parallel=false` alongside `reportCoverage`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
