### PR TITLE
[KAFKA-12644] Add Missing Class-Level Javadoc to Exception Classes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/AuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/AuthorizationException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception is a base class for several authorization error conditions
+ *
+ */
 public class AuthorizationException extends ApiException {
 
     public AuthorizationException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/BrokerIdNotRegisteredException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/BrokerIdNotRegisteredException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates an error condition where the specified broker identifier was not previously registered
+ */
 public class BrokerIdNotRegisteredException extends ApiException {
 
     public BrokerIdNotRegisteredException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/BrokerNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/BrokerNotAvailableException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the broker is not available at the moment
+ */
 public class BrokerNotAvailableException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/ClusterAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ClusterAuthorizationException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the cluster authorization has failed
+ */
 public class ClusterAuthorizationException extends AuthorizationException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/ConcurrentTransactionsException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ConcurrentTransactionsException.java
@@ -16,6 +16,12 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that a concurrent exception has occurred.
+ *
+ * The producer attempted to update a transaction while
+ * another concurrent operation on the same transaction was ongoing.
+ */
 public class ConcurrentTransactionsException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/ControllerMovedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ControllerMovedException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the controller has been relocated to another broker
+ *
+ */
 public class ControllerMovedException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenAuthorizationException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates an error condition where the Delegation Token authorization has failed
+ *
+ */
 public class DelegationTokenAuthorizationException extends AuthorizationException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenDisabledException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenDisabledException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the delegation token feature is not enabled
+ */
 public class DelegationTokenDisabledException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenExpiredException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenExpiredException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the Delegation Token has expired
+ *
+ */
 public class DelegationTokenExpiredException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenNotFoundException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the Delegation Token could not be found
+ *
+ */
 public class DelegationTokenNotFoundException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenOwnerMismatchException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DelegationTokenOwnerMismatchException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the specified principal is not a valid Owner/Renewer
+ */
 public class DelegationTokenOwnerMismatchException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/DuplicateBrokerRegistrationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DuplicateBrokerRegistrationException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the specified broker identifier is already in use
+ *
+ */
 public class DuplicateBrokerRegistrationException extends ApiException {
 
     public DuplicateBrokerRegistrationException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/DuplicateSequenceException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/DuplicateSequenceException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception represents an error condition where the broker has received a duplicate sequence number
+ *
+ */
 public class DuplicateSequenceException extends ApiException {
 
     public DuplicateSequenceException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/ElectionNotNeededException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ElectionNotNeededException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception is thrown when a leader election is not necessary for a topic partition
+ *
+ */
 public class ElectionNotNeededException extends InvalidMetadataException {
 
     public ElectionNotNeededException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/EligibleLeadersNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/EligibleLeadersNotAvailableException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception is thrown when eligible topic partition leaders are not available
+ *
+ */
 public class EligibleLeadersNotAvailableException extends InvalidMetadataException {
 
     public EligibleLeadersNotAvailableException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/FeatureUpdateFailedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FeatureUpdateFailedException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception is thrown when the server is unable to update finalized features due to an unexpected server error
+ */
 public class FeatureUpdateFailedException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/FencedInstanceIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FencedInstanceIdException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception is thrown when the broker rejected this static consumer
+ * since another consumer with the same group.instance.id has registered with a different member.id
+ */
 public class FencedInstanceIdException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/FetchSessionIdNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FetchSessionIdNotFoundException.java
@@ -17,6 +17,10 @@
 
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the fetched session identifier was not found
+ *
+ */
 public class FetchSessionIdNotFoundException extends RetriableException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/GroupAuthorizationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/GroupAuthorizationException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that group authorization has failed
+ *
+ */
 public class GroupAuthorizationException extends AuthorizationException {
     private final String groupId;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/GroupIdNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/GroupIdNotFoundException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates that the group identifier could not be found
+ */
 public class GroupIdNotFoundException extends ApiException {
     public GroupIdNotFoundException(String message) {
         super(message);

--- a/clients/src/main/java/org/apache/kafka/common/errors/GroupNotEmptyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/GroupNotEmptyException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the group is not empty
+ */
 public class GroupNotEmptyException extends ApiException {
     public GroupNotEmptyException(String message) {
         super(message);

--- a/clients/src/main/java/org/apache/kafka/common/errors/GroupSubscribedToTopicException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/GroupSubscribedToTopicException.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Deleting offsets of a topic is forbidden while the consumer group is actively subscribed to it
+ *
+ * This exception is thrown in the event of such occurrence
+ */
 public class GroupSubscribedToTopicException extends ApiException {
     public GroupSubscribedToTopicException(String message) {
         super(message);

--- a/clients/src/main/java/org/apache/kafka/common/errors/IllegalGenerationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/IllegalGenerationException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception represents an error condition where the specified group generation id is not valid
+ */
 public class IllegalGenerationException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/IllegalSaslStateException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/IllegalSaslStateException.java
@@ -18,7 +18,7 @@ package org.apache.kafka.common.errors;
 
 /**
  * This exception indicates unexpected requests prior to SASL authentication.
- * This could be due to misconfigured security, e.g. if PLAINTEXT protocol
+ * This could be due to mis-configured security, e.g. if PLAINTEXT protocol
  * is used to connect to a SASL endpoint.
  */
 public class IllegalSaslStateException extends AuthenticationException {

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentClusterIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentClusterIdException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the clusterId in the request does not match that found on the server
+ */
 public class InconsistentClusterIdException extends ApiException {
 
     public InconsistentClusterIdException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentGroupProtocolException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentGroupProtocolException.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception represents an error condition where the group member's supported protocols are
+ * incompatible with those of existing members or first group member tried
+ * to join with empty protocol type or empty protocol list.
+ */
 public class InconsistentGroupProtocolException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentTopicIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentTopicIdException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the log's topic ID did not match the topic ID in the request
+ */
 public class InconsistentTopicIdException extends InvalidMetadataException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentVoterSetException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentVoterSetException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception represents an error condition where the either the
+ * sender or recipient of a voter-only request is not one of the expected voters
+ */
 public class InconsistentVoterSetException extends ApiException {
 
     private static final long serialVersionUID = 1;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidCommitOffsetSizeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidCommitOffsetSizeException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This error condition indicates that the committing offset data size is not valid.
+ */
 public class InvalidCommitOffsetSizeException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidConfigurationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidConfigurationException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates an error condition where the specified configuration is not valid
+ */
 public class InvalidConfigurationException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSessionEpochException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSessionEpochException.java
@@ -17,6 +17,9 @@
 
 package org.apache.kafka.common.errors;
 
+/**
+ * Represents an error condition where the fetch session epoch is not valid
+ */
 public class InvalidFetchSessionEpochException extends RetriableException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSizeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidFetchSizeException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This error condition indicates that the requested fetch size is not valid
+ */
 public class InvalidFetchSizeException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidGroupIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidGroupIdException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates that the configured group identifier is not valid
+ */
 public class InvalidGroupIdException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidPartitionsException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidPartitionsException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates that the specified number of partitions is less than one
+ */
 public class InvalidPartitionsException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidPidMappingException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidPidMappingException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Represents an error condition where the producer attempted to
+ * use a producer id which is not currently assigned to its transactional id
+ */
 public class InvalidPidMappingException extends ApiException {
     public InvalidPidMappingException(String message) {
         super(message);

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidPrincipalTypeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidPrincipalTypeException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates that the specified principalType is not supported
+ */
 public class InvalidPrincipalTypeException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicaAssignmentException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicaAssignmentException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates that the replica assignment is not valid
+ */
 public class InvalidReplicaAssignmentException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicationFactorException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidReplicationFactorException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the specified replication factor is below 1
+ * or larger than the number of available brokers
+ */
 public class InvalidReplicationFactorException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidRequiredAcksException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidRequiredAcksException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This indicates that the produce request specified an invalid value for required acks
+ */
 public class InvalidRequiredAcksException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidSessionTimeoutException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidSessionTimeoutException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This represents an error condition where the session timeout is not within the range allowed by the broker
+ * (as configured by group.min.session.timeout.ms and group.max.session.timeout.ms)
+ */
 public class InvalidSessionTimeoutException extends ApiException {
     private static final long serialVersionUID = 1L;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidTxnStateException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidTxnStateException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception represents an error condition where
+ * the producer attempted a transactional operation in an invalid state
+ */
 public class InvalidTxnStateException extends ApiException {
     public InvalidTxnStateException(String message) {
         super(message);

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidUpdateVersionException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidUpdateVersionException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This error condition indicates that the specified update version is not valid
+ */
 public class InvalidUpdateVersionException extends ApiException {
 
     public InvalidUpdateVersionException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/MemberIdRequiredException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MemberIdRequiredException.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * The group member needs to have a valid member id before actually entering a consumer group
+ *
+ * This exception is generated when this is not the case
+ */
 public class MemberIdRequiredException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/NotControllerException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/NotControllerException.java
@@ -16,6 +16,9 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This error condition indicates this is not the correct controller for this cluster
+ */
 public class NotControllerException extends RetriableException {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
…ache.kafka.common.errors.ApiException

Added missing class-level javadocs to Exception classes

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
