### PR TITLE
KAFKA-12940: Enable JDK 16 builds in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,10 +142,10 @@ pipeline {
           }
         }
 
-        stage('JDK 15 and Scala 2.13') {
+        stage('JDK 16 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {
-            jdk 'jdk_15_latest'
+            jdk 'jdk_16_latest'
           }
           options {
             timeout(time: 8, unit: 'HOURS') 
@@ -157,7 +157,7 @@ pipeline {
           steps {
             doValidation()
             doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 15'
+            echo 'Skipping Kafka Streams archetype test for Java 16'
           }
         }
 
@@ -231,14 +231,14 @@ pipeline {
           }
         }
 
-        stage('JDK 15 and Scala 2.12') {
+        stage('JDK 16 and Scala 2.12') {
           when {
             not { changeRequest() }
             beforeAgent true
           }
           agent { label 'ubuntu' }
           tools {
-            jdk 'jdk_15_latest'
+            jdk 'jdk_16_latest'
           }
           options {
             timeout(time: 8, unit: 'HOURS') 
@@ -250,7 +250,7 @@ pipeline {
           steps {
             doValidation()
             doTest(env)
-            echo 'Skipping Kafka Streams archetype test for Java 15'
+            echo 'Skipping Kafka Streams archetype test for Java 16'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,26 @@ pipeline {
           }
         }
 
+        // Remove this when all tests pass with JDK 16
+        stage('JDK 15 and Scala 2.13') {
+          agent { label 'ubuntu' }
+          tools {
+            jdk 'jdk_15_latest'
+          }
+          options {
+            timeout(time: 8, unit: 'HOURS') 
+            timestamps()
+          }
+          environment {
+            SCALA_VERSION=2.13
+          }
+          steps {
+            doValidation()
+            doTest(env)
+            echo 'Skipping Kafka Streams archetype test for Java 15'
+          }
+        }
+        
         stage('JDK 16 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
             echo 'Skipping Kafka Streams archetype test for Java 15'
           }
         }
-        
+
         stage('JDK 16 and Scala 2.13') {
           agent { label 'ubuntu' }
           tools {

--- a/build.gradle
+++ b/build.gradle
@@ -353,6 +353,23 @@ subprojects {
     }
   }
 
+  // The suites are for running sets of tests in IDEs.
+  // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
+  def testsToExclude = ['**/*Suite.class']
+  // Exclude PowerMock tests when running with Java 16 until a version of PowerMock that supports Java 16 is released
+  // The relevant issues are https://github.com/powermock/powermock/issues/1094 and https://github.com/powermock/powermock/issues/1099
+  if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
+    testsToExclude.addAll([
+            "**/AbstractHerderTest.*", "**/ErrorHandlingTaskTest.*", "**/WorkerConfigTransformerTest.*", "**/WorkerTaskTest.*",
+            "**/SourceTaskOffsetCommitterTest.*", "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
+            "**/WorkerSourceTaskTest.*", "**/WorkerGroupMemberTest.*", "**/WorkerTest.*", "**/DistributedHerderTest.*",
+            "**/ConnectClusterStateImplTest.*",
+            "**/RestServerTest.*", "**/ConnectorPluginsResourceTest.*", "**/ConnectorsResourceTest.*",
+            "**/StandaloneHerderTest.*", "**/FileOffsetBakingStoreTest.*", "**/KafkaConfigBackingStoreTest.*",
+            "**/KafkaOffsetBackingStoreTest.*", "**/OffsetStorageWriterTest.*", "**/KafkaBasedLogTest.*"
+    ])
+  }
+
   test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
     ignoreFailures = userIgnoreFailures
@@ -367,9 +384,7 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
-    // The suites are for running sets of tests in IDEs.
-    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
-    exclude '**/*Suite.class'
+    exclude testsToExclude
 
     if (shouldUseJUnit5)
       useJUnitPlatform()
@@ -395,9 +410,7 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
-    // The suites are for running sets of tests in IDEs.
-    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
-    exclude '**/*Suite.class'
+    exclude testsToExclude
 
     if (shouldUseJUnit5) {
       useJUnitPlatform {
@@ -429,9 +442,7 @@ subprojects {
     }
     logTestStdout.rehydrate(delegate, owner, this)()
 
-    // The suites are for running sets of tests in IDEs.
-    // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
-    exclude '**/*Suite.class'
+    exclude testsToExclude
 
     if (shouldUseJUnit5) {
       useJUnitPlatform {

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ ext {
   buildVersionFileName = "kafka-version.properties"
 
   defaultMaxHeapSize = "2g"
-  defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC"]
+  defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC", "--illegal-access=permit"]
 
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
   userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,9 @@ ext {
   buildVersionFileName = "kafka-version.properties"
 
   defaultMaxHeapSize = "2g"
-  defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC", "--illegal-access=permit"]
+  defaultJvmArgs = ["-Xss4m", "-XX:+UseParallelGC"]
+  if (JavaVersion.current() == JavaVersion.VERSION_16)  
+    defaultJvmArgs.add("--illegal-access=permit")
 
   userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
   userIgnoreFailures = project.hasProperty('ignoreFailures') ? ignoreFailures : false

--- a/build.gradle
+++ b/build.gradle
@@ -360,13 +360,17 @@ subprojects {
   // The relevant issues are https://github.com/powermock/powermock/issues/1094 and https://github.com/powermock/powermock/issues/1099
   if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_16)) {
     testsToExclude.addAll([
-            "**/AbstractHerderTest.*", "**/ErrorHandlingTaskTest.*", "**/WorkerConfigTransformerTest.*", "**/WorkerTaskTest.*",
-            "**/SourceTaskOffsetCommitterTest.*", "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
-            "**/WorkerSourceTaskTest.*", "**/WorkerGroupMemberTest.*", "**/WorkerTest.*", "**/DistributedHerderTest.*",
-            "**/ConnectClusterStateImplTest.*",
-            "**/RestServerTest.*", "**/ConnectorPluginsResourceTest.*", "**/ConnectorsResourceTest.*",
-            "**/StandaloneHerderTest.*", "**/FileOffsetBakingStoreTest.*", "**/KafkaConfigBackingStoreTest.*",
-            "**/KafkaOffsetBackingStoreTest.*", "**/OffsetStorageWriterTest.*", "**/KafkaBasedLogTest.*"
+      // connect tests
+      "**/AbstractHerderTest.*", "**/ConnectClusterStateImplTest.*", "**/ConnectorPluginsResourceTest.*",
+      "**/ConnectorsResourceTest.*", "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
+      "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
+      "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*", 
+      "**/SourceTaskOffsetCommitterTest.*", "**/WorkerConfigTransformerTest.*", "**/WorkerGroupMemberTest.*",
+      "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*", "**/WorkerSourceTaskTest.*",
+      "**/WorkerTaskTest.*", "**/WorkerTest.*", "**/RestServerTest.*",
+      // streams tests
+      "**/KafkaStreamsTest.*", "**/RepartitionTopicsTest.*", "**/RocksDBMetricsRecorderTest.*",
+      "**/StreamsMetricsImplTest.*", "**/StateManagerUtilTest.*", "**/TableSourceNodeTest.*"
     ])
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -366,7 +366,7 @@ subprojects {
       "**/AbstractHerderTest.*", "**/ConnectClusterStateImplTest.*", "**/ConnectorPluginsResourceTest.*",
       "**/ConnectorsResourceTest.*", "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
       "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
-      "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*", 
+      "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",
       "**/SourceTaskOffsetCommitterTest.*", "**/WorkerConfigTransformerTest.*", "**/WorkerGroupMemberTest.*",
       "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*", "**/WorkerSourceTaskTest.*",
       "**/WorkerTaskTest.*", "**/WorkerTest.*", "**/RestServerTest.*",

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -36,6 +36,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -591,7 +593,7 @@ public class SslTransportLayerTest {
     }
 
     /**
-     * Tests that connection success with the default TLS version.
+     * Tests that connection succeeds with the default TLS version.
      */
     @ParameterizedTest
     @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
@@ -611,12 +613,6 @@ public class SslTransportLayerTest {
         NetworkTestUtils.checkClientConnection(selector, "0", 10, 100);
         server.verifyAuthenticationMetrics(1, 0);
         selector.close();
-
-        checkAuthenticationFailed(args, "1", "TLSv1.1");
-        server.verifyAuthenticationMetrics(1, 1);
-
-        checkAuthenticationFailed(args, "2", "TLSv1");
-        server.verifyAuthenticationMetrics(1, 2);
     }
 
     /** Checks connection failed using the specified {@code tlsVersion}. */
@@ -636,12 +632,15 @@ public class SslTransportLayerTest {
      */
     @ParameterizedTest
     @ArgumentsSource(SslTransportLayerArgumentsProvider.class)
-    public void testUnsupportedTLSVersion(Args args) throws Exception {
-        args.sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
+    @DisabledOnJre(JRE.JAVA_16)
+    public void testUnsupportedTlsVersion(Args args) throws Exception {
         server = createEchoServer(args, SecurityProtocol.SSL);
 
         checkAuthenticationFailed(args, "0", "TLSv1.1");
         server.verifyAuthenticationMetrics(0, 1);
+
+        checkAuthenticationFailed(args, "0", "TLSv1");
+        server.verifyAuthenticationMetrics(0, 2);
     }
 
     /**


### PR DESCRIPTION
JDK 15 no longer receives updates, so we want to switch from JDK 15 to JDK 16.
However, we have a number of tests that don't yet pass with JDK 16.

Instead of replacing JDK 15 with JDK 16, we have both for now and we either
disable (via annotations) or exclude (via gradle) the tests that don't pass with
JDK 16 yet. The annotations approach is better, but it doesn't work for tests
that rely on the PowerMock JUnit 4 runner.

Also add `--illegal-access=permit` when building with JDK 16 to make MiniKdc
work for now. This has been removed in JDK 17, so we'll have to figure out
another solution when we migrate to that.

Relevant JIRAs for the disabled tests: KAFKA-12790, KAFKA-12941, KAFKA-12942.

Moved some assertions from `testTlsDefaults` to `testUnsupportedTlsVersion`
since the former claims to test the success case while the former tests the failure case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
