### PR TITLE
KAFKA-12668: Making MockScheduler.schedule safe to use in concurrent code

### DIFF
--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -640,11 +640,19 @@ class TransactionStateManagerTest {
 
     // immigrate partition at epoch 0
     transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 0, (_, _, _, _) => ())
+
+    // let the time advance to trigger the background thread loading
+    scheduler.tick()
+
     assertEquals(0, transactionManager.loadingPartitions.size)
 
     // Re-immigrate partition at epoch 1. This should be successful even though we didn't get to emigrate the partition.
     prepareTxnLog(topicPartition, 0, records)
     transactionManager.loadTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch = 1, (_, _, _, _) => ())
+
+    // let the time advance to trigger the background thread loading
+    scheduler.tick()
+
     assertEquals(0, transactionManager.loadingPartitions.size)
     assertTrue(transactionManager.transactionMetadataCache.get(partitionId).isDefined)
     assertEquals(1, transactionManager.transactionMetadataCache.get(partitionId).get.coordinatorEpoch)

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -24,25 +24,25 @@ import org.apache.kafka.common.utils.Time
 /**
  * A mock scheduler that executes tasks synchronously using a mock time instance. Tasks are executed synchronously when
  * the time is advanced. This class is meant to be used in conjunction with MockTime.
- * 
+ *
  * Example usage
  * <code>
  *   val time = new MockTime
  *   time.scheduler.schedule("a task", println("hello world: " + time.milliseconds), delay = 1000)
  *   time.sleep(1001) // this should cause our scheduled task to fire
  * </code>
- *   
+ *
  * Incrementing the time to the exact next execution time of a task will result in that task executing (it as if execution itself takes no time).
  */
 class MockScheduler(val time: Time) extends Scheduler {
 
   /* a priority queue of tasks ordered by next execution time */
   private val tasks = new PriorityQueue[MockTask]()
-  
+
   def isStarted = true
 
   def startup(): Unit = {}
-  
+
   def shutdown(): Unit = {
     var currTask: Option[MockTask] = None
     do {
@@ -50,7 +50,7 @@ class MockScheduler(val time: Time) extends Scheduler {
       currTask.foreach(_.fun())
     } while (currTask.nonEmpty)
   }
-  
+
   /**
    * Check for any tasks that need to execute. Since this is a mock scheduler this check only occurs
    * when this method is called and the execution happens synchronously in the calling thread.
@@ -76,7 +76,6 @@ class MockScheduler(val time: Time) extends Scheduler {
   def schedule(name: String, fun: () => Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS): ScheduledFuture[Unit] = {
     val task = MockTask(name, fun, time.milliseconds + delay, period = period, time=time)
     add(task)
-    tick()
     task
   }
 

--- a/core/src/test/scala/unit/kafka/utils/MockSchedulerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockSchedulerTest.scala
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MockSchedulerTest {
+
+  private val lock = new Object
+
+  @Test
+  def nestedSynchronizedBlocks(): Unit = {
+    val scheduler = new MockScheduler(new MockTime())
+    var number = 2
+
+    for (_ <- 0 until 1000000) {
+      lock.synchronized {
+        scheduler.schedule("sumTask", () => {
+          lock.synchronized {
+            number += 4
+          }
+        })
+        number /= 2
+      }
+
+      scheduler.shutdown()
+      assertEquals(5, number)
+      number = 2
+    }
+  }
+}


### PR DESCRIPTION
Link to JIRA-issue: https://issues.apache.org/jira/browse/KAFKA-12668

Making MockScheduler.schedule safe to use in concurrent code
by removing `tick()` call inside MockScheduler.schedule.

To reproduce a bug I wrote a unit-test MockSchedulerTest. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
