### PR TITLE
KAFKA-12913: Make case class's final

### DIFF
--- a/core/src/main/scala/kafka/admin/BrokerMetadata.scala
+++ b/core/src/main/scala/kafka/admin/BrokerMetadata.scala
@@ -20,4 +20,4 @@ package kafka.admin
   * @param rack the rack of the broker, which is used to in rack aware partition assignment for fault tolerance.
   *             Examples: "RACK1", "us-east-1d"
   */
-case class BrokerMetadata(id: Int, rack: Option[String])
+final case class BrokerMetadata(id: Int, rack: Option[String])

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -649,7 +649,7 @@ object ConfigCommand extends Config {
     adminClient.describeClientQuotas(ClientQuotaFilter.containsOnly(components.asJava)).entities.get(30, TimeUnit.SECONDS).asScala
   }
 
-  case class Entity(entityType: String, sanitizedName: Option[String]) {
+  final case class Entity(entityType: String, sanitizedName: Option[String]) {
     val entityPath = sanitizedName match {
       case Some(n) => entityType + "/" + n
       case None => entityType
@@ -671,7 +671,7 @@ object ConfigCommand extends Config {
     }
   }
 
-  case class ConfigEntity(root: Entity, child: Option[Entity]) {
+  final case class ConfigEntity(root: Entity, child: Option[Entity]) {
     val fullSanitizedName = root.sanitizedName.getOrElse("") + child.map(s => "/" + s.entityPath).getOrElse("")
 
     def getAllEntities(zkClient: KafkaZkClient) : Seq[ConfigEntity] = {

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -124,19 +124,19 @@ object ConsumerGroupCommand extends Logging {
     }
   }
 
-  private[admin] case class PartitionAssignmentState(group: String, coordinator: Option[Node], topic: Option[String],
-                                                partition: Option[Int], offset: Option[Long], lag: Option[Long],
-                                                consumerId: Option[String], host: Option[String],
-                                                clientId: Option[String], logEndOffset: Option[Long])
+  private[admin] final case class PartitionAssignmentState(group: String, coordinator: Option[Node], topic: Option[String],
+                                                           partition: Option[Int], offset: Option[Long], lag: Option[Long],
+                                                           consumerId: Option[String], host: Option[String],
+                                                           clientId: Option[String], logEndOffset: Option[Long])
 
-  private[admin] case class MemberAssignmentState(group: String, consumerId: String, host: String, clientId: String, groupInstanceId: String,
-                                             numPartitions: Int, assignment: List[TopicPartition])
+  private[admin] final case class MemberAssignmentState(group: String, consumerId: String, host: String, clientId: String, groupInstanceId: String,
+                                                        numPartitions: Int, assignment: List[TopicPartition])
 
-  private[admin] case class GroupState(group: String, coordinator: Node, assignmentStrategy: String, state: String, numMembers: Int)
+  private[admin] final case class GroupState(group: String, coordinator: Node, assignmentStrategy: String, state: String, numMembers: Int)
 
   private[admin] sealed trait CsvRecord
-  private[admin] case class CsvRecordWithGroup(group: String, topic: String, partition: Int, offset: Long) extends CsvRecord
-  private[admin] case class CsvRecordNoGroup(topic: String, partition: Int, offset: Long) extends CsvRecord
+  private[admin] final case class CsvRecordWithGroup(group: String, topic: String, partition: Int, offset: Long) extends CsvRecord
+  private[admin] final case class CsvRecordNoGroup(topic: String, partition: Int, offset: Long) extends CsvRecord
   private[admin] object CsvRecordWithGroup {
     val fields = Array("group", "topic", "partition", "offset")
   }
@@ -144,7 +144,7 @@ object ConsumerGroupCommand extends Logging {
     val fields = Array("topic", "partition", "offset")
   }
   // Example: CsvUtils().readerFor[CsvRecordWithoutGroup]
-  private[admin] case class CsvUtils() {
+  private[admin] final case class CsvUtils() {
     val mapper = new CsvMapper
     mapper.registerModule(DefaultScalaModule)
     def readerFor[T <: CsvRecord : ClassTag] = {
@@ -963,7 +963,7 @@ object ConsumerGroupCommand extends Logging {
   sealed trait LogOffsetResult
 
   object LogOffsetResult {
-    case class LogOffset(value: Long) extends LogOffsetResult
+    final case class LogOffset(value: Long) extends LogOffsetResult
     case object Unknown extends LogOffsetResult
     case object Ignore extends LogOffsetResult
   }

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -261,10 +261,10 @@ object ReassignPartitionsCommand extends Logging {
    * @param moveStates    A map from log directories to movement states.
    * @param movesOngoing  True if there are any ongoing moves that we know about.
    */
-  case class VerifyAssignmentResult(partStates: Map[TopicPartition, PartitionReassignmentState],
-                                    partsOngoing: Boolean = false,
-                                    moveStates: Map[TopicPartitionReplica, LogDirMoveState] = Map.empty,
-                                    movesOngoing: Boolean = false)
+  final case class VerifyAssignmentResult(partStates: Map[TopicPartition, PartitionReassignmentState],
+                                          partsOngoing: Boolean = false,
+                                          moveStates: Map[TopicPartitionReplica, LogDirMoveState] = Map.empty,
+                                          movesOngoing: Boolean = false)
 
   /**
    * The entry point for the --verify command.

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -96,12 +96,12 @@ object TopicCommand extends Logging {
     def ifTopicDoesntExist(): Boolean = opts.ifNotExists
   }
 
-  case class TopicDescription(topic: String,
-                              topicId: Uuid,
-                              numPartitions: Int,
-                              replicationFactor: Int,
-                              config: JConfig,
-                              markedForDeletion: Boolean) {
+  final case class TopicDescription(topic: String,
+                                    topicId: Uuid,
+                                    numPartitions: Int,
+                                    replicationFactor: Int,
+                                    config: JConfig,
+                                    markedForDeletion: Boolean) {
 
     def printDescription(): Unit = {
       val configsAsString = config.entries.asScala.filter(!_.isDefault).map { ce => s"${ce.name}=${ce.value}" }.mkString(",")
@@ -115,11 +115,11 @@ object TopicCommand extends Logging {
     }
   }
 
-  case class PartitionDescription(topic: String,
-                                  info: TopicPartitionInfo,
-                                  config: Option[JConfig],
-                                  markedForDeletion: Boolean,
-                                  reassignment: Option[PartitionReassignment]) {
+  final case class PartitionDescription(topic: String,
+                                        info: TopicPartitionInfo,
+                                        config: Option[JConfig],
+                                        markedForDeletion: Boolean,
+                                        reassignment: Option[PartitionReassignment]) {
 
     private def minIsrCount: Option[Int] = {
       config.map(_.get(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG).value.toInt)
@@ -209,7 +209,7 @@ object TopicCommand extends Logging {
       new TopicService(createAdminClient(commandConfig, bootstrapServer))
   }
 
-  case class TopicService private (adminClient: Admin) extends AutoCloseable {
+  final case class TopicService private (adminClient: Admin) extends AutoCloseable {
 
     def createTopic(opts: TopicCommandOptions): Unit = {
       val topic = new CommandTopicPartition(opts)

--- a/core/src/main/scala/kafka/api/LeaderAndIsr.scala
+++ b/core/src/main/scala/kafka/api/LeaderAndIsr.scala
@@ -30,10 +30,10 @@ object LeaderAndIsr {
   def duringDelete(isr: List[Int]): LeaderAndIsr = LeaderAndIsr(LeaderDuringDelete, isr)
 }
 
-case class LeaderAndIsr(leader: Int,
-                        leaderEpoch: Int,
-                        isr: List[Int],
-                        zkVersion: Int) {
+final case class LeaderAndIsr(leader: Int,
+                              leaderEpoch: Int,
+                              isr: List[Int],
+                              zkVersion: Int) {
   def withZkVersion(zkVersion: Int) = copy(zkVersion = zkVersion)
 
   def newLeader(leader: Int) = newLeaderAndIsr(leader, isr)

--- a/core/src/main/scala/kafka/cluster/Broker.scala
+++ b/core/src/main/scala/kafka/cluster/Broker.scala
@@ -32,10 +32,10 @@ import scala.collection.Seq
 import scala.jdk.CollectionConverters._
 
 object Broker {
-  private[kafka] case class ServerInfo(clusterResource: ClusterResource,
-                                         brokerId: Int,
-                                         endpoints: util.List[Endpoint],
-                                         interBrokerEndpoint: Endpoint) extends AuthorizerServerInfo
+  private[kafka] final case class ServerInfo(clusterResource: ClusterResource,
+                                             brokerId: Int,
+                                             endpoints: util.List[Endpoint],
+                                             interBrokerEndpoint: Endpoint) extends AuthorizerServerInfo
 
   def apply(id: Int, endPoints: Seq[EndPoint], rack: Option[String]): Broker = {
     new Broker(id, endPoints, rack, emptySupportedFeatures)
@@ -50,7 +50,7 @@ object Broker {
  * @param rack        an optional rack
  * @param features    supported features
  */
-case class Broker(id: Int, endPoints: Seq[EndPoint], rack: Option[String], features: Features[SupportedVersionRange]) {
+final case class Broker(id: Int, endPoints: Seq[EndPoint], rack: Option[String], features: Features[SupportedVersionRange]) {
 
   private val endPointsMap = endPoints.map { endPoint =>
     endPoint.listenerName -> endPoint

--- a/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/BrokerEndPoint.scala
@@ -62,7 +62,7 @@ object BrokerEndPoint {
  * Clients should know which security protocol to use from configuration.
  * This allows us to keep the wire protocol with the clients unchanged where the protocol is not needed.
  */
-case class BrokerEndPoint(id: Int, host: String, port: Int) {
+final case class BrokerEndPoint(id: Int, host: String, port: Int) {
 
   def connectionString(): String = formatAddress(host, port)
 

--- a/core/src/main/scala/kafka/cluster/EndPoint.scala
+++ b/core/src/main/scala/kafka/cluster/EndPoint.scala
@@ -62,7 +62,7 @@ object EndPoint {
 /**
  * Part of the broker definition - matching host/port pair to a protocol
  */
-case class EndPoint(host: String, port: Int, listenerName: ListenerName, securityProtocol: SecurityProtocol) {
+final case class EndPoint(host: String, port: Int, listenerName: ListenerName, securityProtocol: SecurityProtocol) {
   def connectionString: String = {
     val hostport =
       if (host == null)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -117,15 +117,15 @@ sealed trait AssignmentState {
   def isAddingReplica(brokerId: Int): Boolean = false
 }
 
-case class OngoingReassignmentState(addingReplicas: Seq[Int],
-                                    removingReplicas: Seq[Int],
-                                    replicas: Seq[Int]) extends AssignmentState {
+final case class OngoingReassignmentState(addingReplicas: Seq[Int],
+                                          removingReplicas: Seq[Int],
+                                          replicas: Seq[Int]) extends AssignmentState {
 
   override def replicationFactor: Int = replicas.diff(addingReplicas).size // keep the size of the original replicas
   override def isAddingReplica(replicaId: Int): Boolean = addingReplicas.contains(replicaId)
 }
 
-case class SimpleAssignmentState(replicas: Seq[Int]) extends AssignmentState
+final case class SimpleAssignmentState(replicas: Seq[Int]) extends AssignmentState
 
 
 
@@ -150,7 +150,7 @@ sealed trait IsrState {
   def isInflight: Boolean
 }
 
-case class PendingExpandIsr(
+final case class PendingExpandIsr(
   isr: Set[Int],
   newInSyncReplicaId: Int
 ) extends IsrState {
@@ -164,7 +164,7 @@ case class PendingExpandIsr(
   }
 }
 
-case class PendingShrinkIsr(
+final case class PendingShrinkIsr(
   isr: Set[Int],
   outOfSyncReplicaIds: Set[Int]
 ) extends IsrState  {
@@ -178,7 +178,7 @@ case class PendingShrinkIsr(
   }
 }
 
-case class CommittedIsr(
+final case class CommittedIsr(
   isr: Set[Int]
 ) extends IsrState {
   val maximalIsr = isr

--- a/core/src/main/scala/kafka/common/ClientIdAndBroker.scala
+++ b/core/src/main/scala/kafka/common/ClientIdAndBroker.scala
@@ -25,10 +25,10 @@ package kafka.common
 trait ClientIdBroker {
 }
 
-case class ClientIdAndBroker(clientId: String, brokerHost: String, brokerPort: Int) extends ClientIdBroker {
+final case class ClientIdAndBroker(clientId: String, brokerHost: String, brokerPort: Int) extends ClientIdBroker {
   override def toString = "%s-%s-%d".format(clientId, brokerHost, brokerPort)
 }
 
-case class ClientIdAllBrokers(clientId: String) extends ClientIdBroker {
+final case class ClientIdAllBrokers(clientId: String) extends ClientIdBroker {
   override def toString = "%s-%s".format(clientId, "AllBrokers")
 }

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -152,7 +152,7 @@ abstract class InterBrokerSendThread(
   def wakeup(): Unit = networkClient.wakeup()
 }
 
-case class RequestAndCompletionHandler(
+final case class RequestAndCompletionHandler(
   creationTimeMs: Long,
   destination: Node,
   request: AbstractRequest.Builder[_ <: AbstractRequest],

--- a/core/src/main/scala/kafka/common/OffsetAndMetadata.scala
+++ b/core/src/main/scala/kafka/common/OffsetAndMetadata.scala
@@ -19,11 +19,11 @@ package kafka.common
 
 import java.util.Optional
 
-case class OffsetAndMetadata(offset: Long,
-                             leaderEpoch: Optional[Integer],
-                             metadata: String,
-                             commitTimestamp: Long,
-                             expireTimestamp: Option[Long]) {
+final case class OffsetAndMetadata(offset: Long,
+                                   leaderEpoch: Optional[Integer],
+                                   metadata: String,
+                                   commitTimestamp: Long,
+                                   expireTimestamp: Option[Long]) {
 
 
   override def toString: String  = {

--- a/core/src/main/scala/kafka/consumer/BaseConsumerRecord.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumerRecord.scala
@@ -23,11 +23,11 @@ import org.apache.kafka.common.record.{RecordBatch, TimestampType}
 
 @deprecated("This class has been deprecated and will be removed in a future release. " +
   "Please use org.apache.kafka.clients.consumer.ConsumerRecord instead.", "0.11.0.0")
-case class BaseConsumerRecord(topic: String,
-                              partition: Int,
-                              offset: Long,
-                              timestamp: Long = RecordBatch.NO_TIMESTAMP,
-                              timestampType: TimestampType = TimestampType.NO_TIMESTAMP_TYPE,
-                              key: Array[Byte],
-                              value: Array[Byte],
-                              headers: Headers = new RecordHeaders())
+final case class BaseConsumerRecord(topic: String,
+                                    partition: Int,
+                                    offset: Long,
+                                    timestamp: Long = RecordBatch.NO_TIMESTAMP,
+                                    timestampType: TimestampType = TimestampType.NO_TIMESTAMP_TYPE,
+                                    key: Array[Byte],
+                                    value: Array[Byte],
+                                    headers: Headers = new RecordHeaders())

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -209,7 +209,7 @@ class ControllerChannelManager(controllerContext: ControllerContext,
   }
 }
 
-case class QueueItem(apiKey: ApiKeys, request: AbstractControlRequest.Builder[_ <: AbstractControlRequest],
+final case class QueueItem(apiKey: ApiKeys, request: AbstractControlRequest.Builder[_ <: AbstractControlRequest],
                      callback: AbstractResponse => Unit, enqueueTimeMs: Long)
 
 class RequestSendThread(val controllerId: Int,
@@ -673,11 +673,11 @@ abstract class AbstractControllerBrokerRequestBatch(config: KafkaConfig,
   }
 }
 
-case class ControllerBrokerStateInfo(networkClient: NetworkClient,
-                                     brokerNode: Node,
-                                     messageQueue: BlockingQueue[QueueItem],
-                                     requestSendThread: RequestSendThread,
-                                     queueSizeGauge: Gauge[Int],
-                                     requestRateAndTimeMetrics: Timer,
-                                     reconfigurableChannelBuilder: Option[Reconfigurable])
+final case class ControllerBrokerStateInfo(networkClient: NetworkClient,
+                                           brokerNode: Node,
+                                           messageQueue: BlockingQueue[QueueItem],
+                                           requestSendThread: RequestSendThread,
+                                           queueSizeGauge: Gauge[Int],
+                                           requestRateAndTimeMetrics: Timer,
+                                           reconfigurableChannelBuilder: Option[Reconfigurable])
 

--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -38,9 +38,9 @@ object ReplicaAssignment {
  * @param addingReplicas the replicas that are being added if there is a pending reassignment
  * @param removingReplicas the replicas that are being removed if there is a pending reassignment
  */
-case class ReplicaAssignment private (replicas: Seq[Int],
-                                      addingReplicas: Seq[Int],
-                                      removingReplicas: Seq[Int]) {
+final case class ReplicaAssignment private (replicas: Seq[Int],
+                                            addingReplicas: Seq[Int],
+                                            removingReplicas: Seq[Int]) {
 
   lazy val originReplicas: Seq[Int] = replicas.diff(addingReplicas)
   lazy val targetReplicas: Seq[Int] = replicas.diff(removingReplicas)

--- a/core/src/main/scala/kafka/controller/Election.scala
+++ b/core/src/main/scala/kafka/controller/Election.scala
@@ -21,7 +21,7 @@ import org.apache.kafka.common.TopicPartition
 
 import scala.collection.Seq
 
-case class ElectionResult(topicPartition: TopicPartition, leaderAndIsr: Option[LeaderAndIsr], liveReplicas: Seq[Int])
+final case class ElectionResult(topicPartition: TopicPartition, leaderAndIsr: Option[LeaderAndIsr], liveReplicas: Seq[Int])
 
 object Election {
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2618,7 +2618,7 @@ class ControllerChangeHandler(eventManager: ControllerEventManager) extends ZNod
   override def handleDataChange(): Unit = eventManager.put(ControllerChange)
 }
 
-case class PartitionAndReplica(topicPartition: TopicPartition, replica: Int) {
+final case class PartitionAndReplica(topicPartition: TopicPartition, replica: Int) {
   def topic: String = topicPartition.topic
   def partition: Int = topicPartition.partition
 
@@ -2627,7 +2627,7 @@ case class PartitionAndReplica(topicPartition: TopicPartition, replica: Int) {
   }
 }
 
-case class LeaderIsrAndControllerEpoch(leaderAndIsr: LeaderAndIsr, controllerEpoch: Int) {
+final case class LeaderIsrAndControllerEpoch(leaderAndIsr: LeaderAndIsr, controllerEpoch: Int) {
   override def toString: String = {
     val leaderAndIsrInfo = new StringBuilder
     leaderAndIsrInfo.append("(Leader:" + leaderAndIsr.leader)
@@ -2691,29 +2691,29 @@ case object UncleanLeaderElectionEnable extends ControllerEvent {
   override def preempt(): Unit = {}
 }
 
-case class TopicUncleanLeaderElectionEnable(topic: String) extends ControllerEvent {
+final case class TopicUncleanLeaderElectionEnable(topic: String) extends ControllerEvent {
   override def state: ControllerState = ControllerState.TopicUncleanLeaderElectionEnable
   override def preempt(): Unit = {}
 }
 
-case class ControlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit) extends ControllerEvent {
+final case class ControlledShutdown(id: Int, brokerEpoch: Long, controlledShutdownCallback: Try[Set[TopicPartition]] => Unit) extends ControllerEvent {
   override def state: ControllerState = ControllerState.ControlledShutdown
   override def preempt(): Unit = controlledShutdownCallback(Failure(new ControllerMovedException("Controller moved to another broker")))
 }
 
-case class LeaderAndIsrResponseReceived(leaderAndIsrResponse: LeaderAndIsrResponse, brokerId: Int) extends ControllerEvent {
+final case class LeaderAndIsrResponseReceived(leaderAndIsrResponse: LeaderAndIsrResponse, brokerId: Int) extends ControllerEvent {
   override def state: ControllerState = ControllerState.LeaderAndIsrResponseReceived
   override def preempt(): Unit = {}
 }
 
-case class UpdateMetadataResponseReceived(updateMetadataResponse: UpdateMetadataResponse, brokerId: Int) extends ControllerEvent {
+final case class UpdateMetadataResponseReceived(updateMetadataResponse: UpdateMetadataResponse, brokerId: Int) extends ControllerEvent {
   override def state: ControllerState = ControllerState.UpdateMetadataResponseReceived
   override def preempt(): Unit = {}
 }
 
-case class TopicDeletionStopReplicaResponseReceived(replicaId: Int,
-                                                    requestError: Errors,
-                                                    partitionErrors: Map[TopicPartition, Errors]) extends ControllerEvent {
+final case class TopicDeletionStopReplicaResponseReceived(replicaId: Int,
+                                                          requestError: Errors,
+                                                          partitionErrors: Map[TopicPartition, Errors]) extends ControllerEvent {
   override def state: ControllerState = ControllerState.TopicDeletion
   override def preempt(): Unit = {}
 }
@@ -2728,7 +2728,7 @@ case object BrokerChange extends ControllerEvent {
   override def preempt(): Unit = {}
 }
 
-case class BrokerModifications(brokerId: Int) extends ControllerEvent {
+final case class BrokerModifications(brokerId: Int) extends ControllerEvent {
   override def state: ControllerState = ControllerState.BrokerChange
   override def preempt(): Unit = {}
 }
@@ -2743,7 +2743,7 @@ case object LogDirEventNotification extends ControllerEvent {
   override def preempt(): Unit = {}
 }
 
-case class PartitionModifications(topic: String) extends ControllerEvent {
+final case class PartitionModifications(topic: String) extends ControllerEvent {
   override def state: ControllerState = ControllerState.TopicChange
   override def preempt(): Unit = {}
 }
@@ -2758,13 +2758,13 @@ case object ZkPartitionReassignment extends ControllerEvent {
   override def preempt(): Unit = {}
 }
 
-case class ApiPartitionReassignment(reassignments: Map[TopicPartition, Option[Seq[Int]]],
-                                    callback: AlterReassignmentsCallback) extends ControllerEvent {
+final case class ApiPartitionReassignment(reassignments: Map[TopicPartition, Option[Seq[Int]]],
+                                          callback: AlterReassignmentsCallback) extends ControllerEvent {
   override def state: ControllerState = ControllerState.AlterPartitionReassignment
   override def preempt(): Unit = callback(Right(new ApiError(Errors.NOT_CONTROLLER)))
 }
 
-case class PartitionReassignmentIsrChange(partition: TopicPartition) extends ControllerEvent {
+final case class PartitionReassignmentIsrChange(partition: TopicPartition) extends ControllerEvent {
   override def state: ControllerState = ControllerState.AlterPartitionReassignment
   override def preempt(): Unit = {}
 }
@@ -2774,13 +2774,13 @@ case object IsrChangeNotification extends ControllerEvent {
   override def preempt(): Unit = {}
 }
 
-case class AlterIsrReceived(brokerId: Int, brokerEpoch: Long, isrsToAlter: Map[TopicPartition, LeaderAndIsr],
-                            callback: AlterIsrCallback) extends ControllerEvent {
+final case class AlterIsrReceived(brokerId: Int, brokerEpoch: Long, isrsToAlter: Map[TopicPartition, LeaderAndIsr],
+                                  callback: AlterIsrCallback) extends ControllerEvent {
   override def state: ControllerState = ControllerState.IsrChange
   override def preempt(): Unit = {}
 }
 
-case class ReplicaLeaderElection(
+final case class ReplicaLeaderElection(
   partitionsFromAdminClientOpt: Option[Set[TopicPartition]],
   electionType: ElectionType,
   electionTrigger: ElectionTrigger,
@@ -2798,19 +2798,19 @@ case class ReplicaLeaderElection(
 /**
   * @param partitionsOpt - an Optional set of partitions. If not present, all reassigning partitions are to be listed
   */
-case class ListPartitionReassignments(partitionsOpt: Option[Set[TopicPartition]],
-                                      callback: ListReassignmentsCallback) extends ControllerEvent {
+final case class ListPartitionReassignments(partitionsOpt: Option[Set[TopicPartition]],
+                                            callback: ListReassignmentsCallback) extends ControllerEvent {
   override def state: ControllerState = ControllerState.ListPartitionReassignment
   override def preempt(): Unit = callback(Right(new ApiError(Errors.NOT_CONTROLLER, null)))
 }
 
-case class UpdateFeatures(request: UpdateFeaturesRequest,
-                          callback: UpdateFeaturesCallback) extends ControllerEvent {
+final case class UpdateFeatures(request: UpdateFeaturesRequest,
+                                callback: UpdateFeaturesCallback) extends ControllerEvent {
   override def state: ControllerState = ControllerState.UpdateFeatures
   override def preempt(): Unit = {}
 }
 
-case class AllocateProducerIds(brokerId: Int, brokerEpoch: Long, callback: Either[Errors, ProducerIdsBlock] => Unit)
+final case class AllocateProducerIds(brokerId: Int, brokerEpoch: Long, callback: Either[Errors, ProducerIdsBlock] => Unit)
     extends ControllerEvent {
   override def state: ControllerState = ControllerState.Idle
   override def preempt(): Unit = {}

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1680,18 +1680,18 @@ object GroupCoordinator {
   }
 }
 
-case class GroupConfig(groupMinSessionTimeoutMs: Int,
-                       groupMaxSessionTimeoutMs: Int,
-                       groupMaxSize: Int,
-                       groupInitialRebalanceDelayMs: Int)
+final case class GroupConfig(groupMinSessionTimeoutMs: Int,
+                             groupMaxSessionTimeoutMs: Int,
+                             groupMaxSize: Int,
+                             groupInitialRebalanceDelayMs: Int)
 
-case class JoinGroupResult(members: List[JoinGroupResponseMember],
-                           memberId: String,
-                           generationId: Int,
-                           protocolType: Option[String],
-                           protocolName: Option[String],
-                           leaderId: String,
-                           error: Errors)
+final case class JoinGroupResult(members: List[JoinGroupResponseMember],
+                                 memberId: String,
+                                 generationId: Int,
+                                 protocolType: Option[String],
+                                 protocolName: Option[String],
+                                 leaderId: String,
+                                 error: Errors)
 
 object JoinGroupResult {
   def apply(memberId: String, error: Errors): JoinGroupResult = {
@@ -1706,10 +1706,10 @@ object JoinGroupResult {
   }
 }
 
-case class SyncGroupResult(protocolType: Option[String],
-                           protocolName: Option[String],
-                           memberAssignment: Array[Byte],
-                           error: Errors)
+final case class SyncGroupResult(protocolType: Option[String],
+                                 protocolName: Option[String],
+                                 memberAssignment: Array[Byte],
+                                 error: Errors)
 
 object SyncGroupResult {
   def apply(error: Errors): SyncGroupResult = {
@@ -1717,9 +1717,9 @@ object SyncGroupResult {
   }
 }
 
-case class LeaveMemberResponse(memberId: String,
-                               groupInstanceId: Option[String],
-                               error: Errors)
+final case class LeaveMemberResponse(memberId: String,
+                                     groupInstanceId: Option[String],
+                                     error: Errors)
 
-case class LeaveGroupResult(topLevelError: Errors,
-                            memberResponses : List[LeaveMemberResponse])
+final case class LeaveGroupResult(topLevelError: Errors,
+                                  memberResponses : List[LeaveMemberResponse])

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -155,17 +155,17 @@ private object GroupMetadata extends Logging {
 /**
  * Case class used to represent group metadata for the ListGroups API
  */
-case class GroupOverview(groupId: String,
-                         protocolType: String,
-                         state: String)
+final case class GroupOverview(groupId: String,
+                               protocolType: String,
+                               state: String)
 
 /**
  * Case class used to represent group metadata for the DescribeGroup API
  */
-case class GroupSummary(state: String,
-                        protocolType: String,
-                        protocol: String,
-                        members: List[MemberSummary])
+final case class GroupSummary(state: String,
+                              protocolType: String,
+                              protocol: String,
+                              members: List[MemberSummary])
 
 /**
   * We cache offset commits along with their commit record offset. This enables us to ensure that the latest offset
@@ -173,7 +173,7 @@ case class GroupSummary(state: String,
   * information of the commit record offset, compaction of the offsets topic itself may result in the wrong offset commit
   * being materialized.
   */
-case class CommitRecordMetadataAndOffset(appendedBatchOffset: Option[Long], offsetAndMetadata: OffsetAndMetadata) {
+final case class CommitRecordMetadataAndOffset(appendedBatchOffset: Option[Long], offsetAndMetadata: OffsetAndMetadata) {
   def olderThan(that: CommitRecordMetadataAndOffset): Boolean = appendedBatchOffset.get < that.appendedBatchOffset.get
 }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -1335,7 +1335,7 @@ object GroupMetadataManager {
 
 }
 
-case class GroupTopicPartition(group: String, topicPartition: TopicPartition) {
+final case class GroupTopicPartition(group: String, topicPartition: TopicPartition) {
 
   def this(group: String, topic: String, partition: Int) =
     this(group, new TopicPartition(topic, partition))
@@ -1349,12 +1349,12 @@ trait BaseKey{
   def key: Any
 }
 
-case class OffsetKey(version: Short, key: GroupTopicPartition) extends BaseKey {
+final case class OffsetKey(version: Short, key: GroupTopicPartition) extends BaseKey {
 
   override def toString: String = key.toString
 }
 
-case class GroupMetadataKey(version: Short, key: String) extends BaseKey {
+final case class GroupMetadataKey(version: Short, key: String) extends BaseKey {
 
   override def toString: String = key
 }

--- a/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/MemberMetadata.scala
@@ -21,12 +21,12 @@ import java.util
 
 import kafka.utils.nonthreadsafe
 
-case class MemberSummary(memberId: String,
-                         groupInstanceId: Option[String],
-                         clientId: String,
-                         clientHost: String,
-                         metadata: Array[Byte],
-                         assignment: Array[Byte])
+final case class MemberSummary(memberId: String,
+                               groupInstanceId: Option[String],
+                               clientId: String,
+                               clientHost: String,
+                               metadata: Array[Byte],
+                               assignment: Array[Byte])
 
 private object MemberMetadata {
   def plainProtocolSet(supportedProtocols: List[(String, Array[Byte])]) = supportedProtocols.map(_._1).toSet

--- a/core/src/main/scala/kafka/coordinator/group/OffsetConfig.scala
+++ b/core/src/main/scala/kafka/coordinator/group/OffsetConfig.scala
@@ -37,16 +37,16 @@ import kafka.message.{CompressionCodec, NoCompressionCodec}
  * @param offsetCommitRequiredAcks The required acks before the commit can be accepted. In general, the default (-1)
  *                                 should not be overridden.
  */
-case class OffsetConfig(maxMetadataSize: Int = OffsetConfig.DefaultMaxMetadataSize,
-                        loadBufferSize: Int = OffsetConfig.DefaultLoadBufferSize,
-                        offsetsRetentionMs: Long = OffsetConfig.DefaultOffsetRetentionMs,
-                        offsetsRetentionCheckIntervalMs: Long = OffsetConfig.DefaultOffsetsRetentionCheckIntervalMs,
-                        offsetsTopicNumPartitions: Int = OffsetConfig.DefaultOffsetsTopicNumPartitions,
-                        offsetsTopicSegmentBytes: Int = OffsetConfig.DefaultOffsetsTopicSegmentBytes,
-                        offsetsTopicReplicationFactor: Short = OffsetConfig.DefaultOffsetsTopicReplicationFactor,
-                        offsetsTopicCompressionCodec: CompressionCodec = OffsetConfig.DefaultOffsetsTopicCompressionCodec,
-                        offsetCommitTimeoutMs: Int = OffsetConfig.DefaultOffsetCommitTimeoutMs,
-                        offsetCommitRequiredAcks: Short = OffsetConfig.DefaultOffsetCommitRequiredAcks)
+final case class OffsetConfig(maxMetadataSize: Int = OffsetConfig.DefaultMaxMetadataSize,
+                              loadBufferSize: Int = OffsetConfig.DefaultLoadBufferSize,
+                              offsetsRetentionMs: Long = OffsetConfig.DefaultOffsetRetentionMs,
+                              offsetsRetentionCheckIntervalMs: Long = OffsetConfig.DefaultOffsetsRetentionCheckIntervalMs,
+                              offsetsTopicNumPartitions: Int = OffsetConfig.DefaultOffsetsTopicNumPartitions,
+                              offsetsTopicSegmentBytes: Int = OffsetConfig.DefaultOffsetsTopicSegmentBytes,
+                              offsetsTopicReplicationFactor: Short = OffsetConfig.DefaultOffsetsTopicReplicationFactor,
+                              offsetsTopicCompressionCodec: CompressionCodec = OffsetConfig.DefaultOffsetsTopicCompressionCodec,
+                              offsetCommitTimeoutMs: Int = OffsetConfig.DefaultOffsetCommitTimeoutMs,
+                              offsetCommitRequiredAcks: Short = OffsetConfig.DefaultOffsetCommitRequiredAcks)
 
 object OffsetConfig {
   val DefaultMaxMetadataSize = 4096

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -691,4 +691,4 @@ class TransactionCoordinator(brokerId: Int,
   }
 }
 
-case class InitProducerIdResult(producerId: Long, producerEpoch: Short, error: Errors)
+final case class InitProducerIdResult(producerId: Long, producerEpoch: Short, error: Errors)

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionLog.scala
@@ -186,6 +186,6 @@ object TransactionLog {
 
 }
 
-case class TxnKey(version: Short, transactionalId: String) {
+final case class TxnKey(version: Short, transactionalId: String) {
   override def toString: String = transactionalId
 }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -415,12 +415,12 @@ class TransactionMarkerChannelManager(
   }
 }
 
-case class TxnIdAndMarkerEntry(txnId: String, txnMarkerEntry: TxnMarkerEntry)
+final case class TxnIdAndMarkerEntry(txnId: String, txnMarkerEntry: TxnMarkerEntry)
 
-case class PendingCompleteTxn(transactionalId: String,
-                              coordinatorEpoch: Int,
-                              txnMetadata: TransactionMetadata,
-                              newMetadata: TxnTransitMetadata) {
+final case class PendingCompleteTxn(transactionalId: String,
+                                    coordinatorEpoch: Int,
+                                    txnMetadata: TransactionMetadata,
+                                    newMetadata: TxnTransitMetadata) {
 
   override def toString: String = {
     "PendingCompleteTxn(" +

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -181,15 +181,15 @@ private[transaction] object TransactionMetadata {
 }
 
 // this is a immutable object representing the target transition of the transaction metadata
-private[transaction] case class TxnTransitMetadata(producerId: Long,
-                                                   lastProducerId: Long,
-                                                   producerEpoch: Short,
-                                                   lastProducerEpoch: Short,
-                                                   txnTimeoutMs: Int,
-                                                   txnState: TransactionState,
-                                                   topicPartitions: immutable.Set[TopicPartition],
-                                                   txnStartTimestamp: Long,
-                                                   txnLastUpdateTimestamp: Long) {
+private[transaction] final case class TxnTransitMetadata(producerId: Long,
+                                                         lastProducerId: Long,
+                                                         producerEpoch: Short,
+                                                         lastProducerEpoch: Short,
+                                                         txnTimeoutMs: Int,
+                                                         txnState: TransactionState,
+                                                         topicPartitions: immutable.Set[TopicPartition],
+                                                         txnStartTimestamp: Long,
+                                                         txnLastUpdateTimestamp: Long) {
   override def toString: String = {
     "TxnTransitMetadata(" +
       s"producerId=$producerId, " +

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -790,35 +790,35 @@ class TransactionStateManager(brokerId: Int,
 }
 
 
-private[transaction] case class TxnMetadataCacheEntry(coordinatorEpoch: Int,
-                                                      metadataPerTransactionalId: Pool[String, TransactionMetadata]) {
+private[transaction] final case class TxnMetadataCacheEntry(coordinatorEpoch: Int,
+                                                            metadataPerTransactionalId: Pool[String, TransactionMetadata]) {
   override def toString: String = {
     s"TxnMetadataCacheEntry(coordinatorEpoch=$coordinatorEpoch, numTransactionalEntries=${metadataPerTransactionalId.size})"
   }
 }
 
-private[transaction] case class CoordinatorEpochAndTxnMetadata(coordinatorEpoch: Int,
-                                                               transactionMetadata: TransactionMetadata)
+private[transaction] final case class CoordinatorEpochAndTxnMetadata(coordinatorEpoch: Int,
+                                                                     transactionMetadata: TransactionMetadata)
 
-private[transaction] case class TransactionConfig(transactionalIdExpirationMs: Int = TransactionStateManager.DefaultTransactionalIdExpirationMs,
-                                                  transactionMaxTimeoutMs: Int = TransactionStateManager.DefaultTransactionsMaxTimeoutMs,
-                                                  transactionLogNumPartitions: Int = TransactionLog.DefaultNumPartitions,
-                                                  transactionLogReplicationFactor: Short = TransactionLog.DefaultReplicationFactor,
-                                                  transactionLogSegmentBytes: Int = TransactionLog.DefaultSegmentBytes,
-                                                  transactionLogLoadBufferSize: Int = TransactionLog.DefaultLoadBufferSize,
-                                                  transactionLogMinInsyncReplicas: Int = TransactionLog.DefaultMinInSyncReplicas,
-                                                  abortTimedOutTransactionsIntervalMs: Int = TransactionStateManager.DefaultAbortTimedOutTransactionsIntervalMs,
-                                                  removeExpiredTransactionalIdsIntervalMs: Int = TransactionStateManager.DefaultRemoveExpiredTransactionalIdsIntervalMs,
-                                                  requestTimeoutMs: Int = Defaults.RequestTimeoutMs)
+private[transaction] final case class TransactionConfig(transactionalIdExpirationMs: Int = TransactionStateManager.DefaultTransactionalIdExpirationMs,
+                                                        transactionMaxTimeoutMs: Int = TransactionStateManager.DefaultTransactionsMaxTimeoutMs,
+                                                        transactionLogNumPartitions: Int = TransactionLog.DefaultNumPartitions,
+                                                        transactionLogReplicationFactor: Short = TransactionLog.DefaultReplicationFactor,
+                                                        transactionLogSegmentBytes: Int = TransactionLog.DefaultSegmentBytes,
+                                                        transactionLogLoadBufferSize: Int = TransactionLog.DefaultLoadBufferSize,
+                                                        transactionLogMinInsyncReplicas: Int = TransactionLog.DefaultMinInSyncReplicas,
+                                                        abortTimedOutTransactionsIntervalMs: Int = TransactionStateManager.DefaultAbortTimedOutTransactionsIntervalMs,
+                                                        removeExpiredTransactionalIdsIntervalMs: Int = TransactionStateManager.DefaultRemoveExpiredTransactionalIdsIntervalMs,
+                                                        requestTimeoutMs: Int = Defaults.RequestTimeoutMs)
 
-case class TransactionalIdAndProducerIdEpoch(transactionalId: String, producerId: Long, producerEpoch: Short) {
+final case class TransactionalIdAndProducerIdEpoch(transactionalId: String, producerId: Long, producerEpoch: Short) {
   override def toString: String = {
     s"(transactionalId=$transactionalId, producerId=$producerId, producerEpoch=$producerEpoch)"
   }
 }
 
-case class TransactionPartitionAndLeaderEpoch(txnPartitionId: Int, coordinatorEpoch: Int)
+final case class TransactionPartitionAndLeaderEpoch(txnPartitionId: Int, coordinatorEpoch: Int)
 
-case class TransactionalIdCoordinatorEpochAndMetadata(transactionalId: String, coordinatorEpoch: Int, transitMetadata: TxnTransitMetadata)
+final case class TransactionalIdCoordinatorEpochAndMetadata(transactionalId: String, coordinatorEpoch: Int, transitMetadata: TxnTransitMetadata)
 
-case class TransactionalIdCoordinatorEpochAndTransitMetadata(transactionalId: String, coordinatorEpoch: Int, result: TransactionResult, txnMetadata: TransactionMetadata, transitMetadata: TxnTransitMetadata)
+final case class TransactionalIdCoordinatorEpochAndTransitMetadata(transactionalId: String, coordinatorEpoch: Int, result: TransactionResult, txnMetadata: TransactionMetadata, transitMetadata: TxnTransitMetadata)

--- a/core/src/main/scala/kafka/log/CleanerConfig.scala
+++ b/core/src/main/scala/kafka/log/CleanerConfig.scala
@@ -29,13 +29,13 @@ package kafka.log
  * @param enableCleaner Allows completely disabling the log cleaner
  * @param hashAlgorithm The hash algorithm to use in key comparison.
  */
-case class CleanerConfig(numThreads: Int = 1,
-                         dedupeBufferSize: Long = 4*1024*1024L,
-                         dedupeBufferLoadFactor: Double = 0.9d,
-                         ioBufferSize: Int = 1024*1024,
-                         maxMessageSize: Int = 32*1024*1024,
-                         maxIoBytesPerSecond: Double = Double.MaxValue,
-                         backOffMs: Long = 15 * 1000,
-                         enableCleaner: Boolean = true,
-                         hashAlgorithm: String = "MD5") {
+final case class CleanerConfig(numThreads: Int = 1,
+                               dedupeBufferSize: Long = 4*1024*1024L,
+                               dedupeBufferLoadFactor: Double = 0.9d,
+                               ioBufferSize: Int = 1024*1024,
+                               maxMessageSize: Int = 32*1024*1024,
+                               maxIoBytesPerSecond: Double = Double.MaxValue,
+                               backOffMs: Long = 15 * 1000,
+                               enableCleaner: Boolean = true,
+                               hashAlgorithm: String = "MD5") {
 }

--- a/core/src/main/scala/kafka/log/IndexEntry.scala
+++ b/core/src/main/scala/kafka/log/IndexEntry.scala
@@ -30,7 +30,7 @@ sealed trait IndexEntry {
  * in some log file of the beginning of the message set entry with the
  * given offset.
  */
-case class OffsetPosition(offset: Long, position: Int) extends IndexEntry {
+final case class OffsetPosition(offset: Long, position: Int) extends IndexEntry {
   override def indexKey = offset
   override def indexValue = position.toLong
 }
@@ -42,7 +42,7 @@ case class OffsetPosition(offset: Long, position: Int) extends IndexEntry {
  * @param timestamp The max timestamp before the given offset.
  * @param offset The message offset.
  */
-case class TimestampOffset(timestamp: Long, offset: Long) extends IndexEntry {
+final case class TimestampOffset(timestamp: Long, offset: Long) extends IndexEntry {
   override def indexKey = timestamp
   override def indexValue = offset
 }

--- a/core/src/main/scala/kafka/log/LocalLog.scala
+++ b/core/src/main/scala/kafka/log/LocalLog.scala
@@ -41,7 +41,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
  * @param deletedSegments segments deleted when splitting a segment
  * @param newSegments new segments created when splitting a segment
  */
-case class SplitSegmentResult(deletedSegments: Iterable[LogSegment], newSegments: Iterable[LogSegment])
+final case class SplitSegmentResult(deletedSegments: Iterable[LogSegment], newSegments: Iterable[LogSegment])
 
 /**
  * An append-only log for storing messages locally. The log is a sequence of LogSegments, each with a base offset.
@@ -60,15 +60,15 @@ case class SplitSegmentResult(deletedSegments: Iterable[LogSegment], newSegments
  * @param topicPartition The topic partition associated with this log
  * @param logDirFailureChannel The LogDirFailureChannel instance to asynchronously handle Log dir failure
  */
-class LocalLog(@volatile private var _dir: File,
-               @volatile private[log] var config: LogConfig,
-               private[log] val segments: LogSegments,
-               @volatile private[log] var recoveryPoint: Long,
-               @volatile private var nextOffsetMetadata: LogOffsetMetadata,
-               private[log] val scheduler: Scheduler,
-               private[log] val time: Time,
-               private[log] val topicPartition: TopicPartition,
-               private[log] val logDirFailureChannel: LogDirFailureChannel) extends Logging with KafkaMetricsGroup {
+final class LocalLog(@volatile private var _dir: File,
+                     @volatile private[log] var config: LogConfig,
+                     private[log] val segments: LogSegments,
+                     @volatile private[log] var recoveryPoint: Long,
+                     @volatile private var nextOffsetMetadata: LogOffsetMetadata,
+                     private[log] val scheduler: Scheduler,
+                     private[log] val time: Time,
+                     private[log] val topicPartition: TopicPartition,
+                     private[log] val logDirFailureChannel: LogDirFailureChannel) extends Logging with KafkaMetricsGroup {
 
   import kafka.log.LocalLog._
 
@@ -991,19 +991,19 @@ trait SegmentDeletionReason {
   def logReason(toDelete: List[LogSegment]): Unit
 }
 
-case class LogTruncation(log: LocalLog) extends SegmentDeletionReason {
+final case class LogTruncation(log: LocalLog) extends SegmentDeletionReason {
   override def logReason(toDelete: List[LogSegment]): Unit = {
     log.info(s"Deleting segments as part of log truncation: ${toDelete.mkString(",")}")
   }
 }
 
-case class LogRoll(log: LocalLog) extends SegmentDeletionReason {
+final case class LogRoll(log: LocalLog) extends SegmentDeletionReason {
   override def logReason(toDelete: List[LogSegment]): Unit = {
     log.info(s"Deleting segments as part of log roll: ${toDelete.mkString(",")}")
   }
 }
 
-case class LogDeletion(log: LocalLog) extends SegmentDeletionReason {
+final case class LogDeletion(log: LocalLog) extends SegmentDeletionReason {
   override def logReason(toDelete: List[LogSegment]): Unit = {
     log.info(s"Deleting segments as the log has been deleted: ${toDelete.mkString(",")}")
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -1062,11 +1062,11 @@ private class CleanerStats(time: Time = Time.SYSTEM) {
   * Helper class for a log, its topic/partition, the first cleanable position, the first uncleanable dirty position,
   * and whether it needs compaction immediately.
   */
-private case class LogToClean(topicPartition: TopicPartition,
-                              log: UnifiedLog,
-                              firstDirtyOffset: Long,
-                              uncleanableOffset: Long,
-                              needCompactionNow: Boolean = false) extends Ordered[LogToClean] {
+private final case class LogToClean(topicPartition: TopicPartition,
+                                    log: UnifiedLog,
+                                    firstDirtyOffset: Long,
+                                    uncleanableOffset: Long,
+                                    needCompactionNow: Boolean = false) extends Ordered[LogToClean] {
   val cleanBytes = log.logSegments(-1, firstDirtyOffset).map(_.size.toLong).sum
   val (firstUncleanableOffset, cleanableBytes) = LogCleanerManager.calculateCleanableBytes(log, firstDirtyOffset, uncleanableOffset)
   val totalBytes = cleanBytes + cleanableBytes

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -36,7 +36,7 @@ import scala.collection.{Iterable, Seq, mutable}
 private[log] sealed trait LogCleaningState
 private[log] case object LogCleaningInProgress extends LogCleaningState
 private[log] case object LogCleaningAborted extends LogCleaningState
-private[log] case class LogCleaningPaused(pausedCount: Int) extends LogCleaningState
+private[log] final case class LogCleaningPaused(pausedCount: Int) extends LogCleaningState
 
 private[log] class LogCleaningException(val log: UnifiedLog,
                                         private val message: String,
@@ -522,9 +522,9 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
  * @param forceUpdateCheckpoint whether to update the checkpoint associated with this log. if true, checkpoint should be
  *                             reset to firstDirtyOffset
  */
-private case class OffsetsToClean(firstDirtyOffset: Long,
-                                  firstUncleanableDirtyOffset: Long,
-                                  forceUpdateCheckpoint: Boolean = false) {
+private final case class OffsetsToClean(firstDirtyOffset: Long,
+                                        firstUncleanableDirtyOffset: Long,
+                                        forceUpdateCheckpoint: Boolean = false) {
 }
 
 private[log] object LogCleanerManager extends Logging {

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -70,7 +70,7 @@ object Defaults {
   val MessageDownConversionEnable = kafka.server.Defaults.MessageDownConversionEnable
 }
 
-case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] = Set.empty)
+final case class LogConfig(props: java.util.Map[_, _], overriddenConfigs: Set[String] = Set.empty)
   extends AbstractConfig(LogConfig.configDef, props, false) {
   /**
    * Important note: Any configuration parameter that is passed along from KafkaConfig to LogConfig

--- a/core/src/main/scala/kafka/log/LogLoader.scala
+++ b/core/src/main/scala/kafka/log/LogLoader.scala
@@ -31,9 +31,9 @@ import org.apache.kafka.common.utils.Time
 
 import scala.collection.{Set, mutable}
 
-case class LoadedLogOffsets(logStartOffset: Long,
-                            recoveryPoint: Long,
-                            nextOffsetMetadata: LogOffsetMetadata)
+final case class LoadedLogOffsets(logStartOffset: Long,
+                                  recoveryPoint: Long,
+                                  nextOffsetMetadata: LogOffsetMetadata)
 
 /**
  * @param dir The directory from which log segments need to be loaded
@@ -54,19 +54,19 @@ case class LoadedLogOffsets(logStartOffset: Long,
  * @param leaderEpochCache An optional LeaderEpochFileCache instance to be updated during recovery
  * @param producerStateManager The ProducerStateManager instance to be updated during recovery
  */
-case class LoadLogParams(dir: File,
-                         topicPartition: TopicPartition,
-                         config: LogConfig,
-                         scheduler: Scheduler,
-                         time: Time,
-                         logDirFailureChannel: LogDirFailureChannel,
-                         hadCleanShutdown: Boolean,
-                         segments: LogSegments,
-                         logStartOffsetCheckpoint: Long,
-                         recoveryPointCheckpoint: Long,
-                         maxProducerIdExpirationMs: Int,
-                         leaderEpochCache: Option[LeaderEpochFileCache],
-                         producerStateManager: ProducerStateManager) {
+final case class LoadLogParams(dir: File,
+                               topicPartition: TopicPartition,
+                               config: LogConfig,
+                               scheduler: Scheduler,
+                               time: Time,
+                               logDirFailureChannel: LogDirFailureChannel,
+                               hadCleanShutdown: Boolean,
+                               segments: LogSegments,
+                               logStartOffsetCheckpoint: Long,
+                               recoveryPointCheckpoint: Long,
+                               maxProducerIdExpirationMs: Int,
+                               leaderEpochCache: Option[LeaderEpochFileCache],
+                               producerStateManager: ProducerStateManager) {
   val logIdentifier: String = s"[LogLoader partition=$topicPartition, dir=${dir.getParent}] "
 }
 

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -581,11 +581,11 @@ private[log] object LogValidator extends Logging {
     }
   }
 
-  case class ValidationAndOffsetAssignResult(validatedRecords: MemoryRecords,
-                                             maxTimestamp: Long,
-                                             shallowOffsetOfMaxTimestamp: Long,
-                                             messageSizeMaybeChanged: Boolean,
-                                             recordConversionStats: RecordConversionStats)
+  final case class ValidationAndOffsetAssignResult(validatedRecords: MemoryRecords,
+                                                   maxTimestamp: Long,
+                                                   shallowOffsetOfMaxTimestamp: Long,
+                                                   messageSizeMaybeChanged: Boolean,
+                                                   recordConversionStats: RecordConversionStats)
 
-  private case class ApiRecordError(apiError: Errors, recordError: RecordError)
+  private final case class ApiRecordError(apiError: Errors, recordError: RecordError)
 }

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -40,10 +40,10 @@ class CorruptSnapshotException(msg: String) extends KafkaException(msg)
  * The last written record for a given producer. The last data offset may be undefined
  * if the only log entry for a producer is a transaction marker.
  */
-case class LastRecord(lastDataOffset: Option[Long], producerEpoch: Short)
+final case class LastRecord(lastDataOffset: Option[Long], producerEpoch: Short)
 
 
-private[log] case class TxnMetadata(
+private[log] final case class TxnMetadata(
   producerId: Long,
   firstOffset: LogOffsetMetadata,
   var lastOffset: Option[Long] = None
@@ -69,7 +69,7 @@ private[log] object ProducerStateEntry {
     currentTxnFirstOffset = None)
 }
 
-private[log] case class BatchMetadata(lastSeq: Int, lastOffset: Long, offsetDelta: Int, timestamp: Long) {
+private[log] final case class BatchMetadata(lastSeq: Int, lastOffset: Long, offsetDelta: Int, timestamp: Long) {
   def firstSeq: Int =  DefaultRecordBatch.decrementSequence(lastSeq, offsetDelta)
   def firstOffset: Long = lastOffset - offsetDelta
 
@@ -869,8 +869,8 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   }
 }
 
-case class SnapshotFile private[log] (@volatile private var _file: File,
-                                      offset: Long) extends Logging {
+final case class SnapshotFile private[log] (@volatile private var _file: File,
+                                            offset: Long) extends Logging {
   def deleteIfExists(): Boolean = {
     val deleted = Files.deleteIfExists(file.toPath)
     if (deleted) {

--- a/core/src/main/scala/kafka/log/TransactionIndex.scala
+++ b/core/src/main/scala/kafka/log/TransactionIndex.scala
@@ -27,7 +27,7 @@ import org.apache.kafka.common.utils.Utils
 
 import scala.collection.mutable.ListBuffer
 
-private[log] case class TxnIndexSearchResult(abortedTransactions: List[AbortedTxn], isComplete: Boolean)
+private[log] final case class TxnIndexSearchResult(abortedTransactions: List[AbortedTxn], isComplete: Boolean)
 
 /**
  * The transaction index maintains metadata about the aborted transactions for each segment. This includes

--- a/core/src/main/scala/kafka/log/UnifiedLog.scala
+++ b/core/src/main/scala/kafka/log/UnifiedLog.scala
@@ -97,23 +97,23 @@ object LeaderHwChange {
  *                       Same if high watermark is not changed. None is the default value and it means append failed
  *
  */
-case class LogAppendInfo(var firstOffset: Option[LogOffsetMetadata],
-                         var lastOffset: Long,
-                         var lastLeaderEpoch: Option[Int],
-                         var maxTimestamp: Long,
-                         var offsetOfMaxTimestamp: Long,
-                         var logAppendTime: Long,
-                         var logStartOffset: Long,
-                         var recordConversionStats: RecordConversionStats,
-                         sourceCodec: CompressionCodec,
-                         targetCodec: CompressionCodec,
-                         shallowCount: Int,
-                         validBytes: Int,
-                         offsetsMonotonic: Boolean,
-                         lastOffsetOfFirstBatch: Long,
-                         recordErrors: Seq[RecordError] = List(),
-                         errorMessage: String = null,
-                         leaderHwChange: LeaderHwChange = LeaderHwChange.None) {
+final case class LogAppendInfo(var firstOffset: Option[LogOffsetMetadata],
+                               var lastOffset: Long,
+                               var lastLeaderEpoch: Option[Int],
+                               var maxTimestamp: Long,
+                               var offsetOfMaxTimestamp: Long,
+                               var logAppendTime: Long,
+                               var logStartOffset: Long,
+                               var recordConversionStats: RecordConversionStats,
+                               sourceCodec: CompressionCodec,
+                               targetCodec: CompressionCodec,
+                               shallowCount: Int,
+                               validBytes: Int,
+                               offsetsMonotonic: Boolean,
+                               lastOffsetOfFirstBatch: Long,
+                               recordErrors: Seq[RecordError] = List(),
+                               errorMessage: String = null,
+                               leaderHwChange: LeaderHwChange = LeaderHwChange.None) {
   /**
    * Get the first offset if it exists, else get the last offset of the first batch
    * For magic versions 2 and newer, this method will return first offset. For magic versions
@@ -140,20 +140,20 @@ case class LogAppendInfo(var firstOffset: Option[LogOffsetMetadata],
  * of these offsets atomically without the possibility of a leader change affecting their consistency relative
  * to each other. See [[UnifiedLog.fetchOffsetSnapshot()]].
  */
-case class LogOffsetSnapshot(logStartOffset: Long,
-                             logEndOffset: LogOffsetMetadata,
-                             highWatermark: LogOffsetMetadata,
-                             lastStableOffset: LogOffsetMetadata)
+final case class LogOffsetSnapshot(logStartOffset: Long,
+                                   logEndOffset: LogOffsetMetadata,
+                                   highWatermark: LogOffsetMetadata,
+                                   lastStableOffset: LogOffsetMetadata)
 
 /**
  * Another container which is used for lower level reads using  [[kafka.cluster.Partition.readRecords()]].
  */
-case class LogReadInfo(fetchedData: FetchDataInfo,
-                       divergingEpoch: Option[FetchResponseData.EpochEndOffset],
-                       highWatermark: Long,
-                       logStartOffset: Long,
-                       logEndOffset: Long,
-                       lastStableOffset: Long)
+final case class LogReadInfo(fetchedData: FetchDataInfo,
+                             divergingEpoch: Option[FetchResponseData.EpochEndOffset],
+                             highWatermark: Long,
+                             logStartOffset: Long,
+                             logEndOffset: Long,
+                             lastStableOffset: Long)
 
 /**
  * A class used to hold useful metadata about a completed transaction. This is used to build
@@ -165,7 +165,7 @@ case class LogReadInfo(fetchedData: FetchDataInfo,
  *                   COMMIT/ABORT control record which indicates the transaction's completion.
  * @param isAborted Whether or not the transaction was aborted
  */
-case class CompletedTxn(producerId: Long, firstOffset: Long, lastOffset: Long, isAborted: Boolean) {
+final case class CompletedTxn(producerId: Long, firstOffset: Long, lastOffset: Long, isAborted: Boolean) {
   override def toString: String = {
     "CompletedTxn(" +
       s"producerId=$producerId, " +
@@ -178,12 +178,12 @@ case class CompletedTxn(producerId: Long, firstOffset: Long, lastOffset: Long, i
 /**
  * A class used to hold params required to decide to rotate a log segment or not.
  */
-case class RollParams(maxSegmentMs: Long,
-                      maxSegmentBytes: Int,
-                      maxTimestampInMessages: Long,
-                      maxOffsetInMessages: Long,
-                      messagesSize: Int,
-                      now: Long)
+final case class RollParams(maxSegmentMs: Long,
+                            maxSegmentBytes: Int,
+                            maxTimestampInMessages: Long,
+                            maxOffsetInMessages: Long,
+                            messagesSize: Int,
+                            now: Long)
 
 object RollParams {
   def apply(config: LogConfig, appendInfo: LogAppendInfo, messagesSize: Int, now: Long): RollParams = {
@@ -2086,7 +2086,7 @@ object LogMetricNames {
   }
 }
 
-case class RetentionMsBreach(log: UnifiedLog) extends SegmentDeletionReason {
+final case class RetentionMsBreach(log: UnifiedLog) extends SegmentDeletionReason {
   override def logReason(toDelete: List[LogSegment]): Unit = {
     val retentionMs = log.config.retentionMs
     toDelete.foreach { segment =>
@@ -2102,7 +2102,7 @@ case class RetentionMsBreach(log: UnifiedLog) extends SegmentDeletionReason {
   }
 }
 
-case class RetentionSizeBreach(log: UnifiedLog) extends SegmentDeletionReason {
+final case class RetentionSizeBreach(log: UnifiedLog) extends SegmentDeletionReason {
   override def logReason(toDelete: List[LogSegment]): Unit = {
     var size = log.size
     toDelete.foreach { segment =>
@@ -2113,7 +2113,7 @@ case class RetentionSizeBreach(log: UnifiedLog) extends SegmentDeletionReason {
   }
 }
 
-case class StartOffsetBreach(log: UnifiedLog) extends SegmentDeletionReason {
+final case class StartOffsetBreach(log: UnifiedLog) extends SegmentDeletionReason {
   override def logReason(toDelete: List[LogSegment]): Unit = {
     log.info(s"Deleting segments due to log start offset ${log.logStartOffset} breach: ${toDelete.mkString(",")}")
   }

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -55,7 +55,7 @@ object RequestChannel extends Logging {
   sealed trait BaseRequest
   case object ShutdownRequest extends BaseRequest
 
-  case class Session(principal: KafkaPrincipal, clientAddress: InetAddress) {
+  final case class Session(principal: KafkaPrincipal, clientAddress: InetAddress) {
     val sanitizedUser: String = Sanitizer.sanitize(principal.getName)
   }
 

--- a/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
+++ b/core/src/main/scala/kafka/raft/KafkaMetadataLog.scala
@@ -532,15 +532,15 @@ object MetadataLogConfig {
   }
 }
 
-case class MetadataLogConfig(logSegmentBytes: Int,
-                             logSegmentMinBytes: Int,
-                             logSegmentMillis: Long,
-                             retentionMaxBytes: Long,
-                             retentionMillis: Long,
-                             maxBatchSizeInBytes: Int,
-                             maxFetchSizeInBytes: Int,
-                             fileDeleteDelayMs: Int,
-                             nodeId: Int)
+final case class MetadataLogConfig(logSegmentBytes: Int,
+                                   logSegmentMinBytes: Int,
+                                   logSegmentMillis: Long,
+                                   retentionMaxBytes: Long,
+                                   retentionMillis: Long,
+                                   maxBatchSizeInBytes: Int,
+                                   maxFetchSizeInBytes: Int,
+                                   fileDeleteDelayMs: Int,
+                                   nodeId: Int)
 
 object KafkaMetadataLog {
   def apply(

--- a/core/src/main/scala/kafka/raft/SegmentPosition.scala
+++ b/core/src/main/scala/kafka/raft/SegmentPosition.scala
@@ -18,6 +18,6 @@ package kafka.raft
 
 import org.apache.kafka.raft.OffsetMetadata
 
-case class SegmentPosition(baseOffset: Long, relativePosition: Int) extends OffsetMetadata {
+final case class SegmentPosition(baseOffset: Long, relativePosition: Int) extends OffsetMetadata {
   override def toString: String = s"(segmentBaseOffset=$baseOffset,relativePositionInSegment=$relativePosition)"
 }

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -60,7 +60,7 @@ object AclAuthorizer {
   // If set to true when no acls are found for a resource, authorizer allows access to everyone. Defaults to false.
   val AllowEveryoneIfNoAclIsFoundProp = "allow.everyone.if.no.acl.found"
 
-  case class VersionedAcls(acls: Set[AclEntry], zkVersion: Int) {
+  final case class VersionedAcls(acls: Set[AclEntry], zkVersion: Int) {
     def exists: Boolean = zkVersion != ZkVersion.UnknownVersion
   }
 
@@ -747,8 +747,8 @@ class AclAuthorizer extends Authorizer with Logging {
       processAclChangeNotification(resource)
     }
   }
-
-  private case class ResourceTypeKey(ace: AccessControlEntry,
-                                     resourceType: ResourceType,
-                                     patternType: PatternType)
 }
+
+private[authorizer] final case class ResourceTypeKey(ace: AccessControlEntry,
+                                                     resourceType: ResourceType,
+                                                     patternType: PatternType)

--- a/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherManager.scala
@@ -233,8 +233,8 @@ class FailedPartitions {
   }
 }
 
-case class BrokerAndFetcherId(broker: BrokerEndPoint, fetcherId: Int)
+final case class BrokerAndFetcherId(broker: BrokerEndPoint, fetcherId: Int)
 
-case class InitialFetchState(leader: BrokerEndPoint, currentLeaderEpoch: Int, initOffset: Long)
+final case class InitialFetchState(leader: BrokerEndPoint, currentLeaderEpoch: Int, initOffset: Long)
 
-case class BrokerIdAndFetcherId(brokerId: Int, fetcherId: Int)
+final case class BrokerIdAndFetcherId(brokerId: Int, fetcherId: Int)

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -747,8 +747,8 @@ abstract class AbstractFetcherThread(name: String,
 
 object AbstractFetcherThread {
 
-  case class ReplicaFetch(partitionData: util.Map[TopicPartition, FetchRequest.PartitionData], fetchRequest: FetchRequest.Builder)
-  case class ResultWithPartitions[R](result: R, partitionsWithError: Set[TopicPartition])
+  final case class ReplicaFetch(partitionData: util.Map[TopicPartition, FetchRequest.PartitionData], fetchRequest: FetchRequest.Builder)
+  final case class ResultWithPartitions[R](result: R, partitionsWithError: Set[TopicPartition])
 
 }
 
@@ -815,7 +815,7 @@ class FetcherStats(metricId: ClientIdAndBroker) extends KafkaMetricsGroup {
 
 }
 
-case class ClientIdTopicPartition(clientId: String, topicPartition: TopicPartition) {
+final case class ClientIdTopicPartition(clientId: String, topicPartition: TopicPartition) {
   override def toString: String = s"$clientId-$topicPartition"
 }
 
@@ -832,18 +832,18 @@ object PartitionFetchState {
 
 
 /**
- * case class to keep partition offset and its state(truncatingLog, delayed)
+ * final case class to keep partition offset and its state(truncatingLog, delayed)
  * This represents a partition as being either:
  * (1) Truncating its log, for example having recently become a follower
  * (2) Delayed, for example due to an error, where we subsequently back off a bit
  * (3) ReadyForFetch, the is the active state where the thread is actively fetching data.
  */
-case class PartitionFetchState(fetchOffset: Long,
-                               lag: Option[Long],
-                               currentLeaderEpoch: Int,
-                               delay: Option[DelayedItem],
-                               state: ReplicaState,
-                               lastFetchedEpoch: Option[Int]) {
+final case class PartitionFetchState(fetchOffset: Long,
+                                     lag: Option[Long],
+                                     currentLeaderEpoch: Int,
+                                     delay: Option[DelayedItem],
+                                     state: ReplicaState,
+                                     lastFetchedEpoch: Option[Int]) {
 
   def isReadyForFetch: Boolean = state == Fetching && !isDelayed
 
@@ -864,14 +864,14 @@ case class PartitionFetchState(fetchOffset: Long,
   }
 }
 
-case class OffsetTruncationState(offset: Long, truncationCompleted: Boolean) {
+final case class OffsetTruncationState(offset: Long, truncationCompleted: Boolean) {
 
   def this(offset: Long) = this(offset, true)
 
   override def toString: String = s"TruncationState(offset=$offset, completed=$truncationCompleted)"
 }
 
-case class OffsetAndEpoch(offset: Long, leaderEpoch: Int) {
+final case class OffsetAndEpoch(offset: Long, leaderEpoch: Int) {
   override def toString: String = {
     s"(offset=$offset, leaderEpoch=$leaderEpoch)"
   }

--- a/core/src/main/scala/kafka/server/AlterIsrManager.scala
+++ b/core/src/main/scala/kafka/server/AlterIsrManager.scala
@@ -51,10 +51,10 @@ trait AlterIsrManager {
   def submit(alterIsrItem: AlterIsrItem): Boolean
 }
 
-case class AlterIsrItem(topicPartition: TopicPartition,
-                        leaderAndIsr: LeaderAndIsr,
-                        callback: Either[Errors, LeaderAndIsr] => Unit,
-                        controllerEpoch: Int) // controllerEpoch needed for Zk impl
+final case class AlterIsrItem(topicPartition: TopicPartition,
+                              leaderAndIsr: LeaderAndIsr,
+                              callback: Either[Errors, LeaderAndIsr] => Unit,
+                              controllerEpoch: Int) // controllerEpoch needed for Zk impl
 
 object AlterIsrManager {
 

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -106,7 +106,7 @@ object MetaProperties {
   }
 }
 
-case class ZkMetaProperties(
+final case class ZkMetaProperties(
   clusterId: String,
   brokerId: Int
 ) {
@@ -123,7 +123,7 @@ case class ZkMetaProperties(
   }
 }
 
-case class MetaProperties(
+final case class MetaProperties(
   clusterId: String,
   nodeId: Int,
 ) {

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -268,7 +268,7 @@ abstract class ControllerRequestCompletionHandler extends RequestCompletionHandl
   def onTimeout(): Unit
 }
 
-case class BrokerToControllerQueueItem(
+final case class BrokerToControllerQueueItem(
   createdTimeMs: Long,
   request: AbstractRequest.Builder[_ <: AbstractRequest],
   callback: ControllerRequestCompletionHandler

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -40,7 +40,7 @@ import scala.jdk.CollectionConverters._
  * @param quotaSensor @Sensor that tracks the quota
  * @param throttleTimeSensor @Sensor that tracks the throttle time
  */
-case class ClientSensors(metricTags: Map[String, String], quotaSensor: Sensor, throttleTimeSensor: Sensor)
+final case class ClientSensors(metricTags: Map[String, String], quotaSensor: Sensor, throttleTimeSensor: Sensor)
 
 /**
  * Configuration settings for quota management
@@ -48,10 +48,10 @@ case class ClientSensors(metricTags: Map[String, String], quotaSensor: Sensor, t
  * @param quotaWindowSizeSeconds The time span of each sample
  *
  */
-case class ClientQuotaManagerConfig(numQuotaSamples: Int =
-                                        ClientQuotaManagerConfig.DefaultNumQuotaSamples,
-                                    quotaWindowSizeSeconds: Int =
-                                        ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds)
+final case class ClientQuotaManagerConfig(numQuotaSamples: Int =
+                                              ClientQuotaManagerConfig.DefaultNumQuotaSamples,
+                                          quotaWindowSizeSeconds: Int =
+                                              ClientQuotaManagerConfig.DefaultQuotaWindowSizeSeconds)
 
 object ClientQuotaManagerConfig {
   // Always have 10 whole windows + 1 current window
@@ -77,13 +77,13 @@ object ClientQuotaManager {
 
   sealed trait BaseUserEntity extends ClientQuotaEntity.ConfigEntity
 
-  case class UserEntity(sanitizedUser: String) extends BaseUserEntity {
+  final case class UserEntity(sanitizedUser: String) extends BaseUserEntity {
     override def entityType: ClientQuotaEntity.ConfigEntityType = ClientQuotaEntity.ConfigEntityType.USER
     override def name: String = Sanitizer.desanitize(sanitizedUser)
     override def toString: String = s"user $sanitizedUser"
   }
 
-  case class ClientIdEntity(clientId: String) extends ClientQuotaEntity.ConfigEntity {
+  final case class ClientIdEntity(clientId: String) extends ClientQuotaEntity.ConfigEntity {
     override def entityType: ClientQuotaEntity.ConfigEntityType = ClientQuotaEntity.ConfigEntityType.CLIENT_ID
     override def name: String = clientId
     override def toString: String = s"client-id $clientId"
@@ -101,7 +101,7 @@ object ClientQuotaManager {
     override def toString: String = "default client-id"
   }
 
-  case class KafkaQuotaEntity(userEntity: Option[BaseUserEntity],
+  final case class KafkaQuotaEntity(userEntity: Option[BaseUserEntity],
                               clientIdEntity: Option[ClientQuotaEntity.ConfigEntity]) extends ClientQuotaEntity {
     override def configEntities: util.List[ClientQuotaEntity.ConfigEntity] =
       (userEntity.toList ++ clientIdEntity.toList).asJava

--- a/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
+++ b/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
@@ -26,7 +26,7 @@ import scala.collection._
 /**
   * The create metadata maintained by the delayed create topic or create partitions operations.
   */
-case class CreatePartitionsMetadata(topic: String, partitions: Set[Int], error: ApiError)
+final case class CreatePartitionsMetadata(topic: String, partitions: Set[Int], error: ApiError)
 
 object CreatePartitionsMetadata {
   def apply(topic: String, partitions: Set[Int]): CreatePartitionsMetadata = {

--- a/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteRecords.scala
@@ -30,8 +30,8 @@ import org.apache.kafka.common.requests.DeleteRecordsResponse
 import scala.collection._
 
 
-case class DeleteRecordsPartitionStatus(requiredOffset: Long,
-                                        responseStatus: DeleteRecordsResponseData.DeleteRecordsPartitionResult) {
+final case class DeleteRecordsPartitionStatus(requiredOffset: Long,
+                                              responseStatus: DeleteRecordsResponseData.DeleteRecordsPartitionResult) {
   @volatile var acksPending = false
 
   override def toString = "[acksPending: %b, error: %s, lowWatermark: %d, requiredOffset: %d]"

--- a/core/src/main/scala/kafka/server/DelayedDeleteTopics.scala
+++ b/core/src/main/scala/kafka/server/DelayedDeleteTopics.scala
@@ -24,7 +24,7 @@ import scala.collection._
 /**
   * The delete metadata maintained by the delayed delete operation
   */
-case class DeleteTopicMetadata(topic: String, error: Errors)
+final case class DeleteTopicMetadata(topic: String, error: Errors)
 
 object DeleteTopicMetadata {
   def apply(topic: String, throwable: Throwable): DeleteTopicMetadata = {

--- a/core/src/main/scala/kafka/server/DelayedFetch.scala
+++ b/core/src/main/scala/kafka/server/DelayedFetch.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.requests.OffsetsForLeaderEpochResponse.{UNDEFINED
 
 import scala.collection._
 
-case class FetchPartitionStatus(startOffsetMetadata: LogOffsetMetadata, fetchInfo: PartitionData) {
+final case class FetchPartitionStatus(startOffsetMetadata: LogOffsetMetadata, fetchInfo: PartitionData) {
 
   override def toString: String = {
     "[startOffsetMetadata: " + startOffsetMetadata +
@@ -42,15 +42,15 @@ case class FetchPartitionStatus(startOffsetMetadata: LogOffsetMetadata, fetchInf
 /**
  * The fetch metadata maintained by the delayed fetch operation
  */
-case class FetchMetadata(fetchMinBytes: Int,
-                         fetchMaxBytes: Int,
-                         hardMaxBytesLimit: Boolean,
-                         fetchOnlyLeader: Boolean,
-                         fetchIsolation: FetchIsolation,
-                         isFromFollower: Boolean,
-                         replicaId: Int,
-                         topicIds: util.Map[String, Uuid],
-                         fetchPartitionStatus: Seq[(TopicPartition, FetchPartitionStatus)]) {
+final case class FetchMetadata(fetchMinBytes: Int,
+                               fetchMaxBytes: Int,
+                               hardMaxBytesLimit: Boolean,
+                               fetchOnlyLeader: Boolean,
+                               fetchIsolation: FetchIsolation,
+                               isFromFollower: Boolean,
+                               replicaId: Int,
+                               topicIds: util.Map[String, Uuid],
+                               fetchPartitionStatus: Seq[(TopicPartition, FetchPartitionStatus)]) {
 
   override def toString = "FetchMetadata(minBytes=" + fetchMinBytes + ", " +
     "maxBytes=" + fetchMaxBytes + ", " +

--- a/core/src/main/scala/kafka/server/DelayedOperationKey.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperationKey.scala
@@ -31,7 +31,7 @@ object DelayedOperationKey {
 }
 
 /* used by delayed-produce and delayed-fetch operations */
-case class TopicPartitionOperationKey(topic: String, partition: Int) extends DelayedOperationKey {
+final case class TopicPartitionOperationKey(topic: String, partition: Int) extends DelayedOperationKey {
   override def keyLabel: String = "%s-%d".format(topic, partition)
 }
 
@@ -42,21 +42,21 @@ object TopicPartitionOperationKey {
 }
 
 /* used by delayed-join-group operations */
-case class MemberKey(groupId: String, consumerId: String) extends DelayedOperationKey {
+final case class MemberKey(groupId: String, consumerId: String) extends DelayedOperationKey {
   override def keyLabel: String = "%s-%s".format(groupId, consumerId)
 }
 
 /* used by delayed-join operations */
-case class GroupJoinKey(groupId: String) extends DelayedOperationKey {
+final case class GroupJoinKey(groupId: String) extends DelayedOperationKey {
   override def keyLabel: String = "join-%s".format(groupId)
 }
 
 /* used by delayed-sync operations */
-case class GroupSyncKey(groupId: String) extends DelayedOperationKey {
+final case class GroupSyncKey(groupId: String) extends DelayedOperationKey {
   override def keyLabel: String = "sync-%s".format(groupId)
 }
 
 /* used by delayed-topic operations */
-case class TopicKey(topic: String) extends DelayedOperationKey {
+final case class TopicKey(topic: String) extends DelayedOperationKey {
   override def keyLabel: String = topic
 }

--- a/core/src/main/scala/kafka/server/DelayedProduce.scala
+++ b/core/src/main/scala/kafka/server/DelayedProduce.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 
 import scala.collection._
 
-case class ProducePartitionStatus(requiredOffset: Long, responseStatus: PartitionResponse) {
+final case class ProducePartitionStatus(requiredOffset: Long, responseStatus: PartitionResponse) {
   @volatile var acksPending = false
 
   override def toString = s"[acksPending: $acksPending, error: ${responseStatus.error.code}, " +
@@ -40,8 +40,8 @@ case class ProducePartitionStatus(requiredOffset: Long, responseStatus: Partitio
 /**
  * The produce metadata maintained by the delayed produce operation
  */
-case class ProduceMetadata(produceRequiredAcks: Short,
-                           produceStatus: Map[TopicPartition, ProducePartitionStatus]) {
+final case class ProduceMetadata(produceRequiredAcks: Short,
+                                 produceStatus: Map[TopicPartition, ProducePartitionStatus]) {
 
   override def toString = s"[requiredAcks: $produceRequiredAcks, partitionStatus: $produceStatus]"
 }

--- a/core/src/main/scala/kafka/server/DelegationTokenManager.scala
+++ b/core/src/main/scala/kafka/server/DelegationTokenManager.scala
@@ -485,12 +485,12 @@ class DelegationTokenManager(val config: KafkaConfig,
 
 }
 
-case class CreateTokenResult(issueTimestamp: Long,
-                             expiryTimestamp: Long,
-                             maxTimestamp: Long,
-                             tokenId: String,
-                             hmac: Array[Byte],
-                             error: Errors) {
+final case class CreateTokenResult(issueTimestamp: Long,
+                                   expiryTimestamp: Long,
+                                   maxTimestamp: Long,
+                                   tokenId: String,
+                                   hmac: Array[Byte],
+                                   error: Errors) {
 
   override def equals(other: Any): Boolean = {
     other match {

--- a/core/src/main/scala/kafka/server/FetchDataInfo.scala
+++ b/core/src/main/scala/kafka/server/FetchDataInfo.scala
@@ -25,7 +25,7 @@ case object FetchLogEnd extends FetchIsolation
 case object FetchHighWatermark extends FetchIsolation
 case object FetchTxnCommitted extends FetchIsolation
 
-case class FetchDataInfo(fetchOffsetMetadata: LogOffsetMetadata,
-                         records: Records,
-                         firstEntryIncomplete: Boolean = false,
-                         abortedTransactions: Option[List[FetchResponseData.AbortedTransaction]] = None)
+final case class FetchDataInfo(fetchOffsetMetadata: LogOffsetMetadata,
+                               records: Records,
+                               firstEntryIncomplete: Boolean = false,
+                               abortedTransactions: Option[List[FetchResponseData.AbortedTransaction]] = None)

--- a/core/src/main/scala/kafka/server/FetchSession.scala
+++ b/core/src/main/scala/kafka/server/FetchSession.scala
@@ -552,12 +552,12 @@ class IncrementalFetchContext(private val time: Time,
   }
 }
 
-case class LastUsedKey(lastUsedMs: Long, id: Int) extends Comparable[LastUsedKey] {
+final case class LastUsedKey(lastUsedMs: Long, id: Int) extends Comparable[LastUsedKey] {
   override def compareTo(other: LastUsedKey): Int =
     (lastUsedMs, id) compare (other.lastUsedMs, other.id)
 }
 
-case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Comparable[EvictableKey] {
+final case class EvictableKey(privileged: Boolean, size: Int, id: Int) extends Comparable[EvictableKey] {
   override def compareTo(other: EvictableKey): Int =
     (privileged, size, id) compare (other.privileged, other.size, other.id)
 }

--- a/core/src/main/scala/kafka/server/FinalizedFeatureCache.scala
+++ b/core/src/main/scala/kafka/server/FinalizedFeatureCache.scala
@@ -33,7 +33,7 @@ class FeatureCacheUpdateException(message: String) extends RuntimeException(mess
 }
 
 // Helper class that represents finalized features along with an epoch value.
-case class FinalizedFeaturesAndEpoch(features: Features[FinalizedVersionRange], epoch: Long) {
+final case class FinalizedFeaturesAndEpoch(features: Features[FinalizedVersionRange], epoch: Long) {
   override def toString(): String = {
     s"FinalizedFeaturesAndEpoch(features=$features, epoch=$epoch)"
   }

--- a/core/src/main/scala/kafka/server/LogOffsetMetadata.scala
+++ b/core/src/main/scala/kafka/server/LogOffsetMetadata.scala
@@ -38,9 +38,9 @@ object LogOffsetMetadata {
  *  2. the base message offset of the located segment
  *  3. the physical position on the located segment
  */
-case class LogOffsetMetadata(messageOffset: Long,
-                             segmentBaseOffset: Long = UnifiedLog.UnknownOffset,
-                             relativePositionInSegment: Int = LogOffsetMetadata.UnknownFilePosition) {
+final case class LogOffsetMetadata(messageOffset: Long,
+                                   segmentBaseOffset: Long = UnifiedLog.UnknownOffset,
+                                   relativePositionInSegment: Int = LogOffsetMetadata.UnknownFilePosition) {
 
   // check if this offset is already on an older segment compared with the given offset
   def onOlderSegment(that: LogOffsetMetadata): Boolean = {

--- a/core/src/main/scala/kafka/server/MetadataSupport.scala
+++ b/core/src/main/scala/kafka/server/MetadataSupport.scala
@@ -63,11 +63,11 @@ sealed trait MetadataSupport {
   def controllerId: Option[Int]
 }
 
-case class ZkSupport(adminManager: ZkAdminManager,
-                     controller: KafkaController,
-                     zkClient: KafkaZkClient,
-                     forwardingManager: Option[ForwardingManager],
-                     metadataCache: ZkMetadataCache) extends MetadataSupport {
+final case class ZkSupport(adminManager: ZkAdminManager,
+                           controller: KafkaController,
+                           zkClient: KafkaZkClient,
+                           forwardingManager: Option[ForwardingManager],
+                           metadataCache: ZkMetadataCache) extends MetadataSupport {
   val adminZkClient = new AdminZkClient(zkClient)
 
   override def requireZkOrThrow(createException: => Exception): ZkSupport = this
@@ -91,7 +91,7 @@ case class ZkSupport(adminManager: ZkAdminManager,
   override def controllerId: Option[Int] =  metadataCache.getControllerId
 }
 
-case class RaftSupport(fwdMgr: ForwardingManager, metadataCache: KRaftMetadataCache)
+final case class RaftSupport(fwdMgr: ForwardingManager, metadataCache: KRaftMetadataCache)
     extends MetadataSupport {
   override val forwardingManager: Option[ForwardingManager] = Some(fwdMgr)
   override def requireZkOrThrow(createException: => Exception): ZkSupport = throw createException

--- a/core/src/main/scala/kafka/server/QuotaFactory.scala
+++ b/core/src/main/scala/kafka/server/QuotaFactory.scala
@@ -54,14 +54,14 @@ object QuotaFactory extends Logging {
     def record(value: Long): Unit = ()
   }
 
-  case class QuotaManagers(fetch: ClientQuotaManager,
-                           produce: ClientQuotaManager,
-                           request: ClientRequestQuotaManager,
-                           controllerMutation: ControllerMutationQuotaManager,
-                           leader: ReplicationQuotaManager,
-                           follower: ReplicationQuotaManager,
-                           alterLogDirs: ReplicationQuotaManager,
-                           clientQuotaCallback: Option[ClientQuotaCallback]) {
+  final case class QuotaManagers(fetch: ClientQuotaManager,
+                                 produce: ClientQuotaManager,
+                                 request: ClientRequestQuotaManager,
+                                 controllerMutation: ControllerMutationQuotaManager,
+                                 leader: ReplicationQuotaManager,
+                                 follower: ReplicationQuotaManager,
+                                 alterLogDirs: ReplicationQuotaManager,
+                                 clientQuotaCallback: Option[ClientQuotaCallback]) {
     def shutdown(): Unit = {
       fetch.shutdown()
       produce.shutdown()

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -69,14 +69,14 @@ import scala.compat.java8.OptionConverters._
 /*
  * Result metadata of a log append operation on the log
  */
-case class LogAppendResult(info: LogAppendInfo, exception: Option[Throwable] = None) {
+final case class LogAppendResult(info: LogAppendInfo, exception: Option[Throwable] = None) {
   def error: Errors = exception match {
     case None => Errors.NONE
     case Some(e) => Errors.forException(e)
   }
 }
 
-case class LogDeleteRecordsResult(requestedOffset: Long, lowWatermark: Long, exception: Option[Throwable] = None) {
+final case class LogDeleteRecordsResult(requestedOffset: Long, lowWatermark: Long, exception: Option[Throwable] = None) {
   def error: Errors = exception match {
     case None => Errors.NONE
     case Some(e) => Errors.forException(e)
@@ -97,16 +97,16 @@ case class LogDeleteRecordsResult(requestedOffset: Long, lowWatermark: Long, exc
  * @param preferredReadReplica the preferred read replica to be used for future fetches
  * @param exception Exception if error encountered while reading from the log
  */
-case class LogReadResult(info: FetchDataInfo,
-                         divergingEpoch: Option[FetchResponseData.EpochEndOffset],
-                         highWatermark: Long,
-                         leaderLogStartOffset: Long,
-                         leaderLogEndOffset: Long,
-                         followerLogStartOffset: Long,
-                         fetchTimeMs: Long,
-                         lastStableOffset: Option[Long],
-                         preferredReadReplica: Option[Int] = None,
-                         exception: Option[Throwable] = None) {
+final case class LogReadResult(info: FetchDataInfo,
+                               divergingEpoch: Option[FetchResponseData.EpochEndOffset],
+                               highWatermark: Long,
+                               leaderLogStartOffset: Long,
+                               leaderLogEndOffset: Long,
+                               followerLogStartOffset: Long,
+                               fetchTimeMs: Long,
+                               lastStableOffset: Option[Long],
+                               preferredReadReplica: Option[Int] = None,
+                               exception: Option[Throwable] = None) {
 
   def error: Errors = exception match {
     case None => Errors.NONE
@@ -144,15 +144,15 @@ case class LogReadResult(info: FetchDataInfo,
 
 }
 
-case class FetchPartitionData(error: Errors = Errors.NONE,
-                              highWatermark: Long,
-                              logStartOffset: Long,
-                              records: Records,
-                              divergingEpoch: Option[FetchResponseData.EpochEndOffset],
-                              lastStableOffset: Option[Long],
-                              abortedTransactions: Option[List[FetchResponseData.AbortedTransaction]],
-                              preferredReadReplica: Option[Int],
-                              isReassignmentFetch: Boolean)
+final case class FetchPartitionData(error: Errors = Errors.NONE,
+                                    highWatermark: Long,
+                                    logStartOffset: Long,
+                                    records: Records,
+                                    divergingEpoch: Option[FetchResponseData.EpochEndOffset],
+                                    lastStableOffset: Option[Long],
+                                    abortedTransactions: Option[List[FetchResponseData.AbortedTransaction]],
+                                    preferredReadReplica: Option[Int],
+                                    isReassignmentFetch: Boolean)
 
 /**
  * Trait to represent the state of hosted partitions. We create a concrete (active) Partition

--- a/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicationQuotaManager.scala
@@ -39,9 +39,9 @@ import org.apache.kafka.common.utils.Time
   * @param quotaWindowSizeSeconds     The time span of each sample
   *
   */
-case class ReplicationQuotaManagerConfig(quotaBytesPerSecondDefault: Long = QuotaBytesPerSecondDefault,
-                                         numQuotaSamples: Int = DefaultNumQuotaSamples,
-                                         quotaWindowSizeSeconds: Int = DefaultQuotaWindowSizeSeconds)
+final case class ReplicationQuotaManagerConfig(quotaBytesPerSecondDefault: Long = QuotaBytesPerSecondDefault,
+                                               numQuotaSamples: Int = DefaultNumQuotaSamples,
+                                               quotaWindowSizeSeconds: Int = DefaultQuotaWindowSizeSeconds)
 
 object ReplicationQuotaManagerConfig {
   val QuotaBytesPerSecondDefault = Long.MaxValue

--- a/core/src/main/scala/kafka/server/RequestLocal.scala
+++ b/core/src/main/scala/kafka/server/RequestLocal.scala
@@ -32,6 +32,6 @@ object RequestLocal {
  * When each request is handled by one thread, efficient data structures with no locking or atomic operations
  * can be used (see RequestLocal.withThreadConfinedCaching).
  */
-case class RequestLocal(bufferSupplier: BufferSupplier) {
+final case class RequestLocal(bufferSupplier: BufferSupplier) {
   def close(): Unit = bufferSupplier.close()
 }

--- a/core/src/main/scala/kafka/server/ZkIsrManager.scala
+++ b/core/src/main/scala/kafka/server/ZkIsrManager.scala
@@ -31,7 +31,7 @@ import scala.collection.mutable
  * @param maxDelayMs  Maximum time that an ISR change may be delayed before sending the notification
  * @param lingerMs  Maximum time to await additional changes before sending the notification
  */
-case class IsrChangePropagationConfig(checkIntervalMs: Long, maxDelayMs: Long, lingerMs: Long)
+final case class IsrChangePropagationConfig(checkIntervalMs: Long, maxDelayMs: Long, lingerMs: Long)
 
 object ZkIsrManager {
   // This field is mutable to allow overriding change notification behavior in test cases

--- a/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
+++ b/core/src/main/scala/kafka/server/epoch/LeaderEpochFileCache.scala
@@ -294,7 +294,7 @@ class LeaderEpochFileCache(topicPartition: TopicPartition,
 }
 
 // Mapping of epoch to the first offset of the subsequent epoch
-case class EpochEntry(epoch: Int, startOffset: Long) {
+final case class EpochEntry(epoch: Int, startOffset: Long) {
   override def toString: String = {
     s"EpochEntry(epoch=$epoch, startOffset=$startOffset)"
   }

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -165,17 +165,6 @@ class BrokerMetadataListener(
     }
   }
 
-  case class BatchLoadResults(numBatches: Int,
-                              numRecords: Int,
-                              elapsedUs: Long,
-                              numBytes: Long,
-                              highestMetadataOffset: Long) {
-    override def toString(): String = {
-      s"${numBatches} batch(es) with ${numRecords} record(s) in ${numBytes} bytes " +
-        s"ending at offset ${highestMetadataOffset} in ${elapsedUs} microseconds"
-    }
-  }
-
   private def loadBatches(delta: MetadataDelta,
                           iterator: util.Iterator[Batch[ApiMessageAndVersion]]): BatchLoadResults = {
     val startTimeNs = time.nanoseconds()
@@ -283,5 +272,16 @@ class BrokerMetadataListener(
       _image.write(this)
       future.complete(records)
     }
+  }
+}
+
+private[metadata] final case class BatchLoadResults(numBatches: Int,
+                                                    numRecords: Int,
+                                                    elapsedUs: Long,
+                                                    numBytes: Long,
+                                                    highestMetadataOffset: Long) {
+  override def toString(): String = {
+    s"${numBatches} batch(es) with ${numRecords} record(s) in ${numBytes} bytes " +
+      s"ending at offset ${highestMetadataOffset} in ${elapsedUs} microseconds"
   }
 }

--- a/core/src/main/scala/kafka/server/metadata/ClientQuotaMetadataManager.scala
+++ b/core/src/main/scala/kafka/server/metadata/ClientQuotaMetadataManager.scala
@@ -34,15 +34,15 @@ import scala.compat.java8.OptionConverters._
 
 // A strict hierarchy of entities that we support
 sealed trait QuotaEntity
-case class IpEntity(ip: String) extends QuotaEntity
+final case class IpEntity(ip: String) extends QuotaEntity
 case object DefaultIpEntity extends QuotaEntity
-case class UserEntity(user: String) extends QuotaEntity
+final case class UserEntity(user: String) extends QuotaEntity
 case object DefaultUserEntity extends QuotaEntity
-case class ClientIdEntity(clientId: String) extends QuotaEntity
+final case class ClientIdEntity(clientId: String) extends QuotaEntity
 case object DefaultClientIdEntity extends QuotaEntity
-case class ExplicitUserExplicitClientIdEntity(user: String, clientId: String) extends QuotaEntity
-case class ExplicitUserDefaultClientIdEntity(user: String) extends QuotaEntity
-case class DefaultUserExplicitClientIdEntity(clientId: String) extends QuotaEntity
+final case class ExplicitUserExplicitClientIdEntity(user: String, clientId: String) extends QuotaEntity
+final case class ExplicitUserDefaultClientIdEntity(user: String) extends QuotaEntity
+final case class DefaultUserExplicitClientIdEntity(clientId: String) extends QuotaEntity
 case object DefaultUserDefaultClientIdEntity extends QuotaEntity
 
 /**

--- a/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/ZkMetadataCache.scala
@@ -422,12 +422,12 @@ class ZkMetadataCache(brokerId: Int) extends MetadataCache with Logging {
       true
     }
   }
+}
 
-  case class MetadataSnapshot(partitionStates: mutable.AnyRefMap[String, mutable.LongMap[UpdateMetadataPartitionState]],
-                              topicIds: Map[String, Uuid],
-                              controllerId: Option[Int],
-                              aliveBrokers: mutable.LongMap[Broker],
-                              aliveNodes: mutable.LongMap[collection.Map[ListenerName, Node]]) {
-    val topicNames: Map[Uuid, String] = topicIds.map { case (topicName, topicId) => (topicId, topicName) }
-  }
+private[server] final case class MetadataSnapshot(partitionStates: mutable.AnyRefMap[String, mutable.LongMap[UpdateMetadataPartitionState]],
+                                                  topicIds: Map[String, Uuid],
+                                                  controllerId: Option[Int],
+                                                  aliveBrokers: mutable.LongMap[Broker],
+                                                  aliveNodes: mutable.LongMap[collection.Map[ListenerName, Node]]) {
+  val topicNames: Map[Uuid, String] = topicIds.map { case (topicName, topicId) => (topicId, topicName) }
 }

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -262,9 +262,9 @@ object ReplicaVerificationTool extends Logging {
     new KafkaConsumer(consumerConfig)
 }
 
-private case class TopicPartitionReplica(topic: String, partitionId: Int, replicaId: Int)
+private final case class TopicPartitionReplica(topic: String, partitionId: Int, replicaId: Int)
 
-private case class MessageInfo(replicaId: Int, offset: Long, nextOffset: Long, checksum: Long)
+private final case class MessageInfo(replicaId: Int, offset: Long, nextOffset: Long, checksum: Long)
 
 private class ReplicaBuffer(expectedReplicasPerTopicPartition: collection.Map[TopicPartition, Int],
                             initialOffsets: collection.Map[TopicPartition, Long],

--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -148,13 +148,6 @@ class TestRaftServer(
   ) extends ShutdownableThread(name = "raft-workload-generator")
     with RaftClient.Listener[Array[Byte]] {
 
-    sealed trait RaftEvent
-    case class HandleClaim(epoch: Int) extends RaftEvent
-    case object HandleResign extends RaftEvent
-    case class HandleCommit(reader: BatchReader[Array[Byte]]) extends RaftEvent
-    case class HandleSnapshot(reader: SnapshotReader[Array[Byte]]) extends RaftEvent
-    case object Shutdown extends RaftEvent
-
     private val eventQueue = new LinkedBlockingDeque[RaftEvent]()
     private val stats = new WriteStats(metrics, time, printIntervalMs = 5000)
     private val payload = new Array[Byte](recordSize)
@@ -281,7 +274,7 @@ class TestRaftServer(
 
 object TestRaftServer extends Logging {
 
-  case class PendingAppend(
+  final case class PendingAppend(
     offset: Long,
     appendTimeMs: Long
   ) {
@@ -471,3 +464,10 @@ object TestRaftServer extends Logging {
   }
 
 }
+
+private[tools] sealed trait RaftEvent
+private[tools] final case class HandleClaim(epoch: Int) extends RaftEvent
+private[tools] case object HandleResign extends RaftEvent
+private[tools] final case class HandleCommit(reader: BatchReader[Array[Byte]]) extends RaftEvent
+private[tools] final case class HandleSnapshot(reader: SnapshotReader[Array[Byte]]) extends RaftEvent
+private[tools] case object Shutdown extends RaftEvent

--- a/core/src/main/scala/kafka/utils/TopicFilter.scala
+++ b/core/src/main/scala/kafka/utils/TopicFilter.scala
@@ -43,7 +43,7 @@ sealed abstract class TopicFilter(rawRegex: String) extends Logging {
   def isTopicAllowed(topic: String, excludeInternalTopics: Boolean): Boolean
 }
 
-case class IncludeList(rawRegex: String) extends TopicFilter(rawRegex) {
+final case class IncludeList(rawRegex: String) extends TopicFilter(rawRegex) {
   override def isTopicAllowed(topic: String, excludeInternalTopics: Boolean) = {
     val allowed = topic.matches(regex) && !(Topic.isInternal(topic) && excludeInternalTopics)
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -1924,7 +1924,7 @@ object KafkaZkClient {
    *                      can occur if the partition leader updated partition state while the controller attempted to
    *                      update partition state.
    */
-  case class UpdateLeaderAndIsrResult(
+  final case class UpdateLeaderAndIsrResult(
     finishedPartitions: Map[TopicPartition, Either[Exception, LeaderAndIsr]],
     partitionsToRetry: Seq[TopicPartition]
   )

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -108,7 +108,7 @@ object BrokerInfo {
 
 }
 
-case class BrokerInfo(broker: Broker, version: Int, jmxPort: Int) {
+final case class BrokerInfo(broker: Broker, version: Int, jmxPort: Int) {
   val path: String = BrokerIdZNode.path(broker.id)
   def toJsonBytes: Array[Byte] = BrokerIdZNode.encode(this)
 }
@@ -279,9 +279,9 @@ object TopicsZNode {
 }
 
 object TopicZNode {
-  case class TopicIdReplicaAssignment(topic: String,
-                                      topicId: Option[Uuid],
-                                      assignment: Map[TopicPartition, ReplicaAssignment])
+  final case class TopicIdReplicaAssignment(topic: String,
+                                            topicId: Option[Uuid],
+                                            assignment: Map[TopicPartition, ReplicaAssignment])
   def path(topic: String) = s"${TopicsZNode.path}/$topic"
   def encode(topicId: Option[Uuid],
              assignment: collection.Map[TopicPartition, ReplicaAssignment]): Array[Byte] = {
@@ -467,9 +467,9 @@ object ReassignPartitionsZNode {
     * A replica assignment consists of a `topic`, `partition` and a list of `replicas`, which
     * represent the broker ids that the `TopicPartition` is assigned to.
     */
-  case class ReplicaAssignment(@BeanProperty @JsonProperty("topic") topic: String,
-                               @BeanProperty @JsonProperty("partition") partition: Int,
-                               @BeanProperty @JsonProperty("replicas") replicas: java.util.List[Int])
+  final case class ReplicaAssignment(@BeanProperty @JsonProperty("topic") topic: String,
+                                     @BeanProperty @JsonProperty("partition") partition: Int,
+                                     @BeanProperty @JsonProperty("replicas") replicas: java.util.List[Int])
 
   /**
     * An assignment consists of a `version` and a list of `partitions`, which represent the
@@ -477,8 +477,8 @@ object ReassignPartitionsZNode {
     * @deprecated Use the PartitionReassignment Kafka API instead
     */
   @Deprecated
-  case class LegacyPartitionAssignment(@BeanProperty @JsonProperty("version") version: Int,
-                                       @BeanProperty @JsonProperty("partitions") partitions: java.util.List[ReplicaAssignment])
+  final case class LegacyPartitionAssignment(@BeanProperty @JsonProperty("version") version: Int,
+                                             @BeanProperty @JsonProperty("partitions") partitions: java.util.List[ReplicaAssignment])
 
   def path = s"${AdminZNode.path}/reassign_partitions"
 
@@ -637,7 +637,7 @@ trait AclChangeSubscription extends AutoCloseable {
   def close(): Unit
 }
 
-case class AclChangeNode(path: String, bytes: Array[Byte])
+final case class AclChangeNode(path: String, bytes: Array[Byte])
 
 sealed trait ZkAclChangeStore {
   val aclChangePath: String
@@ -727,10 +727,10 @@ object ExtendedAclChangeEvent {
   val currentVersion: Int = 1
 }
 
-case class ExtendedAclChangeEvent(@BeanProperty @JsonProperty("version") version: Int,
-                                  @BeanProperty @JsonProperty("resourceType") resourceType: String,
-                                  @BeanProperty @JsonProperty("name") name: String,
-                                  @BeanProperty @JsonProperty("patternType") patternType: String) {
+final case class ExtendedAclChangeEvent(@BeanProperty @JsonProperty("version") version: Int,
+                                        @BeanProperty @JsonProperty("resourceType") resourceType: String,
+                                        @BeanProperty @JsonProperty("name") name: String,
+                                        @BeanProperty @JsonProperty("patternType") patternType: String) {
   if (version > ExtendedAclChangeEvent.currentVersion)
     throw new UnsupportedVersionException(s"Acl change event received for unsupported version: $version")
 
@@ -862,7 +862,7 @@ object FeatureZNodeStatus {
  * @param status     the status of the ZK node
  * @param features   the cluster-wide finalized features
  */
-case class FeatureZNode(status: FeatureZNodeStatus, features: Features[FinalizedVersionRange]) {
+final case class FeatureZNode(status: FeatureZNodeStatus, features: Features[FinalizedVersionRange]) {
 }
 
 object FeatureZNode {

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -498,23 +498,23 @@ sealed trait ZkOp {
   def toZookeeperOp: Op
 }
 
-case class CreateOp(path: String, data: Array[Byte], acl: Seq[ACL], createMode: CreateMode) extends ZkOp {
+final case class CreateOp(path: String, data: Array[Byte], acl: Seq[ACL], createMode: CreateMode) extends ZkOp {
   override def toZookeeperOp: Op = Op.create(path, data, acl.asJava, createMode)
 }
 
-case class DeleteOp(path: String, version: Int) extends ZkOp {
+final case class DeleteOp(path: String, version: Int) extends ZkOp {
   override def toZookeeperOp: Op = Op.delete(path, version)
 }
 
-case class SetDataOp(path: String, data: Array[Byte], version: Int) extends ZkOp {
+final case class SetDataOp(path: String, data: Array[Byte], version: Int) extends ZkOp {
   override def toZookeeperOp: Op = Op.setData(path, data, version)
 }
 
-case class CheckOp(path: String, version: Int) extends ZkOp {
+final case class CheckOp(path: String, version: Int) extends ZkOp {
   override def toZookeeperOp: Op = Op.check(path, version)
 }
 
-case class ZkOpResult(zkOp: ZkOp, rawOpResult: OpResult)
+final case class ZkOpResult(zkOp: ZkOp, rawOpResult: OpResult)
 
 sealed trait AsyncRequest {
   /**
@@ -526,40 +526,40 @@ sealed trait AsyncRequest {
   def ctx: Option[Any]
 }
 
-case class CreateRequest(path: String, data: Array[Byte], acl: Seq[ACL], createMode: CreateMode,
+final case class CreateRequest(path: String, data: Array[Byte], acl: Seq[ACL], createMode: CreateMode,
                          ctx: Option[Any] = None) extends AsyncRequest {
   type Response = CreateResponse
 }
 
-case class DeleteRequest(path: String, version: Int, ctx: Option[Any] = None) extends AsyncRequest {
+final case class DeleteRequest(path: String, version: Int, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = DeleteResponse
 }
 
-case class ExistsRequest(path: String, ctx: Option[Any] = None) extends AsyncRequest {
+final case class ExistsRequest(path: String, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = ExistsResponse
 }
 
-case class GetDataRequest(path: String, ctx: Option[Any] = None) extends AsyncRequest {
+final case class GetDataRequest(path: String, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = GetDataResponse
 }
 
-case class SetDataRequest(path: String, data: Array[Byte], version: Int, ctx: Option[Any] = None) extends AsyncRequest {
+final case class SetDataRequest(path: String, data: Array[Byte], version: Int, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = SetDataResponse
 }
 
-case class GetAclRequest(path: String, ctx: Option[Any] = None) extends AsyncRequest {
+final case class GetAclRequest(path: String, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = GetAclResponse
 }
 
-case class SetAclRequest(path: String, acl: Seq[ACL], version: Int, ctx: Option[Any] = None) extends AsyncRequest {
+final case class SetAclRequest(path: String, acl: Seq[ACL], version: Int, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = SetAclResponse
 }
 
-case class GetChildrenRequest(path: String, registerWatch: Boolean, ctx: Option[Any] = None) extends AsyncRequest {
+final case class GetChildrenRequest(path: String, registerWatch: Boolean, ctx: Option[Any] = None) extends AsyncRequest {
   type Response = GetChildrenResponse
 }
 
-case class MultiRequest(zkOps: Seq[ZkOp], ctx: Option[Any] = None) extends AsyncRequest {
+final case class MultiRequest(zkOps: Seq[ZkOp], ctx: Option[Any] = None) extends AsyncRequest {
   type Response = MultiResponse
 
   override def path: String = null
@@ -586,28 +586,28 @@ sealed abstract class AsyncResponse {
   def metadata: ResponseMetadata
 }
 
-case class ResponseMetadata(sendTimeMs: Long, receivedTimeMs: Long) {
+final case class ResponseMetadata(sendTimeMs: Long, receivedTimeMs: Long) {
   def responseTimeMs: Long = receivedTimeMs - sendTimeMs
 }
 
-case class CreateResponse(resultCode: Code, path: String, ctx: Option[Any], name: String,
-                          metadata: ResponseMetadata) extends AsyncResponse
-case class DeleteResponse(resultCode: Code, path: String, ctx: Option[Any],
-                          metadata: ResponseMetadata) extends AsyncResponse
-case class ExistsResponse(resultCode: Code, path: String, ctx: Option[Any], stat: Stat,
-                          metadata: ResponseMetadata) extends AsyncResponse
-case class GetDataResponse(resultCode: Code, path: String, ctx: Option[Any], data: Array[Byte], stat: Stat,
-                           metadata: ResponseMetadata) extends AsyncResponse
-case class SetDataResponse(resultCode: Code, path: String, ctx: Option[Any], stat: Stat,
-                           metadata: ResponseMetadata) extends AsyncResponse
-case class GetAclResponse(resultCode: Code, path: String, ctx: Option[Any], acl: Seq[ACL], stat: Stat,
-                          metadata: ResponseMetadata) extends AsyncResponse
-case class SetAclResponse(resultCode: Code, path: String, ctx: Option[Any], stat: Stat,
-                          metadata: ResponseMetadata) extends AsyncResponse
-case class GetChildrenResponse(resultCode: Code, path: String, ctx: Option[Any], children: Seq[String], stat: Stat,
+final case class CreateResponse(resultCode: Code, path: String, ctx: Option[Any], name: String,
+                                metadata: ResponseMetadata) extends AsyncResponse
+final case class DeleteResponse(resultCode: Code, path: String, ctx: Option[Any],
+                                metadata: ResponseMetadata) extends AsyncResponse
+final case class ExistsResponse(resultCode: Code, path: String, ctx: Option[Any], stat: Stat,
+                                metadata: ResponseMetadata) extends AsyncResponse
+final case class GetDataResponse(resultCode: Code, path: String, ctx: Option[Any], data: Array[Byte], stat: Stat,
+                                 metadata: ResponseMetadata) extends AsyncResponse
+final case class SetDataResponse(resultCode: Code, path: String, ctx: Option[Any], stat: Stat,
+                                 metadata: ResponseMetadata) extends AsyncResponse
+final case class GetAclResponse(resultCode: Code, path: String, ctx: Option[Any], acl: Seq[ACL], stat: Stat,
+                                metadata: ResponseMetadata) extends AsyncResponse
+final case class SetAclResponse(resultCode: Code, path: String, ctx: Option[Any], stat: Stat,
+                                metadata: ResponseMetadata) extends AsyncResponse
+final case class GetChildrenResponse(resultCode: Code, path: String, ctx: Option[Any], children: Seq[String], stat: Stat,
+                                     metadata: ResponseMetadata) extends AsyncResponse
+final case class MultiResponse(resultCode: Code, path: String, ctx: Option[Any], zkOpResults: Seq[ZkOpResult],
                                metadata: ResponseMetadata) extends AsyncResponse
-case class MultiResponse(resultCode: Code, path: String, ctx: Option[Any], zkOpResults: Seq[ZkOpResult],
-                         metadata: ResponseMetadata) extends AsyncResponse
 
 class ZooKeeperClientException(message: String) extends RuntimeException(message)
 class ZooKeeperClientExpiredException(message: String) extends ZooKeeperClientException(message)

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -327,7 +327,7 @@ class GroupedUserPrincipalBuilder extends KafkaPrincipalBuilder {
   }
 }
 
-case class GroupedUserPrincipal(user: String, userGroup: String) extends KafkaPrincipal(KafkaPrincipal.USER_TYPE, user)
+final case class GroupedUserPrincipal(user: String, userGroup: String) extends KafkaPrincipal(KafkaPrincipal.USER_TYPE, user)
 
 object GroupedUserQuotaCallback {
   val QuotaGroupTag = "group"

--- a/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
+++ b/core/src/test/scala/integration/kafka/server/MultipleListenersWithSameSecurityProtocolBaseTest.scala
@@ -180,7 +180,7 @@ abstract class MultipleListenersWithSameSecurityProtocolBaseTest extends ZooKeep
     props.put(s"${prefix}${KafkaConfig.SaslJaasConfigProp}", jaasConfig)
   }
 
-  case class ClientMetadata(val listenerName: ListenerName, val saslMechanism: String, topic: String) {
+  case class ClientMetadata(listenerName: ListenerName, saslMechanism: String, topic: String) {
     override def hashCode: Int = Objects.hash(listenerName, saslMechanism)
     override def equals(obj: Any): Boolean = obj match {
       case other: ClientMetadata => listenerName == other.listenerName && saslMechanism == other.saslMechanism && topic == other.topic

--- a/core/src/test/scala/kafka/tools/LogCompactionTester.scala
+++ b/core/src/test/scala/kafka/tools/LogCompactionTester.scala
@@ -335,7 +335,7 @@ object LogCompactionTester {
 
 }
 
-case class TestRecord(topic: String, key: Int, value: Long, delete: Boolean) {
+final case class TestRecord(topic: String, key: Int, value: Long, delete: Boolean) {
   override def toString = topic + "\t" + key + "\t" + value + "\t" + (if (delete) "d" else "u")
   def topicAndKey = topic + key
 }

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -92,7 +92,7 @@ object ReplicationQuotasTestRig {
     }
   }
 
-  case class ExperimentDef(name: String, brokers: Int, partitions: Int, throttle: Long, msgsPerPartition: Int, msgSize: Int) {
+  final case class ExperimentDef(name: String, brokers: Int, partitions: Int, throttle: Long, msgsPerPartition: Int, msgSize: Int) {
     val targetBytesPerBrokerMB: Long = msgsPerPartition.toLong * msgSize.toLong * partitions.toLong / brokers.toLong / 1000000
   }
 

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -1466,7 +1466,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
         "--delete-config", mechanism))
 
     val credentials = mutable.Map[String, Properties]()
-    case class CredentialChange(user: String, mechanisms: Set[String], iterations: Int) extends AdminZkClient(zkClient) {
+    final case class CredentialChange(user: String, mechanisms: Set[String], iterations: Int) extends AdminZkClient(zkClient) {
       override def fetchEntityConfig(entityType: String, entityName: String): Properties = {
         credentials.getOrElse(entityName, new Properties())
       }

--- a/core/src/test/scala/unit/kafka/admin/RackAwareTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/RackAwareTest.scala
@@ -82,4 +82,4 @@ trait RackAwareTest {
 
 }
 
-case class ReplicaDistributions(partitionRacks: Map[Int, Seq[String]], brokerLeaderCount: Map[Int, Int], brokerReplicasCount: Map[Int, Int])
+final case class ReplicaDistributions(partitionRacks: Map[Int, Seq[String]], brokerLeaderCount: Map[Int, Int], brokerReplicasCount: Map[Int, Int])

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -70,7 +70,7 @@ class LogLoaderTest {
     var log: UnifiedLog = null
     val time = new MockTime()
     var cleanShutdownInterceptedValue = false
-    case class SimulateError(var hasError: Boolean = false)
+    final case class SimulateError(var hasError: Boolean = false)
     val simulateError = SimulateError()
 
     // Create a LogManager with some overridden methods to facilitate interception of clean shutdown

--- a/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerWithZkSaslTest.scala
+++ b/core/src/test/scala/unit/kafka/security/authorizer/AclAuthorizerWithZkSaslTest.scala
@@ -26,7 +26,7 @@ import javax.security.auth.callback.CallbackHandler
 import kafka.api.SaslSetup
 import kafka.security.authorizer.AclEntry.WildcardHost
 import kafka.server.KafkaConfig
-import kafka.utils.JaasTestUtils.{JaasModule, JaasSection}
+import kafka.utils.JaasTestUtils.JaasSection
 import kafka.utils.{JaasTestUtils, TestUtils}
 import kafka.zk.{KafkaZkClient, ZooKeeperTestHarness}
 import kafka.zookeeper.ZooKeeperClient
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 
 import scala.jdk.CollectionConverters._
-import scala.collection.Seq
 
 class AclAuthorizerWithZkSaslTest extends ZooKeeperTestHarness with SaslSetup {
 
@@ -69,7 +68,7 @@ class AclAuthorizerWithZkSaslTest extends ZooKeeperTestHarness with SaslSetup {
     val jaasSections = JaasTestUtils.zkSections
     val serverJaas = jaasSections.filter(_.contextName == "Server")
     val clientJaas = jaasSections.filter(_.contextName == "Client")
-      .map(section => new TestableJaasSection(section.contextName, section.modules))
+      .map(section => JaasSection(section.contextName, section.modules))
     startSasl(serverJaas ++ clientJaas)
 
     // Increase maxUpdateRetries to avoid transient failures
@@ -176,11 +175,5 @@ class TestableDigestLoginModule extends DigestLoginModule {
       subject.getPrivateCredentials.add(newPassword)
       subject.getPrivateCredentials.remove(oldPassword)
     }
-  }
-}
-
-class TestableJaasSection(contextName: String, modules: Seq[JaasModule]) extends JaasSection(contextName, modules) {
-  override def toString: String = {
-    super.toString.replaceFirst(classOf[DigestLoginModule].getName, classOf[TestableDigestLoginModule].getName)
   }
 }

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -40,7 +40,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-case class BatchInfo(records: Seq[SimpleRecord], hasKeys: Boolean, hasValues: Boolean)
+final case class BatchInfo(records: Seq[SimpleRecord], hasKeys: Boolean, hasValues: Boolean)
 
 class DumpLogSegmentsTest {
 

--- a/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
@@ -47,7 +47,7 @@ class CoreUtilsTest extends Logging {
 
   @Test
   def testTryAll(): Unit = {
-    case class TestException(key: String) extends Exception
+    final case class TestException(key: String) extends Exception
 
     val recorded = mutable.Map.empty[String, Either[TestException, String]]
     def recordingFunction(v: Either[TestException, String]): Unit = {

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -26,12 +26,12 @@ import org.apache.kafka.common.utils.Java
 
 object JaasTestUtils {
 
-  case class Krb5LoginModule(useKeyTab: Boolean,
-                             storeKey: Boolean,
-                             keyTab: String,
-                             principal: String,
-                             debug: Boolean,
-                             serviceName: Option[String]) extends JaasModule {
+  final case class Krb5LoginModule(useKeyTab: Boolean,
+                                   storeKey: Boolean,
+                                   keyTab: String,
+                                   principal: String,
+                                   debug: Boolean,
+                                   serviceName: Option[String]) extends JaasModule {
 
     def name =
       if (Java.isIbmJdk)
@@ -54,10 +54,10 @@ object JaasTestUtils {
         ) ++ serviceName.map(s => Map("serviceName" -> s)).getOrElse(Map.empty)
   }
 
-  case class PlainLoginModule(username: String,
-                              password: String,
-                              debug: Boolean = false,
-                              validUsers: Map[String, String] = Map.empty) extends JaasModule {
+  final case class PlainLoginModule(username: String,
+                                    password: String,
+                                    debug: Boolean = false,
+                                    validUsers: Map[String, String] = Map.empty) extends JaasModule {
 
     def name = "org.apache.kafka.common.security.plain.PlainLoginModule"
 
@@ -68,15 +68,15 @@ object JaasTestUtils {
 
   }
 
-  case class ZkDigestModule(debug: Boolean = false,
-                            entries: Map[String, String] = Map.empty) extends JaasModule {
+  final case class ZkDigestModule(debug: Boolean = false,
+                                  entries: Map[String, String] = Map.empty) extends JaasModule {
     def name = "org.apache.zookeeper.server.auth.DigestLoginModule"
   }
 
-  case class ScramLoginModule(username: String,
-                              password: String,
-                              debug: Boolean = false,
-                              tokenProps: Map[String, String] = Map.empty) extends JaasModule {
+  final case class ScramLoginModule(username: String,
+                                    password: String,
+                                    debug: Boolean = false,
+                                    tokenProps: Map[String, String] = Map.empty) extends JaasModule {
 
     def name = "org.apache.kafka.common.security.scram.ScramLoginModule"
 
@@ -86,8 +86,8 @@ object JaasTestUtils {
     ) ++ tokenProps.map { case (name, value) => name -> value }
   }
 
-  case class OAuthBearerLoginModule(username: String,
-                              debug: Boolean = false) extends JaasModule {
+  final case class OAuthBearerLoginModule(username: String,
+                                          debug: Boolean = false) extends JaasModule {
 
     def name = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule"
 
@@ -110,7 +110,7 @@ object JaasTestUtils {
     }
   }
 
-  case class JaasSection(contextName: String, modules: Seq[JaasModule]) {
+  final case class JaasSection(contextName: String, modules: Seq[JaasModule]) {
     override def toString: String = {
       s"""|$contextName {
           |  ${modules.mkString("\n  ")}

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -31,7 +31,7 @@ import scala.jdk.CollectionConverters._
 import scala.collection.Map
 
 object JsonTest {
-  case class TestObject(@JsonProperty("foo") foo: String, @JsonProperty("bar") bar: Int)
+  final case class TestObject(@JsonProperty("foo") foo: String, @JsonProperty("bar") bar: Int)
 }
 
 class JsonTest {

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -102,7 +102,7 @@ class MockScheduler(val time: Time) extends Scheduler {
   }
 }
 
-case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends ScheduledFuture[Unit] {
+final case class MockTask(name: String, fun: () => Unit, var nextExecution: Long, period: Long, time: Time) extends ScheduledFuture[Unit] {
   def periodic = period >= 0
   def compare(t: MockTask): Int = {
     if(t.nextExecution == nextExecution)

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -140,6 +140,13 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
 
     <Match>
         <!-- A spurious null check after inlining by the scalac optimizer confuses spotBugs -->
+        <Class name="kafka.log.ProducerStateManager" />
+        <Method name="loadFromSnapshot"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_EXCEPTION"/>
+    </Match>
+
+    <Match>
+        <!-- A spurious null check after inlining by the scalac optimizer confuses spotBugs -->
         <Class name="kafka.tools.StateChangeLogMerger$"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
     </Match>


### PR DESCRIPTION
This PR makes all of the Scala's `case class`'s final to ensure correctness of Kafka's Scala code that uses these case classes. In Scala its best practice to make `case class`'s final since `case class` automatically generates critical methods such as `hashcode`/`equals`/`unapply` which can break code if user's override these methods by subclassing.

Please see the [KIP](https://cwiki.apache.org/confluence/display/KAFKA/KIP-754%3A+Make+Scala+case+class%27s+final) for more info.

Changes of note have been annotated in the PR.

### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
