### PR TITLE
KAFKA-5876: Add `streamsState()` method to StateStoreProvider

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -900,7 +900,7 @@ public class KafkaStreams implements AutoCloseable {
         threadState = new HashMap<>(numStreamThreads);
         streamStateListener = new StreamStateListener(threadState, globalThreadState);
 
-        final GlobalStateStoreProvider globalStateStoreProvider = new GlobalStateStoreProvider(internalTopologyBuilder.globalStateStores());
+        final GlobalStateStoreProvider globalStateStoreProvider = new GlobalStateStoreProvider(this, internalTopologyBuilder.globalStateStores());
 
         if (hasGlobalTopology) {
             globalStreamThread.setStateListener(streamStateListener);
@@ -910,7 +910,7 @@ public class KafkaStreams implements AutoCloseable {
         for (int i = 1; i <= numStreamThreads; i++) {
             createAndAddStreamThread(cacheSizePerThread, i);
         }
-        queryableStoreProvider = new QueryableStoreProvider(storeProviders, globalStateStoreProvider);
+        queryableStoreProvider = new QueryableStoreProvider(this, storeProviders, globalStateStoreProvider);
 
         stateDirCleaner = setupStateDirCleaner();
         rocksDBMetricsRecordingService = maybeCreateRocksDBMetricsRecordingService(clientId, config);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/GlobalStateStoreProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -29,8 +30,10 @@ import java.util.Map;
 
 public class GlobalStateStoreProvider implements StateStoreProvider {
     private final Map<String, StateStore> globalStateStores;
+    private final KafkaStreams streams;
 
-    public GlobalStateStoreProvider(final Map<String, StateStore> globalStateStores) {
+    public GlobalStateStoreProvider(final KafkaStreams streams, final Map<String, StateStore> globalStateStores) {
+        this.streams = streams;
         this.globalStateStores = globalStateStores;
     }
 
@@ -51,4 +54,10 @@ public class GlobalStateStoreProvider implements StateStoreProvider {
         }
         return (List<T>) Collections.singletonList(store);
     }
+
+    @Override
+    public KafkaStreams.State streamsState() {
+        return streams.state();
+    }
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
@@ -30,9 +31,12 @@ public class QueryableStoreProvider {
 
     private final List<StreamThreadStateStoreProvider> storeProviders;
     private final GlobalStateStoreProvider globalStoreProvider;
+    private final KafkaStreams streams;
 
-    public QueryableStoreProvider(final List<StreamThreadStateStoreProvider> storeProviders,
+    public QueryableStoreProvider(final KafkaStreams streams,
+                                  final List<StreamThreadStateStoreProvider> storeProviders,
                                   final GlobalStateStoreProvider globalStateStoreProvider) {
+        this.streams = streams;
         this.storeProviders = new ArrayList<>(storeProviders);
         this.globalStoreProvider = globalStateStoreProvider;
     }
@@ -56,7 +60,7 @@ public class QueryableStoreProvider {
             return queryableStoreType.create(globalStoreProvider, storeName);
         }
         return queryableStoreType.create(
-            new WrappingStoreProvider(storeProviders, storeQueryParameters),
+            new WrappingStoreProvider(streams, storeProviders, storeQueryParameters),
             storeName
         );
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StateStoreProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
@@ -40,4 +41,6 @@ public interface StateStoreProvider {
      * @return  List of the instances of the store in this topology. Empty List if not found
      */
     <T> List<T> stores(String storeName, QueryableStoreType<T> queryableStoreType);
+
+    KafkaStreams.State streamsState();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.InvalidStateStorePartitionException;
@@ -30,10 +31,13 @@ import java.util.List;
 public class WrappingStoreProvider implements StateStoreProvider {
 
     private final List<StreamThreadStateStoreProvider> storeProviders;
+    private final KafkaStreams streams;
     private StoreQueryParameters storeQueryParameters;
 
-    WrappingStoreProvider(final List<StreamThreadStateStoreProvider> storeProviders,
+    WrappingStoreProvider(final KafkaStreams streams,
+                          final List<StreamThreadStateStoreProvider> storeProviders,
                           final StoreQueryParameters storeQueryParameters) {
+        this.streams = streams;
         this.storeProviders = storeProviders;
         this.storeQueryParameters = storeQueryParameters;
     }
@@ -66,5 +70,10 @@ public class WrappingStoreProvider implements StateStoreProvider {
             throw new InvalidStateStoreException("The state store, " + storeName + ", may have migrated to another instance.");
         }
         return allStores;
+    }
+
+    @Override
+    public KafkaStreams.State streamsState() {
+        return streams.state();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlySessionStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -50,6 +51,7 @@ public class CompositeReadOnlySessionStoreTest {
     private final StateStoreProviderStub stubProviderTwo = new StateStoreProviderStub(false);
     private final ReadOnlySessionStoreStub<String, Long> underlyingSessionStore = new ReadOnlySessionStoreStub<>();
     private final ReadOnlySessionStoreStub<String, Long> otherUnderlyingStore = new ReadOnlySessionStoreStub<>();
+    private KafkaStreams streams;
     private CompositeReadOnlySessionStore<String, Long> sessionStore;
 
     @Before
@@ -57,9 +59,9 @@ public class CompositeReadOnlySessionStoreTest {
         stubProviderOne.addStore(storeName, underlyingSessionStore);
         stubProviderOne.addStore("other-session-store", otherUnderlyingStore);
         final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
-
+        streams = StreamsTestUtils.mockStreams();
         sessionStore = new CompositeReadOnlySessionStore<>(
-            new WrappingStoreProvider(Arrays.asList(stubProviderOne, stubProviderTwo), StoreQueryParameters.fromNameAndType(storeName, queryableStoreType)),
+            new WrappingStoreProvider(streams, Arrays.asList(stubProviderOne, stubProviderTwo), StoreQueryParameters.fromNameAndType(storeName, queryableStoreType)),
             QueryableStoreTypes.sessionStore(), storeName);
     }
 
@@ -114,7 +116,7 @@ public class CompositeReadOnlySessionStoreTest {
         final QueryableStoreType<ReadOnlySessionStore<Object, Object>> queryableStoreType = QueryableStoreTypes.sessionStore();
         final CompositeReadOnlySessionStore<String, String> store =
             new CompositeReadOnlySessionStore<>(
-                new WrappingStoreProvider(singletonList(new StateStoreProviderStub(true)), StoreQueryParameters.fromNameAndType("whateva", queryableStoreType)),
+                new WrappingStoreProvider(streams, singletonList(new StateStoreProviderStub(true)), StoreQueryParameters.fromNameAndType("whateva", queryableStoreType)),
                 QueryableStoreTypes.sessionStore(),
                 "whateva"
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStoreTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -52,6 +53,7 @@ public class CompositeReadOnlyWindowStoreTest {
     private static final long WINDOW_SIZE = 30_000;
 
     private final String storeName = "window-store";
+    private KafkaStreams streams;
     private StateStoreProviderStub stubProviderOne;
     private StateStoreProviderStub stubProviderTwo;
     private CompositeReadOnlyWindowStore<String, String> windowStore;
@@ -67,9 +69,9 @@ public class CompositeReadOnlyWindowStoreTest {
 
         otherUnderlyingStore = new ReadOnlyWindowStoreStub<>(WINDOW_SIZE);
         stubProviderOne.addStore("other-window-store", otherUnderlyingStore);
-
+        streams = StreamsTestUtils.mockStreams();
         windowStore = new CompositeReadOnlyWindowStore<>(
-            new WrappingStoreProvider(asList(stubProviderOne, stubProviderTwo), StoreQueryParameters.fromNameAndType(storeName, QueryableStoreTypes.windowStore())),
+            new WrappingStoreProvider(streams, asList(stubProviderOne, stubProviderTwo), StoreQueryParameters.fromNameAndType(storeName, QueryableStoreTypes.windowStore())),
             QueryableStoreTypes.windowStore(),
             storeName
         );
@@ -209,7 +211,7 @@ public class CompositeReadOnlyWindowStoreTest {
         underlyingWindowStore.setOpen(false);
         final CompositeReadOnlyWindowStore<Object, Object> store =
             new CompositeReadOnlyWindowStore<>(
-                new WrappingStoreProvider(singletonList(stubProviderOne), StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.windowStore())),
+                new WrappingStoreProvider(streams, singletonList(stubProviderOne), StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.windowStore())),
                 QueryableStoreTypes.windowStore(),
                 "window-store"
             );
@@ -227,7 +229,7 @@ public class CompositeReadOnlyWindowStoreTest {
         underlyingWindowStore.setOpen(false);
         final CompositeReadOnlyWindowStore<Object, Object> store =
             new CompositeReadOnlyWindowStore<>(
-                new WrappingStoreProvider(singletonList(stubProviderOne), StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.windowStore())),
+                new WrappingStoreProvider(streams, singletonList(stubProviderOne), StoreQueryParameters.fromNameAndType("window-store", QueryableStoreTypes.windowStore())),
                 QueryableStoreTypes.windowStore(),
                 "window-store"
             );

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 
+import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
@@ -24,6 +25,7 @@ import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.test.NoOpReadOnlyStore;
 import org.apache.kafka.test.StateStoreProviderStub;
+import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,6 +41,7 @@ public class QueryableStoreProviderTest {
 
     private final String keyValueStore = "key-value";
     private final String windowStore = "window-store";
+    private KafkaStreams streams;
     private QueryableStoreProvider storeProvider;
     private HashMap<String, StateStore> globalStateStores;
     private final int numStateStorePartitions = 2;
@@ -50,11 +53,12 @@ public class QueryableStoreProviderTest {
             theStoreProvider.addStore(keyValueStore, partition, new NoOpReadOnlyStore<>());
             theStoreProvider.addStore(windowStore, partition, new NoOpWindowStore());
         }
+        streams = StreamsTestUtils.mockStreams();
         globalStateStores = new HashMap<>();
         storeProvider =
-            new QueryableStoreProvider(
+            new QueryableStoreProvider(streams,
                 Collections.singletonList(theStoreProvider),
-                new GlobalStateStoreProvider(globalStateStores)
+                new GlobalStateStoreProvider(streams, globalStateStores)
             );
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.easymock.EasyMock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -233,5 +234,16 @@ public final class StreamsTestUtils {
     public static boolean isCheckSupplierCall() {
         return Arrays.stream(Thread.currentThread().getStackTrace())
                 .anyMatch(caller -> "org.apache.kafka.streams.internals.ApiUtils".equals(caller.getClassName()) && "checkSupplier".equals(caller.getMethodName()));
+    }
+
+    public static KafkaStreams mockStreams(KafkaStreams.State state) {
+        final KafkaStreams kafkaStreams = EasyMock.createNiceMock(KafkaStreams.class);
+        EasyMock.expect(kafkaStreams.state()).andStubReturn(state);
+        EasyMock.replay(kafkaStreams);
+        return kafkaStreams;
+    }
+
+    public static KafkaStreams mockStreams() {
+        return mockStreams(KafkaStreams.State.RUNNING);
     }
 }


### PR DESCRIPTION
follow-up #8200

KAFKA-5876's PR break into multiple parts, this PR is part 5.

In KIP-216, the following exceptions is currently not completed: StreamsRebalancingException, StreamsRebalancingException, StateStoreNotAvailableException. In the CompositeReadOnlyXXXXStore class, we need using streams state to decide which exception should be thrown.

This PR add a new method `streams()` to StateStoreProvider interface. In the next PR, we can get streams state in the CompositeReadOnlyXXXXStore class to determine which exception should be thrown.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
