### PR TITLE
POC for CheckStyle 8.42 regression (with 'Unnecessary Parentheses' errors)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -59,7 +59,7 @@ versions += [
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.66",
-  checkstyle: "8.36.2",
+  checkstyle: "8.42",
   commonsCli: "1.4",
   gradle: "6.8.3",
   grgit: "4.1.0",


### PR DESCRIPTION
⚠️  Not meant to be merged.  Related to https://github.com/checkstyle/checkstyle/issues/9957 

@romani please note that I intentionally fine-grained this PR to a few commits (with appropriate messages, I hope you will find them useful). Rationale: my intention was to dissect important parts bit-by-bit (let me know in case you want me to change something). 

**_Notable temporary changes:_**
- checkstyle gradle `maxError` property is introduced (just for counting error counting purposes)
- module `Indentation` is disable via checkstyle.xml (in this contex those errors are not relevant)

**_How to execute CheckStyle gradle tasks:_**  ` ./gradlew checkstyleMain checkstyleTest` 
https://github.com/dejan2609/kafka/blob/apache-kafka-with-checkstyle-8.42/README.md#running-code-quality-checks

**_CheckStyle gradle configuration / config files:_** 
- https://github.com/dejan2609/kafka/blob/apache-kafka-with-checkstyle-8.42/build.gradle#L588
- https://github.com/dejan2609/kafka/blob/apache-kafka-with-checkstyle-8.42/build.gradle#L712
- https://github.com/dejan2609/kafka/blob/apache-kafka-with-checkstyle-8.42/checkstyle/checkstyle.xml
```
build.gradle
gradle/dependencies.gradle
/chekstyle/ folder (with checkstyle config files)
```

ℹ️ Note: also related to this Kafka PR: #10656

