### PR TITLE
KAFKA-6084: Propagate JSON parsing errors in ReassignPartitionsCommand

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -1581,14 +1581,15 @@ object ReassignPartitionsCommand extends Logging {
   }
 
   def parseTopicsData(jsonData: String): Seq[String] = {
-    Json.parseFull(jsonData) match {
-      case Some(js) =>
+    Json.tryParseFull(jsonData) match {
+      case Right(js) =>
         val version = js.asJsonObject.get("version") match {
           case Some(jsonValue) => jsonValue.to[Int]
           case None => EarliestTopicsJsonVersion
         }
         parseTopicsData(version, js)
-      case None => throw new AdminOperationException("The input string is not a valid JSON")
+      case Left(f) =>
+        throw new AdminOperationException(f)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsUnitTest.scala
@@ -663,6 +663,15 @@ class ReassignPartitionsUnitTest {
       addTopics(adminClient)
       assertStartsWith("Unexpected character",
         assertThrows(classOf[AdminOperationException], () => executeAssignment(adminClient, additional = false, "{invalid_json")).getMessage)
+
+      assertStartsWith("Unexpected character",
+        assertThrows(classOf[AdminOperationException], () => verifyAssignment(adminClient, "{invalid_json", preserveThrottles = false)).getMessage)
+
+      assertStartsWith("Unexpected character",
+        assertThrows(classOf[AdminOperationException], () => cancelAssignment(adminClient, "{invalid_json", preserveThrottles = false)).getMessage)
+
+      assertStartsWith("Unexpected character",
+        assertThrows(classOf[AdminOperationException], () => generateAssignment(adminClient, "{invalid_json", "1", enableRackAwareness = false)).getMessage)
     } finally {
       adminClient.close()
     }


### PR DESCRIPTION
*More detailed description of your change*
I'm verifying reassigning partitions in KRaft mode, and I accidentally find that #4090 only propagate errors when parsing reassignment json, we'd better propagate errors when parsing other json.

*Summary of testing strategy (including rationale)*
unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
