### PR TITLE
MINOR: Update jmh for async profiler 2.0 support

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,7 +71,7 @@ versions += [
   jetty: "9.4.39.v20210325",
   jersey: "2.34",
   jline: "3.12.1",
-  jmh: "1.27",
+  jmh: "1.32",
   hamcrest: "2.2",
   log4j: "1.2.17",
   scalaLogging: "3.9.2",

--- a/jmh-benchmarks/README.md
+++ b/jmh-benchmarks/README.md
@@ -45,6 +45,11 @@ With flame graph output (the semicolon is escaped to ensure it is not treated as
 
     ./jmh-benchmarks/jmh.sh -prof async:libPath=/path/to/libasyncProfiler.so\;output=flamegraph
 
+Simultaneous cpu, allocation and lock profiling with async profiler 2.0 and jfr output (the semicolon is
+escaped to ensure it is not treated as a command separator):
+
+    ./jmh-benchmarks/jmh.sh -prof async:libPath=/path/to/libasyncProfiler.so\;output=jfr\;alloc\;lock LRUCacheBenchmark
+
 A number of arguments can be passed to configure async profiler, run the following for a description:
 
     ./jmh-benchmarks/jmh.sh -prof async:help


### PR DESCRIPTION
Async profiler 2.0 outputs html5 flame graph files
and supports simultaneous collection of cpu,
allocation and lock profiles in jfr format.

Updated the readme to include an example of the
latter and verified that the Readme commands
work with async profiler 2.0.

Release notes:
* 1.28: https://mail.openjdk.java.net/pipermail/jmh-dev/2021-March/003171.html
* 1.29: https://mail.openjdk.java.net/pipermail/jmh-dev/2021-March/003218.html
* 1.30: https://mail.openjdk.java.net/pipermail/jmh-dev/2021-May/003237.html
* 1.31: https://mail.openjdk.java.net/pipermail/jmh-dev/2021-May/003286.html
* 1.32: https://mail.openjdk.java.net/pipermail/jmh-dev/2021-May/003307.html

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
