### PR TITLE
KAFKA-12906 - Added RecordDeserializationException containing partition and offset 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.SerializationException;
@@ -1390,7 +1391,8 @@ public class Fetcher<K, V> implements Closeable {
                                         valueByteArray == null ? ConsumerRecord.NULL_SIZE : valueByteArray.length,
                                         key, value, headers, leaderEpoch);
         } catch (RuntimeException e) {
-            throw new SerializationException("Error deserializing key/value for partition " + partition +
+            throw new RecordDeserializationException(partition, record.offset(),
+                "Error deserializing key/value for partition " + partition +
                     " at offset " + record.offset() + ". If needed, please seek past the record to continue consumption.", e);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ *  Any exception encountered on an invalid record (deserialization error, corrupt record, etc...)
+ */
+public class RecordDeserializationException extends SerializationException {
+
+    private static final long serialVersionUID = 1L;
+    private TopicPartition partition;
+    private long offset;
+
+    public RecordDeserializationException(TopicPartition partition, long offset, String message) {
+        this(partition, offset, message, null);
+    }
+
+    public RecordDeserializationException(TopicPartition partition, long offset, String message, Throwable cause) {
+        super(message, cause);
+        this.partition = partition;
+        this.offset = offset;
+    }
+
+    public TopicPartition partition() {
+        return partition;
+    }
+
+    public long offset() {
+        return offset;
+    }
+
+    /* avoid the expensive and useless stack trace for deserialization exceptions */
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
@@ -44,10 +44,4 @@ public class RecordDeserializationException extends SerializationException {
     public long offset() {
         return offset;
     }
-
-    /* avoid the expensive and useless stack trace for deserialization exceptions */
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
@@ -25,8 +25,8 @@ import org.apache.kafka.common.TopicPartition;
 public class RecordDeserializationException extends SerializationException {
 
     private static final long serialVersionUID = 1L;
-    private TopicPartition partition;
-    private long offset;
+    private final TopicPartition partition;
+    private final long offset;
 
     public RecordDeserializationException(TopicPartition partition, long offset, String message, Throwable cause) {
         super(message, cause);

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.TopicPartition;
 
 /**
  *  This exception is raised for any error that occurs while deserializing records received by the consumer using 
- *  the configured {@link Deserializer}.
+ *  the configured {@link org.apache.kafka.common.serialization.Deserializer}.
  */
 public class RecordDeserializationException extends SerializationException {
 
@@ -28,17 +28,13 @@ public class RecordDeserializationException extends SerializationException {
     private TopicPartition partition;
     private long offset;
 
-    public RecordDeserializationException(TopicPartition partition, long offset, String message) {
-        this(partition, offset, message, null);
-    }
-
     public RecordDeserializationException(TopicPartition partition, long offset, String message, Throwable cause) {
         super(message, cause);
         this.partition = partition;
         this.offset = offset;
     }
 
-    public TopicPartition partition() {
+    public TopicPartition topicPartition() {
         return partition;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/RecordDeserializationException.java
@@ -19,7 +19,8 @@ package org.apache.kafka.common.errors;
 import org.apache.kafka.common.TopicPartition;
 
 /**
- *  Any exception encountered on an invalid record (deserialization error, corrupt record, etc...)
+ *  This exception is raised for any error that occurs while deserializing records received by the consumer using 
+ *  the configured {@link Deserializer}.
  */
 public class RecordDeserializationException extends SerializationException {
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/SerializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SerializationException.java
@@ -41,10 +41,4 @@ public class SerializationException extends KafkaException {
         super();
     }
 
-    /* avoid the expensive and useless stack trace for serialization exceptions */
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
-    }
-
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -190,7 +190,7 @@ public class KafkaConsumerTest {
 
     @Test
     public void testPollReturnsRecords() {
-        KafkaConsumer<String, String> consumer = setUpConsumerWithRecordsToPoll(tp0, 5).consumer;
+        KafkaConsumer<String, String> consumer = setUpConsumerWithRecordsToPoll(tp0, 5);
 
         ConsumerRecords<String, String> records = consumer.poll(Duration.ZERO);
 
@@ -206,7 +206,7 @@ public class KafkaConsumerTest {
         int invalidRecordNumber = 4;
         StringDeserializer deserializer = mockErrorDeserializer(invalidRecordNumber);
 
-        KafkaConsumer<String, String> consumer = setUpConsumerWithRecordsToPoll(tp0, 5, deserializer).consumer;
+        KafkaConsumer<String, String> consumer = setUpConsumerWithRecordsToPoll(tp0, 5, deserializer);
 
         ConsumerRecords<String, String> records = consumer.poll(Duration.ZERO);
 
@@ -225,7 +225,7 @@ public class KafkaConsumerTest {
         int invalidRecordOffset = 3;
         StringDeserializer deserializer = mockErrorDeserializer(invalidRecordNumber);
 
-        KafkaConsumer<String, String> consumer = setUpConsumerWithRecordsToPoll(tp0, 5, deserializer).consumer;
+        KafkaConsumer<String, String> consumer = setUpConsumerWithRecordsToPoll(tp0, 5, deserializer);
         ConsumerRecords<String, String> records = consumer.poll(Duration.ZERO);
 
         assertEquals(invalidRecordNumber - 1, records.count());
@@ -269,23 +269,11 @@ public class KafkaConsumerTest {
         };
     }
 
-    private static class ConsumerHarness {
-        MockClient client;
-        public Node node;
-        KafkaConsumer<String, String> consumer;
-
-        ConsumerHarness(KafkaConsumer<String, String> consumer, MockClient client, Node node) {
-            this.consumer = consumer;
-            this.client = client;
-            this.node = node;
-        }
-    }
-
-    private ConsumerHarness setUpConsumerWithRecordsToPoll(TopicPartition tp, int recordCount) {
+    private KafkaConsumer<String, String> setUpConsumerWithRecordsToPoll(TopicPartition tp, int recordCount) {
         return setUpConsumerWithRecordsToPoll(tp, recordCount, new StringDeserializer());
     }
 
-    private ConsumerHarness setUpConsumerWithRecordsToPoll(TopicPartition tp, int recordCount, Deserializer<String> deserializer) {
+    private KafkaConsumer<String, String> setUpConsumerWithRecordsToPoll(TopicPartition tp, int recordCount, Deserializer<String> deserializer) {
         Time time = new MockTime();
         Cluster cluster = TestUtils.singletonCluster(tp.topic(), 1);
         Node node = cluster.nodes().get(0);
@@ -301,11 +289,8 @@ public class KafkaConsumerTest {
         prepareRebalance(client, node, assignor, singletonList(tp), null);
         consumer.updateAssignmentMetadataIfNeeded(time.timer(Long.MAX_VALUE));
         client.prepareResponseFrom(fetchResponse(tp, 0, recordCount), node);
-
-        return new ConsumerHarness(consumer, client, node);
+        return consumer;
     }
-
-
 
     @Test
     public void testConstructorClose() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -195,7 +195,7 @@ public class KafkaConsumerTest {
         ConsumerRecords<String, String> records = consumer.poll(Duration.ZERO);
 
         assertEquals(records.count(), 5);
-        assertEquals(records.partitions(), new HashSet<>(Collections.singletonList(tp0)));
+        assertEquals(records.partitions(), Collections.singleton(tp0));
         assertEquals(records.records(tp0).size(), 5);
 
         consumer.close(Duration.ofMillis(0));
@@ -211,7 +211,7 @@ public class KafkaConsumerTest {
         ConsumerRecords<String, String> records = consumer.poll(Duration.ZERO);
 
         assertEquals(invalidRecordNumber - 1, records.count());
-        assertEquals(new HashSet<>(Collections.singletonList(tp0)), records.partitions());
+        assertEquals(Collections.singleton(tp0), records.partitions());
         assertEquals(invalidRecordNumber - 1, records.records(tp0).size());
         long lastOffset = records.records(tp0).get(records.records(tp0).size() - 1).offset();
         assertEquals(invalidRecordNumber - 2, lastOffset);


### PR DESCRIPTION
As documented in KIP-334 (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=87297793), we should add a new RecordDeserializationException, which is raised by the consumer when failing to parse a record. This allows the consumer to decide to take an action such as to shut down or skip past the record. 

JIRA: [12906](https://issues.apache.org/jira/browse/KAFKA-12906)

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
