### PR TITLE
MINOR: set replication.factor to 1 to make StreamsBrokerCompatibility…

### DIFF
--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -466,6 +466,15 @@ class StreamsBrokerCompatibilityService(StreamsTestBaseService):
                                                                 "org.apache.kafka.streams.tests.BrokerCompatibilityTest",
                                                                 processingMode)
 
+    def prop_file(self):
+        properties = {streams_property.STATE_DIR: self.PERSISTENT_ROOT,
+                      streams_property.KAFKA_SERVERS: self.kafka.bootstrap_servers(),
+                      # the old broker (< 2.4) does not support configuration replication.factor=-1
+                      "replication.factor": 1}
+
+        cfg = KafkaConfig(**properties)
+        return cfg.render()
+
 
 class StreamsBrokerDownResilienceService(StreamsTestBaseService):
     def __init__(self, test_context, kafka, configs):


### PR DESCRIPTION
related to #10532

the default value of `replication.factor` was changed from `1` to `-1`. The old broker (< 2.4) does not support such configuration so this PR sets the `replication.factor` to `1` to fix `streams_broker_compatibility_test.py`. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
