### PR TITLE
KAFKA-12380 Executor in Connect's Worker is not shut down when the worker is

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -226,6 +226,9 @@ public class Worker {
 
         offsetBackingStore.stop();
         metrics.stop();
+        if (executor != null) {
+            executor.shutdownNow();
+        }
 
         log.info("Worker stopped");
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -227,7 +227,7 @@ public class Worker {
         offsetBackingStore.stop();
         metrics.stop();
         if (executor != null) {
-            executor.shutdown();
+            executor.shutdownNow();
         }
 
         log.info("Worker stopped");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -227,7 +227,7 @@ public class Worker {
         offsetBackingStore.stop();
         metrics.stop();
         if (executor != null) {
-            executor.shutdownNow();
+            executor.shutdown();
         }
 
         log.info("Worker stopped");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -146,7 +146,7 @@ public class WorkerTest extends ThreadedTest {
     private DelegatingClassLoader delegatingLoader;
     @Mock
     private OffsetBackingStore offsetBackingStore;
-    @MockStrict
+    @Mock
     private List<Runnable> listAwaitTask;
     @MockStrict
     private TaskStatus.Listener taskStatusListener;
@@ -662,7 +662,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -746,7 +746,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -956,7 +956,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1035,7 +1035,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -145,8 +145,6 @@ public class WorkerTest extends ThreadedTest {
     @Mock
     private DelegatingClassLoader delegatingLoader;
     @Mock
-    private List<Runnable> listAwaitTask;
-    @Mock
     private OffsetBackingStore offsetBackingStore;
     @MockStrict
     private TaskStatus.Listener taskStatusListener;
@@ -662,7 +660,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andVoid();
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -745,7 +743,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andVoid();
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -955,7 +953,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andVoid();
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1034,7 +1032,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andVoid();
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -660,6 +660,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow());
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -742,6 +743,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow());
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -951,7 +953,8 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        
+        EasyMock.expect(executorService.shutdownNow());
+
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
                 .andReturn(pluginLoader);
@@ -1029,6 +1032,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow());
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1500,7 +1504,6 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(Time.class),
                 anyObject(RetryWithToleranceOperator.class),
                 anyObject(StatusBackingStore.class),
-                anyObject(ExecutorService.class),
                 anyObject(Executor.class))
                 .andReturn(workerTask);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -662,7 +662,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -680,6 +680,7 @@ public class WorkerTest extends ThreadedTest {
         workerTask.stop();
         EasyMock.expectLastCall();
         EasyMock.expect(workerTask.awaitStop(EasyMock.anyLong())).andStubReturn(true);
+
         EasyMock.expectLastCall();
 
         workerTask.removeMetrics();
@@ -745,7 +746,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -955,7 +956,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1034,7 +1035,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -145,6 +145,8 @@ public class WorkerTest extends ThreadedTest {
     @Mock
     private DelegatingClassLoader delegatingLoader;
     @Mock
+    private List<Runnable> listAwaitTask;
+    @Mock
     private OffsetBackingStore offsetBackingStore;
     @MockStrict
     private TaskStatus.Listener taskStatusListener;
@@ -660,7 +662,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -743,7 +745,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -953,7 +955,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1032,7 +1034,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
+        EasyMock.expect(executorService.shutdownNow()).andReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -660,7 +660,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow());
+        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -743,7 +743,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow());
+        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -953,7 +953,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow());
+        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1032,7 +1032,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow());
+        EasyMock.expect(executorService.shutdownNow()).andReturn(null);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -146,7 +146,7 @@ public class WorkerTest extends ThreadedTest {
     private DelegatingClassLoader delegatingLoader;
     @Mock
     private OffsetBackingStore offsetBackingStore;
-    @Mock
+    @MockStrict
     private List<Runnable> listAwaitTask;
     @MockStrict
     private TaskStatus.Listener taskStatusListener;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -146,6 +146,8 @@ public class WorkerTest extends ThreadedTest {
     private DelegatingClassLoader delegatingLoader;
     @Mock
     private OffsetBackingStore offsetBackingStore;
+    @Mock
+    private List<Runnable> listAwaitTask;
     @MockStrict
     private TaskStatus.Listener taskStatusListener;
     @MockStrict
@@ -660,7 +662,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andVoid();
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -743,7 +745,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.CURRENT_CLASSLOADER, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andVoid();
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -953,7 +955,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andVoid();
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
@@ -1032,7 +1034,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-        EasyMock.expect(executorService.shutdownNow()).andVoid();
+        EasyMock.expect(executorService.shutdownNow()).andStubReturn(listAwaitTask);
 
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -951,7 +951,7 @@ public class WorkerTest extends ThreadedTest {
         expectTaskHeaderConverter(ClassLoaderUsage.PLUGINS, taskHeaderConverter);
 
         EasyMock.expect(executorService.submit(workerTask)).andReturn(null);
-
+        
         EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
         EasyMock.expect(delegatingLoader.connectorLoader(WorkerTestConnector.class.getName()))
                 .andReturn(pluginLoader);
@@ -1500,6 +1500,7 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(Time.class),
                 anyObject(RetryWithToleranceOperator.class),
                 anyObject(StatusBackingStore.class),
+                anyObject(ExecutorService.class),
                 anyObject(Executor.class))
                 .andReturn(workerTask);
     }


### PR DESCRIPTION
The `Worker` class has an `executor` field that the public constructor initializes with a new cached thread pool (https://github.com/apache/kafka/blob/02226fa090513882b9229ac834fd493d71ae6d96/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java#L127.]).

When the worker is stopped, it does not shutdown this executor. This is normally okay in the Connect runtime and MirrorMaker 2 runtimes, because the worker is stopped only when the JVM is stopped (via the shutdown hook in the herders).

However, we instantiate and stop the herder many times in our integration tests, and this means we're not necessarily shutting down the herder's executor. Normally this won't hurt, as long as all of the runnables that the executor threads run actually do terminate. But it's possible those threads might not terminate in all tests.

@kkonstantine can you review this? many thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
