### PR TITLE
KAFKA-12648: MINOR - Add TopologyMetadata.Subtopology class for subtopology metadata

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 /**
  * A meta representation of a {@link Topology topology}.
  * <p>
- * The nodes of a topology are grouped into {@link Subtopology sub-topologies} if they are connected.
+ * The nodes of a topology are grouped into {@link SubtopologyDescription sub-topologies} if they are connected.
  * In contrast, two sub-topologies are not connected but can be linked to each other via topics, i.e., if one
  * sub-topology {@link Topology#addSink(String, String, String...) writes} into a topic and another sub-topology
  * {@link Topology#addSource(String, String...) reads} from the same topic.
@@ -43,7 +43,7 @@ public interface TopologyDescription {
      * {@link Topology#connectProcessorAndStateStores(String, String...) state stores}
      * (i.e., if multiple processors share the same state).
      */
-    interface Subtopology {
+    interface SubtopologyDescription {
         /**
          * Internally assigned unique ID.
          * @return the ID of the sub-topology
@@ -62,10 +62,10 @@ public interface TopologyDescription {
      * org.apache.kafka.common.serialization.Deserializer, org.apache.kafka.common.serialization.Deserializer, String,
      * String, org.apache.kafka.streams.processor.api.ProcessorSupplier) global store}.
      * Adding a global store results in adding a source node and one stateful processor node.
-     * Note, that all added global stores form a single unit (similar to a {@link Subtopology}) even if different
+     * Note, that all added global stores form a single unit (similar to a {@link SubtopologyDescription}) even if different
      * global stores are not connected to each other.
      * Furthermore, global stores are available to all processors without connecting them explicitly, and thus global
-     * stores will never be part of any {@link Subtopology}.
+     * stores will never be part of any {@link SubtopologyDescription}.
      */
     interface GlobalStore {
         /**
@@ -168,7 +168,7 @@ public interface TopologyDescription {
      * All sub-topologies of the represented topology.
      * @return set of all sub-topologies
      */
-    Set<Subtopology> subtopologies();
+    Set<SubtopologyDescription> subtopologies();
 
     /**
      * All global stores of the represented topology.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -23,7 +23,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +40,7 @@ public class TaskId implements Comparable<TaskId> {
     /** The ID of the partition. */
     public final int partition;
     /** The namedTopology that this task belongs to, or null if it does not belong to one */
-    private final String namedTopology;
+    protected final String namedTopology;
 
     public TaskId(final int topicGroupId, final int partition) {
         this(topicGroupId, partition, null);
@@ -57,10 +56,6 @@ public class TaskId implements Comparable<TaskId> {
         } else {
             this.namedTopology = namedTopology;
         }
-    }
-
-    public String namedTopology() {
-        return namedTopology;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -59,8 +59,8 @@ public class TaskId implements Comparable<TaskId> {
         }
     }
 
-    public Optional<String> namedTopology() {
-        return namedTopology == null ? Optional.empty() : Optional.of(namedTopology);
+    public String namedTopology() {
+        return namedTopology;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1743,7 +1743,7 @@ public class InternalTopologyBuilder {
         }
     }
 
-    public final static class SubtopologyDescription implements org.apache.kafka.streams.TopologyDescription.Subtopology {
+    public final static class SubtopologyDescription implements org.apache.kafka.streams.TopologyDescription.SubtopologyDescription {
         private final int id;
         private final Set<TopologyDescription.Node> nodes;
 
@@ -1880,10 +1880,10 @@ public class InternalTopologyBuilder {
 
     private final static GlobalStoreComparator GLOBALSTORE_COMPARATOR = new GlobalStoreComparator();
 
-    private static class SubtopologyComparator implements Comparator<TopologyDescription.Subtopology>, Serializable {
+    private static class SubtopologyComparator implements Comparator<org.apache.kafka.streams.TopologyDescription.SubtopologyDescription>, Serializable {
         @Override
-        public int compare(final TopologyDescription.Subtopology subtopology1,
-                           final TopologyDescription.Subtopology subtopology2) {
+        public int compare(final org.apache.kafka.streams.TopologyDescription.SubtopologyDescription subtopology1,
+                           final org.apache.kafka.streams.TopologyDescription.SubtopologyDescription subtopology2) {
             if (subtopology1.equals(subtopology2)) {
                 return 0;
             }
@@ -1894,10 +1894,10 @@ public class InternalTopologyBuilder {
     private final static SubtopologyComparator SUBTOPOLOGY_COMPARATOR = new SubtopologyComparator();
 
     public final static class TopologyDescription implements org.apache.kafka.streams.TopologyDescription {
-        private final TreeSet<TopologyDescription.Subtopology> subtopologies = new TreeSet<>(SUBTOPOLOGY_COMPARATOR);
+        private final TreeSet<SubtopologyDescription> subtopologies = new TreeSet<>(SUBTOPOLOGY_COMPARATOR);
         private final TreeSet<TopologyDescription.GlobalStore> globalStores = new TreeSet<>(GLOBALSTORE_COMPARATOR);
 
-        public void addSubtopology(final TopologyDescription.Subtopology subtopology) {
+        public void addSubtopology(final SubtopologyDescription subtopology) {
             subtopologies.add(subtopology);
         }
 
@@ -1906,7 +1906,7 @@ public class InternalTopologyBuilder {
         }
 
         @Override
-        public Set<TopologyDescription.Subtopology> subtopologies() {
+        public Set<SubtopologyDescription> subtopologies() {
             return Collections.unmodifiableSet(subtopologies);
         }
 
@@ -1919,8 +1919,8 @@ public class InternalTopologyBuilder {
         public String toString() {
             final StringBuilder sb = new StringBuilder();
             sb.append("Topologies:\n ");
-            final TopologyDescription.Subtopology[] sortedSubtopologies =
-                subtopologies.descendingSet().toArray(new Subtopology[0]);
+            final SubtopologyDescription[] sortedSubtopologies =
+                subtopologies.descendingSet().toArray(new SubtopologyDescription[0]);
             final TopologyDescription.GlobalStore[] sortedGlobalStores =
                 globalStores.descendingSet().toArray(new GlobalStore[0]);
             int expectedId = 0;
@@ -1928,7 +1928,7 @@ public class InternalTopologyBuilder {
             int globalStoresIndex = sortedGlobalStores.length - 1;
             while (subtopologiesIndex != -1 && globalStoresIndex != -1) {
                 sb.append("  ");
-                final TopologyDescription.Subtopology subtopology = sortedSubtopologies[subtopologiesIndex];
+                final SubtopologyDescription subtopology = sortedSubtopologies[subtopologiesIndex];
                 final TopologyDescription.GlobalStore globalStore = sortedGlobalStores[globalStoresIndex];
                 if (subtopology.id() == expectedId) {
                     sb.append(subtopology);
@@ -1940,7 +1940,7 @@ public class InternalTopologyBuilder {
                 expectedId++;
             }
             while (subtopologiesIndex != -1) {
-                final TopologyDescription.Subtopology subtopology = sortedSubtopologies[subtopologiesIndex];
+                final SubtopologyDescription subtopology = sortedSubtopologies[subtopologiesIndex];
                 sb.append("  ");
                 sb.append(subtopology);
                 subtopologiesIndex--;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1457,7 +1457,7 @@ public class InternalTopologyBuilder {
             }
         }
 
-        description.addSubtopology(new Subtopology(
+        description.addSubtopology(new SubtopologyDescription(
                 subtopologyId,
                 new HashSet<>(nodesByName.values())));
     }
@@ -1743,11 +1743,11 @@ public class InternalTopologyBuilder {
         }
     }
 
-    public final static class Subtopology implements org.apache.kafka.streams.TopologyDescription.Subtopology {
+    public final static class SubtopologyDescription implements org.apache.kafka.streams.TopologyDescription.Subtopology {
         private final int id;
         private final Set<TopologyDescription.Node> nodes;
 
-        public Subtopology(final int id, final Set<TopologyDescription.Node> nodes) {
+        public SubtopologyDescription(final int id, final Set<TopologyDescription.Node> nodes) {
             this.id = id;
             this.nodes = new TreeSet<>(NODE_COMPARATOR);
             this.nodes.addAll(nodes);
@@ -1792,7 +1792,7 @@ public class InternalTopologyBuilder {
                 return false;
             }
 
-            final Subtopology that = (Subtopology) o;
+            final SubtopologyDescription that = (SubtopologyDescription) o;
             return id == that.id
                 && nodes.equals(that.nodes);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGrouper.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,11 +50,11 @@ public class PartitionGrouper {
      * @param metadata      metadata of the consuming cluster
      * @return The map from generated task ids to the assigned partitions
      */
-    public Map<TaskId, Set<TopicPartition>> partitionGroups(final Map<Integer, Set<String>> topicGroups, final Cluster metadata) {
+    public Map<TaskId, Set<TopicPartition>> partitionGroups(final Map<Subtopology, Set<String>> topicGroups, final Cluster metadata) {
         final Map<TaskId, Set<TopicPartition>> groups = new HashMap<>();
 
-        for (final Map.Entry<Integer, Set<String>> entry : topicGroups.entrySet()) {
-            final Integer topicGroupId = entry.getKey();
+        for (final Map.Entry<Subtopology, Set<String>> entry : topicGroups.entrySet()) {
+            final Subtopology subtopology = entry.getKey();
             final Set<String> topicGroup = entry.getValue();
 
             final int maxNumPartitions = maxNumPartitions(metadata, topicGroup);
@@ -66,7 +68,7 @@ public class PartitionGrouper {
                         group.add(new TopicPartition(topic, partitionId));
                     }
                 }
-                groups.put(new TaskId(topicGroupId, partitionId), Collections.unmodifiableSet(group));
+                groups.put(new TaskId(subtopology.nodeGroupId, partitionId, subtopology.namedTopology), Collections.unmodifiableSet(group));
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RepartitionTopics.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.errors.MissingSourceTopicException;
 import org.apache.kafka.streams.errors.TaskAssignmentException;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.apache.kafka.streams.processor.internals.assignment.CopartitionedTopicsEnforcer;
 import org.slf4j.Logger;
 
@@ -59,7 +60,7 @@ public class RepartitionTopics {
     }
 
     public void setup() {
-        final Map<Integer, TopicsInfo> topicGroups = internalTopologyBuilder.topicGroups();
+        final Map<Subtopology, TopicsInfo> topicGroups = internalTopologyBuilder.topicGroups();
         final Map<String, InternalTopicConfig> repartitionTopicMetadata = computeRepartitionTopicConfig(topicGroups, clusterMetadata);
 
         // ensure the co-partitioning topics within the group have the same number of partitions,
@@ -90,7 +91,7 @@ public class RepartitionTopics {
         return Collections.unmodifiableMap(topicPartitionInfos);
     }
 
-    private Map<String, InternalTopicConfig> computeRepartitionTopicConfig(final Map<Integer, TopicsInfo> topicGroups,
+    private Map<String, InternalTopicConfig> computeRepartitionTopicConfig(final Map<Subtopology, TopicsInfo> topicGroups,
                                                                            final Cluster clusterMetadata) {
 
         final Map<String, InternalTopicConfig> repartitionTopicConfigs = new HashMap<>();
@@ -129,7 +130,7 @@ public class RepartitionTopics {
      * Computes the number of partitions and sets it for each repartition topic in repartitionTopicMetadata
      */
     private void setRepartitionSourceTopicPartitionCount(final Map<String, InternalTopicConfig> repartitionTopicMetadata,
-                                                         final Map<Integer, TopicsInfo> topicGroups,
+                                                         final Map<Subtopology, TopicsInfo> topicGroups,
                                                          final Cluster clusterMetadata) {
         boolean partitionCountNeeded;
         do {
@@ -167,7 +168,7 @@ public class RepartitionTopics {
     }
 
     private Integer computePartitionCount(final Map<String, InternalTopicConfig> repartitionTopicMetadata,
-                                          final Map<Integer, TopicsInfo> topicGroups,
+                                          final Map<Subtopology, TopicsInfo> topicGroups,
                                           final Cluster clusterMetadata,
                                           final String repartitionSourceTopic) {
         Integer partitionCount = null;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -154,10 +154,10 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         @Override
         public String toString() {
             return "ClientMetadata{" +
-                    "hostInfo=" + hostInfo +
-                    ", consumers=" + consumers +
-                    ", state=" + state +
-                    '}';
+                "hostInfo=" + hostInfo +
+                ", consumers=" + consumers +
+                ", state=" + state +
+                '}';
         }
     }
 
@@ -165,7 +165,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private static final UUID FUTURE_ID = randomUUID();
 
     protected static final Comparator<TopicPartition> PARTITION_COMPARATOR =
-            Comparator.comparing(TopicPartition::topic).thenComparingInt(TopicPartition::partition);
+        Comparator.comparing(TopicPartition::topic).thenComparingInt(TopicPartition::partition);
 
     private String userEndPoint;
     private AssignmentConfigs assignmentConfigs;
@@ -250,13 +250,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         uniqueField++;
 
         return new SubscriptionInfo(
-                usedSubscriptionMetadataVersion,
-                LATEST_SUPPORTED_VERSION,
-                taskManager.processId(),
-                userEndPoint,
-                taskManager.getTaskOffsetSums(),
-                uniqueField,
-                assignmentErrorCode.get()
+            usedSubscriptionMetadataVersion,
+            LATEST_SUPPORTED_VERSION,
+            taskManager.processId(),
+            userEndPoint,
+            taskManager.getTaskOffsetSums(),
+            uniqueField,
+            assignmentErrorCode.get()
         ).encode();
     }
 
@@ -266,13 +266,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         for (final ClientMetadata clientMetadata : clientsMetadata.values()) {
             for (final String consumerId : clientMetadata.consumers) {
                 assignment.put(consumerId, new Assignment(
+                    Collections.emptyList(),
+                    new AssignmentInfo(LATEST_SUPPORTED_VERSION,
                         Collections.emptyList(),
-                        new AssignmentInfo(LATEST_SUPPORTED_VERSION,
-                                Collections.emptyList(),
-                                Collections.emptyMap(),
-                                Collections.emptyMap(),
-                                Collections.emptyMap(),
-                                errorCode).encode()
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        errorCode).encode()
                 ));
             }
         }
@@ -350,7 +350,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
         try {
             final boolean versionProbing =
-                    checkMetadataVersions(minReceivedMetadataVersion, minSupportedMetadataVersion, futureMetadataVersion);
+                checkMetadataVersions(minReceivedMetadataVersion, minSupportedMetadataVersion, futureMetadataVersion);
 
             log.debug("Constructed client metadata {} from the member subscriptions.", clientMetadataMap);
 
@@ -381,7 +381,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
             // get the tasks as partition groups from the partition grouper
             final Map<TaskId, Set<TopicPartition>> partitionsForTask =
-                    partitionGrouper.partitionGroups(sourceTopicsByGroup, fullMetadata);
+                partitionGrouper.partitionGroups(sourceTopicsByGroup, fullMetadata);
 
             final Set<TaskId> statefulTasks = new HashSet<>();
 
@@ -403,28 +403,28 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             // compute the assignment of tasks to threads within each client and build the final group assignment
 
             final Map<String, Assignment> assignment = computeNewAssignment(
-                    statefulTasks,
-                    clientMetadataMap,
-                    partitionsForTask,
-                    partitionsByHost,
-                    standbyPartitionsByHost,
-                    allOwnedPartitions,
-                    minReceivedMetadataVersion,
-                    minSupportedMetadataVersion,
-                    versionProbing,
-                    probingRebalanceNeeded
+                statefulTasks,
+                clientMetadataMap,
+                partitionsForTask,
+                partitionsByHost,
+                standbyPartitionsByHost,
+                allOwnedPartitions,
+                minReceivedMetadataVersion,
+                minSupportedMetadataVersion,
+                versionProbing,
+                probingRebalanceNeeded
             );
 
             return new GroupAssignment(assignment);
         } catch (final MissingSourceTopicException e) {
             log.error("Caught an error in the task assignment. Returning an error assignment.", e);
             return new GroupAssignment(
-                    errorAssignment(clientMetadataMap, AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code())
+                errorAssignment(clientMetadataMap, AssignorError.INCOMPLETE_SOURCE_TOPIC_METADATA.code())
             );
         } catch (final TaskAssignmentException e) {
             log.error("Caught an error in the task assignment. Returning an error assignment.", e);
             return new GroupAssignment(
-                    errorAssignment(clientMetadataMap, AssignorError.ASSIGNMENT_ERROR.code())
+                errorAssignment(clientMetadataMap, AssignorError.ASSIGNMENT_ERROR.code())
             );
         }
     }
@@ -444,27 +444,27 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         } else if (minReceivedMetadataVersion >= EARLIEST_PROBEABLE_VERSION) {
             versionProbing = true;
             log.info("Received a future (version probing) subscription (version: {})."
-                            + " Sending assignment back (with supported version {}).",
-                    futureMetadataVersion,
-                    minSupportedMetadataVersion);
+                         + " Sending assignment back (with supported version {}).",
+                futureMetadataVersion,
+                minSupportedMetadataVersion);
 
         } else {
             throw new TaskAssignmentException(
-                    "Received a future (version probing) subscription (version: " + futureMetadataVersion
-                            + ") and an incompatible pre Kafka 2.0 subscription (version: " + minReceivedMetadataVersion
-                            + ") at the same time."
+                "Received a future (version probing) subscription (version: " + futureMetadataVersion
+                    + ") and an incompatible pre Kafka 2.0 subscription (version: " + minReceivedMetadataVersion
+                    + ") at the same time."
             );
         }
 
         if (minReceivedMetadataVersion < LATEST_SUPPORTED_VERSION) {
             log.info("Downgrade metadata to version {}. Latest supported version is {}.",
-                    minReceivedMetadataVersion,
-                    LATEST_SUPPORTED_VERSION);
+                minReceivedMetadataVersion,
+                LATEST_SUPPORTED_VERSION);
         }
         if (minSupportedMetadataVersion < LATEST_SUPPORTED_VERSION) {
             log.info("Downgrade latest supported metadata to version {}. Latest supported version is {}.",
-                    minSupportedMetadataVersion,
-                    LATEST_SUPPORTED_VERSION);
+                minSupportedMetadataVersion,
+                LATEST_SUPPORTED_VERSION);
         }
         return versionProbing;
     }
@@ -477,11 +477,11 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private Map<TopicPartition, PartitionInfo> prepareRepartitionTopics(final Cluster metadata) {
 
         final RepartitionTopics repartitionTopics = new RepartitionTopics(
-                taskManager.builder(),
-                internalTopicManager,
-                copartitionedTopicsEnforcer,
-                metadata,
-                logPrefix
+            taskManager.builder(),
+            internalTopicManager,
+            copartitionedTopicsEnforcer,
+            metadata,
+            logPrefix
         );
         repartitionTopics.setup();
         return repartitionTopics.topicPartitionsInfo();
@@ -534,14 +534,14 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             } else {
                 for (final PartitionInfo partitionInfo : partitionInfoList) {
                     final TopicPartition partition = new TopicPartition(partitionInfo.topic(),
-                            partitionInfo.partition());
+                        partitionInfo.partition());
                     if (!allAssignedPartitions.contains(partition)) {
                         log.warn("Partition {} is not assigned to any tasks: {}"
-                                        + " Possible causes of a partition not getting assigned"
-                                        + " is that another topic defined in the topology has not been"
-                                        + " created when starting your streams application,"
-                                        + " resulting in no tasks created for this topology at all.", partition,
-                                partitionsForTask);
+                                     + " Possible causes of a partition not getting assigned"
+                                     + " is that another topic defined in the topology has not been"
+                                     + " created when starting your streams application,"
+                                     + " resulting in no tasks created for this topology at all.", partition,
+                            partitionsForTask);
                     }
                 }
             }
@@ -568,29 +568,29 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         populateTasksForMaps(taskForPartition, tasksForTopicGroup, allSourceTopics, partitionsForTask, fullMetadata);
 
         final ChangelogTopics changelogTopics = new ChangelogTopics(
-                internalTopicManager,
-                topicGroups,
-                tasksForTopicGroup,
-                logPrefix
+            internalTopicManager,
+            topicGroups,
+            tasksForTopicGroup,
+            logPrefix
         );
         changelogTopics.setup();
 
         final Map<UUID, ClientState> clientStates = new HashMap<>();
         final boolean lagComputationSuccessful =
-                populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
+            populateClientStatesMap(clientStates, clientMetadataMap, taskForPartition, changelogTopics);
 
         final Set<TaskId> allTasks = partitionsForTask.keySet();
         statefulTasks.addAll(changelogTopics.statefulTaskIds());
 
         log.debug("Assigning tasks {} to clients {} with number of replicas {}",
-                allTasks, clientStates, numStandbyReplicas());
+            allTasks, clientStates, numStandbyReplicas());
 
         final TaskAssignor taskAssignor = createTaskAssignor(lagComputationSuccessful);
 
         final boolean probingRebalanceNeeded = taskAssignor.assign(clientStates,
-                allTasks,
-                statefulTasks,
-                assignmentConfigs);
+                                                                   allTasks,
+                                                                   statefulTasks,
+                                                                   assignmentConfigs);
 
         log.info("Assigned tasks {} including stateful {} to clients as: \n{}.",
                 allTasks, statefulTasks, clientStates.entrySet().stream()
@@ -610,7 +610,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             return taskAssignor;
         } else {
             log.info("Failed to fetch end offsets for changelogs, will return previous assignment to clients and "
-                    + "trigger another rebalance to retry.");
+                         + "trigger another rebalance to retry.");
             return new FallbackPriorTaskAssignor();
         }
     }
@@ -636,17 +636,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             // Make the listOffsets request first so it can  fetch the offsets for non-source changelogs
             // asynchronously while we use the blocking Consumer#committed call to fetch source-changelog offsets
             final KafkaFuture<Map<TopicPartition, ListOffsetsResultInfo>> endOffsetsFuture =
-                    fetchEndOffsetsFuture(changelogTopics.preExistingNonSourceTopicBasedPartitions(), adminClient);
+                fetchEndOffsetsFuture(changelogTopics.preExistingNonSourceTopicBasedPartitions(), adminClient);
 
             final Map<TopicPartition, Long> sourceChangelogEndOffsets =
-                    fetchCommittedOffsets(changelogTopics.preExistingSourceTopicBasedPartitions(), mainConsumerSupplier.get());
+                fetchCommittedOffsets(changelogTopics.preExistingSourceTopicBasedPartitions(), mainConsumerSupplier.get());
 
             final Map<TopicPartition, ListOffsetsResultInfo> endOffsets = ClientUtils.getEndOffsets(endOffsetsFuture);
 
             allTaskEndOffsetSums = computeEndOffsetSumsByTask(
-                    endOffsets,
-                    sourceChangelogEndOffsets,
-                    changelogTopics
+                endOffsets,
+                sourceChangelogEndOffsets,
+                changelogTopics
             );
             fetchEndOffsetsSuccessful = true;
         } catch (final StreamsException | TimeoutException e) {
@@ -762,17 +762,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final SortedSet<String> consumers = clientMetadata.consumers;
 
             final Map<String, List<TaskId>> activeTaskAssignment = assignTasksToThreads(
-                    state.statefulActiveTasks(),
-                    state.statelessActiveTasks(),
-                    consumers,
-                    state
+                state.statefulActiveTasks(),
+                state.statelessActiveTasks(),
+                consumers,
+                state
             );
 
             final Map<String, List<TaskId>> standbyTaskAssignment = assignTasksToThreads(
-                    state.standbyTasks(),
-                    Collections.emptySet(),
-                    consumers,
-                    state
+                state.standbyTasks(),
+                Collections.emptySet(),
+                consumers,
+                state
             );
 
             // Arbitrarily choose the leader's client to be responsible for triggering the probing rebalance,
@@ -781,18 +781,18 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final boolean encodeNextProbingRebalanceTime = shouldTriggerProbingRebalance && clientId.equals(taskManager.processId());
 
             final boolean tasksRevoked = addClientAssignments(
-                    statefulTasks,
-                    assignment,
-                    clientMetadata,
-                    partitionsForTask,
-                    partitionsByHostState,
-                    standbyPartitionsByHost,
-                    allOwnedPartitions,
-                    activeTaskAssignment,
-                    standbyTaskAssignment,
-                    minUserMetadataVersion,
-                    minSupportedMetadataVersion,
-                    encodeNextProbingRebalanceTime
+                statefulTasks,
+                assignment,
+                clientMetadata,
+                partitionsForTask,
+                partitionsByHostState,
+                standbyPartitionsByHost,
+                allOwnedPartitions,
+                activeTaskAssignment,
+                standbyTaskAssignment,
+                minUserMetadataVersion,
+                minSupportedMetadataVersion,
+                encodeNextProbingRebalanceTime
             );
 
             if (tasksRevoked || encodeNextProbingRebalanceTime) {
@@ -801,17 +801,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             }
 
             log.info("Client {} per-consumer assignment:\n" +
-                            "\tprev owned active {}\n" +
-                            "\tprev owned standby {}\n" +
-                            "\tassigned active {}\n" +
-                            "\trevoking active {}\n" +
-                            "\tassigned standby {}\n",
-                    clientId,
-                    clientMetadata.state.prevOwnedActiveTasksByConsumer(),
-                    clientMetadata.state.prevOwnedStandbyByConsumer(),
-                    clientMetadata.state.assignedActiveTasksByConsumer(),
-                    clientMetadata.state.revokingActiveTasksByConsumer(),
-                    clientMetadata.state.assignedStandbyTasksByConsumer());
+                "\tprev owned active {}\n" +
+                "\tprev owned standby {}\n" +
+                "\tassigned active {}\n" +
+                "\trevoking active {}\n" +
+                "\tassigned standby {}\n",
+                clientId,
+                clientMetadata.state.prevOwnedActiveTasksByConsumer(),
+                clientMetadata.state.prevOwnedStandbyByConsumer(),
+                clientMetadata.state.assignedActiveTasksByConsumer(),
+                clientMetadata.state.revokingActiveTasksByConsumer(),
+                clientMetadata.state.assignedStandbyTasksByConsumer());
         }
 
         if (rebalanceRequired) {
@@ -855,13 +855,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             final List<TaskId> assignedActiveList = new ArrayList<>();
 
             final Set<TaskId> activeTasksRemovedPendingRevokation = populateActiveTaskAndPartitionsLists(
-                    activePartitionsList,
-                    assignedActiveList,
-                    consumer,
-                    clientMetadata.state,
-                    activeTasksForConsumer,
-                    partitionsForTask,
-                    allOwnedPartitions
+                activePartitionsList,
+                assignedActiveList,
+                consumer,
+                clientMetadata.state,
+                activeTasksForConsumer,
+                partitionsForTask,
+                allOwnedPartitions
             );
 
             final Map<TaskId, Set<TopicPartition>> standbyTaskMap = buildStandbyTaskMap(
@@ -871,16 +871,16 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                     statefulTasks,
                     partitionsForTask,
                     clientMetadata.state
-            );
+                );
 
             final AssignmentInfo info = new AssignmentInfo(
-                    minUserMetadataVersion,
-                    minSupportedMetadataVersion,
-                    assignedActiveList,
-                    standbyTaskMap,
-                    partitionsByHostState,
-                    standbyPartitionsByHost,
-                    AssignorError.NONE.code()
+                minUserMetadataVersion,
+                minSupportedMetadataVersion,
+                assignedActiveList,
+                standbyTaskMap,
+                partitionsByHostState,
+                standbyPartitionsByHost,
+                AssignorError.NONE.code()
             );
 
             if (!activeTasksRemovedPendingRevokation.isEmpty()) {
@@ -899,11 +899,11 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             }
 
             assignment.put(
-                    consumer,
-                    new Assignment(
-                            activePartitionsList,
-                            info.encode()
-                    )
+                consumer,
+                new Assignment(
+                    activePartitionsList,
+                    info.encode()
+                )
             );
         }
         return followupRebalanceRequiredForRevokedTasks;
@@ -938,9 +938,9 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 // until it has been revoked and can safely be reassigned according to the COOPERATIVE protocol
                 if (newPartitionForConsumer && allOwnedPartitions.contains(partition)) {
                     log.info(
-                            "Removing task {} from {} active assignment until it is safely revoked in followup rebalance",
-                            taskId,
-                            consumer
+                        "Removing task {} from {} active assignment until it is safely revoked in followup rebalance",
+                        taskId,
+                        consumer
                     );
                     removedActiveTasks.add(taskId);
 
@@ -1130,17 +1130,17 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
 
         if (receivedAssignmentMetadataVersion > usedSubscriptionMetadataVersion) {
             log.error("Leader sent back an assignment with version {} which was greater than our used version {}",
-                    receivedAssignmentMetadataVersion, usedSubscriptionMetadataVersion);
+                receivedAssignmentMetadataVersion, usedSubscriptionMetadataVersion);
             throw new TaskAssignmentException(
-                    "Sent a version " + usedSubscriptionMetadataVersion
-                            + " subscription but got an assignment with higher version "
-                            + receivedAssignmentMetadataVersion + "."
+                "Sent a version " + usedSubscriptionMetadataVersion
+                    + " subscription but got an assignment with higher version "
+                    + receivedAssignmentMetadataVersion + "."
             );
         }
 
         if (latestCommonlySupportedVersion > LATEST_SUPPORTED_VERSION) {
             log.error("Leader sent back assignment with commonly supported version {} that is greater than our "
-                    + "actual latest supported version {}", latestCommonlySupportedVersion, LATEST_SUPPORTED_VERSION);
+                + "actual latest supported version {}", latestCommonlySupportedVersion, LATEST_SUPPORTED_VERSION);
             throw new TaskAssignmentException("Can't upgrade to metadata version greater than we support");
         }
     }
@@ -1153,13 +1153,13 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             // completed the rolling upgrade and can now update our subscription version for the final rebalance
             if (latestCommonlySupportedVersion > usedSubscriptionMetadataVersion) {
                 log.info(
-                        "Sent a version {} subscription and group's latest commonly supported version is {} (successful "
-                                +
-                                "version probing and end of rolling upgrade). Upgrading subscription metadata version to " +
-                                "{} for next rebalance.",
-                        usedSubscriptionMetadataVersion,
-                        latestCommonlySupportedVersion,
-                        latestCommonlySupportedVersion
+                    "Sent a version {} subscription and group's latest commonly supported version is {} (successful "
+                        +
+                        "version probing and end of rolling upgrade). Upgrading subscription metadata version to " +
+                        "{} for next rebalance.",
+                    usedSubscriptionMetadataVersion,
+                    latestCommonlySupportedVersion,
+                    latestCommonlySupportedVersion
                 );
                 usedSubscriptionMetadataVersion = latestCommonlySupportedVersion;
                 return true;
@@ -1169,20 +1169,20 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             // should downgrade our subscription until everyone is on the latest version
             if (receivedAssignmentMetadataVersion < usedSubscriptionMetadataVersion) {
                 log.info(
-                        "Sent a version {} subscription and got version {} assignment back (successful version probing). "
-                                +
-                                "Downgrade subscription metadata to commonly supported version {} and trigger new rebalance.",
-                        usedSubscriptionMetadataVersion,
-                        receivedAssignmentMetadataVersion,
-                        latestCommonlySupportedVersion
+                    "Sent a version {} subscription and got version {} assignment back (successful version probing). "
+                        +
+                        "Downgrade subscription metadata to commonly supported version {} and trigger new rebalance.",
+                    usedSubscriptionMetadataVersion,
+                    receivedAssignmentMetadataVersion,
+                    latestCommonlySupportedVersion
                 );
                 usedSubscriptionMetadataVersion = latestCommonlySupportedVersion;
                 return true;
             }
         } else {
             log.debug("Received an assignment version {} that is less than the earliest version that allows version " +
-                            "probing {}. If this is not during a rolling upgrade from version 2.0 or below, this is an error.",
-                    receivedAssignmentMetadataVersion, EARLIEST_PROBEABLE_VERSION);
+                "probing {}. If this is not during a rolling upgrade from version 2.0 or below, this is an error.",
+                receivedAssignmentMetadataVersion, EARLIEST_PROBEABLE_VERSION);
         }
 
         return false;
@@ -1266,16 +1266,16 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
                 break;
             default:
                 throw new IllegalStateException(
-                        "This code should never be reached."
-                                + " Please file a bug report at https://issues.apache.org/jira/projects/KAFKA/"
+                    "This code should never be reached."
+                        + " Please file a bug report at https://issues.apache.org/jira/projects/KAFKA/"
                 );
         }
 
         maybeScheduleFollowupRebalance(
-                encodedNextScheduledRebalanceMs,
-                receivedAssignmentMetadataVersion,
-                latestCommonlySupportedVersion,
-                partitionsByHost.keySet()
+            encodedNextScheduledRebalanceMs,
+            receivedAssignmentMetadataVersion,
+            latestCommonlySupportedVersion,
+            partitionsByHost.keySet()
         );
 
         final Cluster fakeCluster = Cluster.empty().withPartitions(topicToPartitionInfo);
@@ -1343,14 +1343,14 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         for (final Set<TopicPartition> value : partitionsByHost.values()) {
             for (final TopicPartition topicPartition : value) {
                 topicToPartitionInfo.put(
-                        topicPartition,
-                        new PartitionInfo(
-                                topicPartition.topic(),
-                                topicPartition.partition(),
-                                null,
-                                new Node[0],
-                                new Node[0]
-                        )
+                    topicPartition,
+                    new PartitionInfo(
+                        topicPartition.topic(),
+                        topicPartition.partition(),
+                        null,
+                        new Node[0],
+                        new Node[0]
+                    )
                 );
             }
         }
@@ -1362,12 +1362,12 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
         // could be duplicated if one task has more than one assigned partitions
         if (partitions.size() != info.activeTasks().size()) {
             throw new TaskAssignmentException(
-                    String.format(
-                            "%sNumber of assigned partitions %d is not equal to "
-                                    + "the number of active taskIds %d, assignmentInfo=%s",
-                            logPrefix, partitions.size(),
-                            info.activeTasks().size(), info.toString()
-                    )
+                String.format(
+                    "%sNumber of assigned partitions %d is not equal to "
+                        + "the number of active taskIds %d, assignmentInfo=%s",
+                    logPrefix, partitions.size(),
+                    info.activeTasks().size(), info.toString()
+                )
             );
         }
     }
@@ -1379,11 +1379,11 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
     private int updateMinSupportedVersion(final int supportedVersion, final int minSupportedMetadataVersion) {
         if (supportedVersion < minSupportedMetadataVersion) {
             log.debug("Downgrade the current minimum supported version {} to the smaller seen supported version {}",
-                    minSupportedMetadataVersion, supportedVersion);
+                minSupportedMetadataVersion, supportedVersion);
             return supportedVersion;
         } else {
             log.debug("Current minimum supported version remains at {}, last seen supported version was {}",
-                    minSupportedMetadataVersion, supportedVersion);
+                minSupportedMetadataVersion, supportedVersion);
             return minSupportedMetadataVersion;
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -50,6 +50,7 @@ import org.apache.kafka.streams.processor.internals.assignment.ReferenceContaine
 import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
 import org.apache.kafka.streams.processor.internals.assignment.TaskAssignor;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTaskId;
 import org.apache.kafka.streams.state.HostInfo;
 import org.slf4j.Logger;
 
@@ -515,7 +516,7 @@ public class StreamsPartitionAssignor implements ConsumerPartitionAssignor, Conf
             }
             allAssignedPartitions.addAll(partitions);
 
-            tasksForTopicGroup.computeIfAbsent(new Subtopology(id.topicGroupId, id.namedTopology()), k -> new HashSet<>()).add(id);
+            tasksForTopicGroup.computeIfAbsent(new Subtopology(id.topicGroupId, NamedTaskId.namedTopology(id)), k -> new HashSet<>()).add(id);
         }
 
         checkAllPartitions(allSourceTopics, partitionsForTask, allAssignedPartitions, fullMetadata);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+public class TopologyMetadata {
+
+    public static class Subtopology {
+        final int nodeGroupId;
+        final String namedTopology;
+
+        public Subtopology(final int nodeGroupId, final String namedTopology) {
+            this.nodeGroupId = nodeGroupId;
+            this.namedTopology = namedTopology;
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
+import java.util.Objects;
+
 public class TopologyMetadata {
     //TODO KAFKA-12648: the TopologyMetadata class is filled in by Pt. 2 (PR #10683)
 
@@ -26,6 +28,24 @@ public class TopologyMetadata {
         public Subtopology(final int nodeGroupId, final String namedTopology) {
             this.nodeGroupId = nodeGroupId;
             this.namedTopology = namedTopology;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final Subtopology that = (Subtopology) o;
+            return nodeGroupId == that.nodeGroupId &&
+                    Objects.equals(namedTopology, that.namedTopology);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(nodeGroupId, namedTopology);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TopologyMetadata.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.processor.internals;
 
 public class TopologyMetadata {
+    //TODO KAFKA-12648: the TopologyMetadata class is filled in by Pt. 2 (PR #10683)
 
     public static class Subtopology {
         final int nodeGroupId;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/namedtopology/NamedTaskId.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.namedtopology;
+
+import org.apache.kafka.streams.processor.TaskId;
+
+public class NamedTaskId extends TaskId {
+    public NamedTaskId(final int topicGroupId, final int partition, final String namedTopology) {
+        super(topicGroupId, partition, namedTopology);
+        if (namedTopology == null) {
+            throw new IllegalStateException("NamedTopology is required for a NamedTaskId");
+        }
+    }
+
+    public String namedTopology() {
+        return namedTopology;
+    }
+
+    public static String namedTopology(final TaskId taskId) {
+        if (taskId instanceof NamedTaskId) {
+            return ((NamedTaskId) taskId).namedTopology();
+        } else {
+            return null;
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -64,6 +64,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_1;
+
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -458,7 +461,7 @@ public class StreamsBuilderTest {
             internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
             equalTo(false));
         assertThat(
-            internalTopologyBuilder.topicGroups().get(0).nonSourceChangelogTopics().isEmpty(),
+            internalTopologyBuilder.topicGroups().get(SUBTOPOLOGY_0).nonSourceChangelogTopics().isEmpty(),
             equalTo(true));
     }
 
@@ -486,7 +489,7 @@ public class StreamsBuilderTest {
             equalTo(true)
         );
         assertThat(
-            internalTopologyBuilder.topicGroups().get(1).stateChangelogTopics.keySet(),
+            internalTopologyBuilder.topicGroups().get(SUBTOPOLOGY_1).stateChangelogTopics.keySet(),
             equalTo(Collections.singleton("appId-store-changelog"))
         );
     }
@@ -509,7 +512,7 @@ public class StreamsBuilderTest {
             internalTopologyBuilder.stateStores().get("store").loggingEnabled(),
             equalTo(true));
         assertThat(
-            internalTopologyBuilder.topicGroups().get(0).stateChangelogTopics.keySet(),
+            internalTopologyBuilder.topicGroups().get(SUBTOPOLOGY_0).stateChangelogTopics.keySet(),
             equalTo(Collections.singleton("appId-store-changelog")));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.SubtopologyDescription;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -427,8 +428,8 @@ public class TopologyTest {
         final TopologyDescription.Source expectedSourceNode = addSource("source", "topic");
 
         expectedDescription.addSubtopology(
-            new InternalTopologyBuilder.Subtopology(0,
-                Collections.singleton(expectedSourceNode)));
+            new SubtopologyDescription(0,
+                                       Collections.singleton(expectedSourceNode)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -439,8 +440,8 @@ public class TopologyTest {
         final TopologyDescription.Source expectedSourceNode = addSource("source", "topic1", "topic2", "topic3");
 
         expectedDescription.addSubtopology(
-            new InternalTopologyBuilder.Subtopology(0,
-                Collections.singleton(expectedSourceNode)));
+            new SubtopologyDescription(0,
+                                       Collections.singleton(expectedSourceNode)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -451,8 +452,8 @@ public class TopologyTest {
         final TopologyDescription.Source expectedSourceNode = addSource("source", Pattern.compile("topic[0-9]"));
 
         expectedDescription.addSubtopology(
-            new InternalTopologyBuilder.Subtopology(0,
-                Collections.singleton(expectedSourceNode)));
+            new SubtopologyDescription(0,
+                                       Collections.singleton(expectedSourceNode)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -462,18 +463,18 @@ public class TopologyTest {
     public void multipleSourcesShouldHaveDistinctSubtopologies() {
         final TopologyDescription.Source expectedSourceNode1 = addSource("source1", "topic1");
         expectedDescription.addSubtopology(
-            new InternalTopologyBuilder.Subtopology(0,
-                Collections.singleton(expectedSourceNode1)));
+            new SubtopologyDescription(0,
+                                       Collections.singleton(expectedSourceNode1)));
 
         final TopologyDescription.Source expectedSourceNode2 = addSource("source2", "topic2");
         expectedDescription.addSubtopology(
-            new InternalTopologyBuilder.Subtopology(1,
-                Collections.singleton(expectedSourceNode2)));
+            new SubtopologyDescription(1,
+                                       Collections.singleton(expectedSourceNode2)));
 
         final TopologyDescription.Source expectedSourceNode3 = addSource("source3", "topic3");
         expectedDescription.addSubtopology(
-            new InternalTopologyBuilder.Subtopology(2,
-                Collections.singleton(expectedSourceNode3)));
+            new SubtopologyDescription(2,
+                                       Collections.singleton(expectedSourceNode3)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -487,7 +488,7 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes = new HashSet<>();
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -503,7 +504,7 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes = new HashSet<>();
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -520,7 +521,7 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes = new HashSet<>();
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -536,7 +537,7 @@ public class TopologyTest {
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode1);
         allNodes.add(expectedProcessorNode2);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -552,7 +553,7 @@ public class TopologyTest {
         allNodes.add(expectedSourceNode1);
         allNodes.add(expectedSourceNode2);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -572,17 +573,17 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes1 = new HashSet<>();
         allNodes1.add(expectedSourceNode1);
         allNodes1.add(expectedProcessorNode1);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes1));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes1));
 
         final Set<TopologyDescription.Node> allNodes2 = new HashSet<>();
         allNodes2.add(expectedSourceNode2);
         allNodes2.add(expectedProcessorNode2);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(1, allNodes2));
+        expectedDescription.addSubtopology(new SubtopologyDescription(1, allNodes2));
 
         final Set<TopologyDescription.Node> allNodes3 = new HashSet<>();
         allNodes3.add(expectedSourceNode3);
         allNodes3.add(expectedProcessorNode3);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(2, allNodes3));
+        expectedDescription.addSubtopology(new SubtopologyDescription(2, allNodes3));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -602,17 +603,17 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes1 = new HashSet<>();
         allNodes1.add(expectedSourceNode1);
         allNodes1.add(expectedSinkNode1);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes1));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes1));
 
         final Set<TopologyDescription.Node> allNodes2 = new HashSet<>();
         allNodes2.add(expectedSourceNode2);
         allNodes2.add(expectedSinkNode2);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(1, allNodes2));
+        expectedDescription.addSubtopology(new SubtopologyDescription(1, allNodes2));
 
         final Set<TopologyDescription.Node> allNodes3 = new HashSet<>();
         allNodes3.add(expectedSourceNode3);
         allNodes3.add(expectedSinkNode3);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(2, allNodes3));
+        expectedDescription.addSubtopology(new SubtopologyDescription(2, allNodes3));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -644,7 +645,7 @@ public class TopologyTest {
         allNodes.add(expectedSourceNode3);
         allNodes.add(expectedProcessorNode3);
         allNodes.add(expectedSinkNode);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));
@@ -675,7 +676,7 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode2);
         allNodes.add(expectedSourceNode3);
         allNodes.add(expectedProcessorNode3);
-        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new SubtopologyDescription(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
         assertThat(topology.describe().hashCode(), equalTo(expectedDescription.hashCode()));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -53,6 +53,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import static java.time.Duration.ofMillis;
+
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -210,8 +212,8 @@ public class KStreamKStreamJoinTest {
 
         assertThat(internalTopologyBuilder.stateStores().get("store-this-join-store").loggingEnabled(), equalTo(true));
         assertThat(internalTopologyBuilder.stateStores().get("store-other-join-store").loggingEnabled(), equalTo(true));
-        assertThat(internalTopologyBuilder.topicGroups().get(0).stateChangelogTopics.size(), equalTo(2));
-        for (final InternalTopicConfig config : internalTopologyBuilder.topicGroups().get(0).stateChangelogTopics.values()) {
+        assertThat(internalTopologyBuilder.topicGroups().get(SUBTOPOLOGY_0).stateChangelogTopics.size(), equalTo(2));
+        for (final InternalTopicConfig config : internalTopologyBuilder.topicGroups().get(SUBTOPOLOGY_0).stateChangelogTopics.values()) {
             assertThat(
                 config.getProperties(Collections.emptyMap(), 0).get("test"),
                 equalTo("property")

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.SubtopologyDescription;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyTestDriverWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -405,7 +406,7 @@ public class KTableImplTest {
     }
 
     private void assertTopologyContainsProcessor(final Topology topology, final String processorName) {
-        for (final TopologyDescription.Subtopology subtopology: topology.describe().subtopologies()) {
+        for (final SubtopologyDescription subtopology: topology.describe().subtopologies()) {
             for (final TopologyDescription.Node node: subtopology.nodes()) {
                 if (node.name().equals(processorName)) {
                     return;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ChangelogTopicsTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.TopicsInfo;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -28,6 +30,8 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
+
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
@@ -80,8 +84,8 @@ public class ChangelogTopicsTest {
     @Test
     public void shouldNotContainChangelogsForStatelessTasks() {
         expect(internalTopicManager.makeReady(Collections.emptyMap())).andStubReturn(Collections.emptySet());
-        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO2));
-        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO2));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, mkSet(TASK_0_0, TASK_0_1, TASK_0_2)));
         replay(internalTopicManager);
 
         final ChangelogTopics changelogTopics =
@@ -100,9 +104,9 @@ public class ChangelogTopicsTest {
     public void shouldNotContainAnyPreExistingChangelogsIfChangelogIsNewlyCreated() {
         expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
             .andStubReturn(mkSet(CHANGELOG_TOPIC_NAME1));
-        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO1));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
         replay(internalTopicManager);
 
         final ChangelogTopics changelogTopics =
@@ -122,9 +126,9 @@ public class ChangelogTopicsTest {
     public void shouldOnlyContainPreExistingNonSourceBasedChangelogs() {
         expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
             .andStubReturn(Collections.emptySet());
-        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO1));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
         replay(internalTopicManager);
 
         final ChangelogTopics changelogTopics =
@@ -149,9 +153,9 @@ public class ChangelogTopicsTest {
     @Test
     public void shouldOnlyContainPreExistingSourceBasedChangelogs() {
         expect(internalTopicManager.makeReady(Collections.emptyMap())).andStubReturn(Collections.emptySet());
-        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO3));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO3));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
         replay(internalTopicManager);
 
         final ChangelogTopics changelogTopics =
@@ -176,9 +180,9 @@ public class ChangelogTopicsTest {
     public void shouldContainBothTypesOfPreExistingChangelogs() {
         expect(internalTopicManager.makeReady(mkMap(mkEntry(CHANGELOG_TOPIC_NAME1, CHANGELOG_TOPIC_CONFIG))))
             .andStubReturn(Collections.emptySet());
-        final Map<Integer, TopicsInfo> topicGroups = mkMap(mkEntry(0, TOPICS_INFO4));
+        final Map<Subtopology, TopicsInfo> topicGroups = mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO4));
         final Set<TaskId> tasks = mkSet(TASK_0_0, TASK_0_1, TASK_0_2);
-        final Map<Integer, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(0, tasks));
+        final Map<Subtopology, Set<TaskId>> tasksForTopicGroup = mkMap(mkEntry(SUBTOPOLOGY_0, tasks));
         replay(internalTopicManager);
 
         final ChangelogTopics changelogTopics =

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.SubtopologyDescription;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -54,6 +55,10 @@ import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_1;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_2;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -571,12 +576,12 @@ public class InternalTopologyBuilderTest {
 
         builder.addProcessor("processor-3", new MockApiProcessorSupplier<>(), "source-3", "source-4");
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> expectedTopicGroups = new HashMap<>();
-        expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-1", "X-topic-1x", "topic-2"), Collections.emptyMap(), Collections.emptyMap()));
-        expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-3", "topic-4"), Collections.emptyMap(), Collections.emptyMap()));
-        expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-5"), Collections.emptyMap(), Collections.emptyMap()));
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> expectedTopicGroups = new HashMap<>();
+        expectedTopicGroups.put(SUBTOPOLOGY_0, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-1", "X-topic-1x", "topic-2"), Collections.emptyMap(), Collections.emptyMap()));
+        expectedTopicGroups.put(SUBTOPOLOGY_1, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-3", "topic-4"), Collections.emptyMap(), Collections.emptyMap()));
+        expectedTopicGroups.put(SUBTOPOLOGY_2, new InternalTopologyBuilder.TopicsInfo(Collections.emptySet(), mkSet("topic-5"), Collections.emptyMap(), Collections.emptyMap()));
 
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);
@@ -608,21 +613,21 @@ public class InternalTopologyBuilderTest {
         builder.connectProcessorAndStateStores("processor-5", "store-3");
         builder.buildTopology();
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> expectedTopicGroups = new HashMap<>();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> expectedTopicGroups = new HashMap<>();
         final String store1 = ProcessorStateManager.storeChangelogTopic("X", "store-1");
         final String store2 = ProcessorStateManager.storeChangelogTopic("X", "store-2");
         final String store3 = ProcessorStateManager.storeChangelogTopic("X", "store-3");
-        expectedTopicGroups.put(0, new InternalTopologyBuilder.TopicsInfo(
+        expectedTopicGroups.put(SUBTOPOLOGY_0, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-1", "topic-1x", "topic-2"),
             Collections.emptyMap(),
             Collections.singletonMap(store1, new UnwindowedChangelogTopicConfig(store1, Collections.emptyMap()))));
-        expectedTopicGroups.put(1, new InternalTopologyBuilder.TopicsInfo(
+        expectedTopicGroups.put(SUBTOPOLOGY_1, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-3", "topic-4"),
             Collections.emptyMap(),
             Collections.singletonMap(store2, new UnwindowedChangelogTopicConfig(store2, Collections.emptyMap()))));
-        expectedTopicGroups.put(2, new InternalTopologyBuilder.TopicsInfo(
+        expectedTopicGroups.put(SUBTOPOLOGY_2, new InternalTopologyBuilder.TopicsInfo(
             Collections.emptySet(), mkSet("topic-5"),
             Collections.emptyMap(),
             Collections.singletonMap(store3, new UnwindowedChangelogTopicConfig(store3, Collections.emptyMap()))));
@@ -838,7 +843,7 @@ public class InternalTopologyBuilderTest {
                 "processor"
         );
         builder.buildTopology();
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
         final InternalTopologyBuilder.TopicsInfo topicsInfo = topicGroups.values().iterator().next();
         final InternalTopicConfig topicConfig1 = topicsInfo.stateChangelogTopics.get("appId-store1-changelog");
         final Map<String, String> properties1 = topicConfig1.getProperties(Collections.emptyMap(), 10000);
@@ -863,7 +868,7 @@ public class InternalTopologyBuilderTest {
         builder.addProcessor("processor", new MockApiProcessorSupplier<>(), "source");
         builder.addStateStore(storeBuilder, "processor");
         builder.buildTopology();
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
         final InternalTopologyBuilder.TopicsInfo topicsInfo = topicGroups.values().iterator().next();
         final InternalTopicConfig topicConfig = topicsInfo.stateChangelogTopics.get("appId-testStore-changelog");
         final Map<String, String> properties = topicConfig.getProperties(Collections.emptyMap(), 10000);
@@ -904,11 +909,11 @@ public class InternalTopologyBuilderTest {
         builder.addSubscribedTopicsFromMetadata(updatedTopics, null);
         builder.setApplicationId("test-id");
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
-        assertTrue(topicGroups.get(0).sourceTopics.contains("topic-foo"));
-        assertTrue(topicGroups.get(1).sourceTopics.contains("topic-A"));
-        assertTrue(topicGroups.get(1).sourceTopics.contains("topic-B"));
-        assertTrue(topicGroups.get(2).sourceTopics.contains("topic-3"));
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        assertTrue(topicGroups.get(SUBTOPOLOGY_0).sourceTopics.contains("topic-foo"));
+        assertTrue(topicGroups.get(SUBTOPOLOGY_1).sourceTopics.contains("topic-A"));
+        assertTrue(topicGroups.get(SUBTOPOLOGY_1).sourceTopics.contains("topic-B"));
+        assertTrue(topicGroups.get(SUBTOPOLOGY_2).sourceTopics.contains("topic-3"));
     }
 
     @Test
@@ -1094,9 +1099,9 @@ public class InternalTopologyBuilderTest {
         builder.addInternalTopic("topic-1z", new InternalTopicProperties(numberOfPartitions));
         builder.addSource(null, "source-1", null, null, null, "topic-1z");
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
-        final Map<String, InternalTopicConfig> repartitionSourceTopics = topicGroups.get(0).repartitionSourceTopics;
+        final Map<String, InternalTopicConfig> repartitionSourceTopics = topicGroups.get(SUBTOPOLOGY_0).repartitionSourceTopics;
 
         assertEquals(
             repartitionSourceTopics.get("Z-topic-1z"),
@@ -1115,9 +1120,9 @@ public class InternalTopologyBuilderTest {
         builder.addInternalTopic("topic-1t", InternalTopicProperties.empty());
         builder.addSource(null, "source-1", null, null, null, "topic-1t");
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
-        final Map<String, InternalTopicConfig> repartitionSourceTopics = topicGroups.get(0).repartitionSourceTopics;
+        final Map<String, InternalTopicConfig> repartitionSourceTopics = topicGroups.get(SUBTOPOLOGY_0).repartitionSourceTopics;
 
         assertEquals(
             repartitionSourceTopics.get("T-topic-1t"),
@@ -1134,9 +1139,9 @@ public class InternalTopologyBuilderTest {
         builder.addInternalTopic("topic-1y", InternalTopicProperties.empty());
         builder.addSource(null, "source-1", null, null, null, "topic-1y");
 
-        final Map<Integer, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
+        final Map<Subtopology, InternalTopologyBuilder.TopicsInfo> topicGroups = builder.topicGroups();
 
-        final Map<String, InternalTopicConfig> repartitionSourceTopics = topicGroups.get(0).repartitionSourceTopics;
+        final Map<String, InternalTopicConfig> repartitionSourceTopics = topicGroups.get(SUBTOPOLOGY_0).repartitionSourceTopics;
 
         assertEquals(
             repartitionSourceTopics.get("Y-topic-1y"),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder.SubtopologyDescription;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -943,7 +944,7 @@ public class InternalTopologyBuilderTest {
 
         assertEquals(1, builder.describe().subtopologies().size());
 
-        final Iterator<TopologyDescription.Node> iterator = ((InternalTopologyBuilder.Subtopology) builder.describe().subtopologies().iterator().next()).nodesInOrder();
+        final Iterator<TopologyDescription.Node> iterator = ((SubtopologyDescription) builder.describe().subtopologies().iterator().next()).nodesInOrder();
 
         assertTrue(iterator.hasNext());
         InternalTopologyBuilder.AbstractNode node = (InternalTopologyBuilder.AbstractNode) iterator.next();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RepartitionTopicsTest.java
@@ -38,6 +38,9 @@ import java.util.Set;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
+import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_1;
+
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
@@ -96,7 +99,7 @@ public class RepartitionTopicsTest {
     @Test
     public void shouldSetupRepartitionTopics() {
         expect(internalTopologyBuilder.topicGroups())
-            .andReturn(mkMap(mkEntry(0, TOPICS_INFO1), mkEntry(1, TOPICS_INFO2)));
+            .andReturn(mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1), mkEntry(SUBTOPOLOGY_1, TOPICS_INFO2)));
         final Set<String> coPartitionGroup1 = mkSet(SOURCE_TOPIC_NAME1, SOURCE_TOPIC_NAME2);
         final Set<String> coPartitionGroup2 = mkSet(REPARTITION_TOPIC_NAME1, REPARTITION_TOPIC_NAME2);
         final List<Set<String>> coPartitionGroups = Arrays.asList(coPartitionGroup1, coPartitionGroup2);
@@ -135,7 +138,7 @@ public class RepartitionTopicsTest {
     @Test
     public void shouldThrowMissingSourceTopicException() {
         expect(internalTopologyBuilder.topicGroups())
-            .andReturn(mkMap(mkEntry(0, TOPICS_INFO1), mkEntry(1, TOPICS_INFO2)));
+            .andReturn(mkMap(mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1), mkEntry(SUBTOPOLOGY_1, TOPICS_INFO2)));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptyList());
         copartitionedTopicsEnforcer.enforce(eq(Collections.emptySet()), anyObject(), eq(clusterMetadata));
         expect(internalTopicManager.makeReady(
@@ -162,8 +165,8 @@ public class RepartitionTopicsTest {
             new RepartitionTopicConfig(REPARTITION_WITHOUT_PARTITION_COUNT, TOPIC_CONFIG5);
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
-                mkEntry(0, TOPICS_INFO1),
-                mkEntry(1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                mkEntry(SUBTOPOLOGY_0, TOPICS_INFO1),
+                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptyList());
         copartitionedTopicsEnforcer.enforce(eq(Collections.emptySet()), anyObject(), eq(clusterMetadata));
@@ -200,8 +203,8 @@ public class RepartitionTopicsTest {
         );
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
-                mkEntry(0, topicsInfo),
-                mkEntry(1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                mkEntry(SUBTOPOLOGY_0, topicsInfo),
+                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptyList());
         copartitionedTopicsEnforcer.enforce(eq(Collections.emptySet()), anyObject(), eq(clusterMetadata));
@@ -243,8 +246,8 @@ public class RepartitionTopicsTest {
         );
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
-                mkEntry(0, topicsInfo),
-                mkEntry(1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                mkEntry(SUBTOPOLOGY_0, topicsInfo),
+                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptyList());
         copartitionedTopicsEnforcer.enforce(eq(Collections.emptySet()), anyObject(), eq(clusterMetadata));
@@ -297,8 +300,8 @@ public class RepartitionTopicsTest {
         );
         expect(internalTopologyBuilder.topicGroups())
             .andReturn(mkMap(
-                mkEntry(0, topicsInfo),
-                mkEntry(1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
+                mkEntry(SUBTOPOLOGY_0, topicsInfo),
+                mkEntry(SUBTOPOLOGY_1, setupTopicInfoWithRepartitionTopicWithoutPartitionCount(repartitionTopicConfigWithoutPartitionCount))
             ));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptyList());
         copartitionedTopicsEnforcer.enforce(eq(Collections.emptySet()), anyObject(), eq(clusterMetadata));
@@ -345,7 +348,7 @@ public class RepartitionTopicsTest {
             Collections.emptyMap()
         );
         expect(internalTopologyBuilder.topicGroups())
-            .andReturn(mkMap(mkEntry(0, topicsInfo)));
+            .andReturn(mkMap(mkEntry(SUBTOPOLOGY_0, topicsInfo)));
         expect(internalTopologyBuilder.copartitionGroups()).andReturn(Collections.emptySet());
         expect(internalTopicManager.makeReady(Collections.emptyMap())).andReturn(Collections.emptySet());
         setupCluster();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentTestUtils.java
@@ -25,6 +25,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.processor.internals.TopologyMetadata.Subtopology;
+
 import org.easymock.EasyMock;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -89,6 +91,10 @@ public final class AssignmentTestUtils {
     public static final TaskId NAMED_TASK_0_1 = new TaskId(0, 1, "topology0");
     public static final TaskId NAMED_TASK_1_0 = new TaskId(1, 0, "topology1");
     public static final TaskId NAMED_TASK_1_1 = new TaskId(1, 1, "topology1");
+
+    public static final Subtopology SUBTOPOLOGY_0 = new Subtopology(0, null);
+    public static final Subtopology SUBTOPOLOGY_1 = new Subtopology(1, null);
+    public static final Subtopology SUBTOPOLOGY_2 = new Subtopology(2, null);
 
     public static final Set<TaskId> EMPTY_TASKS = emptySet();
     public static final Map<TopicPartition, Long> EMPTY_CHANGELOG_END_OFFSETS = new HashMap<>();


### PR DESCRIPTION
Renames the existing `Subtopology` class + interface to `SubtopologyDescription`, since that more closely matches what it is/is used for. Then introduces a new `Subtopology` class which includes basic metadata such as the topic group id and the NamedTopology that this subtopology belongs to, if any.

Also adds an internal `NamedTaskId` class to expose the `namedTopology` of a TaskId outside the package. I realized TaskId is part of the public API, so we can't just add a public `namedTopology()` getter method. I made the `namedTopology` field protected and removed the getter/moved it to the NamedTaskId class.

There are no actual logical changes or features in this PR, it's just a refactoring. Split these changes out to reduce the LOC in the main PRs.