### PR TITLE
KAFKA-12782: Fix Javadocs generation by upgrading JDK

### DIFF
--- a/release.py
+++ b/release.py
@@ -256,7 +256,7 @@ def command_stage_docs():
         sys.exit("%s doesn't exist or does not appear to be the kafka-site repository" % kafka_site_repo_path)
 
     prefs = load_prefs()
-    jdk11_env = get_jdk(prefs, 11)
+    jdk15_env = get_jdk(prefs, 15)
     save_prefs(prefs)
 
     version = get_version()
@@ -265,7 +265,7 @@ def command_stage_docs():
     # version due to already having bumped the bugfix version number.
     gradle_version_override = docs_release_version(version)
 
-    cmd("Building docs", "./gradlew -Pversion=%s clean siteDocsTar aggregatedJavadoc" % gradle_version_override, cwd=REPO_HOME, env=jdk11_env)
+    cmd("Building docs", "./gradlew -Pversion=%s clean siteDocsTar aggregatedJavadoc" % gradle_version_override, cwd=REPO_HOME, env=jdk15_env)
 
     docs_tar = os.path.join(REPO_HOME, 'core', 'build', 'distributions', 'kafka_2.13-%s-site-docs.tgz' % gradle_version_override)
 
@@ -512,6 +512,7 @@ apache_id = get_pref(prefs, 'apache_id', lambda: raw_input("Enter your apache us
 
 jdk8_env = get_jdk(prefs, 8)
 jdk11_env = get_jdk(prefs, 11)
+jdk15_env = get_jdk(prefs, 15)
 
 def select_gpg_key():
     print("Here are the available GPG keys:")
@@ -600,7 +601,7 @@ cmd("Creating source archive", "git archive --format tar.gz --prefix kafka-%(rel
 
 cmd("Building artifacts", "./gradlew clean && ./gradlewAll releaseTarGz", cwd=kafka_dir, env=jdk8_env, shell=True)
 cmd("Copying artifacts", "cp %s/core/build/distributions/* %s" % (kafka_dir, artifacts_dir), shell=True)
-cmd("Building docs", "./gradlew clean aggregatedJavadoc", cwd=kafka_dir, env=jdk11_env)
+cmd("Building docs", "./gradlew clean aggregatedJavadoc", cwd=kafka_dir, env=jdk15_env)
 cmd("Copying docs", "cp -R %s/build/docs/javadoc %s" % (kafka_dir, artifacts_dir))
 
 for filename in os.listdir(artifacts_dir):

--- a/release.py
+++ b/release.py
@@ -426,7 +426,7 @@ prefs = load_prefs()
 
 if not user_ok("""Requirements:
 1. Updated docs to reference the new release version where appropriate.
-2. JDK8 and JDK11 compilers and libraries
+2. JDK8 and JDK15 compilers and libraries
 3. Your Apache ID, already configured with SSH keys on id.apache.org and SSH keys available in this shell session
 4. All issues in the target release resolved with valid resolutions (if not, this script will report the problematic JIRAs)
 5. A GPG key used for signing the release. This key should have been added to public Apache servers and the KEYS file on the Kafka site
@@ -511,7 +511,6 @@ if not rc:
 apache_id = get_pref(prefs, 'apache_id', lambda: raw_input("Enter your apache username: "))
 
 jdk8_env = get_jdk(prefs, 8)
-jdk11_env = get_jdk(prefs, 11)
 jdk15_env = get_jdk(prefs, 15)
 
 def select_gpg_key():


### PR DESCRIPTION
This, upgrades JDK to version 15 for the docs generation, this way we
can circumvent bug https://bugs.openjdk.java.net/browse/JDK-8215291
present in JDK11

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
