### PR TITLE
MINOR: checkstyle version upgrade: 8.20 -->> 8.36.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -59,7 +59,7 @@ versions += [
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.66",
-  checkstyle: "8.20",
+  checkstyle: "8.36.2",
   commonsCli: "1.4",
   gradle: "6.8.3",
   grgit: "4.1.0",


### PR DESCRIPTION
details:
  * checkstyle: 8.20  -->> 8.36.2  https://checkstyle.org/releasenotes.html#Release_8.36.2
  *  ~~spotbugs  : 4.2.2 -->> 4.2.3 https://github.com/spotbugs/spotbugs/blob/4.2.3/CHANGELOG.md~~

Rationale: 
* Checktyle 8.20 is two years old; also, both Gradle 6.8 and 7.0 are using recent Checkstyle version (8.37)
* Checkstyle 8.36.2 is geared towards recent Java versions (see 8.36 release notes: https://checkstyle.org/releasenotes.html#Release_8.36)
* Checkstyle version 8.42 should be skipped (lots of false positives, see here: https://github.com/checkstyle/checkstyle/issues/9957)
* more recent Checkstyle versions (i.e. 8.37 and above) are imposing more strict indentation rules and hence we can opt to:
  * relax Checkstyle indentation rules **_OR_**
  *  comply with these new rules and change affected classes (note: total of 50 violations in 18 classes is recorded when compiled with Checkstyle 8.41.1)
 

@ijuma Please review this. 
Also, let me know what do you prefer: to merge this commit or wait for a full upgrade to a latest checkstyle version ? And in case that you opt for the latter: which strategy do you prefer (i.e. are we going to relax checkstyle rules or comply with them) ?
