### PR TITLE
MINOR: Add @cluster annotation to StreamsNamedRepartitionTopicTest

### DIFF
--- a/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
+++ b/tests/kafkatest/tests/streams/streams_named_repartition_topic_test.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ducktape.mark.resource import cluster
 from ducktape.tests.test import Test
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsNamedRepartitionTopicService
@@ -50,6 +51,7 @@ class StreamsNamedRepartitionTopicTest(Test):
                                            throughput=1000,
                                            acks=1)
 
+    @cluster(num_nodes=8)
     def test_upgrade_topology_with_named_repartition_topic(self):
         self.zookeeper.start()
         self.kafka.start()


### PR DESCRIPTION
The StreamsNamedRepartitionTopicTest system tests did not have the `@cluster` annotation and was therefore taking up the entire cluster.  For example, we see this in the log output:

`kafkatest.tests.streams.streams_named_repartition_topic_test.StreamsNamedRepartitionTopicTest.test_upgrade_topology_with_named_repartition_topic is using entire cluster. It's possible this test has no associated cluster metadata.`

This PR adds the missing annotation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
