### PR TITLE
KAFKA-12791: ConcurrentModificationException in AbstractConfig use by KafkaProducer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -43,8 +43,12 @@ public class AbstractConfig {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    /* configs for which values have been requested, used to detect unused configs */
-    private final Set<String> used;
+    /**
+     * Configs for which values have been requested, used to detect unused configs.
+     * This set must be concurrent modifiable and iterable. It will be modified
+     * when directly accessed or as a result of RecordingMap access.
+     */
+    private final Set<String> used = ConcurrentHashMap.newKeySet();
 
     /* the original values passed in by the user */
     private final Map<String, ?> originals;
@@ -107,7 +111,6 @@ public class AbstractConfig {
 
         this.originals = resolveConfigVariables(configProviderProps, (Map<String, Object>) originals);
         this.values = definition.parse(this.originals);
-        this.used = ConcurrentHashMap.newKeySet();
         Map<String, Object> configUpdates = postProcessParsedConfig(Collections.unmodifiableMap(this.values));
         for (Map.Entry<String, Object> update : configUpdates.entrySet()) {
             this.values.put(update.getKey(), update.getValue());

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * A convenient base class for configurations to extend.
@@ -106,7 +107,7 @@ public class AbstractConfig {
 
         this.originals = resolveConfigVariables(configProviderProps, (Map<String, Object>) originals);
         this.values = definition.parse(this.originals);
-        this.used = Collections.synchronizedSet(new HashSet<>());
+        this.used = new CopyOnWriteArraySet<>();
         Map<String, Object> configUpdates = postProcessParsedConfig(Collections.unmodifiableMap(this.values));
         for (Map.Entry<String, Object> update : configUpdates.entrySet()) {
             this.values.put(update.getKey(), update.getValue());

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A convenient base class for configurations to extend.
@@ -107,7 +107,7 @@ public class AbstractConfig {
 
         this.originals = resolveConfigVariables(configProviderProps, (Map<String, Object>) originals);
         this.values = definition.parse(this.originals);
-        this.used = new CopyOnWriteArraySet<>();
+        this.used = ConcurrentHashMap.newKeySet();
         Map<String, Object> configUpdates = postProcessParsedConfig(Collections.unmodifiableMap(this.values));
         for (Map.Entry<String, Object> update : configUpdates.entrySet()) {
             this.values.put(update.getKey(), update.getValue());

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -514,7 +514,7 @@ public class AbstractConfigTest {
         ConfigDef configDef = new ConfigDef();
         Properties props = new Properties();
         for (int i = 0; i < 1000; i++) {
-            String prop = "a"+i;
+            String prop = "a" + i;
             configDef.define(prop,
                     Type.LIST,
                     "",
@@ -525,7 +525,7 @@ public class AbstractConfigTest {
         AbstractConfig config = new AbstractConfig(configDef, props);
         AtomicBoolean error = new AtomicBoolean(false);
         Thread t1 = new Thread("unused") {
-            public void run(){
+            public void run() {
                 for (int i = 0; i < 1000; i++) {
                     try {
                         config.unused();


### PR DESCRIPTION
Recently we have noticed multiple instances where KafkaProducers have failed to constructer due to the following exception:

```
org.apache.kafka.common.KafkaException: Failed to construct kafka producer at 
org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:440) at 
org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:291) at 
org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:318) 
java.base/java.lang.Thread.run(Thread.java:832) Caused by: java.util.ConcurrentModificationException at 
java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1584) at 
java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1607) at 
java.base/java.util.AbstractSet.removeAll(AbstractSet.java:171) at 
org.apache.kafka.common.config.AbstractConfig.unused(AbstractConfig.java:221) at 
org.apache.kafka.common.config.AbstractConfig.logUnused(AbstractConfig.java:379) at 
org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:433) ... 9 more 
exception.class:org.apache.kafka.common.KafkaException exception.message:Failed to construct kafka producer
```

This is due to the fact that `used` below is a synchronized set. `used` is being modified while removeAll is being called. This is due to the use of RecordingMap in the Sender thread (see below). Switching to a ConcurrentHashSet avoids this issue as it support concurrent iteration.

```
	at org.apache.kafka.clients.producer.ProducerConfig.ignore(ProducerConfig.java:569)
	at org.apache.kafka.common.config.AbstractConfig$RecordingMap.get(AbstractConfig.java:638)
	at org.apache.kafka.common.network.ChannelBuilders.createPrincipalBuilder(ChannelBuilders.java:242)
	at org.apache.kafka.common.network.PlaintextChannelBuilder$PlaintextAuthenticator.<init>(PlaintextChannelBuilder.java:96)
	at org.apache.kafka.common.network.PlaintextChannelBuilder$PlaintextAuthenticator.<init>(PlaintextChannelBuilder.java:89)
	at org.apache.kafka.common.network.PlaintextChannelBuilder.lambda$buildChannel$0(PlaintextChannelBuilder.java:66)
	at org.apache.kafka.common.network.KafkaChannel.<init>(KafkaChannel.java:174)
	at org.apache.kafka.common.network.KafkaChannel.<init>(KafkaChannel.java:164)
	at org.apache.kafka.common.network.PlaintextChannelBuilder.buildChannel(PlaintextChannelBuilder.java:79)
	at org.apache.kafka.common.network.PlaintextChannelBuilder.buildChannel(PlaintextChannelBuilder.java:67)
	at org.apache.kafka.common.network.Selector.buildAndAttachKafkaChannel(Selector.java:356)
	at org.apache.kafka.common.network.Selector.registerChannel(Selector.java:347)
	at org.apache.kafka.common.network.Selector.connect(Selector.java:274)
	at org.apache.kafka.clients.NetworkClient.initiateConnect(NetworkClient.java:1097)
	at org.apache.kafka.clients.NetworkClient.access$700(NetworkClient.java:87)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1276)
	at org.apache.kafka.clients.NetworkClient$DefaultMetadataUpdater.maybeUpdate(NetworkClient.java:1164)
	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:637)
	at org.apache.kafka.clients.producer.internals.Sender.runOnce(Sender.java:327)
	at org.apache.kafka.clients.producer.internals.Sender.run(Sender.java:242)
```