### PR TITLE
MINOR: fix system test TestSecurityRollingUpgrade

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -503,7 +503,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 self._security_config.calc_has_ssl()
         for port in self.port_mappings.values():
             if port.open:
-                self._security_config.enable_security_protocol(port.security_protocol)
+                self._security_config.enable_security_protocol(port.security_protocol, port.sasl_mechanism)
         if self.quorum_info.using_zk:
             if self.zk.zk_sasl:
                 self._security_config.enable_sasl()

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -37,11 +37,12 @@ from kafkatest.services.kafka.util import fix_opts_for_new_jvm
 
 class KafkaListener:
 
-    def __init__(self, name, port_number, security_protocol, open=False):
+    def __init__(self, name, port_number, security_protocol, open=False, sasl_mechanism = None):
         self.name = name
         self.port_number = port_number
         self.security_protocol = security_protocol
         self.open = open
+        self.sasl_mechanism = sasl_mechanism
 
     def listener(self):
         return "%s://:%s" % (self.name, str(self.port_number))
@@ -487,14 +488,19 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                                                    serves_intercontroller_sasl_mechanism=serves_intercontroller_sasl_mechanism,
                                                    uses_controller_sasl_mechanism=uses_controller_sasl_mechanism,
                                                    raft_tls=raft_tls)
+        # Ensure we have the correct client security protocol and SASL mechanism because they may have been mutated
+        self._security_config.properties['security.protocol'] = self.security_protocol
+        self._security_config.properties['sasl.mechanism'] = self.client_sasl_mechanism
         # Ensure we have the right inter-broker security protocol because it may have been mutated
         # since we cached our security config (ignore if this is a remote raft controller quorum case; the
         # inter-broker security protocol is not used there).
-        if (self.quorum_info.using_zk or self.quorum_info.has_brokers) and \
-                self._security_config.interbroker_security_protocol != self.interbroker_security_protocol:
-            self._security_config.interbroker_security_protocol = self.interbroker_security_protocol
-            self._security_config.calc_has_sasl()
-            self._security_config.calc_has_ssl()
+        if (self.quorum_info.using_zk or self.quorum_info.has_brokers):
+            # in case inter-broker SASL mechanism has changed without changing the inter-broker security protocol
+            self._security_config.properties['sasl.mechanism.inter.broker.protocol'] = self.interbroker_sasl_mechanism
+            if self._security_config.interbroker_security_protocol != self.interbroker_security_protocol:
+                self._security_config.interbroker_security_protocol = self.interbroker_security_protocol
+                self._security_config.calc_has_sasl()
+                self._security_config.calc_has_ssl()
         for port in self.port_mappings.values():
             if port.open:
                 self._security_config.enable_security_protocol(port.security_protocol)

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -194,6 +194,7 @@ class SecurityConfig(TemplateRenderer):
         self.zk_tls = zk_tls
         self.static_jaas_conf = static_jaas_conf
         self.listener_security_config = listener_security_config
+        self.additional_sasl_mechanisms = []
         self.properties = {
             'security.protocol' : security_protocol,
             'ssl.keystore.location' : SecurityConfig.KEYSTORE_PATH,
@@ -258,8 +259,10 @@ class SecurityConfig(TemplateRenderer):
     def enable_ssl(self):
         self.has_ssl = True
 
-    def enable_security_protocol(self, security_protocol):
+    def enable_security_protocol(self, security_protocol, sasl_mechanism = None):
         self.has_sasl = self.has_sasl or self.is_sasl(security_protocol)
+        if sasl_mechanism:
+            self.additional_sasl_mechanisms.append(sasl_mechanism)
         self.has_ssl = self.has_ssl or self.is_ssl(security_protocol)
 
     def setup_ssl(self, node):
@@ -387,6 +390,7 @@ class SecurityConfig(TemplateRenderer):
             sasl_mechanisms += list(self.uses_raft_sasl)
         if self.zk_sasl:
             sasl_mechanisms += [SecurityConfig.SASL_MECHANISM_GSSAPI]
+        sasl_mechanisms += self.additional_sasl_mechanisms
         return set(sasl_mechanisms)
 
     @property

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -261,7 +261,7 @@ class SecurityConfig(TemplateRenderer):
 
     def enable_security_protocol(self, security_protocol, sasl_mechanism = None):
         self.has_sasl = self.has_sasl or self.is_sasl(security_protocol)
-        if sasl_mechanism:
+        if sasl_mechanism is not None:
             self.additional_sasl_mechanisms.append(sasl_mechanism)
         self.has_ssl = self.has_ssl or self.is_ssl(security_protocol)
 
@@ -390,7 +390,7 @@ class SecurityConfig(TemplateRenderer):
             sasl_mechanisms += list(self.uses_raft_sasl)
         if self.zk_sasl:
             sasl_mechanisms += [SecurityConfig.SASL_MECHANISM_GSSAPI]
-        sasl_mechanisms += self.additional_sasl_mechanisms
+        sasl_mechanisms.extend(self.additional_sasl_mechanisms)
         return set(sasl_mechanisms)
 
     @property

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -96,7 +96,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.bounce()
 
         # Bounce again with ACLs for new mechanism.
-        self.kafka.client_sasl_mechanism = new_sasl_mechanism # Removes old SASL mechanism completely
+        self.kafka.client_sasl_mechanism = new_sasl_mechanism  # Removes old SASL mechanism completely
         self.set_authorizer_and_bounce(security_protocol, security_protocol)
 
     def add_separate_broker_listener(self, broker_security_protocol, broker_sasl_mechanism):

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -97,7 +97,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
 
         # Bounce again with ACLs for new mechanism. Use old SimpleAclAuthorizer here to ensure that is also tested.
         self.kafka.client_sasl_mechanism = new_sasl_mechanism # Removes old SASL mechanism completely
-        self.set_authorizer_and_bounce(security_protocol, security_protocol, KafkaService.SIMPLE_AUTHORIZER)
+        self.set_authorizer_and_bounce(security_protocol, security_protocol)
 
     def add_separate_broker_listener(self, broker_security_protocol, broker_sasl_mechanism):
         # Enable the new internal listener on all brokers first

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -89,18 +89,21 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.bounce()
 
     def roll_in_sasl_mechanism(self, security_protocol, new_sasl_mechanism):
-        # Roll cluster to update inter-broker SASL mechanism. This disables the old mechanism.
+        # Roll cluster to update inter-broker SASL mechanism.
+        # We need the inter-broker SASL mechanism to still be enabled through this roll.
+        self.kafka.client_sasl_mechanism = "%s,%s" % (self.kafka.interbroker_sasl_mechanism, new_sasl_mechanism)
         self.kafka.interbroker_sasl_mechanism = new_sasl_mechanism
         self.bounce()
 
-        # Bounce again with ACLs for new mechanism.
-        self.set_authorizer_and_bounce(security_protocol, security_protocol)
+        # Bounce again with ACLs for new mechanism. Use old SimpleAclAuthorizer here to ensure that is also tested.
+        self.kafka.client_sasl_mechanism = new_sasl_mechanism # Removes old SASL mechanism completely
+        self.set_authorizer_and_bounce(security_protocol, security_protocol, KafkaService.SIMPLE_AUTHORIZER)
 
     def add_separate_broker_listener(self, broker_security_protocol, broker_sasl_mechanism):
         # Enable the new internal listener on all brokers first
         self.kafka.open_port(self.kafka.INTERBROKER_LISTENER_NAME)
         self.kafka.port_mappings[self.kafka.INTERBROKER_LISTENER_NAME].security_protocol = broker_security_protocol
-        self.kafka.client_sasl_mechanism = broker_sasl_mechanism
+        self.kafka.port_mappings[self.kafka.INTERBROKER_LISTENER_NAME].sasl_mechanism = broker_sasl_mechanism
         self.bounce()
 
         # Update inter-broker listener after all brokers have been updated to enable the new listener

--- a/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/core/security_rolling_upgrade_test.py
@@ -95,7 +95,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.kafka.interbroker_sasl_mechanism = new_sasl_mechanism
         self.bounce()
 
-        # Bounce again with ACLs for new mechanism. Use old SimpleAclAuthorizer here to ensure that is also tested.
+        # Bounce again with ACLs for new mechanism.
         self.kafka.client_sasl_mechanism = new_sasl_mechanism # Removes old SASL mechanism completely
         self.set_authorizer_and_bounce(security_protocol, security_protocol)
 


### PR DESCRIPTION
SecurityConfig for a Kafka cluster in a system test is cached due to https://github.com/apache/kafka/pull/8917, but we mutate the security config during some system tests, and those mutations were not being passed through after-the-fact.  These system tests were not testing what they were supposed to be testing.  This patch passes through the potential changes so that we again test what we are supposed to be testing.

Also, since we became very specific about what SASL mechanisms to enable when updating the system tests for KRaft, we need to explicitly indicate to the SecurityConfig any additional SASL mechanisms that we want to enable.  This was always necessary once we made the KRaft changes, but it was not apparent due to the above bug (where mutations were not being passed through).  This patch provides a way to pass additional SASL mechanisms to the SecurityConfig by adding an optional `sasl_mechanism` to KafkaListener -- this is what gets passed into the SecurityConfig when we enable a new security protocol in the middle of a system test.

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
