### PR TITLE
KAFKA-12770: introduce `checkstyleVersion` build option (for overriding CheckStyle project-defined dependency version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ You can run checkstyle using:
 
 The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` and `reports/checkstyle/reports/test.html` files in the
 subproject build directories. They are also printed to the console. The build will fail if Checkstyle fails.
+For experiments (or regression testing purposes) add -PcheckstyleVersion=8.xy (to override project-defined checkstyle version).
 
 #### Spotbugs ####
 Spotbugs uses static analysis to look for bugs in the code.
@@ -245,7 +246,7 @@ includes inlining of methods within the scala library (which avoids lambda alloc
 only safe if the Scala library version is the same at compile time and runtime. Since we cannot guarantee this for all cases (for example, users
 may depend on the kafka jar for integration tests where they may include a scala library with a different version), we don't enable it by
 default. See https://www.lightbend.com/blog/scala-inliner-optimizer for more details.
-
+* `checkstyleVersion` overrides project-defined checkstyle dependency version. See "Checkstyle" manual section for example how to use it.
 ### Dependency Analysis ###
 
 The gradle [dependency debugging documentation](https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html) mentions using the `dependencies` or `dependencyInsight` tasks to debug dependencies for the root project or individual subprojects.

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,9 @@ ext {
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
 
   commitId = project.hasProperty('commitId') ? commitId : null
+
+  // See README.md for this build option details and example of usage
+  checkstyleVersion = project.hasProperty('checkstyleVersion') ? checkstyleVersion : versions.checkstyle
 }
 
 apply from: file('wrapper.gradle')
@@ -588,7 +591,7 @@ subprojects {
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = checkstyleConfigProperties("import-control.xml")
-    toolVersion = versions.checkstyle
+    toolVersion = checkstyleVersion
   }
 
   configure(checkstyleMain) {


### PR DESCRIPTION
@ijuma please review this.

**Rationale**: Requested by CheckStyle team (@romani); they needs this in order to add Apache Kafka project into their regression suit here https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on.properties

**JIRA ticket**: https://issues.apache.org/jira/browse/KAFKA-12770

**Related PR/comment:** https://github.com/apache/kafka/pull/10656#issuecomment-835809154

@romani how to use this (hopefully this will be merged into trunk at some point):
- this command uses project-defined CheckStyle version: `./gradlew checkstyleMain checkstyleTest` 
- while this one overrides it: `./gradlew checkstyleMain checkstyleTest -PcheckstyleVersion=8.41.1`






