### PR TITLE
KAFKA-12928: Add a check whether the Task's statestore is actually a directory

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -126,9 +126,12 @@ public class StateDirectory {
                 throw new ProcessorStateException(
                     String.format("base state directory [%s] doesn't exist and couldn't be created", stateDirName));
             }
-            if ((stateDir.exists() && !stateDir.isDirectory()) || (!stateDir.exists() && !stateDir.mkdir())) {
+            if (!stateDir.exists() && !stateDir.mkdir()) {
                 throw new ProcessorStateException(
                     String.format("state directory [%s] doesn't exist and couldn't be created", stateDir.getPath()));
+            } else if (stateDir.exists() && !stateDir.isDirectory()) {
+                throw new ProcessorStateException(
+                    String.format("state directory [%s] can't be created as there is an existing file with the same name", stateDir.getPath()));
             }
 
             if (stateDirName.startsWith(System.getProperty("java.io.tmpdir"))) {
@@ -247,11 +250,9 @@ public class StateDirectory {
                             String.format("task directory [%s] doesn't exist and couldn't be created", taskDir.getPath()));
                     }
                 }
-            } else {
-                if (!taskDir.isDirectory()) {
-                    throw new ProcessorStateException(
-                        String.format("task directory [%s] doesn't exist and couldn't be created", taskDir.getPath()));
-                }
+            } else if (!taskDir.isDirectory()) {
+                throw new ProcessorStateException(
+                    String.format("state directory [%s] can't be created as there is an existing file with the same name", taskDir.getPath()));
             }
         }
         return taskDir;
@@ -319,9 +320,14 @@ public class StateDirectory {
      */
     File globalStateDir() {
         final File dir = new File(stateDir, "global");
-        if (hasPersistentStores && ((dir.exists() && !dir.isDirectory()) || (!dir.exists() && !dir.mkdir()))) {
-            throw new ProcessorStateException(
-                String.format("global state directory [%s] doesn't exist and couldn't be created", dir.getPath()));
+        if (hasPersistentStores) {
+            if (!dir.exists() && !dir.mkdir()) {
+                throw new ProcessorStateException(
+                    String.format("global state directory [%s] doesn't exist and couldn't be created", dir.getPath()));
+            } else if (dir.exists() && !dir.isDirectory()) {
+                throw new ProcessorStateException(
+                    String.format("global state directory [%s] can't be created as there is an existing file with the same name", dir.getPath()));
+            }
         }
         return dir;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -82,7 +82,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class StateDirectoryTest {
 
@@ -257,7 +256,7 @@ public class StateDirectoryTest {
         taskDir.createNewFile();
 
         // Error: ProcessorStateException should be thrown.
-        assertDoesNotThrow(() -> directory.getOrCreateDirectoryForTask(taskId));
+        assertThrows(ProcessorStateException.class, () -> directory.getOrCreateDirectoryForTask(taskId));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -247,7 +247,7 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldThrowProcessorStateExceptionIfAppDirOccupied() throws IOException {
+    public void shouldThrowProcessorStateExceptionIfTestDirOccupied() throws IOException {
         final TaskId taskId = new TaskId(0, 0);
 
         // Replace taskDir to a regular file

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -82,6 +82,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class StateDirectoryTest {
 
@@ -233,6 +234,30 @@ public class StateDirectoryTest {
         Utils.delete(stateDir);
 
         assertThrows(ProcessorStateException.class, () -> directory.getOrCreateDirectoryForTask(taskId));
+    }
+
+    @Test
+    public void shouldThrowProcessorStateExceptionIfStateDirOccupied() throws IOException {
+        final TaskId taskId = new TaskId(0, 0);
+
+        // Replace application's stateDir to regular file
+        Utils.delete(appDir);
+        appDir.createNewFile();
+
+        assertThrows(ProcessorStateException.class, () -> directory.getOrCreateDirectoryForTask(taskId));
+    }
+
+    @Test
+    public void shouldThrowProcessorStateExceptionIfAppDirOccupied() throws IOException {
+        final TaskId taskId = new TaskId(0, 0);
+
+        // Replace taskDir to a regular file
+        final File taskDir = new File(appDir, toTaskDirString(taskId));
+        Utils.delete(taskDir);
+        taskDir.createNewFile();
+
+        // Error: ProcessorStateException should be thrown.
+        assertDoesNotThrow(() -> directory.getOrCreateDirectoryForTask(taskId));
     }
 
     @Test


### PR DESCRIPTION
The first commit shows how to reproduce the problem, and the second commit is the fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
