### PR TITLE
KAFKA-12794: Fix trailing json tokens in DescribeProducersRequest.json

### DIFF
--- a/clients/src/main/resources/common/message/DescribeProducersRequest.json
+++ b/clients/src/main/resources/common/message/DescribeProducersRequest.json
@@ -21,11 +21,11 @@
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
-      { "name": "Topics", "type": "[]TopicRequest", "versions": "0+", "fields": [
-        { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
-          "about": "The topic name." },
-        { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
-          "about": "The indexes of the partitions to list producers for." }
-       ]}
+    { "name": "Topics", "type": "[]TopicRequest", "versions": "0+", "fields": [
+      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+        "about": "The topic name." },
+      { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
+        "about": "The indexes of the partitions to list producers for." }
+     ]}
   ]
 }

--- a/clients/src/main/resources/common/message/DescribeProducersRequest.json
+++ b/clients/src/main/resources/common/message/DescribeProducersRequest.json
@@ -27,6 +27,5 @@
         { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
           "about": "The indexes of the partitions to list producers for." }
        ]}
-    ]}
   ]
 }


### PR DESCRIPTION
The schema definition for the DescribeProducersRequest see [here](https://github.com/apache/kafka/blob/3b6599c600f6e7fbeb000a088591f1cf9aba107d/clients/src/main/resources/common/message/DescribeProducersRequest.json) has trailing tokens - specifically, the last two lines in the commit in that link.

This does not cause problems for the generator, because Jackson will ignore trailing input by default.

However, some JSON parsers cannot be configured to ignore trailing characters, and so they fail on that file. This can cause problems for users wishing to use the official schema definitions to generate clients in other languages.

The fix here is pretty simple - just remove the trailing tokens, and optionally configure jackson to fail on trailing tokens. This patch is for the former, and I'll be happy to submit a patch that configures jackson so this won't happen again :).


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
