### PR TITLE
KAFKA-12519: Remove built-in Streams metrics for versions 0.10.0-2.4

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -325,11 +325,6 @@ public class StreamsConfig extends AbstractConfig {
     public static final String EXACTLY_ONCE_V2 = "exactly_once_v2";
 
     /**
-     * Config value for parameter {@link #BUILT_IN_METRICS_VERSION_CONFIG "built.in.metrics.version"} for built-in metrics from version 0.10.0. to 2.4
-     */
-    public static final String METRICS_0100_TO_24 = "0.10.0-2.4";
-
-    /**
      * Config value for parameter {@link #BUILT_IN_METRICS_VERSION_CONFIG "built.in.metrics.version"} for the latest built-in metrics version.
      */
     public static final String METRICS_LATEST = "latest";
@@ -753,7 +748,6 @@ public class StreamsConfig extends AbstractConfig {
                     Type.STRING,
                     METRICS_LATEST,
                     in(
-                        METRICS_0100_TO_24,
                         METRICS_LATEST
                     ),
                     Importance.LOW,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -28,7 +28,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamAggregate<K, V, T> implements KStreamAggProcessorSupplier<K, K, V, T> {
@@ -66,7 +66,7 @@ public class KStreamAggregate<K, V, T> implements KStreamAggProcessorSupplier<K,
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics());

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX;
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
 class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
     private static final Logger LOG = LoggerFactory.getLogger(KStreamKStreamJoin.class);
@@ -91,7 +91,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
+            droppedRecordsSensor = droppedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             otherWindowStore = context.getStateStore(otherWindowName);
 
             if (StreamsConfig.InternalConfig.getBoolean(context().appConfigs(), ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX, true)) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -25,7 +25,7 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1, V1> {
@@ -52,7 +52,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
     public void init(final ProcessorContext context) {
         super.init(context);
         metrics = (StreamsMetricsImpl) context.metrics();
-        droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
+        droppedRecordsSensor = droppedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
         valueGetter.init(context);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V, V> {
@@ -62,7 +62,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregate.java
@@ -27,7 +27,6 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
@@ -38,8 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrLateRecordDropSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
 public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProcessorSupplier<K, Windowed<K>, V, Agg> {
     private static final Logger LOG = LoggerFactory.getLogger(KStreamSessionWindowAggregate.class);
@@ -91,13 +89,12 @@ public class KStreamSessionWindowAggregate<K, V, Agg> implements KStreamAggProce
             super.init(context);
             final StreamsMetricsImpl metrics = (StreamsMetricsImpl) context.metrics();
             final String threadId = Thread.currentThread().getName();
-            lateRecordDropSensor = droppedRecordsSensorOrLateRecordDropSensor(
+            lateRecordDropSensor = droppedRecordsSensor(
                 threadId,
                 context.taskId().toString(),
-                ((InternalProcessorContext) context).currentNode().name(),
                 metrics
             );
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(threadId, context.taskId().toString(), metrics);
+            droppedRecordsSensor = droppedRecordsSensor(threadId, context.taskId().toString(), metrics);
             store = context.getStateStore(storeName);
             tupleForwarder = new SessionTupleForwarder<>(store, context, new SessionCacheFlushListener<>(context), sendOldValues);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamSlidingWindowAggregate.java
@@ -37,8 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrLateRecordDropSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamSlidingWindowAggregate<K, V, Agg> implements KStreamAggProcessorSupplier<K, Windowed<K>, V, Agg> {
@@ -89,13 +88,12 @@ public class KStreamSlidingWindowAggregate<K, V, Agg> implements KStreamAggProce
             final InternalProcessorContext internalProcessorContext = (InternalProcessorContext) context;
             final StreamsMetricsImpl metrics = internalProcessorContext.metrics();
             final String threadId = Thread.currentThread().getName();
-            lateRecordDropSensor = droppedRecordsSensorOrLateRecordDropSensor(
+            lateRecordDropSensor = droppedRecordsSensor(
                 threadId,
                 context.taskId().toString(),
-                internalProcessorContext.currentNode().name(),
                 metrics
             );
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 threadId,
                 context.taskId().toString(),
                 metrics

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -35,8 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrLateRecordDropSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStreamAggProcessorSupplier<K, Windowed<K>, V, Agg> {
@@ -87,13 +86,12 @@ public class KStreamWindowAggregate<K, V, Agg, W extends Window> implements KStr
             final InternalProcessorContext internalProcessorContext = (InternalProcessorContext) context;
             final StreamsMetricsImpl metrics = internalProcessorContext.metrics();
             final String threadId = Thread.currentThread().getName();
-            lateRecordDropSensor = droppedRecordsSensorOrLateRecordDropSensor(
+            lateRecordDropSensor = droppedRecordsSensor(
                 threadId,
                 context.taskId().toString(),
-                internalProcessorContext.currentNode().name(),
                 metrics
             );
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 threadId,
                 context.taskId().toString(),
                 metrics

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoin.java
@@ -28,7 +28,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, V2> {
@@ -76,7 +76,7 @@ class KTableKTableInnerJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.processor.internals.RecordQueue.UNKNOWN;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
@@ -75,7 +75,7 @@ class KTableKTableLeftJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, 
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.processor.internals.RecordQueue.UNKNOWN;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
@@ -74,7 +74,7 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 import static org.apache.kafka.streams.state.ValueAndTimestamp.getValueOrNull;
 
 class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, V2> {
@@ -73,7 +73,7 @@ class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
         @Override
         public void init(final ProcessorContext context) {
             super.init(context);
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableSource.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
 public class KTableSource<K, V> implements ProcessorSupplier<K, V> {
     private static final Logger LOG = LoggerFactory.getLogger(KTableSource.class);
@@ -84,7 +84,7 @@ public class KTableSource<K, V> implements ProcessorSupplier<K, V> {
         public void init(final ProcessorContext context) {
             super.init(context);
             metrics = (StreamsMetricsImpl) context.metrics();
-            droppedRecordsSensor = droppedRecordsSensorOrSkippedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
+            droppedRecordsSensor = droppedRecordsSensor(Thread.currentThread().getName(), context.taskId().toString(), metrics);
             if (queryableName != null) {
                 store = (TimestampedKeyValueStore<K, V>) context.getStateStore(queryableName);
                 tupleForwarder = new TimestampedTupleForwarder<>(

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionProcessorSupplier.java
@@ -64,7 +64,7 @@ public class ForeignJoinSubscriptionProcessorSupplier<K, KO, VO> implements Proc
         public void init(final ProcessorContext context) {
             super.init(context);
             final InternalProcessorContext<?, ?> internalProcessorContext = (InternalProcessorContext<?, ?>) context;
-            droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = TaskMetrics.droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 internalProcessorContext.taskId().toString(),
                 internalProcessorContext.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionSendProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/ForeignJoinSubscriptionSendProcessorSupplier.java
@@ -88,7 +88,7 @@ public class ForeignJoinSubscriptionSendProcessorSupplier<K, KO, V> implements P
             if (valueSerializer == null) {
                 valueSerializer = (Serializer<V>) context.valueSerde().serializer();
             }
-            droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(
+            droppedRecordsSensor = TaskMetrics.droppedRecordsSensor(
                 Thread.currentThread().getName(),
                 context.taskId().toString(),
                 (StreamsMetricsImpl) context.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/foreignkeyjoin/SubscriptionStoreReceiveProcessorSupplier.java
@@ -62,7 +62,7 @@ public class SubscriptionStoreReceiveProcessorSupplier<K, KO>
                 super.init(context);
                 final InternalProcessorContext<?, ?> internalProcessorContext = (InternalProcessorContext<?, ?>) context;
 
-                droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(
+                droppedRecordsSensor = TaskMetrics.droppedRecordsSensor(
                     Thread.currentThread().getName(),
                     internalProcessorContext.taskId().toString(),
                     internalProcessorContext.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor;
+import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
 /**
  * Updates the state for all Global State Stores.
@@ -76,7 +76,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
                     source,
                     deserializationExceptionHandler,
                     logContext,
-                    droppedRecordsSensorOrSkippedRecordsSensor(
+                    droppedRecordsSensor(
                         Thread.currentThread().getName(),
                         processorContext.taskId().toString(),
                         processorContext.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -82,7 +82,7 @@ public class RecordCollectorImpl implements RecordCollector {
         this.eosEnabled = streamsProducer.eosEnabled();
 
         final String threadId = Thread.currentThread().getName();
-        this.droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, taskId.toString(), streamsMetrics);
+        this.droppedRecordsSensor = TaskMetrics.droppedRecordsSensor(threadId, taskId.toString(), streamsMetrics);
 
         this.offsets = new HashMap<>();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -62,7 +62,7 @@ public class RecordQueue {
         this.fifoQueue = new ArrayDeque<>();
         this.timestampExtractor = timestampExtractor;
         this.processorContext = processorContext;
-        droppedRecordsSensor = TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(
+        droppedRecordsSensor = TaskMetrics.droppedRecordsSensor(
             Thread.currentThread().getName(),
             processorContext.taskId().toString(),
             processorContext.metrics()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SourceNode.java
@@ -65,7 +65,7 @@ public class SourceNode<KIn, VIn> extends ProcessorNode<KIn, VIn, KIn, VIn> {
         // without parent is created with the same name.
         // Once the backwards compatibility is not needed anymore it might be possible to
         // change this.
-        processAtSourceSensor = ProcessorNodeMetrics.processorAtSourceSensorOrForwardSensor(
+        processAtSourceSensor = ProcessorNodeMetrics.processAtSourceSensor(
             Thread.currentThread().getName(),
             context.taskId().toString(),
             context.currentNode().name(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -42,7 +42,6 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.metrics.ProcessorNodeMetrics;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 import org.apache.kafka.streams.processor.internals.metrics.TaskMetrics;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
@@ -183,12 +182,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator,
         recordInfo = new PartitionGroup.RecordInfo();
 
         final Sensor enforcedProcessingSensor;
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            final Sensor parent = ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
-            enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics, parent);
-        } else {
-            enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
-        }
+        enforcedProcessingSensor = TaskMetrics.enforcedProcessingSensor(threadId, taskId, streamsMetrics);
         final long maxTaskIdleMs = config.getLong(StreamsConfig.MAX_TASK_IDLE_MS_CONFIG);
         partitionGroup = new PartitionGroup(
             logContext,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -45,7 +45,6 @@ import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 import org.apache.kafka.streams.processor.internals.metrics.ThreadMetrics;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.slf4j.Logger;
@@ -504,14 +503,10 @@ public class StreamThread extends Thread {
         // The following sensors are created here but their references are not stored in this object, since within
         // this object they are not recorded. The sensors are created here so that the stream threads starts with all
         // its metrics initialised. Otherwise, those sensors would have been created during processing, which could
-        // lead to missing metrics. For instance, if no task were created, the metrics for created and closed
+        // lead to missing metrics. If no task were created, the metrics for created and closed
         // tasks would never be added to the metrics.
         ThreadMetrics.createTaskSensor(threadId, streamsMetrics);
         ThreadMetrics.closeTaskSensor(threadId, streamsMetrics);
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            ThreadMetrics.skipRecordSensor(threadId, streamsMetrics);
-            ThreadMetrics.commitOverTasksSensor(threadId, streamsMetrics);
-        }
 
         this.time = time;
         this.builder = builder;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ProcessorNodeMetrics.java
@@ -18,11 +18,9 @@ package org.apache.kafka.streams.processor.internals.metrics;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 
 import java.util.Map;
 
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.PROCESSOR_NODE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY_AVG_DESCRIPTION;
@@ -31,20 +29,14 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMinAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
 
 public class ProcessorNodeMetrics {
     private ProcessorNodeMetrics() {}
 
-    private static final String AVG_DESCRIPTION_PREFIX = "The average ";
-    private static final String MAX_DESCRIPTION_PREFIX = "The maximum ";
     private static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
     private static final String RATE_DESCRIPTION_SUFFIX = " per second";
-    private static final String LATENCY_DESCRIPTION = "latency of ";
-    private static final String AVG_LATENCY_DESCRIPTION_PREFIX = AVG_DESCRIPTION_PREFIX + LATENCY_DESCRIPTION;
-    private static final String MAX_LATENCY_DESCRIPTION_PREFIX = MAX_DESCRIPTION_PREFIX + LATENCY_DESCRIPTION;
 
     private static final String SUPPRESSION_EMIT = "suppression-emit";
     private static final String SUPPRESSION_EMIT_DESCRIPTION = "emitted records from the suppression buffer";
@@ -63,33 +55,6 @@ public class ProcessorNodeMetrics {
     private static final String PROCESS_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PROCESS_DESCRIPTION;
     private static final String PROCESS_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
-    private static final String PROCESS_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION;
-    private static final String PROCESS_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION_PREFIX + PROCESS_DESCRIPTION;
-
-    private static final String PUNCTUATE = "punctuate";
-    private static final String PUNCTUATE_DESCRIPTION = "calls to punctuate";
-    private static final String PUNCTUATE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PUNCTUATE_DESCRIPTION;
-    private static final String PUNCTUATE_RATE_DESCRIPTION =
-        RATE_DESCRIPTION_PREFIX + PUNCTUATE_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
-    private static final String PUNCTUATE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + PUNCTUATE_DESCRIPTION;
-    private static final String PUNCTUATE_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION_PREFIX + PUNCTUATE_DESCRIPTION;
-
-    private static final String CREATE = "create";
-    private static final String CREATE_DESCRIPTION1 = "processor nodes created";
-    private static final String CREATE_DESCRIPTION2 = "creations of processor nodes";
-    private static final String CREATE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + CREATE_DESCRIPTION1;
-    private static final String CREATE_RATE_DESCRIPTION =
-        RATE_DESCRIPTION_PREFIX + CREATE_DESCRIPTION1 + RATE_DESCRIPTION_SUFFIX;
-    private static final String CREATE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + CREATE_DESCRIPTION2;
-    private static final String CREATE_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION_PREFIX + CREATE_DESCRIPTION2;
-
-    private static final String DESTROY = "destroy";
-    private static final String DESTROY_DESCRIPTION = "destructions of processor nodes";
-    private static final String DESTROY_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + DESTROY_DESCRIPTION;
-    private static final String DESTROY_RATE_DESCRIPTION =
-        RATE_DESCRIPTION_PREFIX + DESTROY_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
-    private static final String DESTROY_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + DESTROY_DESCRIPTION;
-    private static final String DESTROY_MAX_LATENCY_DESCRIPTION = MAX_LATENCY_DESCRIPTION_PREFIX + DESTROY_DESCRIPTION;
 
     private static final String FORWARD = "forward";
     private static final String FORWARD_DESCRIPTION = "calls to forward";
@@ -135,27 +100,6 @@ public class ProcessorNodeMetrics {
         );
     }
 
-    public static Sensor processSensor(final String threadId,
-                                       final String taskId,
-                                       final String processorNodeId,
-                                       final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return throughputAndLatencySensorWithParent(
-                threadId,
-                taskId,
-                processorNodeId,
-                PROCESS,
-                PROCESS_RATE_DESCRIPTION,
-                PROCESS_TOTAL_DESCRIPTION,
-                PROCESS_AVG_LATENCY_DESCRIPTION,
-                PROCESS_MAX_LATENCY_DESCRIPTION,
-                RecordingLevel.DEBUG,
-                streamsMetrics
-            );
-        }
-        return emptySensor(threadId, taskId, processorNodeId, PROCESS, RecordingLevel.DEBUG, streamsMetrics);
-    }
-
     public static Sensor processAtSourceSensor(final String threadId,
                                                final String taskId,
                                                final String processorNodeId,
@@ -180,67 +124,6 @@ public class ProcessorNodeMetrics {
             streamsMetrics,
             parentSensor
         );
-    }
-
-    public static Sensor punctuateSensor(final String threadId,
-                                         final String taskId,
-                                         final String processorNodeId,
-                                         final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return throughputAndLatencySensorWithParent(
-                threadId,
-                taskId,
-                processorNodeId,
-                PUNCTUATE,
-                PUNCTUATE_RATE_DESCRIPTION,
-                PUNCTUATE_TOTAL_DESCRIPTION,
-                PUNCTUATE_AVG_LATENCY_DESCRIPTION,
-                PUNCTUATE_MAX_LATENCY_DESCRIPTION,
-                RecordingLevel.DEBUG,
-                streamsMetrics
-            );
-        }
-        return emptySensor(threadId, taskId, processorNodeId, PUNCTUATE, RecordingLevel.DEBUG, streamsMetrics);
-    }
-
-    public static Sensor createSensor(final String threadId,
-                                      final String taskId,
-                                      final String processorNodeId,
-                                      final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return throughputAndLatencySensorWithParent(
-                threadId,
-                taskId,
-                processorNodeId,
-                CREATE,
-                CREATE_RATE_DESCRIPTION,
-                CREATE_TOTAL_DESCRIPTION,
-                CREATE_AVG_LATENCY_DESCRIPTION,
-                CREATE_MAX_LATENCY_DESCRIPTION,
-                RecordingLevel.DEBUG,
-                streamsMetrics);
-        }
-        return emptySensor(threadId, taskId, processorNodeId, CREATE, RecordingLevel.DEBUG, streamsMetrics);
-    }
-
-    public static Sensor destroySensor(final String threadId,
-                                       final String taskId,
-                                       final String processorNodeId,
-                                       final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return throughputAndLatencySensorWithParent(
-                threadId,
-                taskId,
-                processorNodeId,
-                DESTROY,
-                DESTROY_RATE_DESCRIPTION,
-                DESTROY_TOTAL_DESCRIPTION,
-                DESTROY_AVG_LATENCY_DESCRIPTION,
-                DESTROY_MAX_LATENCY_DESCRIPTION,
-                RecordingLevel.DEBUG,
-                streamsMetrics);
-        }
-        return emptySensor(threadId, taskId, processorNodeId, DESTROY, RecordingLevel.DEBUG, streamsMetrics);
     }
 
     public static Sensor forwardSensor(final String threadId,
@@ -284,16 +167,6 @@ public class ProcessorNodeMetrics {
             streamsMetrics);
     }
 
-    public static Sensor processorAtSourceSensorOrForwardSensor(final String threadId,
-                                                                final String taskId,
-                                                                final String processorNodeId,
-                                                                final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return forwardSensor(threadId, taskId, processorNodeId, streamsMetrics);
-        }
-        return processAtSourceSensor(threadId, taskId, processorNodeId, streamsMetrics);
-    }
-
     public static Sensor e2ELatencySensor(final String threadId,
                                           final String taskId,
                                           final String processorNodeId,
@@ -309,72 +182,6 @@ public class ProcessorNodeMetrics {
             RECORD_E2E_LATENCY_AVG_DESCRIPTION,
             RECORD_E2E_LATENCY_MIN_DESCRIPTION,
             RECORD_E2E_LATENCY_MAX_DESCRIPTION
-        );
-        return sensor;
-    }
-
-    private static Sensor throughputAndLatencySensorWithParent(final String threadId,
-                                                               final String taskId,
-                                                               final String processorNodeId,
-                                                               final String metricNamePrefix,
-                                                               final String descriptionOfRate,
-                                                               final String descriptionOfCount,
-                                                               final String descriptionOfAvgLatency,
-                                                               final String descriptionOfMaxLatency,
-                                                               final RecordingLevel recordingLevel,
-                                                               final StreamsMetricsImpl streamsMetrics) {
-        final Sensor parentSensor = throughputAndLatencyParentSensor(
-            threadId,
-            taskId,
-            metricNamePrefix,
-            descriptionOfRate,
-            descriptionOfCount,
-            descriptionOfAvgLatency,
-            descriptionOfMaxLatency,
-            recordingLevel,
-            streamsMetrics
-        );
-        return throughputAndLatencySensor(
-            threadId,
-            taskId,
-            processorNodeId,
-            metricNamePrefix,
-            descriptionOfRate,
-            descriptionOfCount,
-            descriptionOfAvgLatency,
-            descriptionOfMaxLatency,
-            recordingLevel,
-            streamsMetrics,
-            parentSensor
-        );
-    }
-
-    private static Sensor throughputAndLatencyParentSensor(final String threadId,
-                                                           final String taskId,
-                                                           final String metricNamePrefix,
-                                                           final String descriptionOfRate,
-                                                           final String descriptionOfCount,
-                                                           final String descriptionOfAvgLatency,
-                                                           final String descriptionOfMaxLatency,
-                                                           final RecordingLevel recordingLevel,
-                                                           final StreamsMetricsImpl streamsMetrics) {
-        final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, metricNamePrefix, recordingLevel);
-        final Map<String, String> parentTagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, ROLLUP_VALUE);
-        addAvgAndMaxToSensor(
-            sensor,
-            PROCESSOR_NODE_LEVEL_GROUP,
-            parentTagMap,
-            metricNamePrefix + LATENCY_SUFFIX,
-            descriptionOfAvgLatency,
-            descriptionOfMaxLatency
-        );
-        addInvocationRateAndCountToSensor(
-            sensor,
-            PROCESSOR_NODE_LEVEL_GROUP,
-            parentTagMap,
-            metricNamePrefix,
-            descriptionOfRate,
-            descriptionOfCount
         );
         return sensor;
     }
@@ -420,47 +227,5 @@ public class ProcessorNodeMetrics {
             descriptionOfCount
         );
         return sensor;
-    }
-
-    private static Sensor throughputAndLatencySensor(final String threadId,
-                                                     final String taskId,
-                                                     final String processorNodeId,
-                                                     final String metricNamePrefix,
-                                                     final String descriptionOfRate,
-                                                     final String descriptionOfCount,
-                                                     final String descriptionOfAvg,
-                                                     final String descriptionOfMax,
-                                                     final RecordingLevel recordingLevel,
-                                                     final StreamsMetricsImpl streamsMetrics,
-                                                     final Sensor... parentSensors) {
-        final Sensor sensor =
-            streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, metricNamePrefix, recordingLevel, parentSensors);
-        final Map<String, String> tagMap = streamsMetrics.nodeLevelTagMap(threadId, taskId, processorNodeId);
-        addAvgAndMaxToSensor(
-            sensor,
-            PROCESSOR_NODE_LEVEL_GROUP,
-            tagMap,
-            metricNamePrefix + LATENCY_SUFFIX,
-            descriptionOfAvg,
-            descriptionOfMax
-        );
-        addInvocationRateAndCountToSensor(
-            sensor,
-            PROCESSOR_NODE_LEVEL_GROUP,
-            tagMap,
-            metricNamePrefix,
-            descriptionOfRate,
-            descriptionOfCount
-        );
-        return sensor;
-    }
-
-    private static Sensor emptySensor(final String threadId,
-                                      final String taskId,
-                                      final String processorNodeId,
-                                      final String metricNamePrefix,
-                                      final RecordingLevel recordingLevel,
-                                      final StreamsMetricsImpl streamsMetrics) {
-        return streamsMetrics.nodeLevelSensor(threadId, taskId, processorNodeId, metricNamePrefix, recordingLevel);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -33,7 +33,6 @@ import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.metrics.stats.WindowedSum;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.state.internals.metrics.RocksDBMetricsRecordingTrigger;
 
@@ -52,8 +51,7 @@ import java.util.function.Supplier;
 public class StreamsMetricsImpl implements StreamsMetrics {
 
     public enum Version {
-        LATEST,
-        FROM_0100_TO_24
+        LATEST
     }
 
     static class ImmutableMetricValue<T> implements Gauge<T> {
@@ -137,11 +135,9 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     public static final String GROUP_SUFFIX = "-metrics";
     public static final String CLIENT_LEVEL_GROUP = GROUP_PREFIX_WO_DELIMITER + GROUP_SUFFIX;
     public static final String THREAD_LEVEL_GROUP = GROUP_PREFIX + "thread" + GROUP_SUFFIX;
-    public static final String THREAD_LEVEL_GROUP_0100_TO_24 = GROUP_PREFIX_WO_DELIMITER + GROUP_SUFFIX;
     public static final String TASK_LEVEL_GROUP = GROUP_PREFIX + "task" + GROUP_SUFFIX;
     public static final String PROCESSOR_NODE_LEVEL_GROUP = GROUP_PREFIX + "processor-node" + GROUP_SUFFIX;
     public static final String STATE_STORE_LEVEL_GROUP = GROUP_PREFIX + "state" + GROUP_SUFFIX;
-    public static final String BUFFER_LEVEL_GROUP_0100_TO_24 = GROUP_PREFIX + "buffer" + GROUP_SUFFIX;
     public static final String CACHE_LEVEL_GROUP = GROUP_PREFIX + "record-cache" + GROUP_SUFFIX;
 
     public static final String OPERATIONS = " operations";
@@ -175,11 +171,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
     }
 
     private static Version parseBuiltInMetricsVersion(final String builtInMetricsVersion) {
-        if (builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST)) {
-            return Version.LATEST;
-        } else {
-            return Version.FROM_0100_TO_24;
-        }
+        return Version.LATEST;
     }
 
     public Version version() {
@@ -250,7 +242,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public Map<String, String> threadLevelTagMap(final String threadId) {
         final Map<String, String> tagMap = new LinkedHashMap<>();
-        tagMap.put(version == Version.LATEST ? THREAD_ID_TAG : THREAD_ID_TAG_0100_TO_24, threadId);
+        tagMap.put(THREAD_ID_TAG, threadId);
         return tagMap;
     }
 
@@ -386,11 +378,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                                                 final String taskId,
                                                 final String storeName) {
         final Map<String, String> tagMap = new LinkedHashMap<>();
-        if (version == Version.FROM_0100_TO_24) {
-            tagMap.put(THREAD_ID_TAG_0100_TO_24, threadId);
-        } else {
-            tagMap.put(THREAD_ID_TAG, threadId);
-        }
+        tagMap.put(THREAD_ID_TAG, threadId);
         tagMap.put(TASK_ID_TAG, taskId);
         tagMap.put(RECORD_CACHE_ID_TAG, storeName);
         return tagMap;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -112,7 +112,6 @@ public class StreamsMetricsImpl implements StreamsMetrics {
 
     public static final String CLIENT_ID_TAG = "client-id";
     public static final String THREAD_ID_TAG = "thread-id";
-    public static final String THREAD_ID_TAG_0100_TO_24 = "client-id";
     public static final String TASK_ID_TAG = "task-id";
     public static final String PROCESSOR_NODE_ID_TAG = "processor-node-id";
     public static final String STORE_ID_TAG = "state-id";
@@ -164,14 +163,10 @@ public class StreamsMetricsImpl implements StreamsMetrics {
         Objects.requireNonNull(builtInMetricsVersion, "Built-in metrics version cannot be null");
         this.metrics = metrics;
         this.clientId = clientId;
-        version = parseBuiltInMetricsVersion(builtInMetricsVersion);
+        version = Version.LATEST;
         rocksDBMetricsRecordingTrigger = new RocksDBMetricsRecordingTrigger(time);
 
         this.parentSensors = new HashMap<>();
-    }
-
-    private static Version parseBuiltInMetricsVersion(final String builtInMetricsVersion) {
-        return Version.LATEST;
     }
 
     public Version version() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/TaskMetrics.java
@@ -18,8 +18,6 @@ package org.apache.kafka.streams.processor.internals.metrics;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
-import org.apache.kafka.streams.state.internals.metrics.StateStoreMetrics;
 
 import java.util.Map;
 
@@ -89,18 +87,15 @@ public class TaskMetrics {
     public static Sensor processLatencySensor(final String threadId,
                                               final String taskId,
                                               final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.LATEST) {
-            return avgAndMaxSensor(
-                threadId,
-                taskId,
-                PROCESS_LATENCY,
-                PROCESS_AVG_LATENCY_DESCRIPTION,
-                PROCESS_MAX_LATENCY_DESCRIPTION,
-                RecordingLevel.DEBUG,
-                streamsMetrics
-            );
-        }
-        return emptySensor(threadId, taskId, PROCESS_LATENCY, RecordingLevel.DEBUG, streamsMetrics);
+        return avgAndMaxSensor(
+            threadId,
+            taskId,
+            PROCESS_LATENCY,
+            PROCESS_AVG_LATENCY_DESCRIPTION,
+            PROCESS_MAX_LATENCY_DESCRIPTION,
+            RecordingLevel.DEBUG,
+            streamsMetrics
+        );
     }
 
     public static Sensor activeProcessRatioSensor(final String threadId,
@@ -136,20 +131,17 @@ public class TaskMetrics {
     public static Sensor punctuateSensor(final String threadId,
                                          final String taskId,
                                          final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.LATEST) {
-            return invocationRateAndCountAndAvgAndMaxLatencySensor(
-                threadId,
-                taskId,
-                PUNCTUATE,
-                PUNCTUATE_RATE_DESCRIPTION,
-                PUNCTUATE_TOTAL_DESCRIPTION,
-                PUNCTUATE_AVG_LATENCY_DESCRIPTION,
-                PUNCTUATE_MAX_LATENCY_DESCRIPTION,
-                Sensor.RecordingLevel.DEBUG,
-                streamsMetrics
-            );
-        }
-        return emptySensor(threadId, taskId, PUNCTUATE, RecordingLevel.DEBUG, streamsMetrics);
+        return invocationRateAndCountAndAvgAndMaxLatencySensor(
+            threadId,
+            taskId,
+            PUNCTUATE,
+            PUNCTUATE_RATE_DESCRIPTION,
+            PUNCTUATE_TOTAL_DESCRIPTION,
+            PUNCTUATE_AVG_LATENCY_DESCRIPTION,
+            PUNCTUATE_MAX_LATENCY_DESCRIPTION,
+            Sensor.RecordingLevel.DEBUG,
+            streamsMetrics
+        );
     }
 
     public static Sensor commitSensor(final String threadId,
@@ -210,36 +202,6 @@ public class TaskMetrics {
             RecordingLevel.INFO,
             streamsMetrics
         );
-    }
-
-    public static Sensor droppedRecordsSensorOrSkippedRecordsSensor(final String threadId,
-                                                                    final String taskId,
-                                                                    final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return ThreadMetrics.skipRecordSensor(threadId, streamsMetrics);
-        }
-        return droppedRecordsSensor(threadId, taskId, streamsMetrics);
-    }
-
-    public static Sensor droppedRecordsSensorOrExpiredWindowRecordDropSensor(final String threadId,
-                                                                             final String taskId,
-                                                                             final String storeType,
-                                                                             final String storeName,
-                                                                             final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return StateStoreMetrics.expiredWindowRecordDropSensor(taskId, storeType, storeName, streamsMetrics);
-        }
-        return droppedRecordsSensor(threadId, taskId, streamsMetrics);
-    }
-
-    public static Sensor droppedRecordsSensorOrLateRecordDropSensor(final String threadId,
-                                                                    final String taskId,
-                                                                    final String processorNodeId,
-                                                                    final StreamsMetricsImpl streamsMetrics) {
-        if (streamsMetrics.version() == Version.FROM_0100_TO_24) {
-            return ProcessorNodeMetrics.lateRecordDropSensor(threadId, taskId, processorNodeId, streamsMetrics);
-        }
-        return droppedRecordsSensor(threadId, taskId, streamsMetrics);
     }
 
     private static Sensor invocationRateAndCountSensor(final String threadId,
@@ -312,14 +274,5 @@ public class TaskMetrics {
             descriptionOfCount
         );
         return sensor;
-    }
-
-    private static Sensor emptySensor(final String threadId,
-                                      final String taskId,
-                                      final String metricName,
-                                      final RecordingLevel recordingLevel,
-                                      final StreamsMetricsImpl streamsMetrics,
-                                      final Sensor... parentSensors) {
-        return streamsMetrics.taskLevelSensor(threadId, taskId, metricName, recordingLevel, parentSensors);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetrics.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.processor.internals.metrics;
 
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 
 import java.util.Map;
 
@@ -30,7 +29,6 @@ import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetric
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TASK_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_LEVEL_GROUP;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_LEVEL_GROUP_0100_TO_24;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
@@ -163,10 +161,9 @@ public class ThreadMetrics {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + LATENCY_SUFFIX, RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
-        final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         addAvgAndMaxToSensor(
             sensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             PROCESS + LATENCY_SUFFIX,
             PROCESS_AVG_LATENCY_DESCRIPTION,
@@ -180,10 +177,9 @@ public class ThreadMetrics {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, POLL + RECORDS_SUFFIX, RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
-        final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         addAvgAndMaxToSensor(
             sensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             POLL + RECORDS_SUFFIX,
             POLL_AVG_RECORDS_DESCRIPTION,
@@ -197,10 +193,9 @@ public class ThreadMetrics {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + RECORDS_SUFFIX, RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
-        final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         addAvgAndMaxToSensor(
             sensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             PROCESS + RECORDS_SUFFIX,
             PROCESS_AVG_RECORDS_DESCRIPTION,
@@ -214,10 +209,9 @@ public class ThreadMetrics {
         final Sensor sensor =
             streamsMetrics.threadLevelSensor(threadId, PROCESS + RATE_SUFFIX, RecordingLevel.INFO);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
-        final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         addRateOfSumAndSumMetricsToSensor(
             sensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             PROCESS,
             PROCESS_RATE_DESCRIPTION,
@@ -263,7 +257,7 @@ public class ThreadMetrics {
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
-            threadLevelGroup(streamsMetrics),
+            THREAD_LEVEL_GROUP,
             tagMap,
             PROCESS + RATIO_SUFFIX,
             PROCESS_RATIO_DESCRIPTION
@@ -278,7 +272,7 @@ public class ThreadMetrics {
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
-            threadLevelGroup(streamsMetrics),
+            THREAD_LEVEL_GROUP,
             tagMap,
             PUNCTUATE + RATIO_SUFFIX,
             PUNCTUATE_RATIO_DESCRIPTION
@@ -293,7 +287,7 @@ public class ThreadMetrics {
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
-            threadLevelGroup(streamsMetrics),
+            THREAD_LEVEL_GROUP,
             tagMap,
             POLL + RATIO_SUFFIX,
             POLL_RATIO_DESCRIPTION
@@ -308,7 +302,7 @@ public class ThreadMetrics {
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
         addValueMetricToSensor(
             sensor,
-            threadLevelGroup(streamsMetrics),
+            THREAD_LEVEL_GROUP,
             tagMap,
             COMMIT + RATIO_SUFFIX,
             COMMIT_RATIO_DESCRIPTION
@@ -325,7 +319,7 @@ public class ThreadMetrics {
         final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, metricName, recordingLevel);
         addInvocationRateAndCountToSensor(
             sensor,
-            threadLevelGroup(streamsMetrics),
+            THREAD_LEVEL_GROUP,
             streamsMetrics.threadLevelTagMap(threadId),
             metricName,
             descriptionOfRate,
@@ -344,10 +338,9 @@ public class ThreadMetrics {
                                                                           final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor = streamsMetrics.threadLevelSensor(threadId, metricName, recordingLevel);
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(threadId);
-        final String threadLevelGroup = threadLevelGroup(streamsMetrics);
         addAvgAndMaxToSensor(
             sensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             metricName + LATENCY_SUFFIX,
             descriptionOfAvg,
@@ -355,16 +348,12 @@ public class ThreadMetrics {
         );
         addInvocationRateAndCountToSensor(
             sensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             metricName,
             descriptionOfRate,
             descriptionOfCount
         );
         return sensor;
-    }
-
-    private static String threadLevelGroup(final StreamsMetricsImpl streamsMetrics) {
-        return streamsMetrics.version() == Version.LATEST ? THREAD_LEVEL_GROUP : THREAD_LEVEL_GROUP_0100_TO_24;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStore.java
@@ -244,11 +244,9 @@ public class AbstractRocksDBSegmentedBytesStore<S extends Segment> implements Se
         final String threadId = Thread.currentThread().getName();
         final String taskName = context.taskId().toString();
 
-        expiredRecordSensor = TaskMetrics.droppedRecordsSensorOrExpiredWindowRecordDropSensor(
+        expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
             threadId,
             taskName,
-            metricScope,
-            name(),
             metrics
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemorySessionStore.java
@@ -83,11 +83,9 @@ public class InMemorySessionStore implements SessionStore<Bytes, byte[]> {
         if (context instanceof InternalProcessorContext) {
             this.context = (InternalProcessorContext) context;
             final StreamsMetricsImpl metrics = this.context.metrics();
-            expiredRecordSensor = TaskMetrics.droppedRecordsSensorOrExpiredWindowRecordDropSensor(
+            expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
                 threadId,
                 taskName,
-                metricScope,
-                name,
                 metrics
             );
         } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryTimeOrderedKeyValueBuffer.java
@@ -90,7 +90,6 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
     private Sensor bufferSizeSensor;
     private Sensor bufferCountSensor;
     private StreamsMetricsImpl streamsMetrics;
-    private String threadId;
     private String taskId;
 
     private volatile boolean open;
@@ -212,16 +211,13 @@ public final class InMemoryTimeOrderedKeyValueBuffer<K, V> implements TimeOrdere
         taskId = context.taskId().toString();
         streamsMetrics = context.metrics();
 
-        threadId = Thread.currentThread().getName();
         bufferSizeSensor = StateStoreMetrics.suppressionBufferSizeSensor(
-            threadId,
             taskId,
             METRIC_SCOPE,
             storeName,
             streamsMetrics
         );
         bufferCountSensor = StateStoreMetrics.suppressionBufferCountSensor(
-            threadId,
             taskId,
             METRIC_SCOPE,
             storeName,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryWindowStore.java
@@ -93,11 +93,9 @@ public class InMemoryWindowStore implements WindowStore<Bytes, byte[]> {
         final StreamsMetricsImpl metrics = ProcessorContextUtils.getMetricsImpl(context);
         final String threadId = Thread.currentThread().getName();
         final String taskName = context.taskId().toString();
-        expiredRecordSensor = TaskMetrics.droppedRecordsSensorOrExpiredWindowRecordDropSensor(
+        expiredRecordSensor = TaskMetrics.droppedRecordsSensor(
             threadId,
             taskName,
-            metricScope,
-            name,
             metrics
         );
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -103,7 +103,7 @@ public class MeteredKeyValueStore<K, V>
 
         registerMetrics();
         final Sensor restoreSensor =
-            StateStoreMetrics.restoreSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+            StateStoreMetrics.restoreSensor(taskId, metricsScope, name(), streamsMetrics);
 
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
@@ -119,22 +119,22 @@ public class MeteredKeyValueStore<K, V>
 
         registerMetrics();
         final Sensor restoreSensor =
-            StateStoreMetrics.restoreSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+            StateStoreMetrics.restoreSensor(taskId, metricsScope, name(), streamsMetrics);
 
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
     }
 
     private void registerMetrics() {
-        putSensor = StateStoreMetrics.putSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        putIfAbsentSensor = StateStoreMetrics.putIfAbsentSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        putAllSensor = StateStoreMetrics.putAllSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        getSensor = StateStoreMetrics.getSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        allSensor = StateStoreMetrics.allSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        rangeSensor = StateStoreMetrics.rangeSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+        putSensor = StateStoreMetrics.putSensor(taskId, metricsScope, name(), streamsMetrics);
+        putIfAbsentSensor = StateStoreMetrics.putIfAbsentSensor(taskId, metricsScope, name(), streamsMetrics);
+        putAllSensor = StateStoreMetrics.putAllSensor(taskId, metricsScope, name(), streamsMetrics);
+        getSensor = StateStoreMetrics.getSensor(taskId, metricsScope, name(), streamsMetrics);
+        allSensor = StateStoreMetrics.allSensor(taskId, metricsScope, name(), streamsMetrics);
+        rangeSensor = StateStoreMetrics.rangeSensor(taskId, metricsScope, name(), streamsMetrics);
         prefixScanSensor = StateStoreMetrics.prefixScanSensor(taskId, metricsScope, name(), streamsMetrics);
-        flushSensor = StateStoreMetrics.flushSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        deleteSensor = StateStoreMetrics.deleteSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+        flushSensor = StateStoreMetrics.flushSensor(taskId, metricsScope, name(), streamsMetrics);
+        deleteSensor = StateStoreMetrics.deleteSensor(taskId, metricsScope, name(), streamsMetrics);
         e2eLatencySensor = StateStoreMetrics.e2ELatencySensor(taskId, metricsScope, name(), streamsMetrics);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -57,7 +57,6 @@ public class MeteredSessionStore<K, V>
     private Sensor removeSensor;
     private Sensor e2eLatencySensor;
     private InternalProcessorContext context;
-    private final String threadId;
     private String taskId;
 
     MeteredSessionStore(final SessionStore<Bytes, byte[]> inner,
@@ -66,7 +65,6 @@ public class MeteredSessionStore<K, V>
                         final Serde<V> valueSerde,
                         final Time time) {
         super(inner);
-        threadId = Thread.currentThread().getName();
         this.metricsScope = metricsScope;
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredSessionStore.java
@@ -84,7 +84,7 @@ public class MeteredSessionStore<K, V>
 
         registerMetrics();
         final Sensor restoreSensor =
-            StateStoreMetrics.restoreSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+            StateStoreMetrics.restoreSensor(taskId, metricsScope, name(), streamsMetrics);
 
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
@@ -100,17 +100,17 @@ public class MeteredSessionStore<K, V>
 
         registerMetrics();
         final Sensor restoreSensor =
-            StateStoreMetrics.restoreSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+            StateStoreMetrics.restoreSensor(taskId, metricsScope, name(), streamsMetrics);
 
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
     }
 
     private void registerMetrics() {
-        putSensor = StateStoreMetrics.putSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        fetchSensor = StateStoreMetrics.fetchSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        flushSensor = StateStoreMetrics.flushSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        removeSensor = StateStoreMetrics.removeSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+        putSensor = StateStoreMetrics.putSensor(taskId, metricsScope, name(), streamsMetrics);
+        fetchSensor = StateStoreMetrics.fetchSensor(taskId, metricsScope, name(), streamsMetrics);
+        flushSensor = StateStoreMetrics.flushSensor(taskId, metricsScope, name(), streamsMetrics);
+        removeSensor = StateStoreMetrics.removeSensor(taskId, metricsScope, name(), streamsMetrics);
         e2eLatencySensor = StateStoreMetrics.e2ELatencySensor(taskId, metricsScope, name(), streamsMetrics);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredWindowStore.java
@@ -88,7 +88,7 @@ public class MeteredWindowStore<K, V>
 
         registerMetrics();
         final Sensor restoreSensor =
-            StateStoreMetrics.restoreSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+            StateStoreMetrics.restoreSensor(taskId, metricsScope, name(), streamsMetrics);
 
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
@@ -104,7 +104,7 @@ public class MeteredWindowStore<K, V>
 
         registerMetrics();
         final Sensor restoreSensor =
-            StateStoreMetrics.restoreSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+            StateStoreMetrics.restoreSensor(taskId, metricsScope, name(), streamsMetrics);
 
         // register and possibly restore the state from the logs
         maybeMeasureLatency(() -> super.init(context, root), time, restoreSensor);
@@ -114,9 +114,9 @@ public class MeteredWindowStore<K, V>
     }
 
     private void registerMetrics() {
-        putSensor = StateStoreMetrics.putSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        fetchSensor = StateStoreMetrics.fetchSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
-        flushSensor = StateStoreMetrics.flushSensor(threadId, taskId, metricsScope, name(), streamsMetrics);
+        putSensor = StateStoreMetrics.putSensor(taskId, metricsScope, name(), streamsMetrics);
+        fetchSensor = StateStoreMetrics.fetchSensor(taskId, metricsScope, name(), streamsMetrics);
+        flushSensor = StateStoreMetrics.flushSensor(taskId, metricsScope, name(), streamsMetrics);
         e2eLatencySensor = StateStoreMetrics.e2ELatencySensor(taskId, metricsScope, name(), streamsMetrics);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetrics.java
@@ -20,14 +20,11 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.CACHE_LEVEL_GROUP;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version.FROM_0100_TO_24;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMinAndMaxToSensor;
 
 public class NamedCacheMetrics {
     private NamedCacheMetrics() {}
 
-    private static final String HIT_RATIO_0100_TO_24 = "hitRatio";
     private static final String HIT_RATIO = "hit-ratio";
     private static final String HIT_RATIO_AVG_DESCRIPTION = "The average cache hit ratio";
     private static final String HIT_RATIO_MIN_DESCRIPTION = "The minimum cache hit ratio";
@@ -41,41 +38,14 @@ public class NamedCacheMetrics {
 
         final Sensor hitRatioSensor;
         final String hitRatioName;
-        if (streamsMetrics.version() == FROM_0100_TO_24) {
-            hitRatioName = HIT_RATIO_0100_TO_24;
-            final Sensor taskLevelHitRatioSensor = streamsMetrics.taskLevelSensor(
-                threadId,
-                taskName,
-                hitRatioName,
-                Sensor.RecordingLevel.DEBUG
-            );
-            addAvgAndMinAndMaxToSensor(
-                taskLevelHitRatioSensor,
-                CACHE_LEVEL_GROUP,
-                streamsMetrics.cacheLevelTagMap(threadId, taskName, ROLLUP_VALUE),
-                hitRatioName,
-                HIT_RATIO_AVG_DESCRIPTION,
-                HIT_RATIO_MIN_DESCRIPTION,
-                HIT_RATIO_MAX_DESCRIPTION
-            );
-            hitRatioSensor = streamsMetrics.cacheLevelSensor(
-                threadId,
-                taskName,
-                storeName,
-                hitRatioName,
-                Sensor.RecordingLevel.DEBUG,
-                taskLevelHitRatioSensor
-            );
-        } else {
-            hitRatioName = HIT_RATIO;
-            hitRatioSensor = streamsMetrics.cacheLevelSensor(
-                threadId,
-                taskName,
-                storeName,
-                hitRatioName,
-                Sensor.RecordingLevel.DEBUG
-            );
-        }
+        hitRatioName = HIT_RATIO;
+        hitRatioSensor = streamsMetrics.cacheLevelSensor(
+            threadId,
+            taskName,
+            storeName,
+            hitRatioName,
+            Sensor.RecordingLevel.DEBUG
+        );
         addAvgAndMinAndMaxToSensor(
             hitRatioSensor,
             CACHE_LEVEL_GROUP,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetrics.java
@@ -19,42 +19,35 @@ package org.apache.kafka.streams.state.internals.metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
-import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.Version;
 
 import java.util.Map;
 
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.BUFFER_LEVEL_GROUP_0100_TO_24;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.LATENCY_SUFFIX;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY_AVG_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY_MAX_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.RECORD_E2E_LATENCY_MIN_DESCRIPTION;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.STATE_STORE_LEVEL_GROUP;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.TOTAL_DESCRIPTION;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addAvgAndMinAndMaxToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateAndCountToSensor;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addInvocationRateToSensor;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.addValueMetricToSensor;
 
 public class StateStoreMetrics {
     private StateStoreMetrics() {}
 
     private static final String AVG_DESCRIPTION_PREFIX = "The average ";
     private static final String MAX_DESCRIPTION_PREFIX = "The maximum ";
-    private static final String CURRENT_DESCRIPTION_PREFIX = "The current ";
     private static final String LATENCY_DESCRIPTION = "latency of ";
     private static final String AVG_LATENCY_DESCRIPTION_PREFIX = AVG_DESCRIPTION_PREFIX + LATENCY_DESCRIPTION;
     private static final String MAX_LATENCY_DESCRIPTION_PREFIX = MAX_DESCRIPTION_PREFIX + LATENCY_DESCRIPTION;
     private static final String RATE_DESCRIPTION_PREFIX = "The average number of ";
     private static final String RATE_DESCRIPTION_SUFFIX = " per second";
-    private static final String CURRENT_SUFFIX = "-current";
     private static final String BUFFERED_RECORDS = "buffered records";
 
     private static final String PUT = "put";
     private static final String PUT_DESCRIPTION = "calls to put";
-    private static final String PUT_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PUT_DESCRIPTION;
     private static final String PUT_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + PUT_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String PUT_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + PUT_DESCRIPTION;
@@ -62,7 +55,6 @@ public class StateStoreMetrics {
 
     private static final String PUT_IF_ABSENT = "put-if-absent";
     private static final String PUT_IF_ABSENT_DESCRIPTION = "calls to put-if-absent";
-    private static final String PUT_IF_ABSENT_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PUT_IF_ABSENT_DESCRIPTION;
     private static final String PUT_IF_ABSENT_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + PUT_IF_ABSENT_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String PUT_IF_ABSENT_AVG_LATENCY_DESCRIPTION =
@@ -72,7 +64,6 @@ public class StateStoreMetrics {
 
     private static final String PUT_ALL = "put-all";
     private static final String PUT_ALL_DESCRIPTION = "calls to put-all";
-    private static final String PUT_ALL_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + PUT_ALL_DESCRIPTION;
     private static final String PUT_ALL_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + PUT_ALL_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String PUT_ALL_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + PUT_ALL_DESCRIPTION;
@@ -80,7 +71,6 @@ public class StateStoreMetrics {
 
     private static final String GET = "get";
     private static final String GET_DESCRIPTION = "calls to get";
-    private static final String GET_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + GET_DESCRIPTION;
     private static final String GET_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + GET_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String GET_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + GET_DESCRIPTION;
@@ -88,7 +78,6 @@ public class StateStoreMetrics {
 
     private static final String FETCH = "fetch";
     private static final String FETCH_DESCRIPTION = "calls to fetch";
-    private static final String FETCH_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + FETCH_DESCRIPTION;
     private static final String FETCH_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + FETCH_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String FETCH_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + FETCH_DESCRIPTION;
@@ -96,7 +85,6 @@ public class StateStoreMetrics {
 
     private static final String ALL = "all";
     private static final String ALL_DESCRIPTION = "calls to all";
-    private static final String ALL_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + ALL_DESCRIPTION;
     private static final String ALL_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + ALL_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String ALL_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + ALL_DESCRIPTION;
@@ -104,7 +92,6 @@ public class StateStoreMetrics {
 
     private static final String RANGE = "range";
     private static final String RANGE_DESCRIPTION = "calls to range";
-    private static final String RANGE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + RANGE_DESCRIPTION;
     private static final String RANGE_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + RANGE_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String RANGE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + RANGE_DESCRIPTION;
@@ -119,7 +106,6 @@ public class StateStoreMetrics {
 
     private static final String FLUSH = "flush";
     private static final String FLUSH_DESCRIPTION = "calls to flush";
-    private static final String FLUSH_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + FLUSH_DESCRIPTION;
     private static final String FLUSH_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + FLUSH_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String FLUSH_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + FLUSH_DESCRIPTION;
@@ -127,7 +113,6 @@ public class StateStoreMetrics {
 
     private static final String DELETE = "delete";
     private static final String DELETE_DESCRIPTION = "calls to delete";
-    private static final String DELETE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + DELETE_DESCRIPTION;
     private static final String DELETE_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + DELETE_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String DELETE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + DELETE_DESCRIPTION;
@@ -135,7 +120,6 @@ public class StateStoreMetrics {
 
     private static final String REMOVE = "remove";
     private static final String REMOVE_DESCRIPTION = "calls to remove";
-    private static final String REMOVE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + REMOVE_DESCRIPTION;
     private static final String REMOVE_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + REMOVE_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String REMOVE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + REMOVE_DESCRIPTION;
@@ -143,7 +127,6 @@ public class StateStoreMetrics {
 
     private static final String RESTORE = "restore";
     private static final String RESTORE_DESCRIPTION = "restorations";
-    private static final String RESTORE_TOTAL_DESCRIPTION = TOTAL_DESCRIPTION + RESTORE_DESCRIPTION;
     private static final String RESTORE_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + RESTORE_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
     private static final String RESTORE_AVG_LATENCY_DESCRIPTION = AVG_LATENCY_DESCRIPTION_PREFIX + RESTORE_DESCRIPTION;
@@ -151,8 +134,6 @@ public class StateStoreMetrics {
 
     private static final String SUPPRESSION_BUFFER_COUNT = "suppression-buffer-count";
     private static final String SUPPRESSION_BUFFER_COUNT_DESCRIPTION = "count of " + BUFFERED_RECORDS;
-    private static final String SUPPRESSION_BUFFER_COUNT_CURRENT_DESCRIPTION =
-        CURRENT_DESCRIPTION_PREFIX + SUPPRESSION_BUFFER_COUNT_DESCRIPTION;
     private static final String SUPPRESSION_BUFFER_COUNT_AVG_DESCRIPTION =
         AVG_DESCRIPTION_PREFIX + SUPPRESSION_BUFFER_COUNT_DESCRIPTION;
     private static final String SUPPRESSION_BUFFER_COUNT_MAX_DESCRIPTION =
@@ -160,8 +141,6 @@ public class StateStoreMetrics {
 
     private static final String SUPPRESSION_BUFFER_SIZE = "suppression-buffer-size";
     private static final String SUPPRESSION_BUFFER_SIZE_DESCRIPTION = "size of " + BUFFERED_RECORDS;
-    private static final String SUPPRESSION_BUFFER_SIZE_CURRENT_DESCRIPTION =
-        CURRENT_DESCRIPTION_PREFIX + SUPPRESSION_BUFFER_SIZE_DESCRIPTION;
     private static final String SUPPRESSION_BUFFER_SIZE_AVG_DESCRIPTION =
         AVG_DESCRIPTION_PREFIX + SUPPRESSION_BUFFER_SIZE_DESCRIPTION;
     private static final String SUPPRESSION_BUFFER_SIZE_MAX_DESCRIPTION =
@@ -174,19 +153,16 @@ public class StateStoreMetrics {
     private static final String EXPIRED_WINDOW_RECORD_DROP_RATE_DESCRIPTION =
         RATE_DESCRIPTION_PREFIX + EXPIRED_WINDOW_RECORD_DROP_DESCRIPTION + RATE_DESCRIPTION_SUFFIX;
 
-    public static Sensor putSensor(final String threadId,
-                                   final String taskId,
+    public static Sensor putSensor(final String taskId,
                                    final String storeType,
                                    final String storeName,
                                    final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             PUT,
             PUT_RATE_DESCRIPTION,
-            PUT_TOTAL_DESCRIPTION,
             PUT_AVG_LATENCY_DESCRIPTION,
             PUT_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -194,19 +170,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor putIfAbsentSensor(final String threadId,
-                                           final String taskId,
+    public static Sensor putIfAbsentSensor(final String taskId,
                                            final String storeType,
                                            final String storeName,
                                            final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             PUT_IF_ABSENT,
             PUT_IF_ABSENT_RATE_DESCRIPTION,
-            PUT_IF_ABSENT_TOTAL_DESCRIPTION,
             PUT_IF_ABSENT_AVG_LATENCY_DESCRIPTION,
             PUT_IF_ABSENT_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -214,19 +187,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor putAllSensor(final String threadId,
-                                      final String taskId,
+    public static Sensor putAllSensor(final String taskId,
                                       final String storeType,
                                       final String storeName,
                                       final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             PUT_ALL,
             PUT_ALL_RATE_DESCRIPTION,
-            PUT_ALL_TOTAL_DESCRIPTION,
             PUT_ALL_AVG_LATENCY_DESCRIPTION,
             PUT_ALL_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -234,19 +204,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor getSensor(final String threadId,
-                                   final String taskId,
+    public static Sensor getSensor(final String taskId,
                                    final String storeType,
                                    final String storeName,
                                    final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             GET,
             GET_RATE_DESCRIPTION,
-            GET_TOTAL_DESCRIPTION,
             GET_AVG_LATENCY_DESCRIPTION,
             GET_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -254,19 +221,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor fetchSensor(final String threadId,
-                                     final String taskId,
+    public static Sensor fetchSensor(final String taskId,
                                      final String storeType,
                                      final String storeName,
                                      final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             FETCH,
             FETCH_RATE_DESCRIPTION,
-            FETCH_TOTAL_DESCRIPTION,
             FETCH_AVG_LATENCY_DESCRIPTION,
             FETCH_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -274,19 +238,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor allSensor(final String threadId,
-                                   final String taskId,
+    public static Sensor allSensor(final String taskId,
                                    final String storeType,
                                    final String storeName,
                                    final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             ALL,
             ALL_RATE_DESCRIPTION,
-            ALL_TOTAL_DESCRIPTION,
             ALL_AVG_LATENCY_DESCRIPTION,
             ALL_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -294,19 +255,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor rangeSensor(final String threadId,
-                                     final String taskId,
+    public static Sensor rangeSensor(final String taskId,
                                      final String storeType,
                                      final String storeName,
                                      final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             RANGE,
             RANGE_RATE_DESCRIPTION,
-            RANGE_TOTAL_DESCRIPTION,
             RANGE_AVG_LATENCY_DESCRIPTION,
             RANGE_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -341,19 +299,16 @@ public class StateStoreMetrics {
         return sensor;
     }
 
-    public static Sensor flushSensor(final String threadId,
-                                     final String taskId,
+    public static Sensor flushSensor(final String taskId,
                                      final String storeType,
                                      final String storeName,
                                      final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             FLUSH,
             FLUSH_RATE_DESCRIPTION,
-            FLUSH_TOTAL_DESCRIPTION,
             FLUSH_AVG_LATENCY_DESCRIPTION,
             FLUSH_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -361,19 +316,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor deleteSensor(final String threadId,
-                                      final String taskId,
+    public static Sensor deleteSensor(final String taskId,
                                       final String storeType,
                                       final String storeName,
                                       final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             DELETE,
             DELETE_RATE_DESCRIPTION,
-            DELETE_TOTAL_DESCRIPTION,
             DELETE_AVG_LATENCY_DESCRIPTION,
             DELETE_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -381,19 +333,16 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor removeSensor(final String threadId,
-                                      final String taskId,
+    public static Sensor removeSensor(final String taskId,
                                       final String storeType,
                                       final String storeName,
                                       final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             REMOVE,
             REMOVE_RATE_DESCRIPTION,
-            REMOVE_TOTAL_DESCRIPTION,
             REMOVE_AVG_LATENCY_DESCRIPTION,
             REMOVE_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -401,18 +350,15 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor restoreSensor(final String threadId,
-                                       final String taskId,
+    public static Sensor restoreSensor(final String taskId,
                                        final String storeType,
                                        final String storeName,
                                        final StreamsMetricsImpl streamsMetrics) {
         return throughputAndLatencySensor(
-            threadId,
             taskId, storeType,
             storeName,
             RESTORE,
             RESTORE_RATE_DESCRIPTION,
-            RESTORE_TOTAL_DESCRIPTION,
             RESTORE_AVG_LATENCY_DESCRIPTION,
             RESTORE_MAX_LATENCY_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -441,18 +387,15 @@ public class StateStoreMetrics {
         return sensor;
     }
 
-    public static Sensor suppressionBufferCountSensor(final String threadId,
-                                                      final String taskId,
+    public static Sensor suppressionBufferCountSensor(final String taskId,
                                                       final String storeType,
                                                       final String storeName,
                                                       final StreamsMetricsImpl streamsMetrics) {
         return sizeOrCountSensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             SUPPRESSION_BUFFER_COUNT,
-            SUPPRESSION_BUFFER_COUNT_CURRENT_DESCRIPTION,
             SUPPRESSION_BUFFER_COUNT_AVG_DESCRIPTION,
             SUPPRESSION_BUFFER_COUNT_MAX_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -460,18 +403,15 @@ public class StateStoreMetrics {
         );
     }
 
-    public static Sensor suppressionBufferSizeSensor(final String threadId,
-                                                     final String taskId,
+    public static Sensor suppressionBufferSizeSensor(final String taskId,
                                                      final String storeType,
                                                      final String storeName,
                                                      final StreamsMetricsImpl streamsMetrics) {
         return sizeOrCountSensor(
-            threadId,
             taskId,
             storeType,
             storeName,
             SUPPRESSION_BUFFER_SIZE,
-            SUPPRESSION_BUFFER_SIZE_CURRENT_DESCRIPTION,
             SUPPRESSION_BUFFER_SIZE_AVG_DESCRIPTION,
             SUPPRESSION_BUFFER_SIZE_MAX_DESCRIPTION,
             RecordingLevel.DEBUG,
@@ -497,80 +437,40 @@ public class StateStoreMetrics {
         return sensor;
     }
 
-    private static Sensor sizeOrCountSensor(final String threadId,
-                                            final String taskId,
+    private static Sensor sizeOrCountSensor(final String taskId,
                                             final String storeType,
                                             final String storeName,
                                             final String metricName,
-                                            final String descriptionOfCurrentValue,
                                             final String descriptionOfAvg,
                                             final String descriptionOfMax,
                                             final RecordingLevel recordingLevel,
                                             final StreamsMetricsImpl streamsMetrics) {
-        final Version version = streamsMetrics.version();
         final Sensor sensor = streamsMetrics.storeLevelSensor(taskId, storeName, metricName, recordingLevel);
         final String group;
         final Map<String, String> tagMap;
-        if (version == Version.FROM_0100_TO_24) {
-            group = BUFFER_LEVEL_GROUP_0100_TO_24;
-            tagMap = streamsMetrics.bufferLevelTagMap(threadId, taskId, storeName);
-            addValueMetricToSensor(sensor, group, tagMap, metricName + CURRENT_SUFFIX, descriptionOfCurrentValue);
-
-        } else {
-            group = STATE_STORE_LEVEL_GROUP;
-            tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
-        }
+        group = STATE_STORE_LEVEL_GROUP;
+        tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
         addAvgAndMaxToSensor(sensor, group, tagMap, metricName, descriptionOfAvg, descriptionOfMax);
         return sensor;
     }
 
-    private static Sensor throughputAndLatencySensor(final String threadId,
-                                                     final String taskId,
+    private static Sensor throughputAndLatencySensor(final String taskId,
                                                      final String storeType,
                                                      final String storeName,
                                                      final String metricName,
                                                      final String descriptionOfRate,
-                                                     final String descriptionOfCount,
                                                      final String descriptionOfAvg,
                                                      final String descriptionOfMax,
                                                      final RecordingLevel recordingLevel,
                                                      final StreamsMetricsImpl streamsMetrics) {
         final Sensor sensor;
         final String latencyMetricName = metricName + LATENCY_SUFFIX;
-        final Version version = streamsMetrics.version();
         final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, storeName);
-        final String stateStoreLevelGroup = stateStoreLevelGroup(storeType, version);
-        if (version == Version.FROM_0100_TO_24) {
-            final Sensor parentSensor = parentSensor(
-                stateStoreLevelGroup,
-                threadId,
-                taskId,
-                storeType,
-                metricName,
-                latencyMetricName,
-                descriptionOfRate,
-                descriptionOfCount,
-                descriptionOfAvg,
-                descriptionOfMax,
-                recordingLevel,
-                streamsMetrics
-            );
-            sensor = streamsMetrics.storeLevelSensor(taskId, storeName, metricName, recordingLevel, parentSensor);
-            addInvocationRateAndCountToSensor(
-                sensor,
-                stateStoreLevelGroup,
-                tagMap,
-                metricName,
-                descriptionOfRate,
-                descriptionOfCount
-            );
-        } else {
-            sensor = streamsMetrics.storeLevelSensor(taskId, storeName, metricName, recordingLevel);
-            addInvocationRateToSensor(sensor, stateStoreLevelGroup, tagMap, metricName, descriptionOfRate);
-        }
+        sensor = streamsMetrics.storeLevelSensor(taskId, storeName, metricName, recordingLevel);
+        addInvocationRateToSensor(sensor, STATE_STORE_LEVEL_GROUP, tagMap, metricName, descriptionOfRate);
         addAvgAndMaxToSensor(
             sensor,
-            stateStoreLevelGroup,
+            STATE_STORE_LEVEL_GROUP,
             tagMap,
             latencyMetricName,
             descriptionOfAvg,
@@ -578,45 +478,4 @@ public class StateStoreMetrics {
         );
         return sensor;
     }
-
-    private static Sensor parentSensor(final String stateStoreLevelGroup,
-                                       final String threadId,
-                                       final String taskId,
-                                       final String storeType,
-                                       final String metricName,
-                                       final String latencyMetricName,
-                                       final String descriptionOfRate,
-                                       final String descriptionOfCount,
-                                       final String descriptionOfAvg,
-                                       final String descriptionOfMax,
-                                       final RecordingLevel recordingLevel,
-                                       final StreamsMetricsImpl streamsMetrics) {
-        final Sensor sensor = streamsMetrics.taskLevelSensor(threadId, taskId, metricName, recordingLevel);
-        final Map<String, String> allTagMap = streamsMetrics.storeLevelTagMap(taskId, storeType, ROLLUP_VALUE);
-        addAvgAndMaxToSensor(
-            sensor,
-            stateStoreLevelGroup,
-            allTagMap,
-            latencyMetricName,
-            descriptionOfAvg,
-            descriptionOfMax
-        );
-        addInvocationRateAndCountToSensor(
-            sensor,
-            stateStoreLevelGroup,
-            allTagMap,
-            metricName,
-            descriptionOfRate,
-            descriptionOfCount
-        );
-        return sensor;
-    }
-
-    private static String stateStoreLevelGroup(final String metricsScope, final Version builtInMetricsVersion) {
-        if (builtInMetricsVersion == Version.FROM_0100_TO_24) {
-            return "stream-" + metricsScope + "-state-metrics";
-        }
-        return STATE_STORE_LEVEL_GROUP;
-    }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -605,13 +605,6 @@ public class StreamsConfigTest {
     }
 
     @Test
-    public void shouldAcceptBuiltInMetricsVersion0100To24() {
-        // don't use `StreamsConfig.METRICS_0100_TO_24` to actually do a useful test
-        props.put(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, "0.10.0-2.4");
-        new StreamsConfig(props);
-    }
-
-    @Test
     public void shouldAcceptBuiltInMetricsLatestVersion() {
         // don't use `StreamsConfig.METRICS_LATEST` to actually do a useful test
         props.put(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, "latest");

--- a/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/MetricsIntegrationTest.java
@@ -87,7 +87,6 @@ public class MetricsIntegrationTest {
 
     // Metric group
     private static final String STREAM_CLIENT_NODE_METRICS = "stream-metrics";
-    private static final String STREAM_THREAD_NODE_METRICS_0100_TO_24 = "stream-metrics";
     private static final String STREAM_THREAD_NODE_METRICS = "stream-thread-metrics";
     private static final String STREAM_TASK_NODE_METRICS = "stream-task-metrics";
     private static final String STREAM_PROCESSOR_NODE_METRICS = "stream-processor-node-metrics";
@@ -96,13 +95,7 @@ public class MetricsIntegrationTest {
     private static final String IN_MEMORY_KVSTORE_TAG_KEY = "in-memory-state-id";
     private static final String IN_MEMORY_LRUCACHE_TAG_KEY = "in-memory-lru-state-id";
     private static final String ROCKSDB_KVSTORE_TAG_KEY = "rocksdb-state-id";
-    private static final String STATE_STORE_LEVEL_GROUP_IN_MEMORY_KVSTORE_0100_TO_24 = "stream-in-memory-state-metrics";
-    private static final String STATE_STORE_LEVEL_GROUP_IN_MEMORY_LRUCACHE_0100_TO_24 = "stream-in-memory-lru-state-metrics";
-    private static final String STATE_STORE_LEVEL_GROUP_ROCKSDB_KVSTORE_0100_TO_24 = "stream-rocksdb-state-metrics";
     private static final String STATE_STORE_LEVEL_GROUP = "stream-state-metrics";
-    private static final String STATE_STORE_LEVEL_GROUP_ROCKSDB_WINDOW_STORE_0100_TO_24 = "stream-rocksdb-window-state-metrics";
-    private static final String STATE_STORE_LEVEL_GROUP_ROCKSDB_SESSION_STORE_0100_TO_24 = "stream-rocksdb-session-state-metrics";
-    private static final String BUFFER_LEVEL_GROUP_0100_TO_24 = "stream-buffer-metrics";
 
     // Metrics name
     private static final String VERSION = "version";
@@ -203,9 +196,6 @@ public class MetricsIntegrationTest {
     private static final String SKIPPED_RECORDS_TOTAL = "skipped-records-total";
     private static final String RECORD_LATENESS_AVG = "record-lateness-avg";
     private static final String RECORD_LATENESS_MAX = "record-lateness-max";
-    private static final String HIT_RATIO_AVG_BEFORE_24 = "hitRatio-avg";
-    private static final String HIT_RATIO_MIN_BEFORE_24 = "hitRatio-min";
-    private static final String HIT_RATIO_MAX_BEFORE_24 = "hitRatio-max";
     private static final String HIT_RATIO_AVG = "hit-ratio-avg";
     private static final String HIT_RATIO_MIN = "hit-ratio-min";
     private static final String HIT_RATIO_MAX = "hit-ratio-max";
@@ -341,18 +331,7 @@ public class MetricsIntegrationTest {
     }
 
     @Test
-    public void shouldAddMetricsOnAllLevelsWithBuiltInMetricsLatestVersion() throws Exception {
-        shouldAddMetricsOnAllLevels(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldAddMetricsOnAllLevelsWithBuiltInMetricsVersion0100To24() throws Exception {
-        shouldAddMetricsOnAllLevels(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldAddMetricsOnAllLevels(final String builtInMetricsVersion) throws Exception {
-        streamsConfiguration.put(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-
+    public void shouldAddMetricsOnAllLevels() throws Exception {
         builder.stream(STREAM_INPUT, Consumed.with(Serdes.Integer(), Serdes.String()))
             .to(STREAM_OUTPUT_1, Produced.with(Serdes.Integer(), Serdes.String()));
         builder.table(STREAM_OUTPUT_1,
@@ -371,25 +350,13 @@ public class MetricsIntegrationTest {
 
         verifyStateMetric(State.RUNNING);
         checkClientLevelMetrics();
-        checkThreadLevelMetrics(builtInMetricsVersion);
-        checkTaskLevelMetrics(builtInMetricsVersion);
-        checkProcessorNodeLevelMetrics(builtInMetricsVersion);
-        checkKeyValueStoreMetrics(
-            STATE_STORE_LEVEL_GROUP_IN_MEMORY_KVSTORE_0100_TO_24,
-            IN_MEMORY_KVSTORE_TAG_KEY,
-            builtInMetricsVersion
-        );
-        checkKeyValueStoreMetrics(
-            STATE_STORE_LEVEL_GROUP_ROCKSDB_KVSTORE_0100_TO_24,
-            ROCKSDB_KVSTORE_TAG_KEY,
-            builtInMetricsVersion
-        );
-        checkKeyValueStoreMetrics(
-            STATE_STORE_LEVEL_GROUP_IN_MEMORY_LRUCACHE_0100_TO_24,
-            IN_MEMORY_LRUCACHE_TAG_KEY,
-            builtInMetricsVersion
-        );
-        checkCacheMetrics(builtInMetricsVersion);
+        checkThreadLevelMetrics();
+        checkTaskLevelMetrics();
+        checkProcessorNodeLevelMetrics();
+        checkKeyValueStoreMetrics(IN_MEMORY_KVSTORE_TAG_KEY);
+        checkKeyValueStoreMetrics(ROCKSDB_KVSTORE_TAG_KEY);
+        checkKeyValueStoreMetrics(IN_MEMORY_LRUCACHE_TAG_KEY);
+        checkCacheMetrics();
 
         closeApplication();
 
@@ -397,18 +364,7 @@ public class MetricsIntegrationTest {
     }
 
     @Test
-    public void shouldAddMetricsForWindowStoreAndSuppressionBufferWithBuiltInMetricsLatestVersion() throws Exception {
-        shouldAddMetricsForWindowStoreAndSuppressionBuffer(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldAddMetricsForWindowStoreAndSuppressionBufferWithBuiltInMetricsVersion0100To24() throws Exception {
-        shouldAddMetricsForWindowStoreAndSuppressionBuffer(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldAddMetricsForWindowStoreAndSuppressionBuffer(final String builtInMetricsVersion) throws Exception {
-        streamsConfiguration.put(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-
+    public void shouldAddMetricsForWindowStoreAndSuppressionBuffer() throws Exception {
         final Duration windowSize = Duration.ofMillis(50);
         builder.stream(STREAM_INPUT, Consumed.with(Serdes.Integer(), Serdes.String()))
             .groupByKey()
@@ -428,7 +384,7 @@ public class MetricsIntegrationTest {
 
         verifyStateMetric(State.RUNNING);
 
-        checkWindowStoreAndSuppressionBufferMetrics(builtInMetricsVersion);
+        checkWindowStoreAndSuppressionBufferMetrics();
 
         closeApplication();
 
@@ -436,18 +392,7 @@ public class MetricsIntegrationTest {
     }
 
     @Test
-    public void shouldAddMetricsForSessionStoreWithBuiltInMetricsLatestVersion() throws Exception {
-        shouldAddMetricsForSessionStore(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldAddMetricsForSessionStoreWithBuiltInMetricsVersion0100To24() throws Exception {
-        shouldAddMetricsForSessionStore(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldAddMetricsForSessionStore(final String builtInMetricsVersion) throws Exception {
-        streamsConfiguration.put(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-
+    public void shouldAddMetricsForSessionStore() throws Exception {
         final Duration inactivityGap = Duration.ofMillis(50);
         builder.stream(STREAM_INPUT, Consumed.with(Serdes.Integer(), Serdes.String()))
             .groupByKey()
@@ -468,7 +413,7 @@ public class MetricsIntegrationTest {
 
         verifyStateMetric(State.RUNNING);
 
-        checkSessionStoreMetrics(builtInMetricsVersion);
+        checkSessionStoreMetrics();
 
         closeApplication();
 
@@ -525,11 +470,9 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricThread, FAILED_STREAM_THREADS, 1);
     }
 
-    private void checkThreadLevelMetrics(final String builtInMetricsVersion) {
+    private void checkThreadLevelMetrics() {
         final List<Metric> listMetricThread = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
-            .filter(m -> m.metricName().group().equals(
-                StreamsConfig.METRICS_LATEST.equals(builtInMetricsVersion) ? STREAM_THREAD_NODE_METRICS
-                    : STREAM_THREAD_NODE_METRICS_0100_TO_24))
+            .filter(m -> m.metricName().group().equals(STREAM_THREAD_NODE_METRICS))
             .collect(Collectors.toList());
         checkMetricByName(listMetricThread, COMMIT_LATENCY_AVG, NUM_THREADS);
         checkMetricByName(listMetricThread, COMMIT_LATENCY_MAX, NUM_THREADS);
@@ -559,82 +502,49 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricThread, TASK_CREATED_TOTAL, NUM_THREADS);
         checkMetricByName(listMetricThread, TASK_CLOSED_RATE, NUM_THREADS);
         checkMetricByName(listMetricThread, TASK_CLOSED_TOTAL, NUM_THREADS);
-        checkMetricByName(
-            listMetricThread,
-            SKIPPED_RECORDS_RATE,
-            StreamsConfig.METRICS_LATEST.equals(builtInMetricsVersion) ? 0 : NUM_THREADS
-        );
-        checkMetricByName(
-            listMetricThread,
-            SKIPPED_RECORDS_TOTAL,
-            StreamsConfig.METRICS_LATEST.equals(builtInMetricsVersion) ? 0 : NUM_THREADS
-        );
     }
 
-    private void checkTaskLevelMetrics(final String builtInMetricsVersion) {
+    private void checkTaskLevelMetrics() {
         final List<Metric> listMetricTask = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
             .filter(m -> m.metricName().group().equals(STREAM_TASK_NODE_METRICS))
             .collect(Collectors.toList());
-        final int numberOfAddedMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 0 : 4;
         checkMetricByName(listMetricTask, ENFORCED_PROCESSING_RATE, 4);
         checkMetricByName(listMetricTask, ENFORCED_PROCESSING_TOTAL, 4);
         checkMetricByName(listMetricTask, RECORD_LATENESS_AVG, 4);
         checkMetricByName(listMetricTask, RECORD_LATENESS_MAX, 4);
         checkMetricByName(listMetricTask, ACTIVE_PROCESS_RATIO, 4);
         checkMetricByName(listMetricTask, ACTIVE_BUFFER_COUNT, 4);
-        checkMetricByName(listMetricTask, PROCESS_LATENCY_AVG, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PROCESS_LATENCY_MAX, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PUNCTUATE_LATENCY_AVG, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PUNCTUATE_LATENCY_MAX, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PUNCTUATE_RATE, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PUNCTUATE_TOTAL, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PROCESS_RATE, numberOfAddedMetrics);
-        checkMetricByName(listMetricTask, PROCESS_TOTAL, numberOfAddedMetrics);
+        checkMetricByName(listMetricTask, PROCESS_LATENCY_AVG, 4);
+        checkMetricByName(listMetricTask, PROCESS_LATENCY_MAX, 4);
+        checkMetricByName(listMetricTask, PUNCTUATE_LATENCY_AVG, 4);
+        checkMetricByName(listMetricTask, PUNCTUATE_LATENCY_MAX, 4);
+        checkMetricByName(listMetricTask, PUNCTUATE_RATE, 4);
+        checkMetricByName(listMetricTask, PUNCTUATE_TOTAL, 4);
+        checkMetricByName(listMetricTask, PROCESS_RATE, 4);
+        checkMetricByName(listMetricTask, PROCESS_TOTAL, 4);
     }
 
-    private void checkProcessorNodeLevelMetrics(final String builtInMetricsVersion) {
+    private void checkProcessorNodeLevelMetrics() {
         final List<Metric> listMetricProcessor = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
             .filter(m -> m.metricName().group().equals(STREAM_PROCESSOR_NODE_METRICS))
             .collect(Collectors.toList());
-        final int numberOfRemovedMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 18 : 0;
-        final int numberOfModifiedProcessMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 18 : 4;
-        final int numberOfModifiedForwardMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 8 : 0;
         final int numberOfSourceNodes = 4;
         final int numberOfTerminalNodes = 4;
-        checkMetricByName(listMetricProcessor, PROCESS_LATENCY_AVG, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, PROCESS_LATENCY_MAX, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, PUNCTUATE_LATENCY_AVG, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, PUNCTUATE_LATENCY_MAX, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, CREATE_LATENCY_AVG, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, CREATE_LATENCY_MAX, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, DESTROY_LATENCY_AVG, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, DESTROY_LATENCY_MAX, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, PROCESS_RATE, numberOfModifiedProcessMetrics);
-        checkMetricByName(listMetricProcessor, PROCESS_TOTAL, numberOfModifiedProcessMetrics);
-        checkMetricByName(listMetricProcessor, PUNCTUATE_RATE, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, PUNCTUATE_TOTAL, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, CREATE_RATE, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, CREATE_TOTAL, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, DESTROY_RATE, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, DESTROY_TOTAL, numberOfRemovedMetrics);
-        checkMetricByName(listMetricProcessor, FORWARD_TOTAL, numberOfModifiedForwardMetrics);
-        checkMetricByName(listMetricProcessor, FORWARD_RATE, numberOfModifiedForwardMetrics);
+        checkMetricByName(listMetricProcessor, PROCESS_RATE, 4);
+        checkMetricByName(listMetricProcessor, PROCESS_TOTAL, 4);
         checkMetricByName(listMetricProcessor, RECORD_E2E_LATENCY_AVG, numberOfSourceNodes + numberOfTerminalNodes);
         checkMetricByName(listMetricProcessor, RECORD_E2E_LATENCY_MIN, numberOfSourceNodes + numberOfTerminalNodes);
         checkMetricByName(listMetricProcessor, RECORD_E2E_LATENCY_MAX, numberOfSourceNodes + numberOfTerminalNodes);
     }
 
-    private void checkKeyValueStoreMetrics(final String group0100To24,
-                                           final String tagKey,
-                                           final String builtInMetricsVersion) {
+    private void checkKeyValueStoreMetrics(final String tagKey) {
         final List<Metric> listMetricStore = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
-            .filter(m -> m.metricName().tags().containsKey(tagKey) &&
-                (m.metricName().group().equals(group0100To24) || m.metricName().group().equals(STATE_STORE_LEVEL_GROUP))
-            ).collect(Collectors.toList());
+            .filter(m -> m.metricName().tags().containsKey(tagKey) && m.metricName().group().equals(STATE_STORE_LEVEL_GROUP))
+            .collect(Collectors.toList());
 
-        final int expectedNumberOfLatencyMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 1;
-        final int expectedNumberOfRateMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 1;
-        final int expectedNumberOfTotalMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 0;
+        final int expectedNumberOfLatencyMetrics = 1;
+        final int expectedNumberOfRateMetrics = 1;
+        final int expectedNumberOfTotalMetrics = 0;
         checkMetricByName(listMetricStore, PUT_LATENCY_AVG, expectedNumberOfLatencyMetrics);
         checkMetricByName(listMetricStore, PUT_LATENCY_MAX, expectedNumberOfLatencyMetrics);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_LATENCY_AVG, expectedNumberOfLatencyMetrics);
@@ -697,40 +607,21 @@ public class MetricsIntegrationTest {
         assertThat(listMetricAfterClosingApp.size(), is(0));
     }
 
-    private void checkCacheMetrics(final String builtInMetricsVersion) {
+    private void checkCacheMetrics() {
         final List<Metric> listMetricCache = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
             .filter(m -> m.metricName().group().equals(STREAM_CACHE_NODE_METRICS))
             .collect(Collectors.toList());
-        checkMetricByName(
-            listMetricCache,
-            builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? HIT_RATIO_AVG : HIT_RATIO_AVG_BEFORE_24,
-            builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? 3 : 6 /* includes parent sensors */
-        );
-        checkMetricByName(
-            listMetricCache,
-            builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? HIT_RATIO_MIN : HIT_RATIO_MIN_BEFORE_24,
-            builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? 3 : 6 /* includes parent sensors */
-        );
-        checkMetricByName(
-            listMetricCache,
-            builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? HIT_RATIO_MAX : HIT_RATIO_MAX_BEFORE_24,
-            builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? 3 : 6 /* includes parent sensors */
-        );
+        checkMetricByName(listMetricCache, HIT_RATIO_AVG, 3);
+        checkMetricByName(listMetricCache, HIT_RATIO_MIN, 3);
+        checkMetricByName(listMetricCache, HIT_RATIO_MAX, 3);
     }
 
-    private void checkWindowStoreAndSuppressionBufferMetrics(final String builtInMetricsVersion) {
+    private void checkWindowStoreAndSuppressionBufferMetrics() {
         final List<Metric> listMetricStore = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
-            .filter(m -> m.metricName().group().equals(STATE_STORE_LEVEL_GROUP_ROCKSDB_WINDOW_STORE_0100_TO_24) ||
-                m.metricName().group().equals(BUFFER_LEVEL_GROUP_0100_TO_24) ||
-                m.metricName().group().equals("stream-rocksdb-window-metrics") ||
-                m.metricName().group().equals(STATE_STORE_LEVEL_GROUP)
-            ).collect(Collectors.toList());
-        final int expectedNumberOfLatencyMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 1;
-        final int expectedNumberOfRateMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 1;
-        final int expectedNumberOfTotalMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 0;
-        final int expectedNumberOfRemovedMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 1 : 0;
-        checkMetricByName(listMetricStore, PUT_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, PUT_LATENCY_MAX, expectedNumberOfLatencyMetrics);
+            .filter(m -> m.metricName().group().equals(STATE_STORE_LEVEL_GROUP))
+            .collect(Collectors.toList());
+        checkMetricByName(listMetricStore, PUT_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, PUT_LATENCY_MAX, 1);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_LATENCY_MAX, 0);
         checkMetricByName(listMetricStore, GET_LATENCY_AVG, 0);
@@ -745,14 +636,13 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricStore, ALL_LATENCY_MAX, 0);
         checkMetricByName(listMetricStore, RANGE_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, RANGE_LATENCY_MAX, 0);
-        checkMetricByName(listMetricStore, FLUSH_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, FLUSH_LATENCY_MAX, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, RESTORE_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, RESTORE_LATENCY_MAX, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, FETCH_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, FETCH_LATENCY_MAX, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, PUT_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, PUT_TOTAL, expectedNumberOfTotalMetrics);
+        checkMetricByName(listMetricStore, FLUSH_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, FLUSH_LATENCY_MAX, 1);
+        checkMetricByName(listMetricStore, RESTORE_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, RESTORE_LATENCY_MAX, 1);
+        checkMetricByName(listMetricStore, FETCH_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, FETCH_LATENCY_MAX, 1);
+        checkMetricByName(listMetricStore, PUT_RATE, 1);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_RATE, 0);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_TOTAL, 0);
         checkMetricByName(listMetricStore, GET_RATE, 0);
@@ -767,18 +657,11 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricStore, ALL_TOTAL, 0);
         checkMetricByName(listMetricStore, RANGE_RATE, 0);
         checkMetricByName(listMetricStore, RANGE_TOTAL, 0);
-        checkMetricByName(listMetricStore, FLUSH_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, FLUSH_TOTAL, expectedNumberOfTotalMetrics);
-        checkMetricByName(listMetricStore, RESTORE_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, RESTORE_TOTAL, expectedNumberOfTotalMetrics);
-        checkMetricByName(listMetricStore, FETCH_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, FETCH_TOTAL, expectedNumberOfTotalMetrics);
-        checkMetricByName(listMetricStore, EXPIRED_WINDOW_RECORD_DROP_RATE, expectedNumberOfRemovedMetrics);
-        checkMetricByName(listMetricStore, EXPIRED_WINDOW_RECORD_DROP_TOTAL, expectedNumberOfRemovedMetrics);
-        checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_COUNT_CURRENT, expectedNumberOfRemovedMetrics);
+        checkMetricByName(listMetricStore, FLUSH_RATE, 1);
+        checkMetricByName(listMetricStore, RESTORE_RATE, 1);
+        checkMetricByName(listMetricStore, FETCH_RATE, 1);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_COUNT_AVG, 1);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_COUNT_MAX, 1);
-        checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_SIZE_CURRENT, expectedNumberOfRemovedMetrics);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_SIZE_AVG, 1);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_SIZE_MAX, 1);
         checkMetricByName(listMetricStore, RECORD_E2E_LATENCY_AVG, 1);
@@ -786,63 +669,49 @@ public class MetricsIntegrationTest {
         checkMetricByName(listMetricStore, RECORD_E2E_LATENCY_MAX, 1);
     }
 
-    private void checkSessionStoreMetrics(final String builtInMetricsVersion) {
+    private void checkSessionStoreMetrics() {
         final List<Metric> listMetricStore = new ArrayList<Metric>(kafkaStreams.metrics().values()).stream()
-            .filter(m -> m.metricName().group().equals(STATE_STORE_LEVEL_GROUP_ROCKSDB_SESSION_STORE_0100_TO_24) ||
-                m.metricName().group().equals(BUFFER_LEVEL_GROUP_0100_TO_24) ||
-                m.metricName().group().equals("stream-rocksdb-session-metrics") ||
-                m.metricName().group().equals(STATE_STORE_LEVEL_GROUP)
-            ).collect(Collectors.toList());
-        final int expectedNumberOfLatencyMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 1;
-        final int expectedNumberOfRateMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 1;
-        final int expectedNumberOfTotalMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 2 : 0;
-        final int expectedNumberOfRemovedMetrics = StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? 1 : 0;
-        checkMetricByName(listMetricStore, PUT_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, PUT_LATENCY_MAX, expectedNumberOfLatencyMetrics);
+            .filter(m -> m.metricName().group().equals(STATE_STORE_LEVEL_GROUP))
+            .collect(Collectors.toList());
+        checkMetricByName(listMetricStore, PUT_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, PUT_LATENCY_MAX, 1);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_LATENCY_MAX, 0);
         checkMetricByName(listMetricStore, GET_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, GET_LATENCY_MAX, 0);
         checkMetricByName(listMetricStore, DELETE_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, DELETE_LATENCY_MAX, 0);
-        checkMetricByName(listMetricStore, REMOVE_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, REMOVE_LATENCY_MAX, expectedNumberOfLatencyMetrics);
+        checkMetricByName(listMetricStore, REMOVE_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, REMOVE_LATENCY_MAX, 1);
         checkMetricByName(listMetricStore, PUT_ALL_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, PUT_ALL_LATENCY_MAX, 0);
         checkMetricByName(listMetricStore, ALL_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, ALL_LATENCY_MAX, 0);
         checkMetricByName(listMetricStore, RANGE_LATENCY_AVG, 0);
         checkMetricByName(listMetricStore, RANGE_LATENCY_MAX, 0);
-        checkMetricByName(listMetricStore, FLUSH_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, FLUSH_LATENCY_MAX, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, RESTORE_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, RESTORE_LATENCY_MAX, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, FETCH_LATENCY_AVG, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, FETCH_LATENCY_MAX, expectedNumberOfLatencyMetrics);
-        checkMetricByName(listMetricStore, PUT_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, PUT_TOTAL, expectedNumberOfTotalMetrics);
+        checkMetricByName(listMetricStore, FLUSH_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, FLUSH_LATENCY_MAX, 1);
+        checkMetricByName(listMetricStore, RESTORE_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, RESTORE_LATENCY_MAX, 1);
+        checkMetricByName(listMetricStore, FETCH_LATENCY_AVG, 1);
+        checkMetricByName(listMetricStore, FETCH_LATENCY_MAX, 1);
+        checkMetricByName(listMetricStore, PUT_RATE, 1);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_RATE, 0);
         checkMetricByName(listMetricStore, PUT_IF_ABSENT_TOTAL, 0);
         checkMetricByName(listMetricStore, GET_RATE, 0);
         checkMetricByName(listMetricStore, GET_TOTAL, 0);
         checkMetricByName(listMetricStore, DELETE_RATE, 0);
         checkMetricByName(listMetricStore, DELETE_TOTAL, 0);
-        checkMetricByName(listMetricStore, REMOVE_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, REMOVE_TOTAL, expectedNumberOfTotalMetrics);
+        checkMetricByName(listMetricStore, REMOVE_RATE, 1);
         checkMetricByName(listMetricStore, PUT_ALL_RATE, 0);
         checkMetricByName(listMetricStore, PUT_ALL_TOTAL, 0);
         checkMetricByName(listMetricStore, ALL_RATE, 0);
         checkMetricByName(listMetricStore, ALL_TOTAL, 0);
         checkMetricByName(listMetricStore, RANGE_RATE, 0);
         checkMetricByName(listMetricStore, RANGE_TOTAL, 0);
-        checkMetricByName(listMetricStore, FLUSH_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, FLUSH_TOTAL, expectedNumberOfTotalMetrics);
-        checkMetricByName(listMetricStore, RESTORE_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, RESTORE_TOTAL, expectedNumberOfTotalMetrics);
-        checkMetricByName(listMetricStore, FETCH_RATE, expectedNumberOfRateMetrics);
-        checkMetricByName(listMetricStore, FETCH_TOTAL, expectedNumberOfTotalMetrics);
-        checkMetricByName(listMetricStore, EXPIRED_WINDOW_RECORD_DROP_RATE, expectedNumberOfRemovedMetrics);
-        checkMetricByName(listMetricStore, EXPIRED_WINDOW_RECORD_DROP_TOTAL, expectedNumberOfRemovedMetrics);
+        checkMetricByName(listMetricStore, FLUSH_RATE, 1);
+        checkMetricByName(listMetricStore, RESTORE_RATE, 1);
+        checkMetricByName(listMetricStore, FETCH_RATE, 1);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_COUNT_CURRENT, 0);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_COUNT_AVG, 0);
         checkMetricByName(listMetricStore, SUPPRESSION_BUFFER_COUNT_MAX, 0);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TestOutputTopic;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Grouped;
@@ -54,7 +53,6 @@ import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -266,16 +264,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @Test
-    public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterWhenSkippingNullKey(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeterWhenSkippingNullKeyWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterWhenSkippingNullKey(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeterWhenSkippingNullKey(final String builtInMetricsVersion) {
+    public void shouldLogAndMeterWhenSkippingNullKey() {
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -289,8 +278,6 @@ public class KStreamWindowAggregateTest {
                 Materialized.<String, String, WindowStore<Bytes, byte[]>>as("topic1-Canonicalized").withValueSerde(Serdes.String())
             );
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamWindowAggregate.class);
              final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
 
@@ -298,27 +285,12 @@ public class KStreamWindowAggregateTest {
                 driver.createInputTopic(topic, new StringSerializer(), new StringSerializer());
             inputTopic.pipeInput(null, "1");
 
-            if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-                assertEquals(
-                    1.0,
-                    getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue()
-                );
-            }
             assertThat(appender.getMessages(), hasItem("Skipping record due to null key. value=[1] topic=[topic] partition=[0] offset=[0]"));
         }
     }
 
     @Test
-    public void shouldLogAndMeterWhenSkippingExpiredWindowWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterWhenSkippingExpiredWindow(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeterWhenSkippingExpiredWindowWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterWhenSkippingExpiredWindow(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeterWhenSkippingExpiredWindow(final String builtInMetricsVersion) {
+    public void shouldLogAndMeterWhenSkippingExpiredWindow() {
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -338,8 +310,6 @@ public class KStreamWindowAggregateTest {
                .map((key, value) -> new KeyValue<>(key.toString(), value))
                .to("output");
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamWindowAggregate.class);
              final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
 
@@ -356,7 +326,6 @@ public class KStreamWindowAggregateTest {
 
             assertLatenessMetrics(
                 driver,
-                builtInMetricsVersion,
                 is(7.0), // how many events get dropped
                 is(100.0), // k:0 is 100ms late, since its time is 0, but it arrives at stream time 100.
                 is(84.875) // (0 + 100 + 99 + 98 + 97 + 96 + 95 + 94) / 8
@@ -384,16 +353,7 @@ public class KStreamWindowAggregateTest {
     }
 
     @Test
-    public void shouldLogAndMeterWhenSkippingExpiredWindowByGraceWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterWhenSkippingExpiredWindowByGrace(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeterWhenSkippingExpiredWindowByGraceWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterWhenSkippingExpiredWindowByGrace(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeterWhenSkippingExpiredWindowByGrace(final String builtInMetricsVersion) {
+    public void shouldLogAndMeterWhenSkippingExpiredWindowByGrace() {
         final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
 
@@ -409,8 +369,6 @@ public class KStreamWindowAggregateTest {
                .map((key, value) -> new KeyValue<>(key.toString(), value))
                .to("output");
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
-
         try (final LogCaptureAppender appender = LogCaptureAppender.createAndRegister(KStreamWindowAggregate.class);
              final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
 
@@ -425,7 +383,7 @@ public class KStreamWindowAggregateTest {
             inputTopic.pipeInput("k", "5", 105L);
             inputTopic.pipeInput("k", "6", 6L);
 
-            assertLatenessMetrics(driver, builtInMetricsVersion, is(7.0), is(194.0), is(97.375));
+            assertLatenessMetrics(driver, is(7.0), is(194.0), is(97.375));
 
             assertThat(appender.getMessages(), hasItems(
                 "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[1] timestamp=[100] window=[100,110) expiration=[110] streamTime=[200]",
@@ -445,7 +403,6 @@ public class KStreamWindowAggregateTest {
     }
 
     private void assertLatenessMetrics(final TopologyTestDriver driver,
-                                       final String builtInMetricsVersion,
                                        final Matcher<Object> dropTotal,
                                        final Matcher<Object> maxLateness,
                                        final Matcher<Object> avgLateness) {
@@ -454,88 +411,45 @@ public class KStreamWindowAggregateTest {
         final MetricName dropRateMetric;
         final MetricName latenessMaxMetric;
         final MetricName latenessAvgMetric;
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            dropTotalMetric = new MetricName(
-                "late-record-drop-total",
-                "stream-processor-node-metrics",
-                "The total number of dropped late records",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
-                )
-            );
-            dropRateMetric = new MetricName(
-                "late-record-drop-rate",
-                "stream-processor-node-metrics",
-                "The average number of dropped late records per second",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry("processor-node-id", "KSTREAM-AGGREGATE-0000000001")
-                )
-            );
-            latenessMaxMetric = new MetricName(
-                "record-lateness-max",
-                "stream-task-metrics",
-                "The observed maximum lateness of records in milliseconds, measured by comparing the record "
-                    + "timestamp with the current stream time",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            );
-            latenessAvgMetric = new MetricName(
-                "record-lateness-avg",
-                "stream-task-metrics",
-                "The observed average lateness of records in milliseconds, measured by comparing the record "
-                    + "timestamp with the current stream time",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            );
-        } else {
-            dropTotalMetric = new MetricName(
-                "dropped-records-total",
-                "stream-task-metrics",
-                "The total number of dropped records",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            );
-            dropRateMetric = new MetricName(
-                "dropped-records-rate",
-                "stream-task-metrics",
-                "The average number of dropped records per second",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            );
-            latenessMaxMetric = new MetricName(
-                "record-lateness-max",
-                "stream-task-metrics",
-                "The observed maximum lateness of records in milliseconds, measured by comparing the record "
-                    + "timestamp with the current stream time",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            );
-            latenessAvgMetric = new MetricName(
-                "record-lateness-avg",
-                "stream-task-metrics",
-                "The observed average lateness of records in milliseconds, measured by comparing the record "
-                    + "timestamp with the current stream time",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            );
+        dropTotalMetric = new MetricName(
+            "dropped-records-total",
+            "stream-task-metrics",
+            "The total number of dropped records",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        );
+        dropRateMetric = new MetricName(
+            "dropped-records-rate",
+            "stream-task-metrics",
+            "The average number of dropped records per second",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        );
+        latenessMaxMetric = new MetricName(
+            "record-lateness-max",
+            "stream-task-metrics",
+            "The observed maximum lateness of records in milliseconds, measured by comparing the record "
+                + "timestamp with the current stream time",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        );
+        latenessAvgMetric = new MetricName(
+            "record-lateness-avg",
+            "stream-task-metrics",
+            "The observed average lateness of records in milliseconds, measured by comparing the record "
+                + "timestamp with the current stream time",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        );
 
-        }
         assertThat(driver.metrics().get(dropTotalMetric).metricValue(), dropTotal);
         assertThat(driver.metrics().get(dropRateMetric).metricValue(), not(0.0));
         assertThat(driver.metrics().get(latenessMaxMetric).metricValue(), maxLateness);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableInnerJoinTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.TopologyTestDriver;
@@ -47,7 +46,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -248,16 +246,7 @@ public class KTableKTableInnerJoinTest {
     }
 
     @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final String builtInMetricsVersion) {
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey() {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -267,7 +256,6 @@ public class KTableKTableInnerJoinTest {
             null
         ).get();
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
         final MockProcessorContext context = new MockProcessorContext(props);
         context.setRecordMetadata("left", -1, -2, null, -3);
         join.init(context);
@@ -278,13 +266,6 @@ public class KTableKTableInnerJoinTest {
             assertThat(
                 appender.getMessages(),
                 hasItem("Skipping record due to null key. change=[(new<-old)] topic=[left] partition=[-1] offset=[-2]")
-            );
-        }
-
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertEquals(
-                1.0,
-                getMetricByName(context.metrics().metrics(), "skipped-records-total", "stream-metrics").metricValue()
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
@@ -54,7 +53,6 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -514,16 +512,7 @@ public class KTableKTableLeftJoinTest {
     }
 
     @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final String builtInMetricsVersion) {
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey() {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -533,7 +522,6 @@ public class KTableKTableLeftJoinTest {
             null
         ).get();
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
         final MockProcessorContext context = new MockProcessorContext(props);
         context.setRecordMetadata("left", -1, -2, null, -3);
         join.init(context);
@@ -544,13 +532,6 @@ public class KTableKTableLeftJoinTest {
             assertThat(
                 appender.getMessages(),
                 hasItem("Skipping record due to null key. change=[(new<-old)] topic=[left] partition=[-1] offset=[-2]")
-            );
-        }
-
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertEquals(
-                1.0,
-                getMetricByName(context.metrics().metrics(), "skipped-records-total", "stream-metrics").metricValue()
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValueTimestamp;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
 import org.apache.kafka.streams.Topology;
@@ -45,7 +44,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -405,16 +403,7 @@ public class KTableKTableOuterJoinTest {
     }
 
     @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final String builtInMetricsVersion) {
+    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKey() {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -424,7 +413,6 @@ public class KTableKTableOuterJoinTest {
                 null
         ).get();
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
         final MockProcessorContext context = new MockProcessorContext(props);
         context.setRecordMetadata("left", -1, -2, null, -3);
         join.init(context);
@@ -435,13 +423,6 @@ public class KTableKTableOuterJoinTest {
             assertThat(
                 appender.getMessages(),
                 hasItem("Skipping record due to null key. change=[(new<-old)] topic=[left] partition=[-1] offset=[-2]")
-            );
-        }
-
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertEquals(
-                1.0,
-                getMetricByName(context.metrics().metrics(), "skipped-records-total", "stream-metrics").metricValue()
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoinTest.java
@@ -28,26 +28,15 @@ import org.junit.Test;
 
 import java.util.Properties;
 
-import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 public class KTableKTableRightJoinTest {
 
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     @Test
-    public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    @Test
     public void shouldLogAndMeterSkippedRecordsDueToNullLeftKeyWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeterSkippedRecordsDueToNullLeftKey(StreamsConfig.METRICS_LATEST);
-    }
-
-    private void shouldLogAndMeterSkippedRecordsDueToNullLeftKey(final String builtInMetricsVersion) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         @SuppressWarnings("unchecked")
@@ -57,7 +46,7 @@ public class KTableKTableRightJoinTest {
             null
         ).get();
 
-        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
+        props.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         final MockProcessorContext context = new MockProcessorContext(props);
         context.setRecordMetadata("left", -1, -2, null, -3);
         join.init(context);
@@ -68,13 +57,6 @@ public class KTableKTableRightJoinTest {
             assertThat(
                 appender.getMessages(),
                 hasItem("Skipping record due to null key. change=[(new<-old)] topic=[left] partition=[-1] offset=[-2]")
-            );
-        }
-
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertEquals(
-                1.0,
-                getMetricByName(context.metrics().metrics(), "skipped-records-total", "stream-metrics").metricValue()
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessorMetricsTest.java
@@ -55,34 +55,12 @@ public class KTableSuppressProcessorMetricsTest {
     private Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
     private final String threadId = Thread.currentThread().getName();
 
-    private final MetricName evictionTotalMetric0100To24 = new MetricName(
-        "suppression-emit-total",
-        "stream-processor-node-metrics",
-        "The total number of emitted records from the suppression buffer",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("processor-node-id", "testNode")
-        )
-    );
-
     private final MetricName evictionTotalMetricLatest = new MetricName(
         "suppression-emit-total",
         "stream-processor-node-metrics",
         "The total number of emitted records from the suppression buffer",
         mkMap(
             mkEntry("thread-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("processor-node-id", "testNode")
-        )
-    );
-
-    private final MetricName evictionRateMetric0100To24 = new MetricName(
-        "suppression-emit-rate",
-        "stream-processor-node-metrics",
-        "The average number of emitted records from the suppression buffer per second",
-        mkMap(
-            mkEntry("client-id", threadId),
             mkEntry("task-id", TASK_ID.toString()),
             mkEntry("processor-node-id", "testNode")
         )
@@ -99,17 +77,6 @@ public class KTableSuppressProcessorMetricsTest {
         )
     );
 
-    private final MetricName bufferSizeAvgMetric0100To24 = new MetricName(
-        "suppression-buffer-size-avg",
-        "stream-buffer-metrics",
-        "The average size of buffered records",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("buffer-id", "test-store")
-        )
-    );
-
     private final MetricName bufferSizeAvgMetricLatest = new MetricName(
         "suppression-buffer-size-avg",
         "stream-state-metrics",
@@ -118,28 +85,6 @@ public class KTableSuppressProcessorMetricsTest {
             mkEntry("thread-id", threadId),
             mkEntry("task-id", TASK_ID.toString()),
             mkEntry("in-memory-suppression-state-id", "test-store")
-        )
-    );
-
-    private final MetricName bufferSizeCurrentMetric = new MetricName(
-        "suppression-buffer-size-current",
-        "stream-buffer-metrics",
-        "The current size of buffered records",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("buffer-id", "test-store")
-        )
-    );
-
-    private final MetricName bufferSizeMaxMetric0100To24 = new MetricName(
-        "suppression-buffer-size-max",
-        "stream-buffer-metrics",
-        "The maximum size of buffered records",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("buffer-id", "test-store")
         )
     );
 
@@ -154,17 +99,6 @@ public class KTableSuppressProcessorMetricsTest {
         )
     );
 
-    private final MetricName bufferCountAvgMetric0100To24 = new MetricName(
-        "suppression-buffer-count-avg",
-        "stream-buffer-metrics",
-        "The average count of buffered records",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("buffer-id", "test-store")
-        )
-    );
-
     private final MetricName bufferCountAvgMetricLatest = new MetricName(
         "suppression-buffer-count-avg",
         "stream-state-metrics",
@@ -173,28 +107,6 @@ public class KTableSuppressProcessorMetricsTest {
             mkEntry("thread-id", threadId),
             mkEntry("task-id", TASK_ID.toString()),
             mkEntry("in-memory-suppression-state-id", "test-store")
-        )
-    );
-
-    private final MetricName bufferCountCurrentMetric = new MetricName(
-        "suppression-buffer-count-current",
-        "stream-buffer-metrics",
-        "The current count of buffered records",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("buffer-id", "test-store")
-        )
-    );
-
-    private final MetricName bufferCountMaxMetric0100To24 = new MetricName(
-        "suppression-buffer-count-max",
-        "stream-buffer-metrics",
-        "The maximum count of buffered records",
-        mkMap(
-            mkEntry("client-id", threadId),
-            mkEntry("task-id", TASK_ID.toString()),
-            mkEntry("buffer-id", "test-store")
         )
     );
 
@@ -211,15 +123,6 @@ public class KTableSuppressProcessorMetricsTest {
 
     @Test
     public void shouldRecordMetricsWithBuiltInMetricsVersionLatest() {
-        shouldRecordMetrics(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldRecordMetricsWithBuiltInMetricsVersion0100To24() {
-        shouldRecordMetrics(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldRecordMetrics(final String builtInMetricsVersion) {
         final String storeName = "test-store";
 
         final StateStore buffer = new InMemoryTimeOrderedKeyValueBuffer.Builder<>(
@@ -237,7 +140,7 @@ public class KTableSuppressProcessorMetricsTest {
                 mock
             ).get();
 
-        streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
+        streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, StreamsConfig.METRICS_LATEST);
         final MockInternalProcessorContext context =
             new MockInternalProcessorContext(streamsConfig, TASK_ID, TestUtils.tempDirectory());
         final Time time = new SystemTime();
@@ -253,18 +156,12 @@ public class KTableSuppressProcessorMetricsTest {
         final Change<Long> value = new Change<>(null, ARBITRARY_LONG);
         processor.process(key, value);
 
-        final MetricName evictionRateMetric =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? evictionRateMetric0100To24 : evictionRateMetricLatest;
-        final MetricName evictionTotalMetric =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? evictionTotalMetric0100To24 : evictionTotalMetricLatest;
-        final MetricName bufferSizeAvgMetric =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? bufferSizeAvgMetric0100To24 : bufferSizeAvgMetricLatest;
-        final MetricName bufferSizeMaxMetric =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? bufferSizeMaxMetric0100To24 : bufferSizeMaxMetricLatest;
-        final MetricName bufferCountAvgMetric =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? bufferCountAvgMetric0100To24 : bufferCountAvgMetricLatest;
-        final MetricName bufferCountMaxMetric =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? bufferCountMaxMetric0100To24 : bufferCountMaxMetricLatest;
+        final MetricName evictionRateMetric = evictionRateMetricLatest;
+        final MetricName evictionTotalMetric = evictionTotalMetricLatest;
+        final MetricName bufferSizeAvgMetric = bufferSizeAvgMetricLatest;
+        final MetricName bufferSizeMaxMetric = bufferSizeMaxMetricLatest;
+        final MetricName bufferCountAvgMetric = bufferCountAvgMetricLatest;
+        final MetricName bufferCountMaxMetric = bufferCountMaxMetricLatest;
 
         {
             final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
@@ -275,10 +172,6 @@ public class KTableSuppressProcessorMetricsTest {
             verifyMetric(metrics, bufferSizeMaxMetric, is(43.0));
             verifyMetric(metrics, bufferCountAvgMetric, is(0.5));
             verifyMetric(metrics, bufferCountMaxMetric, is(1.0));
-            if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-                verifyMetric(metrics, bufferSizeCurrentMetric, is(43.0));
-                verifyMetric(metrics, bufferCountCurrentMetric, is(1.0));
-            }
         }
 
         context.setRecordMetadata("", 0, 1L, null, timestamp + 1);
@@ -293,10 +186,6 @@ public class KTableSuppressProcessorMetricsTest {
             verifyMetric(metrics, bufferSizeMaxMetric, is(82.0));
             verifyMetric(metrics, bufferCountAvgMetric, is(1.0));
             verifyMetric(metrics, bufferCountMaxMetric, is(2.0));
-            if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-                verifyMetric(metrics, bufferSizeCurrentMetric, is(39.0));
-                verifyMetric(metrics, bufferCountCurrentMetric, is(1.0));
-            }
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -98,18 +98,9 @@ public class ProcessorNodeTest {
 
     @Test
     public void testMetricsWithBuiltInMetricsVersionLatest() {
-        testMetrics(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void testMetricsWithBuiltInMetricsVersion0100To24() {
-        testMetrics(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void testMetrics(final String builtInMetricsVersion) {
         final Metrics metrics = new Metrics();
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, "test-client", builtInMetricsVersion, new MockTime());
+            new StreamsMetricsImpl(metrics, "test-client", StreamsConfig.METRICS_LATEST, new MockTime());
         final InternalMockProcessorContext<Object, Object> context = new InternalMockProcessorContext<>(streamsMetrics);
         final ProcessorNode<Object, Object, Object, Object> node = new ProcessorNode<>("name", new NoOpProcessor(), Collections.<String>emptySet());
         node.init(context);
@@ -118,44 +109,25 @@ public class ProcessorNodeTest {
         final String[] latencyOperations = {"process", "punctuate", "create", "destroy"};
         final String groupName = "stream-processor-node-metrics";
         final Map<String, String> metricTags = new LinkedHashMap<>();
-        final String threadIdTagKey =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? "client-id" : "thread-id";
+        final String threadIdTagKey = "client-id";
         metricTags.put("processor-node-id", node.name());
         metricTags.put("task-id", context.taskId().toString());
         metricTags.put(threadIdTagKey, threadId);
 
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            for (final String opName : latencyOperations) {
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-latency-avg", groupName, metricTags));
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-latency-max", groupName, metricTags));
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-rate", groupName, metricTags));
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-total", groupName, metricTags));
-            }
+        for (final String opName : latencyOperations) {
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-avg", groupName, metricTags));
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-max", groupName, metricTags));
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-rate", groupName, metricTags));
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-total", groupName, metricTags));
+        }
 
-            // test parent sensors
-            metricTags.put("processor-node-id", ROLLUP_VALUE);
-            for (final String opName : latencyOperations) {
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-latency-avg", groupName, metricTags));
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-latency-max", groupName, metricTags));
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-rate", groupName, metricTags));
-                assertTrue(StreamsTestUtils.containsMetric(metrics, opName + "-total", groupName, metricTags));
-            }
-        } else {
-            for (final String opName : latencyOperations) {
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-avg", groupName, metricTags));
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-max", groupName, metricTags));
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-rate", groupName, metricTags));
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-total", groupName, metricTags));
-            }
-
-            // test parent sensors
-            metricTags.put("processor-node-id", ROLLUP_VALUE);
-            for (final String opName : latencyOperations) {
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-avg", groupName, metricTags));
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-max", groupName, metricTags));
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-rate", groupName, metricTags));
-                assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-total", groupName, metricTags));
-            }
+        // test parent sensors
+        metricTags.put("processor-node-id", ROLLUP_VALUE);
+        for (final String opName : latencyOperations) {
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-avg", groupName, metricTags));
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-latency-max", groupName, metricTags));
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-rate", groupName, metricTags));
+            assertFalse(StreamsTestUtils.containsMetric(metrics, opName + "-total", groupName, metricTags));
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -71,19 +71,10 @@ public class SourceNodeTest {
     }
 
     @Test
-    public void shouldExposeProcessMetricsWithBuiltInMetricsVersionLatest() {
-        shouldExposeProcessMetrics(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldExposeProcessWithBuiltInMetricsVersion0100To24() {
-        shouldExposeProcessMetrics(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldExposeProcessMetrics(final String builtInMetricsVersion) {
+    public void shouldExposeProcessMetrics() {
         final Metrics metrics = new Metrics();
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, "test-client", builtInMetricsVersion, new MockTime());
+            new StreamsMetricsImpl(metrics, "test-client", StreamsConfig.METRICS_LATEST, new MockTime());
         final InternalMockProcessorContext<String, String> context = new InternalMockProcessorContext<>(streamsMetrics);
         final SourceNode<String, String> node =
             new SourceNode<>(context.currentNode().name(), new TheDeserializer(), new TheDeserializer());
@@ -91,41 +82,28 @@ public class SourceNodeTest {
 
         final String threadId = Thread.currentThread().getName();
         final String groupName = "stream-processor-node-metrics";
-        final String threadIdTagKey =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? "client-id" : "thread-id";
         final Map<String, String> metricTags = mkMap(
-            mkEntry(threadIdTagKey, threadId),
+            mkEntry("thread-id", threadId),
             mkEntry("task-id", context.taskId().toString()),
             mkEntry("processor-node-id", node.name())
         );
 
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "forward-rate", groupName, metricTags));
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "forward-total", groupName, metricTags));
+        assertTrue(StreamsTestUtils.containsMetric(metrics, "process-rate", groupName, metricTags));
+        assertTrue(StreamsTestUtils.containsMetric(metrics, "process-total", groupName, metricTags));
 
-            // test parent sensors
-            metricTags.put("processor-node-id", StreamsMetricsImpl.ROLLUP_VALUE);
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "forward-rate", groupName, metricTags));
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "forward-total", groupName, metricTags));
+        // test parent sensors
+        final String parentGroupName = "stream-task-metrics";
+        metricTags.remove("processor-node-id");
+        assertTrue(StreamsTestUtils.containsMetric(metrics, "process-rate", parentGroupName, metricTags));
+        assertTrue(StreamsTestUtils.containsMetric(metrics, "process-total", parentGroupName, metricTags));
 
-        } else {
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "process-rate", groupName, metricTags));
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "process-total", groupName, metricTags));
-
-            // test parent sensors
-            final String parentGroupName = "stream-task-metrics";
-            metricTags.remove("processor-node-id");
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "process-rate", parentGroupName, metricTags));
-            assertTrue(StreamsTestUtils.containsMetric(metrics, "process-total", parentGroupName, metricTags));
-
-            final String sensorNamePrefix = "internal." + threadId + ".task." + context.taskId().toString();
-            final Sensor processSensor =
-                metrics.getSensor(sensorNamePrefix + ".node." + context.currentNode().name() + ".s.process");
-            final SensorAccessor sensorAccessor = new SensorAccessor(processSensor);
-            assertThat(
-                sensorAccessor.parents().stream().map(Sensor::name).collect(Collectors.toList()),
-                contains(sensorNamePrefix + ".s.process")
-            );
-        }
+        final String sensorNamePrefix = "internal." + threadId + ".task." + context.taskId().toString();
+        final Sensor processSensor =
+            metrics.getSensor(sensorNamePrefix + ".node." + context.currentNode().name() + ".s.process");
+        final SensorAccessor sensorAccessor = new SensorAccessor(processSensor);
+        assertThat(
+            sensorAccessor.parents().stream().map(Sensor::name).collect(Collectors.toList()),
+            contains(sensorNamePrefix + ".s.process")
+        );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -105,7 +105,6 @@ import static org.apache.kafka.streams.processor.internals.Task.State.RESTORING;
 import static org.apache.kafka.streams.processor.internals.Task.State.RUNNING;
 import static org.apache.kafka.streams.processor.internals.Task.State.SUSPENDED;
 import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_24;
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByNameFilterByTags;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -845,10 +844,7 @@ public class StreamTaskTest {
             mkMap(
                 mkEntry("task-id", taskId),
                 mkEntry("processor-node-id", processorNodeId),
-                mkEntry(
-                    StreamsConfig.METRICS_LATEST.equals(builtInMetricsVersion) ? THREAD_ID_TAG
-                        : THREAD_ID_TAG_0100_TO_24,
-                    Thread.currentThread().getName()
+                mkEntry(THREAD_ID_TAG, Thread.currentThread().getName()
                 )
             )
         );

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImplTest.java
@@ -100,7 +100,6 @@ public class StreamsMetricsImplTest {
     private final static String METRIC_NAME1 = "test-metric1";
     private final static String METRIC_NAME2 = "test-metric2";
     private final static String THREAD_ID_TAG = "thread-id";
-    private final static String THREAD_ID_TAG_0100_TO_24 = "client-id";
     private final static String TASK_ID_TAG = "task-id";
     private final static String SCOPE_NAME = "test-scope";
     private final static String STORE_ID_TAG = "-state-id";
@@ -843,17 +842,8 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldAddLatencyRateTotalSensorWithBuiltInMetricsVersionLatest() {
-        shouldAddLatencyRateTotalSensor(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldAddLatencyRateTotalSensorWithBuiltInMetricsVersion0100To24() {
-        shouldAddLatencyRateTotalSensor(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldAddLatencyRateTotalSensor(final String builtInMetricsVersion) {
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, builtInMetricsVersion, time);
+    public void shouldAddLatencyRateTotalSensor() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
         shouldAddCustomSensor(
             streamsMetrics.addLatencyRateTotalSensor(SCOPE_NAME, ENTITY_NAME, OPERATION_NAME, RecordingLevel.DEBUG),
             streamsMetrics,
@@ -867,17 +857,8 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldAddRateTotalSensorWithBuiltInMetricsVersionLatest() {
-        shouldAddRateTotalSensor(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldAddRateTotalSensorWithBuiltInMetricsVersion0100To24() {
-        shouldAddRateTotalSensor(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldAddRateTotalSensor(final String builtInMetricsVersion) {
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, builtInMetricsVersion, time);
+    public void shouldAddRateTotalSensor() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, CLIENT_ID, VERSION, time);
         shouldAddCustomSensor(
             streamsMetrics.addRateTotalSensor(SCOPE_NAME, ENTITY_NAME, OPERATION_NAME, RecordingLevel.DEBUG),
             streamsMetrics,
@@ -1008,54 +989,34 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldGetStoreLevelTagMapForBuiltInMetricsLatestVersion() {
-        shouldGetStoreLevelTagMap(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldGetStoreLevelTagMapForBuiltInMetricsVersion0100To24() {
-        shouldGetStoreLevelTagMap(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldGetStoreLevelTagMap(final String builtInMetricsVersion) {
+    public void shouldGetStoreLevelTagMap() {
         final String taskName = "test-task";
         final String storeType = "remote-window";
         final String storeName = "window-keeper";
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID1, builtInMetricsVersion, time);
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID1, VERSION, time);
 
         final Map<String, String> tagMap = streamsMetrics.storeLevelTagMap(taskName, storeType, storeName);
 
         assertThat(tagMap.size(), equalTo(3));
-        final boolean isMetricsLatest = builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST);
         assertThat(
-            tagMap.get(isMetricsLatest ? StreamsMetricsImpl.THREAD_ID_TAG : StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_24),
+            tagMap.get(StreamsMetricsImpl.THREAD_ID_TAG),
             equalTo(Thread.currentThread().getName()));
         assertThat(tagMap.get(StreamsMetricsImpl.TASK_ID_TAG), equalTo(taskName));
         assertThat(tagMap.get(storeType + "-" + StreamsMetricsImpl.STORE_ID_TAG), equalTo(storeName));
     }
 
     @Test
-    public void shouldGetCacheLevelTagMapForBuiltInMetricsLatestVersion() {
-        shouldGetCacheLevelTagMap(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldGetCacheLevelTagMapForBuiltInMetricsVersion0100To24() {
-        shouldGetCacheLevelTagMap(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldGetCacheLevelTagMap(final String builtInMetricsVersion) {
+    public void shouldGetCacheLevelTagMap() {
         final StreamsMetricsImpl streamsMetrics =
-            new StreamsMetricsImpl(metrics, THREAD_ID1, builtInMetricsVersion, time);
+            new StreamsMetricsImpl(metrics, THREAD_ID1, VERSION, time);
         final String taskName = "taskName";
         final String storeName = "storeName";
 
         final Map<String, String> tagMap = streamsMetrics.cacheLevelTagMap(THREAD_ID1, taskName, storeName);
 
         assertThat(tagMap.size(), equalTo(3));
-        final boolean isMetricsLatest = builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST);
         assertThat(
-            tagMap.get(isMetricsLatest ? StreamsMetricsImpl.THREAD_ID_TAG : StreamsMetricsImpl.THREAD_ID_TAG_0100_TO_24),
+            tagMap.get(StreamsMetricsImpl.THREAD_ID_TAG),
             equalTo(THREAD_ID1)
         );
         assertThat(tagMap.get(TASK_ID_TAG), equalTo(taskName));
@@ -1063,24 +1024,14 @@ public class StreamsMetricsImplTest {
     }
 
     @Test
-    public void shouldGetThreadLevelTagMapForBuiltInMetricsLatestVersion() {
-        shouldGetThreadLevelTagMap(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldGetThreadLevelTagMapForBuiltInMetricsVersion0100To24() {
-        shouldGetThreadLevelTagMap(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldGetThreadLevelTagMap(final String builtInMetricsVersion) {
-        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID1, builtInMetricsVersion, time);
+    public void shouldGetThreadLevelTagMap() {
+        final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, THREAD_ID1, VERSION, time);
 
         final Map<String, String> tagMap = streamsMetrics.threadLevelTagMap(THREAD_ID1);
 
         assertThat(tagMap.size(), equalTo(1));
         assertThat(
-            tagMap.get(builtInMetricsVersion.equals(StreamsConfig.METRICS_LATEST) ? THREAD_ID_TAG
-                : THREAD_ID_TAG_0100_TO_24),
+            tagMap.get(THREAD_ID_TAG),
             equalTo(THREAD_ID1)
         );
     }
@@ -1196,14 +1147,6 @@ public class StreamsMetricsImplTest {
         assertThat(
             new StreamsMetricsImpl(metrics, THREAD_ID1, StreamsConfig.METRICS_LATEST, time).version(),
             equalTo(Version.LATEST)
-        );
-    }
-
-    @Test
-    public void shouldReturnMetricsVersionFrom100To23() {
-        assertThat(
-            new StreamsMetricsImpl(metrics, THREAD_ID1, StreamsConfig.METRICS_0100_TO_24, time).version(),
-            equalTo(Version.FROM_0100_TO_24)
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/metrics/ThreadMetricsTest.java
@@ -22,15 +22,9 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.V
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
@@ -47,12 +41,10 @@ import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({StreamsMetricsImpl.class, Sensor.class})
 public class ThreadMetricsTest {
 
     private static final String THREAD_ID = "thread-id";
-    private static final String THREAD_LEVEL_GROUP_0100_TO_24 = "stream-metrics";
     private static final String THREAD_LEVEL_GROUP = "stream-thread-metrics";
     private static final String TASK_LEVEL_GROUP = "stream-task-metrics";
 
@@ -60,23 +52,9 @@ public class ThreadMetricsTest {
     private final StreamsMetricsImpl streamsMetrics = createMock(StreamsMetricsImpl.class);
     private final Map<String, String> tagMap = Collections.singletonMap("hello", "world");
 
-    @Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {Version.LATEST, THREAD_LEVEL_GROUP},
-            {Version.FROM_0100_TO_24, THREAD_LEVEL_GROUP_0100_TO_24}
-        });
-    }
-
-    @Parameter
-    public Version builtInMetricsVersion;
-
-    @Parameter(1)
-    public String threadLevelGroup;
-
     @Before
     public void setUp() {
-        expect(streamsMetrics.version()).andReturn(builtInMetricsVersion).anyTimes();
+        expect(streamsMetrics.version()).andStubReturn(Version.LATEST);
         mockStatic(StreamsMetricsImpl.class);
     }
 
@@ -88,7 +66,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addValueMetricToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             ratioDescription
@@ -110,7 +88,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             avgDescription,
@@ -133,7 +111,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operationLatency,
             avgLatencyDescription,
@@ -157,7 +135,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addRateOfSumAndSumMetricsToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,
@@ -179,7 +157,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addValueMetricToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             ratioDescription
@@ -201,7 +179,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             avgDescription,
@@ -227,7 +205,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,
@@ -235,7 +213,7 @@ public class ThreadMetricsTest {
         );
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operationLatency,
             avgLatencyDescription,
@@ -261,7 +239,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,
@@ -269,7 +247,7 @@ public class ThreadMetricsTest {
         );
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operationLatency,
             avgLatencyDescription,
@@ -290,7 +268,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addValueMetricToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             ratioDescription
@@ -306,15 +284,10 @@ public class ThreadMetricsTest {
     @Test
     public void shouldGetCommitOverTasksSensor() {
         final String operation = "commit";
-        final String operationLatency = operation + StreamsMetricsImpl.LATENCY_SUFFIX;
         final String totalDescription =
             "The total number of calls to commit over all tasks assigned to one stream thread";
         final String rateDescription =
             "The average per-second number of calls to commit over all tasks assigned to one stream thread";
-        final String avgLatencyDescription =
-            "The average commit latency over all tasks assigned to one stream thread";
-        final String maxLatencyDescription =
-            "The maximum commit latency over all tasks assigned to one stream thread";
         expect(streamsMetrics.threadLevelSensor(THREAD_ID, operation, RecordingLevel.DEBUG)).andReturn(expectedSensor);
         expect(streamsMetrics.taskLevelTagMap(THREAD_ID, ROLLUP_VALUE)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
@@ -345,7 +318,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,
@@ -353,7 +326,7 @@ public class ThreadMetricsTest {
         );
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operationLatency,
             avgLatencyDescription,
@@ -375,7 +348,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addValueMetricToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             ratioDescription
@@ -398,7 +371,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,
@@ -422,7 +395,7 @@ public class ThreadMetricsTest {
 
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,
@@ -446,7 +419,7 @@ public class ThreadMetricsTest {
         expect(streamsMetrics.threadLevelTagMap(THREAD_ID)).andReturn(tagMap);
         StreamsMetricsImpl.addInvocationRateAndCountToSensor(
             expectedSensor,
-            threadLevelGroup,
+            THREAD_LEVEL_GROUP,
             tagMap,
             operation,
             rateDescription,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractRocksDBSegmentedBytesStoreTest.java
@@ -397,18 +397,8 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
     }
 
     @Test
-    public void shouldLogAndMeasureExpiredRecordsWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeasureExpiredRecords(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeasureExpiredRecordsWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeasureExpiredRecords(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeasureExpiredRecords(final String builtInMetricsVersion) {
+    public void shouldLogAndMeasureExpiredRecords() {
         final Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
-        streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
         final AbstractRocksDBSegmentedBytesStore<S> bytesStore = getBytesStore();
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
@@ -435,49 +425,25 @@ public abstract class AbstractRocksDBSegmentedBytesStoreTest<S extends Segment> 
         final String threadId = Thread.currentThread().getName();
         final Metric dropTotal;
         final Metric dropRate;
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            dropTotal = metrics.get(new MetricName(
-                "expired-window-record-drop-total",
-                "stream-metrics-scope-metrics",
-                "The total number of dropped records due to an expired window",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry("metrics-scope-state-id", "bytes-store")
-                )
-            ));
+        dropTotal = metrics.get(new MetricName(
+            "dropped-records-total",
+            "stream-task-metrics",
+            "",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        ));
 
-            dropRate = metrics.get(new MetricName(
-                "expired-window-record-drop-rate",
-                "stream-metrics-scope-metrics",
-                "The average number of dropped records due to an expired window per second.",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry("metrics-scope-state-id", "bytes-store")
-                )
-            ));
-        } else {
-            dropTotal = metrics.get(new MetricName(
-                "dropped-records-total",
-                "stream-task-metrics",
-                "",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            ));
-
-            dropRate = metrics.get(new MetricName(
-                "dropped-records-rate",
-                "stream-task-metrics",
-                "",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            ));
-        }
+        dropRate = metrics.get(new MetricName(
+            "dropped-records-rate",
+            "stream-task-metrics",
+            "",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        ));
         assertEquals(1.0, dropTotal.metricValue());
         assertNotEquals(0.0, dropRate.metricValue());
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractSessionBytesStoreTest.java
@@ -83,8 +83,6 @@ public abstract class AbstractSessionBytesStoreTest {
                                                          final Serde<K> keySerde,
                                                          final Serde<V> valueSerde);
 
-    abstract String getMetricsScope();
-
     @Before
     public void setUp() {
         sessionStore = buildSessionStore(RETENTION_PERIOD, Serdes.String(), Serdes.Long());
@@ -602,18 +600,8 @@ public abstract class AbstractSessionBytesStoreTest {
     }
 
     @Test
-    public void shouldLogAndMeasureExpiredRecordsWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeasureExpiredRecords(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeasureExpiredRecordsWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeasureExpiredRecords(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeasureExpiredRecords(final String builtInMetricsVersion) {
+    public void shouldLogAndMeasureExpiredRecords() {
         final Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
-        streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
         final SessionStore<String, Long> sessionStore = buildSessionStore(RETENTION_PERIOD, Serdes.String(), Serdes.Long());
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
@@ -639,53 +627,28 @@ public abstract class AbstractSessionBytesStoreTest {
         }
 
         final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
-        final String metricScope = getMetricsScope();
         final String threadId = Thread.currentThread().getName();
         final Metric dropTotal;
         final Metric dropRate;
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            dropTotal = metrics.get(new MetricName(
-                "expired-window-record-drop-total",
-                "stream-" + metricScope + "-metrics",
-                "The total number of dropped records due to an expired window",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry(metricScope + "-state-id", sessionStore.name())
-                )
-            ));
+        dropTotal = metrics.get(new MetricName(
+            "dropped-records-total",
+            "stream-task-metrics",
+            "",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        ));
 
-            dropRate = metrics.get(new MetricName(
-                "expired-window-record-drop-rate",
-                "stream-" + metricScope + "-metrics",
-                "The average number of dropped records due to an expired window per second",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry(metricScope + "-state-id", sessionStore.name())
-                )
-            ));
-        } else {
-            dropTotal = metrics.get(new MetricName(
-                "dropped-records-total",
-                "stream-task-metrics",
-                "",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            ));
-
-            dropRate = metrics.get(new MetricName(
-                "dropped-records-rate",
-                "stream-task-metrics",
-                "",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            ));
-        }
+        dropRate = metrics.get(new MetricName(
+            "dropped-records-rate",
+            "stream-task-metrics",
+            "",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        ));
         assertEquals(1.0, dropTotal.metricValue());
         assertNotEquals(0.0, dropRate.metricValue());
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractWindowBytesStoreTest.java
@@ -92,10 +92,6 @@ public abstract class AbstractWindowBytesStoreTest {
                                                        final Serde<K> keySerde,
                                                        final Serde<V> valueSerde);
 
-    abstract String getMetricsScope();
-
-    abstract void setClassLoggerToDebug();
-
     @Before
     public void setup() {
         windowStore = buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, false, Serdes.Integer(), Serdes.String());
@@ -1018,18 +1014,8 @@ public abstract class AbstractWindowBytesStoreTest {
     }
 
     @Test
-    public void shouldLogAndMeasureExpiredRecordsWithBuiltInMetricsVersionLatest() {
-        shouldLogAndMeasureExpiredRecords(StreamsConfig.METRICS_LATEST);
-    }
-
-    @Test
-    public void shouldLogAndMeasureExpiredRecordsWithBuiltInMetricsVersion0100To24() {
-        shouldLogAndMeasureExpiredRecords(StreamsConfig.METRICS_0100_TO_24);
-    }
-
-    private void shouldLogAndMeasureExpiredRecords(final String builtInMetricsVersion) {
+    public void shouldLogAndMeasureExpiredRecords() {
         final Properties streamsConfig = StreamsTestUtils.getStreamsConfig();
-        streamsConfig.setProperty(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG, builtInMetricsVersion);
         final WindowStore<Integer, String> windowStore =
             buildWindowStore(RETENTION_PERIOD, WINDOW_SIZE, false, Serdes.Integer(), Serdes.String());
         final InternalMockProcessorContext context = new InternalMockProcessorContext(
@@ -1056,53 +1042,28 @@ public abstract class AbstractWindowBytesStoreTest {
 
         final Map<MetricName, ? extends Metric> metrics = context.metrics().metrics();
 
-        final String metricScope = getMetricsScope();
         final String threadId = Thread.currentThread().getName();
         final Metric dropTotal;
         final Metric dropRate;
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            dropTotal = metrics.get(new MetricName(
-                "expired-window-record-drop-total",
-                "stream-" + metricScope + "-metrics",
-                "The total number of dropped records due to an expired window",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry(metricScope + "-state-id", windowStore.name())
-                )
-            ));
+        dropTotal = metrics.get(new MetricName(
+            "dropped-records-total",
+            "stream-task-metrics",
+            "",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        ));
 
-            dropRate = metrics.get(new MetricName(
-                "expired-window-record-drop-rate",
-                "stream-" + metricScope + "-metrics",
-                "The average number of dropped records due to an expired window per second",
-                mkMap(
-                    mkEntry("client-id", threadId),
-                    mkEntry("task-id", "0_0"),
-                    mkEntry(metricScope + "-state-id", windowStore.name())
-                )
-            ));
-        } else {
-            dropTotal = metrics.get(new MetricName(
-                "dropped-records-total",
-                "stream-task-metrics",
-                "",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            ));
-
-            dropRate = metrics.get(new MetricName(
-                "dropped-records-rate",
-                "stream-task-metrics",
-                "",
-                mkMap(
-                    mkEntry("thread-id", threadId),
-                    mkEntry("task-id", "0_0")
-                )
-            ));
-        }
+        dropRate = metrics.get(new MetricName(
+            "dropped-records-rate",
+            "stream-task-metrics",
+            "",
+            mkMap(
+                mkEntry("thread-id", threadId),
+                mkEntry("task-id", "0_0")
+            )
+        ));
         assertEquals(1.0, dropTotal.metricValue());
         assertNotEquals(0.0, dropRate.metricValue());
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemorySessionStoreTest.java
@@ -48,11 +48,6 @@ public class InMemorySessionStoreTest extends AbstractSessionBytesStoreTest {
             valueSerde).build();
     }
 
-    @Override
-    String getMetricsScope() {
-        return new InMemorySessionBytesStoreSupplier(null, 0).metricsScope();
-    }
-
     @Test
     public void shouldRemoveExpired() {
         sessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 1L);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryWindowStoreTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.Stores;
@@ -55,16 +54,6 @@ public class InMemoryWindowStoreTest extends AbstractWindowBytesStoreTest {
             keySerde,
             valueSerde)
             .build();
-    }
-
-    @Override
-    String getMetricsScope() {
-        return new InMemoryWindowBytesStoreSupplier(null, 0, 0, false).metricsScope();
-    }
-
-    @Override
-    void setClassLoggerToDebug() {
-        LogCaptureAppender.setClassLoggerToDebug(InMemoryWindowStore.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -68,6 +68,7 @@ import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -228,6 +229,19 @@ public class MeteredKeyValueStoreTest {
             STORE_TYPE,
             STORE_NAME
         )));
+    }
+
+    @Test
+    public void shouldRecordRestoreLatencyOnInit() {
+        inner.init((StateStoreContext) context, metered);
+
+        init();
+
+        // it suffices to verify one restore metric since all restore metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
+        final KafkaMetric metric = metric("restore-rate");
+        assertThat((Double) metric.metricValue(), greaterThan(0.0));
+        verify(inner);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStoreTest.java
@@ -48,13 +48,7 @@ import org.easymock.MockType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +56,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.aryEq;
 import static org.easymock.EasyMock.eq;
@@ -81,7 +74,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
 public class MeteredKeyValueStoreTest {
 
     @Rule
@@ -90,10 +82,8 @@ public class MeteredKeyValueStoreTest {
     private static final String APPLICATION_ID = "test-app";
     private static final String STORE_NAME = "store-name";
     private static final String STORE_TYPE = "scope";
-    private static final String STORE_LEVEL_GROUP_FROM_0100_TO_24 = "stream-" + STORE_TYPE + "-state-metrics";
     private static final String STORE_LEVEL_GROUP = "stream-state-metrics";
     private static final String CHANGELOG_TOPIC = "changelog-topic";
-    private static final String THREAD_ID_TAG_KEY_FROM_0100_TO_24 = "client-id";
     private static final String THREAD_ID_TAG_KEY = "thread-id";
     private static final String KEY = "key";
     private static final Bytes KEY_BYTES = Bytes.wrap(KEY.getBytes());
@@ -111,20 +101,7 @@ public class MeteredKeyValueStoreTest {
 
     private MeteredKeyValueStore<String, String> metered;
     private final Metrics metrics = new Metrics();
-    private String storeLevelGroup;
-    private String threadIdTagKey;
     private Map<String, String> tags;
-
-    @Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {StreamsConfig.METRICS_LATEST},
-            {StreamsConfig.METRICS_0100_TO_24}
-        });
-    }
-
-    @Parameter
-    public String builtInMetricsVersion;
 
     @Before
     public void before() {
@@ -139,17 +116,13 @@ public class MeteredKeyValueStoreTest {
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
         expect(context.applicationId()).andStubReturn(APPLICATION_ID);
         expect(context.metrics()).andStubReturn(
-            new StreamsMetricsImpl(metrics, "test", builtInMetricsVersion, mockTime)
+            new StreamsMetricsImpl(metrics, "test", StreamsConfig.METRICS_LATEST, mockTime)
         );
         expect(context.taskId()).andStubReturn(taskId);
         expect(context.changelogFor(STORE_NAME)).andStubReturn(CHANGELOG_TOPIC);
         expect(inner.name()).andStubReturn(STORE_NAME);
-        storeLevelGroup =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? STORE_LEVEL_GROUP_FROM_0100_TO_24 : STORE_LEVEL_GROUP;
-        threadIdTagKey =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? THREAD_ID_TAG_KEY_FROM_0100_TO_24 : THREAD_ID_TAG_KEY;
         tags = mkMap(
-            mkEntry(threadIdTagKey, threadId),
+            mkEntry(THREAD_ID_TAG_KEY, threadId),
             mkEntry("task-id", taskId.toString()),
             mkEntry(STORE_TYPE + "-state-id", STORE_NAME)
         );
@@ -248,24 +221,13 @@ public class MeteredKeyValueStoreTest {
         metrics.addReporter(reporter);
         assertTrue(reporter.containsMbean(String.format(
             "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
-            storeLevelGroup,
-            threadIdTagKey,
+            STORE_LEVEL_GROUP,
+            THREAD_ID_TAG_KEY,
             threadId,
             taskId.toString(),
             STORE_TYPE,
             STORE_NAME
         )));
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertTrue(reporter.containsMbean(String.format(
-                "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
-                storeLevelGroup,
-                threadIdTagKey,
-                threadId,
-                taskId.toString(),
-                STORE_TYPE,
-                ROLLUP_VALUE
-            )));
-        }
     }
 
     @Test
@@ -357,7 +319,7 @@ public class MeteredKeyValueStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
-        final KafkaMetric metric = metric(new MetricName("all-rate", storeLevelGroup, "", tags));
+        final KafkaMetric metric = metric(new MetricName("all-rate", STORE_LEVEL_GROUP, "", tags));
         assertTrue((Double) metric.metricValue() > 0);
         verify(inner);
     }
@@ -507,14 +469,14 @@ public class MeteredKeyValueStoreTest {
     }
 
     private KafkaMetric metric(final String name) {
-        return metrics.metric(new MetricName(name, storeLevelGroup, "", tags));
+        return metrics.metric(new MetricName(name, STORE_LEVEL_GROUP, "", tags));
     }
 
     private List<MetricName> storeMetrics() {
         return metrics.metrics()
                       .keySet()
                       .stream()
-                      .filter(name -> name.group().equals(storeLevelGroup) && name.tags().equals(tags))
+                      .filter(name -> name.group().equals(STORE_LEVEL_GROUP) && name.tags().equals(tags))
                       .collect(Collectors.toList());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -242,6 +242,8 @@ public class MeteredSessionStoreTest {
 
         store.put(WINDOWED_KEY, VALUE);
 
+        // it suffices to verify one put metric since all put metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("put-rate");
         assertTrue(((Double) metric.metricValue()) > 0);
         verify(innerStore);
@@ -259,6 +261,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all put metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -279,6 +283,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all put metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -296,6 +302,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all put metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -316,6 +324,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all put metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -330,6 +340,8 @@ public class MeteredSessionStoreTest {
 
         store.remove(new Windowed<>(KEY, new SessionWindow(0, 0)));
 
+        // it suffices to verify one remove metric since all remove metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("remove-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -347,6 +359,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -367,6 +381,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -384,6 +400,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -404,6 +422,8 @@ public class MeteredSessionStoreTest {
         assertFalse(iterator.hasNext());
         iterator.close();
 
+        // it suffices to verify one fetch metric since all fetch metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("fetch-rate");
         assertTrue((Double) metric.metricValue() > 0);
         verify(innerStore);
@@ -412,6 +432,9 @@ public class MeteredSessionStoreTest {
     @Test
     public void shouldRecordRestoreTimeOnInit() {
         init();
+
+        // it suffices to verify one restore metric since all restore metrics are recorded by the same sensor
+        // and the sensor is tested elsewhere
         final KafkaMetric metric = metric("restore-rate");
         assertTrue((Double) metric.metricValue() > 0);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSessionStoreTest.java
@@ -50,13 +50,7 @@ import org.easymock.MockType;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +58,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.kafka.common.utils.Utils.mkEntry;
 import static org.apache.kafka.common.utils.Utils.mkMap;
-import static org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.ROLLUP_VALUE;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.aryEq;
 import static org.easymock.EasyMock.eq;
@@ -83,7 +76,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
 public class MeteredSessionStoreTest {
 
     @Rule
@@ -92,9 +84,7 @@ public class MeteredSessionStoreTest {
     private static final String APPLICATION_ID = "test-app";
     private static final String STORE_TYPE = "scope";
     private static final String STORE_NAME = "mocked-store";
-    private static final String STORE_LEVEL_GROUP_FROM_0100_TO_24 = "stream-" + STORE_TYPE + "-state-metrics";
     private static final String STORE_LEVEL_GROUP = "stream-state-metrics";
-    private static final String THREAD_ID_TAG_KEY_FROM_0100_TO_24 = "client-id";
     private static final String THREAD_ID_TAG_KEY = "thread-id";
     private static final String CHANGELOG_TOPIC = "changelog-topic";
     private static final String KEY = "key";
@@ -115,21 +105,8 @@ public class MeteredSessionStoreTest {
     @Mock(type = MockType.NICE)
     private InternalProcessorContext context;
 
-    private String storeLevelGroup;
-    private String threadIdTagKey;
     private Map<String, String> tags;
-
-    @Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {StreamsConfig.METRICS_LATEST},
-            {StreamsConfig.METRICS_0100_TO_24}
-        });
-    }
-
-    @Parameter
-    public String builtInMetricsVersion;
-
+    
     @Before
     public void before() {
         final Time mockTime = new MockTime();
@@ -143,16 +120,12 @@ public class MeteredSessionStoreTest {
         metrics.config().recordLevel(Sensor.RecordingLevel.DEBUG);
         expect(context.applicationId()).andStubReturn(APPLICATION_ID);
         expect(context.metrics())
-            .andStubReturn(new StreamsMetricsImpl(metrics, "test", builtInMetricsVersion, mockTime));
+            .andStubReturn(new StreamsMetricsImpl(metrics, "test", StreamsConfig.METRICS_LATEST, mockTime));
         expect(context.taskId()).andStubReturn(taskId);
         expect(context.changelogFor(STORE_NAME)).andStubReturn(CHANGELOG_TOPIC);
         expect(innerStore.name()).andStubReturn(STORE_NAME);
-        storeLevelGroup =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? STORE_LEVEL_GROUP_FROM_0100_TO_24 : STORE_LEVEL_GROUP;
-        threadIdTagKey =
-            StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion) ? THREAD_ID_TAG_KEY_FROM_0100_TO_24 : THREAD_ID_TAG_KEY;
         tags = mkMap(
-            mkEntry(threadIdTagKey, threadId),
+            mkEntry(THREAD_ID_TAG_KEY, threadId),
             mkEntry("task-id", taskId.toString()),
             mkEntry(STORE_TYPE + "-state-id", STORE_NAME)
         );
@@ -252,24 +225,13 @@ public class MeteredSessionStoreTest {
         metrics.addReporter(reporter);
         assertTrue(reporter.containsMbean(String.format(
             "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
-            storeLevelGroup,
-            threadIdTagKey,
+            STORE_LEVEL_GROUP,
+            THREAD_ID_TAG_KEY,
             threadId,
             taskId.toString(),
             STORE_TYPE,
             STORE_NAME
         )));
-        if (StreamsConfig.METRICS_0100_TO_24.equals(builtInMetricsVersion)) {
-            assertTrue(reporter.containsMbean(String.format(
-                "kafka.streams:type=%s,%s=%s,task-id=%s,%s-state-id=%s",
-                storeLevelGroup,
-                threadIdTagKey,
-                threadId,
-                taskId.toString(),
-                STORE_TYPE,
-                ROLLUP_VALUE
-            )));
-        }
     }
 
     @Test
@@ -609,14 +571,14 @@ public class MeteredSessionStoreTest {
     }
 
     private KafkaMetric metric(final String name) {
-        return this.metrics.metric(new MetricName(name, storeLevelGroup, "", this.tags));
+        return this.metrics.metric(new MetricName(name, STORE_LEVEL_GROUP, "", this.tags));
     }
 
     private List<MetricName> storeMetrics() {
         return metrics.metrics()
                       .keySet()
                       .stream()
-                      .filter(name -> name.group().equals(storeLevelGroup) && name.tags().equals(tags))
+                      .filter(name -> name.group().equals(STORE_LEVEL_GROUP) && name.tags().equals(tags))
                       .collect(Collectors.toList());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -48,11 +48,6 @@ public class RocksDBSessionStoreTest extends AbstractSessionBytesStoreTest {
             valueSerde).build();
     }
 
-    @Override
-    String getMetricsScope() {
-        return new RocksDbSessionBytesStoreSupplier(null, 0).metricsScope();
-    }
-
     @Test
     public void shouldRemoveExpired() {
         sessionStore.put(new Windowed<>("a", new SessionWindow(0, 0)), 1L);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
@@ -68,16 +67,6 @@ public class RocksDBWindowStoreTest extends AbstractWindowBytesStoreTest {
             keySerde,
             valueSerde)
             .build();
-    }
-
-    @Override
-    String getMetricsScope() {
-        return new RocksDbWindowBytesStoreSupplier(null, 0, 0, 0, false, false).metricsScope();
-    }
-
-    @Override
-    void setClassLoggerToDebug() {
-        LogCaptureAppender.setClassLoggerToDebug(AbstractRocksDBSegmentedBytesStore.class);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/NamedCacheMetricsTest.java
@@ -38,7 +38,6 @@ import static org.powermock.api.easymock.PowerMock.mockStatic;
 import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
 
-
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({StreamsMetricsImpl.class, Sensor.class})
 public class NamedCacheMetricsTest {
@@ -58,47 +57,8 @@ public class NamedCacheMetricsTest {
     public void shouldGetHitRatioSensorWithBuiltInMetricsVersionCurrent() {
         final String hitRatio = "hit-ratio";
         mockStatic(StreamsMetricsImpl.class);
-        setUpStreamsMetrics(Version.LATEST, hitRatio);
-        replay(streamsMetrics);
-        replay(StreamsMetricsImpl.class);
-
-        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, THREAD_ID, TASK_ID, STORE_NAME);
-
-        verifyResult(sensor);
-    }
-
-    @Test
-    public void shouldGetHitRatioSensorWithBuiltInMetricsVersionBefore24() {
-        final Map<String, String> parentTagMap = mkMap(mkEntry("key", "all"));
-        final String hitRatio = "hitRatio";
-        final RecordingLevel recordingLevel = RecordingLevel.DEBUG;
-        mockStatic(StreamsMetricsImpl.class);
-        final Sensor parentSensor = mock(Sensor.class);
-        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, hitRatio, recordingLevel)).andReturn(parentSensor);
-        expect(streamsMetrics.cacheLevelTagMap(THREAD_ID, TASK_ID, StreamsMetricsImpl.ROLLUP_VALUE))
-            .andReturn(parentTagMap);
-        StreamsMetricsImpl.addAvgAndMinAndMaxToSensor(
-            parentSensor,
-            StreamsMetricsImpl.CACHE_LEVEL_GROUP,
-            parentTagMap,
-            hitRatio,
-            HIT_RATIO_AVG_DESCRIPTION,
-            HIT_RATIO_MIN_DESCRIPTION,
-            HIT_RATIO_MAX_DESCRIPTION);
-        setUpStreamsMetrics(Version.FROM_0100_TO_24, hitRatio, parentSensor);
-        replay(streamsMetrics);
-        replay(StreamsMetricsImpl.class);
-
-        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, THREAD_ID, TASK_ID, STORE_NAME);
-
-        verifyResult(sensor);
-    }
-
-    private void setUpStreamsMetrics(final Version builtInMetricsVersion,
-                                     final String hitRatio,
-                                     final Sensor... parents) {
-        expect(streamsMetrics.version()).andReturn(builtInMetricsVersion);
-        expect(streamsMetrics.cacheLevelSensor(THREAD_ID, TASK_ID, STORE_NAME, hitRatio, RecordingLevel.DEBUG, parents))
+        expect(streamsMetrics.version()).andStubReturn(Version.LATEST);
+        expect(streamsMetrics.cacheLevelSensor(THREAD_ID, TASK_ID, STORE_NAME, hitRatio, RecordingLevel.DEBUG))
             .andReturn(expectedSensor);
         expect(streamsMetrics.cacheLevelTagMap(THREAD_ID, TASK_ID, STORE_NAME)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMinAndMaxToSensor(
@@ -109,6 +69,12 @@ public class NamedCacheMetricsTest {
             HIT_RATIO_AVG_DESCRIPTION,
             HIT_RATIO_MIN_DESCRIPTION,
             HIT_RATIO_MAX_DESCRIPTION);
+        replay(streamsMetrics);
+        replay(StreamsMetricsImpl.class);
+
+        final Sensor sensor = NamedCacheMetrics.hitRatioSensor(streamsMetrics, THREAD_ID, TASK_ID, STORE_NAME);
+
+        verifyResult(sensor);
     }
 
     private void verifyResult(final Sensor sensor) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/metrics/StateStoreMetricsTest.java
@@ -23,15 +23,9 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl.V
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -45,43 +39,22 @@ import static org.powermock.api.easymock.PowerMock.replay;
 import static org.powermock.api.easymock.PowerMock.verify;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({StreamsMetricsImpl.class, Sensor.class})
 public class StateStoreMetricsTest {
 
-    private static final String THREAD_ID = "test-thread";
     private static final String TASK_ID = "test-task";
     private static final String STORE_NAME = "test-store";
     private static final String STORE_TYPE = "test-type";
-    private static final String STORE_LEVEL_GROUP_FROM_0100_TO_24 = "stream-" + STORE_TYPE + "-state-metrics";
     private static final String STORE_LEVEL_GROUP = "stream-state-metrics";
     private static final String BUFFER_NAME = "test-buffer";
-    private static final String BUFFER_LEVEL_GROUP_FROM_0100_TO_24 = "stream-buffer-metrics";
 
     private final Sensor expectedSensor = createMock(Sensor.class);
-    private final Sensor parentSensor = createMock(Sensor.class);
     private final StreamsMetricsImpl streamsMetrics = createMock(StreamsMetricsImpl.class);
     private final Map<String, String> storeTagMap = Collections.singletonMap("hello", "world");
-    private final Map<String, String> bufferTagMap = Collections.singletonMap("hi", "galaxy");
-    private final Map<String, String> allTagMap = Collections.singletonMap("hello", "universe");
-    private String storeLevelGroup;
-
-    @Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {Version.LATEST},
-            {Version.FROM_0100_TO_24}
-        });
-    }
-
-    @Parameter
-    public Version builtInMetricsVersion;
 
     @Before
     public void setUp() {
-        storeLevelGroup =
-            builtInMetricsVersion == Version.FROM_0100_TO_24 ? STORE_LEVEL_GROUP_FROM_0100_TO_24 : STORE_LEVEL_GROUP;
-        expect(streamsMetrics.version()).andReturn(builtInMetricsVersion).anyTimes();
+        expect(streamsMetrics.version()).andStubReturn(Version.LATEST);
         mockStatic(StreamsMetricsImpl.class);
     }
 
@@ -89,16 +62,14 @@ public class StateStoreMetricsTest {
     public void shouldGetPutSensor() {
         final String metricName = "put";
         final String descriptionOfRate = "The average number of calls to put per second";
-        final String descriptionOfCount = "The total number of calls to put";
         final String descriptionOfAvg = "The average latency of calls to put";
         final String descriptionOfMax = "The maximum latency of calls to put";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.putSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.putSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -106,16 +77,14 @@ public class StateStoreMetricsTest {
     public void shouldGetPutIfAbsentSensor() {
         final String metricName = "put-if-absent";
         final String descriptionOfRate = "The average number of calls to put-if-absent per second";
-        final String descriptionOfCount = "The total number of calls to put-if-absent";
         final String descriptionOfAvg = "The average latency of calls to put-if-absent";
         final String descriptionOfMax = "The maximum latency of calls to put-if-absent";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.putIfAbsentSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.putIfAbsentSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -123,16 +92,14 @@ public class StateStoreMetricsTest {
     public void shouldGetPutAllSensor() {
         final String metricName = "put-all";
         final String descriptionOfRate = "The average number of calls to put-all per second";
-        final String descriptionOfCount = "The total number of calls to put-all";
         final String descriptionOfAvg = "The average latency of calls to put-all";
         final String descriptionOfMax = "The maximum latency of calls to put-all";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.putAllSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.putAllSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -140,16 +107,14 @@ public class StateStoreMetricsTest {
     public void shouldGetFetchSensor() {
         final String metricName = "fetch";
         final String descriptionOfRate = "The average number of calls to fetch per second";
-        final String descriptionOfCount = "The total number of calls to fetch";
         final String descriptionOfAvg = "The average latency of calls to fetch";
         final String descriptionOfMax = "The maximum latency of calls to fetch";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.fetchSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.fetchSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -157,16 +122,14 @@ public class StateStoreMetricsTest {
     public void shouldGetGetSensor() {
         final String metricName = "get";
         final String descriptionOfRate = "The average number of calls to get per second";
-        final String descriptionOfCount = "The total number of calls to get";
         final String descriptionOfAvg = "The average latency of calls to get";
         final String descriptionOfMax = "The maximum latency of calls to get";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.getSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.getSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -174,16 +137,14 @@ public class StateStoreMetricsTest {
     public void shouldGetAllSensor() {
         final String metricName = "all";
         final String descriptionOfRate = "The average number of calls to all per second";
-        final String descriptionOfCount = "The total number of calls to all";
         final String descriptionOfAvg = "The average latency of calls to all";
         final String descriptionOfMax = "The maximum latency of calls to all";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.allSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.allSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -191,16 +152,14 @@ public class StateStoreMetricsTest {
     public void shouldGetRangeSensor() {
         final String metricName = "range";
         final String descriptionOfRate = "The average number of calls to range per second";
-        final String descriptionOfCount = "The total number of calls to range";
         final String descriptionOfAvg = "The average latency of calls to range";
         final String descriptionOfMax = "The maximum latency of calls to range";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.rangeSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.rangeSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -240,16 +199,14 @@ public class StateStoreMetricsTest {
     public void shouldGetFlushSensor() {
         final String metricName = "flush";
         final String descriptionOfRate = "The average number of calls to flush per second";
-        final String descriptionOfCount = "The total number of calls to flush";
         final String descriptionOfAvg = "The average latency of calls to flush";
         final String descriptionOfMax = "The maximum latency of calls to flush";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.flushSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.flushSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -257,16 +214,14 @@ public class StateStoreMetricsTest {
     public void shouldGetRemoveSensor() {
         final String metricName = "remove";
         final String descriptionOfRate = "The average number of calls to remove per second";
-        final String descriptionOfCount = "The total number of calls to remove";
         final String descriptionOfAvg = "The average latency of calls to remove";
         final String descriptionOfMax = "The maximum latency of calls to remove";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.removeSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.removeSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -274,16 +229,14 @@ public class StateStoreMetricsTest {
     public void shouldGetDeleteSensor() {
         final String metricName = "delete";
         final String descriptionOfRate = "The average number of calls to delete per second";
-        final String descriptionOfCount = "The total number of calls to delete";
         final String descriptionOfAvg = "The average latency of calls to delete";
         final String descriptionOfMax = "The maximum latency of calls to delete";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.deleteSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.deleteSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
@@ -291,46 +244,40 @@ public class StateStoreMetricsTest {
     public void shouldGetRestoreSensor() {
         final String metricName = "restore";
         final String descriptionOfRate = "The average number of restorations per second";
-        final String descriptionOfCount = "The total number of restorations";
         final String descriptionOfAvg = "The average latency of restorations";
         final String descriptionOfMax = "The maximum latency of restorations";
         shouldGetSensor(
             metricName,
             descriptionOfRate,
-            descriptionOfCount,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.restoreSensor(THREAD_ID, TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
+            () -> StateStoreMetrics.restoreSensor(TASK_ID, STORE_TYPE, STORE_NAME, streamsMetrics)
         );
     }
 
     @Test
     public void shouldGetSuppressionBufferCountSensor() {
         final String metricName = "suppression-buffer-count";
-        final String descriptionOfCurrentValue = "The current count of buffered records";
         final String descriptionOfAvg = "The average count of buffered records";
         final String descriptionOfMax = "The maximum count of buffered records";
         shouldGetSuppressionBufferSensor(
             metricName,
-            descriptionOfCurrentValue,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.suppressionBufferCountSensor(THREAD_ID, TASK_ID, STORE_TYPE, BUFFER_NAME, streamsMetrics)
+            () -> StateStoreMetrics.suppressionBufferCountSensor(TASK_ID, STORE_TYPE, BUFFER_NAME, streamsMetrics)
         );
     }
 
     @Test
     public void shouldGetSuppressionBufferSizeSensor() {
         final String metricName = "suppression-buffer-size";
-        final String descriptionOfCurrentValue = "The current size of buffered records";
         final String descriptionOfAvg = "The average size of buffered records";
         final String descriptionOfMax = "The maximum size of buffered records";
         shouldGetSuppressionBufferSensor(
             metricName,
-            descriptionOfCurrentValue,
             descriptionOfAvg,
             descriptionOfMax,
-            () -> StateStoreMetrics.suppressionBufferSizeSensor(THREAD_ID, TASK_ID, STORE_TYPE, BUFFER_NAME, streamsMetrics)
+            () -> StateStoreMetrics.suppressionBufferSizeSensor(TASK_ID, STORE_TYPE, BUFFER_NAME, streamsMetrics)
         );
     }
 
@@ -393,46 +340,26 @@ public class StateStoreMetricsTest {
 
     private void shouldGetSensor(final String metricName,
                                  final String descriptionOfRate,
-                                 final String descriptionOfCount,
                                  final String descriptionOfAvg,
                                  final String descriptionOfMax,
                                  final Supplier<Sensor> sensorSupplier) {
-        if (builtInMetricsVersion == Version.FROM_0100_TO_24) {
-            setUpParentSensor(metricName, descriptionOfRate, descriptionOfCount, descriptionOfAvg, descriptionOfMax);
-            expect(streamsMetrics.storeLevelSensor(
-                TASK_ID,
-                STORE_NAME,
-                metricName,
-                RecordingLevel.DEBUG,
-                parentSensor
-            )).andReturn(expectedSensor);
-            StreamsMetricsImpl.addInvocationRateAndCountToSensor(
-                expectedSensor,
-                storeLevelGroup,
-                storeTagMap,
-                metricName,
-                descriptionOfRate,
-                descriptionOfCount
-            );
-        } else {
-            expect(streamsMetrics.storeLevelSensor(
-                TASK_ID,
-                STORE_NAME,
-                metricName,
-                RecordingLevel.DEBUG
-            )).andReturn(expectedSensor);
-            StreamsMetricsImpl.addInvocationRateToSensor(
-                expectedSensor,
-                storeLevelGroup,
-                storeTagMap,
-                metricName,
-                descriptionOfRate
-            );
-        }
+        expect(streamsMetrics.storeLevelSensor(
+            TASK_ID,
+            STORE_NAME,
+            metricName,
+            RecordingLevel.DEBUG
+        )).andReturn(expectedSensor);
+        StreamsMetricsImpl.addInvocationRateToSensor(
+            expectedSensor,
+            STORE_LEVEL_GROUP,
+            storeTagMap,
+            metricName,
+            descriptionOfRate
+        );
         expect(streamsMetrics.storeLevelTagMap(TASK_ID, STORE_TYPE, STORE_NAME)).andReturn(storeTagMap);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            storeLevelGroup,
+            STORE_LEVEL_GROUP,
             storeTagMap,
             latencyMetricName(metricName),
             descriptionOfAvg,
@@ -445,65 +372,22 @@ public class StateStoreMetricsTest {
         verify(StreamsMetricsImpl.class, streamsMetrics);
         assertThat(sensor, is(expectedSensor));
     }
-    private void setUpParentSensor(final String metricName,
-                                   final String descriptionOfRate,
-                                   final String descriptionOfCount,
-                                   final String descriptionOfAvg,
-                                   final String descriptionOfMax) {
-        expect(streamsMetrics.taskLevelSensor(THREAD_ID, TASK_ID, metricName, RecordingLevel.DEBUG))
-            .andReturn(parentSensor);
-        expect(streamsMetrics.storeLevelTagMap(TASK_ID, STORE_TYPE, StreamsMetricsImpl.ROLLUP_VALUE))
-            .andReturn(allTagMap);
-        StreamsMetricsImpl.addInvocationRateAndCountToSensor(
-            parentSensor,
-            storeLevelGroup,
-            allTagMap,
-            metricName,
-            descriptionOfRate,
-            descriptionOfCount
-        );
-        StreamsMetricsImpl.addAvgAndMaxToSensor(
-            parentSensor,
-            storeLevelGroup,
-            allTagMap,
-            latencyMetricName(metricName),
-            descriptionOfAvg,
-            descriptionOfMax
-        );
-    }
 
     private String latencyMetricName(final String metricName) {
         return metricName + StreamsMetricsImpl.LATENCY_SUFFIX;
     }
 
     private void shouldGetSuppressionBufferSensor(final String metricName,
-                                                  final String descriptionOfCurrentValue,
                                                   final String descriptionOfAvg,
                                                   final String descriptionOfMax,
                                                   final Supplier<Sensor> sensorSupplier) {
-        final String currentMetricName = metricName + "-current";
-        final String group;
         final Map<String, String> tagMap;
         expect(streamsMetrics.storeLevelSensor(TASK_ID, BUFFER_NAME, metricName, RecordingLevel.DEBUG)).andReturn(expectedSensor);
-        if (builtInMetricsVersion == Version.FROM_0100_TO_24) {
-            group = BUFFER_LEVEL_GROUP_FROM_0100_TO_24;
-            tagMap = bufferTagMap;
-            expect(streamsMetrics.bufferLevelTagMap(THREAD_ID, TASK_ID, BUFFER_NAME)).andReturn(tagMap);
-            StreamsMetricsImpl.addValueMetricToSensor(
-                expectedSensor,
-                group,
-                bufferTagMap,
-                currentMetricName,
-                descriptionOfCurrentValue
-            );
-        } else {
-            group = STORE_LEVEL_GROUP;
-            tagMap = storeTagMap;
-            expect(streamsMetrics.storeLevelTagMap(TASK_ID, STORE_TYPE, BUFFER_NAME)).andReturn(tagMap);
-        }
+        tagMap = storeTagMap;
+        expect(streamsMetrics.storeLevelTagMap(TASK_ID, STORE_TYPE, BUFFER_NAME)).andReturn(tagMap);
         StreamsMetricsImpl.addAvgAndMaxToSensor(
             expectedSensor,
-            group,
+            STORE_LEVEL_GROUP,
             tagMap,
             metricName,
             descriptionOfAvg,

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -398,7 +398,7 @@ public class TopologyTestDriver implements Closeable {
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG),
             mockWallClockTime
         );
-        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, TASK_ID.toString(), streamsMetrics);
+        TaskMetrics.droppedRecordsSensor(threadId, TASK_ID.toString(), streamsMetrics);
 
         return streamsMetrics;
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -237,7 +237,7 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG),
             Time.SYSTEM
         );
-        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, taskId.toString(), metrics);
+        TaskMetrics.droppedRecordsSensor(threadId, taskId.toString(), metrics);
     }
 
     @Override

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/api/MockProcessorContext.java
@@ -257,7 +257,7 @@ public class MockProcessorContext<KForward, VForward> implements ProcessorContex
             streamsConfig.getString(StreamsConfig.BUILT_IN_METRICS_VERSION_CONFIG),
             Time.SYSTEM
         );
-        TaskMetrics.droppedRecordsSensorOrSkippedRecordsSensor(threadId, taskId.toString(), metrics);
+        TaskMetrics.droppedRecordsSensor(threadId, taskId.toString(), metrics);
     }
 
     @Override


### PR DESCRIPTION
As specified in KIP-743, this PR removes the built-in metrics
in Streams that are superseded by the refactoring proposed in KIP-444.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
