### PR TITLE
KAFKA-12813: Remove Deprecated schedule method in ProcessorContext

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -101,43 +101,6 @@ public interface ProcessorContext {
      * Schedules a periodic operation for processors. A processor may call this method during
      * {@link Processor#init(ProcessorContext) initialization} or
      * {@link Processor#process(Object, Object) processing} to
-     * schedule a periodic callback &mdash; called a punctuation  &mdash; to {@link Punctuator#punctuate(long)}.
-     * The type parameter controls what notion of time is used for punctuation:
-     * <ul>
-     *   <li>{@link PunctuationType#STREAM_TIME} &mdash; uses "stream time", which is advanced by the processing of messages
-     *   in accordance with the timestamp as extracted by the {@link TimestampExtractor} in use.
-     *   The first punctuation will be triggered by the first record that is processed.
-     *   <b>NOTE:</b> Only advanced if messages arrive</li>
-     *   <li>{@link PunctuationType#WALL_CLOCK_TIME} &mdash; uses system time (the wall-clock time),
-     *   which is advanced independent of whether new messages arrive.
-     *   The first punctuation will be triggered after interval has elapsed.
-     *   <b>NOTE:</b> This is best effort only as its granularity is limited by how long an iteration of the
-     *   processing loop takes to complete</li>
-     * </ul>
-     *
-     * <b>Skipping punctuations:</b> Punctuations will not be triggered more than once at any given timestamp.
-     * This means that "missed" punctuation will be skipped.
-     * It's possible to "miss" a punctuation if:
-     * <ul>
-     *   <li>with {@link PunctuationType#STREAM_TIME}, when stream time advances more than interval</li>
-     *   <li>with {@link PunctuationType#WALL_CLOCK_TIME}, on GC pause, too short interval, ...</li>
-     * </ul>
-     *
-     * @param intervalMs the time interval between punctuations in milliseconds
-     * @param type one of: {@link PunctuationType#STREAM_TIME}, {@link PunctuationType#WALL_CLOCK_TIME}
-     * @param callback a function consuming timestamps representing the current stream or system time
-     * @return a handle allowing cancellation of the punctuation schedule established by this method
-     * @deprecated Use {@link #schedule(Duration, PunctuationType, Punctuator)} instead
-     */
-    @Deprecated
-    Cancellable schedule(final long intervalMs,
-                         final PunctuationType type,
-                         final Punctuator callback);
-
-    /**
-     * Schedules a periodic operation for processors. A processor may call this method during
-     * {@link Processor#init(ProcessorContext) initialization} or
-     * {@link Processor#process(Object, Object) processing} to
      * schedule a periodic callback &mdash; called a punctuation &mdash; to {@link Punctuator#punctuate(long)}.
      * The type parameter controls what notion of time is used for punctuation:
      * <ul>

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ForwardingDisabledProcessorContext.java
@@ -91,14 +91,6 @@ public final class ForwardingDisabledProcessorContext implements ProcessorContex
     }
 
     @Override
-    @Deprecated
-    public Cancellable schedule(final long intervalMs,
-                                final PunctuationType type,
-                                final Punctuator callback) {
-        return delegate.schedule(intervalMs, type, callback);
-    }
-
-    @Override
     public Cancellable schedule(final Duration interval,
                                 final PunctuationType type,
                                 final Punctuator callback) throws IllegalArgumentException {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -114,15 +114,6 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
      * @throws UnsupportedOperationException on every invocation
      */
     @Override
-    @Deprecated
-    public Cancellable schedule(final long interval, final PunctuationType type, final Punctuator callback) {
-        throw new UnsupportedOperationException("this should not happen: schedule() not supported in global processor context.");
-    }
-
-    /**
-     * @throws UnsupportedOperationException on every invocation
-     */
-    @Override
     public Cancellable schedule(final Duration interval, final PunctuationType type, final Punctuator callback) {
         throw new UnsupportedOperationException("this should not happen: schedule() not supported in global processor context.");
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -263,18 +263,6 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         streamTask.requestCommit();
     }
 
-    @Override
-    @Deprecated
-    public Cancellable schedule(final long intervalMs,
-                                final PunctuationType type,
-                                final Punctuator callback) {
-        throwUnsupportedOperationExceptionIfStandby("schedule");
-        if (intervalMs < 1) {
-            throw new IllegalArgumentException("The minimum supported scheduling interval is 1 millisecond.");
-        }
-        return streamTask.schedule(intervalMs, type, callback);
-    }
-
     @SuppressWarnings("deprecation") // removing #schedule(final long intervalMs,...) will fix this
     @Override
     public Cancellable schedule(final Duration interval,
@@ -282,7 +270,11 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
                                 final Punctuator callback) throws IllegalArgumentException {
         throwUnsupportedOperationExceptionIfStandby("schedule");
         final String msgPrefix = prepareMillisCheckFailMsgPrefix(interval, "interval");
-        return schedule(validateMillisecondDuration(interval, msgPrefix), type, callback);
+        final long intervalMs = validateMillisecondDuration(interval, msgPrefix);
+        if (intervalMs < 1) {
+            throw new IllegalArgumentException("The minimum supported scheduling interval is 1 millisecond.");
+        }
+        return streamTask.schedule(intervalMs, type, callback);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapter.java
@@ -88,12 +88,6 @@ public final class StoreToProcessorContextAdapter implements ProcessorContext {
         throw new UnsupportedOperationException("StateStores can't access getStateStore.");
     }
 
-    @Deprecated
-    @Override
-    public Cancellable schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) {
-        throw new UnsupportedOperationException("StateStores can't access schedule.");
-    }
-
     @Override
     public Cancellable schedule(final Duration interval, final PunctuationType type, final Punctuator callback) {
         throw new UnsupportedOperationException("StateStores can't access schedule.");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -195,14 +195,6 @@ public class AbstractProcessorContextTest {
         }
 
         @Override
-        @Deprecated
-        public Cancellable schedule(final long interval,
-                                    final PunctuationType type,
-                                    final Punctuator callback) {
-            return null;
-        }
-
-        @Override
         public Cancellable schedule(final Duration interval,
                                     final PunctuationType type,
                                     final Punctuator callback) throws IllegalArgumentException {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImplTest.java
@@ -122,12 +122,6 @@ public class GlobalProcessorContextImplTest {
         globalContext.commit();
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldNotAllowToSchedulePunctuationsUsingDeprecatedApi() {
-        assertThrows(UnsupportedOperationException.class, () -> globalContext.schedule(0L, null, null));
-    }
-
     @Test
     public void shouldNotAllowToSchedulePunctuations() {
         assertThrows(UnsupportedOperationException.class, () -> globalContext.schedule(null, null, null));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorContextImplTest.java
@@ -455,16 +455,6 @@ public class ProcessorContextImplTest {
         );
     }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    public void shouldThrowUnsupportedOperationExceptionOnScheduleWithInterval() {
-        context = getStandbyContext();
-        assertThrows(
-            UnsupportedOperationException.class,
-            () -> context.schedule(100L, PunctuationType.STREAM_TIME, t -> { })
-        );
-    }
-
     @Test
     public void shouldThrowUnsupportedOperationExceptionOnSchedule() {
         context = getStandbyContext();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreToProcessorContextAdapterTest.java
@@ -58,12 +58,6 @@ public class StoreToProcessorContextAdapterTest {
         context.getStateStore("store");
     }
 
-    @SuppressWarnings("deprecation") // need to test deprecated code until removed
-    @Test(expected = UnsupportedOperationException.class)
-    public void shouldThrowOnSchedule() {
-        context.schedule(0, PunctuationType.WALL_CLOCK_TIME, punctuator);
-    }
-
     @Test(expected = UnsupportedOperationException.class)
     public void shouldThrowOnScheduleWithDuration() {
         context.schedule(Duration.ZERO, PunctuationType.WALL_CLOCK_TIME, punctuator);

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -280,12 +280,6 @@ public class InternalMockProcessorContext
     }
 
     @Override
-    @Deprecated
-    public Cancellable schedule(final long interval, final PunctuationType type, final Punctuator callback) {
-        throw new UnsupportedOperationException("schedule() not supported.");
-    }
-
-    @Override
     public Cancellable schedule(final Duration interval,
                                 final PunctuationType type,
                                 final Punctuator callback) throws IllegalArgumentException {

--- a/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
@@ -71,14 +71,6 @@ public class NoOpProcessorContext extends AbstractProcessorContext {
     }
 
     @Override
-    @Deprecated
-    public Cancellable schedule(final long interval,
-                                final PunctuationType type,
-                                final Punctuator callback) {
-        return null;
-    }
-
-    @Override
     public Cancellable schedule(final Duration interval,
                                 final PunctuationType type,
                                 final Punctuator callback) throws IllegalArgumentException {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -456,6 +456,9 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
                                 final PunctuationType type,
                                 final Punctuator callback) throws IllegalArgumentException {
         final long intervalMs = ApiUtils.validateMillisecondDuration(interval, "interval");
+        if (intervalMs < 1) {
+            throw new IllegalArgumentException("The minimum supported scheduling interval is 1 millisecond.");
+        }
         final CapturedPunctuator capturedPunctuator = new CapturedPunctuator(intervalMs, type, callback);
 
         punctuators.add(capturedPunctuator);

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -450,24 +450,17 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
         return (S) stateStores.get(name);
     }
 
-    @Override
-    @Deprecated
-    public Cancellable schedule(final long intervalMs,
-                                final PunctuationType type,
-                                final Punctuator callback) {
-        final CapturedPunctuator capturedPunctuator = new CapturedPunctuator(intervalMs, type, callback);
-
-        punctuators.add(capturedPunctuator);
-
-        return capturedPunctuator::cancel;
-    }
-
     @SuppressWarnings("deprecation") // removing #schedule(final long intervalMs,...) will fix this
     @Override
     public Cancellable schedule(final Duration interval,
                                 final PunctuationType type,
                                 final Punctuator callback) throws IllegalArgumentException {
-        return schedule(ApiUtils.validateMillisecondDuration(interval, "interval"), type, callback);
+        final long intervalMs = ApiUtils.validateMillisecondDuration(interval, "interval");
+        final CapturedPunctuator capturedPunctuator = new CapturedPunctuator(intervalMs, type, callback);
+
+        punctuators.add(capturedPunctuator);
+
+        return capturedPunctuator::cancel;
     }
 
     /**


### PR DESCRIPTION
Removes the schedule method in ProcessorContext and all its
implementations

Method was deprecated back in 2.1

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
