### PR TITLE
KAFKA-12789: Remove Stale comments for meta response handling logic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1089,8 +1089,8 @@ public class NetworkClient implements KafkaClient {
             if (!errors.isEmpty())
                 log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
 
-            // Don't update the cluster if there are no valid nodes which may happened during the startup phase of
-            // the visited node.
+            // When talking to the startup phase of a broker, it is possible to receive an empty metadata set, which
+            // we should retry later.
             if (response.brokers().isEmpty()) {
                 log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
                 this.metadata.failedUpdate(now);

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1089,8 +1089,6 @@ public class NetworkClient implements KafkaClient {
             if (!errors.isEmpty())
                 log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
 
-            // Don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
-            // created which means we will get errors and no nodes until it exists
             if (response.brokers().isEmpty()) {
                 log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
                 this.metadata.failedUpdate(now);

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -1089,6 +1089,8 @@ public class NetworkClient implements KafkaClient {
             if (!errors.isEmpty())
                 log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
 
+            // Don't update the cluster if there are no valid nodes which may happened during the startup phase of
+            // the visited node.
             if (response.brokers().isEmpty()) {
                 log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
                 this.metadata.failedUpdate(now);


### PR DESCRIPTION
According to my understanding, the following paragraph looks like a stale comments.

> public void handleSuccessfulResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
            ...
            // Don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
            // created which means we will get errors and no nodes until it exists
            if (response.brokers().isEmpty()) {
                log.trace("Ignoring empty metadata response with correlation id {}.", requestHeader.correlationId());
                this.metadata.failedUpdate(now);
            } else {
                this.metadata.update(inProgress.requestVersion, response, inProgress.isPartialUpdate, now);
            }
            ...

The comments above mean we will may get errors and no nodes if the topic we want may still be in the process of being created.
However, every meta request will return all brokers from the logic of the server side, just as followed

>   def handleTopicMetadataRequest(request: RequestChannel.Request): Unit = {
    ...
    val brokers = metadataCache.getAliveBrokers
    ...
  }


I studied the related git commit history and figured out why.

1. This comments was first introduced in KAFKA-642 (e11447650a). which means meta request only need brokers related to the topics we want.
2. KAFKA-1535 (commitId: 4ebcdfd51f) changed the server side logic. which has the metadata response contain all alive brokers rather than just the ones needed for the given topics.
3. However, this comments are retained till now.
So According to my understanding, this comments looks like a stale one and can be removed.