### PR TITLE
KAFKA-12792: Fix metrics bug and introduce TimelineInteger

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
@@ -33,6 +33,8 @@ import org.slf4j.Logger;
  * Therefore, we use ArrayLists here rather than a data structure with higher overhead.
  */
 public class SnapshotRegistry {
+    public final static long LATEST_EPOCH = Long.MAX_VALUE;
+
     /**
      * Iterate through the list of snapshots in order of creation, such that older
      * snapshots come first.

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.timeline;
+
+import java.util.Iterator;
+
+
+/**
+ * This is a mutable integer which can be snapshotted. 
+ *
+ * This class requires external synchronization.
+ */
+public class TimelineInteger implements Revertable {
+    static class IntegerContainer implements Delta {
+        private int value = 0;
+
+        int value() {
+            return value;
+        }
+
+        void setValue(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public void mergeFrom(long destinationEpoch, Delta delta) {
+            // Nothing to do
+        }
+    }
+
+    private final SnapshotRegistry snapshotRegistry;
+    private int value;
+
+    public TimelineInteger(SnapshotRegistry snapshotRegistry) {
+        this.snapshotRegistry = snapshotRegistry;
+        this.value = 0;
+    }
+
+    public int get() {
+        return value;
+    }
+
+    public int get(long epoch) {
+        if (epoch == SnapshotRegistry.LATEST_EPOCH) return value;
+        Iterator<Snapshot> iterator = snapshotRegistry.iterator(epoch);
+        while (iterator.hasNext()) {
+            Snapshot snapshot = iterator.next();
+            IntegerContainer container = snapshot.getDelta(TimelineInteger.this);
+            if (container != null) return container.value();
+        }
+        return value;
+    }
+
+    public void set(int newValue) {
+        Iterator<Snapshot> iterator = snapshotRegistry.reverseIterator();
+        if (iterator.hasNext()) {
+            Snapshot snapshot = iterator.next();
+            IntegerContainer container = snapshot.getDelta(TimelineInteger.this);
+            if (container == null) {
+                container = new IntegerContainer();
+                snapshot.setDelta(TimelineInteger.this, container);
+                container.setValue(value);
+            }
+        }
+        this.value = newValue;
+    }
+
+    public void increment() {
+        set(get() + 1);
+    }
+
+    public void decrement() {
+        set(get() - 1);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void executeRevert(long targetEpoch, Delta delta) {
+        IntegerContainer container = (IntegerContainer) delta;
+        this.value = container.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TimelineInteger)) return false;
+        TimelineInteger other = (TimelineInteger) o;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return Integer.toString(value);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.timeline;
+
+import java.util.Iterator;
+
+
+/**
+ * This is a mutable long which can be snapshotted.
+ *
+ * This class requires external synchronization.
+ */
+public class TimelineLong implements Revertable {
+    static class LongContainer implements Delta {
+        private long value = 0;
+
+        long value() {
+            return value;
+        }
+
+        void setValue(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public void mergeFrom(long destinationEpoch, Delta delta) {
+            // Nothing to do
+        }
+    }
+
+    private final SnapshotRegistry snapshotRegistry;
+    private long value;
+
+    public TimelineLong(SnapshotRegistry snapshotRegistry) {
+        this.snapshotRegistry = snapshotRegistry;
+        this.value = 0;
+    }
+
+    public long get() {
+        return value;
+    }
+
+    public long get(long epoch) {
+        if (epoch == SnapshotRegistry.LATEST_EPOCH) return value;
+        Iterator<Snapshot> iterator = snapshotRegistry.iterator(epoch);
+        while (iterator.hasNext()) {
+            Snapshot snapshot = iterator.next();
+            LongContainer container = snapshot.getDelta(TimelineLong.this);
+            if (container != null) return container.value();
+        }
+        return value;
+    }
+
+    public void set(long newValue) {
+        Iterator<Snapshot> iterator = snapshotRegistry.reverseIterator();
+        if (iterator.hasNext()) {
+            Snapshot snapshot = iterator.next();
+            LongContainer prevContainer = snapshot.getDelta(TimelineLong.this);
+            if (prevContainer == null) {
+                prevContainer = new LongContainer();
+                snapshot.setDelta(TimelineLong.this, prevContainer);
+                prevContainer.setValue(value);
+            }
+        }
+        this.value = newValue;
+    }
+
+    public void increment() {
+        set(get() + 1L);
+    }
+
+    public void decrement() {
+        set(get() - 1L);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void executeRevert(long targetEpoch, Delta delta) {
+        LongContainer container = (LongContainer) delta;
+        this.value = container.value();
+    }
+
+    @Override
+    public int hashCode() {
+        return ((int) value) ^ (int) (value >>> 32);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TimelineLong)) return false;
+        TimelineLong other = (TimelineLong) o;
+        return value == other.value;
+    }
+
+    @Override
+    public String toString() {
+        return Long.toString(value);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.timeline;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class TimelineIntegerTest {
+    @Test
+    public void testModifyValue() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineInteger integer = new TimelineInteger(registry);
+        assertEquals(0, integer.get());
+        assertEquals(0, integer.get(Long.MAX_VALUE));
+        integer.set(1);
+        integer.set(2);
+        assertEquals(2, integer.get());
+        assertEquals(2, integer.get(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testToStringAndEquals() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineInteger integer = new TimelineInteger(registry);
+        assertEquals("0", integer.toString());
+        integer.set(1);
+        TimelineInteger integer2 = new TimelineInteger(registry);
+        integer2.set(1);
+        assertEquals("1", integer2.toString());
+        assertEquals(integer, integer2);
+    }
+
+    @Test
+    public void testSnapshot() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineInteger integer = new TimelineInteger(registry);
+        registry.createSnapshot(2);
+        integer.set(1);
+        registry.createSnapshot(3);
+        integer.set(2);
+        integer.increment();
+        integer.increment();
+        integer.decrement();
+        registry.createSnapshot(4);
+        assertEquals(0, integer.get(2));
+        assertEquals(1, integer.get(3));
+        assertEquals(3, integer.get(4));
+        registry.revertToSnapshot(3);
+        assertEquals(1, integer.get());
+        registry.revertToSnapshot(2);
+        assertEquals(0, integer.get());
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.timeline;
+
+import org.apache.kafka.common.utils.LogContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class TimelineLongTest {
+    @Test
+    public void testModifyValue() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineLong value = new TimelineLong(registry);
+        assertEquals(0L, value.get());
+        assertEquals(0L, value.get(Long.MAX_VALUE));
+        value.set(1L);
+        value.set(Long.MAX_VALUE);
+        assertEquals(Long.MAX_VALUE, value.get());
+        assertEquals(Long.MAX_VALUE, value.get(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testToStringAndEquals() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineLong value = new TimelineLong(registry);
+        assertEquals("0", value.toString());
+        value.set(1L);
+        TimelineLong integer2 = new TimelineLong(registry);
+        integer2.set(1);
+        assertEquals("1", integer2.toString());
+        assertEquals(value, integer2);
+    }
+
+    @Test
+    public void testSnapshot() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        TimelineLong value = new TimelineLong(registry);
+        registry.createSnapshot(2);
+        value.set(1L);
+        registry.createSnapshot(3);
+        value.set(2L);
+        value.increment();
+        value.increment();
+        value.decrement();
+        registry.createSnapshot(4);
+        assertEquals(0L, value.get(2));
+        assertEquals(1L, value.get(3));
+        assertEquals(3L, value.get(4));
+        registry.revertToSnapshot(3);
+        assertEquals(1L, value.get());
+        registry.revertToSnapshot(2);
+        assertEquals(0L, value.get());
+    }
+}


### PR DESCRIPTION
Introduce a TimelineInteger class which represents a single integer
value which can be changed while maintaining snapshot consistency. Fix a
case where a metric value would be corrupted after a snapshot restore.