### PR TITLE
KAFKA-12885: Add the --timeout property to kafka-leader-election.sh

### DIFF
--- a/core/src/main/scala/kafka/admin/LeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/LeaderElectionCommand.scala
@@ -26,7 +26,6 @@ import kafka.utils.CoreUtils
 import kafka.utils.Implicits._
 import kafka.utils.Json
 import kafka.utils.Logging
-import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.{Admin, AdminClientConfig}
 import org.apache.kafka.common.ElectionType
 import org.apache.kafka.common.TopicPartition
@@ -287,7 +286,7 @@ private final class LeaderElectionCommandOptions(args: Array[String]) extends Co
   val requestTimeout = parser
     .accepts(
       "timeout",
-      CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC)
+      "The configuration controls the maximum amount of time the client will wait for the response of a request. If the response is not received before the timeout elapses the client will resend the request if necessary or fail the request if retries are exhausted.")
     .withRequiredArg
     .describedAs("timeout ms")
     .ofType(classOf[String])

--- a/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/LeaderElectionCommandTest.scala
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
-import scala.concurrent.duration._
 
 final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
   import LeaderElectionCommandTest._
@@ -268,8 +267,7 @@ final class LeaderElectionCommandTest extends ZooKeeperTestHarness {
         "--bootstrap-server", "example.com:1234",
         "--election-type", "unclean",
         "--all-topic-partitions"
-      ),
-      1.seconds
+      )
     ))
     assertTrue(e.getCause.isInstanceOf[TimeoutException])
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-9220 mentions kafka-preferred-replica-election.sh script hard-coded timeout problems. I see a similar problem with kafka-leader-election.sh.

I would like to add a --timeout parameter to kafka-leader-election.sh to control the request timeout. To solve similar problems.