### PR TITLE
MINOR: deprecate TaskMetadata constructor and add KIP-740 notes to upgrade guide

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -117,6 +117,14 @@
     <p>
         We removed the default implementation of <code>RocksDBConfigSetter#close()</code>.
     </p>
+
+    <p>
+        The public <code>topicGroupId</code> and <code>partition</code> fields on TaskId have been deprecated and replaced with getters, please migrate to using the new <code>TaskId.subtopology()</code>
+        and <code>TaskId.partition()</code> APIs instead. Also, the <code>TaskId#readFrom</code> and <code>TaskId#writeTo</code> methods have been deprecated and will be removed, as they were never intended
+        for public use to begin with. Finally, we have deprecated the <code>TaskMetadata.taskId()</code> method as well as the <code>TaskMetadata</code>constructor. These have been replaced with APIs that
+        better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new <code>TaskMetadata#getTaskId</code> method and the new constructor which accepts
+        the task id parameter as a <code>TaskId</code> rather than a String. See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> for more details.
+    </p>
     <p>
         We removed the following deprecated APIs:
     </p>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -119,11 +119,11 @@
     </p>
 
     <p>
-        The public <code>topicGroupId</code> and <code>partition</code> fields on TaskId have been deprecated and replaced with getters, please migrate to using the new <code>TaskId.subtopology()</code>
+        The public <code>topicGroupId</code> and <code>partition</code> fields on TaskId have been deprecated and replaced with getters. Please migrate to using the new <code>TaskId.subtopology()</code>
+        (which replaces <code>topicGroupId</code>)
         and <code>TaskId.partition()</code> APIs instead. Also, the <code>TaskId#readFrom</code> and <code>TaskId#writeTo</code> methods have been deprecated and will be removed, as they were never intended
-        for public use to begin with. Finally, we have deprecated the <code>TaskMetadata.taskId()</code> method as well as the <code>TaskMetadata</code>constructor. These have been replaced with APIs that
-        better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new <code>TaskMetadata#getTaskId</code> method and the new constructor which accepts
-        the task id parameter as a <code>TaskId</code> rather than a String. See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> for more details.
+        for public use. Finally, we have deprecated the <code>TaskMetadata.taskId()</code> method as well as the <code>TaskMetadata</code> constructor. These have been replaced with APIs that
+        better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new <code>TaskMetadata#getTaskId</code> method. See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> for more details.
     </p>
     <p>
         We removed the following deprecated APIs:

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -120,10 +120,10 @@
 
     <p>
         The public <code>topicGroupId</code> and <code>partition</code> fields on TaskId have been deprecated and replaced with getters. Please migrate to using the new <code>TaskId.subtopology()</code>
-        (which replaces <code>topicGroupId</code>)
-        and <code>TaskId.partition()</code> APIs instead. Also, the <code>TaskId#readFrom</code> and <code>TaskId#writeTo</code> methods have been deprecated and will be removed, as they were never intended
-        for public use. Finally, we have deprecated the <code>TaskMetadata.taskId()</code> method as well as the <code>TaskMetadata</code> constructor. These have been replaced with APIs that
-        better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new <code>TaskMetadata#getTaskId</code> method. See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> for more details.
+        (which replaces <code>topicGroupId</code>) and <code>TaskId.partition()</code> APIs instead. Also, the <code>TaskId#readFrom</code> and <code>TaskId#writeTo</code> methods have been deprecated
+        and will be removed, as they were never intended for public use. Finally, we have deprecated the <code>TaskMetadata.taskId()</code> method as well as the <code>TaskMetadata</code> constructor.
+        These have been replaced with APIs that better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new <code>TaskMetadata#getTaskId</code>
+        method. See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> for more details.
     </p>
     <p>
         We removed the following deprecated APIs:

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -16,13 +16,14 @@
  */
 package org.apache.kafka.streams.processor;
 
+import org.apache.kafka.streams.errors.TaskIdFormatException;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
-import org.apache.kafka.streams.errors.TaskIdFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -80,7 +80,11 @@ public class TaskId implements Comparable<TaskId> {
 
     @Override
     public String toString() {
-        return topicGroupId + "_" + partition;
+        if (namedTopology != null) {
+            return namedTopology + "_" + topicGroupId + "_" + partition;
+        } else {
+            return topicGroupId + "_" + partition;
+        }
     }
 
     /**
@@ -88,7 +92,7 @@ public class TaskId implements Comparable<TaskId> {
      */
     public static TaskId parse(final String taskIdStr) {
         final int firstIndex = taskIdStr.indexOf('_');
-        final int secondIndex = taskIdStr.substring(firstIndex + 1).indexOf('_');
+        final int secondIndex = taskIdStr.indexOf('_', firstIndex + 1);
         if (firstIndex <= 0 || firstIndex + 1 >= taskIdStr.length()) {
             throw new TaskIdFormatException(taskIdStr);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -80,11 +80,7 @@ public class TaskId implements Comparable<TaskId> {
 
     @Override
     public String toString() {
-        if (namedTopology != null) {
-            return namedTopology + "_" + topicGroupId + "_" + partition;
-        } else {
-            return topicGroupId + "_" + partition;
-        }
+        return namedTopology != null ? namedTopology + "_" + topicGroupId + "_" + partition : topicGroupId + "_" + partition;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
@@ -41,7 +41,7 @@ public class TaskMetadata {
     private final Optional<Long> timeCurrentIdlingStarted;
 
     /**
-     * @deprecated since 3.0, please use the constructor that accepts a TaskId object instead of a String
+     * @deprecated since 3.0, please use {@link #TaskMetadata(TaskId, Set, Map, Map, Optional) instead}
      */
     @Deprecated
     public TaskMetadata(final String taskId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
@@ -40,6 +40,18 @@ public class TaskMetadata {
 
     private final Optional<Long> timeCurrentIdlingStarted;
 
+    /**
+     * @deprecated since 3.0, please use the constructor that accepts a TaskId object instead of a String
+     */
+    @Deprecated
+    public TaskMetadata(final String taskId,
+                        final Set<TopicPartition> topicPartitions,
+                        final Map<TopicPartition, Long> committedOffsets,
+                        final Map<TopicPartition, Long> endOffsets,
+                        final Optional<Long> timeCurrentIdlingStarted) {
+        this(TaskId.parse(taskId), topicPartitions, committedOffsets, endOffsets, timeCurrentIdlingStarted);
+    }
+
     public TaskMetadata(final TaskId taskId,
                         final Set<TopicPartition> topicPartitions,
                         final Map<TopicPartition, Long> committedOffsets,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
@@ -41,7 +41,7 @@ public class TaskMetadata {
     private final Optional<Long> timeCurrentIdlingStarted;
 
     /**
-     * @deprecated since 3.0, please use {@link #TaskMetadata(TaskId, Set, Map, Map, Optional) instead}
+     * @deprecated since 3.0, not intended for public use
      */
     @Deprecated
     public TaskMetadata(final String taskId,
@@ -52,6 +52,7 @@ public class TaskMetadata {
         this(TaskId.parse(taskId), topicPartitions, committedOffsets, endOffsets, timeCurrentIdlingStarted);
     }
 
+    // For internal use -- not a public API
     public TaskMetadata(final TaskId taskId,
                         final Set<TopicPartition> topicPartitions,
                         final Map<TopicPartition, Long> committedOffsets,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -149,6 +149,18 @@ public class StateDirectoryTest {
     }
 
     @Test
+    public void shouldParseUnnamedTaskId() {
+        final TaskId task = new TaskId(1, 0);
+        assertThat(TaskId.parse(task.toString()), equalTo(task));
+    }
+
+    @Test
+    public void shouldParseNamedTaskId() {
+        final TaskId task = new TaskId(1, 0, "namedTopology");
+        assertThat(TaskId.parse(task.toString()), equalTo(task));
+    }
+
+    @Test
     public void shouldCreateTaskStateDirectory() {
         final TaskId taskId = new TaskId(0, 0);
         final File taskDirectory = directory.getOrCreateDirectoryForTask(taskId);


### PR DESCRIPTION
Quick followup to KIP-740 to actually deprecate this constructor, and update the upgrade guide with what we changed in KIP-740. I also noticed the TaskId#parse method had been modified previously, and should be re-added to the public TaskId class. It had no tests, so now it does 
