### PR TITLE
KAFKA-12811: kafka-topics.sh should let the user know they cannot adj…ust the replication factor for a topic using the --alter flag and not warn about missing the --partition flag

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -574,7 +574,7 @@ object TopicCommand extends Logging {
       if (has(alterOpt)) {
         CommandLineUtils.checkInvalidArgsSet(parser, options, Set(bootstrapServerOpt, configOpt), Set(alterOpt),
         Some(kafkaConfigsCanAlterTopicConfigsViaBootstrapServer))
-        CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, Set(alterOpt))
+        CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, Set(alterOpt, replicaAssignmentOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt)
       }
 

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -574,6 +574,7 @@ object TopicCommand extends Logging {
       if (has(alterOpt)) {
         CommandLineUtils.checkInvalidArgsSet(parser, options, Set(bootstrapServerOpt, configOpt), Set(alterOpt),
         Some(kafkaConfigsCanAlterTopicConfigsViaBootstrapServer))
+        CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, Set(alterOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt)
       }
 


### PR DESCRIPTION
KAFKA-12811: kafka-topics.sh should let the user know they cannot adj…ust the replication factor for a topic using the --alter flag and not warn about missing the --partition flag

This work is my own and I license it to the project. 

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*


*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
