### PR TITLE
KAFKA-12921: Upgrade ZSTD JNI to 1.5.0-2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,7 @@ versions += [
   spotbugs: "4.2.2",
   zinc: "1.3.5",
   zookeeper: "3.5.9",
-  zstd: "1.5.0-1"
+  zstd: "1.5.0-2"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -112,7 +112,7 @@ versions += [
   spotbugs: "4.2.2",
   zinc: "1.3.5",
   zookeeper: "3.5.9",
-  zstd: "1.4.9-1"
+  zstd: "1.5.0-1"
 ]
 libs += [
   activation: "javax.activation:activation:$versions.activation",


### PR DESCRIPTION
This PR aims to upgrade `zstd-jni` from `1.4.9-1` to `1.5.0-2`.

This change will incorporate a number of bug fixes and performance improvements made in `1.5.0` of `zstd`:
- https://github.com/facebook/zstd/releases/tag/v1.5.0
- https://github.com/luben/zstd-jni/releases/tag/v1.5.0-1
- https://github.com/luben/zstd-jni/releases/tag/v1.5.0-2

The most recent `1.5.0` release offers +25%-140% (compression) and +15% (decompression) performance
improvements under certain conditions. Those conditions are unlikely to apply to Kafka with the default
configuration, however.

Since this is a dependency change, this should pass all the existing CIs.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
