### PR TITLE
KAFKA-4793: Connect API to restart connector and tasks (KIP-745)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -108,7 +108,7 @@
 
     <!-- Connect -->
     <suppress checks="ClassFanOutComplexity"
-              files="(DistributedHerder|Worker).java"/>
+              files="(AbstractHerder|DistributedHerder|Worker).java"/>
     <suppress checks="ClassFanOutComplexity"
               files="Worker(|Test).java"/>
     <suppress checks="MethodLength"

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -375,7 +375,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
      * @return the restart plan, or empty if this worker has no status for the connector named in the request and therefore the
      *         connector cannot be restarted
      */
-    public Optional<RestartPlan> buildRestartPlanFor(RestartRequest request) {
+    public Optional<RestartPlan> buildRestartPlan(RestartRequest request) {
         String connectorName = request.connectorName();
         ConnectorStatus connectorStatus = statusBackingStore.get(connectorName);
         if (connectorStatus == null) {
@@ -397,20 +397,20 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
         // Collect the task states, If requested, mark the task as restarting
         List<ConnectorStateInfo.TaskState> taskStates = statusBackingStore.getAll(connectorName)
-                                                                     .stream()
-                                                                     .map(taskStatus -> {
-                                                                         AbstractStatus.State state = taskStatus.state();
-                                                                         if (request.shouldRestartTask(taskStatus)) {
-                                                                             state = AbstractStatus.State.RESTARTING;
-                                                                         }
-                                                                         return new ConnectorStateInfo.TaskState(
-                                                                                 taskStatus.id().task(),
-                                                                                 state.toString(),
-                                                                                 taskStatus.workerId(),
-                                                                                 taskStatus.trace()
-                                                                         );
-                                                                     })
-                                                                     .collect(Collectors.toList());
+                .stream()
+                .map(taskStatus -> {
+                    AbstractStatus.State state = taskStatus.state();
+                    if (request.shouldRestartTask(taskStatus)) {
+                        state = AbstractStatus.State.RESTARTING;
+                    }
+                    return new ConnectorStateInfo.TaskState(
+                            taskStatus.id().task(),
+                            state.toString(),
+                            taskStatus.workerId(),
+                            taskStatus.trace()
+                    );
+                })
+                .collect(Collectors.toList());
         // Construct the response from the various states
         Map<String, String> conf = rawConfig(connectorName);
         ConnectorStateInfo stateInfo = new ConnectorStateInfo(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -211,18 +211,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.DESTROYED, workerId, generation()));
     }
 
-    /**
-     * Invoked when the connector is restarted asynchronously by the herder on processing a restart request.
-     * @param connector The connector name
-     */
     public void onRestart(String connector) {
         statusBackingStore.put(new ConnectorStatus(connector, ConnectorStatus.State.RESTARTING,
                 workerId, generation()));
     }
-    /**
-     * Invoked when the task is restarted asynchronously by the herder on processing a restart request.
-     * @param id The id of the task
-     */
+
     public void onRestart(ConnectorTaskId id) {
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.RESTARTING, workerId, generation()));
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -384,7 +384,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
         // If requested, mark the connector as restarting
         AbstractStatus.State connectorState;
-        if (request.includeConnector(connectorStatus)) {
+        if (request.shouldRestartConnector(connectorStatus)) {
             connectorState = AbstractStatus.State.RESTARTING;
         } else {
             connectorState = connectorStatus.state();
@@ -400,7 +400,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                                                                      .stream()
                                                                      .map(taskStatus -> {
                                                                          AbstractStatus.State state = taskStatus.state();
-                                                                         if (request.includeTask(taskStatus)) {
+                                                                         if (request.shouldRestartTask(taskStatus)) {
                                                                              state = AbstractStatus.State.RESTARTING;
                                                                          }
                                                                          return new ConnectorStateInfo.TaskState(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -372,7 +372,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
      * and the current status of the connector and task instances.
      *
      * @param request the restart request; may not be null
-     * @return the restart plan, or empty this worker has no status for the connector named in the request and therefore the
+     * @return the restart plan, or empty if this worker has no status for the connector named in the request and therefore the
      *         connector cannot be restarted
      */
     public Optional<RestartPlan> buildRestartPlanFor(RestartRequest request) {
@@ -395,7 +395,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                 connectorStatus.trace()
         );
 
-        // Collect the task IDs to stop and restart (may be none)
+        // Collect the task states, If requested, mark the task as restarting
         List<ConnectorStateInfo.TaskState> taskStates = statusBackingStore.getAll(connectorName)
                                                                      .stream()
                                                                      .map(taskStatus -> {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -211,12 +211,12 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.DESTROYED, workerId, generation()));
     }
 
-    public void recordRestarting(String connector) {
+    public void onRestart(String connector) {
         statusBackingStore.put(new ConnectorStatus(connector, ConnectorStatus.State.RESTARTING,
                 workerId, generation()));
     }
 
-    public void recordRestarting(ConnectorTaskId id) {
+    public void onRestart(ConnectorTaskId id) {
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.RESTARTING, workerId, generation()));
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -211,11 +211,18 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.DESTROYED, workerId, generation()));
     }
 
+    /**
+     * Invoked when the connector is restarted asynchronously by the herder on processing a restart request.
+     * @param connector The connector name
+     */
     public void onRestart(String connector) {
         statusBackingStore.put(new ConnectorStatus(connector, ConnectorStatus.State.RESTARTING,
                 workerId, generation()));
     }
-
+    /**
+     * Invoked when the task is restarted asynchronously by the herder on processing a restart request.
+     * @param id The id of the task
+     */
     public void onRestart(ConnectorTaskId id) {
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.RESTARTING, workerId, generation()));
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -59,6 +59,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -210,6 +211,15 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         statusBackingStore.put(new TaskStatus(id, TaskStatus.State.DESTROYED, workerId, generation()));
     }
 
+    public void recordRestarting(String connector) {
+        statusBackingStore.put(new ConnectorStatus(connector, ConnectorStatus.State.RESTARTING,
+                workerId, generation()));
+    }
+
+    public void recordRestarting(ConnectorTaskId id) {
+        statusBackingStore.put(new TaskStatus(id, TaskStatus.State.RESTARTING, workerId, generation()));
+    }
+
     @Override
     public void pauseConnector(String connector) {
         if (!configBackingStore.contains(connector))
@@ -355,6 +365,62 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
                 callback.onCompletion(t, null);
             }
         });
+    }
+
+    /**
+     * Build the {@link RestartPlan} that describes what should and should not be restarted given the restart request
+     * and the current status of the connector and task instances.
+     *
+     * @param request the restart request; may not be null
+     * @return the restart plan, or empty this worker has no status for the connector named in the request and therefore the
+     *         connector cannot be restarted
+     */
+    protected Optional<RestartPlan> buildRestartPlanFor(RestartRequest request) {
+        String connectorName = request.connectorName();
+        ConnectorStatus connectorStatus = statusBackingStore.get(connectorName);
+        if (connectorStatus == null) {
+            return Optional.empty();
+        }
+
+        // If requested, mark the connector as restarting
+        AbstractStatus.State connectorState;
+        if (request.includeConnector(connectorStatus)) {
+            connectorState = AbstractStatus.State.RESTARTING;
+        } else {
+            connectorState = connectorStatus.state();
+        }
+        ConnectorStateInfo.ConnectorState connectorInfoState = new ConnectorStateInfo.ConnectorState(
+                connectorState.toString(),
+                connectorStatus.workerId(),
+                connectorStatus.trace()
+        );
+
+        // Collect the task IDs to stop and restart (may be none)
+        List<ConnectorStateInfo.TaskState> taskStates = statusBackingStore.getAll(connectorName)
+                                                                     .stream()
+                                                                     .map(taskStatus -> {
+                                                                         AbstractStatus.State state = taskStatus.state();
+                                                                         if (request.includeTask(taskStatus)) {
+                                                                             state = AbstractStatus.State.RESTARTING;
+                                                                         }
+                                                                         return new ConnectorStateInfo.TaskState(
+                                                                                 taskStatus.id().task(),
+                                                                                 state.toString(),
+                                                                                 taskStatus.workerId(),
+                                                                                 taskStatus.trace()
+                                                                         );
+                                                                     })
+                                                                     .collect(Collectors.toList());
+        // Construct the response from the various states
+        Map<String, String> conf = rawConfig(connectorName);
+        ConnectorStateInfo stateInfo = new ConnectorStateInfo(
+                connectorName,
+                connectorInfoState,
+                taskStates,
+                conf == null ? ConnectorType.UNKNOWN : connectorTypeForClass(conf.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG))
+        );
+        return Optional.of(new RestartPlan(request, stateInfo));
+
     }
 
     ConfigInfos validateConnectorConfig(Map<String, String> connectorProps, boolean doLog) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -383,12 +383,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         }
 
         // If requested, mark the connector as restarting
-        AbstractStatus.State connectorState;
-        if (request.shouldRestartConnector(connectorStatus)) {
-            connectorState = AbstractStatus.State.RESTARTING;
-        } else {
-            connectorState = connectorStatus.state();
-        }
+        AbstractStatus.State connectorState = request.shouldRestartConnector(connectorStatus) ? AbstractStatus.State.RESTARTING : connectorStatus.state();
         ConnectorStateInfo.ConnectorState connectorInfoState = new ConnectorStateInfo.ConnectorState(
                 connectorState.toString(),
                 connectorStatus.workerId(),
@@ -399,13 +394,10 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         List<ConnectorStateInfo.TaskState> taskStates = statusBackingStore.getAll(connectorName)
                 .stream()
                 .map(taskStatus -> {
-                    AbstractStatus.State state = taskStatus.state();
-                    if (request.shouldRestartTask(taskStatus)) {
-                        state = AbstractStatus.State.RESTARTING;
-                    }
+                    AbstractStatus.State taskState = request.shouldRestartTask(taskStatus) ? AbstractStatus.State.RESTARTING : taskStatus.state();
                     return new ConnectorStateInfo.TaskState(
                             taskStatus.id().task(),
-                            state.toString(),
+                            taskState.toString(),
                             taskStatus.workerId(),
                             taskStatus.trace()
                     );

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -375,7 +375,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
      * @return the restart plan, or empty this worker has no status for the connector named in the request and therefore the
      *         connector cannot be restarted
      */
-    protected Optional<RestartPlan> buildRestartPlanFor(RestartRequest request) {
+    public Optional<RestartPlan> buildRestartPlanFor(RestartRequest request) {
         String connectorName = request.connectorName();
         ConnectorStatus connectorStatus = statusBackingStore.get(connectorName);
         if (connectorStatus == null) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractStatus.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractStatus.java
@@ -26,6 +26,7 @@ public abstract class AbstractStatus<T> {
         PAUSED,
         FAILED,
         DESTROYED,
+        RESTARTING,
     }
 
     private final T id;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -49,6 +49,7 @@ public class ConnectMetricsRegistry {
     public final MetricNameTemplate connectorFailedTaskCount;
     public final MetricNameTemplate connectorUnassignedTaskCount;
     public final MetricNameTemplate connectorDestroyedTaskCount;
+    public final MetricNameTemplate connectorRestartingTaskCount;
     public final MetricNameTemplate taskStatus;
     public final MetricNameTemplate taskRunningRatio;
     public final MetricNameTemplate taskPauseRatio;
@@ -315,6 +316,9 @@ public class ConnectMetricsRegistry {
         connectorDestroyedTaskCount = createTemplate("connector-destroyed-task-count",
             WORKER_GROUP_NAME,
             "The number of destroyed tasks of the connector on the worker.", workerConnectorTags);
+        connectorRestartingTaskCount = createTemplate("connector-restarting-task-count",
+            WORKER_GROUP_NAME,
+            "The number of restarting tasks of the connector on the worker.", workerConnectorTags);
 
         connectorStatusMetrics = new HashMap<>();
         connectorStatusMetrics.put(connectorRunningTaskCount, TaskStatus.State.RUNNING);
@@ -322,6 +326,7 @@ public class ConnectMetricsRegistry {
         connectorStatusMetrics.put(connectorFailedTaskCount, TaskStatus.State.FAILED);
         connectorStatusMetrics.put(connectorUnassignedTaskCount, TaskStatus.State.UNASSIGNED);
         connectorStatusMetrics.put(connectorDestroyedTaskCount, TaskStatus.State.DESTROYED);
+        connectorStatusMetrics.put(connectorRestartingTaskCount, TaskStatus.State.RESTARTING);
         connectorStatusMetrics = Collections.unmodifiableMap(connectorStatusMetrics);
 
         /***** Worker rebalance level *****/

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorStatus.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorStatus.java
@@ -69,5 +69,10 @@ public class ConnectorStatus extends AbstractStatus<String> {
          */
         void onDeletion(String connector);
 
+        /**
+         * Invoked when the connector is restarted asynchronously by the herder on processing a restart request.
+         * @param connector The connector name
+         */
+        void onRestart(String connector);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -225,6 +225,13 @@ public interface Herder {
     HerderRequest restartConnector(long delayMs, String connName, Callback<Void> cb);
 
     /**
+     * Restart the connector and optionally its tasks.
+     * @param request the details of the restart request
+     * @param cb      callback to invoke upon completion with the connector state info
+     */
+    void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> cb);
+
+    /**
      * Pause the connector. This call will asynchronously suspend processing by the connector and all
      * of its tasks.
      * @param connector name of the connector

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -132,11 +132,7 @@ public class RestartPlan {
         return stateInfo.tasks().size();
     }
 
-    private boolean isRestarting(ConnectorStateInfo.ConnectorState state) {
-        return isRestarting(state.state());
-    }
-
-    private boolean isRestarting(ConnectorStateInfo.TaskState state) {
+    private boolean isRestarting(ConnectorStateInfo.AbstractState state) {
         return isRestarting(state.state());
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -142,13 +142,8 @@ public class RestartPlan {
 
     @Override
     public String toString() {
-        if (shouldRestartConnector()) {
-            return String.format(
-                    "plan to restart connector and %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request
-            );
-        }
-        return String.format(
-                "plan to restart %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request
-        );
+        return shouldRestartConnector()
+                ? String.format("plan to restart connector and %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request)
+                : String.format("plan to restart %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -44,6 +44,7 @@ public class RestartPlan {
     public RestartPlan(RestartRequest request, ConnectorStateInfo restartStateInfo) {
         this.request = Objects.requireNonNull(request, "RestartRequest name may not be null");
         this.stateInfo = Objects.requireNonNull(restartStateInfo, "ConnectorStateInfo name may not be null");
+        // Collect the task IDs to stop and restart (may be none)
         idsToRestart = Collections.unmodifiableList(
                 stateInfo.tasks()
                         .stream()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -109,7 +109,7 @@ public class RestartPlan {
      *
      * @return true if any {@link Task} instances are to be restarted, or false if none are to be restarted
      */
-    public boolean shouldRestartAnyTasks() {
+    public boolean shouldRestartTasks() {
         return !taskIdsToRestart().isEmpty();
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -27,7 +27,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 
 /**
- * An immutable restart plan.
+ * An immutable restart plan per connector.
  */
 public class RestartPlan {
 
@@ -36,7 +36,7 @@ public class RestartPlan {
     private final Collection<ConnectorTaskId> idsToRestart;
 
     /**
-     * Create a new request to restart a connector and optionally its tasks.
+     * Create a new plan to restart a connector and optionally its tasks.
      *
      * @param request          the restart request; may not be null
      * @param restartStateInfo the current state info for the connector; may not be null
@@ -45,7 +45,7 @@ public class RestartPlan {
         this.request = Objects.requireNonNull(request, "RestartRequest name may not be null");
         this.stateInfo = Objects.requireNonNull(restartStateInfo, "ConnectorStateInfo name may not be null");
         // Collect the task IDs to stop and restart (may be none)
-        idsToRestart = Collections.unmodifiableList(
+        this.idsToRestart = Collections.unmodifiableList(
                 stateInfo.tasks()
                         .stream()
                         .filter(this::isRestarting)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -48,7 +48,7 @@ public class RestartPlan {
         idsToRestart = Collections.unmodifiableList(
                 stateInfo.tasks()
                         .stream()
-                        .filter(taskState -> isRestarting(taskState))
+                        .filter(this::isRestarting)
                         .map(taskState -> new ConnectorTaskId(request.connectorName(), taskState.id()))
                         .collect(Collectors.toList())
         );

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -99,7 +99,7 @@ public class RestartPlan {
      *
      * @return true if the {@link Connector} instance is to be restarted, or false otherwise
      */
-    public boolean restartConnector() {
+    public boolean shouldRestartConnector() {
         return isRestarting(stateInfo.connector());
     }
 
@@ -109,7 +109,7 @@ public class RestartPlan {
      *
      * @return true if any {@link Task} instances are to be restarted, or false if none are to be restarted
      */
-    public boolean restartAnyTasks() {
+    public boolean shouldRestartAnyTasks() {
         return !taskIdsToRestart().isEmpty();
     }
 
@@ -142,7 +142,7 @@ public class RestartPlan {
 
     @Override
     public String toString() {
-        if (restartConnector()) {
+        if (shouldRestartConnector()) {
             return String.format(
                     "plan to restart connector and %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request
             );

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+
+/**
+ * An immutable restart plan.
+ */
+public class RestartPlan {
+
+    private final RestartRequest request;
+    private final ConnectorStateInfo stateInfo;
+    private final Collection<ConnectorTaskId> idsToRestart;
+
+    /**
+     * Create a new request to restart a connector and optionally its tasks.
+     *
+     * @param request          the restart request; may not be null
+     * @param restartStateInfo the current state info for the connector; may not be null
+     */
+    public RestartPlan(RestartRequest request, ConnectorStateInfo restartStateInfo) {
+        this.request = Objects.requireNonNull(request, "RestartRequest name may not be null");
+        this.stateInfo = Objects.requireNonNull(restartStateInfo, "ConnectorStateInfo name may not be null");
+        idsToRestart = Collections.unmodifiableList(
+                stateInfo.tasks()
+                         .stream()
+                         .filter(taskState -> isRestarting(taskState))
+                         .map(taskState -> new ConnectorTaskId(request.connectorName(), taskState.id()))
+                         .collect(Collectors.toList())
+        );
+    }
+
+    /**
+     * Get the connector name.
+     *
+     * @return the name of the connector; never null
+     */
+    public String connectorName() {
+        return request.connectorName();
+    }
+
+    /**
+     * Get the original {@link RestartRequest}.
+     *
+     * @return the restart request; never null
+     */
+    public RestartRequest restartRequest() {
+        return request;
+    }
+
+    /**
+     * Get the {@link ConnectorStateInfo} that reflects the current state of the connector <em>except</em> with the {@code status}
+     * set to {@link AbstractStatus.State#RESTARTING} for the {@link Connector} instance and any {@link Task} instances that
+     * are to be restarted, based upon the {@link #restartRequest() restart request}.
+     *
+     * @return the connector state info that reflects the restart plan; never null
+     */
+    public ConnectorStateInfo restartConnectorStateInfo() {
+        return stateInfo;
+    }
+
+    /**
+     * Get the immutable collection of {@link ConnectorTaskId} for all tasks to be restarted
+     * based upon the {@link #restartRequest() restart request}.
+     *
+     * @return the IDs of the tasks to be restarted; never null but possibly empty
+     */
+    public Collection<ConnectorTaskId> taskIdsToRestart() {
+        return idsToRestart;
+    }
+
+    /**
+     * Determine whether the {@link Connector} instance is to be restarted
+     * based upon the {@link #restartRequest() restart request}.
+     *
+     * @return true if the {@link Connector} instance is to be restarted, or false otherwise
+     */
+    public boolean restartConnector() {
+        return isRestarting(stateInfo.connector());
+    }
+
+    /**
+     * Determine whether at least one {@link Task} instance is to be restarted
+     * based upon the {@link #restartRequest() restart request}.
+     *
+     * @return true if any {@link Task} instances are to be restarted, or false if none are to be restarted
+     */
+    public boolean restartAnyTasks() {
+        return isRestarting(stateInfo.connector());
+    }
+
+    /**
+     * Get the number of connector tasks that are to be restarted
+     * based upon the {@link #restartRequest() restart request}.
+     *
+     * @return the number of {@link Task} instance is to be restarted
+     */
+    public int restartTaskCount() {
+        return taskIdsToRestart().size();
+    }
+
+    /**
+     * Get the total number of tasks in the connector.
+     *
+     * @return the total number of tasks
+     */
+    public int totalTaskCount() {
+        return stateInfo.tasks().size();
+    }
+
+    protected boolean isRestarting(ConnectorStateInfo.ConnectorState state) {
+        return isRestarting(state.state());
+    }
+
+    protected boolean isRestarting(ConnectorStateInfo.TaskState state) {
+        return isRestarting(state.state());
+    }
+
+    protected boolean isRestarting(String state) {
+        return AbstractStatus.State.RESTARTING.toString().equalsIgnoreCase(state);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RestartPlan that = (RestartPlan) o;
+        return Objects.equals(this.request, that.request) && Objects.equals(stateInfo, that.stateInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(request, stateInfo);
+    }
+
+    @Override
+    public String toString() {
+        if (restartConnector()) {
+            return String.format(
+                "request to restart connector '%s' and %d of %d tasks (onlyFailed=%s, includeTasks=%s)",
+                connectorName(), restartTaskCount(), totalTaskCount()
+            );
+        }
+        return String.format(
+                "request to restart %d of %d tasks for connector '%s' (onlyFailed=%s, includeTasks=%s)",
+                restartTaskCount(), totalTaskCount(), connectorName()
+        );
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -145,23 +145,6 @@ public class RestartPlan {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RestartPlan that = (RestartPlan) o;
-        return Objects.equals(this.request, that.request) && Objects.equals(stateInfo, that.stateInfo);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(request, stateInfo);
-    }
-
-    @Override
     public String toString() {
         if (restartConnector()) {
             return String.format(

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -109,7 +109,7 @@ public class RestartPlan {
      * @return true if any {@link Task} instances are to be restarted, or false if none are to be restarted
      */
     public boolean restartAnyTasks() {
-        return isRestarting(stateInfo.connector());
+        return !taskIdsToRestart().isEmpty();
     }
 
     /**
@@ -131,15 +131,15 @@ public class RestartPlan {
         return stateInfo.tasks().size();
     }
 
-    protected boolean isRestarting(ConnectorStateInfo.ConnectorState state) {
+    private boolean isRestarting(ConnectorStateInfo.ConnectorState state) {
         return isRestarting(state.state());
     }
 
-    protected boolean isRestarting(ConnectorStateInfo.TaskState state) {
+    private boolean isRestarting(ConnectorStateInfo.TaskState state) {
         return isRestarting(state.state());
     }
 
-    protected boolean isRestarting(String state) {
+    private boolean isRestarting(String state) {
         return AbstractStatus.State.RESTARTING.toString().equalsIgnoreCase(state);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -165,12 +165,12 @@ public class RestartPlan {
         if (restartConnector()) {
             return String.format(
                 "request to restart connector '%s' and %d of %d tasks (onlyFailed=%s, includeTasks=%s)",
-                connectorName(), restartTaskCount(), totalTaskCount()
+                connectorName(), restartTaskCount(), totalTaskCount(), request.onlyFailed(), request.includeTasks()
             );
         }
         return String.format(
                 "request to restart %d of %d tasks for connector '%s' (onlyFailed=%s, includeTasks=%s)",
-                restartTaskCount(), totalTaskCount(), connectorName()
+                restartTaskCount(), totalTaskCount(), connectorName(), request.onlyFailed(), request.includeTasks()
         );
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartPlan.java
@@ -46,10 +46,10 @@ public class RestartPlan {
         this.stateInfo = Objects.requireNonNull(restartStateInfo, "ConnectorStateInfo name may not be null");
         idsToRestart = Collections.unmodifiableList(
                 stateInfo.tasks()
-                         .stream()
-                         .filter(taskState -> isRestarting(taskState))
-                         .map(taskState -> new ConnectorTaskId(request.connectorName(), taskState.id()))
-                         .collect(Collectors.toList())
+                        .stream()
+                        .filter(taskState -> isRestarting(taskState))
+                        .map(taskState -> new ConnectorTaskId(request.connectorName(), taskState.id()))
+                        .collect(Collectors.toList())
         );
     }
 
@@ -164,13 +164,11 @@ public class RestartPlan {
     public String toString() {
         if (restartConnector()) {
             return String.format(
-                "request to restart connector '%s' and %d of %d tasks (onlyFailed=%s, includeTasks=%s)",
-                connectorName(), restartTaskCount(), totalTaskCount(), request.onlyFailed(), request.includeTasks()
+                    "plan to restart connector and %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request
             );
         }
         return String.format(
-                "request to restart %d of %d tasks for connector '%s' (onlyFailed=%s, includeTasks=%s)",
-                restartTaskCount(), totalTaskCount(), connectorName(), request.onlyFailed(), request.includeTasks()
+                "plan to restart %d of %d tasks for %s", restartTaskCount(), totalTaskCount(), request
         );
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -121,6 +121,23 @@ public class RestartRequest implements Comparable<RestartRequest> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RestartRequest that = (RestartRequest) o;
+        return onlyFailed == that.onlyFailed && includeTasks == that.includeTasks && Objects.equals(connectorName, that.connectorName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectorName, onlyFailed, includeTasks);
+    }
+
+    @Override
     public String toString() {
         return "restart request for {" + "connectorName='" + connectorName + "', onlyFailed=" + onlyFailed + ", includeTasks=" + includeTasks + '}';
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.connector.Task;
 
 /**
  * A request to restart a connector and/or task instances.
+ * <p>The natural order is based upon the connector name, if two requests have the same connector name, then the requests are ordered based on the probable number of tasks/connector this request is going to restart.
  */
 public class RestartRequest implements Comparable<RestartRequest> {
 
@@ -107,7 +108,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
         }
         return result;
     }
-
+    //calculates an internal rank for the restart request based on the probable number of tasks/connector this request is going to restart
     private int impactRank() {
         if (onlyFailed && !includeTasks) { //restarts only failed connector so least impactful
             return 0;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -88,7 +88,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
      *
      * @return true if only the {@link Connector} instance is to be restarted even if not failed, or false otherwise
      */
-    public boolean forciblyRestartConnectorOnly() {
+    public boolean forceRestartConnectorOnly() {
         return !onlyFailed() && !includeTasks();
     }
 
@@ -105,10 +105,7 @@ public class RestartRequest implements Comparable<RestartRequest> {
     @Override
     public int compareTo(RestartRequest o) {
         int result = connectorName.compareTo(o.connectorName);
-        if (result == 0) {
-            result = impactRank() - o.impactRank();
-        }
-        return result;
+        return result == 0 ? impactRank() - o.impactRank() : result;
     }
     //calculates an internal rank for the restart request based on the probable number of tasks/connector this request is going to restart
     private int impactRank() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import java.util.Objects;
+
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.connector.Task;
+
+/**
+ * A request to restart a connector and/or task instances.
+ *
+ * <p>Hashcode and equality are based purely upon the connector name, making it possible to use a Set to track multiple
+ * requests. For example, a {@link java.util.concurrent.ConcurrentSkipListSet} could be used to record a batch of requests,
+ * where a subsequent request to restart the same connector would overwrite the earlier request.
+ *
+ * <p>The natural order is based upon the connector name.
+ */
+public class RestartRequest implements Comparable<RestartRequest> {
+
+    private final String connectorName;
+    private final boolean onlyFailed;
+    private final boolean includeTasks;
+
+    /**
+     * Create a new request to restart a connector and optionally its tasks.
+     *
+     * @param connectorName the name of the connector; may not be null
+     * @param onlyFailed    true if only failed instances should be restarted
+     * @param includeTasks  true if tasks should be restarted, or false if only the connector should be restarted
+     */
+    public RestartRequest(String connectorName, boolean onlyFailed, boolean includeTasks) {
+        this.connectorName = Objects.requireNonNull(connectorName, "Connector name may not be null");
+        this.onlyFailed = onlyFailed;
+        this.includeTasks = includeTasks;
+    }
+
+    /**
+     * Get the name of the connector.
+     *
+     * @return the connector name; never null
+     */
+    public String connectorName() {
+        return connectorName;
+    }
+
+    /**
+     * Determine whether only failed instances be restarted.
+     *
+     * @return true if only failed instances should be restarted, or false if all applicable instances should be restarted
+     */
+    public boolean onlyFailed() {
+        return onlyFailed;
+    }
+
+    /**
+     * Determine whether {@link Task} instances should also be restarted in addition to the {@link Connector} instance.
+     *
+     * @return true if the connector and task instances should be restarted, or false if just the connector should be restarted
+     */
+    public boolean includeTasks() {
+        return includeTasks;
+    }
+
+    /**
+     * Determine whether the connector with the given status is to be restarted.
+     *
+     * @param status the connector status; may not be null
+     * @return true if the connector is to be restarted, or false otherwise
+     */
+    public boolean includeConnector(ConnectorStatus status) {
+        return !onlyFailed || status.state() == AbstractStatus.State.FAILED;
+    }
+
+    /**
+     * Determine whether only the {@link Connector} instance is to be restarted even if not failed.
+     *
+     * @return true if only the {@link Connector} instance is to be restarted even if not failed, or false otherwise
+     */
+    public boolean forciblyRestartConnectorOnly() {
+        return !onlyFailed() && !includeTasks();
+    }
+
+    /**
+     * Determine whether the task instance with the given status is to be restarted.
+     *
+     * @param status the task status; may not be null
+     * @return true if the task is to be restarted, or false otherwise
+     */
+    public boolean includeTask(TaskStatus status) {
+        return includeTasks && (!onlyFailed || status.state() == AbstractStatus.State.FAILED);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RestartRequest that = (RestartRequest) o;
+        return Objects.equals(this.connectorName, that.connectorName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectorName);
+    }
+
+    @Override
+    public int compareTo(RestartRequest o) {
+        if (o == this) {
+            return 0;
+        }
+        return connectorName.compareTo(o.connectorName());
+    }
+
+    @Override
+    public String toString() {
+        return "RestartRequest{" + "connectorName='" + connectorName + "', onlyFailed=" + onlyFailed + ", includeTasks=" + includeTasks + '}';
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -23,7 +23,9 @@ import org.apache.kafka.connect.connector.Task;
 
 /**
  * A request to restart a connector and/or task instances.
- * <p>The natural order is based upon the connector name, if two requests have the same connector name, then the requests are ordered based on the probable number of tasks/connector this request is going to restart.
+ * <p>The natural order is based first upon the connector name and then requested restart behaviors. 
+ * If two requests have the same connector name, then the requests are ordered based on the 
+ * probable number of tasks/connector this request is going to restart.
  */
 public class RestartRequest implements Comparable<RestartRequest> {
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -24,13 +24,8 @@ import org.apache.kafka.connect.connector.Task;
 /**
  * A request to restart a connector and/or task instances.
  *
- * <p>Hashcode and equality are based purely upon the connector name, making it possible to use a Set to track multiple
- * requests. For example, a {@link java.util.concurrent.ConcurrentSkipListSet} could be used to record a batch of requests,
- * where a subsequent request to restart the same connector would overwrite the earlier request.
- *
- * <p>The natural order is based upon the connector name.
  */
-public class RestartRequest implements Comparable<RestartRequest> {
+public class RestartRequest {
 
     private final String connectorName;
     private final boolean onlyFailed;
@@ -103,31 +98,6 @@ public class RestartRequest implements Comparable<RestartRequest> {
      */
     public boolean includeTask(TaskStatus status) {
         return includeTasks && (!onlyFailed || status.state() == AbstractStatus.State.FAILED);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        RestartRequest that = (RestartRequest) o;
-        return Objects.equals(this.connectorName, that.connectorName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(connectorName);
-    }
-
-    @Override
-    public int compareTo(RestartRequest o) {
-        if (o == this) {
-            return 0;
-        }
-        return connectorName.compareTo(o.connectorName());
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.connect.connector.Task;
 
 /**
  * A request to restart a connector and/or task instances.
- *
  */
 public class RestartRequest {
 
@@ -102,6 +101,6 @@ public class RestartRequest {
 
     @Override
     public String toString() {
-        return "RestartRequest{" + "connectorName='" + connectorName + "', onlyFailed=" + onlyFailed + ", includeTasks=" + includeTasks + '}';
+        return "restart request for {" + "connectorName='" + connectorName + "', onlyFailed=" + onlyFailed + ", includeTasks=" + includeTasks + '}';
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/RestartRequest.java
@@ -76,7 +76,7 @@ public class RestartRequest {
      * @param status the connector status; may not be null
      * @return true if the connector is to be restarted, or false otherwise
      */
-    public boolean includeConnector(ConnectorStatus status) {
+    public boolean shouldRestartConnector(ConnectorStatus status) {
         return !onlyFailed || status.state() == AbstractStatus.State.FAILED;
     }
 
@@ -95,7 +95,7 @@ public class RestartRequest {
      * @param status the task status; may not be null
      * @return true if the task is to be restarted, or false otherwise
      */
-    public boolean includeTask(TaskStatus status) {
+    public boolean shouldRestartTask(TaskStatus status) {
         return includeTasks && (!onlyFailed || status.state() == AbstractStatus.State.FAILED);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/StateTracker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/StateTracker.java
@@ -75,16 +75,17 @@ public class StateTracker {
         private final long pausedTotalTimeMs;
         private final long failedTotalTimeMs;
         private final long destroyedTotalTimeMs;
+        private final long restartingTotalTimeMs;
 
         /**
          * The initial StateChange instance before any state has changed.
          */
         StateChange() {
-            this(null, 0L, 0L, 0L, 0L, 0L, 0L);
+            this(null, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
         }
 
         StateChange(State state, long startTime, long unassignedTotalTimeMs, long runningTotalTimeMs,
-                            long pausedTotalTimeMs, long failedTotalTimeMs, long destroyedTotalTimeMs) {
+                            long pausedTotalTimeMs, long failedTotalTimeMs, long destroyedTotalTimeMs, long restartingTotalTimeMs) {
             this.state = state;
             this.startTime = startTime;
             this.unassignedTotalTimeMs = unassignedTotalTimeMs;
@@ -92,6 +93,7 @@ public class StateTracker {
             this.pausedTotalTimeMs = pausedTotalTimeMs;
             this.failedTotalTimeMs = failedTotalTimeMs;
             this.destroyedTotalTimeMs = destroyedTotalTimeMs;
+            this.restartingTotalTimeMs = restartingTotalTimeMs;
         }
 
         /**
@@ -104,7 +106,7 @@ public class StateTracker {
          */
         public StateChange newState(State state, long now) {
             if (this.state == null) {
-                return new StateChange(state, now, 0L, 0L, 0L, 0L, 0L);
+                return new StateChange(state, now, 0L, 0L, 0L, 0L, 0L, 0L);
             }
             if (state == this.state) {
                 return this;
@@ -114,6 +116,7 @@ public class StateTracker {
             long pausedTime = this.pausedTotalTimeMs;
             long failedTime = this.failedTotalTimeMs;
             long destroyedTime = this.destroyedTotalTimeMs;
+            long restartingTime = this.restartingTotalTimeMs;
             long duration = now - startTime;
             switch (this.state) {
                 case UNASSIGNED:
@@ -131,8 +134,11 @@ public class StateTracker {
                 case DESTROYED:
                     destroyedTime += duration;
                     break;
+                case RESTARTING:
+                    restartingTime += duration;
+                    break;
             }
-            return new StateChange(state, now, unassignedTime, runningTime, pausedTime, failedTime, destroyedTime);
+            return new StateChange(state, now, unassignedTime, runningTime, pausedTime, failedTime, destroyedTime, restartingTime);
         }
 
         /**
@@ -164,9 +170,12 @@ public class StateTracker {
                 case DESTROYED:
                     durationDesired += destroyedTotalTimeMs;
                     break;
+                case RESTARTING:
+                    durationDesired += restartingTotalTimeMs;
+                    break;
             }
             long total = durationCurrent + unassignedTotalTimeMs + runningTotalTimeMs + pausedTotalTimeMs +
-                                 failedTotalTimeMs + destroyedTotalTimeMs;
+                                 failedTotalTimeMs + destroyedTotalTimeMs + restartingTotalTimeMs;
             return total == 0.0d ? 0.0d : (double) durationDesired / total;
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TaskStatus.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TaskStatus.java
@@ -68,5 +68,11 @@ public class TaskStatus extends AbstractStatus<ConnectorTaskId> {
          * @param id The id of the task
          */
         void onDeletion(ConnectorTaskId id);
+
+        /**
+         * Invoked when the task is restarted asynchronously by the herder on processing a restart request.
+         * @param id The id of the task
+         */
+        void onRestart(ConnectorTaskId id);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -472,6 +472,12 @@ public class WorkerConnector implements Runnable {
             delegate.onDeletion(connector);
         }
 
+        @Override
+        public void onRestart(String connector) {
+            state = AbstractStatus.State.RESTARTING;
+            delegate.onRestart(connector);
+        }
+
         boolean isUnassigned() {
             return state == AbstractStatus.State.UNASSIGNED;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -434,6 +434,12 @@ abstract class WorkerTask implements Runnable {
             delegateListener.onDeletion(id);
         }
 
+        @Override
+        public void onRestart(ConnectorTaskId id) {
+            taskStateTimer.changeState(State.RESTARTING, time.milliseconds());
+            delegateListener.onRestart(id);
+        }
+
         public void recordState(TargetState state) {
             switch (state) {
                 case STARTED:

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1025,7 +1025,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 } else if (isLeader()) {
                     callback.onCompletion(new NotAssignedException("Cannot restart connector since it is not assigned to this member", member.ownerUrl(connName)), null);
                 } else {
-                    callback.onCompletion(new NotLeaderException("Cannot restart connector since it is not assigned to this member", leaderUrl()), null);
+                    callback.onCompletion(new NotLeaderException("Only the leader can process restart requests.", leaderUrl()), null);
                 }
                 return null;
             },
@@ -1102,7 +1102,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             callback.onCompletion(null, plan.restartConnectorStateInfo());
                         }
                     } else {
-                        callback.onCompletion(new NotLeaderException("Cannot restart task since it is not assigned to this member", leaderUrl()), null);
+                        callback.onCompletion(new NotLeaderException("Cannot process restart request since it is not assigned to this member", leaderUrl()), null);
                     }
 
                     return null;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1103,7 +1103,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                             callback.onCompletion(null, plan.restartConnectorStateInfo());
                         }
                     } else {
-                        callback.onCompletion(new NotLeaderException("Cannot process restart request since it is not assigned to this member", leaderUrl()), null);
+                        callback.onCompletion(new NotLeaderException("Only the leader can process restart requests.", leaderUrl()), null);
                     }
 
                     return null;
@@ -1159,7 +1159,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         if (restartConnector) {
             startConnector(connectorName, (error, targetState) -> {
                 if (error == null) {
-                    log.info("Connector {} successfully restarted", connectorName);
+                    log.info("Connector '{}' successfully restarted", connectorName);
                 } else {
                     log.error("Failed to restart connector '" + connectorName + "'", error);
                 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1099,7 +1099,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         if (!maybePlan.isPresent()) {
                             callback.onCompletion(new NotFoundException("Status for connector " + connectorName + " not found", null), null);
                         } else {
-                            // TODO: Should we update the status to RESTARTING here in addition to doRestartConnectorAndTasks
                             RestartPlan plan = maybePlan.get();
                             callback.onCompletion(null, plan.restartConnectorStateInfo());
                         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1166,9 +1166,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             });
         }
         if (restartTasks) {
-            log.debug("Restarting {} of {} tasks connector {}", plan.restartTaskCount(), plan.totalTaskCount(), connectorName);
+            log.debug("Restarting {} of {} tasks for {}", plan.restartTaskCount(), plan.totalTaskCount(), request);
             plan.taskIdsToRestart().forEach(this::startTask);
-            log.debug("{} tasks for connector {} restarted as requested ({} were left running)", plan.restartTaskCount(), plan.totalTaskCount(), connectorName);
+            log.debug("Restarted {} of {} tasks for {} as requested", plan.restartTaskCount(), plan.totalTaskCount(), request);
         }
         log.info("Completed {}", plan);
         return restartConnector || restartTasks;
@@ -1706,7 +1706,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
         @Override
         public void onRestartRequest(RestartRequest request) {
-            log.info("Received connector '{}' restart request ({})", request.connectorName(), request);
+            log.info("Received {}", request);
 
             synchronized (DistributedHerder.this) {
                 //since RestartRequest equality is based only on connector name, and we track only the latest pending restart request

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -73,6 +73,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -83,7 +84,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -195,7 +195,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
     // visible for testing
     // The latest pending restart requests for the connectors;
-    final Map<String, RestartRequest> pendingRestartRequests = new ConcurrentHashMap<>();
+    final Map<String, RestartRequest> pendingRestartRequests = new HashMap<>();
 
     private final DistributedConfig config;
 
@@ -1128,12 +1128,12 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         }
     }
 
-    protected synchronized boolean doRestartConnectorAndTasks(RestartRequest request) {
+    protected synchronized void doRestartConnectorAndTasks(RestartRequest request) {
         final String connectorName = request.connectorName();
         Optional<RestartPlan> maybePlan = buildRestartPlanFor(request);
         if (!maybePlan.isPresent()) {
             log.debug("Skipping restart of connector '{}' since no status is available: {}", connectorName, request);
-            return false;
+            return;
         }
         RestartPlan plan = maybePlan.get();
         log.info("Executing {}", plan);
@@ -1173,8 +1173,6 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.debug("Restarted {} of {} tasks for {} as requested", plan.restartTaskCount(), plan.totalTaskCount(), request);
         }
         log.info("Completed {}", plan);
-        //return value only used by tests
-        return restartConnector || restartTasks;
     }
 
     // Should only be called from work thread, so synchronization should not be needed

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1092,11 +1092,11 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                         // Write a restart request to the config backing store, to be executed asynchronously in tick()
                         configBackingStore.putRestartRequest(request);
                         // Compute and send the response that this was accepted
-                        Optional<RestartPlan> maybePlan = buildRestartPlan(request);
-                        if (!maybePlan.isPresent()) {
+                        Optional<RestartPlan> plan = buildRestartPlan(request);
+                        if (!plan.isPresent()) {
                             callback.onCompletion(new NotFoundException("Status for connector " + connectorName + " not found", null), null);
                         } else {
-                            callback.onCompletion(null, maybePlan.get().restartConnectorStateInfo());
+                            callback.onCompletion(null, plan.get().restartConnectorStateInfo());
                         }
                     } else {
                         callback.onCompletion(new NotLeaderException("Only the leader can process restart requests.", leaderUrl()), null);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1158,16 +1158,16 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 .stream()
                 .filter(taskId -> currentAssignments.tasks().contains(taskId))
                 .collect(Collectors.toList());
-        final boolean restartConnector = plan.restartConnector() && currentAssignments.connectors().contains(connectorName);
+        final boolean restartConnector = plan.shouldRestartConnector() && currentAssignments.connectors().contains(connectorName);
         final boolean restartTasks = !assignedIdsToRestart.isEmpty();
         if (restartConnector) {
             worker.stopAndAwaitConnector(connectorName);
-            recordRestarting(connectorName);
+            onRestart(connectorName);
         }
         if (restartTasks) {
             // Stop the tasks and mark as restarting
             worker.stopAndAwaitTasks(assignedIdsToRestart);
-            assignedIdsToRestart.forEach(this::recordRestarting);
+            assignedIdsToRestart.forEach(this::onRestart);
         }
 
         // Now restart the connector and tasks

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -1171,6 +1171,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
             log.debug("Restarted {} of {} tasks for {} as requested", plan.restartTaskCount(), plan.totalTaskCount(), request);
         }
         log.info("Completed {}", plan);
+        //return value only used by tests
         return restartConnector || restartTasks;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
 import org.apache.kafka.connect.runtime.distributed.RequestTargetException;
@@ -255,12 +256,29 @@ public class ConnectorsResource {
 
     @POST
     @Path("/{connector}/restart")
-    public void restartConnector(final @PathParam("connector") String connector,
+    public Response restartConnector(final @PathParam("connector") String connector,
                                  final @Context HttpHeaders headers,
+                                 final @QueryParam("includeTasks") Boolean includeTasks,
+                                 final @QueryParam("onlyFailed") Boolean onlyFailed,
                                  final @QueryParam("forward") Boolean forward) throws Throwable {
-        FutureCallback<Void> cb = new FutureCallback<>();
-        herder.restartConnector(connector, cb);
-        completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", headers, null, forward);
+        RestartRequest restartRequest = new RestartRequest(connector, onlyFailed, includeTasks);
+        if (restartRequest.forciblyRestartConnectorOnly()) {
+            // For backward compatibility, just restart the connector instance and return OK with no body
+            FutureCallback<Void> cb = new FutureCallback<>();
+            herder.restartConnector(connector, cb);
+            completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", headers, null, forward);
+            return Response.ok().build();
+        }
+
+        FutureCallback<ConnectorStateInfo> cb = new FutureCallback<>();
+        herder.restartConnectorAndTasks(restartRequest, cb);
+        Map<String, String> queryParameters = new HashMap<>();
+        queryParameters.put("includeTasks", String.valueOf(includeTasks));
+        queryParameters.put("onlyFailed", String.valueOf(onlyFailed));
+        String forwardingPath = "/connectors/" + connector + "/restart";
+        ConnectorStateInfo stateInfo = completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<ConnectorStateInfo>() {
+        }, new IdentityTranslator<>(), forward);
+        return Response.accepted().entity(stateInfo).build();
     }
 
     @PUT
@@ -348,6 +366,7 @@ public class ConnectorsResource {
                                               String path,
                                               String method,
                                               HttpHeaders headers,
+                                              Map<String, String> queryParameters,
                                               Object body,
                                               TypeReference<U> resultType,
                                               Translator<T, U> translator,
@@ -371,11 +390,13 @@ public class ConnectorsResource {
                                 "Cannot complete request momentarily due to no known leader URL, "
                                 + "likely because a rebalance was underway.");
                     }
-                    String forwardUrl = UriBuilder.fromUri(forwardedUrl)
+                    UriBuilder uriBuilder = UriBuilder.fromUri(forwardedUrl)
                             .path(path)
-                            .queryParam("forward", recursiveForward)
-                            .build()
-                            .toString();
+                            .queryParam("forward", recursiveForward);
+                    if (queryParameters != null) {
+                        queryParameters.forEach((k, v) ->  uriBuilder.queryParam(k, v));
+                    }
+                    String forwardUrl = uriBuilder.build().toString();
                     log.debug("Forwarding request {} {} {}", forwardUrl, method, body);
                     return translator.translate(RestClient.httpRequest(forwardUrl, method, headers, body, resultType, config));
                 } else {
@@ -397,6 +418,11 @@ public class ConnectorsResource {
         } catch (InterruptedException e) {
             throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request interrupted");
         }
+    }
+
+    private <T, U> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers, Object body,
+                                              TypeReference<U> resultType, Translator<T, U> translator, Boolean forward) throws Throwable {
+        return completeOrForwardRequest(cb, path, method, headers, null, body, resultType, translator, forward);
     }
 
     private <T> T completeOrForwardRequest(FutureCallback<T> cb, String path, String method, HttpHeaders headers, Object body,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.rest.resources;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.HttpHeaders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -258,8 +259,8 @@ public class ConnectorsResource {
     @Path("/{connector}/restart")
     public Response restartConnector(final @PathParam("connector") String connector,
                                  final @Context HttpHeaders headers,
-                                 final @QueryParam("includeTasks") Boolean includeTasks,
-                                 final @QueryParam("onlyFailed") Boolean onlyFailed,
+                                 final @DefaultValue ("false") @QueryParam("includeTasks") Boolean includeTasks,
+                                 final @DefaultValue ("false") @QueryParam("onlyFailed") Boolean onlyFailed,
                                  final @QueryParam("forward") Boolean forward) throws Throwable {
         RestartRequest restartRequest = new RestartRequest(connector, onlyFailed, includeTasks);
         if (restartRequest.forciblyRestartConnectorOnly()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -263,11 +263,12 @@ public class ConnectorsResource {
                                  final @DefaultValue ("false") @QueryParam("onlyFailed") Boolean onlyFailed,
                                  final @QueryParam("forward") Boolean forward) throws Throwable {
         RestartRequest restartRequest = new RestartRequest(connector, onlyFailed, includeTasks);
+        String forwardingPath = "/connectors/" + connector + "/restart";
         if (restartRequest.forciblyRestartConnectorOnly()) {
             // For backward compatibility, just restart the connector instance and return OK with no body
             FutureCallback<Void> cb = new FutureCallback<>();
             herder.restartConnector(connector, cb);
-            completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", headers, null, forward);
+            completeOrForwardRequest(cb, forwardingPath, "POST", headers, null, forward);
             return Response.ok().build();
         }
 
@@ -276,7 +277,6 @@ public class ConnectorsResource {
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put("includeTasks", String.valueOf(includeTasks));
         queryParameters.put("onlyFailed", String.valueOf(onlyFailed));
-        String forwardingPath = "/connectors/" + connector + "/restart";
         ConnectorStateInfo stateInfo = completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<ConnectorStateInfo>() {
         }, new IdentityTranslator<>(), forward);
         return Response.accepted().entity(stateInfo).build();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -264,7 +264,7 @@ public class ConnectorsResource {
                                  final @QueryParam("forward") Boolean forward) throws Throwable {
         RestartRequest restartRequest = new RestartRequest(connector, onlyFailed, includeTasks);
         String forwardingPath = "/connectors/" + connector + "/restart";
-        if (restartRequest.forciblyRestartConnectorOnly()) {
+        if (restartRequest.forceRestartConnectorOnly()) {
             // For backward compatibility, just restart the connector instance and return OK with no body
             FutureCallback<Void> cb = new FutureCallback<>();
             herder.restartConnector(connector, cb);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -259,8 +259,8 @@ public class ConnectorsResource {
     @Path("/{connector}/restart")
     public Response restartConnector(final @PathParam("connector") String connector,
                                  final @Context HttpHeaders headers,
-                                 final @DefaultValue ("false") @QueryParam("includeTasks") Boolean includeTasks,
-                                 final @DefaultValue ("false") @QueryParam("onlyFailed") Boolean onlyFailed,
+                                 final @DefaultValue("false") @QueryParam("includeTasks") Boolean includeTasks,
+                                 final @DefaultValue("false") @QueryParam("onlyFailed") Boolean onlyFailed,
                                  final @QueryParam("forward") Boolean forward) throws Throwable {
         RestartRequest restartRequest = new RestartRequest(connector, onlyFailed, includeTasks);
         String forwardingPath = "/connectors/" + connector + "/restart";
@@ -272,11 +272,12 @@ public class ConnectorsResource {
             return Response.ok().build();
         }
 
+        // In all other cases, submit the async restart request and return connector state
         FutureCallback<ConnectorStateInfo> cb = new FutureCallback<>();
         herder.restartConnectorAndTasks(restartRequest, cb);
         Map<String, String> queryParameters = new HashMap<>();
-        queryParameters.put("includeTasks", String.valueOf(includeTasks));
-        queryParameters.put("onlyFailed", String.valueOf(onlyFailed));
+        queryParameters.put("includeTasks", includeTasks.toString());
+        queryParameters.put("onlyFailed", onlyFailed.toString());
         ConnectorStateInfo stateInfo = completeOrForwardRequest(cb, forwardingPath, "POST", headers, queryParameters, null, new TypeReference<ConnectorStateInfo>() {
         }, new IdentityTranslator<>(), forward);
         return Response.accepted().entity(stateInfo).build();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -24,6 +24,8 @@ import org.apache.kafka.connect.runtime.AbstractHerder;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.HerderConnectorContext;
 import org.apache.kafka.connect.runtime.HerderRequest;
+import org.apache.kafka.connect.runtime.RestartPlan;
+import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.SessionKey;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.SourceConnectorConfig;
@@ -33,6 +35,7 @@ import org.apache.kafka.connect.runtime.distributed.ClusterConfigState;
 import org.apache.kafka.connect.runtime.rest.InternalRequestSignature;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
 import org.apache.kafka.connect.storage.ConfigBackingStore;
 import org.apache.kafka.connect.storage.MemoryConfigBackingStore;
@@ -48,6 +51,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -297,6 +301,56 @@ public class StandaloneHerder extends AbstractHerder {
         return new StandaloneHerderRequest(requestSeqNum.incrementAndGet(), future);
     }
 
+    @Override
+    public synchronized void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> cb) {
+        // Ensure the connector exists
+        String connectorName = request.connectorName();
+        configState = configBackingStore.snapshot();
+        if (!configState.contains(connectorName)) {
+            cb.onCompletion(new NotFoundException("Connector " + connectorName + " not found", null), null);
+            return;
+        }
+
+        Optional<RestartPlan> maybePlan = buildRestartPlanFor(request);
+        if (!maybePlan.isPresent()) {
+            cb.onCompletion(new NotFoundException("Status for connector " + connectorName + " not found", null), null);
+            return;
+        }
+        RestartPlan plan = maybePlan.get();
+
+        // If requested, stop the connector and any tasks, marking each as restarting
+        log.info("Received {}", plan);
+        if (plan.restartConnector()) {
+            worker.stopAndAwaitConnector(connectorName);
+            recordRestarting(connectorName);
+        }
+        if (plan.restartAnyTasks()) {
+            // Stop the tasks and mark as restarting
+            worker.stopAndAwaitTasks(plan.taskIdsToRestart());
+            plan.taskIdsToRestart().forEach(this::recordRestarting);
+        }
+
+        // Now restart the connector and tasks
+        if (plan.restartConnector()) {
+            log.debug("Restarting connector {}", connectorName);
+            startConnector(connectorName, (error, targetState) -> {
+                if (error == null) {
+                    log.debug("Connector {} successfully restarted", connectorName);
+                } else {
+                    log.debug("Connector {} failed to restart", connectorName, error);
+                }
+            });
+        }
+        if (plan.restartAnyTasks()) {
+            log.debug("Restarting {} of {} tasks connector {}", plan.restartTaskCount(), plan.totalTaskCount(), connectorName);
+            createConnectorTasks(connectorName, plan.taskIdsToRestart());
+            log.debug("{} tasks for connector {} restarted as requested ({} were left running)", plan.restartTaskCount(), plan.totalTaskCount(), connectorName);
+        }
+        // Complete the restart request
+        log.info("Completed {}", plan);
+        cb.onCompletion(null, plan.restartConnectorStateInfo());
+    }
+
     private void startConnector(String connName, Callback<TargetState> onStart) {
         Map<String, String> connConfigs = configState.connectorConfig(connName);
         TargetState targetState = configState.targetState(connName);
@@ -313,10 +367,15 @@ public class StandaloneHerder extends AbstractHerder {
         return worker.connectorTaskConfigs(connName, connConfig);
     }
 
-    private void createConnectorTasks(String connName, TargetState initialState) {
-        Map<String, String> connConfigs = configState.connectorConfig(connName);
+    private void createConnectorTasks(String connName) {
+        List<ConnectorTaskId> taskIds = configState.tasks(connName);
+        createConnectorTasks(connName, taskIds);
+    }
 
-        for (ConnectorTaskId taskId : configState.tasks(connName)) {
+    private void createConnectorTasks(String connName, Collection<ConnectorTaskId> taskIds) {
+        TargetState initialState = configState.targetState(connName);
+        Map<String, String> connConfigs = configState.connectorConfig(connName);
+        for (ConnectorTaskId taskId : taskIds) {
             Map<String, String> taskConfigMap = configState.taskConfig(taskId);
             worker.startTask(taskId, configState, connConfigs, taskConfigMap, this, initialState);
         }
@@ -344,7 +403,7 @@ public class StandaloneHerder extends AbstractHerder {
             removeConnectorTasks(connName);
             List<Map<String, String>> rawTaskConfigs = reverseTransform(connName, configState, newTaskConfigs);
             configBackingStore.putTaskConfigs(connName, rawTaskConfigs);
-            createConnectorTasks(connName, configState.targetState(connName));
+            createConnectorTasks(connName);
         }
     }
 
@@ -400,6 +459,11 @@ public class StandaloneHerder extends AbstractHerder {
 
         @Override
         public void onSessionKeyUpdate(SessionKey sessionKey) {
+            // no-op
+        }
+
+        @Override
+        public void onRestartRequest(RestartRequest restartRequest) {
             // no-op
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -323,7 +323,7 @@ public class StandaloneHerder extends AbstractHerder {
             worker.stopAndAwaitConnector(connectorName);
             onRestart(connectorName);
         }
-        if (plan.shouldRestartAnyTasks()) {
+        if (plan.shouldRestartTasks()) {
             // Stop the tasks and mark as restarting
             worker.stopAndAwaitTasks(plan.taskIdsToRestart());
             plan.taskIdsToRestart().forEach(this::onRestart);
@@ -340,7 +340,7 @@ public class StandaloneHerder extends AbstractHerder {
                 }
             });
         }
-        if (plan.shouldRestartAnyTasks()) {
+        if (plan.shouldRestartTasks()) {
             log.debug("Restarting {} of {} tasks for {}", plan.restartTaskCount(), plan.totalTaskCount(), request);
             createConnectorTasks(connectorName, plan.taskIdsToRestart());
             log.debug("Restarted {} of {} tasks for {} as requested", plan.restartTaskCount(), plan.totalTaskCount(), request);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -305,7 +305,6 @@ public class StandaloneHerder extends AbstractHerder {
     public synchronized void restartConnectorAndTasks(RestartRequest request, Callback<ConnectorStateInfo> cb) {
         // Ensure the connector exists
         String connectorName = request.connectorName();
-        configState = configBackingStore.snapshot();
         if (!configState.contains(connectorName)) {
             cb.onCompletion(new NotFoundException("Connector " + connectorName + " not found", null), null);
             return;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -341,9 +341,9 @@ public class StandaloneHerder extends AbstractHerder {
             });
         }
         if (plan.restartAnyTasks()) {
-            log.debug("Restarting {} of {} tasks connector {}", plan.restartTaskCount(), plan.totalTaskCount(), connectorName);
+            log.debug("Restarting {} of {} tasks for {}", plan.restartTaskCount(), plan.totalTaskCount(), request);
             createConnectorTasks(connectorName, plan.taskIdsToRestart());
-            log.debug("{} tasks for connector {} restarted as requested ({} were left running)", plan.restartTaskCount(), plan.totalTaskCount(), connectorName);
+            log.debug("Restarted {} of {} tasks for {} as requested", plan.restartTaskCount(), plan.totalTaskCount(), request);
         }
         // Complete the restart request
         log.info("Completed {}", plan);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -310,7 +310,7 @@ public class StandaloneHerder extends AbstractHerder {
             return;
         }
 
-        Optional<RestartPlan> maybePlan = buildRestartPlanFor(request);
+        Optional<RestartPlan> maybePlan = buildRestartPlan(request);
         if (!maybePlan.isPresent()) {
             cb.onCompletion(new NotFoundException("Status for connector " + connectorName + " not found", null), null);
             return;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -331,12 +331,12 @@ public class StandaloneHerder extends AbstractHerder {
 
         // Now restart the connector and tasks
         if (plan.restartConnector()) {
-            log.debug("Restarting connector {}", connectorName);
+            log.debug("Restarting connector '{}'", connectorName);
             startConnector(connectorName, (error, targetState) -> {
                 if (error == null) {
-                    log.debug("Connector {} successfully restarted", connectorName);
+                    log.debug("Connector '{}' successfully restarted", connectorName);
                 } else {
-                    log.debug("Connector {} failed to restart", connectorName, error);
+                    log.debug("Connector '{}' failed to restart", connectorName, error);
                 }
             });
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -334,9 +334,9 @@ public class StandaloneHerder extends AbstractHerder {
             log.debug("Restarting connector '{}'", connectorName);
             startConnector(connectorName, (error, targetState) -> {
                 if (error == null) {
-                    log.debug("Connector '{}' successfully restarted", connectorName);
+                    log.info("Connector '{}' restart successful", connectorName);
                 } else {
-                    log.debug("Connector '{}' failed to restart", connectorName, error);
+                    log.error("Connector '{}' restart failed", connectorName , error);
                 }
             });
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -336,7 +336,7 @@ public class StandaloneHerder extends AbstractHerder {
                 if (error == null) {
                     log.info("Connector '{}' restart successful", connectorName);
                 } else {
-                    log.error("Connector '{}' restart failed", connectorName , error);
+                    log.error("Connector '{}' restart failed", connectorName, error);
                 }
             });
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -306,7 +306,7 @@ public class StandaloneHerder extends AbstractHerder {
         // Ensure the connector exists
         String connectorName = request.connectorName();
         if (!configState.contains(connectorName)) {
-            cb.onCompletion(new NotFoundException("Connector " + connectorName + " not found", null), null);
+            cb.onCompletion(new NotFoundException("Unknown connector: " + connectorName, null), null);
             return;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -319,18 +319,18 @@ public class StandaloneHerder extends AbstractHerder {
 
         // If requested, stop the connector and any tasks, marking each as restarting
         log.info("Received {}", plan);
-        if (plan.restartConnector()) {
+        if (plan.shouldRestartConnector()) {
             worker.stopAndAwaitConnector(connectorName);
-            recordRestarting(connectorName);
+            onRestart(connectorName);
         }
-        if (plan.restartAnyTasks()) {
+        if (plan.shouldRestartAnyTasks()) {
             // Stop the tasks and mark as restarting
             worker.stopAndAwaitTasks(plan.taskIdsToRestart());
-            plan.taskIdsToRestart().forEach(this::recordRestarting);
+            plan.taskIdsToRestart().forEach(this::onRestart);
         }
 
         // Now restart the connector and tasks
-        if (plan.restartConnector()) {
+        if (plan.shouldRestartConnector()) {
             log.debug("Restarting connector '{}'", connectorName);
             startConnector(connectorName, (error, targetState) -> {
                 if (error == null) {
@@ -340,7 +340,7 @@ public class StandaloneHerder extends AbstractHerder {
                 }
             });
         }
-        if (plan.restartAnyTasks()) {
+        if (plan.shouldRestartAnyTasks()) {
             log.debug("Restarting {} of {} tasks for {}", plan.restartTaskCount(), plan.totalTaskCount(), request);
             createConnectorTasks(connectorName, plan.taskIdsToRestart());
             log.debug("Restarted {} of {} tasks for {} as requested", plan.restartTaskCount(), plan.totalTaskCount(), request);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/ConfigBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.SessionKey;
 import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.runtime.distributed.ClusterConfigState;
@@ -92,6 +93,12 @@ public interface ConfigBackingStore {
     void putSessionKey(SessionKey sessionKey);
 
     /**
+     * Request a restart of a connector and optionally its tasks.
+     * @param restartRequest the restart request details
+     */
+    void putRestartRequest(RestartRequest restartRequest);
+
+    /**
      * Set an update listener to get notifications when there are config/target state
      * changes.
      * @param listener non-null listener
@@ -128,6 +135,12 @@ public interface ConfigBackingStore {
          * @param sessionKey the {@link SessionKey session key}
          */
         void onSessionKeyUpdate(SessionKey sessionKey);
+
+        /**
+         * Invoked when a connector and possibly its tasks have been requested to be restarted.
+         * @param restartRequest the {@link RestartRequest restart request}
+         */
+        void onRestartRequest(RestartRequest restartRequest);
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -752,13 +752,13 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                     updateListener.onTaskConfigUpdate(updatedTasks);
             } else if (record.key().startsWith(RESTART_PREFIX)) {
                 RestartRequest request = recordToRestartRequest(record, value);
-                if (request == null) return;
-
+                if (request == null) {
+                    return;
+                }
                 // Only notify the listener if this backing store is already successfully started (having caught up the first time)
                 if (started) {
                     updateListener.onRestartRequest(request);
                 }
-
             } else if (record.key().equals(SESSION_KEY_KEY)) {
                 if (value.value() == null) {
                     log.error("Ignoring session key because it is unexpectedly null");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -484,7 +484,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
 
     @Override
     public void putRestartRequest(RestartRequest restartRequest) {
-        log.debug("Request to restart: {}", restartRequest);
+        log.debug("Writing {} to Kafka", restartRequest);
         String key = RESTART_KEY(restartRequest.connectorName());
         Struct value = new Struct(RESTART_REQUEST_V0);
         value.put("include-tasks", restartRequest.includeTasks());
@@ -494,8 +494,8 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
             configLog.send(key, serializedValue);
             configLog.readToEnd().get(READ_TO_END_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            log.error("Failed to write restart request {} to Kafka: ", restartRequest, e);
-            throw new ConnectException("Error writing restart request " + restartRequest + " to Kafka", e);
+            log.error("Failed to write {} to Kafka: ", restartRequest, e);
+            throw new ConnectException("Error writing " + restartRequest + " to Kafka", e);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -747,7 +747,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                 if (started)
                     updateListener.onTaskConfigUpdate(updatedTasks);
             } else if (record.key().startsWith(RESTART_PREFIX)) {
-                String connectorName = record.key().substring(COMMIT_TASKS_PREFIX.length());
+                String connectorName = record.key().substring(RESTART_PREFIX.length());
                 if (value.value() == null) {
                     log.error("Ignoring restart request because it is unexpectedly null");
                     return;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryConfigBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.SessionKey;
 import org.apache.kafka.connect.runtime.TargetState;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
@@ -147,6 +148,11 @@ public class MemoryConfigBackingStore implements ConfigBackingStore {
 
     @Override
     public void putSessionKey(SessionKey sessionKey) {
+        // no-op
+    }
+
+    @Override
+    public void putRestartRequest(RestartRequest restartRequest) {
         // no-op
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -75,6 +75,15 @@ public class ConnectorHandle {
     }
 
     /**
+     * Gets the start and stop counter corresponding to this handle.
+     *
+     * @return the start and stop counter
+     */
+    public StartAndStopCounter startAndStopCounter() {
+        return startAndStopCounter;
+    }
+
+    /**
      * Get the connector's name corresponding to this handle.
      *
      * @return the connector's name

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -289,6 +289,16 @@ public class ConnectorHandle {
         return startAndStopCounter.expectedStarts(expectedStarts, taskLatches);
     }
 
+    public StartAndStopLatch expectedStarts(int expectedStarts, int expectedTasksStart, boolean includeTasks) {
+        List<StartAndStopLatch> taskLatches = null;
+        if (includeTasks) {
+            taskLatches = taskHandles.values().stream()
+                    .map(task -> task.expectedStarts(expectedTasksStart))
+                    .collect(Collectors.toList());
+        }
+        return startAndStopCounter.expectedStarts(expectedStarts, taskLatches);
+    }
+
     /**
      * Obtain a {@link StartAndStopLatch} that can be used to wait until the connector using this handle
      * and optionally all tasks using {@link TaskHandle} have completed the minimum number of
@@ -343,6 +353,15 @@ public class ConnectorHandle {
         return startAndStopCounter.expectedStops(expectedStops, taskLatches);
     }
 
+    public StartAndStopLatch expectedStops(int expectedStops, int expectedTasksStop, boolean includeTasks) {
+        List<StartAndStopLatch> taskLatches = null;
+        if (includeTasks) {
+            taskLatches = taskHandles.values().stream()
+                    .map(task -> task.expectedStops(expectedTasksStop))
+                    .collect(Collectors.toList());
+        }
+        return startAndStopCounter.expectedStops(expectedStops, taskLatches);
+    }
     @Override
     public String toString() {
         return "ConnectorHandle{" +

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -280,22 +281,20 @@ public class ConnectorHandle {
      * @return the latch that can be used to wait for the starts to complete; never null
      */
     public StartAndStopLatch expectedStarts(int expectedStarts, boolean includeTasks) {
-        List<StartAndStopLatch> taskLatches = null;
-        if (includeTasks) {
-            taskLatches = taskHandles.values().stream()
-                                     .map(task -> task.expectedStarts(expectedStarts))
-                                     .collect(Collectors.toList());
-        }
+        List<StartAndStopLatch> taskLatches = includeTasks
+                ? taskHandles.values().stream()
+                .map(task -> task.expectedStarts(expectedStarts))
+                .collect(Collectors.toList())
+                : Collections.emptyList();
         return startAndStopCounter.expectedStarts(expectedStarts, taskLatches);
     }
 
     public StartAndStopLatch expectedStarts(int expectedStarts, Map<String, Integer> expectedTasksStarts, boolean includeTasks) {
-        List<StartAndStopLatch> taskLatches = null;
-        if (includeTasks) {
-            taskLatches = taskHandles.values().stream()
-                    .map(task -> task.expectedStarts(expectedTasksStarts.get(task.taskId())))
-                    .collect(Collectors.toList());
-        }
+        List<StartAndStopLatch> taskLatches = includeTasks
+                ? taskHandles.values().stream()
+                .map(task -> task.expectedStarts(expectedTasksStarts.get(task.taskId())))
+                .collect(Collectors.toList())
+                : Collections.emptyList();
         return startAndStopCounter.expectedStarts(expectedStarts, taskLatches);
     }
 
@@ -344,24 +343,23 @@ public class ConnectorHandle {
      * @return the latch that can be used to wait for the starts to complete; never null
      */
     public StartAndStopLatch expectedStops(int expectedStops, boolean includeTasks) {
-        List<StartAndStopLatch> taskLatches = null;
-        if (includeTasks) {
-            taskLatches = taskHandles.values().stream()
-                                     .map(task -> task.expectedStops(expectedStops))
-                                     .collect(Collectors.toList());
-        }
+        List<StartAndStopLatch> taskLatches = includeTasks
+                ? taskHandles.values().stream()
+                .map(task -> task.expectedStops(expectedStops))
+                .collect(Collectors.toList())
+                : Collections.emptyList();
         return startAndStopCounter.expectedStops(expectedStops, taskLatches);
     }
 
     public StartAndStopLatch expectedStops(int expectedStops, Map<String, Integer> expectedTasksStops, boolean includeTasks) {
-        List<StartAndStopLatch> taskLatches = null;
-        if (includeTasks) {
-            taskLatches = taskHandles.values().stream()
-                    .map(task -> task.expectedStops(expectedTasksStops.get(task.taskId())))
-                    .collect(Collectors.toList());
-        }
+        List<StartAndStopLatch> taskLatches = includeTasks
+                ? taskHandles.values().stream()
+                .map(task -> task.expectedStops(expectedTasksStops.get(task.taskId())))
+                .collect(Collectors.toList())
+                : Collections.emptyList();
         return startAndStopCounter.expectedStops(expectedStops, taskLatches);
     }
+
     @Override
     public String toString() {
         return "ConnectorHandle{" +

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorHandle.java
@@ -289,11 +289,11 @@ public class ConnectorHandle {
         return startAndStopCounter.expectedStarts(expectedStarts, taskLatches);
     }
 
-    public StartAndStopLatch expectedStarts(int expectedStarts, int expectedTasksStart, boolean includeTasks) {
+    public StartAndStopLatch expectedStarts(int expectedStarts, Map<String, Integer> expectedTasksStarts, boolean includeTasks) {
         List<StartAndStopLatch> taskLatches = null;
         if (includeTasks) {
             taskLatches = taskHandles.values().stream()
-                    .map(task -> task.expectedStarts(expectedTasksStart))
+                    .map(task -> task.expectedStarts(expectedTasksStarts.get(task.taskId())))
                     .collect(Collectors.toList());
         }
         return startAndStopCounter.expectedStarts(expectedStarts, taskLatches);
@@ -353,11 +353,11 @@ public class ConnectorHandle {
         return startAndStopCounter.expectedStops(expectedStops, taskLatches);
     }
 
-    public StartAndStopLatch expectedStops(int expectedStops, int expectedTasksStop, boolean includeTasks) {
+    public StartAndStopLatch expectedStops(int expectedStops, Map<String, Integer> expectedTasksStops, boolean includeTasks) {
         List<StartAndStopLatch> taskLatches = null;
         if (includeTasks) {
             taskLatches = taskHandles.values().stream()
-                    .map(task -> task.expectedStops(expectedTasksStop))
+                    .map(task -> task.expectedStops(expectedTasksStops.get(task.taskId())))
                     .collect(Collectors.toList());
         }
         return startAndStopCounter.expectedStops(expectedStops, taskLatches);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.integration;
+
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.connect.integration.MonitorableSourceConnector.TOPIC_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.TopicCreationConfig.DEFAULT_TOPIC_CREATION_PREFIX;
+import static org.apache.kafka.connect.runtime.TopicCreationConfig.PARTITIONS_CONFIG;
+import static org.apache.kafka.connect.runtime.TopicCreationConfig.REPLICATION_FACTOR_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.connect.util.clusters.EmbeddedConnectClusterAssertions.CONNECTOR_SETUP_DURATION_MS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Test connectors restart API use cases.
+ */
+@Category(IntegrationTest.class)
+public class ConnectorRestartApiIntegrationTest {
+    private static final Logger log = LoggerFactory.getLogger(ConnectorRestartApiIntegrationTest.class);
+
+    private static final long OFFSET_COMMIT_INTERVAL_MS = TimeUnit.SECONDS.toMillis(30);
+    private static final int NUM_WORKERS = 1;
+    private static final int NUM_TASKS = 4;
+    private static final int MESSAGES_PER_POLL = 10;
+    private static final String CONNECTOR_NAME = "simple-source";
+    private static final String TOPIC_NAME = "test-topic";
+
+    private EmbeddedConnectCluster.Builder connectBuilder;
+    private EmbeddedConnectCluster connect;
+    private Map<String, String> workerProps;
+    private Properties brokerProps;
+    private ConnectorHandle connectorHandle;
+
+    @Rule
+    public TestRule watcher = ConnectIntegrationTestUtils.newTestWatcher(log);
+
+    @Before
+    public void setup() {
+        // setup Connect worker properties
+        workerProps = new HashMap<>();
+        workerProps.put(OFFSET_COMMIT_INTERVAL_MS_CONFIG, String.valueOf(OFFSET_COMMIT_INTERVAL_MS));
+        workerProps.put(CONNECTOR_CLIENT_POLICY_CLASS_CONFIG, "All");
+
+        // setup Kafka broker properties
+        brokerProps = new Properties();
+        brokerProps.put("auto.create.topics.enable", String.valueOf(false));
+
+        // build a Connect cluster backed by Kafka and Zk
+        connectBuilder = new EmbeddedConnectCluster.Builder()
+                .name("connect-cluster")
+                .numWorkers(NUM_WORKERS)
+                .workerProps(workerProps)
+                .brokerProps(brokerProps)
+                .maskExitProcedures(true); // true is the default, setting here as example
+        // get connector handles before starting test.
+        connectorHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
+    }
+
+    @After
+    public void close() {
+        RuntimeHandles.get().deleteConnector(CONNECTOR_NAME);
+        // stop all Connect, Kafka and Zk threads.
+        connect.stop();
+    }
+
+    @Test
+    public void testRestartOnlyConnector() throws Exception {
+        testRestartAPI(false, false, 1, 0, false);
+    }
+
+    @Test
+    public void testRestartBoth() throws Exception {
+        testRestartAPI(false, true, 1, 1, false);
+    }
+
+    @Test
+    public void testRestartNoopConnector() throws Exception {
+        testRestartAPI(true, false, 0, 0, true);
+    }
+
+    @Test
+    public void testRestartNoopBoth() throws Exception {
+        testRestartAPI(true, true, 0, 0, true);
+    }
+
+    private void testRestartAPI(boolean onlyFailed, boolean includeTasks, int expectedConnectorRestarts, int expectedTasksRestarts, boolean noopRequest) throws Exception {
+        connect = connectBuilder.build();
+        // start the clusters
+        connect.start();
+
+        // setup up props for the source connector
+        Map<String, String> props = defaultSourceConnectorProps(TOPIC_NAME);
+
+        connect.assertions().assertExactlyNumWorkersAreUp(NUM_WORKERS,
+                "Initial group of workers did not start in time.");
+
+        // Try to start the connector and its single task.
+        connect.configureConnector(CONNECTOR_NAME, props);
+
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
+                "Connector tasks are not all in running state.");
+
+        StartAndStopCounterSnapshot beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        Map<String, StartAndStopCounterSnapshot> beforeTasksSnapshot = connectorHandle.tasks().stream().collect(Collectors.toMap(TaskHandle::taskId, task -> task.startAndStopCounter().countsSnapshot()));
+
+        StartAndStopLatch stopLatch = connectorHandle.expectedStops(expectedConnectorRestarts, includeTasks);
+        StartAndStopLatch startLatch = connectorHandle.expectedStarts(expectedConnectorRestarts, includeTasks);
+
+        // expect that the connector will be stopped once the restart request is sent
+        // Call the Restart API
+        String taskRestartEndpoint = connect.endpointForResource(
+                String.format("connectors/%s/restart?onlyFailed=" + onlyFailed + "&includeTasks=" + includeTasks, CONNECTOR_NAME));
+        connect.requestPost(taskRestartEndpoint, "", Collections.emptyMap());
+
+        if (noopRequest) {
+            //for noop requests as everything is in RUNNING state, we need to wait for CONNECTOR_SETUP_DURATION_MS to ensure no unexpected restart events were fired
+            Thread.sleep(CONNECTOR_SETUP_DURATION_MS);
+        }
+
+        // Wait for the connector to be stopped
+        assertTrue("Failed to stop connector and tasks after coordinator failure within "
+                        + CONNECTOR_SETUP_DURATION_MS + "ms",
+                stopLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+
+        connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(CONNECTOR_NAME, NUM_TASKS,
+                "Connector tasks are not all in running state.");
+        // Expect that the connector has started again
+        assertTrue("Failed to stop connector and tasks after coordinator failure within "
+                        + CONNECTOR_SETUP_DURATION_MS + "ms",
+                startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
+        StartAndStopCounterSnapshot afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+
+        assertEquals(beforeSnapshot.starts() + expectedConnectorRestarts, afterSnapshot.starts());
+        assertEquals(beforeSnapshot.stops() + expectedConnectorRestarts, afterSnapshot.stops());
+        connectorHandle.tasks().forEach(t -> {
+            StartAndStopCounterSnapshot afterTaskSnapshot = t.startAndStopCounter().countsSnapshot();
+            assertEquals(beforeTasksSnapshot.get(t.taskId()).starts() + expectedTasksRestarts, afterTaskSnapshot.starts());
+            assertEquals(beforeTasksSnapshot.get(t.taskId()).stops() + expectedTasksRestarts, afterTaskSnapshot.stops());
+        });
+    }
+
+
+    private Map<String, String> defaultSourceConnectorProps(String topic) {
+        // setup up props for the source connector
+        Map<String, String> props = new HashMap<>();
+        props.put(CONNECTOR_CLASS_CONFIG, MonitorableSourceConnector.class.getSimpleName());
+        props.put(TASKS_MAX_CONFIG, String.valueOf(NUM_TASKS));
+        props.put(TOPIC_CONFIG, topic);
+        props.put("throughput", "10");
+        props.put("messages.per.poll", String.valueOf(MESSAGES_PER_POLL));
+        props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(VALUE_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
+        props.put(DEFAULT_TOPIC_CREATION_PREFIX + REPLICATION_FACTOR_CONFIG, String.valueOf(1));
+        props.put(DEFAULT_TOPIC_CREATION_PREFIX + PARTITIONS_CONFIG, String.valueOf(1));
+        return props;
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -66,6 +66,7 @@ public class ConnectorRestartApiIntegrationTest {
     private static final int ONE_WORKER = 1;
     private static final int NUM_TASKS = 4;
     private static final int MESSAGES_PER_POLL = 10;
+    public static final long NOOP_REQUEST_SLEEP_MS = TimeUnit.SECONDS.toMillis(5);
     private static final String CONNECTOR_NAME_PREFIX = "conn-";
 
     private static final String TOPIC_NAME = "test-topic";
@@ -267,8 +268,8 @@ public class ConnectorRestartApiIntegrationTest {
         connect.requestPost(restartEndpoint, "", Collections.emptyMap());
 
         if (noopRequest) {
-            //for noop requests as everything is in RUNNING state, we need to wait for CONNECTOR_SETUP_DURATION_MS to ensure no unexpected restart events were fired
-            Thread.sleep(CONNECTOR_SETUP_DURATION_MS);
+            //for noop requests as everything is in RUNNING state, we need to wait for NOOP_REQUEST_SLEEP_MS to ensure no unexpected restart events were fired
+            Thread.sleep(NOOP_REQUEST_SLEEP_MS);
         }
 
         // Wait for the connector to be stopped
@@ -360,8 +361,8 @@ public class ConnectorRestartApiIntegrationTest {
         connect.requestPost(restartEndpoint, "", Collections.emptyMap());
 
         if (noopRequest) {
-            //for noop requests as everything is in RUNNING state, we need to wait for CONNECTOR_SETUP_DURATION_MS to ensure no unexpected restart events were fired
-            Thread.sleep(CONNECTOR_SETUP_DURATION_MS);
+            //for noop requests as everything is in RUNNING state, we need to wait for NOOP_REQUEST_SLEEP_MS to ensure no unexpected restart events were fired
+            Thread.sleep(NOOP_REQUEST_SLEEP_MS);
         }
 
         // Wait for the connector to be stopped

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -52,7 +52,6 @@ import static org.apache.kafka.connect.util.clusters.EmbeddedConnectClusterAsser
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-
 /**
  * Test connectors restart API use cases.
  */
@@ -88,7 +87,7 @@ public class ConnectorRestartApiIntegrationTest {
         brokerProps.put("auto.create.topics.enable", String.valueOf(false));
 
         // build a Connect cluster backed by Kafka and Zk
-        connectBuilder = connectBuilderWithNumWorkers(ONE_WORKER); // true is the default, setting here as example
+        connectBuilder = connectBuilderWithNumWorkers(ONE_WORKER);
         // get connector handles before starting test.
         connectorHandle = RuntimeHandles.get().connectorHandle(CONNECTOR_NAME);
     }
@@ -99,6 +98,7 @@ public class ConnectorRestartApiIntegrationTest {
                 .numWorkers(numWorkers)
                 .workerProps(workerProps)
                 .brokerProps(brokerProps)
+                // true is the default, setting here as example
                 .maskExitProcedures(true);
     }
 
@@ -146,22 +146,22 @@ public class ConnectorRestartApiIntegrationTest {
     }
 
     @Test
-    public void testRestartOnlyConnector() throws Exception {
+    public void testRunningConnectorAndTasksRestartOnlyConnector() throws Exception {
         runningConnectorAndTasksRestart(false, false, 1, allTasksExpectedRestarts(0), false);
     }
 
     @Test
-    public void testRestartBoth() throws Exception {
+    public void testRunningConnectorAndTasksRestartBothConnectorAndTasks() throws Exception {
         runningConnectorAndTasksRestart(false, true, 1, allTasksExpectedRestarts(1), false);
     }
 
     @Test
-    public void testRestartNoopOnlyConnector() throws Exception {
+    public void testRunningConnectorAndTasksRestartOnlyFailedConnectorNoop() throws Exception {
         runningConnectorAndTasksRestart(true, false, 0, allTasksExpectedRestarts(0), true);
     }
 
     @Test
-    public void testRestartNoopBoth() throws Exception {
+    public void testRunningConnectorAndTasksRestartBothConnectorAndTasksNoop() throws Exception {
         runningConnectorAndTasksRestart(true, true, 0, allTasksExpectedRestarts(0), true);
     }
 
@@ -171,12 +171,12 @@ public class ConnectorRestartApiIntegrationTest {
     }
 
     @Test
-    public void testFailedConnectorRestartBoth() throws Exception {
+    public void testFailedConnectorRestartBothConnectorAndTasks() throws Exception {
         failedConnectorRestart(false, true, 1);
     }
 
     @Test
-    public void testFailedConnectorRestartBoth2() throws Exception {
+    public void testFailedConnectorRestartOnlyFailedConnectorAndTasks() throws Exception {
         failedConnectorRestart(true, true, 1);
     }
 
@@ -191,12 +191,12 @@ public class ConnectorRestartApiIntegrationTest {
     }
 
     @Test
-    public void testFailedTasksRestartNoop() throws Exception {
+    public void testFailedTasksRestartWithoutIncludeTasksNoop() throws Exception {
         failedTasksRestart(true, false, 0, allTasksExpectedRestarts(0), buildAllTasksToFail(), true);
     }
 
     @Test
-    public void testFailedTasksRestartBoth() throws Exception {
+    public void testFailedTasksRestartBothConnectorAndTasks() throws Exception {
         failedTasksRestart(false, true, 1, allTasksExpectedRestarts(1), buildAllTasksToFail(), false);
     }
 
@@ -212,7 +212,7 @@ public class ConnectorRestartApiIntegrationTest {
     }
 
     @Test
-    public void testMultiWorkerRestartBoth() throws Exception {
+    public void testMultiWorkerRestartBothConnectorAndTasks() throws Exception {
         runningConnectorAndTasksRestart(false, true, 1, allTasksExpectedRestarts(1), false, 4);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/ConnectorRestartApiIntegrationTest.java
@@ -252,8 +252,8 @@ public class ConnectorRestartApiIntegrationTest {
         connect.assertions().assertConnectorAndAtLeastNumTasksAreRunning(connectorName, NUM_TASKS,
                 "Connector tasks are not all in running state.");
 
-        StartAndStopCounterSnapshot beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
-        Map<String, StartAndStopCounterSnapshot> beforeTasksSnapshot = connectorHandle.tasks().stream().collect(Collectors.toMap(TaskHandle::taskId, task -> task.startAndStopCounter().countsSnapshot()));
+        StartsAndStops beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        Map<String, StartsAndStops> beforeTasksSnapshot = connectorHandle.tasks().stream().collect(Collectors.toMap(TaskHandle::taskId, task -> task.startAndStopCounter().countsSnapshot()));
 
         StartAndStopLatch stopLatch = connectorHandle.expectedStops(expectedConnectorRestarts, expectedTasksRestarts, includeTasks);
         StartAndStopLatch startLatch = connectorHandle.expectedStarts(expectedConnectorRestarts, expectedTasksRestarts, includeTasks);
@@ -280,12 +280,12 @@ public class ConnectorRestartApiIntegrationTest {
         assertTrue("Failed to start connector and tasks within "
                         + CONNECTOR_SETUP_DURATION_MS + "ms",
                 startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
-        StartAndStopCounterSnapshot afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        StartsAndStops afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 
         assertEquals(beforeSnapshot.starts() + expectedConnectorRestarts, afterSnapshot.starts());
         assertEquals(beforeSnapshot.stops() + expectedConnectorRestarts, afterSnapshot.stops());
         connectorHandle.tasks().forEach(t -> {
-            StartAndStopCounterSnapshot afterTaskSnapshot = t.startAndStopCounter().countsSnapshot();
+            StartsAndStops afterTaskSnapshot = t.startAndStopCounter().countsSnapshot();
             if (numWorkers == 1) {
                 assertEquals(beforeTasksSnapshot.get(t.taskId()).starts() + expectedTasksRestarts.get(t.taskId()), afterTaskSnapshot.starts());
                 assertEquals(beforeTasksSnapshot.get(t.taskId()).stops() + expectedTasksRestarts.get(t.taskId()), afterTaskSnapshot.stops());
@@ -313,7 +313,7 @@ public class ConnectorRestartApiIntegrationTest {
         connect.assertions().assertConnectorIsFailedAndTasksHaveFailed(connectorName, 0,
                 "Connector or tasks are in running state.");
 
-        StartAndStopCounterSnapshot beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        StartsAndStops beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 
         StartAndStopLatch startLatch = connectorHandle.expectedStarts(expectedConnectorRestarts, expectedTasksStarts, includeTasks);
 
@@ -326,7 +326,7 @@ public class ConnectorRestartApiIntegrationTest {
         assertTrue("Failed to start connector and tasks after coordinator failure within "
                         + CONNECTOR_SETUP_DURATION_MS + "ms",
                 startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
-        StartAndStopCounterSnapshot afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        StartsAndStops afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 
         assertEquals(beforeSnapshot.starts() + expectedConnectorRestarts, afterSnapshot.starts());
     }
@@ -344,8 +344,8 @@ public class ConnectorRestartApiIntegrationTest {
         connect.assertions().assertConnectorIsRunningAndNumTasksHaveFailed(connectorName, NUM_TASKS, tasksToFail.size(),
                 "Connector tasks are in running state.");
 
-        StartAndStopCounterSnapshot beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
-        Map<String, StartAndStopCounterSnapshot> beforeTasksSnapshot = connectorHandle.tasks().stream().collect(Collectors.toMap(TaskHandle::taskId, task -> task.startAndStopCounter().countsSnapshot()));
+        StartsAndStops beforeSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        Map<String, StartsAndStops> beforeTasksSnapshot = connectorHandle.tasks().stream().collect(Collectors.toMap(TaskHandle::taskId, task -> task.startAndStopCounter().countsSnapshot()));
 
         StartAndStopLatch stopLatch = connectorHandle.expectedStops(expectedConnectorRestarts, expectedTasksRestarts, includeTasks);
         StartAndStopLatch startLatch = connectorHandle.expectedStarts(expectedConnectorRestarts, expectedTasksRestarts, includeTasks);
@@ -369,12 +369,12 @@ public class ConnectorRestartApiIntegrationTest {
                         + CONNECTOR_SETUP_DURATION_MS + "ms",
                 startLatch.await(CONNECTOR_SETUP_DURATION_MS, TimeUnit.MILLISECONDS));
 
-        StartAndStopCounterSnapshot afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
+        StartsAndStops afterSnapshot = connectorHandle.startAndStopCounter().countsSnapshot();
 
         assertEquals(beforeSnapshot.starts() + expectedConnectorRestarts, afterSnapshot.starts());
         assertEquals(beforeSnapshot.stops() + expectedConnectorRestarts, afterSnapshot.stops());
         connectorHandle.tasks().forEach(t -> {
-            StartAndStopCounterSnapshot afterTaskSnapshot = t.startAndStopCounter().countsSnapshot();
+            StartsAndStops afterTaskSnapshot = t.startAndStopCounter().countsSnapshot();
             assertEquals(beforeTasksSnapshot.get(t.taskId()).starts() + expectedTasksRestarts.get(t.taskId()), afterTaskSnapshot.starts());
             assertEquals(beforeTasksSnapshot.get(t.taskId()).stops() + expectedTasksRestarts.get(t.taskId()), afterTaskSnapshot.stops());
         });

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -58,6 +58,9 @@ public class MonitorableSourceConnector extends TestSourceConnector {
         commonConfigs = props;
         log.info("Started {} connector {}", this.getClass().getSimpleName(), connectorName);
         connectorHandle.recordConnectorStart();
+        if ("true".equalsIgnoreCase(props.getOrDefault("connector.start.inject.error", "false"))) {
+            throw new RuntimeException("Injecting errors during connector start");
+        }
     }
 
     @Override
@@ -121,6 +124,9 @@ public class MonitorableSourceConnector extends TestSourceConnector {
             log.info("Started {} task {} with properties {}", this.getClass().getSimpleName(), taskId, props);
             throttler = new ThroughputThrottler(throughput, System.currentTimeMillis());
             taskHandle.recordTaskStart();
+            if ("true".equalsIgnoreCase(props.getOrDefault("task.start.inject.error", "false"))) {
+                throw new RuntimeException("Injecting errors during task start");
+            }
         }
 
         @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -58,7 +58,7 @@ public class MonitorableSourceConnector extends TestSourceConnector {
         commonConfigs = props;
         log.info("Started {} connector {}", this.getClass().getSimpleName(), connectorName);
         connectorHandle.recordConnectorStart();
-        if ("true".equalsIgnoreCase(props.getOrDefault("connector.start.inject.error", "false"))) {
+        if (Boolean.parseBoolean(props.getOrDefault("connector.start.inject.error", "false"))) {
             throw new RuntimeException("Injecting errors during connector start");
         }
     }
@@ -124,7 +124,7 @@ public class MonitorableSourceConnector extends TestSourceConnector {
             log.info("Started {} task {} with properties {}", this.getClass().getSimpleName(), taskId, props);
             throttler = new ThroughputThrottler(throughput, System.currentTimeMillis());
             taskHandle.recordTaskStart();
-            if ("true".equalsIgnoreCase(props.getOrDefault("task-" + taskId + ".start.inject.error", "false"))) {
+            if (Boolean.parseBoolean(props.getOrDefault("task-" + taskId + ".start.inject.error", "false"))) {
                 throw new RuntimeException("Injecting errors during task start");
             }
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/MonitorableSourceConnector.java
@@ -124,7 +124,7 @@ public class MonitorableSourceConnector extends TestSourceConnector {
             log.info("Started {} task {} with properties {}", this.getClass().getSimpleName(), taskId, props);
             throttler = new ThroughputThrottler(throughput, System.currentTimeMillis());
             taskHandle.recordTaskStart();
-            if ("true".equalsIgnoreCase(props.getOrDefault("task.start.inject.error", "false"))) {
+            if ("true".equalsIgnoreCase(props.getOrDefault("task-" + taskId + ".start.inject.error", "false"))) {
                 throw new RuntimeException("Injecting errors during task start");
             }
         }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
@@ -72,6 +72,10 @@ public class StartAndStopCounter {
         return stopCounter.get();
     }
 
+    public StartAndStopCounterSnapshot countsSnapshot() {
+        return new StartAndStopCounterSnapshot(starts(), stops());
+    }
+
     /**
      * Obtain a {@link StartAndStopLatch} that can be used to wait until the expected number of restarts
      * has been completed.

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounter.java
@@ -72,8 +72,8 @@ public class StartAndStopCounter {
         return stopCounter.get();
     }
 
-    public StartAndStopCounterSnapshot countsSnapshot() {
-        return new StartAndStopCounterSnapshot(starts(), stops());
+    public StartsAndStops countsSnapshot() {
+        return new StartsAndStops(starts(), stops());
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounterSnapshot.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartAndStopCounterSnapshot.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.integration;
+
+public class StartAndStopCounterSnapshot {
+    private final int starts;
+    private final int stops;
+
+    public StartAndStopCounterSnapshot(int starts, int stops) {
+        this.starts = starts;
+        this.stops = stops;
+    }
+
+    public int starts() {
+        return starts;
+    }
+
+    public int stops() {
+        return stops;
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartsAndStops.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/StartsAndStops.java
@@ -17,11 +17,11 @@
 
 package org.apache.kafka.connect.integration;
 
-public class StartAndStopCounterSnapshot {
+public class StartsAndStops {
     private final int starts;
     private final int stops;
 
-    public StartAndStopCounterSnapshot(int starts, int stops) {
+    public StartsAndStops(int starts, int stops) {
         this.starts = starts;
         this.stops = stops;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/integration/TaskHandle.java
@@ -52,6 +52,10 @@ public class TaskHandle {
         this.consumer = consumer;
     }
 
+    public String taskId() {
+        return taskId;
+    }
+
     public void record() {
         record(null);
     }
@@ -209,6 +213,15 @@ public class TaskHandle {
         }
         log.debug("Task {} saw {} records, expected {} records",
                   taskId, expectedCommits - recordsToCommitLatch.getCount(), expectedCommits);
+    }
+
+    /**
+     * Gets the start and stop counter corresponding to this handle.
+     *
+     * @return the start and stop counter
+     */
+    public StartAndStopCounter startAndStopCounter() {
+        return startAndStopCounter;
     }
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -323,7 +323,7 @@ public class AbstractHerderTest {
         assertTrue(mayBeRestartPlan.isPresent());
         RestartPlan restartPlan = mayBeRestartPlan.get();
         assertTrue(restartPlan.shouldRestartConnector());
-        assertTrue(restartPlan.shouldRestartAnyTasks());
+        assertTrue(restartPlan.shouldRestartTasks());
         assertEquals(2, restartPlan.taskIdsToRestart().size());
         assertTrue(restartPlan.taskIdsToRestart().contains(taskId1));
         assertTrue(restartPlan.taskIdsToRestart().contains(taskId2));
@@ -365,7 +365,7 @@ public class AbstractHerderTest {
         assertTrue(mayBeRestartPlan.isPresent());
         RestartPlan restartPlan = mayBeRestartPlan.get();
         assertFalse(restartPlan.shouldRestartConnector());
-        assertFalse(restartPlan.shouldRestartAnyTasks());
+        assertFalse(restartPlan.shouldRestartTasks());
         assertTrue(restartPlan.taskIdsToRestart().isEmpty());
 
         PowerMock.verifyAll();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -269,8 +269,8 @@ public class AbstractHerderTest {
     }
 
     @Test
-    public void testBuildRestartPlanForMissingConnector() {
-        String connectorName = "InvalidConnector";
+    public void testBuildRestartPlanForUnknownConnector() {
+        String connectorName = "UnknownConnector";
         RestartRequest restartRequest = new RestartRequest(connectorName, false, true);
         AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
                 .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -322,8 +322,8 @@ public class AbstractHerderTest {
 
         assertTrue(mayBeRestartPlan.isPresent());
         RestartPlan restartPlan = mayBeRestartPlan.get();
-        assertTrue(restartPlan.restartConnector());
-        assertTrue(restartPlan.restartAnyTasks());
+        assertTrue(restartPlan.shouldRestartConnector());
+        assertTrue(restartPlan.shouldRestartAnyTasks());
         assertEquals(2, restartPlan.taskIdsToRestart().size());
         assertTrue(restartPlan.taskIdsToRestart().contains(taskId1));
         assertTrue(restartPlan.taskIdsToRestart().contains(taskId2));
@@ -364,8 +364,8 @@ public class AbstractHerderTest {
 
         assertTrue(mayBeRestartPlan.isPresent());
         RestartPlan restartPlan = mayBeRestartPlan.get();
-        assertFalse(restartPlan.restartConnector());
-        assertFalse(restartPlan.restartAnyTasks());
+        assertFalse(restartPlan.shouldRestartConnector());
+        assertFalse(restartPlan.shouldRestartAnyTasks());
         assertTrue(restartPlan.taskIdsToRestart().isEmpty());
 
         PowerMock.verifyAll();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -284,7 +284,7 @@ public class AbstractHerderTest {
         EasyMock.expect(statusStore.get(connectorName)).andReturn(null);
         replayAll();
 
-        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlanFor(restartRequest);
+        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlan(restartRequest);
 
         assertFalse(mayBeRestartPlan.isPresent());
     }
@@ -318,7 +318,7 @@ public class AbstractHerderTest {
 
         replayAll();
 
-        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlanFor(restartRequest);
+        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlan(restartRequest);
 
         assertTrue(mayBeRestartPlan.isPresent());
         RestartPlan restartPlan = mayBeRestartPlan.get();
@@ -360,7 +360,7 @@ public class AbstractHerderTest {
 
         replayAll();
 
-        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlanFor(restartRequest);
+        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlan(restartRequest);
 
         assertTrue(mayBeRestartPlan.isPresent());
         RestartPlan restartPlan = mayBeRestartPlan.get();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -62,6 +62,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -267,6 +268,108 @@ public class AbstractHerderTest {
         verifyAll();
     }
 
+    @Test
+    public void testBuildRestartPlanForMissingConnector() {
+        String connectorName = "InvalidConnector";
+        RestartRequest restartRequest = new RestartRequest(connectorName, false, true);
+        AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
+                .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
+                        ConnectorClientConfigOverridePolicy.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                .addMockedMethod("generation")
+                .createMock();
+
+        EasyMock.expect(herder.generation()).andStubReturn(generation);
+
+        EasyMock.expect(statusStore.get(connectorName)).andReturn(null);
+        replayAll();
+
+        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlanFor(restartRequest);
+
+        assertFalse(mayBeRestartPlan.isPresent());
+    }
+
+    @Test
+    public void testBuildRestartPlanForConnectorAndTasks() {
+        RestartRequest restartRequest = new RestartRequest(connector, false, true);
+
+        ConnectorTaskId taskId1 = new ConnectorTaskId(connector, 1);
+        ConnectorTaskId taskId2 = new ConnectorTaskId(connector, 2);
+        List<TaskStatus> taskStatuses = new ArrayList<>();
+        taskStatuses.add(new TaskStatus(taskId1, AbstractStatus.State.RUNNING, workerId, generation));
+        taskStatuses.add(new TaskStatus(taskId2, AbstractStatus.State.FAILED, workerId, generation));
+
+        AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
+                .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
+                        ConnectorClientConfigOverridePolicy.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                .addMockedMethod("generation")
+                .createMock();
+
+        EasyMock.expect(herder.generation()).andStubReturn(generation);
+        EasyMock.expect(herder.rawConfig(connector)).andReturn(null);
+
+        EasyMock.expect(statusStore.get(connector))
+                .andReturn(new ConnectorStatus(connector, AbstractStatus.State.RUNNING, workerId, generation));
+
+        EasyMock.expect(statusStore.getAll(connector))
+                .andReturn(taskStatuses);
+        EasyMock.expect(worker.getPlugins()).andStubReturn(plugins);
+
+        replayAll();
+
+        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlanFor(restartRequest);
+
+        assertTrue(mayBeRestartPlan.isPresent());
+        RestartPlan restartPlan = mayBeRestartPlan.get();
+        assertTrue(restartPlan.restartConnector());
+        assertTrue(restartPlan.restartAnyTasks());
+        assertEquals(2, restartPlan.taskIdsToRestart().size());
+        assertTrue(restartPlan.taskIdsToRestart().contains(taskId1));
+        assertTrue(restartPlan.taskIdsToRestart().contains(taskId2));
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testBuildRestartPlanForNoRestart() {
+        RestartRequest restartRequest = new RestartRequest(connector, true, false);
+
+        ConnectorTaskId taskId1 = new ConnectorTaskId(connector, 1);
+        ConnectorTaskId taskId2 = new ConnectorTaskId(connector, 2);
+        List<TaskStatus> taskStatuses = new ArrayList<>();
+        taskStatuses.add(new TaskStatus(taskId1, AbstractStatus.State.RUNNING, workerId, generation));
+        taskStatuses.add(new TaskStatus(taskId2, AbstractStatus.State.FAILED, workerId, generation));
+
+        AbstractHerder herder = partialMockBuilder(AbstractHerder.class)
+                .withConstructor(Worker.class, String.class, String.class, StatusBackingStore.class, ConfigBackingStore.class,
+                        ConnectorClientConfigOverridePolicy.class)
+                .withArgs(worker, workerId, kafkaClusterId, statusStore, configStore, noneConnectorClientConfigOverridePolicy)
+                .addMockedMethod("generation")
+                .createMock();
+
+        EasyMock.expect(herder.generation()).andStubReturn(generation);
+        EasyMock.expect(herder.rawConfig(connector)).andReturn(null);
+
+        EasyMock.expect(statusStore.get(connector))
+                .andReturn(new ConnectorStatus(connector, AbstractStatus.State.RUNNING, workerId, generation));
+
+        EasyMock.expect(statusStore.getAll(connector))
+                .andReturn(taskStatuses);
+        EasyMock.expect(worker.getPlugins()).andStubReturn(plugins);
+
+        replayAll();
+
+        Optional<RestartPlan> mayBeRestartPlan = herder.buildRestartPlanFor(restartRequest);
+
+        assertTrue(mayBeRestartPlan.isPresent());
+        RestartPlan restartPlan = mayBeRestartPlan.get();
+        assertFalse(restartPlan.restartConnector());
+        assertFalse(restartPlan.restartAnyTasks());
+        assertTrue(restartPlan.taskIdsToRestart().isEmpty());
+
+        PowerMock.verifyAll();
+    }
 
     @Test
     public void testConfigValidationEmptyConfig() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
@@ -54,7 +54,7 @@ public class RestartPlanTest {
         assertTrue(restartPlan.restartAnyTasks());
         assertEquals(1, restartPlan.taskIdsToRestart().size());
         assertEquals(3, restartPlan.taskIdsToRestart().iterator().next().task());
-        assertTrue(restartPlan.toString().contains("request to restart connector"));
+        assertTrue(restartPlan.toString().contains("plan to restart connector"));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class RestartPlanTest {
         assertFalse(restartPlan.restartConnector());
         assertFalse(restartPlan.restartAnyTasks());
         assertEquals(0, restartPlan.taskIdsToRestart().size());
-        assertTrue(restartPlan.toString().contains("request to restart 0 of"));
+        assertTrue(restartPlan.toString().contains("plan to restart 0 of"));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
@@ -50,8 +50,8 @@ public class RestartPlanTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
 
-        assertTrue(restartPlan.restartConnector());
-        assertTrue(restartPlan.restartAnyTasks());
+        assertTrue(restartPlan.shouldRestartConnector());
+        assertTrue(restartPlan.shouldRestartAnyTasks());
         assertEquals(1, restartPlan.taskIdsToRestart().size());
         assertEquals(3, restartPlan.taskIdsToRestart().iterator().next().task());
         assertTrue(restartPlan.toString().contains("plan to restart connector"));
@@ -71,8 +71,8 @@ public class RestartPlanTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
 
-        assertFalse(restartPlan.restartConnector());
-        assertFalse(restartPlan.restartAnyTasks());
+        assertFalse(restartPlan.shouldRestartConnector());
+        assertFalse(restartPlan.shouldRestartAnyTasks());
         assertEquals(0, restartPlan.taskIdsToRestart().size());
         assertTrue(restartPlan.toString().contains("plan to restart 0 of"));
     }
@@ -91,8 +91,8 @@ public class RestartPlanTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
 
-        assertTrue(restartPlan.restartConnector());
-        assertFalse(restartPlan.restartAnyTasks());
+        assertTrue(restartPlan.shouldRestartConnector());
+        assertFalse(restartPlan.shouldRestartAnyTasks());
         assertEquals(0, restartPlan.taskIdsToRestart().size());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo.TaskState;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RestartPlanTest {
+    private static final String CONNECTOR_NAME = "foo";
+
+    @Test
+    public void testRestartPlan() {
+        ConnectorStateInfo.ConnectorState state = new ConnectorStateInfo.ConnectorState(
+                AbstractStatus.State.RESTARTING.name(),
+                "foo",
+                null
+        );
+        List<TaskState> tasks = new ArrayList<>();
+        tasks.add(new TaskState(1, AbstractStatus.State.RUNNING.name(), "worker1", null));
+        tasks.add(new TaskState(2, AbstractStatus.State.PAUSED.name(), "worker1", null));
+        tasks.add(new TaskState(3, AbstractStatus.State.RESTARTING.name(), "worker1", null));
+        tasks.add(new TaskState(4, AbstractStatus.State.DESTROYED.name(), "worker1", null));
+        tasks.add(new TaskState(5, AbstractStatus.State.RUNNING.name(), "worker1", null));
+        tasks.add(new TaskState(6, AbstractStatus.State.RUNNING.name(), "worker1", null));
+        ConnectorStateInfo connectorStateInfo = new ConnectorStateInfo(CONNECTOR_NAME, state, tasks, ConnectorType.SOURCE);
+
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
+
+        assertTrue(restartPlan.restartConnector());
+        assertTrue(restartPlan.restartAnyTasks());
+        assertEquals(1, restartPlan.taskIdsToRestart().size());
+        assertEquals(3, restartPlan.taskIdsToRestart().iterator().next().task());
+    }
+
+    @Test
+    public void testNoRestartsPlan() {
+        ConnectorStateInfo.ConnectorState state = new ConnectorStateInfo.ConnectorState(
+                AbstractStatus.State.RUNNING.name(),
+                "foo",
+                null
+        );
+        List<TaskState> tasks = new ArrayList<>();
+        tasks.add(new TaskState(1, AbstractStatus.State.RUNNING.name(), "worker1", null));
+        tasks.add(new TaskState(2, AbstractStatus.State.PAUSED.name(), "worker1", null));
+        ConnectorStateInfo connectorStateInfo = new ConnectorStateInfo(CONNECTOR_NAME, state, tasks, ConnectorType.SOURCE);
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
+
+        assertFalse(restartPlan.restartConnector());
+        assertFalse(restartPlan.restartAnyTasks());
+        assertEquals(0, restartPlan.taskIdsToRestart().size());
+    }
+
+    @Test
+    public void testRestartsOnlyConnector() {
+        ConnectorStateInfo.ConnectorState state = new ConnectorStateInfo.ConnectorState(
+                AbstractStatus.State.RESTARTING.name(),
+                "foo",
+                null
+        );
+        List<TaskState> tasks = new ArrayList<>();
+        tasks.add(new TaskState(1, AbstractStatus.State.RUNNING.name(), "worker1", null));
+        tasks.add(new TaskState(2, AbstractStatus.State.PAUSED.name(), "worker1", null));
+        ConnectorStateInfo connectorStateInfo = new ConnectorStateInfo(CONNECTOR_NAME, state, tasks, ConnectorType.SOURCE);
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
+
+        assertTrue(restartPlan.restartConnector());
+        assertFalse(restartPlan.restartAnyTasks());
+        assertEquals(0, restartPlan.taskIdsToRestart().size());
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
@@ -51,7 +51,7 @@ public class RestartPlanTest {
         RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
 
         assertTrue(restartPlan.shouldRestartConnector());
-        assertTrue(restartPlan.shouldRestartAnyTasks());
+        assertTrue(restartPlan.shouldRestartTasks());
         assertEquals(1, restartPlan.taskIdsToRestart().size());
         assertEquals(3, restartPlan.taskIdsToRestart().iterator().next().task());
         assertTrue(restartPlan.toString().contains("plan to restart connector"));
@@ -72,7 +72,7 @@ public class RestartPlanTest {
         RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
 
         assertFalse(restartPlan.shouldRestartConnector());
-        assertFalse(restartPlan.shouldRestartAnyTasks());
+        assertFalse(restartPlan.shouldRestartTasks());
         assertEquals(0, restartPlan.taskIdsToRestart().size());
         assertTrue(restartPlan.toString().contains("plan to restart 0 of"));
     }
@@ -92,7 +92,7 @@ public class RestartPlanTest {
         RestartPlan restartPlan = new RestartPlan(restartRequest, connectorStateInfo);
 
         assertTrue(restartPlan.shouldRestartConnector());
-        assertFalse(restartPlan.shouldRestartAnyTasks());
+        assertFalse(restartPlan.shouldRestartTasks());
         assertEquals(0, restartPlan.taskIdsToRestart().size());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartPlanTest.java
@@ -54,6 +54,7 @@ public class RestartPlanTest {
         assertTrue(restartPlan.restartAnyTasks());
         assertEquals(1, restartPlan.taskIdsToRestart().size());
         assertEquals(3, restartPlan.taskIdsToRestart().iterator().next().task());
+        assertTrue(restartPlan.toString().contains("request to restart connector"));
     }
 
     @Test
@@ -73,6 +74,7 @@ public class RestartPlanTest {
         assertFalse(restartPlan.restartConnector());
         assertFalse(restartPlan.restartAnyTasks());
         assertEquals(0, restartPlan.taskIdsToRestart().size());
+        assertTrue(restartPlan.toString().contains("request to restart 0 of"));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
@@ -18,6 +18,11 @@ package org.apache.kafka.connect.runtime;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -79,6 +84,22 @@ public class RestartRequestTest {
         assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.RUNNING)));
     }
 
+    @Test
+    public void compareImpact() {
+        RestartRequest onlyFailedConnector = new RestartRequest(CONNECTOR_NAME, true, false);
+        RestartRequest failedConnectorAndTasks = new RestartRequest(CONNECTOR_NAME, true, true);
+        RestartRequest onlyConnector = new RestartRequest(CONNECTOR_NAME, false, false);
+        RestartRequest connectorAndTasks = new RestartRequest(CONNECTOR_NAME, false, true);
+        List<RestartRequest> restartRequests = Arrays.asList(connectorAndTasks, onlyConnector, onlyFailedConnector, failedConnectorAndTasks);
+        Collections.sort(restartRequests);
+        assertEquals(onlyFailedConnector, restartRequests.get(0));
+        assertEquals(failedConnectorAndTasks, restartRequests.get(1));
+        assertEquals(onlyConnector, restartRequests.get(2));
+        assertEquals(connectorAndTasks, restartRequests.get(3));
+
+        RestartRequest onlyFailedDiffConnector = new RestartRequest(CONNECTOR_NAME + "foo", true, false);
+        assertTrue(onlyFailedConnector.compareTo(onlyFailedDiffConnector) != 0);
+    }
 
     private TaskStatus createTaskStatus(AbstractStatus.State state) {
         return new TaskStatus(null, state, null, 0);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
@@ -32,13 +32,13 @@ public class RestartRequestTest {
     @Test
     public void forciblyRestartConnectorOnly() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, false);
-        assertTrue(restartRequest.forciblyRestartConnectorOnly());
+        assertTrue(restartRequest.forceRestartConnectorOnly());
         restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        assertFalse(restartRequest.forciblyRestartConnectorOnly());
+        assertFalse(restartRequest.forceRestartConnectorOnly());
         restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        assertFalse(restartRequest.forciblyRestartConnectorOnly());
+        assertFalse(restartRequest.forceRestartConnectorOnly());
         restartRequest = new RestartRequest(CONNECTOR_NAME, true, true);
-        assertFalse(restartRequest.forciblyRestartConnectorOnly());
+        assertFalse(restartRequest.forceRestartConnectorOnly());
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
@@ -39,44 +39,44 @@ public class RestartRequestTest {
     @Test
     public void restartOnlyFailedConnector() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.FAILED)));
-        assertFalse(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.RUNNING)));
-        assertFalse(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.PAUSED)));
+        assertTrue(restartRequest.shouldRestartConnector(createConnectorStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.shouldRestartConnector(createConnectorStatus(AbstractStatus.State.RUNNING)));
+        assertFalse(restartRequest.shouldRestartConnector(createConnectorStatus(AbstractStatus.State.PAUSED)));
     }
 
     @Test
     public void restartAnyStatusConnector() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, false);
-        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.FAILED)));
-        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.RUNNING)));
-        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.PAUSED)));
+        assertTrue(restartRequest.shouldRestartConnector(createConnectorStatus(AbstractStatus.State.FAILED)));
+        assertTrue(restartRequest.shouldRestartConnector(createConnectorStatus(AbstractStatus.State.RUNNING)));
+        assertTrue(restartRequest.shouldRestartConnector(createConnectorStatus(AbstractStatus.State.PAUSED)));
     }
 
     @Test
     public void restartOnlyFailedTasks() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, true);
-        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
-        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
-        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.PAUSED)));
+        assertTrue(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+        assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.PAUSED)));
     }
 
     @Test
     public void restartAnyStatusTasks() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
-        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
-        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.PAUSED)));
+        assertTrue(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertTrue(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+        assertTrue(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.PAUSED)));
     }
 
     @Test
     public void doNotRestartTasks() {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, false);
-        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
-        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+        assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.RUNNING)));
 
         restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
-        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
-        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+        assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.shouldRestartTask(createTaskStatus(AbstractStatus.State.RUNNING)));
     }
 
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/RestartRequestTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RestartRequestTest {
+    private static final String CONNECTOR_NAME = "foo";
+
+    @Test
+    public void forciblyRestartConnectorOnly() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, false);
+        assertTrue(restartRequest.forciblyRestartConnectorOnly());
+        restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        assertFalse(restartRequest.forciblyRestartConnectorOnly());
+        restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
+        assertFalse(restartRequest.forciblyRestartConnectorOnly());
+        restartRequest = new RestartRequest(CONNECTOR_NAME, true, true);
+        assertFalse(restartRequest.forciblyRestartConnectorOnly());
+    }
+
+    @Test
+    public void restartOnlyFailedConnector() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
+        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.RUNNING)));
+        assertFalse(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.PAUSED)));
+    }
+
+    @Test
+    public void restartAnyStatusConnector() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, false);
+        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.FAILED)));
+        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.RUNNING)));
+        assertTrue(restartRequest.includeConnector(createConnectorStatus(AbstractStatus.State.PAUSED)));
+    }
+
+    @Test
+    public void restartOnlyFailedTasks() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, true);
+        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.PAUSED)));
+    }
+
+    @Test
+    public void restartAnyStatusTasks() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+        assertTrue(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.PAUSED)));
+    }
+
+    @Test
+    public void doNotRestartTasks() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, false);
+        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+
+        restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
+        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.FAILED)));
+        assertFalse(restartRequest.includeTask(createTaskStatus(AbstractStatus.State.RUNNING)));
+    }
+
+
+    private TaskStatus createTaskStatus(AbstractStatus.State state) {
+        return new TaskStatus(null, state, null, 0);
+    }
+
+    private ConnectorStatus createConnectorStatus(AbstractStatus.State state) {
+        return new ConnectorStatus(null, state, null, 0);
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/StateTrackerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/StateTrackerTest.java
@@ -62,6 +62,7 @@ public class StateTrackerTest {
         assertEquals(0.0d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.RESTARTING, time.milliseconds()), DELTA);
 
         tracker.changeState(State.RUNNING, time.milliseconds());
         time.sleep(3000L);
@@ -70,6 +71,7 @@ public class StateTrackerTest {
         assertEquals(0.0d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.RESTARTING, time.milliseconds()), DELTA);
 
         tracker.changeState(State.PAUSED, time.milliseconds());
         time.sleep(4000L);
@@ -78,6 +80,7 @@ public class StateTrackerTest {
         assertEquals(0.500d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.RESTARTING, time.milliseconds()), DELTA);
 
         tracker.changeState(State.RUNNING, time.milliseconds());
         time.sleep(8000L);
@@ -86,6 +89,7 @@ public class StateTrackerTest {
         assertEquals(0.2500d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.RESTARTING, time.milliseconds()), DELTA);
 
         tracker.changeState(State.FAILED, time.milliseconds());
         time.sleep(16000L);
@@ -94,6 +98,7 @@ public class StateTrackerTest {
         assertEquals(0.12500d, tracker.durationRatio(State.PAUSED, time.milliseconds()), DELTA);
         assertEquals(0.50000d, tracker.durationRatio(State.FAILED, time.milliseconds()), DELTA);
         assertEquals(0.0d, tracker.durationRatio(State.DESTROYED, time.milliseconds()), DELTA);
+        assertEquals(0.0d, tracker.durationRatio(State.RESTARTING, time.milliseconds()), DELTA);
 
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -2798,14 +2798,14 @@ public class DistributedHerderTest {
         restartRequest = new RestartRequest(connectorName, false, true);
         configUpdateListener.onRestartRequest(restartRequest);
         assertEquals(1, herder.pendingRestartRequests.size());
-        assertFalse(herder.pendingRestartRequests.first().onlyFailed());
-        assertTrue(herder.pendingRestartRequests.first().includeTasks());
+        assertFalse(herder.pendingRestartRequests.get(connectorName).onlyFailed());
+        assertTrue(herder.pendingRestartRequests.get(connectorName).includeTasks());
 
         restartRequest = new RestartRequest(connectorName, true, false);
         configUpdateListener.onRestartRequest(restartRequest);
         assertEquals(1, herder.pendingRestartRequests.size());
-        assertTrue(herder.pendingRestartRequests.first().onlyFailed());
-        assertFalse(herder.pendingRestartRequests.first().includeTasks());
+        assertTrue(herder.pendingRestartRequests.get(connectorName).onlyFailed());
+        assertFalse(herder.pendingRestartRequests.get(connectorName).includeTasks());
     }
 
     // We need to use a real class here due to some issue with mocking java.lang.Class

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1247,8 +1247,8 @@ public class DistributedHerderTest {
         ConnectorTaskId taskId = new ConnectorTaskId(CONN1, 0);
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
 
         EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
@@ -1264,8 +1264,8 @@ public class DistributedHerderTest {
         ConnectorTaskId taskId = new ConnectorTaskId(CONN1, 0);
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
 
         EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
@@ -1282,7 +1282,7 @@ public class DistributedHerderTest {
                 EasyMock.eq(herder), EasyMock.anyObject(TargetState.class), capture(stateCallback));
 
 
-        herder.recordRestarting(CONN1);
+        herder.onRestart(CONN1);
         EasyMock.expectLastCall();
 
         PowerMock.replayAll();
@@ -1295,8 +1295,8 @@ public class DistributedHerderTest {
         ConnectorTaskId taskId = new ConnectorTaskId(CONN1, 0);
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
@@ -1309,7 +1309,7 @@ public class DistributedHerderTest {
         worker.stopAndAwaitTasks(Collections.singletonList(taskId));
         PowerMock.expectLastCall();
 
-        herder.recordRestarting(taskId);
+        herder.onRestart(taskId);
         EasyMock.expectLastCall();
 
         worker.startTask(EasyMock.eq(TASK0), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),
@@ -1326,8 +1326,8 @@ public class DistributedHerderTest {
         ConnectorTaskId taskId = new ConnectorTaskId(CONN1, 0);
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
@@ -1345,13 +1345,13 @@ public class DistributedHerderTest {
                 EasyMock.eq(herder), EasyMock.anyObject(TargetState.class), capture(stateCallback));
 
 
-        herder.recordRestarting(CONN1);
+        herder.onRestart(CONN1);
         EasyMock.expectLastCall();
 
         worker.stopAndAwaitTasks(Collections.singletonList(taskId));
         PowerMock.expectLastCall();
 
-        herder.recordRestarting(taskId);
+        herder.onRestart(taskId);
         EasyMock.expectLastCall();
 
         worker.startTask(EasyMock.eq(TASK0), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(),

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1238,7 +1238,7 @@ public class DistributedHerderTest {
 
         PowerMock.replayAll();
 
-        assertFalse(herder.doRestartConnectorAndTasks(restartRequest));
+        herder.doRestartConnectorAndTasks(restartRequest);
         PowerMock.verifyAll();
     }
 
@@ -1255,7 +1255,7 @@ public class DistributedHerderTest {
 
         PowerMock.replayAll();
         herder.assignment = ExtendedAssignment.empty();
-        assertFalse(herder.doRestartConnectorAndTasks(restartRequest));
+        herder.doRestartConnectorAndTasks(restartRequest);
         PowerMock.verifyAll();
     }
 
@@ -1286,7 +1286,7 @@ public class DistributedHerderTest {
         EasyMock.expectLastCall();
 
         PowerMock.replayAll();
-        assertTrue(herder.doRestartConnectorAndTasks(restartRequest));
+        herder.doRestartConnectorAndTasks(restartRequest);
         PowerMock.verifyAll();
     }
 
@@ -1317,7 +1317,7 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall().andReturn(true);
 
         PowerMock.replayAll();
-        assertTrue(herder.doRestartConnectorAndTasks(restartRequest));
+        herder.doRestartConnectorAndTasks(restartRequest);
         PowerMock.verifyAll();
     }
 
@@ -1359,7 +1359,7 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall().andReturn(true);
 
         PowerMock.replayAll();
-        assertTrue(herder.doRestartConnectorAndTasks(restartRequest));
+        herder.doRestartConnectorAndTasks(restartRequest);
         PowerMock.verifyAll();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1248,7 +1248,7 @@ public class DistributedHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
 
         EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
@@ -1265,7 +1265,7 @@ public class DistributedHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
 
         EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
@@ -1296,7 +1296,7 @@ public class DistributedHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
@@ -1327,7 +1327,7 @@ public class DistributedHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -1160,7 +1160,7 @@ public class DistributedHerderTest {
     @Test
     public void testRestartConnectorAndTasksUnknownStatus() throws Exception {
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.empty()).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.empty()).anyTimes();
 
         configBackingStore.putRestartRequest(restartRequest);
         PowerMock.expectLastCall();
@@ -1200,7 +1200,7 @@ public class DistributedHerderTest {
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
 
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
 
         configBackingStore.putRestartRequest(restartRequest);
         PowerMock.expectLastCall();
@@ -1234,7 +1234,7 @@ public class DistributedHerderTest {
     @Test
     public void testDoRestartConnectorAndTasksEmptyPlan() throws Exception {
         RestartRequest restartRequest = new RestartRequest(CONN1, false, true);
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.empty()).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.empty()).anyTimes();
 
         PowerMock.replayAll();
 
@@ -1251,7 +1251,7 @@ public class DistributedHerderTest {
         EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
 
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
 
         PowerMock.replayAll();
         herder.assignment = ExtendedAssignment.empty();
@@ -1268,7 +1268,7 @@ public class DistributedHerderTest {
         EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
 
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
 
         herder.assignment = PowerMock.createMock(ExtendedAssignment.class);
         EasyMock.expect(herder.assignment.connectors()).andReturn(Collections.singletonList(CONN1)).anyTimes();
@@ -1300,7 +1300,7 @@ public class DistributedHerderTest {
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
 
         herder.assignment = PowerMock.createMock(ExtendedAssignment.class);
         EasyMock.expect(herder.assignment.connectors()).andReturn(Collections.emptyList()).anyTimes();
@@ -1331,7 +1331,7 @@ public class DistributedHerderTest {
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.of(restartPlan)).anyTimes();
 
         herder.assignment = PowerMock.createMock(ExtendedAssignment.class);
         EasyMock.expect(herder.assignment.connectors()).andReturn(Collections.singletonList(CONN1)).anyTimes();
@@ -2792,7 +2792,7 @@ public class DistributedHerderTest {
 
         final String connectorName = "foo";
         RestartRequest restartRequest = new RestartRequest(connectorName, false, false);
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andThrow(new RuntimeException()).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andThrow(new RuntimeException()).anyTimes();
 
         PowerMock.replayAll();
 
@@ -2807,7 +2807,7 @@ public class DistributedHerderTest {
         member.wakeup();
         PowerMock.expectLastCall().anyTimes();
 
-        EasyMock.expect(herder.buildRestartPlanFor(EasyMock.anyObject(RestartRequest.class))).andReturn(Optional.empty()).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(EasyMock.anyObject(RestartRequest.class))).andReturn(Optional.empty()).anyTimes();
 
         PowerMock.replayAll();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -224,7 +224,7 @@ public class DistributedHerderTest {
         connectProtocolVersion = CONNECT_PROTOCOL_V0;
 
         herder = PowerMock.createPartialMock(DistributedHerder.class,
-                new String[]{"connectorTypeForClass", "updateDeletedConnectorStatus", "updateDeletedTaskStatus", "validateConnectorConfig", "buildRestartPlanFor", "recordRestarting"},
+                new String[]{"connectorTypeForClass", "updateDeletedConnectorStatus", "updateDeletedTaskStatus", "validateConnectorConfig", "buildRestartPlan", "recordRestarting"},
                 new DistributedConfig(HERDER_CONFIG), worker, WORKER_ID, KAFKA_CLUSTER_ID,
                 statusBackingStore, configBackingStore, member, MEMBER_URL, metrics, time, noneConnectorClientConfigOverridePolicy,
                 new AutoCloseable[]{uponShutdown});

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -2821,7 +2821,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void preserveOnlyLatestRestartRequest() {
+    public void preserveHighestImpactRestartRequest() {
         member.wakeup();
         PowerMock.expectLastCall().anyTimes();
         PowerMock.replayAll();
@@ -2830,17 +2830,20 @@ public class DistributedHerderTest {
         RestartRequest restartRequest = new RestartRequest(connectorName, false, false);
         configUpdateListener.onRestartRequest(restartRequest);
 
+        //will overwrite as this is higher impact
         restartRequest = new RestartRequest(connectorName, false, true);
         configUpdateListener.onRestartRequest(restartRequest);
         assertEquals(1, herder.pendingRestartRequests.size());
         assertFalse(herder.pendingRestartRequests.get(connectorName).onlyFailed());
         assertTrue(herder.pendingRestartRequests.get(connectorName).includeTasks());
 
+        //will be ignored as the existing request has higher impact
         restartRequest = new RestartRequest(connectorName, true, false);
         configUpdateListener.onRestartRequest(restartRequest);
         assertEquals(1, herder.pendingRestartRequests.size());
-        assertTrue(herder.pendingRestartRequests.get(connectorName).onlyFailed());
-        assertFalse(herder.pendingRestartRequests.get(connectorName).includeTasks());
+        //compare against existing request
+        assertFalse(herder.pendingRestartRequests.get(connectorName).onlyFailed());
+        assertTrue(herder.pendingRestartRequests.get(connectorName).includeTasks());
     }
 
     // We need to use a real class here due to some issue with mocking java.lang.Class

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -820,7 +820,7 @@ public class ConnectorsResourceTest {
         ConnectRestException ex = assertThrows(ConnectRestException.class, () ->
                 connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), FORWARD)
         );
-        assertEquals(ex.statusCode(), Response.Status.CONFLICT.getStatusCode());
+        assertEquals(Response.Status.CONFLICT.getStatusCode(), ex.statusCode());
         PowerMock.verifyAll();
     }
 
@@ -843,7 +843,7 @@ public class ConnectorsResourceTest {
         Response response = connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), FORWARD);
         assertEquals(CONNECTOR_NAME, ((ConnectorStateInfo) response.getEntity()).name());
         assertEquals(state.state(), ((ConnectorStateInfo) response.getEntity()).connector().state());
-        assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+        assertEquals(Response.Status.ACCEPTED.getStatusCode(), response.getStatus());
         PowerMock.verifyAll();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.connect.errors.AlreadyExistsException;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
+import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.NotAssignedException;
 import org.apache.kafka.connect.runtime.distributed.NotLeaderException;
@@ -772,6 +773,40 @@ public class ConnectorsResourceTest {
     }
 
     @Test
+    public void testRestartConnectorAndTasksConnectorNotFound() {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
+        final Capture<Callback<ConnectorStateInfo>> cb = Capture.newInstance();
+        herder.restartConnectorAndTasks(EasyMock.eq(restartRequest), EasyMock.capture(cb));
+        expectAndCallbackException(cb, new NotFoundException("not found"));
+
+        PowerMock.replayAll();
+
+        assertThrows(NotFoundException.class, () ->
+                connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), FORWARD)
+        );
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testRestartConnectorAndTasksLeaderRedirect() throws Throwable {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, true, false);
+        final Capture<Callback<ConnectorStateInfo>> cb = Capture.newInstance();
+        herder.restartConnectorAndTasks(EasyMock.eq(restartRequest), EasyMock.capture(cb));
+        expectAndCallbackNotLeaderException(cb);
+
+        EasyMock.expect(RestClient.httpRequest(EasyMock.eq("http://leader:8083/connectors/" + CONNECTOR_NAME + "/restart?forward=true&includeTasks=" + restartRequest.includeTasks() + "&onlyFailed=" + restartRequest.onlyFailed()),
+                EasyMock.eq("POST"), EasyMock.isNull(), EasyMock.isNull(), EasyMock.<TypeReference>anyObject(), EasyMock.anyObject(WorkerConfig.class)))
+                .andReturn(new RestClient.HttpResponse<>(202, new HashMap<>(), null));
+
+        PowerMock.replayAll();
+
+        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, restartRequest.includeTasks(), restartRequest.onlyFailed(), null);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
     public void testRestartConnectorNotFound() {
         final Capture<Callback<Void>> cb = Capture.newInstance();
         herder.restartConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
@@ -779,7 +814,9 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        assertThrows(NotFoundException.class, () -> connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, FORWARD));
+        assertThrows(NotFoundException.class, () ->
+                connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, FORWARD)
+        );
 
         PowerMock.verifyAll();
     }
@@ -796,7 +833,7 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, null);
+        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, null);
 
         PowerMock.verifyAll();
     }
@@ -814,7 +851,7 @@ public class ConnectorsResourceTest {
 
         PowerMock.replayAll();
 
-        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, true);
+        connectorsResource.restartConnector(CONNECTOR_NAME, NULL_HEADERS, false, false, true);
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -441,7 +441,7 @@ public class StandaloneHerderTest {
     @Test
     public void testRestartConnectorAndTasksNoStatus() throws Exception {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.empty()).anyTimes();
+        EasyMock.expect(herder.buildRestartPlan(restartRequest)).andReturn(Optional.empty()).anyTimes();
 
         connector = PowerMock.createMock(BogusSinkConnector.class);
         expectAdd(SourceSink.SINK);
@@ -471,7 +471,7 @@ public class StandaloneHerderTest {
         EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+        EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
         connector = PowerMock.createMock(BogusSinkConnector.class);
@@ -501,7 +501,7 @@ public class StandaloneHerderTest {
         EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+        EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
         herder.recordRestarting(CONNECTOR_NAME);
@@ -549,7 +549,7 @@ public class StandaloneHerderTest {
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+        EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
         herder.recordRestarting(taskId);
@@ -600,7 +600,7 @@ public class StandaloneHerderTest {
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+        EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
         herder.recordRestarting(CONNECTOR_NAME);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -126,7 +126,7 @@ public class StandaloneHerderTest {
     @Before
     public void setup() {
         worker = PowerMock.createMock(Worker.class);
-        String[] methodNames = new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/, "buildRestartPlanFor", "recordRestarting"};
+        String[] methodNames = new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/, "buildRestartPlan", "recordRestarting"};
         herder = PowerMock.createPartialMock(StandaloneHerder.class, methodNames,
                 worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
         createCallback = new FutureCallback<>();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -31,6 +31,8 @@ import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.ConnectorStatus;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.HerderConnectorContext;
+import org.apache.kafka.connect.runtime.RestartPlan;
+import org.apache.kafka.connect.runtime.RestartRequest;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.SourceConnectorConfig;
 import org.apache.kafka.connect.runtime.TargetState;
@@ -44,6 +46,7 @@ import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
 import org.apache.kafka.connect.runtime.rest.errors.BadRequestException;
@@ -74,6 +77,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -94,9 +98,7 @@ import static org.junit.Assert.fail;
 @PrepareForTest({StandaloneHerder.class, Plugins.class, WorkerConnector.class})
 public class StandaloneHerderTest {
     private static final String CONNECTOR_NAME = "test";
-    private static final List<String> TOPICS_LIST = Arrays.asList("topic1", "topic2");
     private static final String TOPICS_LIST_STR = "topic1,topic2";
-    private static final int DEFAULT_MAX_TASKS = 1;
     private static final String WORKER_ID = "localhost:8083";
     private static final String KAFKA_CLUSTER_ID = "I4ZmrWqfT2e-upky_4fdPA";
 
@@ -124,8 +126,7 @@ public class StandaloneHerderTest {
     @Before
     public void setup() {
         worker = PowerMock.createMock(Worker.class);
-        herder = PowerMock.createPartialMock(StandaloneHerder.class, new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/},
-            worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
+        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/});
         createCallback = new FutureCallback<>();
         plugins = PowerMock.createMock(Plugins.class);
         pluginLoader = PowerMock.createMock(PluginClassLoader.class);
@@ -134,6 +135,11 @@ public class StandaloneHerderTest {
         PowerMock.mockStatic(WorkerConnector.class);
         Capture<Map<String, String>> configCapture = Capture.newInstance();
         EasyMock.expect(transformer.transform(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(configCapture))).andAnswer(configCapture::getValue).anyTimes();
+    }
+
+    private StandaloneHerder getStandaloneHerderPartialMock(String[] methodNames) {
+        return PowerMock.createPartialMock(StandaloneHerder.class, methodNames,
+                worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
     }
 
     @Test
@@ -419,6 +425,175 @@ public class StandaloneHerderTest {
             assertEquals(ConnectException.class, exception.getCause().getClass());
         }
 
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testRestartConnectorAndTasksUnknownConnector() throws Exception {
+        PowerMock.replayAll();
+
+        FutureCallback<ConnectorStateInfo> restartCallback = new FutureCallback<>();
+        RestartRequest restartRequest = new RestartRequest("UnknownConnector", false, true);
+        herder.restartConnectorAndTasks(restartRequest, restartCallback);
+        ExecutionException ee = assertThrows(ExecutionException.class, () -> restartCallback.get(1000L, TimeUnit.MILLISECONDS));
+        assertTrue(ee.getCause() instanceof NotFoundException);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testRestartConnectorAndTasksNoStatus() throws Exception {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor"});
+        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+                .andReturn(Optional.empty()).anyTimes();
+
+        connector = PowerMock.createMock(BogusSinkConnector.class);
+        expectAdd(SourceSink.SINK);
+
+        Map<String, String> config = connectorConfig(SourceSink.SINK);
+        Connector connectorMock = PowerMock.createMock(SinkConnector.class);
+        expectConfigValidation(connectorMock, true, config);
+        PowerMock.replayAll();
+
+        herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SINK), connectorInfo.result());
+
+        FutureCallback<ConnectorStateInfo> restartCallback = new FutureCallback<>();
+        herder.restartConnectorAndTasks(restartRequest, restartCallback);
+        ExecutionException ee = assertThrows(ExecutionException.class, () -> restartCallback.get(1000L, TimeUnit.MILLISECONDS));
+        assertTrue(ee.getCause() instanceof NotFoundException);
+        assertTrue(ee.getMessage().contains("Status for connector"));
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testRestartConnectorAndTasksNoRestarts() throws Exception {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor"});
+        RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
+        ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
+        EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
+        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+                .andReturn(Optional.of(restartPlan)).anyTimes();
+
+        connector = PowerMock.createMock(BogusSinkConnector.class);
+        expectAdd(SourceSink.SINK);
+
+        Map<String, String> config = connectorConfig(SourceSink.SINK);
+        Connector connectorMock = PowerMock.createMock(SinkConnector.class);
+        expectConfigValidation(connectorMock, true, config);
+
+        PowerMock.replayAll();
+
+        herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SINK), connectorInfo.result());
+
+        FutureCallback<ConnectorStateInfo> restartCallback = new FutureCallback<>();
+        herder.restartConnectorAndTasks(restartRequest, restartCallback);
+        assertEquals(connectorStateInfo, restartCallback.get(1000L, TimeUnit.MILLISECONDS));
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testRestartConnectorAndTasksOnlyConnectorRestart() throws Exception {
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor", "recordRestarting"});
+        RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
+        ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
+        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
+        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+                .andReturn(Optional.of(restartPlan)).anyTimes();
+
+        herder.recordRestarting(CONNECTOR_NAME);
+        EasyMock.expectLastCall();
+
+        connector = PowerMock.createMock(BogusSinkConnector.class);
+        expectAdd(SourceSink.SINK);
+
+        Map<String, String> config = connectorConfig(SourceSink.SINK);
+        Connector connectorMock = PowerMock.createMock(SinkConnector.class);
+        expectConfigValidation(connectorMock, true, config);
+
+        worker.stopAndAwaitConnector(CONNECTOR_NAME);
+        EasyMock.expectLastCall();
+
+        Capture<Callback<TargetState>> onStart = EasyMock.newCapture();
+        worker.startConnector(EasyMock.eq(CONNECTOR_NAME), EasyMock.eq(config), EasyMock.anyObject(HerderConnectorContext.class),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED), EasyMock.capture(onStart));
+        EasyMock.expectLastCall().andAnswer(() -> {
+            onStart.getValue().onCompletion(null, TargetState.STARTED);
+            return true;
+        });
+
+        PowerMock.replayAll();
+
+        herder.putConnectorConfig(CONNECTOR_NAME, config, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SINK), connectorInfo.result());
+
+        FutureCallback<ConnectorStateInfo> restartCallback = new FutureCallback<>();
+        herder.restartConnectorAndTasks(restartRequest, restartCallback);
+        assertEquals(connectorStateInfo, restartCallback.get(1000L, TimeUnit.MILLISECONDS));
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testRestartConnectorAndTasksOnlyTasksRestart() throws Exception {
+        ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
+        RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
+        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor", "recordRestarting"});
+        RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
+        ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
+        EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
+        EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
+        EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
+        EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
+        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
+                .andReturn(Optional.of(restartPlan)).anyTimes();
+
+        herder.recordRestarting(taskId);
+        EasyMock.expectLastCall();
+
+        connector = PowerMock.createMock(BogusSinkConnector.class);
+        expectAdd(SourceSink.SINK);
+
+        Map<String, String> connectorConfig = connectorConfig(SourceSink.SINK);
+        Connector connectorMock = PowerMock.createMock(SinkConnector.class);
+        expectConfigValidation(connectorMock, true, connectorConfig);
+
+        worker.stopAndAwaitTasks(Collections.singletonList(taskId));
+        EasyMock.expectLastCall();
+
+        ClusterConfigState configState = new ClusterConfigState(
+                -1,
+                null,
+                Collections.singletonMap(CONNECTOR_NAME, 1),
+                Collections.singletonMap(CONNECTOR_NAME, connectorConfig),
+                Collections.singletonMap(CONNECTOR_NAME, TargetState.STARTED),
+                Collections.singletonMap(taskId, taskConfig(SourceSink.SINK)),
+                new HashSet<>(),
+                transformer);
+
+        worker.startTask(taskId, configState, connectorConfig, taskConfig(SourceSink.SINK), herder, TargetState.STARTED);
+        EasyMock.expectLastCall().andReturn(true);
+        PowerMock.replayAll();
+
+        herder.putConnectorConfig(CONNECTOR_NAME, connectorConfig, false, createCallback);
+        Herder.Created<ConnectorInfo> connectorInfo = createCallback.get(1000L, TimeUnit.SECONDS);
+        assertEquals(createdInfo(SourceSink.SINK), connectorInfo.result());
+
+        FutureCallback<ConnectorStateInfo> restartCallback = new FutureCallback<>();
+        herder.restartConnectorAndTasks(restartRequest, restartCallback);
+        assertEquals(connectorStateInfo, restartCallback.get(1000L, TimeUnit.MILLISECONDS));
         PowerMock.verifyAll();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -469,7 +469,7 @@ public class StandaloneHerderTest {
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(false).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
         EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
@@ -499,7 +499,7 @@ public class StandaloneHerderTest {
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
         EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
@@ -544,7 +544,7 @@ public class StandaloneHerderTest {
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(false).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
@@ -595,7 +595,7 @@ public class StandaloneHerderTest {
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -468,8 +468,8 @@ public class StandaloneHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
         EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
@@ -498,13 +498,13 @@ public class StandaloneHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(false).anyTimes();
         EasyMock.expect(restartPlan.restartConnectorStateInfo()).andReturn(connectorStateInfo).anyTimes();
         EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
-        herder.recordRestarting(CONNECTOR_NAME);
+        herder.onRestart(CONNECTOR_NAME);
         EasyMock.expectLastCall();
 
         connector = PowerMock.createMock(BogusSinkConnector.class);
@@ -543,8 +543,8 @@ public class StandaloneHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(false).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
@@ -552,7 +552,7 @@ public class StandaloneHerderTest {
         EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
-        herder.recordRestarting(taskId);
+        herder.onRestart(taskId);
         EasyMock.expectLastCall();
 
         connector = PowerMock.createMock(BogusSinkConnector.class);
@@ -594,8 +594,8 @@ public class StandaloneHerderTest {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
-        EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
-        EasyMock.expect(restartPlan.restartAnyTasks()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartConnector()).andReturn(true).anyTimes();
+        EasyMock.expect(restartPlan.shouldRestartAnyTasks()).andReturn(true).anyTimes();
         EasyMock.expect(restartPlan.restartTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.totalTaskCount()).andReturn(1).anyTimes();
         EasyMock.expect(restartPlan.taskIdsToRestart()).andReturn(Collections.singletonList(taskId)).anyTimes();
@@ -603,9 +603,9 @@ public class StandaloneHerderTest {
         EasyMock.expect(herder.buildRestartPlan(restartRequest))
                 .andReturn(Optional.of(restartPlan)).anyTimes();
 
-        herder.recordRestarting(CONNECTOR_NAME);
+        herder.onRestart(CONNECTOR_NAME);
         EasyMock.expectLastCall();
-        herder.recordRestarting(taskId);
+        herder.onRestart(taskId);
         EasyMock.expectLastCall();
 
         connector = PowerMock.createMock(BogusSinkConnector.class);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -126,7 +126,9 @@ public class StandaloneHerderTest {
     @Before
     public void setup() {
         worker = PowerMock.createMock(Worker.class);
-        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/});
+        String[] methodNames = new String[]{"connectorTypeForClass"/*, "validateConnectorConfig"*/, "buildRestartPlanFor", "recordRestarting"};
+        herder = PowerMock.createPartialMock(StandaloneHerder.class, methodNames,
+                worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
         createCallback = new FutureCallback<>();
         plugins = PowerMock.createMock(Plugins.class);
         pluginLoader = PowerMock.createMock(PluginClassLoader.class);
@@ -135,11 +137,6 @@ public class StandaloneHerderTest {
         PowerMock.mockStatic(WorkerConnector.class);
         Capture<Map<String, String>> configCapture = Capture.newInstance();
         EasyMock.expect(transformer.transform(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(configCapture))).andAnswer(configCapture::getValue).anyTimes();
-    }
-
-    private StandaloneHerder getStandaloneHerderPartialMock(String[] methodNames) {
-        return PowerMock.createPartialMock(StandaloneHerder.class, methodNames,
-                worker, WORKER_ID, KAFKA_CLUSTER_ID, statusBackingStore, new MemoryConfigBackingStore(transformer), noneConnectorClientConfigOverridePolicy);
     }
 
     @Test
@@ -444,9 +441,7 @@ public class StandaloneHerderTest {
     @Test
     public void testRestartConnectorAndTasksNoStatus() throws Exception {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor"});
-        EasyMock.expect(herder.buildRestartPlanFor(restartRequest))
-                .andReturn(Optional.empty()).anyTimes();
+        EasyMock.expect(herder.buildRestartPlanFor(restartRequest)).andReturn(Optional.empty()).anyTimes();
 
         connector = PowerMock.createMock(BogusSinkConnector.class);
         expectAdd(SourceSink.SINK);
@@ -471,7 +466,6 @@ public class StandaloneHerderTest {
     @Test
     public void testRestartConnectorAndTasksNoRestarts() throws Exception {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor"});
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
@@ -502,7 +496,6 @@ public class StandaloneHerderTest {
     @Test
     public void testRestartConnectorAndTasksOnlyConnector() throws Exception {
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor", "recordRestarting"});
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();
@@ -548,7 +541,6 @@ public class StandaloneHerderTest {
     public void testRestartConnectorAndTasksOnlyTasks() throws Exception {
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor", "recordRestarting"});
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.restartConnector()).andReturn(false).anyTimes();
@@ -600,7 +592,6 @@ public class StandaloneHerderTest {
     public void testRestartConnectorAndTasksBoth() throws Exception {
         ConnectorTaskId taskId = new ConnectorTaskId(CONNECTOR_NAME, 0);
         RestartRequest restartRequest = new RestartRequest(CONNECTOR_NAME, false, true);
-        herder = getStandaloneHerderPartialMock(new String[]{"connectorTypeForClass", "buildRestartPlanFor", "recordRestarting"});
         RestartPlan restartPlan = PowerMock.createMock(RestartPlan.class);
         ConnectorStateInfo connectorStateInfo = PowerMock.createMock(ConnectorStateInfo.class);
         EasyMock.expect(restartPlan.restartConnector()).andReturn(true).anyTimes();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -453,8 +453,6 @@ public class EmbeddedConnectCluster {
                 if (response.getStatus() == Response.Status.ACCEPTED.getStatusCode()) {
                     return mapper.readerFor(ConnectorStateInfo.class)
                             .readValue(responseToString(response));
-                } else {
-                    return null;
                 }
             }
             return null;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectCluster.java
@@ -430,7 +430,10 @@ public class EmbeddedConnectCluster {
     /**
      * Restart an existing connector and its tasks.
      *
-     * @param connName name of the connector to be restarted
+     * @param connName  name of the connector to be restarted
+     * @param onlyFailed    true if only failed instances should be restarted
+     * @param includeTasks  true if tasks should be restarted, or false if only the connector should be restarted
+     * @param onlyCallOnEmptyWorker true if the REST API call should be called on a worker not running this connector or its tasks
      * @throws ConnectRestException if the REST API returns error status
      * @throws ConnectException for any other error.
      */
@@ -439,7 +442,7 @@ public class EmbeddedConnectCluster {
         String restartPath = String.format("connectors/%s/restart?onlyFailed=" + onlyFailed + "&includeTasks=" + includeTasks, connName);
         String restartEndpoint;
         if (onlyCallOnEmptyWorker) {
-            restartEndpoint = endpointForWorkerRunningNoResourceForConnector(restartPath, connName);
+            restartEndpoint = endpointForResourceNotRunningConnector(restartPath, connName);
         } else {
             restartEndpoint = endpointForResource(restartPath);
         }
@@ -601,7 +604,7 @@ public class EmbeddedConnectCluster {
      * @return the admin endpoint URL
      * @throws ConnectException if no REST endpoint is available
      */
-    public String endpointForWorkerRunningNoResourceForConnector(String resource, String connectorName) {
+    public String endpointForResourceNotRunningConnector(String resource, String connectorName) {
         ConnectorStateInfo info = connectorStatus(connectorName);
         Set<String> activeWorkerUrls = new HashSet<>();
         activeWorkerUrls.add(String.format("http://%s/", info.connector().workerId()));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -351,6 +351,33 @@ public class EmbeddedConnectClusterAssertions {
     }
 
     /**
+     * Assert that a connector is in FAILED state, that it has a specific number of tasks, and that all of
+     * its tasks are in the FAILED state.
+     *
+     * @param connectorName the connector name
+     * @param numTasks the number of tasks
+     * @param detailMessage the assertion message
+     * @throws InterruptedException
+     */
+    public void assertConnectorIsFailedAndTasksHaveFailed(String connectorName, int numTasks, String detailMessage)
+            throws InterruptedException {
+        try {
+            waitForCondition(
+                    () -> checkConnectorState(
+                            connectorName,
+                            AbstractStatus.State.FAILED,
+                            numTasks,
+                            AbstractStatus.State.FAILED,
+                            (actual, expected) -> actual >= expected
+                    ).orElse(false),
+                    CONNECTOR_SETUP_DURATION_MS,
+                    "Either the connector is running or not all the " + numTasks + " tasks have failed.");
+        } catch (AssertionError e) {
+            throw new AssertionError(detailMessage, e);
+        }
+    }
+
+    /**
      * Assert that a connector and its tasks are not running.
      *
      * @param connectorName the connector name

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/clusters/EmbeddedConnectClusterAssertions.java
@@ -351,6 +351,34 @@ public class EmbeddedConnectClusterAssertions {
     }
 
     /**
+     * Assert that a connector is running, that it has a specific number of tasks out of that numFailedTasks are in the FAILED state.
+     *
+     * @param connectorName the connector name
+     * @param numTasks the number of tasks
+     * @param numFailedTasks the number of failed tasks
+     * @param detailMessage the assertion message
+     * @throws InterruptedException
+     */
+    public void assertConnectorIsRunningAndNumTasksHaveFailed(String connectorName, int numTasks, int numFailedTasks, String detailMessage)
+            throws InterruptedException {
+        try {
+            waitForCondition(
+                    () -> checkConnectorState(
+                            connectorName,
+                            AbstractStatus.State.RUNNING,
+                            numTasks,
+                            numFailedTasks,
+                            AbstractStatus.State.FAILED,
+                            (actual, expected) -> actual >= expected
+                    ).orElse(false),
+                    CONNECTOR_SETUP_DURATION_MS,
+                    "Either the connector is not running or not all the " + numTasks + " tasks have failed.");
+        } catch (AssertionError e) {
+            throw new AssertionError(detailMessage, e);
+        }
+    }
+
+    /**
      * Assert that a connector is in FAILED state, that it has a specific number of tasks, and that all of
      * its tasks are in the FAILED state.
      *
@@ -449,6 +477,36 @@ public class EmbeddedConnectClusterAssertions {
         }
     }
 
+    /**
+     * Check whether the given connector state matches the current state of the connector and
+     * whether it has at least the given number of tasks, with numTasksInTasksState matching the given
+     * task state.
+     * @param connectorName the connector
+     * @param connectorState
+     * @param numTasks the expected number of tasks
+     * @param tasksState
+     * @return true if the connector and tasks are in RUNNING state; false otherwise
+     */
+    protected Optional<Boolean> checkConnectorState(
+            String connectorName,
+            AbstractStatus.State connectorState,
+            int numTasks,
+            int numTasksInTasksState,
+            AbstractStatus.State tasksState,
+            BiFunction<Integer, Integer, Boolean> comp
+    ) {
+        try {
+            ConnectorStateInfo info = connect.connectorStatus(connectorName);
+            boolean result = info != null
+                    && comp.apply(info.tasks().size(), numTasks)
+                    && info.connector().state().equals(connectorState.toString())
+                    && info.tasks().stream().filter(s -> s.state().equals(tasksState.toString())).count() == numTasksInTasksState;
+            return Optional.of(result);
+        } catch (Exception e) {
+            log.error("Could not check connector state info.", e);
+            return Optional.empty();
+        }
+    }
     /**
      * Assert that a connector's set of active topics matches the given collection of topic names.
      *

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -218,7 +218,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         return self._rest_with_retry('/connectors/' + name + '/restart', node=node, method="POST", **kwargs)
 
     def restart_connector_and_tasks(self, name, only_failed, include_tasks, node=None, **kwargs):
-        return self._rest_with_retry('/connectors/' + name + '/restart?onlyFailed=' + onlyFailed + '&includeTasks=' + includeTasks, node=node, method="POST", **kwargs)
+        return self._rest_with_retry('/connectors/' + name + '/restart?onlyFailed=' + only_failed + '&includeTasks=' + include_tasks, node=node, method="POST", **kwargs)
 
     def restart_task(self, connector_name, task_id, node=None):
         return self._rest('/connectors/' + connector_name + '/tasks/' + str(task_id) + '/restart', node=node, method="POST")

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -217,6 +217,9 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
     def restart_connector(self, name, node=None, **kwargs):
         return self._rest_with_retry('/connectors/' + name + '/restart', node=node, method="POST", **kwargs)
 
+    def restart_connector_and_tasks(self, name, only_failed, include_tasks, node=None, **kwargs):
+        return self._rest_with_retry('/connectors/' + name + '/restart?onlyFailed=' + onlyFailed + '&includeTasks=' + includeTasks, node=node, method="POST", **kwargs)
+
     def restart_task(self, connector_name, task_id, node=None):
         return self._rest('/connectors/' + connector_name + '/tasks/' + str(task_id) + '/restart', node=node, method="POST")
 

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -202,6 +202,31 @@ class ConnectDistributedTest(Test):
                    err_msg="Failed to see task transition to the RUNNING state")
 
     @cluster(num_nodes=5)
+    @matrix(connector_type=['source', 'sink'], connect_protocol=['sessioned', 'compatible', 'eager'])
+    def test_restart_connector_and_failed_task(self, connector_type, connect_protocol):
+        self.CONNECT_PROTOCOL = connect_protocol
+        self.setup_services()
+        self.cc.set_configs(lambda node: self.render("connect-distributed.properties", node=node))
+        self.cc.start()
+
+        connector = None
+        if connector_type == "sink":
+            connector = MockSink(self.cc, self.topics.keys(), mode='task-failure', delay_sec=5)
+        else:
+            connector = MockSource(self.cc, mode='task-failure', delay_sec=5)
+
+        connector.start()
+
+        task_id = 0
+        wait_until(lambda: self.task_is_failed(connector, task_id), timeout_sec=20,
+                   err_msg="Failed to see task transition to the FAILED state")
+
+        self.cc.restart_connector_and_tasks(connector.name, only_failed = "false", include_tasks = "true")
+
+        wait_until(lambda: self.task_is_running(connector, task_id), timeout_sec=10,
+                   err_msg="Failed to see task transition to the RUNNING state")
+
+    @cluster(num_nodes=5)
     @matrix(connect_protocol=['sessioned', 'compatible', 'eager'])
     def test_pause_and_resume_source(self, connect_protocol):
         """


### PR DESCRIPTION
Implements [KIP-745](https://cwiki.apache.org/confluence/display/KAFKA/KIP-745%3A+Connect+API+to+restart+connector+and+tasks) to change connector restart API to also restart tasks.

Testing strategy 
- [x]  Unit tests added for all possible combinations of onlyFailed and includeTasks
- [x]  Integration tests added for all possible combinations of onlyFailed and includeTasks
- [x]  System tests for happy path 

@rhauch @kkonstantine @tombentley @ryannedolan @dongjinleekr  Could you please check if this looks good?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
