### PR TITLE
KAFKA-12446: Call subtractor before adder if key is the same

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -1024,7 +1024,9 @@ KTable&lt;byte[], Long&gt; aggregatedTable = groupedTable.aggregate(
                                     <li>When the first non-<code class="docutils literal"><span class="pre">null</span></code> value is received for a key (e.g.,  INSERT), then only the adder is called.</li>
                                     <li>When subsequent non-<code class="docutils literal"><span class="pre">null</span></code> values are received for a key (e.g.,  UPDATE), then (1) the subtractor is
                                         called with the old value as stored in the table and (2) the adder is called with the new value of the
-                                        input record that was just received.  The order of execution for the subtractor and adder is not defined.</li>
+                                        input record that was just received. The subtractor will be called before the adder if and only if the extracted grouping key of the old and new value is the same.
+                                        The detection of this case depends on the correct implementation of the equals() method of the extracted key type. Otherwise, the order of execution for the subtractor
+                                        and adder is not defined.</li>
                                     <li>When a tombstone record &#8211; i.e. a record with a <code class="docutils literal"><span class="pre">null</span></code> value &#8211; is received for a key (e.g.,  DELETE),
                                         then only the subtractor is called.  Note that, whenever the subtractor returns a <code class="docutils literal"><span class="pre">null</span></code> value itself,
                                         then the corresponding key is removed from the resulting <code class="docutils literal"><span class="pre">KTable</span></code>.  If that happens, any next input
@@ -1272,7 +1274,9 @@ KTable&lt;String, Long&gt; aggregatedTable = groupedTable.reduce(
                                     <li>When the first non-<code class="docutils literal"><span class="pre">null</span></code> value is received for a key (e.g.,  INSERT), then only the adder is called.</li>
                                     <li>When subsequent non-<code class="docutils literal"><span class="pre">null</span></code> values are received for a key (e.g.,  UPDATE), then (1) the subtractor is
                                         called with the old value as stored in the table and (2) the adder is called with the new value of the
-                                        input record that was just received.  The order of execution for the subtractor and adder is not defined.</li>
+                                        input record that was just received. The subtractor will be called before the adder if and only if the extracted grouping key of the old and new value is the same.
+                                        The detection of this case depends on the correct implementation of the equals() method of the extracted key type. Otherwise, the order of execution for the subtractor
+                                        and adder is not defined.</li>
                                     <li>When a tombstone record &#8211; i.e. a record with a <code class="docutils literal"><span class="pre">null</span></code> value &#8211; is received for a key (e.g.,  DELETE),
                                         then only the subtractor is called.  Note that, whenever the subtractor returns a <code class="docutils literal"><span class="pre">null</span></code> value itself,
                                         then the corresponding key is removed from the resulting <code class="docutils literal"><span class="pre">KTable</span></code>.  If that happens, any next input

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -84,7 +84,7 @@
 
         For a downgrade, first switch the config from <code>"upgrade.from"</code> to the version you are downgrading to.
         This disables writing of the new serialization format in your application. It's important to wait in this state
-        for a few minutes to make sure that the application has finished processing any "in-flight" messages written
+        log enough to make sure that the application has finished processing any "in-flight" messages written
         into the repartition topics in the new serialization format. Afterwards, you can downgrade your application to a
         pre-3.5.x version.
     </p>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -76,6 +76,20 @@
     </p>
 
     <p>
+        Downgrading from 3.5.x or newer version to 3.4.x or older version needs special attention:
+        Since 3.5.0 release, Kafka Streams uses a new serialization format for repartition topics.
+        This means that older versions of Kafka Streams would not be able to recognize the bytes written by newer versions,
+        and hence it is harder to downgrade Kafka Streams with version 3.5.0 or newer to older versions in-flight. For
+        more details, please refer to <a href="https://cwiki.apache.org/confluence/x/P5VbDg">KIP-904</a>.
+
+        For a downgrade, first switch the config from <code>"upgrade.from"</code> to the version you are downgrading to.
+        This disables writing of the new serialization format in your application. It's important to wait in this state
+        for a few minutes to make sure that the application has finished processing any "in-flight" messages written
+        into the repartition topics in the new serialization format. Afterwards, you can downgrade your application to a
+        pre-3.5.x version.
+    </p>
+
+    <p>
         Kafka Streams does not support running multiple instances of the same application as different processes on the same physical state directory. Starting in 2.8.0 (as well as 2.7.1 and 2.6.2),
         this restriction will be enforced. If you wish to run more than one instance of Kafka Streams, you must configure them with different values for <code>state.dir</code>.
     </p>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -34,6 +34,8 @@
     </div>
 
     <p>
+        Do I need to make changes in here?
+
         Upgrading from any older version to {{fullDotVersion}} is possible: if upgrading from 3.2 or below, you will need to do two rolling bounces, where during the first rolling bounce phase you set the config <code>upgrade.from="older version"</code>
         (possible values are <code>"0.10.0" - "3.2"</code>) and during the second you remove it. This is required to safely handle 2 changes. The first is introduction of the new cooperative rebalancing protocol of the embedded consumer. The second is a change in foreign-key join serialization format.
         Note that you will remain using the old eager rebalancing protocol if you skip or delay the second rolling bounce, but you can safely switch over to cooperative at any time once the entire group is on 2.4+ by removing the config value and bouncing. For more details please refer to

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -84,7 +84,7 @@
 
         For a downgrade, first switch the config from <code>"upgrade.from"</code> to the version you are downgrading to.
         This disables writing of the new serialization format in your application. It's important to wait in this state
-        log enough to make sure that the application has finished processing any "in-flight" messages written
+        long enough to make sure that the application has finished processing any "in-flight" messages written
         into the repartition topics in the new serialization format. Afterwards, you can downgrade your application to a
         pre-3.5.x version.
     </p>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -34,12 +34,10 @@
     </div>
 
     <p>
-        Do I need to make changes in here?
-
-        Upgrading from any older version to {{fullDotVersion}} is possible: if upgrading from 3.2 or below, you will need to do two rolling bounces, where during the first rolling bounce phase you set the config <code>upgrade.from="older version"</code>
-        (possible values are <code>"0.10.0" - "3.2"</code>) and during the second you remove it. This is required to safely handle 2 changes. The first is introduction of the new cooperative rebalancing protocol of the embedded consumer. The second is a change in foreign-key join serialization format.
+        Upgrading from any older version to {{fullDotVersion}} is possible: if upgrading from 3.4 or below, you will need to do two rolling bounces, where during the first rolling bounce phase you set the config <code>upgrade.from="older version"</code>
+        (possible values are <code>"0.10.0" - "3.4"</code>) and during the second you remove it. This is required to safely handle 3 changes. The first is introduction of the new cooperative rebalancing protocol of the embedded consumer. The second is a change in foreign-key join serialization format.
         Note that you will remain using the old eager rebalancing protocol if you skip or delay the second rolling bounce, but you can safely switch over to cooperative at any time once the entire group is on 2.4+ by removing the config value and bouncing. For more details please refer to
-        <a href="https://cwiki.apache.org/confluence/x/vAclBg">KIP-429</a>:
+        <a href="https://cwiki.apache.org/confluence/x/vAclBg">KIP-429</a>. The third is a change in the serialization format for an internal repartition topic. For more details, please refer to <a href="https://cwiki.apache.org/confluence/x/P5VbDg">KIP-904</a>:
     </p>
     <ul>
         <li> prepare your application instances for a rolling bounce and make sure that config <code>upgrade.from</code> is set to the version from which it is being upgrade.</li>

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -399,6 +399,12 @@ public class StreamsConfig extends AbstractConfig {
     public static final String UPGRADE_FROM_33 = "3.3";
 
     /**
+     * Config value for parameter {@link #UPGRADE_FROM_CONFIG "upgrade.from"} for upgrading an application from version {@code 3.4.x}.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final String UPGRADE_FROM_34 = "3.4";
+
+    /**
      * Config value for parameter {@link #PROCESSING_GUARANTEE_CONFIG "processing.guarantee"} for at-least-once processing guarantees.
      */
     @SuppressWarnings("WeakerAccess")
@@ -749,7 +755,7 @@ public class StreamsConfig extends AbstractConfig {
         UPGRADE_FROM_22 + "\", \"" + UPGRADE_FROM_23 + "\", \"" + UPGRADE_FROM_24 + "\", \"" +
         UPGRADE_FROM_25 + "\", \"" + UPGRADE_FROM_26 + "\", \"" + UPGRADE_FROM_27 + "\", \"" +
         UPGRADE_FROM_28 + "\", \"" + UPGRADE_FROM_30 + "\", \"" + UPGRADE_FROM_31 + "\", \"" +
-        UPGRADE_FROM_32 + "\", \"" + UPGRADE_FROM_33 + "\" (for upgrading from the corresponding old version).";
+        UPGRADE_FROM_32 + "\", \"" + UPGRADE_FROM_33 + "\", \"" + UPGRADE_FROM_34 + "\" (for upgrading from the corresponding old version).";
 
     /** {@code windowstore.changelog.additional.retention.ms} */
     @SuppressWarnings("WeakerAccess")
@@ -1104,7 +1110,8 @@ public class StreamsConfig extends AbstractConfig {
                        UPGRADE_FROM_30,
                        UPGRADE_FROM_31,
                        UPGRADE_FROM_32,
-                       UPGRADE_FROM_33),
+                       UPGRADE_FROM_33,
+                       UPGRADE_FROM_34),
                     Importance.LOW,
                     UPGRADE_FROM_DOC)
             .define(WINDOWED_INNER_CLASS_SERDE,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -18,13 +18,14 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 
 import java.nio.ByteBuffer;
 
 public class ChangedDeserializer<T> implements Deserializer<Change<T>>, WrappingNullableDeserializer<Change<T>, Void, T> {
 
-    private static final int NEWFLAG_SIZE = 1;
+    private static final int NEW_OLD_FLAG_SIZE = 1;
 
     private Deserializer<T> inner;
 
@@ -46,16 +47,41 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
 
     @Override
     public Change<T> deserialize(final String topic, final Headers headers, final byte[] data) {
+        // The format we need to deserialize is:
+        // {BYTE_ARRAY oldValue}{BYTE newOldFlag=0}
+        // {BYTE_ARRAY newValue}{BYTE newOldFlag=1}
+        // {INT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE newOldFlag=2}
+        final ByteBuffer buffer = ByteBuffer.wrap(data);
+        final byte newOldFlag = buffer.get(data.length - NEW_OLD_FLAG_SIZE);
 
-        final byte[] bytes = new byte[data.length - NEWFLAG_SIZE];
+        final byte[] newData;
+        final byte[] oldData;
+        if (newOldFlag == (byte) 0) {
+            newData = null;
+            final int oldDataLength = data.length - NEW_OLD_FLAG_SIZE;
+            oldData = new byte[oldDataLength];
+            buffer.get(oldData);
+        } else if (newOldFlag == (byte) 1) {
+            oldData = null;
+            final int newDataLength = data.length - NEW_OLD_FLAG_SIZE;
+            newData = new byte[newDataLength];
+            buffer.get(newData);
+        } else if (newOldFlag == (byte) 2) {
+            final int newDataLength = buffer.getInt();
+            newData = new byte[newDataLength];
 
-        System.arraycopy(data, 0, bytes, 0, bytes.length);
+            final int oldDataLength = data.length - Integer.BYTES - newDataLength - NEW_OLD_FLAG_SIZE;
+            oldData = new byte[oldDataLength];
 
-        if (ByteBuffer.wrap(data).get(data.length - NEWFLAG_SIZE) != 0) {
-            return new Change<>(inner.deserialize(topic, headers, bytes), null);
+            buffer.get(newData);
+            buffer.get(oldData);
         } else {
-            return new Change<>(null, inner.deserialize(topic, headers, bytes));
+            throw new StreamsException("Encountered unknown byte value `" + newOldFlag + "` for oldNewFlag in in ChangedDeserializer.");
         }
+
+        return new Change<>(
+                inner.deserialize(topic, headers, newData),
+                inner.deserialize(topic, headers, oldData));
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -77,7 +77,7 @@ public class ChangedDeserializer<T> implements Deserializer<Change<T>>, Wrapping
             buffer.get(newData);
             buffer.get(oldData);
         } else {
-            throw new StreamsException("Encountered unknown byte value `" + newOldFlag + "` for oldNewFlag in in ChangedDeserializer.");
+            throw new StreamsException("Encountered unknown byte value `" + newOldFlag + "` for oldNewFlag in ChangedDeserializer.");
         }
 
         return new Change<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
@@ -50,7 +50,7 @@ public class ChangedSerializer<T> implements Serializer<Change<T>>, WrappingNull
     }
 
     @SuppressWarnings("checkstyle:cyclomaticComplexity")
-    private boolean isUpgrade(final Map<String, ?> configs) {
+    private static boolean isUpgrade(final Map<String, ?> configs) {
         final Object upgradeFrom = configs.get(StreamsConfig.UPGRADE_FROM_CONFIG);
         if (upgradeFrom == null) {
             return false;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
@@ -76,6 +76,7 @@ public class ChangedSerializer<T> implements Serializer<Change<T>>, WrappingNull
             case StreamsConfig.UPGRADE_FROM_31:
             case StreamsConfig.UPGRADE_FROM_32:
             case StreamsConfig.UPGRADE_FROM_33:
+            case StreamsConfig.UPGRADE_FROM_34:
                 return true;
             default:
                 return false;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
@@ -18,16 +18,18 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.internals.SerdeGetter;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 public class ChangedSerializer<T> implements Serializer<Change<T>>, WrappingNullableSerializer<Change<T>, Void, T> {
 
-    private static final int NEWFLAG_SIZE = 1;
-
+    private static final int NEW_OLD_FLAG_SIZE = 1;
     private Serializer<T> inner;
+    private boolean isUpgrade;
 
     public ChangedSerializer(final Serializer<T> inner) {
         this.inner = inner;
@@ -45,33 +47,84 @@ public class ChangedSerializer<T> implements Serializer<Change<T>>, WrappingNull
         }
     }
 
+    @SuppressWarnings("checkstyle:cyclomaticComplexity")
+    private boolean isUpgrade(final Map<String, ?> configs) {
+        final Object upgradeFrom = configs.get(StreamsConfig.UPGRADE_FROM_CONFIG);
+        if (upgradeFrom == null) {
+            return false;
+        }
+
+        switch ((String) upgradeFrom) {
+            case StreamsConfig.UPGRADE_FROM_0100:
+            case StreamsConfig.UPGRADE_FROM_0101:
+            case StreamsConfig.UPGRADE_FROM_0102:
+            case StreamsConfig.UPGRADE_FROM_0110:
+            case StreamsConfig.UPGRADE_FROM_10:
+            case StreamsConfig.UPGRADE_FROM_11:
+            case StreamsConfig.UPGRADE_FROM_20:
+            case StreamsConfig.UPGRADE_FROM_21:
+            case StreamsConfig.UPGRADE_FROM_22:
+            case StreamsConfig.UPGRADE_FROM_23:
+            case StreamsConfig.UPGRADE_FROM_24:
+            case StreamsConfig.UPGRADE_FROM_25:
+            case StreamsConfig.UPGRADE_FROM_26:
+            case StreamsConfig.UPGRADE_FROM_27:
+            case StreamsConfig.UPGRADE_FROM_28:
+            case StreamsConfig.UPGRADE_FROM_30:
+            case StreamsConfig.UPGRADE_FROM_31:
+            case StreamsConfig.UPGRADE_FROM_32:
+            case StreamsConfig.UPGRADE_FROM_33:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+        this.isUpgrade = isUpgrade(configs);
+    }
+
     /**
      * @throws StreamsException if both old and new values of data are null, or if
-     * both values are not null
+     * both values are not null and is upgrading from a version less than 3.4
      */
     @Override
     public byte[] serialize(final String topic, final Headers headers, final Change<T> data) {
-        final byte[] serializedKey;
+        final boolean oldValueIsNull = data.oldValue == null;
+        final boolean newValueIsNull = data.newValue == null;
 
-        // only one of the old / new values would be not null
-        if (data.newValue != null) {
-            if (data.oldValue != null) {
+        final byte[] newData = inner.serialize(topic, headers, data.newValue);
+        final byte[] oldData = inner.serialize(topic, headers, data.oldValue);
+
+        final int newDataLength = newValueIsNull ? 0 : newData.length;
+        final int oldDataLength = oldValueIsNull ? 0 : oldData.length;
+
+        // The serialization format is:
+        // {BYTE_ARRAY oldValue}{BYTE newOldFlag=0}
+        // {BYTE_ARRAY newValue}{BYTE newOldFlag=1}
+        // {INT newDataLength}{BYTE_ARRAY newValue}{BYTE_ARRAY oldValue}{BYTE newOldFlag=2}
+        final ByteBuffer buf;
+        if (!newValueIsNull && !oldValueIsNull) {
+            if (isUpgrade) {
                 throw new StreamsException("Both old and new values are not null (" + data.oldValue
-                    + " : " + data.newValue + ") in ChangeSerializer, which is not allowed.");
+                        + " : " + data.newValue + ") in ChangeSerializer, which is not allowed unless upgrading.");
+            } else {
+                final int capacity = Integer.BYTES + newDataLength + oldDataLength + NEW_OLD_FLAG_SIZE;
+                buf = ByteBuffer.allocate(capacity);
+                buf.putInt(newDataLength).put(newData).put(oldData).put((byte) 2);
             }
-
-            serializedKey = inner.serialize(topic, headers, data.newValue);
+        } else if (!newValueIsNull) {
+            final int capacity = newDataLength + NEW_OLD_FLAG_SIZE;
+            buf = ByteBuffer.allocate(capacity);
+            buf.put(newData).put((byte) 1);
+        } else if (!oldValueIsNull) {
+            final int capacity = oldDataLength + NEW_OLD_FLAG_SIZE;
+            buf = ByteBuffer.allocate(capacity);
+            buf.put(oldData).put((byte) 0);
         } else {
-            if (data.oldValue == null) {
-                throw new StreamsException("Both old and new values are null in ChangeSerializer, which is not allowed.");
-            }
-
-            serializedKey = inner.serialize(topic, headers, data.oldValue);
+            throw new StreamsException("Both old and new values are null in ChangeSerializer, which is not allowed.");
         }
-
-        final ByteBuffer buf = ByteBuffer.allocate(serializedKey.length + NEWFLAG_SIZE);
-        buf.put(serializedKey);
-        buf.put((byte) (data.newValue != null ? 1 : 0));
 
         return buf.array();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -108,6 +108,7 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
                 case StreamsConfig.UPGRADE_FROM_31:
                 case StreamsConfig.UPGRADE_FROM_32:
                 case StreamsConfig.UPGRADE_FROM_33:
+                case StreamsConfig.UPGRADE_FROM_34:
                     return false;
                 default:
                     return true;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
@@ -25,6 +26,8 @@ import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.ValueAndTimestamp;
+
+import java.util.Map;
 
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
@@ -76,6 +79,47 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
 
     private class KTableMapProcessor extends ContextualProcessor<K, Change<V>, K1, Change<V1>> {
 
+        private boolean isNotUpgrade;
+
+        @SuppressWarnings("checkstyle:cyclomaticComplexity")
+        private boolean isNotUpgrade(final Map<String, ?> configs) {
+            final Object upgradeFrom = configs.get(StreamsConfig.UPGRADE_FROM_CONFIG);
+            if (upgradeFrom == null) {
+                return true;
+            }
+
+            switch ((String) upgradeFrom) {
+                case StreamsConfig.UPGRADE_FROM_0100:
+                case StreamsConfig.UPGRADE_FROM_0101:
+                case StreamsConfig.UPGRADE_FROM_0102:
+                case StreamsConfig.UPGRADE_FROM_0110:
+                case StreamsConfig.UPGRADE_FROM_10:
+                case StreamsConfig.UPGRADE_FROM_11:
+                case StreamsConfig.UPGRADE_FROM_20:
+                case StreamsConfig.UPGRADE_FROM_21:
+                case StreamsConfig.UPGRADE_FROM_22:
+                case StreamsConfig.UPGRADE_FROM_23:
+                case StreamsConfig.UPGRADE_FROM_24:
+                case StreamsConfig.UPGRADE_FROM_25:
+                case StreamsConfig.UPGRADE_FROM_26:
+                case StreamsConfig.UPGRADE_FROM_27:
+                case StreamsConfig.UPGRADE_FROM_28:
+                case StreamsConfig.UPGRADE_FROM_30:
+                case StreamsConfig.UPGRADE_FROM_31:
+                case StreamsConfig.UPGRADE_FROM_32:
+                case StreamsConfig.UPGRADE_FROM_33:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+
+        @Override
+        public void init(final ProcessorContext<K1, Change<V1>> context) {
+            super.init(context);
+            isNotUpgrade = isNotUpgrade(context().appConfigs());
+        }
+
         /**
          * @throws StreamsException if key is null
          */
@@ -94,12 +138,18 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableRepartitionMapS
 
             // if the selected repartition key or value is null, skip
             // forward oldPair first, to be consistent with reduce and aggregate
-            if (oldPair != null && oldPair.key != null && oldPair.value != null) {
-                context().forward(record.withKey(oldPair.key).withValue(new Change<>(null, oldPair.value)));
-            }
+            final boolean oldPairNotNull = oldPair != null && oldPair.key != null && oldPair.value != null;
+            final boolean newPairNotNull = newPair != null && newPair.key != null && newPair.value != null;
+            if (isNotUpgrade && oldPairNotNull && newPairNotNull && oldPair.key.equals(newPair.key)) {
+                context().forward(record.withKey(oldPair.key).withValue(new Change<>(newPair.value, oldPair.value)));
+            } else {
+                if (oldPairNotNull) {
+                    context().forward(record.withKey(oldPair.key).withValue(new Change<>(null, oldPair.value)));
+                }
 
-            if (newPair != null && newPair.key != null && newPair.value != null) {
-                context().forward(record.withKey(newPair.key).withValue(new Change<>(newPair.value, null)));
+                if (newPairNotNull) {
+                    context().forward(record.withKey(newPair.key).withValue(new Change<>(newPair.value, null)));
+                }
             }
 
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
+
+public class ChangedSerdeTest {
+    private static final String TOPIC = "some-topic";
+
+    private static final ChangedSerializer<String> CHANGED_STRING_SERIALIZER =
+            new ChangedSerializer<>(Serdes.String().serializer());
+
+    private static final ChangedDeserializer<String> CHANGED_STRING_DESERIALIZER =
+            new ChangedDeserializer<>(Serdes.String().deserializer());
+
+    final String nonNullNewValue = "hello";
+    final String nonNullOldValue = "world";
+
+    private static <T> void checkRoundTrip(final T data, final Serializer<T> serializer, final Deserializer<T> deserializer) {
+        final byte[] serialized = serializer.serialize(TOPIC, data);
+        assertThat(serialized, is(notNullValue()));
+        final T deserialized = deserializer.deserialize(TOPIC, serialized);
+        assertThat(deserialized, is(data));
+    }
+
+    @Test
+    public void serializerShouldThrowIfGivenAChangeWithBothNewAndOldValuesAsNull() {
+        final Change<String> data = new Change<>(null, null);
+
+        assertThrows(
+                StreamsException.class,
+                () -> CHANGED_STRING_SERIALIZER.serialize(TOPIC, data));
+    }
+
+    @Test
+    public void serializerShouldThrowIfGivenAChangeWithBothNonNullNewAndOldValuesAndIsUpgrade() {
+        final Change<String> data = new Change<>(nonNullNewValue, nonNullOldValue);
+        final ChangedSerializer<String> serializer = new ChangedSerializer<>(Serdes.String().serializer());
+        final Map<String, String> configs = Collections.singletonMap(StreamsConfig.UPGRADE_FROM_CONFIG, StreamsConfig.UPGRADE_FROM_33);
+        serializer.configure(configs, false);
+
+        assertThrows(
+                StreamsException.class,
+                () -> serializer.serialize(TOPIC, data));
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeChangeWithNonNullNewAndOldValues() {
+        final Change<String> data = new Change<>(nonNullNewValue, nonNullOldValue);
+        checkRoundTrip(data, CHANGED_STRING_SERIALIZER, CHANGED_STRING_DESERIALIZER);
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeChangeWithNonNullNewValueAndNullOldValue() {
+        final Change<String> data = new Change<>(nonNullNewValue, null);
+        checkRoundTrip(data, CHANGED_STRING_SERIALIZER, CHANGED_STRING_DESERIALIZER);
+    }
+
+    @Test
+    public void shouldSerializeAndDeserializeChangeWithNullNewValueAndNonNullOldValue() {
+        final Change<String> data = new Change<>(null, nonNullOldValue);
+        checkRoundTrip(data, CHANGED_STRING_SERIALIZER, CHANGED_STRING_DESERIALIZER);
+    }
+
+    @Test
+    public void shouldThrowErrorIfEncountersAnUnknownByteValueForOldNewFlag() {
+        final Change<String> data = new Change<>(null, nonNullOldValue);
+        final byte[] serialized = CHANGED_STRING_SERIALIZER.serialize(TOPIC, data);
+        assertThat(serialized, is(notNullValue()));
+
+        // mutate the serialized array to replace OLD_NEW_FLAG with an unsupported byte value
+        final ByteBuffer buffer = ByteBuffer.wrap(serialized);
+        buffer.position(serialized.length - 1);
+        buffer.put((byte) 3);
+
+        Assert.assertThrows(
+            StreamsException.class,
+            () -> CHANGED_STRING_DESERIALIZER.deserialize(TOPIC, serialized));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/ChangedSerdeTest.java
@@ -100,7 +100,7 @@ public class ChangedSerdeTest {
         // mutate the serialized array to replace OLD_NEW_FLAG with an unsupported byte value
         final ByteBuffer buffer = ByteBuffer.wrap(serialized);
         buffer.position(serialized.length - 1);
-        buffer.put((byte) 3);
+        buffer.put((byte) -1);
 
         Assert.assertThrows(
             StreamsException.class,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableTransformValuesTest.java
@@ -66,6 +66,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
@@ -439,11 +440,9 @@ public class KTableTransformValuesTest {
         inputTopic.pipeInput("A", "ignored1", 15L);
         inputTopic.pipeInput("A", "ignored2", 10L);
 
-        assertThat(output(), hasItems(new KeyValueTimestamp<>("A", "1", 5),
-                new KeyValueTimestamp<>("A", "0", 15),
+        assertThat(output(), equalTo(Arrays.asList(new KeyValueTimestamp<>("A", "1", 5),
                 new KeyValueTimestamp<>("A", "2", 15),
-                new KeyValueTimestamp<>("A", "0", 15),
-                new KeyValueTimestamp<>("A", "3", 15)));
+                new KeyValueTimestamp<>("A", "3", 15))));
 
         final KeyValueStore<String, Integer> keyValueStore = driver.getKeyValueStore(QUERYABLE_NAME);
         assertThat(keyValueStore.get("A"), is(3));
@@ -468,11 +467,9 @@ public class KTableTransformValuesTest {
         inputTopic.pipeInput("A", "aa", 15L);
         inputTopic.pipeInput("A", "aaa", 10);
 
-        assertThat(output(), hasItems(new KeyValueTimestamp<>("A", "1", 5),
-                 new KeyValueTimestamp<>("A", "0", 15),
-                 new KeyValueTimestamp<>("A", "2", 15),
-                 new KeyValueTimestamp<>("A", "0", 15),
-                 new KeyValueTimestamp<>("A", "3", 15)));
+        assertThat(output(), equalTo(Arrays.asList(new KeyValueTimestamp<>("A", "1", 5),
+                new KeyValueTimestamp<>("A", "2", 15),
+                new KeyValueTimestamp<>("A", "3", 15))));
     }
 
     private ArrayList<KeyValueTimestamp<String, String>> output() {


### PR DESCRIPTION
For full details, please see [KIP-904](https://cwiki.apache.org/confluence/x/P5VbDg). 

# Problem
During `KTable.groupBy`, we write into a repartition topic. Since the grouping key can change, we need to send separate events for the oldValue and the newValue to downstream nodes (where they will be “subtracted” and “added” respectively from/to the aggregate for the old key and the new key respectively). 

However, sending the oldValue and the newValue as separate events is not strictly necessary when the grouping key does not change and doing so poses two challenges for users: 
1. Firstly, the resulting KTable (i.e. the result of `KTable.groupBy(???).aggregate(???)`) can briefly be in an “inconsistent” state where the oldValue has been “subtracted” from the aggregate for the key but the newValue has not yet been “added” to the aggregate of the key because each event (oldValue, newValue) is processed separately.  
2. Secondly, if users fail to correctly configure their producers correctly to avoid re-ordering during `send()`, it’s possible the newValue may be sent (and therefore processed by the aggregator) before the oldValue. If the user’s`adder` and `subtractor` functions are non-commutative, this would put the aggregate in a permanently “inconsistent” state. 

Whilst there are ways to get around this issue by dropping down to the Processor API level, it would be nicer if this was handled by Kafka Streams more seamlessly. 

# Solution
If the grouping key has not changed, the oldValue and newValue events are guaranteed to be processed by the same processor.  As such, we should be able to send them as a single `Change<T>` event. The subtractor and adder functions can then be executed (in that order) and the KTable can be updated in a single “atomic” operation. In this way, we are able to remove any possibility of ending up in an “inconsistent” state. Also, note that sending the oldValue and newValue in the same event ensures that they can’t be re-ordered relative to each other irrespective of how a user has configured the producer settings. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
