### PR TITLE
KAFKA-12810: Remove deprecated TopologyDescription.Source#topics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
@@ -113,13 +113,6 @@ public interface TopologyDescription {
      * A source node of a topology.
      */
     interface Source extends Node {
-        /**
-         * The topic names this source node is reading from.
-         * @return comma separated list of topic names or pattern (as String)
-         * @deprecated use {@link #topicSet()} or {@link #topicPattern()} instead
-         */
-        @Deprecated
-        String topics();
 
         /**
          * The topic names this source node is reading from.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1589,12 +1589,6 @@ public class InternalTopologyBuilder {
             this.topicPattern = pattern;
         }
 
-        @Deprecated
-        @Override
-        public String topics() {
-            return topics.toString();
-        }
-
         @Override
         public Set<String> topicSet() {
             return topics;


### PR DESCRIPTION
Remove already deprecated method that was already not in use internally

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
