### PR TITLE
KAFKA-12863: Configure controller snapshot generation

### DIFF
--- a/core/src/main/scala/kafka/raft/RaftManager.scala
+++ b/core/src/main/scala/kafka/raft/RaftManager.scala
@@ -36,7 +36,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{TopicPartition, Uuid}
 import org.apache.kafka.raft.RaftConfig.{AddressSpec, InetAddressSpec, NON_ROUTABLE_ADDRESS, UnknownAddressSpec}
-import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, LeaderAndEpoch, RaftClient, RaftConfig, RaftRequest}
+import org.apache.kafka.raft.{FileBasedStateStore, KafkaRaftClient, LeaderAndEpoch, RaftClient, RaftConfig, RaftRequest, ReplicatedLog}
 import org.apache.kafka.server.common.serialization.RecordSerde
 import scala.jdk.CollectionConverters._
 
@@ -104,6 +104,8 @@ trait RaftManager[T] {
   def leaderAndEpoch: LeaderAndEpoch
 
   def client: RaftClient[T]
+
+  def replicatedLog: ReplicatedLog
 }
 
 class KafkaRaftManager[T](
@@ -127,9 +129,9 @@ class KafkaRaftManager[T](
   scheduler.startup()
 
   private val dataDir = createDataDir()
-  private val metadataLog = buildMetadataLog()
+  override val replicatedLog = buildMetadataLog()
   private val netChannel = buildNetworkChannel()
-  val client: KafkaRaftClient[T] = buildRaftClient()
+  override val client: KafkaRaftClient[T] = buildRaftClient()
   private val raftIoThread = new RaftIoThread(client, threadNamePrefix)
 
   def kafkaRaftClient: KafkaRaftClient[T] = client
@@ -158,7 +160,7 @@ class KafkaRaftManager[T](
     client.close()
     scheduler.shutdown()
     netChannel.close()
-    metadataLog.close()
+    replicatedLog.close()
   }
 
   override def register(
@@ -221,7 +223,7 @@ class KafkaRaftManager[T](
     val client = new KafkaRaftClient(
       recordSerde,
       netChannel,
-      metadataLog,
+      replicatedLog,
       quorumStateStore,
       time,
       metrics,

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -152,6 +152,7 @@ class ControllerServer(
         setDefaultNumPartitions(config.numPartitions.intValue()).
         setSessionTimeoutNs(TimeUnit.NANOSECONDS.convert(config.brokerSessionTimeoutMs.longValue(),
           TimeUnit.MILLISECONDS)).
+        setSnapshotMinNewRecordBytes(config.metadataSnapshotMinNewRecordBytes.toLong).
         setMetrics(new QuorumControllerMetrics(KafkaYammerMetrics.defaultRegistry())).
         build()
 

--- a/core/src/main/scala/kafka/server/ControllerServer.scala
+++ b/core/src/main/scala/kafka/server/ControllerServer.scala
@@ -152,7 +152,7 @@ class ControllerServer(
         setDefaultNumPartitions(config.numPartitions.intValue()).
         setSessionTimeoutNs(TimeUnit.NANOSECONDS.convert(config.brokerSessionTimeoutMs.longValue(),
           TimeUnit.MILLISECONDS)).
-        setSnapshotMinNewRecordBytes(config.metadataSnapshotMinNewRecordBytes.toLong).
+        setSnapshotMaxNewRecordBytes(config.metadataSnapshotMaxNewRecordBytes).
         setMetrics(new QuorumControllerMetrics(KafkaYammerMetrics.defaultRegistry())).
         build()
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -74,7 +74,6 @@ object Defaults {
   val InitialBrokerRegistrationTimeoutMs = 60000
   val BrokerHeartbeatIntervalMs = 2000
   val BrokerSessionTimeoutMs = 9000
-  // TODO: Create a Jira to change this default
   val MetadataSnapshotMinNewRecordBytes = Int.MaxValue
 
   /** KRaft mode configs */

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -74,7 +74,7 @@ object Defaults {
   val InitialBrokerRegistrationTimeoutMs = 60000
   val BrokerHeartbeatIntervalMs = 2000
   val BrokerSessionTimeoutMs = 9000
-  val MetadataSnapshotMaxNewRecordBytes = Long.MaxValue
+  val MetadataSnapshotMaxNewRecordBytes = 20 * 1024 * 1024
 
   /** KRaft mode configs */
   val EmptyNodeId: Int = -1

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -1052,7 +1052,7 @@ object KafkaConfig {
       .defineInternal(BrokerHeartbeatIntervalMsProp, INT, Defaults.BrokerHeartbeatIntervalMs, null, MEDIUM, BrokerHeartbeatIntervalMsDoc)
       .defineInternal(BrokerSessionTimeoutMsProp, INT, Defaults.BrokerSessionTimeoutMs, null, MEDIUM, BrokerSessionTimeoutMsDoc)
       .defineInternal(MetadataLogDirProp, STRING, null, null, HIGH, MetadataLogDirDoc)
-      .defineInternal(MetadataSnapshotMinNewRecordBytesProp, INT, Defaults.MetadataSnapshotMinNewRecordBytes, atLeast(0), HIGH, MetadataSnapshotMinNewRecordBytesDoc)
+      .defineInternal(MetadataSnapshotMinNewRecordBytesProp, INT, Defaults.MetadataSnapshotMinNewRecordBytes, atLeast(1), HIGH, MetadataSnapshotMinNewRecordBytesDoc)
       .defineInternal(ControllerListenerNamesProp, STRING, null, null, HIGH, ControllerListenerNamesDoc)
       .defineInternal(SaslMechanismControllerProtocolProp, STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, null, HIGH, SaslMechanismControllerProtocolDoc)
 

--- a/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
+++ b/core/src/test/java/kafka/testkit/KafkaClusterTestKit.java
@@ -127,7 +127,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
         public KafkaClusterTestKit build() throws Exception {
             Map<Integer, ControllerServer> controllers = new HashMap<>();
             Map<Integer, BrokerServer> brokers = new HashMap<>();
-            Map<Integer, KafkaRaftManager> raftManagers = new HashMap<>();
+            Map<Integer, KafkaRaftManager<ApiMessageAndVersion>> raftManagers = new HashMap<>();
             String uninitializedQuorumVotersString = nodes.controllerNodes().keySet().stream().
                 map(controllerNode -> String.format("%d@0.0.0.0:0", controllerNode)).
                 collect(Collectors.joining(","));
@@ -250,7 +250,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                 for (BrokerServer brokerServer : brokers.values()) {
                     brokerServer.shutdown();
                 }
-                for (KafkaRaftManager raftManager : raftManagers.values()) {
+                for (KafkaRaftManager<ApiMessageAndVersion> raftManager : raftManagers.values()) {
                     raftManager.shutdown();
                 }
                 connectFutureManager.close();
@@ -278,7 +278,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
     private final TestKitNodes nodes;
     private final Map<Integer, ControllerServer> controllers;
     private final Map<Integer, BrokerServer> brokers;
-    private final Map<Integer, KafkaRaftManager> raftManagers;
+    private final Map<Integer, KafkaRaftManager<ApiMessageAndVersion>> raftManagers;
     private final ControllerQuorumVotersFutureManager controllerQuorumVotersFutureManager;
     private final File baseDirectory;
 
@@ -286,7 +286,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
                                 TestKitNodes nodes,
                                 Map<Integer, ControllerServer> controllers,
                                 Map<Integer, BrokerServer> brokers,
-                                Map<Integer, KafkaRaftManager> raftManagers,
+                                Map<Integer, KafkaRaftManager<ApiMessageAndVersion>> raftManagers,
                                 ControllerQuorumVotersFutureManager controllerQuorumVotersFutureManager,
                                 File baseDirectory) {
         this.executorService = executorService;
@@ -350,7 +350,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
             for (ControllerServer controller : controllers.values()) {
                 futures.add(executorService.submit(controller::startup));
             }
-            for (KafkaRaftManager raftManager : raftManagers.values()) {
+            for (KafkaRaftManager<ApiMessageAndVersion> raftManager : raftManagers.values()) {
                 futures.add(controllerQuorumVotersFutureManager.future.thenRunAsync(raftManager::startup));
             }
             for (BrokerServer broker : brokers.values()) {
@@ -430,7 +430,7 @@ public class KafkaClusterTestKit implements AutoCloseable {
         return brokers;
     }
 
-    public Map<Integer, KafkaRaftManager> raftManagers() {
+    public Map<Integer, KafkaRaftManager<ApiMessageAndVersion>> raftManagers() {
         return raftManagers;
     }
 
@@ -459,9 +459,9 @@ public class KafkaClusterTestKit implements AutoCloseable {
             }
             waitForAllFutures(futureEntries);
             futureEntries.clear();
-            for (Entry<Integer, KafkaRaftManager> entry : raftManagers.entrySet()) {
+            for (Entry<Integer, KafkaRaftManager<ApiMessageAndVersion>> entry : raftManagers.entrySet()) {
                 int raftManagerId = entry.getKey();
-                KafkaRaftManager raftManager = entry.getValue();
+                KafkaRaftManager<ApiMessageAndVersion> raftManager = entry.getValue();
                 futureEntries.add(new SimpleImmutableEntry<>("raftManager" + raftManagerId,
                     executorService.submit(raftManager::shutdown)));
             }

--- a/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.testkit.KafkaClusterTestKit
+import kafka.testkit.TestKitNodes
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin.Admin
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.Assertions._
+
+@Timeout(120000)
+class RaftClusterSnapshotTest {
+
+  @Test
+  def testContorllerSnapshotGenerated(): Unit = {
+    val metadataSnapshotMinNewRecordBytes = 1
+    val cluster = new KafkaClusterTestKit
+      .Builder(
+        new TestKitNodes.Builder()
+          .setNumBrokerNodes(0)
+          .setNumControllerNodes(3)
+          .build()
+      )
+      .setConfigProp(
+        KafkaConfig.MetadataSnapshotMinNewRecordBytesProp,
+        metadataSnapshotMinNewRecordBytes.toString
+      )
+      .build()
+
+    try {
+      cluster.format()
+      cluster.startup()
+      TestUtils.waitUntilTrue(
+        () => {
+          cluster
+          .raftManagers()
+          .values()
+          .iterator()
+          .next()
+          .kafkaRaftClient
+          .leaderAndEpoch()
+          .leaderId
+          .isPresent
+        },
+        "RaftManager was not initialized."
+      )
+
+      // TODO: check that a snapshot was generated
+
+      val admin = Admin.create(cluster.controllerClientProperties())
+      try {
+        assertEquals(
+          cluster.nodes().clusterId().toString,
+          admin.describeCluster().clusterId().get()
+        )
+      } finally {
+        admin.close()
+      }
+    } finally {
+      cluster.close()
+    }
+  }
+}

--- a/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterSnapshotTest.scala
@@ -31,7 +31,7 @@ class RaftClusterSnapshotTest {
 
   @Test
   def testContorllerSnapshotGenerated(): Unit = {
-    val metadataSnapshotMinNewRecordBytes = 1
+    val metadataSnapshotMaxNewRecordBytes = 1
     val cluster = new KafkaClusterTestKit
       .Builder(
         new TestKitNodes.Builder()
@@ -40,8 +40,8 @@ class RaftClusterSnapshotTest {
           .build()
       )
       .setConfigProp(
-        KafkaConfig.MetadataSnapshotMinNewRecordBytesProp,
-        metadataSnapshotMinNewRecordBytes.toString
+        KafkaConfig.MetadataSnapshotMaxNewRecordBytesProp,
+        metadataSnapshotMaxNewRecordBytes.toString
       )
       .build()
 

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -132,6 +132,8 @@ class BrokerMetadataListenerTest {
           Batch.of(
             baseOffset,
             leaderEpoch,
+            // Assumes that each record in one byte; TODO: should we fix this?
+            records.size,
             records.asJava
           )
         ).asJava,

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -25,8 +25,10 @@ import kafka.server.RaftReplicaManager
 import kafka.utils.Implicits._
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.metadata.{ConfigRecord, PartitionRecord, RemoveTopicRecord, TopicRecord}
+import org.apache.kafka.common.protocol.ObjectSerializationCache
 import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.common.{TopicPartition, Uuid}
+import org.apache.kafka.metadata.MetadataRecordSerde
 import org.apache.kafka.raft.Batch
 import org.apache.kafka.raft.BatchReader;
 import org.apache.kafka.raft.internals.MemoryBatchReader;
@@ -52,6 +54,7 @@ class BrokerMetadataListenerTest {
   private val txnCoordinator = mock(classOf[TransactionCoordinator])
   private val clientQuotaManager = mock(classOf[ClientQuotaMetadataManager])
   private var lastMetadataOffset = 0L
+  private val metadataSerde = new MetadataRecordSerde
 
   private val listener = new BrokerMetadataListener(
     brokerId,
@@ -83,6 +86,10 @@ class BrokerMetadataListenerTest {
     applyBatch(List.empty);
   }
 
+  private def messageSize(messageAndVersion: ApiMessageAndVersion, objectCache: ObjectSerializationCache): Int = {
+    metadataSerde.recordSize(messageAndVersion, objectCache);
+  }
+
   private def deleteTopic(
     topicId: Uuid,
     topic: String,
@@ -92,9 +99,7 @@ class BrokerMetadataListenerTest {
     val deleteRecord = new RemoveTopicRecord()
       .setTopicId(topicId)
 
-    applyBatch(List[ApiMessageAndVersion](
-      new ApiMessageAndVersion(deleteRecord, 0.toShort),
-    ))
+    applyBatch(List(new ApiMessageAndVersion(deleteRecord, 0.toShort)))
     assertFalse(metadataCache.contains(topic))
     assertEquals(new Properties, configRepository.topicConfig(topic))
 
@@ -127,13 +132,13 @@ class BrokerMetadataListenerTest {
     val batchReader = if (records.isEmpty) {
       MemoryBatchReader.empty[ApiMessageAndVersion](baseOffset, baseOffset, _ => ())
     } else {
+      val objectCache = new ObjectSerializationCache()
       MemoryBatchReader.of(
         List(
           Batch.of(
             baseOffset,
             leaderEpoch,
-            // Assumes that each record in one byte; TODO: should we fix this?
-            records.size,
+            records.map(messageSize(_, objectCache)).sum,
             records.asJava
           )
         ).asJava,

--- a/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/BrokerMetadataListenerTest.scala
@@ -86,10 +86,6 @@ class BrokerMetadataListenerTest {
     applyBatch(List.empty);
   }
 
-  private def messageSize(messageAndVersion: ApiMessageAndVersion, objectCache: ObjectSerializationCache): Int = {
-    metadataSerde.recordSize(messageAndVersion, objectCache);
-  }
-
   private def deleteTopic(
     topicId: Uuid,
     topic: String,
@@ -138,7 +134,7 @@ class BrokerMetadataListenerTest {
           Batch.of(
             baseOffset,
             leaderEpoch,
-            records.map(messageSize(_, objectCache)).sum,
+            records.map(metadataSerde.recordSize(_, objectCache)).sum,
             records.asJava
           )
         ).asJava,

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -697,6 +697,8 @@ public final class QuorumController implements Controller {
                             )
                         );
                     }
+                    log.info("Starting to replay snapshot ({}), from last commit offset ({}) and epoch ({})",
+                        reader.snapshotId(), lastCommittedOffset, lastCommittedEpoch);
 
                     resetState();
 
@@ -893,8 +895,7 @@ public final class QuorumController implements Controller {
                 snapshotRegistry.createSnapshot(lastCommittedOffset);
             }
 
-            log.info(
-                "Generating a snapshot that includes (epoch={}, offset={}) after {} committed bytes since the last snapshot.",
+            log.info("Generating a snapshot that includes (epoch={}, offset={}) after {} committed bytes since the last snapshot.",
                 lastCommittedEpoch, lastCommittedOffset, newBytesSinceLastSnapshot);
 
             snapshotGeneratorManager.createSnapshotGenerator(lastCommittedOffset, lastCommittedEpoch);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -133,6 +133,7 @@ public final class QuorumController implements Controller {
         private short defaultReplicationFactor = 3;
         private int defaultNumPartitions = 1;
         private ReplicaPlacer replicaPlacer = new StripedReplicaPlacer(new Random());
+        private long snapshotMinNewRecordBytes = Long.MAX_VALUE;
         private long sessionTimeoutNs = NANOSECONDS.convert(18, TimeUnit.SECONDS);
         private ControllerMetrics controllerMetrics = null;
 
@@ -185,6 +186,11 @@ public final class QuorumController implements Controller {
             return this;
         }
 
+        public Builder setSnapshotMinNewRecordBytes(long value) {
+            this.snapshotMinNewRecordBytes = value;
+            return this;
+        }
+
         public Builder setSessionTimeoutNs(long sessionTimeoutNs) {
             this.sessionTimeoutNs = sessionTimeoutNs;
             return this;
@@ -215,7 +221,7 @@ public final class QuorumController implements Controller {
                 queue = new KafkaEventQueue(time, logContext, threadNamePrefix);
                 return new QuorumController(logContext, nodeId, queue, time, configDefs,
                     raftClient, supportedFeatures, defaultReplicationFactor,
-                    defaultNumPartitions, replicaPlacer,
+                    defaultNumPartitions, replicaPlacer, snapshotMinNewRecordBytes,
                     sessionTimeoutNs, controllerMetrics);
             } catch (Exception e) {
                 Utils.closeQuietly(queue, "event queue");
@@ -329,7 +335,6 @@ public final class QuorumController implements Controller {
     class SnapshotGeneratorManager implements Runnable {
         private final ExponentialBackoff exponentialBackoff = new ExponentialBackoff(10, 2, 5000, 0);
         private SnapshotGenerator generator = null;
-
 
         void createSnapshotGenerator(long committedOffset, int committedEpoch) {
             if (generator != null) {
@@ -627,6 +632,7 @@ public final class QuorumController implements Controller {
             appendControlEvent("handleCommits[baseOffset=" + reader.baseOffset() + "]", () -> {
                 try {
                     boolean isActiveController = curClaimEpoch != -1;
+                    long processedRecordsSize = 0;
                     while (reader.hasNext()) {
                         Batch<ApiMessageAndVersion> batch = reader.next();
                         long offset = batch.lastOffset();
@@ -664,9 +670,13 @@ public final class QuorumController implements Controller {
                                 replay(messageAndVersion.message(), Optional.empty(), offset);
                             }
                         }
+
                         lastCommittedOffset = offset;
                         lastCommittedEpoch = batch.epoch();
+                        processedRecordsSize += batch.sizeInBytes();
                     }
+
+                    checkSnapshotGeneration(processedRecordsSize);
                 } finally {
                     reader.close();
                 }
@@ -687,15 +697,8 @@ public final class QuorumController implements Controller {
                             )
                         );
                     }
-                    if (lastCommittedOffset != -1) {
-                        throw new IllegalStateException(
-                            String.format(
-                                "Asked to re-load snapshot (%s) after processing records up to %s",
-                                reader.snapshotId(),
-                                lastCommittedOffset
-                            )
-                        );
-                    }
+
+                    resetState();
 
                     while (reader.hasNext()) {
                         Batch<ApiMessageAndVersion> batch = reader.next();
@@ -731,6 +734,7 @@ public final class QuorumController implements Controller {
                     lastCommittedEpoch = reader.lastContainedLogEpoch();
                     snapshotRegistry.createSnapshot(lastCommittedOffset);
                 } finally {
+                    resetSnapshotGeneration();
                     reader.close();
                 }
             });
@@ -877,6 +881,36 @@ public final class QuorumController implements Controller {
         }
     }
 
+    private void checkSnapshotGeneration(long batchSizeInBytes) {
+        newBytesSinceLastSnapshot += batchSizeInBytes;
+        if (newBytesSinceLastSnapshot >= snapshotMinNewRecordBytes &&
+            snapshotGeneratorManager.generator == null
+        ) {
+            boolean isActiveController = curClaimEpoch != -1;
+            if (!isActiveController) {
+                // The active controller creates in-memory snapshot every time an uncommitted
+                // batch gets appended. The in-active controller can be more efficient and only
+                // create an in-memory snapshot when needed.
+                snapshotRegistry.createSnapshot(lastCommittedOffset);
+            }
+
+            snapshotGeneratorManager.createSnapshotGenerator(lastCommittedOffset, lastCommittedEpoch);
+            newBytesSinceLastSnapshot = 0;
+        }
+    }
+
+    private void resetSnapshotGeneration() {
+        snapshotGeneratorManager.cancel();
+        newBytesSinceLastSnapshot = 0;
+    }
+
+    private void resetState() {
+        snapshotRegistry.reset();
+        lastCommittedOffset = -1;
+        lastCommittedEpoch = -1;
+        snapshotRegistry.createSnapshot(lastCommittedOffset);
+    }
+
     private final LogContext logContext;
 
     private final Logger log;
@@ -987,6 +1021,17 @@ public final class QuorumController implements Controller {
      */
     private long writeOffset;
 
+
+    /**
+     * Minimum number of bytes processed through handling commits before generating a snapshot.
+     */
+    private final long snapshotMinNewRecordBytes;
+
+    /**
+     * Number of bytes processed through handling commits since the last snapshot was generated.
+     */
+    private long newBytesSinceLastSnapshot = 0;
+
     private QuorumController(LogContext logContext,
                              int nodeId,
                              KafkaEventQueue queue,
@@ -997,6 +1042,7 @@ public final class QuorumController implements Controller {
                              short defaultReplicationFactor,
                              int defaultNumPartitions,
                              ReplicaPlacer replicaPlacer,
+                             long snapshotMinNewRecordBytes,
                              long sessionTimeoutNs,
                              ControllerMetrics controllerMetrics) {
         this.logContext = logContext;
@@ -1014,6 +1060,7 @@ public final class QuorumController implements Controller {
             snapshotRegistry, sessionTimeoutNs, replicaPlacer);
         this.featureControl = new FeatureControlManager(supportedFeatures, snapshotRegistry);
         this.producerIdControlManager = new ProducerIdControlManager(clusterControl, snapshotRegistry);
+        this.snapshotMinNewRecordBytes = snapshotMinNewRecordBytes;
         this.replicationControl = new ReplicationControlManager(snapshotRegistry,
             logContext, defaultReplicationFactor, defaultNumPartitions,
             configurationControl, clusterControl, controllerMetrics);

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -734,7 +734,6 @@ public final class QuorumController implements Controller {
                     lastCommittedEpoch = reader.lastContainedLogEpoch();
                     snapshotRegistry.createSnapshot(lastCommittedOffset);
                 } finally {
-                    resetSnapshotGeneration();
                     reader.close();
                 }
             });
@@ -899,15 +898,14 @@ public final class QuorumController implements Controller {
         }
     }
 
-    private void resetSnapshotGeneration() {
-        snapshotGeneratorManager.cancel();
-        newBytesSinceLastSnapshot = 0;
-    }
-
     private void resetState() {
+        snapshotGeneratorManager.cancel();
         snapshotRegistry.reset();
+
+        newBytesSinceLastSnapshot = 0;
         lastCommittedOffset = -1;
         lastCommittedEpoch = -1;
+
         snapshotRegistry.createSnapshot(lastCommittedOffset);
     }
 

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -269,7 +269,10 @@ public class QuorumControllerTest {
                 reader = logEnv.waitForSnapshot(snapshotLogOffset);
                 SnapshotReader<ApiMessageAndVersion> snapshot = createSnapshotReader(reader);
                 assertEquals(snapshotLogOffset, snapshot.lastContainedLogOffset());
-                checkSnapshotContents(fooId, brokerEpochs, snapshot);
+                checkSnapshotContent(
+                    expectedSnapshotContent(fooId, brokerEpochs),
+                    snapshot
+                );
             }
         }
 
@@ -282,7 +285,71 @@ public class QuorumControllerTest {
                     logEnv.waitForSnapshot(snapshotLogOffset)
                 );
                 assertEquals(snapshotLogOffset, snapshot.lastContainedLogOffset());
-                checkSnapshotContents(fooId, brokerEpochs, snapshot);
+                checkSnapshotContent(
+                    expectedSnapshotContent(fooId, brokerEpochs),
+                    snapshot
+                );
+            }
+        }
+    }
+
+    @Test
+    public void testSnapshotConfiguration() throws Throwable {
+        final int numBrokers = 4;
+        final int minNewRecordBytes = 4;
+        Map<Integer, Long> brokerEpochs = new HashMap<>();
+        Uuid fooId;
+        try (LocalLogManagerTestEnv logEnv = new LocalLogManagerTestEnv(3, Optional.empty())) {
+            try (QuorumControllerTestEnv controlEnv = new QuorumControllerTestEnv(
+                    logEnv,
+                    builder -> {
+                        builder
+                            .setConfigDefs(CONFIGS)
+                            .setSnapshotMinNewRecordBytes(minNewRecordBytes);
+                    })
+                ) {
+
+                QuorumController active = controlEnv.activeController();
+                for (int i = 0; i < numBrokers; i++) {
+                    BrokerRegistrationReply reply = active.registerBroker(
+                        new BrokerRegistrationRequestData().
+                            setBrokerId(i).
+                            setRack(null).
+                            setClusterId("06B-K3N1TBCNYFgruEVP0Q").
+                            setIncarnationId(Uuid.fromString("kxAT73dKQsitIedpiPtwB" + i)).
+                            setListeners(new ListenerCollection(Arrays.asList(new Listener().
+                                setName("PLAINTEXT").setHost("localhost").
+                                setPort(9092 + i)).iterator()))).get();
+                    brokerEpochs.put(i, reply.epoch());
+                }
+                for (int i = 0; i < numBrokers - 1; i++) {
+                    assertEquals(new BrokerHeartbeatReply(true, false, false, false),
+                        active.processBrokerHeartbeat(new BrokerHeartbeatRequestData().
+                            setWantFence(false).setBrokerEpoch(brokerEpochs.get(i)).
+                            setBrokerId(i).setCurrentMetadataOffset(100000L)).get());
+                }
+                CreateTopicsResponseData fooData = active.createTopics(
+                    new CreateTopicsRequestData().setTopics(
+                        new CreatableTopicCollection(Collections.singleton(
+                            new CreatableTopic().setName("foo").setNumPartitions(-1).
+                                setReplicationFactor((short) -1).
+                                setAssignments(new CreatableReplicaAssignmentCollection(
+                                    Arrays.asList(new CreatableReplicaAssignment().
+                                        setPartitionIndex(0).
+                                        setBrokerIds(Arrays.asList(0, 1, 2)),
+                                    new CreatableReplicaAssignment().
+                                        setPartitionIndex(1).
+                                        setBrokerIds(Arrays.asList(1, 2, 0))).
+                                            iterator()))).iterator()))).get();
+                fooId = fooData.topics().find("foo").topicId();
+                active.allocateProducerIds(
+                    new AllocateProducerIdsRequestData().setBrokerId(0).setBrokerEpoch(brokerEpochs.get(0))).get();
+
+                SnapshotReader<ApiMessageAndVersion> snapshot = createSnapshotReader(logEnv.waitForLatestSnapshot());
+                checkSnapshotSubcontent(
+                    expectedSnapshotContent(fooId, brokerEpochs),
+                    snapshot
+                );
             }
         }
     }
@@ -296,12 +363,8 @@ public class QuorumControllerTest {
         );
     }
 
-    private void checkSnapshotContents(
-        Uuid fooId,
-        Map<Integer, Long> brokerEpochs,
-        Iterator<Batch<ApiMessageAndVersion>> iterator
-    ) throws Exception {
-        List<ApiMessageAndVersion> expected = Arrays.asList(
+    private List<ApiMessageAndVersion> expectedSnapshotContent(Uuid fooId, Map<Integer, Long> brokerEpochs) {
+        return Arrays.asList(
             new ApiMessageAndVersion(new TopicRecord().
                 setName("foo").setTopicId(fooId), (short) 1),
             new ApiMessageAndVersion(new PartitionRecord().setPartitionId(0).
@@ -356,7 +419,12 @@ public class QuorumControllerTest {
                 setBrokerEpoch(brokerEpochs.get(0)).
                 setProducerIdsEnd(1000), (short) 0)
         );
+    }
 
+    private void checkSnapshotContent(
+        List<ApiMessageAndVersion> expected,
+        Iterator<Batch<ApiMessageAndVersion>> iterator
+    ) throws Exception {
         RecordTestUtils.assertBatchIteratorContains(
             Arrays.asList(expected),
             Arrays.asList(
@@ -364,6 +432,36 @@ public class QuorumControllerTest {
                              .flatMap(batch ->  batch.records().stream())
                              .collect(Collectors.toList())
             ).iterator()
+        );
+    }
+
+    private void checkSnapshotSubcontent(
+        List<ApiMessageAndVersion> expected,
+        Iterator<Batch<ApiMessageAndVersion>> iterator
+    ) throws Exception {
+        RecordTestUtils.deepSortRecords(expected);
+
+        List<ApiMessageAndVersion> actual = StreamSupport
+            .stream(
+                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED),
+                false
+            )
+            .flatMap(batch ->  batch.records().stream())
+            .collect(Collectors.toList());
+
+        RecordTestUtils.deepSortRecords(actual);
+
+        int expectedIndex = 0;
+        for (ApiMessageAndVersion current : actual) {
+            while (expectedIndex < expected.size() && !expected.get(expectedIndex).equals(current)) {
+                expectedIndex += 1;
+            }
+            expectedIndex += 1;
+        }
+
+        assertTrue(
+            expectedIndex <= expected.size(),
+            String.format("actual is not a subset of expected: expected = %s; actual = %s", expected, actual)
         );
     }
 

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -281,7 +281,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
         /**
          * Returns the snapshot whos last offset is the committed offset.
          *
-         * If such snapshot doesn't exists it wait until it does.
+         * If such snapshot doesn't exists, it waits until it does.
          */
         synchronized RawSnapshotReader waitForSnapshot(long committedOffset) throws InterruptedException {
             while (true) {
@@ -293,14 +293,57 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                 }
             }
         }
+
+        /**
+         * Returns the latest snapshot.
+         *
+         * If a snapshot doesn't exists, it waits until it does.
+         */
+        synchronized RawSnapshotReader waitForLatestSnapshot() throws InterruptedException {
+            while (snapshots.isEmpty()) {
+                this.wait();
+            }
+
+            return Objects.requireNonNull(snapshots.lastEntry()).getValue();
+        }
     }
 
     private static class MetaLogListenerData {
         private long offset = -1;
+        private LeaderAndEpoch notifiedLeader = new LeaderAndEpoch(OptionalInt.empty(), 0);
+
         private final RaftClient.Listener<ApiMessageAndVersion> listener;
 
         MetaLogListenerData(RaftClient.Listener<ApiMessageAndVersion> listener) {
             this.listener = listener;
+        }
+
+        long offset() {
+            return offset;
+        }
+
+        LeaderAndEpoch notifiedLeader() {
+            return notifiedLeader;
+        }
+
+        void handleCommit(MemoryBatchReader<ApiMessageAndVersion> reader) {
+            listener.handleCommit(reader);
+            offset = reader.lastOffset().getAsLong();
+        }
+
+        void handleSnapshot(SnapshotReader<ApiMessageAndVersion> reader) {
+            listener.handleSnapshot(reader);
+            offset = reader.lastContainedLogOffset();
+        }
+
+        void handleLeaderChange(long offset, LeaderAndEpoch leader) {
+            listener.handleLeaderChange(leader);
+            notifiedLeader = leader;
+            this.offset = offset;
+        }
+
+        void beginShutdown() {
+            listener.beginShutdown();
         }
     }
 
@@ -365,22 +408,24 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                 int numEntriesFound = 0;
                 for (MetaLogListenerData listenerData : listeners) {
                     while (true) {
-                        // Load the snapshot if needed
-                        Optional<RawSnapshotReader> snapshot = shared.nextSnapshot(listenerData.offset);
-                        if (snapshot.isPresent()) {
-                            log.trace("Node {}: handling snapshot with id {}.", nodeId, snapshot.get().snapshotId());
-                            listenerData.listener.handleSnapshot(
-                                SnapshotReader.of(
-                                    snapshot.get(),
-                                    new  MetadataRecordSerde(),
-                                    BufferSupplier.create(),
-                                    Integer.MAX_VALUE
-                                )
-                            );
-                            listenerData.offset = snapshot.get().snapshotId().offset - 1;
+                        // Load the snapshot if needed and we are not the leader
+                        LeaderAndEpoch notifiedLeader = listenerData.notifiedLeader();
+                        if (!OptionalInt.of(nodeId).equals(notifiedLeader.leaderId())) {
+                            Optional<RawSnapshotReader> snapshot = shared.nextSnapshot(listenerData.offset());
+                            if (snapshot.isPresent()) {
+                                log.trace("Node {}: handling snapshot with id {}.", nodeId, snapshot.get().snapshotId());
+                                listenerData.handleSnapshot(
+                                    SnapshotReader.of(
+                                        snapshot.get(),
+                                        new  MetadataRecordSerde(),
+                                        BufferSupplier.create(),
+                                        Integer.MAX_VALUE
+                                    )
+                                );
+                            }
                         }
 
-                        Entry<Long, LocalBatch> entry = shared.nextBatch(listenerData.offset);
+                        Entry<Long, LocalBatch> entry = shared.nextBatch(listenerData.offset());
                         if (entry == null) {
                             log.trace("Node {}: reached the end of the log after finding " +
                                 "{} entries.", nodeId, numEntriesFound);
@@ -397,7 +442,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                             LeaderChangeBatch batch = (LeaderChangeBatch) entry.getValue();
                             log.trace("Node {}: handling LeaderChange to {}.",
                                 nodeId, batch.newLeader);
-                            listenerData.listener.handleLeaderChange(batch.newLeader);
+                            listenerData.handleLeaderChange(entryOffset, batch.newLeader);
                             if (batch.newLeader.epoch() > leader.epoch()) {
                                 leader = batch.newLeader;
                             }
@@ -405,12 +450,14 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                             LocalRecordBatch batch = (LocalRecordBatch) entry.getValue();
                             log.trace("Node {}: handling LocalRecordBatch with offset {}.",
                                 nodeId, entryOffset);
-                            listenerData.listener.handleCommit(
+                            listenerData.handleCommit(
                                 MemoryBatchReader.of(
                                     Collections.singletonList(
                                         Batch.of(
                                             entryOffset - batch.records.size() + 1,
                                             Math.toIntExact(batch.leaderEpoch),
+                                            // Assume each entry takes one byte; TODO: should we fix this?
+                                            batch.records.size(),
                                             batch.records
                                         )
                                     ),
@@ -419,7 +466,6 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                             );
                         }
                         numEntriesFound++;
-                        listenerData.offset = entryOffset;
                     }
                 }
                 log.trace("Completed log check for node " + nodeId);
@@ -436,7 +482,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                     log.debug("Node {}: beginning shutdown.", nodeId);
                     resign(leader.epoch());
                     for (MetaLogListenerData listenerData : listeners) {
-                        listenerData.listener.beginShutdown();
+                        listenerData.beginShutdown();
                     }
                     shared.unregisterLogManager(this);
                 }

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
@@ -141,6 +141,10 @@ public class LocalLogManagerTestEnv implements AutoCloseable {
         return shared.waitForLatestSnapshot();
     }
 
+    public long appendedBytes() {
+        return shared.appendedBytes();
+    }
+
     @Override
     public void close() throws InterruptedException {
         try {

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManagerTestEnv.java
@@ -137,6 +137,10 @@ public class LocalLogManagerTestEnv implements AutoCloseable {
         return shared.waitForSnapshot(committedOffset);
     }
 
+    public RawSnapshotReader waitForLatestSnapshot() throws InterruptedException {
+        return shared.waitForLatestSnapshot();
+    }
+
     @Override
     public void close() throws InterruptedException {
         try {

--- a/raft/src/main/java/org/apache/kafka/raft/Batch.java
+++ b/raft/src/main/java/org/apache/kafka/raft/Batch.java
@@ -30,12 +30,14 @@ public final class Batch<T> implements Iterable<T> {
     private final long baseOffset;
     private final int epoch;
     private final long lastOffset;
+    private final int sizeInBytes;
     private final List<T> records;
 
-    private Batch(long baseOffset, int epoch, long lastOffset, List<T> records) {
+    private Batch(long baseOffset, int epoch, long lastOffset, int sizeInBytes, List<T> records) {
         this.baseOffset = baseOffset;
         this.epoch = epoch;
         this.lastOffset = lastOffset;
+        this.sizeInBytes = sizeInBytes;
         this.records = records;
     }
 
@@ -67,6 +69,13 @@ public final class Batch<T> implements Iterable<T> {
         return epoch;
     }
 
+    /**
+     * The number of bytes used by this batch.
+     */
+    public int sizeInBytes() {
+        return sizeInBytes;
+    }
+
     @Override
     public Iterator<T> iterator() {
         return records.iterator();
@@ -78,6 +87,7 @@ public final class Batch<T> implements Iterable<T> {
             "baseOffset=" + baseOffset +
             ", epoch=" + epoch +
             ", lastOffset=" + lastOffset +
+            ", sizeInBytes=" + sizeInBytes +
             ", records=" + records +
             ')';
     }
@@ -89,12 +99,14 @@ public final class Batch<T> implements Iterable<T> {
         Batch<?> batch = (Batch<?>) o;
         return baseOffset == batch.baseOffset &&
             epoch == batch.epoch &&
+            lastOffset == batch.lastOffset &&
+            sizeInBytes == batch.sizeInBytes &&
             Objects.equals(records, batch.records);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(baseOffset, epoch, records);
+        return Objects.hash(baseOffset, epoch, lastOffset, sizeInBytes, records);
     }
 
     /**
@@ -105,9 +117,10 @@ public final class Batch<T> implements Iterable<T> {
      * @param baseOffset offset of the batch
      * @param epoch epoch of the leader that created this batch
      * @param lastOffset offset of the last record of this batch
+     * @param sizeInBytes number of bytes used by this batch
      */
-    public static <T> Batch<T> empty(long baseOffset, int epoch, long lastOffset) {
-        return new Batch<>(baseOffset, epoch, lastOffset, Collections.emptyList());
+    public static <T> Batch<T> empty(long baseOffset, int epoch, long lastOffset, int sizeInBytes) {
+        return new Batch<>(baseOffset, epoch, lastOffset, sizeInBytes, Collections.emptyList());
     }
 
     /**
@@ -117,7 +130,7 @@ public final class Batch<T> implements Iterable<T> {
      * @param epoch epoch of the leader that created this batch
      * @param records the list of records in this batch
      */
-    public static <T> Batch<T> of(long baseOffset, int epoch, List<T> records) {
+    public static <T> Batch<T> of(long baseOffset, int epoch, int sizeInBytes, List<T> records) {
         if (records.isEmpty()) {
             throw new IllegalArgumentException(
                 String.format(
@@ -128,6 +141,6 @@ public final class Batch<T> implements Iterable<T> {
             );
         }
 
-        return new Batch<>(baseOffset, epoch, baseOffset + records.size() - 1, records);
+        return new Batch<>(baseOffset, epoch, baseOffset + records.size() - 1, sizeInBytes, records);
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -341,12 +341,12 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
         );
     }
 
-    private void maybeFireHandleCommit(long baseOffset, int epoch, List<T> records) {
+    private void maybeFireHandleCommit(long baseOffset, int epoch, int sizeInBytes, List<T> records) {
         for (ListenerContext listenerContext : listenerContexts) {
-            OptionalLong nextExpectedOffsetOpt = listenerContext.nextExpectedOffset();
-            nextExpectedOffsetOpt.ifPresent(nextOffset -> {
-                if (nextOffset == baseOffset)
-                    listenerContext.fireHandleCommit(baseOffset, epoch, records);
+            listenerContext.nextExpectedOffset().ifPresent(nextOffset -> {
+                if (nextOffset == baseOffset) {
+                    listenerContext.fireHandleCommit(baseOffset, epoch, sizeInBytes, records);
+                }
             });
         }
     }
@@ -1853,7 +1853,9 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
                     double elapsedTimePerRecord = (double) elapsedTime / batch.numRecords;
                     kafkaRaftMetrics.updateCommitLatency(elapsedTimePerRecord, appendTimeMs);
                     logger.debug("Completed commit of {} records at {}", batch.numRecords, offsetAndEpoch);
-                    batch.records.ifPresent(records -> maybeFireHandleCommit(batch.baseOffset, epoch, records));
+                    batch.records.ifPresent(records -> {
+                        maybeFireHandleCommit(batch.baseOffset, epoch, batch.sizeInBytes(), records);
+                    });
                 }
             });
         } finally {
@@ -2408,8 +2410,8 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
          * a nice optimization for the leader which is typically doing more work than all of the
          * followers.
          */
-        public void fireHandleCommit(long baseOffset, int epoch, List<T> records) {
-            Batch<T> batch = Batch.of(baseOffset, epoch, records);
+        public void fireHandleCommit(long baseOffset, int epoch, int sizeInBytes, List<T> records) {
+            Batch<T> batch = Batch.of(baseOffset, epoch, sizeInBytes, records);
             MemoryBatchReader<T> reader = MemoryBatchReader.of(Collections.singletonList(batch), this);
             fireHandleCommit(reader);
         }

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
@@ -182,7 +182,7 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
     private Batch<T> readBatch(DefaultRecordBatch batch) {
         final Batch<T> result;
         if (batch.isControlBatch()) {
-            result = Batch.empty(batch.baseOffset(), batch.partitionLeaderEpoch(), batch.lastOffset());
+            result = Batch.empty(batch.baseOffset(), batch.partitionLeaderEpoch(), batch.lastOffset(), batch.sizeInBytes());
         } else {
             Integer numRecords = batch.countOrNull();
             if (numRecords == null) {
@@ -197,7 +197,7 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
                 }
             }
 
-            result = Batch.of(batch.baseOffset(), batch.partitionLeaderEpoch(), records);
+            result = Batch.of(batch.baseOffset(), batch.partitionLeaderEpoch(), batch.sizeInBytes(), records);
         }
 
         return result;

--- a/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
+++ b/raft/src/main/java/org/apache/kafka/raft/internals/RecordsIterator.java
@@ -182,7 +182,12 @@ public final class RecordsIterator<T> implements Iterator<Batch<T>>, AutoCloseab
     private Batch<T> readBatch(DefaultRecordBatch batch) {
         final Batch<T> result;
         if (batch.isControlBatch()) {
-            result = Batch.empty(batch.baseOffset(), batch.partitionLeaderEpoch(), batch.lastOffset(), batch.sizeInBytes());
+            result = Batch.empty(
+                batch.baseOffset(),
+                batch.partitionLeaderEpoch(),
+                batch.lastOffset(),
+                batch.sizeInBytes()
+            );
         } else {
             Integer numRecords = batch.countOrNull();
             if (numRecords == null) {

--- a/raft/src/test/java/org/apache/kafka/raft/internals/MemoryBatchReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/MemoryBatchReaderTest.java
@@ -33,13 +33,13 @@ class MemoryBatchReaderTest {
     @Test
     public void testIteration() {
         Batch<String> batch1 = Batch.of(
-            0L, 1, Arrays.asList("a", "b", "c")
+            0L, 1, 3, Arrays.asList("a", "b", "c")
         );
         Batch<String> batch2 = Batch.of(
-            3L, 2, Arrays.asList("d", "e")
+            3L, 2, 2, Arrays.asList("d", "e")
         );
         Batch<String> batch3 = Batch.of(
-            5L, 2, Arrays.asList("f", "g", "h", "i")
+            5L, 2, 4, Arrays.asList("f", "g", "h", "i")
         );
 
         @SuppressWarnings("unchecked")

--- a/raft/src/test/java/org/apache/kafka/raft/internals/RecordsBatchReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/RecordsBatchReaderTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.kafka.raft.internals;
 
-import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.FileRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Records;
-import org.apache.kafka.raft.Batch;
+import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.raft.BatchReader;
+import org.apache.kafka.raft.internals.RecordsIteratorTest.TestBatch;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
@@ -50,7 +50,7 @@ class RecordsBatchReaderTest {
     public void testReadFromMemoryRecords(CompressionType compressionType) {
         long baseOffset = 57;
 
-        List<Batch<String>> batches = RecordsIteratorTest.createBatches(baseOffset);
+        List<TestBatch<String>> batches = RecordsIteratorTest.createBatches(baseOffset);
         MemoryRecords memRecords = RecordsIteratorTest.buildRecords(compressionType, batches);
 
         testBatchReader(baseOffset, memRecords, batches);
@@ -61,7 +61,7 @@ class RecordsBatchReaderTest {
     public void testReadFromFileRecords(CompressionType compressionType) throws Exception {
         long baseOffset = 57;
 
-        List<Batch<String>> batches = RecordsIteratorTest.createBatches(baseOffset);
+        List<TestBatch<String>> batches = RecordsIteratorTest.createBatches(baseOffset);
         MemoryRecords memRecords = RecordsIteratorTest.buildRecords(compressionType, batches);
 
         FileRecords fileRecords = FileRecords.open(tempFile());
@@ -73,7 +73,7 @@ class RecordsBatchReaderTest {
     private void testBatchReader(
         long baseOffset,
         Records records,
-        List<Batch<String>> expectedBatches
+        List<TestBatch<String>> expectedBatches
     ) {
         BufferSupplier bufferSupplier = Mockito.mock(BufferSupplier.class);
         Set<ByteBuffer> allocatedBuffers = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -103,9 +103,9 @@ class RecordsBatchReaderTest {
             closeListener
         );
 
-        for (Batch<String> batch : expectedBatches) {
+        for (TestBatch<String> batch : expectedBatches) {
             assertTrue(reader.hasNext());
-            assertEquals(batch, reader.next());
+            assertEquals(batch, TestBatch.from(reader.next()));
         }
 
         assertFalse(reader.hasNext());

--- a/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/RecordsIteratorTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,7 +68,7 @@ public final class RecordsIteratorTest {
         @ForAll CompressionType compressionType,
         @ForAll long seed
     ) {
-        List<Batch<String>> batches = createBatches(seed);
+        List<TestBatch<String>> batches = createBatches(seed);
 
         MemoryRecords memRecords = buildRecords(compressionType, batches);
         testIterator(batches, memRecords);
@@ -78,7 +79,7 @@ public final class RecordsIteratorTest {
         @ForAll CompressionType compressionType,
         @ForAll long seed
     ) throws IOException {
-        List<Batch<String>> batches = createBatches(seed);
+        List<TestBatch<String>> batches = createBatches(seed);
 
         MemoryRecords memRecords = buildRecords(compressionType, batches);
         FileRecords fileRecords = FileRecords.open(TestUtils.tempFile());
@@ -88,7 +89,7 @@ public final class RecordsIteratorTest {
     }
 
     private void testIterator(
-        List<Batch<String>> expectedBatches,
+        List<TestBatch<String>> expectedBatches,
         Records records
     ) {
         Set<ByteBuffer> allocatedBuffers = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -98,9 +99,9 @@ public final class RecordsIteratorTest {
             mockBufferSupplier(allocatedBuffers)
         );
 
-        for (Batch<String> batch : expectedBatches) {
+        for (TestBatch<String> batch : expectedBatches) {
             assertTrue(iterator.hasNext());
-            assertEquals(batch, iterator.next());
+            assertEquals(batch, TestBatch.from(iterator.next()));
         }
 
         assertFalse(iterator.hasNext());
@@ -133,13 +134,13 @@ public final class RecordsIteratorTest {
         return bufferSupplier;
     }
 
-    public static List<Batch<String>> createBatches(long seed) {
+    public static List<TestBatch<String>> createBatches(long seed) {
         Random random = new Random(seed);
         long baseOffset = random.nextInt(100);
         int epoch = random.nextInt(3) + 1;
 
         int numberOfBatches = random.nextInt(100) + 1;
-        List<Batch<String>> batches = new ArrayList<>(numberOfBatches);
+        List<TestBatch<String>> batches = new ArrayList<>(numberOfBatches);
         for (int i = 0; i < numberOfBatches; i++) {
             int numberOfRecords = random.nextInt(100) + 1;
             List<String> records = random
@@ -147,7 +148,7 @@ public final class RecordsIteratorTest {
                 .mapToObj(String::valueOf)
                 .collect(Collectors.toList());
 
-            batches.add(Batch.of(baseOffset, epoch, records));
+            batches.add(new TestBatch<>(baseOffset, epoch, records));
             baseOffset += records.size();
             if (i % 5 == 0) {
                 epoch += random.nextInt(3);
@@ -159,23 +160,23 @@ public final class RecordsIteratorTest {
 
     public static MemoryRecords buildRecords(
         CompressionType compressionType,
-        List<Batch<String>> batches
+        List<TestBatch<String>> batches
     ) {
         ByteBuffer buffer = ByteBuffer.allocate(102400);
 
-        for (Batch<String> batch : batches) {
+        for (TestBatch<String> batch : batches) {
             BatchBuilder<String> builder = new BatchBuilder<>(
                 buffer,
                 STRING_SERDE,
                 compressionType,
-                batch.baseOffset(),
+                batch.baseOffset,
                 12345L,
                 false,
-                batch.epoch(),
+                batch.epoch,
                 1024
             );
 
-            for (String record : batch.records()) {
+            for (String record : batch.records) {
                 builder.appendRecord(record, null);
             }
 
@@ -184,5 +185,46 @@ public final class RecordsIteratorTest {
 
         buffer.flip();
         return MemoryRecords.readableRecords(buffer);
+    }
+
+    public static final class TestBatch<T> {
+        final long baseOffset;
+        final int epoch;
+        final List<T> records;
+
+        TestBatch(long baseOffset, int epoch, List<T> records) {
+            this.baseOffset = baseOffset;
+            this.epoch = epoch;
+            this.records = records;
+        }
+
+        @Override
+        public String toString() {
+            return String.format(
+                "TestBatch(baseOffset=%s, epoch=%s, records=%s)",
+                baseOffset,
+                epoch,
+                records
+            );
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TestBatch<?> testBatch = (TestBatch<?>) o;
+            return baseOffset == testBatch.baseOffset &&
+                epoch == testBatch.epoch &&
+                Objects.equals(records, testBatch.records);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(baseOffset, epoch, records);
+        }
+
+        static <T> TestBatch<T> from(Batch<T> batch) {
+            return new TestBatch<>(batch.baseOffset(), batch.epoch(), batch.records());
+        }
     }
 }

--- a/shell/src/main/java/org/apache/kafka/shell/SnapshotFileReader.java
+++ b/shell/src/main/java/org/apache/kafka/shell/SnapshotFileReader.java
@@ -158,6 +158,7 @@ public final class SnapshotFileReader implements AutoCloseable {
                     Batch.of(
                         batch.baseOffset(),
                         batch.partitionLeaderEpoch(),
+                        batch.sizeInBytes(),
                         messages
                     )
                 ),


### PR DESCRIPTION
Controller snapshot generation will be triggered based on the number of new bytes in the log since the latest snapshot.

1. Add the property `metadata.log.snapshot.min.new_record.bytes` and disabled it by default by setting the default to `Int.MaxValue`
2. Expose the number of bytes in a batch to the quorum controller
3. Change the commit handling implementation for the quorum controller so that it generates a new snapshot after a configured number of bytes have been read.
4. Fix `LocalLogManager` so that snapshot loading in only triggered when the listener is not the leader.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
