### PR TITLE
MINOR: Add missing apiversion test for 3.0

### DIFF
--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -171,6 +171,7 @@ class ApiVersionTest {
     assertEquals("2.6", KAFKA_2_6_IV0.shortVersion)
     assertEquals("2.7", KAFKA_2_7_IV2.shortVersion)
     assertEquals("2.8", KAFKA_2_8_IV0.shortVersion)
+    assertEquals("2.8", KAFKA_2_8_IV1.shortVersion)
     assertEquals("3.0", KAFKA_3_0_IV0.shortVersion)
     assertEquals("3.0", KAFKA_3_0_IV1.shortVersion)
   }

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -119,6 +119,9 @@ class ApiVersionTest {
     assertEquals(KAFKA_2_8_IV1, ApiVersion("2.8"))
     assertEquals(KAFKA_2_8_IV0, ApiVersion("2.8-IV0"))
     assertEquals(KAFKA_2_8_IV1, ApiVersion("2.8-IV1"))
+
+    assertEquals(KAFKA_3_0_IV0, ApiVersion("3.0"))
+    assertEquals(KAFKA_3_0_IV0, ApiVersion("3.0-IV0"))
   }
 
   @Test
@@ -167,6 +170,7 @@ class ApiVersionTest {
     assertEquals("2.6", KAFKA_2_6_IV0.shortVersion)
     assertEquals("2.7", KAFKA_2_7_IV2.shortVersion)
     assertEquals("2.8", KAFKA_2_8_IV0.shortVersion)
+    assertEquals("3.0", KAFKA_3_0_IV0.shortVersion)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -120,8 +120,9 @@ class ApiVersionTest {
     assertEquals(KAFKA_2_8_IV0, ApiVersion("2.8-IV0"))
     assertEquals(KAFKA_2_8_IV1, ApiVersion("2.8-IV1"))
 
-    assertEquals(KAFKA_3_0_IV0, ApiVersion("3.0"))
+    assertEquals(KAFKA_3_0_IV1, ApiVersion("3.0"))
     assertEquals(KAFKA_3_0_IV0, ApiVersion("3.0-IV0"))
+    assertEquals(KAFKA_3_0_IV1, ApiVersion("3.0-IV1"))
   }
 
   @Test
@@ -171,6 +172,7 @@ class ApiVersionTest {
     assertEquals("2.7", KAFKA_2_7_IV2.shortVersion)
     assertEquals("2.8", KAFKA_2_8_IV0.shortVersion)
     assertEquals("3.0", KAFKA_3_0_IV0.shortVersion)
+    assertEquals("3.0", KAFKA_3_0_IV1.shortVersion)
   }
 
   @Test


### PR DESCRIPTION
*More detailed description of your change*
#10504 bump apiversion to 3.0.0, we'd better also add test for it.

*Summary of testing strategy (including rationale)*
Unit test

