### PR TITLE
MINOR: Log constructor: Flip logical NOT for readability

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -324,14 +324,14 @@ class Log(@volatile private var _dir: File,
     // write to the partition metadata file.
     // Ensure we do not try to assign a provided topicId that is inconsistent with the ID on file.
     if (partitionMetadataFile.exists()) {
-        if (!keepPartitionMetadataFile)
-          partitionMetadataFile.delete()
-        else {
+        if (keepPartitionMetadataFile) {
           val fileTopicId = partitionMetadataFile.read().topicId
           if (topicId.isDefined && !topicId.contains(fileTopicId))
             throw new InconsistentTopicIdException(s"Tried to assign topic ID $topicId to log for topic partition $topicPartition," +
               s"but log already contained topic ID $fileTopicId")
           topicId = Some(fileTopicId)
+        } else {
+          partitionMetadataFile.delete()
         }
     } else if (keepPartitionMetadataFile) {
       topicId.foreach(partitionMetadataFile.write)


### PR DESCRIPTION
I've done a small improvement in this PR by flipping logical NOT for readability in the `Log` constructor.
Basically, the following code:

```
if (A) {
 if (B) {
 } else {
 }
} else if (B) {
}
```

is a bit more readable than:

```
if (A) {
 if (!B) {
 } else {
 }
} else if (B) {
}
```

**Tests:**

Relying on existing tests.