### PR TITLE
KAFKA-12820: Upgrade maven-artifact dependency to resolve CVE-2021-26291

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,7 +97,7 @@ versions += [
   kafka_26: "2.6.2",
   kafka_27: "2.7.1",
   lz4: "1.7.1",
-  mavenArtifact: "3.6.3",
+  mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "3.9.0",
   netty: "4.1.62.Final",


### PR DESCRIPTION
[CVE-2021-26291](https://nvd.nist.gov/vuln/detail/CVE-2021-26291), which makes Man-In-The-Middle-Attack possible, was fixed in maven [3.8.1](https://maven.apache.org/docs/3.8.1/release-notes.html).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
