### PR TITLE
KAFKA-12777 Refactor and cleanup AutoTopicCreationManager

### DIFF
--- a/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
+++ b/core/src/main/scala/kafka/server/AutoTopicCreationManager.scala
@@ -46,11 +46,9 @@ abstract class AutoTopicCreationManager(config: KafkaConfig,
                                      controllerMutationQuota: ControllerMutationQuota,
                                      metadataRequestContext: Option[RequestContext]): Seq[MetadataResponseTopic]
 
-  def createTopics(
-                    topicNames: Set[String],
-                    controllerMutationQuota: ControllerMutationQuota,
-                    metadataRequestContext: Option[RequestContext]
-                  ): Seq[MetadataResponseTopic] = {
+  def createTopics(topicNames: Set[String],
+                   controllerMutationQuota: ControllerMutationQuota,
+                   metadataRequestContext: Option[RequestContext]): Seq[MetadataResponseTopic] = {
     val (creatableTopics, uncreatableTopicResponses) = filterCreatableTopics(topicNames)
     val creatableTopicResponses = if (creatableTopics.isEmpty) {
       Seq.empty

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -134,7 +134,7 @@ class KafkaServer(
 
   var autoTopicCreationManager: AutoTopicCreationManager = null
 
-  var clientToControllerChannelManager: Option[BrokerToControllerChannelManager] = None
+  var clientToControllerChannelManager: BrokerToControllerChannelManager = null
 
   var alterIsrManager: AlterIsrManager = null
 
@@ -257,19 +257,19 @@ class KafkaServer(
         tokenCache = new DelegationTokenCache(ScramMechanism.mechanismNames)
         credentialProvider = new CredentialProvider(ScramMechanism.mechanismNames, tokenCache)
 
+        clientToControllerChannelManager = BrokerToControllerChannelManager(
+          controllerNodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache),
+          time = time,
+          metrics = metrics,
+          config = config,
+          channelName = "forwarding",
+          threadNamePrefix = threadNamePrefix,
+          retryTimeoutMs = config.requestTimeoutMs.longValue)
+        clientToControllerChannelManager.start()
+
         /* start forwarding manager */
         if (enableForwarding) {
-          val brokerToControllerManager = BrokerToControllerChannelManager(
-            controllerNodeProvider = MetadataCacheControllerNodeProvider(config, metadataCache),
-            time = time,
-            metrics = metrics,
-            config = config,
-            channelName = "forwarding",
-            threadNamePrefix = threadNamePrefix,
-            retryTimeoutMs = config.requestTimeoutMs.longValue)
-          brokerToControllerManager.start()
-          this.forwardingManager = Some(ForwardingManager(brokerToControllerManager))
-          clientToControllerChannelManager = Some(brokerToControllerManager)
+          this.forwardingManager = Some(ForwardingManager(clientToControllerChannelManager))
         }
 
         val apiVersionManager = ApiVersionManager(
@@ -337,14 +337,13 @@ class KafkaServer(
         transactionCoordinator.startup(
           () => zkClient.getTopicPartitionCount(Topic.TRANSACTION_STATE_TOPIC_NAME).getOrElse(config.transactionTopicPartitions))
 
+        val zkSupport = ZkSupport(adminManager, kafkaController, zkClient, forwardingManager, metadataCache)
+
         /* start auto topic creation manager */
         this.autoTopicCreationManager = AutoTopicCreationManager(
           config,
-          metadataCache,
-          threadNamePrefix,
           clientToControllerChannelManager,
-          Some(adminManager),
-          Some(kafkaController),
+          zkSupport,
           groupCoordinator,
           transactionCoordinator
         )
@@ -368,7 +367,6 @@ class KafkaServer(
             KafkaServer.MIN_INCREMENTAL_FETCH_SESSION_EVICTION_MS))
 
         /* start processing requests */
-        val zkSupport = ZkSupport(adminManager, kafkaController, zkClient, forwardingManager, metadataCache)
         dataPlaneRequestProcessor = new KafkaApis(socketServer.dataPlaneRequestChannel, zkSupport, replicaManager, groupCoordinator, transactionCoordinator,
           autoTopicCreationManager, config.brokerId, config, configRepository, metadataCache, metrics, authorizer, quotaManagers,
           fetchManager, brokerTopicStats, clusterId, time, tokenManager, apiVersionManager)
@@ -698,7 +696,8 @@ class KafkaServer(
         if (alterIsrManager != null)
           CoreUtils.swallow(alterIsrManager.shutdown(), this)
 
-        CoreUtils.swallow(clientToControllerChannelManager.foreach(_.shutdown()), this)
+        if (clientToControllerChannelManager != null)
+          CoreUtils.swallow(clientToControllerChannelManager.shutdown(), this)
 
         if (logManager != null)
           CoreUtils.swallow(logManager.shutdown(), this)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -103,9 +103,7 @@ class AutoTopicCreationManagerTest {
                               replicationFactor: Short = 1): Unit = {
     autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
-      Some(brokerToController),
-      Some(adminManager),
-      Some(controller),
+      brokerToController,
       groupCoordinator,
       transactionCoordinator)
 
@@ -129,11 +127,9 @@ class AutoTopicCreationManagerTest {
 
   @Test
   def testCreateTopicsWithForwardingDisabled(): Unit = {
-    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+    autoTopicCreationManager = new ZkAutoTopicCreationManager(
       config,
-      None,
-      Some(adminManager),
-      Some(controller),
+      ZkSupport(adminManager, controller, null, None, null),
       groupCoordinator,
       transactionCoordinator)
 
@@ -314,9 +310,7 @@ class AutoTopicCreationManagerTest {
 
     autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
-      Some(brokerToController),
-      Some(adminManager),
-      Some(controller),
+      brokerToController,
       groupCoordinator,
       transactionCoordinator)
 
@@ -342,11 +336,9 @@ class AutoTopicCreationManagerTest {
                                         topicName: String,
                                         isInternal: Boolean,
                                         expectedError: Option[Errors] = None): Unit = {
-    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
+    autoTopicCreationManager = new ZkAutoTopicCreationManager(
       config,
-      None,
-      Some(adminManager),
-      Some(controller),
+      ZkSupport(adminManager, controller, null, None, null),
       groupCoordinator,
       transactionCoordinator)
 


### PR DESCRIPTION
Rather than using multiple optional class members to determine if we are in ZK or KRaft mode, use inheritance. The factory method in AutoTopicCreationManager now makes the decision about which mode we're in and provides only the needed dependencies to the concrete classes (i.e., no optionals).

```scala
object AutoTopicCreationManager {
  def apply(
    config: KafkaConfig,
    channelManager: BrokerToControllerChannelManager,
    metadataSupport: MetadataSupport,
    groupCoordinator: GroupCoordinator,
    txnCoordinator: TransactionCoordinator,
  ): AutoTopicCreationManager = {
    metadataSupport match {
      case zk: ZkSupport => new ZkAutoTopicCreationManager(config, zk, groupCoordinator, txnCoordinator)
      case _: RaftSupport => new DefaultAutoTopicCreationManager(config, channelManager, groupCoordinator, txnCoordinator)
    }
  }
}
```

This also adds some error handling to the response handler when running in KRaft mode (KAFKA-12777).