### PR TITLE
optimize offset reset strategy and fix lose data when add partition

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3939,7 +3939,8 @@ public class KafkaAdminClient extends AdminClient {
                 ListOffsetRequest.Builder createRequest(int timeoutMs) {
                     return ListOffsetRequest.Builder
                             .forConsumer(true, context.options().isolationLevel())
-                            .setTargetTimes(partitionsToQuery);
+                            .setTargetTimes(partitionsToQuery)
+                            .setLimitTimeStamp(ListOffsetRequest.UNLIMITED_TIMESTAMP);
                 }
 
                 @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -127,6 +127,13 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String AUTO_OFFSET_RESET_DOC = "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): <ul><li>earliest: automatically reset the offset to the earliest offset<li>latest: automatically reset the offset to the latest offset</li><li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li><li>anything else: throw exception to the consumer.</li></ul>";
 
     /**
+     * <code>nearest.offset.reset</code>
+     */
+    public static final String NEAREST_OFFSET_RESET_CONFIG = "nearest.offset.reset";
+    private static final String NEAREST_OFFSET_RESET_DOC = "If true, then out of range errors will reset the consumer's offset to the nearest offset. to the earliest end of the broker range if it was under the range, or to the latest end of the broker range if it was over the range";
+    public static final boolean DEFAULT_NEAREST_OFFSET_RESET = false;
+
+    /**
      * <code>fetch.min.bytes</code>
      */
     public static final String FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
@@ -426,9 +433,14 @@ public class ConsumerConfig extends AbstractConfig {
                                 .define(AUTO_OFFSET_RESET_CONFIG,
                                         Type.STRING,
                                         "latest",
-                                        in("latest", "earliest", "none"),
+                                        in("latest", "earliest", "none", "latest-on-start", "earliest-on-start"),
                                         Importance.MEDIUM,
                                         AUTO_OFFSET_RESET_DOC)
+                                .define(NEAREST_OFFSET_RESET_CONFIG,
+                                        Type.BOOLEAN,
+                                        DEFAULT_NEAREST_OFFSET_RESET,
+                                        Importance.MEDIUM,
+                                        NEAREST_OFFSET_RESET_DOC)
                                 .define(CHECK_CRCS_CONFIG,
                                         Type.BOOLEAN,
                                         true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.InvalidOffsetResetStrategyException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.JmxReporter;
@@ -780,6 +781,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                         config.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG),
                         this.interceptors,
                         config.getBoolean(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED));
+
+            long createTimeStamp = System.currentTimeMillis();
+            validateOffsetResetStrategy(offsetResetStrategy, config.getBoolean(ConsumerConfig.NEAREST_OFFSET_RESET_CONFIG));
             this.fetcher = new Fetcher<>(
                     logContext,
                     this.client,
@@ -800,6 +804,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.retryBackoffMs,
                     this.requestTimeoutMs,
                     isolationLevel,
+                    config.getBoolean(ConsumerConfig.NEAREST_OFFSET_RESET_CONFIG),
+                    createTimeStamp,
                     apiVersions);
 
             this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, metricGrpPrefix);
@@ -2471,6 +2477,15 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private void updateLastSeenEpochIfNewer(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
         if (offsetAndMetadata != null)
             offsetAndMetadata.leaderEpoch().ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(topicPartition, epoch));
+    }
+
+    private void validateOffsetResetStrategy(OffsetResetStrategy offsetResetStrategy, boolean useNearestOffsetReset) {
+        if (offsetResetStrategy == OffsetResetStrategy.EARLIEST_ON_START || offsetResetStrategy == OffsetResetStrategy.LATEST_ON_START) {
+            if (useNearestOffsetReset) {
+                throw new InvalidOffsetResetStrategyException("Can not use nearest when out-of-range, if offset " +
+                        "reset strategy is EARLIEST_ON_START or LATEST_ON_START.");
+            }
+        }
     }
 
     // Visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -501,11 +501,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private void resetOffsetPosition(TopicPartition tp) {
         OffsetResetStrategy strategy = subscriptions.resetStrategy(tp);
         Long offset;
-        if (strategy == OffsetResetStrategy.EARLIEST) {
+        if (strategy == OffsetResetStrategy.EARLIEST || strategy == OffsetResetStrategy.EARLIEST_ON_START) {
             offset = beginningOffsets.get(tp);
             if (offset == null)
                 throw new IllegalStateException("MockConsumer didn't have beginning offset specified, but tried to seek to beginning");
-        } else if (strategy == OffsetResetStrategy.LATEST) {
+        } else if (strategy == OffsetResetStrategy.LATEST || strategy == OffsetResetStrategy.LATEST_ON_START) {
             offset = endOffsets.get(tp);
             if (offset == null)
                 throw new IllegalStateException("MockConsumer didn't have end offset specified, but tried to seek to end");

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidOffsetResetStrategyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidOffsetResetStrategyException.java
@@ -14,8 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.clients.consumer;
+package org.apache.kafka.common.errors;
 
-public enum OffsetResetStrategy {
-    LATEST, EARLIEST, NONE, NEAREST, LATEST_ON_START, EARLIEST_ON_START
+public class InvalidOffsetResetStrategyException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidOffsetResetStrategyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidOffsetResetStrategyException(String message) {
+        super(message);
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -129,9 +129,11 @@ public class ListOffsetResponse extends AbstractResponse {
 
     private static final Schema LIST_OFFSET_RESPONSE_V5 = LIST_OFFSET_RESPONSE_V4;
 
+    private static final Schema LIST_OFFSET_RESPONSE_V6 = LIST_OFFSET_RESPONSE_V5;
+
     public static Schema[] schemaVersions() {
         return new Schema[] {LIST_OFFSET_RESPONSE_V0, LIST_OFFSET_RESPONSE_V1, LIST_OFFSET_RESPONSE_V2,
-            LIST_OFFSET_RESPONSE_V3, LIST_OFFSET_RESPONSE_V4, LIST_OFFSET_RESPONSE_V5};
+            LIST_OFFSET_RESPONSE_V3, LIST_OFFSET_RESPONSE_V4, LIST_OFFSET_RESPONSE_V5, LIST_OFFSET_RESPONSE_V6};
     }
 
     public static final class PartitionData {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2226,6 +2226,8 @@ public class KafkaConsumerTest {
         int maxPollRecords = Integer.MAX_VALUE;
         boolean checkCrcs = true;
         int rebalanceTimeoutMs = 60000;
+        boolean nearestOffsetReset = false;
+        long createTimestamp = System.currentTimeMillis();
 
         Deserializer<String> keyDeserializer = new StringDeserializer();
         Deserializer<String> valueDeserializer = new StringDeserializer();
@@ -2280,6 +2282,8 @@ public class KafkaConsumerTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 IsolationLevel.READ_UNCOMMITTED,
+                nearestOffsetReset,
+                createTimestamp,
                 new ApiVersions());
 
         return new KafkaConsumer<>(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -165,6 +165,8 @@ public class FetcherTest {
     private FetcherMetricsRegistry metricsRegistry;
     private MockClient client;
     private Metrics metrics;
+    private boolean nearestOffsetReset = false;
+    private long createTimeStamp = System.currentTimeMillis();
     private ApiVersions apiVersions = new ApiVersions();
     private ConsumerNetworkClient consumerClient;
     private Fetcher<?, ?> fetcher;
@@ -3244,6 +3246,8 @@ public class FetcherTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 IsolationLevel.READ_UNCOMMITTED,
+                nearestOffsetReset,
+                createTimeStamp,
                 apiVersions) {
             @Override
             protected FetchSessionHandler sessionHandler(int id) {
@@ -4434,6 +4438,8 @@ public class FetcherTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 isolationLevel,
+                nearestOffsetReset,
+                createTimeStamp,
                 apiVersions);
     }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -979,11 +979,13 @@ class KafkaApis(val requestChannel: RequestChannel,
             Some(offsetRequest.isolationLevel)
           else
             None
+          val limitTimeStamp = offsetRequest.limitTimeStamp
 
           val foundOpt = replicaManager.fetchOffsetForTimestamp(topicPartition,
             partitionData.timestamp,
             isolationLevelOpt,
             partitionData.currentLeaderEpoch,
+            limitTimeStamp,
             fetchOnlyFromLeader)
 
           val response = foundOpt match {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -232,6 +232,7 @@ class ReplicaFetcherThread(name: String,
     val requestPartitions = Map(topicPartition -> requestPartitionData)
     val requestBuilder = ListOffsetRequest.Builder.forReplica(listOffsetRequestVersion, replicaId)
       .setTargetTimes(requestPartitions.asJava)
+      .setLimitTimeStamp(ListOffsetRequest.UNLIMITED_TIMESTAMP)
 
     val clientResponse = leaderEndpoint.sendRequest(requestBuilder)
     val response = clientResponse.responseBody.asInstanceOf[ListOffsetResponse]

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -921,9 +921,10 @@ class ReplicaManager(val config: KafkaConfig,
                               timestamp: Long,
                               isolationLevel: Option[IsolationLevel],
                               currentLeaderEpoch: Optional[Integer],
+                              limitTimeStamp: Long,
                               fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
     val partition = getPartitionOrException(topicPartition, expectLeader = fetchOnlyFromLeader)
-    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
+    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, limitTimeStamp, fetchOnlyFromLeader)
   }
 
   def legacyFetchOffsetsForTimestamp(topicPartition: TopicPartition,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -389,6 +389,7 @@ class PartitionTest extends AbstractPartitionTest {
         partition.fetchOffsetForTimestamp(0L,
           isolationLevel = None,
           currentLeaderEpoch = currentLeaderEpochOpt,
+          System.currentTimeMillis(),
           fetchOnlyFromLeader = true)
         if (error != Errors.NONE)
           fail(s"Expected readRecords to fail with error $error")
@@ -416,6 +417,7 @@ class PartitionTest extends AbstractPartitionTest {
         partition.fetchOffsetForTimestamp(0L,
           isolationLevel = None,
           currentLeaderEpoch = currentLeaderEpochOpt,
+          System.currentTimeMillis(),
           fetchOnlyFromLeader = fetchOnlyLeader)
         if (error != Errors.NONE)
           fail(s"Expected readRecords to fail with error $error")
@@ -444,6 +446,7 @@ class PartitionTest extends AbstractPartitionTest {
     val timestampAndOffsetOpt = partition.fetchOffsetForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP,
       isolationLevel = None,
       currentLeaderEpoch = Optional.empty(),
+      System.currentTimeMillis(),
       fetchOnlyFromLeader = true)
 
     assertTrue(timestampAndOffsetOpt.isDefined)
@@ -512,6 +515,7 @@ class PartitionTest extends AbstractPartitionTest {
           timestamp = timestamp,
           isolationLevel = isolation,
           currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
+          System.currentTimeMillis(),
           fetchOnlyFromLeader = true
         ))
       } catch {
@@ -751,6 +755,7 @@ class PartitionTest extends AbstractPartitionTest {
       val res = partition.fetchOffsetForTimestamp(ListOffsetRequest.LATEST_TIMESTAMP,
         isolationLevel = isolationLevel,
         currentLeaderEpoch = Optional.empty(),
+        System.currentTimeMillis(),
         fetchOnlyFromLeader = true)
       assertTrue(res.isDefined)
       res.get
@@ -760,6 +765,7 @@ class PartitionTest extends AbstractPartitionTest {
       val res = partition.fetchOffsetForTimestamp(ListOffsetRequest.EARLIEST_TIMESTAMP,
         isolationLevel = isolationLevel,
         currentLeaderEpoch = Optional.empty(),
+        ListOffsetRequest.UNLIMITED_TIMESTAMP,
         fetchOnlyFromLeader = true)
       assertTrue(res.isDefined)
       res.get

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -960,6 +960,7 @@ class KafkaApisTest {
       EasyMock.eq(ListOffsetRequest.EARLIEST_TIMESTAMP),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
+      ListOffsetRequest.UNLIMITED_TIMESTAMP,
       fetchOnlyFromLeader = EasyMock.eq(true))
     ).andThrow(error.exception)
 
@@ -1963,6 +1964,7 @@ class KafkaApisTest {
       EasyMock.eq(ListOffsetRequest.LATEST_TIMESTAMP),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
+      System.currentTimeMillis(),
       fetchOnlyFromLeader = EasyMock.eq(true))
     ).andReturn(Some(new TimestampAndOffset(ListOffsetResponse.UNKNOWN_TIMESTAMP, latestOffset, currentLeaderEpoch)))
 


### PR DESCRIPTION
1. besides `latest` and `earliest`, we also add `nearest`: reset to either latest or earliest depending on the current offset (i.e. this policy won't trigger under the scenario when we see a partition for the first time, without committed offsets; it will only trigger for out-of-range).
2. `latest-on-start`, `earliest-on-start`: reset to either latest or earliest only when we see the partition for the first time without committed offset; when out-of-range default to `none`, i.e. throw exception.
3. an additional `limitTimeStamp` limit used for `latest/earliest/latest-on-start/earliest-on-start`: it means we only reset to latest / earliest if its partition's first record timestamp is smaller / larger than the given `limitTimeStamp` parameter, otherwise, reset to earliest / latest. set the `limitTimeStamp` value to the consumer group started timestamp, when new partitions are added it would reset to `earliest` to avoid losing data.
