### PR TITLE
KAFKA-12867: Fix ConsumeBenchWorker exit behavior for maxMessages config

### DIFF
--- a/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
+++ b/trogdor/src/main/java/org/apache/kafka/trogdor/workload/ConsumeBenchWorker.java
@@ -282,7 +282,6 @@ public class ConsumeBenchWorker implements TaskWorker {
                 log.info("{} Consumed total number of messages={}, bytes={} in {} ms.  status: {}",
                          clientId, messagesConsumed, bytesConsumed, curTimeMs - startTimeMs, statusData);
             }
-            doneFuture.complete("");
             consumer.close();
             return null;
         }
@@ -307,6 +306,7 @@ public class ConsumeBenchWorker implements TaskWorker {
             }
             statusUpdaterFuture.cancel(false);
             statusUpdater.update();
+            doneFuture.complete("");
         }
     }
 


### PR DESCRIPTION
**Bug:**
The trogdor `ConsumeBenchWorker` has a bug. It allows several consumption tasks to be run in parallel, the number is configurable using the `threadsPerWorker` config. If one of the consumption tasks completes executing successfully due to `maxMessages` being consumed, then, the consumption task prematurely notifies the `doneFuture` causing the entire  `ConsumeBenchWorker` to halt. This becomes a problem when more than 1 consumption task is running in parallel, because the successful completion of 1 of the tasks shuts down the entire worker while the other tasks are still running. When the worker is shut down, it kills all the active consumption tasks, though they have not consumed `maxMessages` yet. This is not the desired behavior.

**How to reproduce?:**
The bug is easily reproducible by running a `ConsumeBenchSpec` task configured with `maxMessages` value and `threadsPerWorker` > 1. When a trogdor workload is started with such a spec, and when one of the threads (i.e. consumption task) has consumed `maxMessages`, you can notice that it prematurely shuts down the worker although the other threads have **not** yet consumed at least `maxMessages`.

**Fix:**
The fix is to defer the notification of the `doneFuture` to the `CloseStatusUpdater` thread. This thread is already responsible for tracking the status of the tasks and updating their status when all of the tasks complete, so this seems like the right place to inject the `doneFuture` notification.