### PR TITLE
MINOR: fix client_compatibility_features_test.py - DescribeAcls is al…

### DIFF
--- a/tests/kafkatest/tests/client/client_compatibility_features_test.py
+++ b/tests/kafkatest/tests/client/client_compatibility_features_test.py
@@ -133,7 +133,4 @@ class ClientCompatibilityFeaturesTest(Test):
         self.kafka.set_version(KafkaVersion(broker_version))
         self.kafka.start()
         features = get_broker_features(broker_version)
-        if not self.zk:
-            #  The KRaft mode doesn't support acls yet, we should remove this once it does
-            features["describe-acls-supported"] = False
         self.invoke_compatibility_program(features)


### PR DESCRIPTION
Kraft already supports `DescribeAcls` (see 5b0c58ed53c420e93957369516f34346580dac95). Hence, the flag `describe-acls-supported` should be `True` rather than `False`


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
