### PR TITLE
KAFKA-12798: Fixing MM2 rebalance timeout issue when source cluster is not available

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorConnectorConfig.java
@@ -198,6 +198,10 @@ public class MirrorConnectorConfig extends AbstractConfig {
             + " properties to replicate.";
     public static final Class<?> CONFIG_PROPERTY_FILTER_CLASS_DEFAULT = DefaultConfigPropertyFilter.class;
 
+    private static final String SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_CONFIG = "source.cluster.start.task.timeout";
+    private static final String SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_DOC = "Milliseconds to wait for tasks that affects source cluster at startup";
+    private static final long SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_DEFAULT = 15000;
+
     public static final String OFFSET_LAG_MAX = "offset.lag.max";
     private static final String OFFSET_LAG_MAX_DOC = "How out-of-sync a remote partition can be before it is resynced.";
     public static final long OFFSET_LAG_MAX_DEFAULT = 100L;
@@ -235,6 +239,10 @@ public class MirrorConnectorConfig extends AbstractConfig {
 
     Duration adminTimeout() {
         return Duration.ofMillis(getLong(ADMIN_TASK_TIMEOUT_MILLIS));
+    }
+
+    Duration sourceClusterTaskStartTimeout() {
+        return Duration.ofMillis(getLong(SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_CONFIG));
     }
 
     Map<String, Object> sourceProducerConfig() {
@@ -666,6 +674,11 @@ public class MirrorConnectorConfig extends AbstractConfig {
                     CommonClientConfigs.DEFAULT_SECURITY_PROTOCOL,
                     ConfigDef.Importance.MEDIUM,
                     CommonClientConfigs.SECURITY_PROTOCOL_DOC)
+            .define(SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_CONFIG,
+                    ConfigDef.Type.LONG,
+                    SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_DEFAULT,
+                    ConfigDef.Importance.MEDIUM,
+                    SOURCE_CLUSTER_START_TASK_TIMEOUT_MILLISECOND_DOC)
             .withClientSslSupport()
             .withClientSaslSupport();
 }

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -42,6 +42,7 @@ import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
@@ -115,9 +116,11 @@ public class MirrorSourceConnector extends SourceConnector {
         replicationFactor = config.replicationFactor();
         sourceAdminClient = AdminClient.create(config.sourceAdminConfig());
         targetAdminClient = AdminClient.create(config.targetAdminConfig());
-        scheduler = new Scheduler(MirrorSourceConnector.class, config.adminTimeout());
-        scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
-        scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
+        // Number of threads is 3, because there are 2 tasks affecting the source cluster, which can block longer, and 1 thread is given for the other tasks
+        scheduler = new Scheduler(MirrorSourceConnector.class, config.adminTimeout(), 3);
+        Duration sourceClusterTaskStartTimeout = config.sourceClusterTaskStartTimeout();
+        scheduler.executeWithTimeout(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic", sourceClusterTaskStartTimeout);
+        scheduler.executeWithTimeout(this::loadTopicPartitions, "loading initial set of topic-partitions", sourceClusterTaskStartTimeout);
         scheduler.execute(this::computeAndCreateTopicPartitions, "creating downstream topic-partitions");
         scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
         scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/Scheduler.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/Scheduler.java
@@ -30,17 +30,22 @@ class Scheduler implements AutoCloseable {
     private static Logger log = LoggerFactory.getLogger(Scheduler.class);
 
     private final String name;
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executor;
     private final Duration timeout;
     private boolean closed = false;
 
-    Scheduler(String name, Duration timeout) {
+    Scheduler(String name, Duration timeout, int numberOfThreads) {
         this.name = name;
         this.timeout = timeout;
+        executor = Executors.newScheduledThreadPool(numberOfThreads);
     }
 
-    Scheduler(Class<?> clazz, Duration timeout) {
-        this("Scheduler for " + clazz.getSimpleName(), timeout);
+    Scheduler(Class clazz, Duration timeout, int numberOfThreads) {
+        this("Scheduler for " + clazz.getSimpleName(), timeout, numberOfThreads);
+    }
+
+    Scheduler(Class clazz, Duration timeout) {
+        this("Scheduler for " + clazz.getSimpleName(), timeout, 1);
     }
 
     void scheduleRepeating(Task task, Duration interval, String description) {
@@ -58,7 +63,7 @@ class Scheduler implements AutoCloseable {
             interval.toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    void execute(Task task, String description) {
+    void executeWithTimeout(Task task, String description, Duration timeout) {
         try {
             executor.submit(() -> executeThread(task, description)).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
@@ -68,7 +73,11 @@ class Scheduler implements AutoCloseable {
         } catch (Throwable e) {
             log.error("{} caught exception in task: {}", name, description, e);
         }
-    } 
+    }
+
+    void execute(Task task, String description) {
+        executeWithTimeout(task, description, timeout);
+    }
 
     public void close() {
         closed = true;


### PR DESCRIPTION
If the network configuration of a source cluster which is taking part in a replication flow is changed (change of port number, if, for instance TLS is enabled or disabled) MirrorMaker2 won't update its internal configuration even after a reconfiguration followed by a restart.

What happens in MirrorMaker2 after a cluster "identity" (i.e. connectivity config) changes:

1. MM2 driver (MirrorMaker class) starts up with the new config.
2. DistributedHerder joins a dedicated consumer group that decides which driver instance has control over the assignments and the configuration topic.
3. The driver caches the consumer group assignment, which indicates that it is the leader of the group.
4. The driver reads the configuration topic (which is still not containing the new config), and starts the mm connectors.
5. Since the old config is invalid, the connectors cannot connect to the cluster anymore - MirrorSourceConnector tries to query the cluster through the admin client, but the queries time out after 2 minutes (it contains 2 tasks affecting the source cluster, the timeout is 1 minute for both).
In the meantime, the background heartbeat thread checks on the state of the herder consumer membership. There is a default rebalance timeout of 1 minute. Since the herder thread was blocked due to the connector query timeouts, it wasn't able to call poll on the consumer. Heartbeat thread invalidates the consumer membership and triggers a new consumer creation.
6. The herder thread finishes the connector startup, and after realizing that the configuration has changed, tries to update the config topic.

The config topic can only be updated by the leader herder.
The driver checks the group assignment to see if it is the leader.
In the local cache, the old assignment is present, in which the leader is the previous consumer with its own ID.
The current consumer ID of the driver does not match the cached leader ID.

7. The driver refuses to update the config topic.

**The proposed fix for this:**
The rebalance issue can be fixed by decreasing the time that we wait for tasks that affects the source cluster at the start of MM2. By decreasing the timeout (from 1 minute to 15 seconds by default), if the kafka config is old, the tasks affecting the source cluster won't block for too long. With this the herder will be able to update the config topic. This timout is configurable now and defaults to 15 seconds.

Also needed to increase the number of threads in the scheduler so that other tasks won't be blocked.

**Testing done:**

-  configure replication between source->target
-  checked that the replication is working
-  change source kafka cluster broker port
-  restart kafka/mirrormaker2, produced new messages in the replicated topic
-  after the restart mm2 was trying to use the old kafka configs, and even after a long time, it couldn't replicate. After applying the fix, the issue was solved, replication worked.

Also tested with the same scenario, but instead of changing the port, ssl was turned on the source kafka cluster.
