### PR TITLE
KAFKA-12909: disable spurious left/outer stream-stream join fix for old JoinWindows API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/JoinWindowsInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/JoinWindowsInternal.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.streams.kstream.JoinWindows;
+
+public class JoinWindowsInternal extends JoinWindows {
+
+    public JoinWindowsInternal(final JoinWindows joinWindows) {
+        super(joinWindows);
+    }
+
+    public boolean spuriousResultFixEnabled() {
+        return enableSpuriousResultFix;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -104,13 +104,6 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
                     true
                 )) {
                 outerJoinWindowStore = outerJoinWindowName.map(context::getStateStore);
-            } else {
-                if (outerJoinWindowName.isPresent()) {
-                    throw new IllegalStateException(String.format(
-                        "Fix for KAFKA-10847 disabled; `outerJoinWindowName` should be `null` but is %s",
-                        outerJoinWindowName.get()
-                        ));
-                }
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -104,6 +104,13 @@ class KStreamKStreamJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
                     true
                 )) {
                 outerJoinWindowStore = outerJoinWindowName.map(context::getStateStore);
+            } else {
+                if (outerJoinWindowName.isPresent()) {
+                    throw new IllegalStateException(String.format(
+                        "Fix for KAFKA-10847 disabled; `outerJoinWindowName` should be `null` but is %s",
+                        outerJoinWindowName.get()
+                        ));
+                }
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -37,8 +37,6 @@ import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Printed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.StreamJoined;
-import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
-import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.Branched;
@@ -36,6 +37,8 @@ import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Printed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.StreamJoined;
+import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -703,6 +706,56 @@ public class StreamsBuilderTest {
                                 "KSTREAM-SOURCE-0000000002",
                                 "KTABLE-SOURCE-0000000003",
                                 STREAM_OPERATION_NAME);
+    }
+
+    @Test
+    public void shouldNotAddThirdStateStoreIfStreamStreamJoinFixIsDisabledViaConfig() {
+        shouldNotAddThirdStateStoreIfStreamStreamJoinFixIsDisabled(
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            false
+        );
+    }
+
+    @Test
+    public void shouldNotAddThirdStateStoreIfStreamStreamJoinFixIsDisabledViaOldApi() {
+        shouldNotAddThirdStateStoreIfStreamStreamJoinFixIsDisabled(
+            JoinWindows.of(Duration.ofHours(1)),
+            true
+        );
+    }
+
+    private void shouldNotAddThirdStateStoreIfStreamStreamJoinFixIsDisabled(
+        final JoinWindows joinWindows,
+        final boolean enableFix
+    ) {
+        final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
+        final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
+
+        streamOne.leftJoin(
+            streamTwo,
+            (value1, value2) -> value1,
+            joinWindows,
+            StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME)
+                .withName(STREAM_OPERATION_NAME)
+        );
+
+        final Properties properties = new Properties();
+        properties.put(InternalConfig.ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX, enableFix);
+        builder.build(properties);
+
+        final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
+        assertNamesForStateStore(topology.stateStores(),
+            STREAM_OPERATION_NAME + "-this-join-store",
+            STREAM_OPERATION_NAME + "-outer-other-join-store"
+        );
+        assertNamesForOperation(topology,
+            "KSTREAM-SOURCE-0000000000",
+            "KSTREAM-SOURCE-0000000001",
+            STREAM_OPERATION_NAME + "-this-windowed",
+            STREAM_OPERATION_NAME + "-other-windowed",
+            STREAM_OPERATION_NAME + "-this-join",
+            STREAM_OPERATION_NAME + "-outer-other-join",
+            STREAM_OPERATION_NAME + "-merge");
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -710,7 +710,13 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
-        streamOne.leftJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
+        streamOne.leftJoin(
+            streamTwo,
+            (value1, value2) -> value1,
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME)
+                .withName(STREAM_OPERATION_NAME)
+        );
         builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -734,7 +740,13 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
-        streamOne.leftJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName(STREAM_OPERATION_NAME));
+        streamOne.leftJoin(
+            streamTwo,
+            (value1, value2) -> value1,
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
+                .withName(STREAM_OPERATION_NAME)
+        );
         builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
@@ -804,7 +816,13 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
-        streamOne.outerJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME).withName(STREAM_OPERATION_NAME));
+        streamOne.outerJoin(
+            streamTwo,
+            (value1, value2) -> value1,
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            StreamJoined.<String, String, String>as(STREAM_OPERATION_NAME)
+                .withName(STREAM_OPERATION_NAME)
+        );
         builder.build();
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();
         assertNamesForStateStore(topology.stateStores(),
@@ -827,7 +845,13 @@ public class StreamsBuilderTest {
         final KStream<String, String> streamOne = builder.stream(STREAM_TOPIC);
         final KStream<String, String> streamTwo = builder.stream(STREAM_TOPIC_TWO);
 
-        streamOne.outerJoin(streamTwo, (value1, value2) -> value1, JoinWindows.of(Duration.ofHours(1)), StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String()).withName(STREAM_OPERATION_NAME));
+        streamOne.outerJoin(
+            streamTwo,
+            (value1, value2) -> value1,
+            JoinWindows.ofTimeDifferenceWithNoGrace(Duration.ofHours(1)),
+            StreamJoined.with(Serdes.String(), Serdes.String(), Serdes.String())
+                .withName(STREAM_OPERATION_NAME)
+        );
         builder.build();
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.rewriteTopology(new StreamsConfig(props)).buildTopology();

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -848,7 +848,7 @@ public class TopologyTest {
         stream1.leftJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
 
         final TopologyDescription describe = builder.build().describe();
@@ -890,7 +890,7 @@ public class TopologyTest {
         stream1.leftJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
                 .withStoreName("custom-name"));
 
@@ -930,7 +930,7 @@ public class TopologyTest {
         stream1 = builder.stream("input-topic1");
         stream2 = builder.stream("input-topic2");
 
-        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100));
+        final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100));
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store",
             Duration.ofMillis(joinWindows.size() + joinWindows.gracePeriodMs()),
@@ -987,7 +987,7 @@ public class TopologyTest {
         stream1.outerJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
 
         final TopologyDescription describe = builder.build().describe();
@@ -1029,7 +1029,7 @@ public class TopologyTest {
         stream1.outerJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
+            JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100)),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
                 .withStoreName("custom-name"));
 
@@ -1069,7 +1069,7 @@ public class TopologyTest {
         stream1 = builder.stream("input-topic1");
         stream2 = builder.stream("input-topic2");
 
-        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100));
+        final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(100));
 
         final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store",
             Duration.ofMillis(joinWindows.size() + joinWindows.gracePeriodMs()),

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static java.time.Duration.ofHours;
 import static java.time.Duration.ofSeconds;
 
 /**
@@ -96,7 +97,11 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
-        leftStream.join(rightStream, valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+        leftStream.join(
+            rightStream,
+            valueJoiner,
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+        ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }
@@ -138,9 +143,12 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         );
 
         leftStream.map(MockMapper.noOpKeyValueMapper())
-                .join(rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
-                                 .selectKey(MockMapper.selectKeyKeyValueMapper()),
-                       valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+            .join(
+                rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
+                    .selectKey(MockMapper.selectKeyKeyValueMapper()),
+                valueJoiner,
+                JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }
@@ -181,7 +189,11 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
-        leftStream.leftJoin(rightStream, valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+        leftStream.leftJoin(
+            rightStream,
+            valueJoiner,
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+        ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }
@@ -223,9 +235,12 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         );
 
         leftStream.map(MockMapper.noOpKeyValueMapper())
-                .leftJoin(rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
-                                     .selectKey(MockMapper.selectKeyKeyValueMapper()),
-                        valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+            .leftJoin(
+                rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
+                     .selectKey(MockMapper.selectKeyKeyValueMapper()),
+                valueJoiner,
+                JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }
@@ -266,7 +281,11 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d", null, 15L))
         );
 
-        leftStream.outerJoin(rightStream, valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+        leftStream.outerJoin(
+            rightStream,
+            valueJoiner,
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+        ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }
@@ -308,9 +327,12 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         );
 
         leftStream.map(MockMapper.noOpKeyValueMapper())
-                .outerJoin(rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
-                                .selectKey(MockMapper.selectKeyKeyValueMapper()),
-                        valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+            .outerJoin(
+                rightStream.flatMap(MockMapper.noOpFlatKeyValueMapper())
+                    .selectKey(MockMapper.selectKeyKeyValueMapper()),
+                valueJoiner,
+                JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+            ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }
@@ -399,8 +421,15 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                 new TestRecord<>(ANY_UNIQUE_KEY, "D-d-d", null, 15L))
         );
 
-        leftStream.join(rightStream, valueJoiner, JoinWindows.of(ofSeconds(10)))
-                .join(rightStream, valueJoiner, JoinWindows.of(ofSeconds(10))).to(OUTPUT_TOPIC);
+        leftStream.join(
+            rightStream,
+            valueJoiner,
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+        ).join(
+            rightStream,
+            valueJoiner,
+            JoinWindows.ofTimeDifferenceAndGrace(ofSeconds(10), ofHours(24))
+        ).to(OUTPUT_TOPIC);
 
         runTestWithDriver(expectedResult);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplValueJoinerWithKeyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplValueJoinerWithKeyTest.java
@@ -39,11 +39,11 @@ import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMillis;
 import static org.junit.Assert.assertEquals;
 
@@ -64,7 +64,7 @@ public class KStreamImplValueJoinerWithKeyTest {
 
     private final ValueJoinerWithKey<String, Integer, Integer, String> valueJoinerWithKey =
         (key, lv, rv) -> key + ":" + (lv + (rv == null ? 0 : rv));
-    private final JoinWindows joinWindows = JoinWindows.of(ofMillis(100));
+    private final JoinWindows joinWindows = JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100), ofHours(24L));
     private final StreamJoined<String, Integer, Integer> streamJoined =
             StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
     private final Joined<String, Integer, Integer> joined =
@@ -84,53 +84,56 @@ public class KStreamImplValueJoinerWithKeyTest {
     @Test
     public void shouldIncludeKeyInStreamSteamJoinResults() {
         leftStream.join(
-                rightStream,
-                valueJoinerWithKey,
-                joinWindows,
-                streamJoined
+            rightStream,
+            valueJoinerWithKey,
+            joinWindows,
+            streamJoined
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, Right KV A, 5
-        runJoinTopology(builder,
-                Collections.singletonList(KeyValue.pair("A", "A:5")),
-                false,
-                rightTopic
+        runJoinTopology(
+            builder,
+            Collections.singletonList(KeyValue.pair("A", "A:5")),
+            false,
+            rightTopic
         );
     }
 
     @Test
     public void shouldIncludeKeyInStreamLeftJoinResults() {
         leftStream.leftJoin(
-                rightStream,
-                valueJoinerWithKey,
-                joinWindows,
-                streamJoined
+            rightStream,
+            valueJoinerWithKey,
+            joinWindows,
+            streamJoined
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, Right KV A, 5
         // TTD pipes records to left stream first, then right
-        final List<KeyValue<String, String>> expectedResults = Arrays.asList(KeyValue.pair("A", "A:5"));
-        runJoinTopology(builder,
-                expectedResults,
-                false,
-                rightTopic
+        final List<KeyValue<String, String>> expectedResults = Collections.singletonList(KeyValue.pair("A", "A:5"));
+        runJoinTopology(
+            builder,
+            expectedResults,
+            false,
+            rightTopic
         );
     }
 
     @Test
     public void shouldIncludeKeyInStreamOuterJoinResults() {
         leftStream.outerJoin(
-                rightStream,
-                valueJoinerWithKey,
-                joinWindows,
-                streamJoined
+            rightStream,
+            valueJoinerWithKey,
+            joinWindows,
+            streamJoined
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
         // Left KV A, 3, Right KV A, 5
         // TTD pipes records to left stream first, then right
-        final List<KeyValue<String, String>> expectedResults = Arrays.asList(KeyValue.pair("A", "A:5"));
-        runJoinTopology(builder,
-                expectedResults,
-                false,
-                rightTopic
+        final List<KeyValue<String, String>> expectedResults = Collections.singletonList(KeyValue.pair("A", "A:5"));
+        runJoinTopology(
+            builder,
+            expectedResults,
+            false,
+            rightTopic
         );
     }
 
@@ -142,10 +145,11 @@ public class KStreamImplValueJoinerWithKeyTest {
             joined
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, Table KV A, 5
-        runJoinTopology(builder,
-                Collections.singletonList(KeyValue.pair("A", "A:5")),
-                true,
-                ktableTopic
+        runJoinTopology(
+            builder,
+            Collections.singletonList(KeyValue.pair("A", "A:5")),
+            true,
+            ktableTopic
         );
     }
 
@@ -157,10 +161,11 @@ public class KStreamImplValueJoinerWithKeyTest {
             joined
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, Table KV A, 5
-        runJoinTopology(builder,
-                Collections.singletonList(KeyValue.pair("A", "A:5")),
-                true,
-                ktableTopic
+        runJoinTopology(
+            builder,
+            Collections.singletonList(KeyValue.pair("A", "A:5")),
+            true,
+            ktableTopic
         );
     }
 
@@ -172,10 +177,11 @@ public class KStreamImplValueJoinerWithKeyTest {
             valueJoinerWithKey
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, GlobalTable KV A, 5
-        runJoinTopology(builder,
-                Collections.singletonList(KeyValue.pair("A", "A:5")),
-                true,
-                globalTopic
+        runJoinTopology(
+            builder,
+            Collections.singletonList(KeyValue.pair("A", "A:5")),
+            true,
+            globalTopic
         );
     }
 
@@ -187,10 +193,11 @@ public class KStreamImplValueJoinerWithKeyTest {
            valueJoinerWithKey
         ).to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
         // Left KV A, 3, GlobalTable KV A, 5
-        runJoinTopology(builder,
-                Collections.singletonList(KeyValue.pair("A", "A:5")),
-                true,
-                globalTopic
+        runJoinTopology(
+            builder,
+            Collections.singletonList(KeyValue.pair("A", "A:5")),
+            true,
+            globalTopic
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -1198,7 +1198,6 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            //JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(0L)).after(ofMillis(100L)),
             JoinWindows.of(ofMillis(0)).after(ofMillis(100)).grace(ofMillis(0)),
             StreamJoined.with(Serdes.Integer(),
                 Serdes.String(),
@@ -1468,7 +1467,6 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            //JoinWindows.ofTimeDifferenceAndGrace(ofMillis(0L), ofHours(24L)).before(ofMillis(100L)),
             JoinWindows.of(ofMillis(0)).before(ofMillis(100)),
             StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
         );

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -52,6 +52,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
+import static java.time.Duration.ofHours;
 import static java.time.Duration.ofMillis;
 
 import static org.apache.kafka.streams.processor.internals.assignment.AssignmentTestUtils.SUBTOPOLOGY_0;
@@ -63,8 +64,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class KStreamKStreamJoinTest {
-    private final static KeyValueTimestamp<?, ?>[] EMPTY = new KeyValueTimestamp[0];
-
     private final String topic1 = "topic1";
     private final String topic2 = "topic2";
     private final Consumed<Integer, String> consumed = Consumed.with(Serdes.Integer(), Serdes.String());
@@ -152,7 +151,7 @@ public class KStreamKStreamJoinTest {
 
         left.join(
             right,
-            (value1, value2) -> value1 + value2,
+            Integer::sum,
             joinWindows,
             streamJoined
         );
@@ -179,7 +178,7 @@ public class KStreamKStreamJoinTest {
 
         left.join(
             right,
-            (value1, value2) -> value1 + value2,
+            Integer::sum,
             joinWindows,
             streamJoined
         );
@@ -203,68 +202,79 @@ public class KStreamKStreamJoinTest {
     @Test
     public void shouldThrowExceptionThisStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace() {
         // Case where retention of thisJoinStore doesn't match JoinWindows
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 500, 100, true);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150, 100, true);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 500L, 100L, true);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
 
-
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            errorMessagePrefix);
+            errorMessagePrefix
+        );
     }
 
     @Test
     public void shouldThrowExceptionThisStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize() {
         //Case where window size of thisJoinStore doesn't match JoinWindows
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 150, true);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150, 100, true);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 150L, true);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
 
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            errorMessagePrefix);
+            errorMessagePrefix
+        );
     }
 
     @Test
     public void shouldThrowExceptionWhenThisJoinStoreSetsRetainDuplicatesFalse() {
         //Case where thisJoinStore retain duplicates false
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 100, false);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150, 100, true);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, false);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, true);
 
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            "The StoreSupplier must set retainDuplicates=true, found retainDuplicates=false");
+            "The StoreSupplier must set retainDuplicates=true, found retainDuplicates=false"
+        );
     }
 
     @Test
     public void shouldThrowExceptionOtherStoreSupplierRetentionDoNotMatchWindowsSizeAndGrace() {
         //Case where retention size of otherJoinStore doesn't match JoinWindows
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 100, true);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 500, 100, true);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 500L, 100L, true);
 
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            errorMessagePrefix);
+            errorMessagePrefix
+        );
     }
 
     @Test
     public void shouldThrowExceptionOtherStoreSupplierWindowSizeDoesNotMatchJoinWindowsWindowSize() {
         //Case where window size of otherJoinStore doesn't match JoinWindows
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 100, true);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150, 150, true);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 150L, true);
 
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            errorMessagePrefix);
+            errorMessagePrefix
+        );
     }
 
     @Test
     public void shouldThrowExceptionWhenOtherJoinStoreSetsRetainDuplicatesFalse() {
         //Case where otherJoinStore retain duplicates false
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 100, true);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150, 100, false);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store-other", 150L, 100L, false);
 
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            "The StoreSupplier must set retainDuplicates=true, found retainDuplicates=false");
+            "The StoreSupplier must set retainDuplicates=true, found retainDuplicates=false"
+        );
     }
 
     @Test
@@ -277,35 +287,43 @@ public class KStreamKStreamJoinTest {
         left.join(right,
             Integer::sum,
             joinWindows,
-            streamJoined);
+            streamJoined
+        );
 
         builder.build();
     }
 
     @Test
     public void shouldExceptionWhenJoinStoresDontHaveUniqueNames() {
-        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100)).grace(Duration.ofMillis(50));
+        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100L)).grace(Duration.ofMillis(50L));
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
-        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 100, true);
-        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150, 100, true);
+        final WindowBytesStoreSupplier thisStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
+        final WindowBytesStoreSupplier otherStoreSupplier = buildWindowBytesStoreSupplier("in-memory-join-store", 150L, 100L, true);
 
-        buildStreamsJoinThatShouldThrow(streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
+        buildStreamsJoinThatShouldThrow(
+            streamJoined.withThisStoreSupplier(thisStoreSupplier).withOtherStoreSupplier(otherStoreSupplier),
             joinWindows,
-            "Both StoreSuppliers have the same name.  StoreSuppliers must provide unique names");
+            "Both StoreSuppliers have the same name.  StoreSuppliers must provide unique names"
+        );
     }
 
     @Test
     public void shouldJoinWithCustomStoreSuppliers() {
+        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100L));
 
-        final JoinWindows joinWindows = JoinWindows.of(ofMillis(100));
-
-        final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store",
+        final WindowBytesStoreSupplier thisStoreSupplier = Stores.inMemoryWindowStore(
+            "in-memory-join-store",
             Duration.ofMillis(joinWindows.size() + joinWindows.gracePeriodMs()),
-            Duration.ofMillis(joinWindows.size()), true);
+            Duration.ofMillis(joinWindows.size()),
+            true
+        );
 
-        final WindowBytesStoreSupplier otherStoreSupplier = Stores.inMemoryWindowStore("in-memory-join-store-other",
+        final WindowBytesStoreSupplier otherStoreSupplier = Stores.inMemoryWindowStore(
+            "in-memory-join-store-other",
             Duration.ofMillis(joinWindows.size() + joinWindows.gracePeriodMs()),
-            Duration.ofMillis(joinWindows.size()), true);
+            Duration.ofMillis(joinWindows.size()),
+            true
+        );
 
         final StreamJoined<String, Integer, Integer> streamJoined = StreamJoined.with(Serdes.String(), Serdes.Integer(), Serdes.Integer());
 
@@ -317,8 +335,6 @@ public class KStreamKStreamJoinTest {
 
         //Case with other stream store supplier
         runJoin(streamJoined.withOtherStoreSupplier(otherStoreSupplier), joinWindows);
-
-
     }
 
     private void runJoin(final StreamJoined<String, Integer, Integer> streamJoined,
@@ -334,7 +350,8 @@ public class KStreamKStreamJoinTest {
             right,
             Integer::sum,
             joinWindows,
-            streamJoined);
+            streamJoined
+        );
 
         joinedStream.process(supplier);
 
@@ -351,8 +368,10 @@ public class KStreamKStreamJoinTest {
             inputTopicRight.pipeInput("A", 1, 1L);
             inputTopicRight.pipeInput("B", 2, 2L);
 
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>("A", 2, 1L),
-                new KeyValueTimestamp<>("B", 3, 2L));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>("A", 2, 1L),
+                new KeyValueTimestamp<>("B", 3, 2L)
+            );
         }
     }
 
@@ -371,8 +390,9 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
-            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+            JoinWindows.of(ofMillis(100L)),
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
         joined.process(supplier);
 
         final Collection<Set<String>> copartitionGroups =
@@ -396,7 +416,7 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic1.pipeInput(expectedKeys[i], "A" + expectedKeys[i]);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push two items to the other stream; this should produce two items
             // w1 = { 0:A0, 1:A1 }
@@ -406,8 +426,10 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic2.pipeInput(expectedKeys[i], "a" + expectedKeys[i]);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+a0", 0),
-                new KeyValueTimestamp<>(1, "A1+a1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+a0", 0L),
+                new KeyValueTimestamp<>(1, "A1+a1", 0L)
+            );
 
             // push all four items to the primary stream; this should produce two items
             // w1 = { 0:A0, 1:A1 }
@@ -417,8 +439,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "B" + expectedKey);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+a0", 0),
-                new KeyValueTimestamp<>(1, "B1+a1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+a0", 0L),
+                new KeyValueTimestamp<>(1, "B1+a1", 0L)
+            );
 
             // push all items to the other stream; this should produce six items
             // w1 = { 0:A0, 1:A1, 0:B0, 1:B1, 2:B2, 3:B3 }
@@ -428,12 +452,14 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "b" + expectedKey);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+b0", 0),
-                new KeyValueTimestamp<>(0, "B0+b0", 0),
-                new KeyValueTimestamp<>(1, "A1+b1", 0),
-                new KeyValueTimestamp<>(1, "B1+b1", 0),
-                new KeyValueTimestamp<>(2, "B2+b2", 0),
-                new KeyValueTimestamp<>(3, "B3+b3", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+b0", 0L),
+                new KeyValueTimestamp<>(0, "B0+b0", 0L),
+                new KeyValueTimestamp<>(1, "A1+b1", 0L),
+                new KeyValueTimestamp<>(1, "B1+b1", 0L),
+                new KeyValueTimestamp<>(2, "B2+b2", 0L),
+                new KeyValueTimestamp<>(3, "B3+b3", 0L)
+            );
 
             // push all four items to the primary stream; this should produce six items
             // w1 = { 0:A0, 1:A1, 0:B0, 1:B1, 2:B2, 3:B3 }
@@ -443,12 +469,14 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "C" + expectedKey);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "C0+a0", 0),
-                new KeyValueTimestamp<>(0, "C0+b0", 0),
-                new KeyValueTimestamp<>(1, "C1+a1", 0),
-                new KeyValueTimestamp<>(1, "C1+b1", 0),
-                new KeyValueTimestamp<>(2, "C2+b2", 0),
-                new KeyValueTimestamp<>(3, "C3+b3", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "C0+a0", 0L),
+                new KeyValueTimestamp<>(0, "C0+b0", 0L),
+                new KeyValueTimestamp<>(1, "C1+a1", 0L),
+                new KeyValueTimestamp<>(1, "C1+b1", 0L),
+                new KeyValueTimestamp<>(2, "C2+b2", 0L),
+                new KeyValueTimestamp<>(3, "C3+b3", 0L)
+            );
 
             // push two items to the other stream; this should produce six items
             // w1 = { 0:A0, 1:A1, 0:B0, 1:B1, 2:B2, 3:B3, 0:C0, 1:C1, 2:C2, 3:C3 }
@@ -458,12 +486,14 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic2.pipeInput(expectedKeys[i], "c" + expectedKeys[i]);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+c0", 0),
-                new KeyValueTimestamp<>(0, "B0+c0", 0),
-                new KeyValueTimestamp<>(0, "C0+c0", 0),
-                new KeyValueTimestamp<>(1, "A1+c1", 0),
-                new KeyValueTimestamp<>(1, "B1+c1", 0),
-                new KeyValueTimestamp<>(1, "C1+c1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+c0", 0L),
+                new KeyValueTimestamp<>(0, "B0+c0", 0L),
+                new KeyValueTimestamp<>(0, "C0+c0", 0L),
+                new KeyValueTimestamp<>(1, "A1+c1", 0L),
+                new KeyValueTimestamp<>(1, "B1+c1", 0L),
+                new KeyValueTimestamp<>(1, "C1+c1", 0L)
+            );
         }
     }
 
@@ -483,8 +513,9 @@ public class KStreamKStreamJoinTest {
         joined = stream1.outerJoin(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
-            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+            JoinWindows.ofTimeDifferenceAndGrace(ofMillis(100L), ofHours(24L)),
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
         joined.process(supplier);
         final Collection<Set<String>> copartitionGroups =
             TopologyWrapper.getInternalTopologyBuilder(builder.build()).copartitionGroups();
@@ -517,8 +548,10 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic2.pipeInput(expectedKeys[i], "a" + expectedKeys[i]);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+a0", 0),
-                new KeyValueTimestamp<>(1, "A1+a1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+a0", 0L),
+                new KeyValueTimestamp<>(1, "A1+a1", 0L)
+            );
 
             // push all four items to the primary stream; this should produce two items
             // w1 = { 0:A0, 1:A1 }
@@ -528,8 +561,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "B" + expectedKey);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+a0", 0),
-                new KeyValueTimestamp<>(1, "B1+a1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+a0", 0L),
+                new KeyValueTimestamp<>(1, "B1+a1", 0L)
+            );
 
             // push all items to the other stream; this should produce six items
             // w1 = { 0:A0, 1:A1, 0:B0, 1:B1, 2:B2, 3:B3 }
@@ -539,12 +574,14 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "b" + expectedKey);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+b0", 0),
-                new KeyValueTimestamp<>(0, "B0+b0", 0),
-                new KeyValueTimestamp<>(1, "A1+b1", 0),
-                new KeyValueTimestamp<>(1, "B1+b1", 0),
-                new KeyValueTimestamp<>(2, "B2+b2", 0),
-                new KeyValueTimestamp<>(3, "B3+b3", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+b0", 0L),
+                new KeyValueTimestamp<>(0, "B0+b0", 0L),
+                new KeyValueTimestamp<>(1, "A1+b1", 0L),
+                new KeyValueTimestamp<>(1, "B1+b1", 0L),
+                new KeyValueTimestamp<>(2, "B2+b2", 0L),
+                new KeyValueTimestamp<>(3, "B3+b3", 0L)
+            );
 
             // push all four items to the primary stream; this should produce six items
             // w1 = { 0:A0, 1:A1, 0:B0, 1:B1, 2:B2, 3:B3 }
@@ -554,12 +591,14 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "C" + expectedKey);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "C0+a0", 0),
-                new KeyValueTimestamp<>(0, "C0+b0", 0),
-                new KeyValueTimestamp<>(1, "C1+a1", 0),
-                new KeyValueTimestamp<>(1, "C1+b1", 0),
-                new KeyValueTimestamp<>(2, "C2+b2", 0),
-                new KeyValueTimestamp<>(3, "C3+b3", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "C0+a0", 0L),
+                new KeyValueTimestamp<>(0, "C0+b0", 0L),
+                new KeyValueTimestamp<>(1, "C1+a1", 0L),
+                new KeyValueTimestamp<>(1, "C1+b1", 0L),
+                new KeyValueTimestamp<>(2, "C2+b2", 0L),
+                new KeyValueTimestamp<>(3, "C3+b3", 0L)
+            );
 
             // push two items to the other stream; this should produce six items
             // w1 = { 0:A0, 1:A1, 0:B0, 1:B1, 2:B2, 3:B3, 0:C0, 1:C1, 2:C2, 3:C3 }
@@ -569,12 +608,14 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic2.pipeInput(expectedKeys[i], "c" + expectedKeys[i]);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+c0", 0),
-                new KeyValueTimestamp<>(0, "B0+c0", 0),
-                new KeyValueTimestamp<>(0, "C0+c0", 0),
-                new KeyValueTimestamp<>(1, "A1+c1", 0),
-                new KeyValueTimestamp<>(1, "B1+c1", 0),
-                new KeyValueTimestamp<>(1, "C1+c1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+c0", 0L),
+                new KeyValueTimestamp<>(0, "B0+c0", 0L),
+                new KeyValueTimestamp<>(0, "C0+c0", 0L),
+                new KeyValueTimestamp<>(1, "A1+c1", 0L),
+                new KeyValueTimestamp<>(1, "B1+c1", 0L),
+                new KeyValueTimestamp<>(1, "C1+c1", 0L)
+            );
         }
     }
 
@@ -594,8 +635,9 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
-            JoinWindows.of(ofMillis(100)),
-            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+            JoinWindows.of(ofMillis(100L)),
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
         joined.process(supplier);
 
         final Collection<Set<String>> copartitionGroups =
@@ -620,7 +662,7 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic1.pipeInput(expectedKeys[i], "A" + expectedKeys[i], time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push two items to the other stream; this should produce two items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0) }
@@ -630,8 +672,10 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < 2; i++) {
                 inputTopic2.pipeInput(expectedKeys[i], "a" + expectedKeys[i], time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+a0", 0),
-                new KeyValueTimestamp<>(1, "A1+a1", 0));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+a0", 0L),
+                new KeyValueTimestamp<>(1, "A1+a1", 0L)
+            );
 
             // push four items to the primary stream with larger and increasing timestamp; this should produce no items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0) }
@@ -643,7 +687,7 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < expectedKeys.length; i++) {
                 inputTopic1.pipeInput(expectedKeys[i], "B" + expectedKeys[i], time + i);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items to the other stream with fixed larger timestamp; this should produce four items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -657,10 +701,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "b" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+b0", 1100),
-                new KeyValueTimestamp<>(1, "B1+b1", 1100),
-                new KeyValueTimestamp<>(2, "B2+b2", 1100),
-                new KeyValueTimestamp<>(3, "B3+b3", 1100));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+b0", 1100L),
+                new KeyValueTimestamp<>(1, "B1+b1", 1100L),
+                new KeyValueTimestamp<>(2, "B2+b2", 1100L),
+                new KeyValueTimestamp<>(3, "B3+b3", 1100L)
+            );
 
             // push four items to the other stream with incremented timestamp; this should produce three items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -676,9 +722,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "c" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(1, "B1+c1", 1101),
-                new KeyValueTimestamp<>(2, "B2+c2", 1101),
-                new KeyValueTimestamp<>(3, "B3+c3", 1101));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(1, "B1+c1", 1101L),
+                new KeyValueTimestamp<>(2, "B2+c2", 1101L),
+                new KeyValueTimestamp<>(3, "B3+c3", 1101L)
+            );
 
             // push four items to the other stream with incremented timestamp; this should produce two items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -696,8 +744,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "d" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(2, "B2+d2", 1102),
-                new KeyValueTimestamp<>(3, "B3+d3", 1102));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(2, "B2+d2", 1102L),
+                new KeyValueTimestamp<>(3, "B3+d3", 1102L)
+            );
 
             // push four items to the other stream with incremented timestamp; this should produce one item
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -717,7 +767,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "e" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(3, "B3+e3", 1103));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(3, "B3+e3", 1103L)
+            );
 
             // push four items to the other stream with incremented timestamp; this should produce no items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -739,7 +791,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "f" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items to the other stream with timestamp before the window bound; this should produce no items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -763,7 +815,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "g" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items to the other stream with with incremented timestamp; this should produce one item
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -789,7 +841,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "h" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+h0", 1000));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+h0", 1000L)
+            );
 
             // push four items to the other stream with with incremented timestamp; this should produce two items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -817,8 +871,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "i" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+i0", 1000),
-                new KeyValueTimestamp<>(1, "B1+i1", 1001));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+i0", 1000L),
+                new KeyValueTimestamp<>(1, "B1+i1", 1001L)
+            );
 
             // push four items to the other stream with with incremented timestamp; this should produce three items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -848,9 +904,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "j" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+j0", 1000),
-                new KeyValueTimestamp<>(1, "B1+j1", 1001),
-                new KeyValueTimestamp<>(2, "B2+j2", 1002));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+j0", 1000L),
+                new KeyValueTimestamp<>(1, "B1+j1", 1001L),
+                new KeyValueTimestamp<>(2, "B2+j2", 1002L)
+            );
 
             // push four items to the other stream with with incremented timestamp; this should produce four items
             // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0),
@@ -882,10 +940,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "k" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "B0+k0", 1000),
-                new KeyValueTimestamp<>(1, "B1+k1", 1001),
-                new KeyValueTimestamp<>(2, "B2+k2", 1002),
-                new KeyValueTimestamp<>(3, "B3+k3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "B0+k0", 1000L),
+                new KeyValueTimestamp<>(1, "B1+k1", 1001L),
+                new KeyValueTimestamp<>(2, "B2+k2", 1002L),
+                new KeyValueTimestamp<>(3, "B3+k3", 1003L)
+            );
 
             // advance time to not join with existing data
             // we omit above exiting data, even if it's still in the window
@@ -899,7 +959,7 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < expectedKeys.length; i++) {
                 inputTopic2.pipeInput(expectedKeys[i], "l" + expectedKeys[i], time + i);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items with larger timestamps to the primary stream; this should produce four items
             // w1 = {}
@@ -910,10 +970,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "C" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "C0+l0", 2100),
-                new KeyValueTimestamp<>(1, "C1+l1", 2100),
-                new KeyValueTimestamp<>(2, "C2+l2", 2100),
-                new KeyValueTimestamp<>(3, "C3+l3", 2100));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "C0+l0", 2100L),
+                new KeyValueTimestamp<>(1, "C1+l1", 2100L),
+                new KeyValueTimestamp<>(2, "C2+l2", 2100L),
+                new KeyValueTimestamp<>(3, "C3+l3", 2100L)
+            );
 
             // push four items with increase timestamps to the primary stream; this should produce three items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100) }
@@ -925,9 +987,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "D" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(1, "D1+l1", 2101),
-                new KeyValueTimestamp<>(2, "D2+l2", 2101),
-                new KeyValueTimestamp<>(3, "D3+l3", 2101));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(1, "D1+l1", 2101L),
+                new KeyValueTimestamp<>(2, "D2+l2", 2101L),
+                new KeyValueTimestamp<>(3, "D3+l3", 2101L)
+            );
 
             // push four items with increase timestamps to the primary stream; this should produce two items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -941,8 +1005,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "E" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(2, "E2+l2", 2102),
-                new KeyValueTimestamp<>(3, "E3+l3", 2102));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(2, "E2+l2", 2102L),
+                new KeyValueTimestamp<>(3, "E3+l3", 2102L)
+            );
 
             // push four items with increase timestamps to the primary stream; this should produce one item
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -958,7 +1024,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "F" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(3, "F3+l3", 2103));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(3, "F3+l3", 2103L)
+            );
 
             // push four items with increase timestamps (now out of window) to the primary stream; this should produce no items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -976,7 +1044,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "G" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items with smaller timestamps (before window) to the primary stream; this should produce no items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -996,7 +1064,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "H" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items with increased timestamps to the primary stream; this should produce one item
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -1018,7 +1086,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "I" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "I0+l0", 2000));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "I0+l0", 2000L)
+            );
 
             // push four items with increased timestamps to the primary stream; this should produce two items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -1042,8 +1112,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "J" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "J0+l0", 2000),
-                new KeyValueTimestamp<>(1, "J1+l1", 2001));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "J0+l0", 2000L),
+                new KeyValueTimestamp<>(1, "J1+l1", 2001L)
+            );
 
             // push four items with increased timestamps to the primary stream; this should produce three items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -1069,9 +1141,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "K" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "K0+l0", 2000),
-                new KeyValueTimestamp<>(1, "K1+l1", 2001),
-                new KeyValueTimestamp<>(2, "K2+l2", 2002));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "K0+l0", 2000L),
+                new KeyValueTimestamp<>(1, "K1+l1", 2001L),
+                new KeyValueTimestamp<>(2, "K2+l2", 2002L)
+            );
 
             // push four items with increased timestamps to the primary stream; this should produce four items
             // w1 = { 0:C0 (ts: 2100), 1:C1 (ts: 2100), 2:C2 (ts: 2100), 3:C3 (ts: 2100),
@@ -1099,10 +1173,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic1.pipeInput(expectedKey, "L" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "L0+l0", 2000),
-                new KeyValueTimestamp<>(1, "L1+l1", 2001),
-                new KeyValueTimestamp<>(2, "L2+l2", 2002),
-                new KeyValueTimestamp<>(3, "L3+l3", 2003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "L0+l0", 2000L),
+                new KeyValueTimestamp<>(1, "L1+l1", 2001L),
+                new KeyValueTimestamp<>(2, "L2+l2", 2002L),
+                new KeyValueTimestamp<>(3, "L3+l3", 2003L)
+            );
         }
     }
 
@@ -1122,10 +1198,12 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
+            //JoinWindows.ofTimeDifferenceWithNoGrace(ofMillis(0L)).after(ofMillis(100L)),
             JoinWindows.of(ofMillis(0)).after(ofMillis(100)).grace(ofMillis(0)),
             StreamJoined.with(Serdes.Integer(),
                 Serdes.String(),
-                Serdes.String()));
+                Serdes.String())
+        );
         joined.process(supplier);
 
         final Collection<Set<String>> copartitionGroups =
@@ -1150,7 +1228,7 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < expectedKeys.length; i++) {
                 inputTopic1.pipeInput(expectedKeys[i], "A" + expectedKeys[i], time + i);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items smaller timestamps (out of window) to the secondary stream; this should produce no items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1161,7 +1239,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "a" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items with increased timestamps to the secondary stream; this should produce one item
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1173,7 +1251,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "b" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+b0", 1000));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+b0", 1000L)
+            );
 
             // push four items with increased timestamps to the secondary stream; this should produce two items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1187,8 +1267,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "c" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+c0", 1001),
-                new KeyValueTimestamp<>(1, "A1+c1", 1001));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+c0", 1001L),
+                new KeyValueTimestamp<>(1, "A1+c1", 1001L)
+            );
 
             // push four items with increased timestamps to the secondary stream; this should produce three items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1204,9 +1286,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "d" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+d0", 1002),
-                new KeyValueTimestamp<>(1, "A1+d1", 1002),
-                new KeyValueTimestamp<>(2, "A2+d2", 1002));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+d0", 1002L),
+                new KeyValueTimestamp<>(1, "A1+d1", 1002L),
+                new KeyValueTimestamp<>(2, "A2+d2", 1002L)
+            );
 
             // push four items with increased timestamps to the secondary stream; this should produce four items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1224,10 +1308,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "e" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+e0", 1003),
-                new KeyValueTimestamp<>(1, "A1+e1", 1003),
-                new KeyValueTimestamp<>(2, "A2+e2", 1003),
-                new KeyValueTimestamp<>(3, "A3+e3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+e0", 1003L),
+                new KeyValueTimestamp<>(1, "A1+e1", 1003L),
+                new KeyValueTimestamp<>(2, "A2+e2", 1003L),
+                new KeyValueTimestamp<>(3, "A3+e3", 1003L)
+            );
 
             // push four items with larger timestamps to the secondary stream; this should produce four items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1247,10 +1333,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "f" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+f0", 1100),
-                new KeyValueTimestamp<>(1, "A1+f1", 1100),
-                new KeyValueTimestamp<>(2, "A2+f2", 1100),
-                new KeyValueTimestamp<>(3, "A3+f3", 1100));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+f0", 1100L),
+                new KeyValueTimestamp<>(1, "A1+f1", 1100L),
+                new KeyValueTimestamp<>(2, "A2+f2", 1100L),
+                new KeyValueTimestamp<>(3, "A3+f3", 1100L)
+            );
 
             // push four items with increased timestamps to the secondary stream; this should produce three items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1272,9 +1360,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "g" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(1, "A1+g1", 1101),
-                new KeyValueTimestamp<>(2, "A2+g2", 1101),
-                new KeyValueTimestamp<>(3, "A3+g3", 1101));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(1, "A1+g1", 1101L),
+                new KeyValueTimestamp<>(2, "A2+g2", 1101L),
+                new KeyValueTimestamp<>(3, "A3+g3", 1101L)
+            );
 
             // push four items with increased timestamps to the secondary stream; this should produce two items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1298,8 +1388,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "h" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(2, "A2+h2", 1102),
-                new KeyValueTimestamp<>(3, "A3+h3", 1102));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(2, "A2+h2", 1102L),
+                new KeyValueTimestamp<>(3, "A3+h3", 1102L)
+            );
 
             // push four items with increased timestamps to the secondary stream; this should produce one item
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1325,7 +1417,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "i" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(3, "A3+i3", 1103));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(3, "A3+i3", 1103L)
+            );
 
             // push four items with increased timestamps (no out of window) to the secondary stream; this should produce no items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1353,7 +1447,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "j" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
         }
     }
 
@@ -1374,8 +1468,10 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(
             stream2,
             MockValueJoiner.TOSTRING_JOINER,
+            //JoinWindows.ofTimeDifferenceAndGrace(ofMillis(0L), ofHours(24L)).before(ofMillis(100L)),
             JoinWindows.of(ofMillis(0)).before(ofMillis(100)),
-            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String()));
+            StreamJoined.with(Serdes.Integer(), Serdes.String(), Serdes.String())
+        );
         joined.process(supplier);
 
         final Collection<Set<String>> copartitionGroups =
@@ -1400,7 +1496,7 @@ public class KStreamKStreamJoinTest {
             for (int i = 0; i < expectedKeys.length; i++) {
                 inputTopic1.pipeInput(expectedKeys[i], "A" + expectedKeys[i], time + i);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items with smaller timestamps (before the window) to the other stream; this should produce no items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1411,7 +1507,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "a" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
 
             // push four items with increased timestamp to the other stream; this should produce one item
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1423,7 +1519,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "b" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+b0", 1000));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+b0", 1000L)
+            );
 
             // push four items with increased timestamp to the other stream; this should produce two items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1437,8 +1535,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "c" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+c0", 1000),
-                new KeyValueTimestamp<>(1, "A1+c1", 1001));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+c0", 1000L),
+                new KeyValueTimestamp<>(1, "A1+c1", 1001L)
+            );
 
             // push four items with increased timestamp to the other stream; this should produce three items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1454,9 +1554,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "d" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+d0", 1000),
-                new KeyValueTimestamp<>(1, "A1+d1", 1001),
-                new KeyValueTimestamp<>(2, "A2+d2", 1002));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+d0", 1000L),
+                new KeyValueTimestamp<>(1, "A1+d1", 1001L),
+                new KeyValueTimestamp<>(2, "A2+d2", 1002L)
+            );
 
             // push four items with increased timestamp to the other stream; this should produce four items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1474,10 +1576,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "e" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+e0", 1000),
-                new KeyValueTimestamp<>(1, "A1+e1", 1001),
-                new KeyValueTimestamp<>(2, "A2+e2", 1002),
-                new KeyValueTimestamp<>(3, "A3+e3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+e0", 1000L),
+                new KeyValueTimestamp<>(1, "A1+e1", 1001L),
+                new KeyValueTimestamp<>(2, "A2+e2", 1002L),
+                new KeyValueTimestamp<>(3, "A3+e3", 1003L)
+            );
 
             // push four items with larger timestamp to the other stream; this should produce four items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1497,10 +1601,12 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "f" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(0, "A0+f0", 1000),
-                new KeyValueTimestamp<>(1, "A1+f1", 1001),
-                new KeyValueTimestamp<>(2, "A2+f2", 1002),
-                new KeyValueTimestamp<>(3, "A3+f3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(0, "A0+f0", 1000L),
+                new KeyValueTimestamp<>(1, "A1+f1", 1001L),
+                new KeyValueTimestamp<>(2, "A2+f2", 1002L),
+                new KeyValueTimestamp<>(3, "A3+f3", 1003L)
+            );
 
             // push four items with increase timestamp to the other stream; this should produce three items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1522,9 +1628,11 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "g" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(1, "A1+g1", 1001),
-                new KeyValueTimestamp<>(2, "A2+g2", 1002),
-                new KeyValueTimestamp<>(3, "A3+g3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(1, "A1+g1", 1001L),
+                new KeyValueTimestamp<>(2, "A2+g2", 1002L),
+                new KeyValueTimestamp<>(3, "A3+g3", 1003L)
+            );
 
             // push four items with increase timestamp to the other stream; this should produce two items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1548,8 +1656,10 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "h" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(2, "A2+h2", 1002),
-                new KeyValueTimestamp<>(3, "A3+h3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(2, "A2+h2", 1002L),
+                new KeyValueTimestamp<>(3, "A3+h3", 1003L)
+            );
 
             // push four items with increase timestamp to the other stream; this should produce one item
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1575,7 +1685,9 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "i" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(new KeyValueTimestamp<>(3, "A3+i3", 1003));
+            processor.checkAndClearProcessResult(
+                new KeyValueTimestamp<>(3, "A3+i3", 1003L)
+            );
 
             // push four items with increase timestamp (no out of window) to the other stream; this should produce no items
             // w1 = { 0:A0 (ts: 1000), 1:A1 (ts: 1001), 2:A2 (ts: 1002), 3:A3 (ts: 1003) }
@@ -1603,7 +1715,7 @@ public class KStreamKStreamJoinTest {
             for (final int expectedKey : expectedKeys) {
                 inputTopic2.pipeInput(expectedKey, "j" + expectedKey, time);
             }
-            processor.checkAndClearProcessResult(EMPTY);
+            processor.checkAndClearProcessResult();
         }
     }
 
@@ -1615,11 +1727,15 @@ public class KStreamKStreamJoinTest {
         final KStream<String, Integer> left = builder.stream("left", Consumed.with(Serdes.String(), Serdes.Integer()));
         final KStream<String, Integer> right = builder.stream("right", Consumed.with(Serdes.String(), Serdes.Integer()));
 
-        final StreamsException streamsException = assertThrows(StreamsException.class, () -> left.join(
-            right,
-            (value1, value2) -> value1 + value2,
-            joinWindows,
-            streamJoined));
+        final StreamsException streamsException = assertThrows(
+            StreamsException.class,
+            () -> left.join(
+                right,
+                Integer::sum,
+                joinWindows,
+                streamJoined
+            )
+        );
 
         assertTrue(streamsException.getMessage().startsWith(expectedExceptionMessagePrefix));
     }


### PR DESCRIPTION
We changed the behavior of left/outer stream-stream join via KAFKA-10847.
To avoid a breaking change during an upgrade, we need to disable this
fix by default.

We only enable the fix if users opt-in expliclity by changing their
code. We leverage KIP-633 (KAFKA-8613) that offers a new JoinWindows
API with mandatory grace-period to enable the fix.

Call for review @guozhangwang @spena @ableegoldman @izzyacademy