### PR TITLE
KAFKA-12800: Configure generator to fail on trailing JSON tokens

### DIFF
--- a/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
+++ b/generator/src/main/java/org/apache/kafka/message/MessageGenerator.java
@@ -165,6 +165,7 @@ public final class MessageGenerator {
         JSON_SERDE = new ObjectMapper();
         JSON_SERDE.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         JSON_SERDE.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        JSON_SERDE.configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, true);
         JSON_SERDE.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         JSON_SERDE.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }


### PR DESCRIPTION
See #10709 for an example of this happening.

The tl;dr is that Jackson will ignore trailing tokens by default, but other Json parsers cannot be configured to ignore them. This makes sure we don't regress :).

# Testing

I ran `./gradlew processMessages` and saw that everything completed succesfully. I then put a trailing `}` into one of the files and saw that `processMessages` failed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
