### PR TITLE
optimize offset reset strategy and fix lose consumer data when add pa…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -130,6 +130,13 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String AUTO_OFFSET_RESET_DOC = "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): <ul><li>earliest: automatically reset the offset to the earliest offset<li>latest: automatically reset the offset to the latest offset</li><li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li><li>anything else: throw exception to the consumer.</li></ul>";
 
     /**
+     * <code>nearest.offset.reset</code>
+     */
+    public static final String NEAREST_OFFSET_RESET_CONFIG = "nearest.offset.reset";
+    private static final String NEAREST_OFFSET_RESET_DOC = "If true, then out of range errors will reset the consumer's offset to the nearest offset. to the earliest end of the broker range if it was under the range, or to the latest end of the broker range if it was over the range";
+    public static final boolean DEFAULT_NEAREST_OFFSET_RESET = false;
+
+    /**
      * <code>fetch.min.bytes</code>
      */
     public static final String FETCH_MIN_BYTES_CONFIG = "fetch.min.bytes";
@@ -434,9 +441,14 @@ public class ConsumerConfig extends AbstractConfig {
                                 .define(AUTO_OFFSET_RESET_CONFIG,
                                         Type.STRING,
                                         "latest",
-                                        in("latest", "earliest", "none"),
+                                        in("latest", "earliest", "none", "latest-on-start", "earliest-on-start"),
                                         Importance.MEDIUM,
                                         AUTO_OFFSET_RESET_DOC)
+                                .define(NEAREST_OFFSET_RESET_CONFIG,
+                                        Type.BOOLEAN,
+                                        DEFAULT_NEAREST_OFFSET_RESET,
+                                        Importance.MEDIUM,
+                                        NEAREST_OFFSET_RESET_DOC)
                                 .define(CHECK_CRCS_CONFIG,
                                         Type.BOOLEAN,
                                         true,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.errors.InvalidOffsetResetStrategyException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.JmxReporter;
@@ -786,6 +787,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                         config.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG),
                         this.interceptors,
                         config.getBoolean(ConsumerConfig.THROW_ON_FETCH_STABLE_OFFSET_UNSUPPORTED));
+            long createTimeStamp = System.currentTimeMillis();
+            validateOffsetResetStrategy(offsetResetStrategy, config.getBoolean(ConsumerConfig.NEAREST_OFFSET_RESET_CONFIG));
             this.fetcher = new Fetcher<>(
                     logContext,
                     this.client,
@@ -806,6 +809,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.retryBackoffMs,
                     this.requestTimeoutMs,
                     isolationLevel,
+                    config.getBoolean(ConsumerConfig.NEAREST_OFFSET_RESET_CONFIG),
+                    createTimeStamp,
                     apiVersions);
 
             this.kafkaConsumerMetrics = new KafkaConsumerMetrics(metrics, metricGrpPrefix);
@@ -2471,6 +2476,15 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private void updateLastSeenEpochIfNewer(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
         if (offsetAndMetadata != null)
             offsetAndMetadata.leaderEpoch().ifPresent(epoch -> metadata.updateLastSeenEpochIfNewer(topicPartition, epoch));
+    }
+
+    private void validateOffsetResetStrategy(OffsetResetStrategy offsetResetStrategy, boolean useNearestOffsetReset) {
+        if (offsetResetStrategy == OffsetResetStrategy.EARLIEST_ON_START || offsetResetStrategy == OffsetResetStrategy.LATEST_ON_START) {
+            if (useNearestOffsetReset) {
+                throw new InvalidOffsetResetStrategyException("Can not use nearest when out-of-range, if offset " +
+                        "reset strategy is EARLIEST_ON_START or LATEST_ON_START.");
+            }
+        }
     }
 
     // Functions below are for testing only

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -497,11 +497,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private void resetOffsetPosition(TopicPartition tp) {
         OffsetResetStrategy strategy = subscriptions.resetStrategy(tp);
         Long offset;
-        if (strategy == OffsetResetStrategy.EARLIEST) {
+        if (strategy == OffsetResetStrategy.EARLIEST || strategy == OffsetResetStrategy.EARLIEST_ON_START) {
             offset = beginningOffsets.get(tp);
             if (offset == null)
                 throw new IllegalStateException("MockConsumer didn't have beginning offset specified, but tried to seek to beginning");
-        } else if (strategy == OffsetResetStrategy.LATEST) {
+        } else if (strategy == OffsetResetStrategy.LATEST || strategy == OffsetResetStrategy.LATEST_ON_START) {
             offset = endOffsets.get(tp);
             if (offset == null)
                 throw new IllegalStateException("MockConsumer didn't have end offset specified, but tried to seek to end");

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetResetStrategy.java
@@ -17,5 +17,5 @@
 package org.apache.kafka.clients.consumer;
 
 public enum OffsetResetStrategy {
-    LATEST, EARLIEST, NONE
+    LATEST, EARLIEST, NONE, NEAREST, LATEST_ON_START, EARLIEST_ON_START
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -157,6 +157,8 @@ public class Fetcher<K, V> implements Closeable {
     private final AtomicReference<RuntimeException> cachedOffsetForLeaderException = new AtomicReference<>();
     private final OffsetsForLeaderEpochClient offsetsForLeaderEpochClient;
     private final Set<Integer> nodesWithPendingFetchRequests;
+    private final boolean useNearestOffsetReset;
+    private final long createFetchTimeStamp;
     private final ApiVersions apiVersions;
     private final AtomicInteger metadataUpdateVersion = new AtomicInteger(-1);
 
@@ -182,6 +184,8 @@ public class Fetcher<K, V> implements Closeable {
                    long retryBackoffMs,
                    long requestTimeoutMs,
                    IsolationLevel isolationLevel,
+                   boolean useNearestOffsetReset,
+                   long createFetchTimeStamp,
                    ApiVersions apiVersions) {
         this.log = logContext.logger(Fetcher.class);
         this.logContext = logContext;
@@ -203,6 +207,8 @@ public class Fetcher<K, V> implements Closeable {
         this.retryBackoffMs = retryBackoffMs;
         this.requestTimeoutMs = requestTimeoutMs;
         this.isolationLevel = isolationLevel;
+        this.useNearestOffsetReset = useNearestOffsetReset;
+        this.createFetchTimeStamp = createFetchTimeStamp;
         this.apiVersions = apiVersions;
         this.sessionHandlers = new HashMap<>();
         this.offsetsForLeaderEpochClient = new OffsetsForLeaderEpochClient(client, logContext);
@@ -438,10 +444,12 @@ public class Fetcher<K, V> implements Closeable {
 
     private Long offsetResetStrategyTimestamp(final TopicPartition partition) {
         OffsetResetStrategy strategy = subscriptions.resetStrategy(partition);
-        if (strategy == OffsetResetStrategy.EARLIEST)
+        if (strategy == OffsetResetStrategy.EARLIEST || strategy == OffsetResetStrategy.EARLIEST_ON_START)
             return ListOffsetsRequest.EARLIEST_TIMESTAMP;
-        else if (strategy == OffsetResetStrategy.LATEST)
+        else if (strategy == OffsetResetStrategy.LATEST || strategy == OffsetResetStrategy.LATEST_ON_START)
             return ListOffsetsRequest.LATEST_TIMESTAMP;
+        else if (strategy == OffsetResetStrategy.NEAREST)
+            return ListOffsetsRequest.NEAREST_TIMESTAMP;
         else
             return null;
     }
@@ -478,7 +486,7 @@ public class Fetcher<K, V> implements Closeable {
                 offsetResetTimestamps.put(partition, timestamp);
         }
 
-        resetOffsetsAsync(offsetResetTimestamps);
+        resetOffsetsAsync(offsetResetTimestamps, false);
     }
 
     /**
@@ -721,6 +729,23 @@ public class Fetcher<K, V> implements Closeable {
         return emptyList();
     }
 
+    private Map<TopicPartition, ListOffsetsPartition> formatToValidResetTimestamp(Map<TopicPartition, ListOffsetsPartition> original) {
+        Map<TopicPartition, ListOffsetsPartition> formatted = new HashMap<>();
+        original.forEach((tp, pd) -> {
+            // since NEAREST_TIMESTAMP is not implemented on the broker server,
+            // we'll try to set earliest timestamp firstly.
+            if (pd.timestamp() == ListOffsetsRequest.NEAREST_TIMESTAMP) {
+                formatted.put(tp, new ListOffsetsPartition()
+                        .setPartitionIndex(tp.partition())
+                        .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
+                        .setCurrentLeaderEpoch(pd.currentLeaderEpoch()));
+            } else {
+                formatted.put(tp, pd);
+            }
+        });
+        return formatted;
+    }
+
     // Visible for testing
     void resetOffsetIfNeeded(TopicPartition partition, OffsetResetStrategy requestedResetStrategy, ListOffsetData offsetData) {
         FetchPosition position = new FetchPosition(
@@ -731,7 +756,7 @@ public class Fetcher<K, V> implements Closeable {
         subscriptions.maybeSeekUnvalidated(partition, position, requestedResetStrategy);
     }
 
-    private void resetOffsetsAsync(Map<TopicPartition, Long> partitionResetTimestamps) {
+    private void resetOffsetsAsync(Map<TopicPartition, Long> partitionResetTimestamps, boolean dealNearest) {
         Map<Node, Map<TopicPartition, ListOffsetsPartition>> timestampsToSearchByNode =
                 groupListOffsetRequests(partitionResetTimestamps, new HashSet<>());
         for (Map.Entry<Node, Map<TopicPartition, ListOffsetsPartition>> entry : timestampsToSearchByNode.entrySet()) {
@@ -739,33 +764,86 @@ public class Fetcher<K, V> implements Closeable {
             final Map<TopicPartition, ListOffsetsPartition> resetTimestamps = entry.getValue();
             subscriptions.setNextAllowedRetry(resetTimestamps.keySet(), time.milliseconds() + requestTimeoutMs);
 
-            RequestFuture<ListOffsetResult> future = sendListOffsetRequest(node, resetTimestamps, false);
-            future.addListener(new RequestFutureListener<ListOffsetResult>() {
-                @Override
-                public void onSuccess(ListOffsetResult result) {
-                    if (!result.partitionsToRetry.isEmpty()) {
-                        subscriptions.requestFailed(result.partitionsToRetry, time.milliseconds() + retryBackoffMs);
-                        metadata.requestUpdate();
+            Map<TopicPartition, ListOffsetsPartition> validatedResetTimestamps = formatToValidResetTimestamp(resetTimestamps);
+            if (dealNearest) {
+                RequestFuture<ListOffsetResult> future;
+                future = sendListOffsetRequest(node, validatedResetTimestamps, false, ListOffsetsRequest.UNLIMITED_TIMESTAMP);
+                addListenerForListOffsetRequest(future, resetTimestamps, validatedResetTimestamps, true);
+            } else {
+                // skip nearest first
+                Map<OffsetResetStrategy, Map<TopicPartition, ListOffsetsPartition>> partitionMapByStrategy = regroupPartitionMapByOffsetResetStrategy(validatedResetTimestamps);
+                for (Map.Entry<OffsetResetStrategy, Map<TopicPartition, ListOffsetsPartition>> entryByStrategy: partitionMapByStrategy.entrySet()) {
+                    RequestFuture<ListOffsetResult> future;
+                    OffsetResetStrategy strategy = entryByStrategy.getKey();
+                    final Map<TopicPartition, ListOffsetsPartition> partitionDataMap = entryByStrategy.getValue();
+                    final Map<TopicPartition, ListOffsetsPartition> resetPartitionTimestamps = resetTimestamps
+                            .entrySet()
+                            .stream()
+                            .filter(partitionData -> partitionDataMap.containsKey(partitionData.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    if (strategy == OffsetResetStrategy.LATEST || strategy == OffsetResetStrategy.LATEST_ON_START) {
+                        // only relay on createFetchTimeStamp when set to LATEST or LATEST_ON_START
+                        future = sendListOffsetRequest(node, partitionDataMap, false, createFetchTimeStamp);
+                    } else {
+                        future = sendListOffsetRequest(node, partitionDataMap, false, ListOffsetsRequest.UNLIMITED_TIMESTAMP);
                     }
-
-                    for (Map.Entry<TopicPartition, ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
-                        TopicPartition partition = fetchedOffset.getKey();
-                        ListOffsetData offsetData = fetchedOffset.getValue();
-                        ListOffsetsPartition requestedReset = resetTimestamps.get(partition);
-                        resetOffsetIfNeeded(partition, timestampToOffsetResetStrategy(requestedReset.timestamp()), offsetData);
-                    }
+                    addListenerForListOffsetRequest(future, resetPartitionTimestamps, partitionDataMap, false);
                 }
-
-                @Override
-                public void onFailure(RuntimeException e) {
-                    subscriptions.requestFailed(resetTimestamps.keySet(), time.milliseconds() + retryBackoffMs);
-                    metadata.requestUpdate();
-
-                    if (!(e instanceof RetriableException) && !cachedListOffsetsException.compareAndSet(null, e))
-                        log.error("Discarding error in ListOffsetResponse because another error is pending", e);
-                }
-            });
+            }
         }
+    }
+
+    private void addListenerForListOffsetRequest(RequestFuture<ListOffsetResult> future,
+                                                 Map<TopicPartition, ListOffsetsPartition> resetTimestamps,
+                                                 Map<TopicPartition, ListOffsetsPartition> validatedResetTimestamps,
+                                                 boolean dealNearest) {
+        future.addListener(new RequestFutureListener<ListOffsetResult>() {
+            @Override
+            public void onSuccess(ListOffsetResult result) {
+                if (!result.partitionsToRetry.isEmpty()) {
+                    subscriptions.requestFailed(result.partitionsToRetry, time.milliseconds() + retryBackoffMs);
+                    metadata.requestUpdate();
+                }
+
+                Map<TopicPartition, Long> needNewReset = new HashMap<>();
+                for (Map.Entry<TopicPartition, ListOffsetData> fetchedOffset : result.fetchedOffsets.entrySet()) {
+                    TopicPartition partition = fetchedOffset.getKey();
+                    ListOffsetData offsetData = fetchedOffset.getValue();
+                    ListOffsetsPartition requestedReset = resetTimestamps.get(partition);
+                    if (requestedReset != null && requestedReset.timestamp() == ListOffsetsRequest.NEAREST_TIMESTAMP) {
+                        if (dealNearest) {
+                            // if outOfRangeOffset is higher than log size,
+                            // we will send a request again to reset to latest.
+                            Long outOfRangeOffset = subscriptions.outOfRangeOffset(partition);
+                            if (outOfRangeOffset != null && outOfRangeOffset > offsetData.offset) {
+                                needNewReset.put(partition, ListOffsetsRequest.LATEST_TIMESTAMP);
+                                continue;
+                            }
+                        } else {
+                            // skip nearest first
+                            needNewReset.put(partition, ListOffsetsRequest.NEAREST_TIMESTAMP);
+                            continue;
+                        }
+                    }
+                    ListOffsetsPartition validatedReset = validatedResetTimestamps.get(partition);
+                    resetOffsetIfNeeded(partition, timestampToOffsetResetStrategy(validatedReset.timestamp()), offsetData);
+                }
+                if (needNewReset.size() > 0) {
+                    // when dealNearest is true, i.e. get offset with UNLIMITED_TIMESTAMP,
+                    // it will be called only when processing out of range partitions.
+                    resetOffsetsAsync(needNewReset, true);
+                }
+            }
+
+            @Override
+            public void onFailure(RuntimeException e) {
+                subscriptions.requestFailed(resetTimestamps.keySet(), time.milliseconds() + retryBackoffMs);
+                metadata.requestUpdate();
+
+                if (!(e instanceof RetriableException) && !cachedListOffsetsException.compareAndSet(null, e))
+                    log.error("Discarding error in ListOffsetResponse because another error is pending", e);
+            }
+        });
     }
 
     static boolean hasUsableOffsetForLeaderEpochVersion(NodeApiVersions nodeApiVersions) {
@@ -894,7 +972,7 @@ public class Fetcher<K, V> implements Closeable {
 
         for (Map.Entry<Node, Map<TopicPartition, ListOffsetsPartition>> entry : timestampsToSearchByNode.entrySet()) {
             RequestFuture<ListOffsetResult> future =
-                sendListOffsetRequest(entry.getKey(), entry.getValue(), requireTimestamps);
+                sendListOffsetRequest(entry.getKey(), entry.getValue(), requireTimestamps, ListOffsetsRequest.UNLIMITED_TIMESTAMP);
             future.addListener(new RequestFutureListener<ListOffsetResult>() {
                 @Override
                 public void onSuccess(ListOffsetResult partialResult) {
@@ -975,10 +1053,12 @@ public class Fetcher<K, V> implements Closeable {
      */
     private RequestFuture<ListOffsetResult> sendListOffsetRequest(final Node node,
                                                                   final Map<TopicPartition, ListOffsetsPartition> timestampsToSearch,
-                                                                  boolean requireTimestamp) {
+                                                                  boolean requireTimestamp,
+                                                                  long limitTimeStamp) {
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
                 .forConsumer(requireTimestamp, isolationLevel)
-                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch));
+                .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch))
+                .setLimitTimeStamp(limitTimeStamp);
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);
         return client.send(node, builder)
@@ -1223,6 +1303,13 @@ public class Fetcher<K, V> implements Closeable {
                         Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
+    private <T> Map<OffsetResetStrategy, Map<TopicPartition, T>> regroupPartitionMapByOffsetResetStrategy(Map<TopicPartition, T> partitionMap) {
+        return partitionMap.entrySet()
+                .stream()
+                .collect(Collectors.groupingBy(entry -> subscriptions.resetStrategy(entry.getKey()),
+                        Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
     /**
      * Initialize a CompletedFetch object.
      */
@@ -1357,8 +1444,15 @@ public class Fetcher<K, V> implements Closeable {
     private void handleOffsetOutOfRange(FetchPosition fetchPosition, TopicPartition topicPartition) {
         String errorMessage = "Fetch position " + fetchPosition + " is out of range for partition " + topicPartition;
         if (subscriptions.hasDefaultOffsetResetPolicy()) {
-            log.info("{}, resetting offset", errorMessage);
-            subscriptions.requestOffsetReset(topicPartition);
+            if (useNearestOffsetReset) {
+                log.info("Fetch offset epoch {} is out of range for partition {}, resetting offset with nearest offset",
+                        fetchPosition, topicPartition);
+                subscriptions.requestOffsetReset(topicPartition, OffsetResetStrategy.NEAREST, fetchPosition.offset);
+            } else {
+                log.info("Fetch offset epoch {} is out of range for partition {}, resetting offset",
+                        fetchPosition, topicPartition);
+                subscriptions.requestOffsetReset(topicPartition);
+            }
         } else {
             log.info("{}, raising error to the application since no reset policy is configured", errorMessage);
             throw new OffsetOutOfRangeException(errorMessage,

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidOffsetResetStrategyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidOffsetResetStrategyException.java
@@ -1,0 +1,13 @@
+package org.apache.kafka.common.errors;
+
+public class InvalidOffsetResetStrategyException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidOffsetResetStrategyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidOffsetResetStrategyException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -38,6 +38,8 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 public class ListOffsetsRequest extends AbstractRequest {
+    public static final long UNLIMITED_TIMESTAMP = Long.MIN_VALUE;
+    public static final long NEAREST_TIMESTAMP = -3L;
     public static final long EARLIEST_TIMESTAMP = -2L;
     public static final long LATEST_TIMESTAMP = -1L;
 
@@ -75,6 +77,11 @@ public class ListOffsetsRequest extends AbstractRequest {
 
         public Builder setTargetTimes(List<ListOffsetsTopic> topics) {
             data.setTopics(topics);
+            return this;
+        }
+
+        public Builder setLimitTimeStamp(long limitTimeStamp) {
+            data.setLimitTimeStamp(limitTimeStamp);
             return this;
         }
 
@@ -148,6 +155,10 @@ public class ListOffsetsRequest extends AbstractRequest {
 
     public IsolationLevel isolationLevel() {
         return IsolationLevel.forId(data.isolationLevel());
+    }
+
+    public long limitTimeStamp() {
+        return data.limitTimeStamp();
     }
 
     public List<ListOffsetsTopic> topics() {

--- a/clients/src/main/resources/common/message/ListOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetsRequest.json
@@ -30,13 +30,17 @@
   // Version 5 is the same as version 4.
   //
   // Version 6 enables flexible versions.
-  "validVersions": "0-6",
-  "flexibleVersions": "6+",
+  //
+  // Version 7 add limitTimeStamp, which is used for LATEST.
+  "validVersions": "0-7",
+  "flexibleVersions": "7+",
   "fields": [
     { "name": "ReplicaId", "type": "int32", "versions": "0+", "entityType": "brokerId",
       "about": "The broker ID of the requestor, or -1 if this request is being made by a normal consumer." },
     { "name": "IsolationLevel", "type": "int8", "versions": "2+",
       "about": "This setting controls the visibility of transactional records. Using READ_UNCOMMITTED (isolation_level = 0) makes all records visible. With READ_COMMITTED (isolation_level = 1), non-transactional and COMMITTED transactional records are visible. To be more concrete, READ_COMMITTED returns all data from offsets smaller than the current LSO (last stable offset), and enables the inclusion of the list of aborted transactions in the result, which allows consumers to discard ABORTED transactional records" },
+    { "name": "LimitTimeStamp", "type": "int64", "versions": "7+",
+      "about": "The limit timestamp to calibrate when set to LATEST." },
     { "name": "Topics", "type": "[]ListOffsetsTopic", "versions": "0+",
       "about": "Each topic in the request.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2342,6 +2342,8 @@ public class KafkaConsumerTest {
         int maxPollRecords = Integer.MAX_VALUE;
         boolean checkCrcs = true;
         int rebalanceTimeoutMs = 60000;
+        boolean nearestOffsetReset = false;
+        long createTimestamp = System.currentTimeMillis();
 
         Deserializer<String> keyDeserializer = new StringDeserializer();
         Deserializer<String> valueDeserializer = new StringDeserializer();
@@ -2396,6 +2398,8 @@ public class KafkaConsumerTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 IsolationLevel.READ_UNCOMMITTED,
+                nearestOffsetReset,
+                createTimestamp,
                 new ApiVersions());
 
         return new KafkaConsumer<>(

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -177,6 +177,8 @@ public class FetcherTest {
     private FetcherMetricsRegistry metricsRegistry;
     private MockClient client;
     private Metrics metrics;
+    private boolean nearestOffsetReset = false;
+    private long createTimeStamp = System.currentTimeMillis();
     private ApiVersions apiVersions = new ApiVersions();
     private ConsumerNetworkClient consumerClient;
     private Fetcher<?, ?> fetcher;
@@ -3351,6 +3353,8 @@ public class FetcherTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 IsolationLevel.READ_UNCOMMITTED,
+                nearestOffsetReset,
+                createTimeStamp,
                 apiVersions) {
             @Override
             protected FetchSessionHandler sessionHandler(int id) {
@@ -4689,6 +4693,8 @@ public class FetcherTest {
                 retryBackoffMs,
                 requestTimeoutMs,
                 isolationLevel,
+                nearestOffsetReset,
+                createTimeStamp,
                 apiVersions);
     }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1031,11 +1031,13 @@ class KafkaApis(val requestChannel: RequestChannel,
               Some(offsetRequest.isolationLevel)
             else
               None
+            val limitTimeStamp = offsetRequest.limitTimeStamp
 
             val foundOpt = replicaManager.fetchOffsetForTimestamp(topicPartition,
               partition.timestamp,
               isolationLevelOpt,
               if (partition.currentLeaderEpoch == ListOffsetsResponse.UNKNOWN_EPOCH) Optional.empty() else Optional.of(partition.currentLeaderEpoch),
+              limitTimeStamp,
               fetchOnlyFromLeader)
 
             val response = foundOpt match {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -246,6 +246,7 @@ class ReplicaFetcherThread(name: String,
             .setTimestamp(earliestOrLatest)))
     val requestBuilder = ListOffsetsRequest.Builder.forReplica(listOffsetRequestVersion, replicaId)
       .setTargetTimes(Collections.singletonList(topic))
+      .setLimitTimeStamp(ListOffsetsRequest.UNLIMITED_TIMESTAMP)
 
     val clientResponse = leaderEndpoint.sendRequest(requestBuilder)
     val response = clientResponse.responseBody.asInstanceOf[ListOffsetsResponse]

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -993,9 +993,10 @@ class ReplicaManager(val config: KafkaConfig,
                               timestamp: Long,
                               isolationLevel: Option[IsolationLevel],
                               currentLeaderEpoch: Optional[Integer],
+                              limitTimeStamp: Long,
                               fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
     val partition = getPartitionOrException(topicPartition)
-    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
+    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, limitTimeStamp, fetchOnlyFromLeader)
   }
 
   def legacyFetchOffsetsForTimestamp(topicPartition: TopicPartition,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -492,6 +492,7 @@ class PartitionTest extends AbstractPartitionTest {
         partition.fetchOffsetForTimestamp(0L,
           isolationLevel = None,
           currentLeaderEpoch = currentLeaderEpochOpt,
+          System.currentTimeMillis(),
           fetchOnlyFromLeader = true)
         if (error != Errors.NONE)
           fail(s"Expected readRecords to fail with error $error")
@@ -519,6 +520,7 @@ class PartitionTest extends AbstractPartitionTest {
         partition.fetchOffsetForTimestamp(0L,
           isolationLevel = None,
           currentLeaderEpoch = currentLeaderEpochOpt,
+          System.currentTimeMillis(),
           fetchOnlyFromLeader = fetchOnlyLeader)
         if (error != Errors.NONE)
           fail(s"Expected readRecords to fail with error $error")
@@ -547,6 +549,7 @@ class PartitionTest extends AbstractPartitionTest {
     val timestampAndOffsetOpt = partition.fetchOffsetForTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP,
       isolationLevel = None,
       currentLeaderEpoch = Optional.empty(),
+      System.currentTimeMillis(),
       fetchOnlyFromLeader = true)
 
     assertTrue(timestampAndOffsetOpt.isDefined)
@@ -614,6 +617,7 @@ class PartitionTest extends AbstractPartitionTest {
           timestamp = timestamp,
           isolationLevel = isolation,
           currentLeaderEpoch = Optional.of(partition.getLeaderEpoch),
+          System.currentTimeMillis(),
           fetchOnlyFromLeader = true
         ))
       } catch {
@@ -845,6 +849,7 @@ class PartitionTest extends AbstractPartitionTest {
       val res = partition.fetchOffsetForTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP,
         isolationLevel = isolationLevel,
         currentLeaderEpoch = Optional.empty(),
+        System.currentTimeMillis(),
         fetchOnlyFromLeader = true)
       assertTrue(res.isDefined)
       res.get
@@ -854,6 +859,7 @@ class PartitionTest extends AbstractPartitionTest {
       val res = partition.fetchOffsetForTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP,
         isolationLevel = isolationLevel,
         currentLeaderEpoch = Optional.empty(),
+        ListOffsetsRequest.UNLIMITED_TIMESTAMP,
         fetchOnlyFromLeader = true)
       assertTrue(res.isDefined)
       res.get

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -1961,6 +1961,7 @@ class KafkaApisTest {
       EasyMock.eq(ListOffsetsRequest.EARLIEST_TIMESTAMP),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
+      ListOffsetsRequest.UNLIMITED_TIMESTAMP,
       fetchOnlyFromLeader = EasyMock.eq(true))
     ).andThrow(error.exception)
 
@@ -3066,6 +3067,7 @@ class KafkaApisTest {
       EasyMock.eq(ListOffsetsRequest.LATEST_TIMESTAMP),
       EasyMock.eq(Some(isolationLevel)),
       EasyMock.eq(currentLeaderEpoch),
+      System.currentTimeMillis(),
       fetchOnlyFromLeader = EasyMock.eq(true))
     ).andReturn(Some(new TimestampAndOffset(ListOffsetsResponse.UNKNOWN_TIMESTAMP, latestOffset, currentLeaderEpoch)))
 


### PR DESCRIPTION
1. besides latest and earliest, we also add nearest: reset to either latest or earliest depending on the current offset (i.e. this policy won't trigger under the scenario when we see a partition for the first time, without committed offsets; it will only trigger for out-of-range).
2. latest-on-start, earliest-on-start: reset to either latest or earliest only when we see the partition for the first time without committed offset; when out-of-range default to none, i.e. throw exception.
3. an additional limitTimeStamp limit used for latest/earliest/latest-on-start/earliest-on-start: it means we only reset to latest / earliest if its partition's first record timestamp is smaller / larger than the given limitTimeStamp parameter, otherwise, reset to earliest / latest. set the limitTimeStamp value to the consumer group started timestamp, when new partitions are added it would reset to earliest to avoid losing data.