### PR TITLE
MINOR: update java doc for deprecated methods

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
@@ -26,7 +26,11 @@ import java.util.Objects;
 
 /**
  * This class is used to provide the optional parameters when producing to new topics
- * using {@link KStream#through(String, Produced)} or {@link KStream#to(String, Produced)}.
+ * using {@link KStream#to(String, Produced)}.
+ *
+ * <p>
+ * Note: {@link KStream#through(String, Produced)} is deprecated, please use {@link KStream#repartition(Repartitioned)} instead
+ *
  * @param <K> key type
  * @param <V> value type
  */
@@ -61,7 +65,6 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with keySerde and valueSerde
-     * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
     public static <K, V> Produced<K, V> with(final Serde<K> keySerde,
@@ -80,7 +83,6 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with keySerde, valueSerde, and partitioner
-     * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
     public static <K, V> Produced<K, V> with(final Serde<K> keySerde,
@@ -107,7 +109,6 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with keySerde
-     * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
     public static <K, V> Produced<K, V> keySerde(final Serde<K> keySerde) {
@@ -120,7 +121,6 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with valueSerde
-     * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
     public static <K, V> Produced<K, V> valueSerde(final Serde<V> valueSerde) {
@@ -135,7 +135,6 @@ public class Produced<K, V> implements NamedOperation<Produced<K, V>> {
      * @param <K>           key type
      * @param <V>           value type
      * @return  A new {@link Produced} instance configured with partitioner
-     * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
     public static <K, V> Produced<K, V> streamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
@@ -28,9 +28,6 @@ import java.util.Objects;
  * This class is used to provide the optional parameters when producing to new topics
  * using {@link KStream#to(String, Produced)}.
  *
- * <p>
- * Note: {@link KStream#through(String, Produced)} is deprecated, please use {@link KStream#repartition(Repartitioned)} instead
- *
  * @param <K> key type
  * @param <V> value type
  */

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -73,7 +73,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
  *     See {@link org.apache.kafka.tools.VerifiableConsumer.PartitionsRevoked}</li>
  * <li>partitions_assigned: outputs the partitions assigned through {@link ConsumerRebalanceListener#onPartitionsAssigned(Collection)}
  *     See {@link org.apache.kafka.tools.VerifiableConsumer.PartitionsAssigned}.</li>
- * <li>records_consumed: contains a summary of records consumed in a single call to {@link KafkaConsumer#poll(long)}.
+ * <li>records_consumed: contains a summary of records consumed in a single call to {@link KafkaConsumer#poll(Duration)}.
  *     See {@link org.apache.kafka.tools.VerifiableConsumer.RecordsConsumed}.</li>
  * <li>record_data: contains the key, value, and offset of an individual consumed record (only included if verbose
  *     output is enabled). See {@link org.apache.kafka.tools.VerifiableConsumer.RecordData}.</li>


### PR DESCRIPTION
Update deprecated methods: 
1. `KStream#through(String, Produced)`
2. `KafkaConsumer#poll(long)`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
