### PR TITLE
KAFKA-4083: prevent changing replication factor via partition reassignment

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1833,13 +1833,18 @@ class KafkaController(val config: KafkaConfig,
     else {
       // Ensure that any new replicas are among the live brokers
       val currentAssignment = controllerContext.partitionFullReplicaAssignment(topicPartition)
-      val newAssignment = currentAssignment.reassignTo(replicas)
-      val areNewReplicasAlive = newAssignment.addingReplicas.toSet.subsetOf(controllerContext.liveBrokerIds)
-      if (!areNewReplicasAlive)
+      if (currentAssignment.originReplicas.nonEmpty && currentAssignment.originReplicas.size != replicas.size) {
         Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
-          s"Replica assignment has brokers that are not alive. Replica list: " +
-            s"${newAssignment.addingReplicas}, live broker list: ${controllerContext.liveBrokerIds}"))
-      else None
+          s"Replica assignment on ${topicPartition}: ${replicas} violates its replication factor"))
+      } else {
+        val newAssignment = currentAssignment.reassignTo(replicas)
+        val areNewReplicasAlive = newAssignment.addingReplicas.toSet.subsetOf(controllerContext.liveBrokerIds)
+        if (!areNewReplicasAlive)
+          Some(new ApiError(Errors.INVALID_REPLICA_ASSIGNMENT,
+            s"Replica assignment has brokers that are not alive. Replica list: " +
+              s"${newAssignment.addingReplicas}, live broker list: ${controllerContext.liveBrokerIds}"))
+        else None
+      }
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1930,8 +1930,8 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val tp1 = new TopicPartition(topic, 0)
     val tp2 = new TopicPartition(topic, 1)
     val tp3 = new TopicPartition(topic, 2)
-    createTopic(topic, numPartitions = 4)
-
+    val tp4 = new TopicPartition(topic, 3)
+    createTopic(topic, numPartitions = 4, brokerCount)
 
     val validAssignment = Optional.of(new NewPartitionReassignment(
       (0 until brokerCount).map(_.asInstanceOf[Integer]).asJava
@@ -1952,14 +1952,17 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val extraNonExistentReplica = Optional.of(new NewPartitionReassignment((0 until brokerCount + 1).map(_.asInstanceOf[Integer]).asJava))
     val negativeIdReplica = Optional.of(new NewPartitionReassignment(Seq(-3, -2, -1).map(_.asInstanceOf[Integer]).asJava))
     val duplicateReplica = Optional.of(new NewPartitionReassignment(Seq(0, 1, 1).map(_.asInstanceOf[Integer]).asJava))
+    val shrinkReplica = Optional.of(new NewPartitionReassignment((0 until brokerCount - 1).map(_.asInstanceOf[Integer]).asJava))
     val invalidReplicaResult = client.alterPartitionReassignments(Map(
       tp1 -> extraNonExistentReplica,
       tp2 -> negativeIdReplica,
-      tp3 -> duplicateReplica
+      tp3 -> duplicateReplica,
+      tp4 -> shrinkReplica
     ).asJava).values()
     assertFutureExceptionTypeEquals(invalidReplicaResult.get(tp1), classOf[InvalidReplicaAssignmentException])
     assertFutureExceptionTypeEquals(invalidReplicaResult.get(tp2), classOf[InvalidReplicaAssignmentException])
     assertFutureExceptionTypeEquals(invalidReplicaResult.get(tp3), classOf[InvalidReplicaAssignmentException])
+    assertFutureExceptionTypeEquals(invalidReplicaResult.get(tp4), classOf[InvalidReplicaAssignmentException])
   }
 
   @Test


### PR DESCRIPTION
### Summary

`ReassignPartitionsCommand` does _not_ check whether the replication factor of a partition is the same as the existing replication factor, which may result that different partitions of a topic have different numbers of replicas.

A few years ago, I attempted a fix to `ReassignPartitionsCommand` within https://github.com/apache/kafka/pull/1779, but now I think it should be fixed on the broker side.

### Tests

Besides the integration test I have changed, I built a 3-node Kafka cluster on my laptop with Docker containers and ran a few shell scripts to test.

Create a topic
```
bin/kafka-topics.sh --bootstrap-server localhost:29092 --create --topic test-reassign-partitions --partitions 3 --replication-factor 3
```

reassignment-plan.json
```
{
   "version":1,
   "partitions":[
      {
         "topic": "test-reassign-partitions",
         "partition": 0,
         "replicas" :[1, 2]
      }
   ]
}
```

Execute a partition reassignment
```
bin/kafka-reassign-partitions.sh --bootstrap-server localhost:29092 --reassignment-json-file reassignment-plan.json --execute
```

The output is
```
Current partition replica assignment

{"version":1,"partitions":[{"topic":"test-reassign-partitions","partition":0,"replicas":[2,1,0],"log_dirs":["any","any","any"]}]}

Save this to use as the --reassignment-json-file option during rollback
Error reassigning partition(s):
test-reassign-partitions-0: Replica assignment on test-reassign-partitions-0: [1, 2] violates its replication factor
```