### PR TITLE
KAFKA-12889: log clean relative index range check of group consider empty log segment to avoid too many empty log segment left

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -837,7 +837,10 @@ private[log] class Cleaner(val id: Int,
             logSize + segs.head.size <= maxSize &&
             indexSize + segs.head.offsetIndex.sizeInBytes <= maxIndexSize &&
             timeIndexSize + segs.head.timeIndex.sizeInBytes <= maxIndexSize &&
-            lastOffsetForFirstSegment(segs, firstUncleanableOffset) - group.last.baseOffset <= Int.MaxValue) {
+            //if next Log segment is empty, no need to make sure index relative offset range.
+            //this will avoid empty log left every 2^31 message.
+            (segs.head.size==0 ||
+              lastOffsetForFirstSegment(segs, firstUncleanableOffset) - group.last.baseOffset <= Int.MaxValue)) {
         group = segs.head :: group
         logSize += segs.head.size
         indexSize += segs.head.offsetIndex.sizeInBytes

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -837,9 +837,9 @@ private[log] class Cleaner(val id: Int,
             logSize + segs.head.size <= maxSize &&
             indexSize + segs.head.offsetIndex.sizeInBytes <= maxIndexSize &&
             timeIndexSize + segs.head.timeIndex.sizeInBytes <= maxIndexSize &&
-            //if next Log segment is empty, no need to make sure index relative offset range.
+            //if first segment size is 0, we don't need to do the index offset range check.
             //this will avoid empty log left every 2^31 message.
-            (segs.head.size==0 ||
+            (segs.head.size == 0 ||
               lastOffsetForFirstSegment(segs, firstUncleanableOffset) - group.last.baseOffset <= Int.MaxValue)) {
         group = segs.head :: group
         logSize += segs.head.size

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1200,7 +1200,7 @@ class LogCleanerTest {
     val firstUncleanableOffset = log.logEndOffset - 1
     val notCleanableSegments = 1
 
-    assertEquals(totalSegments,log.numberOfSegments)
+    assertEquals(totalSegments, log.numberOfSegments)
     var groups = cleaner.groupSegmentsBySize(log.logSegments, maxSize = Int.MaxValue, maxIndexSize = Int.MaxValue, firstUncleanableOffset)
     //because index file uses 4 byte relative index offset and current segments all none empty,
     //segments will not group even their size is very small.

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1184,7 +1184,7 @@ class LogCleanerTest {
     val v="val".getBytes()
 
     //create 3 segments
-    for(i<-0 until 3){
+    for(i <- 0 until 3){
       log.appendAsLeader(TestUtils.singletonRecords(value = v, key = k), leaderEpoch = 0)
       //0 to Int.MaxValue is Int.MaxValue+1 message, -1 will be the last message of i-th segment
       val records = messageWithOffset(k, v, (i + 1L) * (Int.MaxValue + 1L) -1 )


### PR DESCRIPTION
more detail see jira [KAFKA-12889](https://issues.apache.org/jira/browse/KAFKA-12889)

to avoid log index 4 byte relative offset overflow, log cleaner group check log segments offset to make sure group offset range not exceed Int.MaxValue.

this offset check currentlly not cosider next is next log segment is empty, so there will left empty log files every about 2^31 messages.

the left empty logs will be reprocessed every clean cycle, which will rewrite it with same empty content, witch cause little no need io.

for __consumer_offsets topic, normally we can set cleanup.policy to compact,delete to get rid of this.

my cluster is 0.10.1.1, but after aylize trunk code, it should has same problem too.

 

some of my left empty logs,(run ls -l)

rw-r---- 1 u g 0 Dec 16 2017 00000000000000000000.index
rw-r---- 1 u g 0 Dec 16 2017 00000000000000000000.log
rw-r---- 1 u g 0 Dec 16 2017 00000000000000000000.timeindex
rw-r---- 1 u g 0 Jan  15 2018 00000000002148249632.index
rw-r---- 1 u g 0 Jan  15 2018 00000000002148249632.log
rw-r---- 1 u g 0 Jan  15 2018 00000000002148249632.timeindex
rw-r---- 1 u g 0 Jan  27 2018 00000000004295766494.index
rw-r---- 1 u g 0 Jan  27 2018 00000000004295766494.log
rw-r---- 1 u g 0 Jan  27 2018 00000000004295766494.timeindex