### PR TITLE
KAFKA-12904: Corrected the timeout for config validation REST API resource

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResource.java
@@ -88,7 +88,7 @@ public class ConnectorPluginsResource {
         herder.validateConnectorConfig(connectorConfig, validationCallback, false);
 
         try {
-            return validationCallback.get(ConnectorsResource.REQUEST_TIMEOUT_MS, TimeUnit.SECONDS);
+            return validationCallback.get(ConnectorsResource.REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
             // error is the best option


### PR DESCRIPTION
The constant is specified in milliseconds, and so the MILLISECOND time unit should be used instead of SECONDS. See #8069/[KAFKA-9374](https://issues.apache.org/jira/browse/KAFKA-9374).

Inspected other uses of the same constant and other changes in the original PR, and found no other errors. This kind of change is actually difficult to test for, so this relies upon existing unit and integration tests.

Users may run into this whenever validating a connector configuration where the connector implementation takes more than the 90 seconds to actually validate the configuration. 
* Without this fix, the `PUT /connector-plugins/(string:name)/config/validate` REST requests might **_not_** return `500 Internal Server Error` and may block (the request thread) for a long period of time. 
* With this fix, the `PUT /connector-plugins/(string:name)/config/validate` REST requests might **_not_** return `500 Internal Server Error` if the connector does not complete the validation of a connector configuration within 90 seconds.

The user will not see a difference between the behavior before or after this fix if/when the connectors complete validation of connector configurations before 90 seconds, since the method will return those results to the client.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
