### PR TITLE
MINOR: redundant dependency (scalatest) is removed out of libraries list

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -185,7 +185,6 @@ libs += [
   scalaLibrary: "org.scala-lang:scala-library:$versions.scala",
   scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScala:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
-  scalatest: "org.scalatest:scalatest_$versions.baseScala:$versions.scalatest",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",
   slf4jlog4j: "org.slf4j:slf4j-log4j12:$versions.slf4j",
   snappy: "org.xerial.snappy:snappy-java:$versions.snappy",


### PR DESCRIPTION
**_Notes_**:
- related PR: #9858
- related commit/diff: https://github.com/apache/kafka/commit/9af81955c497b31b211b1e21d8323c875518df39#diff-02b139e755ab0e27e0b0a6f9845843ef189116955cc340c49a4022587dbb2b52L110

FYI @ijuma 
