### PR TITLE
KAFKA-12890; Consumer group stuck in `CompletingRebalance`

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/DelayedJoin.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedJoin.scala
@@ -17,7 +17,7 @@
 
 package kafka.coordinator.group
 
-import kafka.server.{DelayedOperation, DelayedOperationPurgatory, GroupKey}
+import kafka.server.{DelayedOperationPurgatory, GroupJoinKey}
 
 import scala.math.{max, min}
 
@@ -31,11 +31,16 @@ import scala.math.{max, min}
  * the group are marked as failed, and complete this operation to proceed rebalance with
  * the rest of the group.
  */
-private[group] class DelayedJoin(coordinator: GroupCoordinator,
-                                 group: GroupMetadata,
-                                 rebalanceTimeout: Long) extends DelayedOperation(rebalanceTimeout, Some(group.lock)) {
-
+private[group] class DelayedJoin(
+  coordinator: GroupCoordinator,
+  group: GroupMetadata,
+  rebalanceTimeout: Long
+) extends DelayedRebalance(
+  rebalanceTimeout,
+  group.lock
+) {
   override def tryComplete(): Boolean = coordinator.tryCompleteJoin(group, forceComplete _)
+
   override def onExpiration(): Unit = {
     // try to complete delayed actions introduced by coordinator.onCompleteJoin
     tryToCompleteDelayedAction()
@@ -54,13 +59,18 @@ private[group] class DelayedJoin(coordinator: GroupCoordinator,
   * before the rebalance timeout. If both are true we then schedule a further delay. Otherwise we complete the
   * rebalance.
   */
-private[group] class InitialDelayedJoin(coordinator: GroupCoordinator,
-                                        purgatory: DelayedOperationPurgatory[DelayedJoin],
-                                        group: GroupMetadata,
-                                        configuredRebalanceDelay: Int,
-                                        delayMs: Int,
-                                        remainingMs: Int) extends DelayedJoin(coordinator, group, delayMs) {
-
+private[group] class InitialDelayedJoin(
+  coordinator: GroupCoordinator,
+  purgatory: DelayedOperationPurgatory[DelayedRebalance],
+  group: GroupMetadata,
+  configuredRebalanceDelay: Int,
+  delayMs: Int,
+  remainingMs: Int
+) extends DelayedJoin(
+  coordinator,
+  group,
+  delayMs
+) {
   override def tryComplete(): Boolean = false
 
   override def onComplete(): Unit = {
@@ -75,7 +85,7 @@ private[group] class InitialDelayedJoin(coordinator: GroupCoordinator,
           configuredRebalanceDelay,
           delay,
           remaining
-        ), Seq(GroupKey(group.groupId)))
+        ), Seq(GroupJoinKey(group.groupId)))
       } else
         super.onComplete()
     }

--- a/core/src/main/scala/kafka/coordinator/group/DelayedRebalance.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedRebalance.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.locks.Lock
 
 /**
  * Delayed rebalance operation that is shared by DelayedJoin and DelayedSync
- * operations. This allows to use a common purgatory for both cases.
+ * operations. This allows us to use a common purgatory for both cases.
  */
 private[group] abstract class DelayedRebalance(
   rebalanceTimeoutMs: Long,

--- a/core/src/main/scala/kafka/coordinator/group/DelayedRebalance.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedRebalance.scala
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.coordinator.group
+
+import kafka.server.DelayedOperation
+
+import java.util.concurrent.locks.Lock
+
+/**
+ * Delayed rebalance operation that is shared by DelayedJoin and DelayedSync
+ * operations. This allows to use a common purgatory for both cases.
+ */
+private[group] abstract class DelayedRebalance(
+  rebalanceTimeoutMs: Long,
+  groupLock: Lock
+) extends DelayedOperation(
+  rebalanceTimeoutMs,
+  Some(groupLock)
+)

--- a/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
@@ -17,8 +17,6 @@
 
 package kafka.coordinator.group
 
-import kafka.server.DelayedOperation
-
 /**
  * Delayed rebalance operation that is added to the purgatory when is completing the rebalance.
  *
@@ -33,9 +31,9 @@ private[group] class DelayedSync(
   group: GroupMetadata,
   generationId: Int,
   rebalanceTimeoutMs: Long
-) extends DelayedOperation(
+) extends DelayedRebalance(
   rebalanceTimeoutMs,
-  Some(group.lock)
+  group.lock
 ) {
   override def tryComplete(): Boolean = {
     coordinator.tryCompletePendingSync(group, generationId, forceComplete _)

--- a/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
@@ -22,7 +22,7 @@ import kafka.server.DelayedOperation
 /**
  * Delayed rebalance operation that is added to the purgatory when is completing the rebalance.
  *
- * Whenever a SyncGroup is receives, checks that we received all the SyncGroup request from
+ * Whenever a SyncGroup is received, checks that we received all the SyncGroup request from
  * each member of the group; if yes, complete this operation.
  *
  * When the operation has expired, any known members that have not sent a SyncGroup requests
@@ -31,17 +31,18 @@ import kafka.server.DelayedOperation
 private[group] class DelayedSync(
   coordinator: GroupCoordinator,
   group: GroupMetadata,
+  generationId: Int,
   rebalanceTimeoutMs: Long
 ) extends DelayedOperation(
   rebalanceTimeoutMs,
   Some(group.lock)
 ) {
   override def tryComplete(): Boolean = {
-    coordinator.tryCompletePendingSync(group, forceComplete _)
+    coordinator.tryCompletePendingSync(group, generationId, forceComplete _)
   }
 
   override def onExpiration(): Unit = {
-    coordinator.onExpirePendingSync(group)
+    coordinator.onExpirePendingSync(group, generationId)
   }
 
   override def onComplete(): Unit = { }

--- a/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
@@ -18,7 +18,8 @@
 package kafka.coordinator.group
 
 /**
- * Delayed rebalance operation that is added to the purgatory when is completing the rebalance.
+ * Delayed rebalance operation that is added to the purgatory when the group is completing the
+ * rebalance.
  *
  * Whenever a SyncGroup is received, checks that we received all the SyncGroup request from
  * each member of the group; if yes, complete this operation.

--- a/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.coordinator.group
+
+import kafka.server.DelayedOperation
+
+/**
+ * TODO
+ */
+private[group] class DelayedSync(
+  coordinator: GroupCoordinator,
+  group: GroupMetadata,
+  rebalanceTimeoutMs: Long
+) extends DelayedOperation(
+  rebalanceTimeoutMs,
+  Some(group.lock)
+) {
+  override def tryComplete(): Boolean = {
+    coordinator.tryCompletePendingSync(group, forceComplete _)
+  }
+
+  override def onExpiration(): Unit = {
+    coordinator.onExpirePendingSync(group)
+  }
+
+  override def onComplete(): Unit = {
+    // Nothing
+  }
+}

--- a/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
@@ -22,8 +22,8 @@ import kafka.server.DelayedOperation
 /**
  * Delayed rebalance operation that is added to the purgatory when is completing the rebalance.
  *
- * Whenever a SyncGroup is receives, checks that a SyncGroup has been received for each
- * member of the group; if yes, complete this operation.
+ * Whenever a SyncGroup is receives, checks that we received all the SyncGroup request from
+ * each member of the group; if yes, complete this operation.
  *
  * When the operation has expired, any known members that have not sent a SyncGroup requests
  * are removed from the group. If any members is removed, the group is rebalanced.
@@ -44,7 +44,5 @@ private[group] class DelayedSync(
     coordinator.onExpirePendingSync(group)
   }
 
-  override def onComplete(): Unit = {
-    // Nothing
-  }
+  override def onComplete(): Unit = { }
 }

--- a/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
+++ b/core/src/main/scala/kafka/coordinator/group/DelayedSync.scala
@@ -20,7 +20,13 @@ package kafka.coordinator.group
 import kafka.server.DelayedOperation
 
 /**
- * TODO
+ * Delayed rebalance operation that is added to the purgatory when is completing the rebalance.
+ *
+ * Whenever a SyncGroup is receives, checks that a SyncGroup has been received for each
+ * member of the group; if yes, complete this operation.
+ *
+ * When the operation has expired, any known members that have not sent a SyncGroup requests
+ * are removed from the group. If any members is removed, the group is rebalanced.
  */
 private[group] class DelayedSync(
   coordinator: GroupCoordinator,

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1537,13 +1537,13 @@ class GroupCoordinator(val brokerId: Int,
             if (!group.hasReceivedSyncFromAllMembers) {
               val pendingSyncMembers = group.allPendingSyncMembers
 
-              debug(s"Group ${group.groupId} removed members who haven't " +
-                s"sent their sync request: $pendingSyncMembers")
-
               pendingSyncMembers.foreach { memberId =>
                 group.remove(memberId)
                 removeHeartbeatForLeavingMember(group, memberId)
               }
+
+              debug(s"Group ${group.groupId} removed members who haven't " +
+                s"sent their sync request: $pendingSyncMembers")
 
               prepareRebalance(group, s"Removing $pendingSyncMembers on pending sync request expiration")
             }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1616,9 +1616,8 @@ object GroupCoordinator {
             time: Time,
             metrics: Metrics): GroupCoordinator = {
     val heartbeatPurgatory = DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", config.brokerId)
-    // TODO Check if we could consolidate both purgatories.
-    val joinPurgatory = DelayedOperationPurgatory[DelayedJoin]("Rebalance", config.brokerId)
-    val syncPurgatory = DelayedOperationPurgatory[DelayedSync]("Rebalance", config.brokerId)
+    val joinPurgatory = DelayedOperationPurgatory[DelayedJoin]("Rebalance (DelayedJoin)", config.brokerId)
+    val syncPurgatory = DelayedOperationPurgatory[DelayedSync]("Rebalance (DelayedSync)", config.brokerId)
     GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, syncPurgatory, time, metrics)
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -1511,7 +1511,7 @@ class GroupCoordinator(val brokerId: Int,
           case Dead | Empty | PreparingRebalance =>
             forceComplete()
           case CompletingRebalance | Stable =>
-            if (group.hasReceivedSyncFromAllMembers())
+            if (group.hasReceivedSyncFromAllMembers)
               forceComplete()
             else false
         }
@@ -1525,17 +1525,17 @@ class GroupCoordinator(val brokerId: Int,
   ): Unit = {
     group.inLock {
       if (generationId != group.generationId) {
-        debug(s"Received unexpected notification of sync expiration for ${group.groupId} " +
+        error(s"Received unexpected notification of sync expiration for ${group.groupId} " +
           s"with an old generation $generationId while the group has ${group.generationId}.")
       } else {
         group.currentState match {
           case Dead | Empty | PreparingRebalance =>
-            debug(s"Received unexpected notification of sync expiration after group ${group.groupId} " +
+            error(s"Received unexpected notification of sync expiration after group ${group.groupId} " +
               s"already transitioned to the ${group.currentState} state.")
 
           case CompletingRebalance | Stable =>
-            if (!group.hasReceivedSyncFromAllMembers()) {
-              val pendingSyncMembers = group.allPendingSyncMembers()
+            if (!group.hasReceivedSyncFromAllMembers) {
+              val pendingSyncMembers = group.allPendingSyncMembers
 
               debug(s"Group ${group.groupId} removed members who haven't " +
                 s"sent their sync request: $pendingSyncMembers")

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -214,7 +214,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private val pendingTransactionalOffsetCommits = new mutable.HashMap[Long, mutable.Map[TopicPartition, CommitRecordMetadataAndOffset]]()
   private var receivedTransactionalOffsetCommits = false
   private var receivedConsumerOffsetCommits = false
-  val pendingSyncMembers = new mutable.HashSet[String]
+  private val pendingSyncMembers = new mutable.HashSet[String]
 
   // When protocolType == `consumer`, a set of subscribed topics is maintained. The set is
   // computed when a new generation is created or when the group is restored from the log.
@@ -364,6 +364,10 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def hasReceivedSyncFromAllMembers(): Boolean = {
     pendingSyncMembers.isEmpty
+  }
+
+  def allPendingSyncMembers(): Set[String] = {
+    pendingSyncMembers.toSet
   }
 
   def hasStaticMember(groupInstanceId: String): Boolean = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -370,6 +370,10 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     pendingSyncMembers.toSet
   }
 
+  def clearPendingSyncMembers(): Unit = {
+    pendingSyncMembers.clear()
+  }
+
   def hasStaticMember(groupInstanceId: String): Boolean = {
     staticMembers.contains(groupInstanceId)
   }
@@ -572,7 +576,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     }
     receivedConsumerOffsetCommits = false
     receivedTransactionalOffsetCommits = false
-    pendingSyncMembers.clear()
+    clearPendingSyncMembers()
   }
 
   def currentMemberMetadata: List[JoinGroupResponseMember] = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -214,6 +214,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   private val pendingTransactionalOffsetCommits = new mutable.HashMap[Long, mutable.Map[TopicPartition, CommitRecordMetadataAndOffset]]()
   private var receivedTransactionalOffsetCommits = false
   private var receivedConsumerOffsetCommits = false
+  val pendingSyncMembers = new mutable.HashSet[String]
 
   // When protocolType == `consumer`, a set of subscribed topics is maintained. The set is
   // computed when a new generation is created or when the group is restored from the log.
@@ -274,6 +275,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
       leaderId = members.keys.headOption
 
     pendingMembers.remove(memberId)
+    pendingSyncMembers.remove(memberId)
   }
 
   /**
@@ -342,6 +344,26 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
         s"a stable member of the group")
     }
     pendingMembers.add(memberId)
+  }
+
+  def addPendingSyncMember(memberId: String): Boolean = {
+    if (!has(memberId)) {
+      throw new IllegalStateException(s"Attempt to add a pending sync for member $memberId which " +
+        "is not a member of the group")
+    }
+    pendingSyncMembers.add(memberId)
+  }
+
+  def removePendingSyncMember(memberId: String): Boolean = {
+    if (!has(memberId)) {
+      throw new IllegalStateException(s"Attempt to remove a pending sync for member $memberId which " +
+        "is not a member of the group")
+    }
+    pendingSyncMembers.remove(memberId)
+  }
+
+  def hasReceivedSyncFromAllMembers(): Boolean = {
+    pendingSyncMembers.isEmpty
   }
 
   def hasStaticMember(groupInstanceId: String): Boolean = {
@@ -546,6 +568,7 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     }
     receivedConsumerOffsetCommits = false
     receivedTransactionalOffsetCommits = false
+    pendingSyncMembers.clear()
   }
 
   def currentMemberMetadata: List[JoinGroupResponseMember] = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -362,11 +362,11 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     pendingSyncMembers.remove(memberId)
   }
 
-  def hasReceivedSyncFromAllMembers(): Boolean = {
+  def hasReceivedSyncFromAllMembers: Boolean = {
     pendingSyncMembers.isEmpty
   }
 
-  def allPendingSyncMembers(): Set[String] = {
+  def allPendingSyncMembers: Set[String] = {
     pendingSyncMembers.toSet
   }
 

--- a/core/src/main/scala/kafka/server/DelayedOperationKey.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperationKey.scala
@@ -32,9 +32,7 @@ object DelayedOperationKey {
 
 /* used by delayed-produce and delayed-fetch operations */
 case class TopicPartitionOperationKey(topic: String, partition: Int) extends DelayedOperationKey {
-
-
-  override def keyLabel = "%s-%d".format(topic, partition)
+  override def keyLabel: String = "%s-%d".format(topic, partition)
 }
 
 object TopicPartitionOperationKey {
@@ -45,18 +43,20 @@ object TopicPartitionOperationKey {
 
 /* used by delayed-join-group operations */
 case class MemberKey(groupId: String, consumerId: String) extends DelayedOperationKey {
-
-  override def keyLabel = "%s-%s".format(groupId, consumerId)
+  override def keyLabel: String = "%s-%s".format(groupId, consumerId)
 }
 
-/* used by delayed-rebalance operations */
-case class GroupKey(groupId: String) extends DelayedOperationKey {
+/* used by delayed-join operations */
+case class GroupJoinKey(groupId: String) extends DelayedOperationKey {
+  override def keyLabel: String = "join-%s".format(groupId)
+}
 
-  override def keyLabel = groupId
+/* used by delayed-sync operations */
+case class GroupSyncKey(groupId: String) extends DelayedOperationKey {
+  override def keyLabel: String = "sync-%s".format(groupId)
 }
 
 /* used by delayed-topic operations */
 case class TopicKey(topic: String) extends DelayedOperationKey {
-
-  override def keyLabel = topic
+  override def keyLabel: String = topic
 }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -62,8 +62,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
   )
 
   var heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat] = _
-  var joinPurgatory: DelayedOperationPurgatory[DelayedJoin] = _
-  var syncPurgatory: DelayedOperationPurgatory[DelayedSync] = _
+  var rebalancePurgatory: DelayedOperationPurgatory[DelayedRebalance] = _
   var groupCoordinator: GroupCoordinator = _
 
   @BeforeEach
@@ -82,10 +81,9 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     val config = KafkaConfig.fromProps(serverProps)
 
     heartbeatPurgatory = new DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", timer, config.brokerId, reaperEnabled = false)
-    joinPurgatory = new DelayedOperationPurgatory[DelayedJoin]("Rebalance", timer, config.brokerId, reaperEnabled = false)
-    syncPurgatory = new DelayedOperationPurgatory[DelayedSync]("Rebalance", timer, config.brokerId, reaperEnabled = false)
+    rebalancePurgatory = new DelayedOperationPurgatory[DelayedRebalance]("Rebalance", timer, config.brokerId, reaperEnabled = false)
 
-    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, syncPurgatory, timer.time, new Metrics())
+    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, rebalancePurgatory, timer.time, new Metrics())
     groupCoordinator.startup(() => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions),
       false)
   }
@@ -152,7 +150,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     if (groupCoordinator != null)
       groupCoordinator.shutdown()
     groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory,
-      joinPurgatory, syncPurgatory, timer.time, new Metrics())
+      rebalancePurgatory, timer.time, new Metrics())
     groupCoordinator.startup(() => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions),
       false)
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorConcurrencyTest.scala
@@ -63,6 +63,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
 
   var heartbeatPurgatory: DelayedOperationPurgatory[DelayedHeartbeat] = _
   var joinPurgatory: DelayedOperationPurgatory[DelayedJoin] = _
+  var syncPurgatory: DelayedOperationPurgatory[DelayedSync] = _
   var groupCoordinator: GroupCoordinator = _
 
   @BeforeEach
@@ -82,8 +83,9 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
 
     heartbeatPurgatory = new DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", timer, config.brokerId, reaperEnabled = false)
     joinPurgatory = new DelayedOperationPurgatory[DelayedJoin]("Rebalance", timer, config.brokerId, reaperEnabled = false)
+    syncPurgatory = new DelayedOperationPurgatory[DelayedSync]("Rebalance", timer, config.brokerId, reaperEnabled = false)
 
-    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, timer.time, new Metrics())
+    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, syncPurgatory, timer.time, new Metrics())
     groupCoordinator.startup(() => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions),
       false)
   }
@@ -150,7 +152,7 @@ class GroupCoordinatorConcurrencyTest extends AbstractCoordinatorConcurrencyTest
     if (groupCoordinator != null)
       groupCoordinator.shutdown()
     groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory,
-      joinPurgatory, timer.time, new Metrics())
+      joinPurgatory, syncPurgatory, timer.time, new Metrics())
     groupCoordinator.startup(() => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions),
       false)
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -2295,7 +2295,7 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def testRebalanceTimesOutWhenSyncRequestIsNotReceiced(): Unit = {
+  def testRebalanceTimesOutWhenSyncRequestIsNotReceived(): Unit = {
     // This test case ensure that the DelayedSync does kick out all members
     // if they don't sent a sync request before the rebalance timeout. The
     // group is in the Stable state in this case.
@@ -2327,7 +2327,7 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def testRebalanceTimesOutWhenSyncRequestIsNotReceicedFromFollowers(): Unit = {
+  def testRebalanceTimesOutWhenSyncRequestIsNotReceivedFromFollowers(): Unit = {
     // This test case ensure that the DelayedSync does kick out the followers
     // if they don't sent a sync request before the rebalance timeout. The
     // group is in the Stable state in this case.

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -113,10 +113,9 @@ class GroupCoordinatorTest {
     val config = KafkaConfig.fromProps(props)
 
     val heartbeatPurgatory = new DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", timer, config.brokerId, reaperEnabled = false)
-    val joinPurgatory = new DelayedOperationPurgatory[DelayedJoin]("Rebalance", timer, config.brokerId, reaperEnabled = false)
-    val syncPurgatory = new DelayedOperationPurgatory[DelayedSync]("Rebalance", timer, config.brokerId, reaperEnabled = false)
+    val rebalancePurgatory = new DelayedOperationPurgatory[DelayedRebalance]("Rebalance", timer, config.brokerId, reaperEnabled = false)
 
-    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, syncPurgatory, timer.time, new Metrics())
+    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, rebalancePurgatory, timer.time, new Metrics())
     groupCoordinator.startup(() => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions),
       enableMetadataExpiration = false)
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -114,8 +114,9 @@ class GroupCoordinatorTest {
 
     val heartbeatPurgatory = new DelayedOperationPurgatory[DelayedHeartbeat]("Heartbeat", timer, config.brokerId, reaperEnabled = false)
     val joinPurgatory = new DelayedOperationPurgatory[DelayedJoin]("Rebalance", timer, config.brokerId, reaperEnabled = false)
+    val syncPurgatory = new DelayedOperationPurgatory[DelayedSync]("Rebalance", timer, config.brokerId, reaperEnabled = false)
 
-    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, timer.time, new Metrics())
+    groupCoordinator = GroupCoordinator(config, replicaManager, heartbeatPurgatory, joinPurgatory, syncPurgatory, timer.time, new Metrics())
     groupCoordinator.startup(() => zkClient.getTopicPartitionCount(Topic.GROUP_METADATA_TOPIC_NAME).getOrElse(config.offsetsTopicPartitions),
       enableMetadataExpiration = false)
 
@@ -1667,7 +1668,7 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def testheartbeatDeadGroup(): Unit = {
+  def testHeartbeatDeadGroup(): Unit = {
     val memberId = "memberId"
 
     val deadGroupId = "deadGroupId"
@@ -1678,7 +1679,7 @@ class GroupCoordinatorTest {
   }
 
   @Test
-  def testheartbeatEmptyGroup(): Unit = {
+  def testHeartbeatEmptyGroup(): Unit = {
     val memberId = "memberId"
 
     val group = new GroupMetadata(groupId, Empty, new MockTime())
@@ -2252,6 +2253,222 @@ class GroupCoordinatorTest {
     assertEquals(2, group().allMembers.size)
     assertEquals(2, group().allDynamicMembers.size)
     assertEquals(0, group().numPending)
+  }
+
+  private def verifyHeartbeat(
+    joinGroupResult: JoinGroupResult,
+    expectedError: Errors
+  ): Unit = {
+    EasyMock.reset(replicaManager)
+    val heartbeatResult = heartbeat(
+      groupId,
+      joinGroupResult.memberId,
+      joinGroupResult.generationId
+    )
+    assertEquals(expectedError, heartbeatResult)
+  }
+
+  private def joinWithNMembers(nbMembers: Int): Seq[JoinGroupResult] = {
+    val requiredKnownMemberId = true
+
+    // First JoinRequests
+    var futures = 1.to(nbMembers).map { _ =>
+      EasyMock.reset(replicaManager)
+      sendJoinGroup(groupId, JoinGroupRequest.UNKNOWN_MEMBER_ID, protocolType, protocols,
+        None, DefaultSessionTimeout, DefaultRebalanceTimeout, requiredKnownMemberId)
+    }
+
+    // Get back the assigned member ids
+    val memberIds = futures.map(await(_, 1).memberId)
+
+    // Second JoinRequests
+    futures = memberIds.map { memberId =>
+      EasyMock.reset(replicaManager)
+      sendJoinGroup(groupId, memberId, protocolType, protocols,
+        None, DefaultSessionTimeout, DefaultRebalanceTimeout, requiredKnownMemberId)
+    }
+
+    timer.advanceClock(GroupInitialRebalanceDelay + 1)
+    timer.advanceClock(DefaultRebalanceTimeout + 1)
+
+    futures.map(await(_, 1))
+  }
+
+  @Test
+  def testRebalanceTimesOutWhenSyncRequestIsNotReceiced(): Unit = {
+    // This test case ensure that the DelayedSync does kick out all members
+    // if they don't sent a sync request before the rebalance timeout. The
+    // group is in the Stable state in this case.
+    val results = joinWithNMembers(nbMembers = 3)
+    assertEquals(Set(Errors.NONE), results.map(_.error).toSet)
+
+    // Advance time
+    timer.advanceClock(DefaultRebalanceTimeout / 2)
+
+    // Heartbeats succeed
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.NONE)
+    }
+
+    EasyMock.reset(replicaManager)
+    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
+      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
+      .anyTimes()
+    EasyMock.replay(replicaManager)
+
+    timer.advanceClock(DefaultRebalanceTimeout / 2 + 1)
+
+    // Heartbeats fail because none of the members have sent the sync request
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.UNKNOWN_MEMBER_ID)
+    }
+  }
+
+  @Test
+  def testRebalanceTimesOutWhenSyncRequestIsNotReceicedFromFollowers(): Unit = {
+    // This test case ensure that the DelayedSync does kick out the followers
+    // if they don't sent a sync request before the rebalance timeout. The
+    // group is in the Stable state in this case.
+    val results = joinWithNMembers(nbMembers = 3)
+    assertEquals(Set(Errors.NONE), results.map(_.error).toSet)
+
+    // Advance time
+    timer.advanceClock(DefaultRebalanceTimeout / 2)
+
+    // Heartbeats succeed
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.NONE)
+    }
+
+    // Leader sends Sync
+    EasyMock.reset(replicaManager)
+    val assignments = results.map(result => result.memberId -> Array.empty[Byte]).toMap
+    val leaderResult = sendSyncGroupLeader(groupId, results.head.generationId, results.head.memberId,
+      Some(protocolType), Some(protocolName), None, assignments)
+
+    assertEquals(Errors.NONE, await(leaderResult, 1).error)
+
+    // Leader should be able to heartbeart
+    verifyHeartbeat(results.head, Errors.NONE)
+
+    EasyMock.reset(replicaManager)
+    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
+      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
+      .anyTimes()
+    EasyMock.replay(replicaManager)
+
+    // Advance past the rebalance timeout to kick out members without Sync.
+    timer.advanceClock(DefaultRebalanceTimeout / 2 + 1)
+
+    // Leader should be able to heartbeart
+    verifyHeartbeat(results.head, Errors.REBALANCE_IN_PROGRESS)
+
+    // Followers should have been removed.
+    results.tail.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.UNKNOWN_MEMBER_ID)
+    }
+  }
+
+  @Test
+  def testRebalanceTimesOutWhenSyncRequestIsNotReceivedFromLeaders(): Unit = {
+    // This test case ensure that the DelayedSync does kick out the leader
+    // if it does not sent a sync request before the rebalance timeout. The
+    // group is in the CompletingRebalance state in this case.
+    val results = joinWithNMembers(nbMembers = 3)
+    assertEquals(Set(Errors.NONE), results.map(_.error).toSet)
+
+    // Advance time
+    timer.advanceClock(DefaultRebalanceTimeout / 2)
+
+    // Heartbeats succeed
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.NONE)
+    }
+
+    // Followers send Sync
+    EasyMock.reset(replicaManager)
+    val followerResults = results.tail.map { joinGroupResult =>
+      EasyMock.reset(replicaManager)
+      sendSyncGroupFollower(groupId, joinGroupResult.generationId, joinGroupResult.memberId,
+        Some(protocolType), Some(protocolName), None)
+    }
+
+    EasyMock.reset(replicaManager)
+    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
+      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
+      .anyTimes()
+    EasyMock.replay(replicaManager)
+
+    // Advance past the rebalance timeout to kick out members without Sync.
+    timer.advanceClock(DefaultRebalanceTimeout / 2 + 1)
+
+    val followerErrors = followerResults.map(await(_, 1).error)
+    assertEquals(Set(Errors.REBALANCE_IN_PROGRESS), followerErrors.toSet)
+
+    // Leader should have been removed.
+    verifyHeartbeat(results.head, Errors.UNKNOWN_MEMBER_ID)
+
+    // Followers should be able to heartbeat.
+    results.tail.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.REBALANCE_IN_PROGRESS)
+    }
+  }
+
+  @Test
+  def testRebalanceDoesNotTimeOutWhenAllSyncAreReceived(): Unit = {
+    // This test case ensure that the DelayedSync does not kick any
+    // members out when they have all sent their sync requests.
+    val results = joinWithNMembers(nbMembers = 3)
+    assertEquals(Set(Errors.NONE), results.map(_.error).toSet)
+
+    // Advance time
+    timer.advanceClock(DefaultRebalanceTimeout / 2)
+
+    // Heartbeats succeed
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.NONE)
+    }
+
+    EasyMock.reset(replicaManager)
+    val assignments = results.map(result => result.memberId -> Array.empty[Byte]).toMap
+    val leaderResult = sendSyncGroupLeader(groupId, results.head.generationId, results.head.memberId,
+      Some(protocolType), Some(protocolName), None, assignments)
+
+    assertEquals(Errors.NONE, await(leaderResult, 1).error)
+
+    // Followers send Sync
+    EasyMock.reset(replicaManager)
+    val followerResults = results.tail.map { joinGroupResult =>
+      EasyMock.reset(replicaManager)
+      sendSyncGroupFollower(groupId, joinGroupResult.generationId, joinGroupResult.memberId,
+        Some(protocolType), Some(protocolName), None)
+    }
+
+    val followerErrors = followerResults.map(await(_, 1).error)
+    assertEquals(Set(Errors.NONE), followerErrors.toSet)
+
+    EasyMock.reset(replicaManager)
+    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
+      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
+      .anyTimes()
+    EasyMock.replay(replicaManager)
+
+    // Advance past the rebalance timeout to expire the Sync timout. All
+    // members should remain and the group should not rebalance.
+    timer.advanceClock(DefaultRebalanceTimeout / 2 + 1)
+
+    // Followers should be able to heartbeat.
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.NONE)
+    }
+
+    // Advance a bit more.
+    timer.advanceClock(DefaultRebalanceTimeout / 2)
+
+    // Followers should be able to heartbeat.
+    results.foreach { joinGroupResult =>
+      verifyHeartbeat(joinGroupResult, Errors.NONE)
+    }
   }
 
   private def group(groupId: String = groupId) = {

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupCoordinatorTest.scala
@@ -2305,11 +2305,13 @@ class GroupCoordinatorTest {
     // Advance time
     timer.advanceClock(DefaultRebalanceTimeout / 2)
 
-    // Heartbeats succeed
+    // Heartbeats to ensure that heartbeating does not interfere with the
+    // delayed sync operation.
     results.foreach { joinGroupResult =>
       verifyHeartbeat(joinGroupResult, Errors.NONE)
     }
 
+    // Advance part the rebalance timeout to trigger the delayed operation.
     EasyMock.reset(replicaManager)
     EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
@@ -2335,7 +2337,8 @@ class GroupCoordinatorTest {
     // Advance time
     timer.advanceClock(DefaultRebalanceTimeout / 2)
 
-    // Heartbeats succeed
+    // Heartbeats to ensure that heartbeating does not interfere with the
+    // delayed sync operation.
     results.foreach { joinGroupResult =>
       verifyHeartbeat(joinGroupResult, Errors.NONE)
     }
@@ -2351,13 +2354,7 @@ class GroupCoordinatorTest {
     // Leader should be able to heartbeart
     verifyHeartbeat(results.head, Errors.NONE)
 
-    EasyMock.reset(replicaManager)
-    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
-      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
-      .anyTimes()
-    EasyMock.replay(replicaManager)
-
-    // Advance past the rebalance timeout to kick out members without Sync.
+    // Advance part the rebalance timeout to trigger the delayed operation.
     timer.advanceClock(DefaultRebalanceTimeout / 2 + 1)
 
     // Leader should be able to heartbeart
@@ -2380,7 +2377,8 @@ class GroupCoordinatorTest {
     // Advance time
     timer.advanceClock(DefaultRebalanceTimeout / 2)
 
-    // Heartbeats succeed
+    // Heartbeats to ensure that heartbeating does not interfere with the
+    // delayed sync operation.
     results.foreach { joinGroupResult =>
       verifyHeartbeat(joinGroupResult, Errors.NONE)
     }
@@ -2393,13 +2391,7 @@ class GroupCoordinatorTest {
         Some(protocolType), Some(protocolName), None)
     }
 
-    EasyMock.reset(replicaManager)
-    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
-      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
-      .anyTimes()
-    EasyMock.replay(replicaManager)
-
-    // Advance past the rebalance timeout to kick out members without Sync.
+    // Advance part the rebalance timeout to trigger the delayed operation.
     timer.advanceClock(DefaultRebalanceTimeout / 2 + 1)
 
     val followerErrors = followerResults.map(await(_, 1).error)
@@ -2424,7 +2416,8 @@ class GroupCoordinatorTest {
     // Advance time
     timer.advanceClock(DefaultRebalanceTimeout / 2)
 
-    // Heartbeats succeed
+    // Heartbeats to ensure that heartbeating does not interfere with the
+    // delayed sync operation.
     results.foreach { joinGroupResult =>
       verifyHeartbeat(joinGroupResult, Errors.NONE)
     }
@@ -2446,12 +2439,6 @@ class GroupCoordinatorTest {
 
     val followerErrors = followerResults.map(await(_, 1).error)
     assertEquals(Set(Errors.NONE), followerErrors.toSet)
-
-    EasyMock.reset(replicaManager)
-    EasyMock.expect(replicaManager.getMagic(EasyMock.anyObject()))
-      .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
-      .anyTimes()
-    EasyMock.replay(replicaManager)
 
     // Advance past the rebalance timeout to expire the Sync timout. All
     // members should remain and the group should not rebalance.

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -663,6 +663,40 @@ class GroupMetadataTest {
     assertThrows(classOf[IllegalStateException], () => group.add(member))
   }
 
+  @Test
+  def testCannotAddPendingSyncOfUnknownMember(): Unit = {
+    assertThrows(classOf[IllegalStateException],
+      () => group.addPendingSyncMember(memberId))
+  }
+
+  @Test
+  def testCannotRemovePendingSyncOfUnknownMember(): Unit = {
+    assertThrows(classOf[IllegalStateException],
+      () => group.addPendingSyncMember(memberId))
+  }
+
+  @Test
+  def testCanAddAndRemovePendingSyncMember(): Unit = {
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), clientId, clientHost,
+      rebalanceTimeoutMs, sessionTimeoutMs, protocolType, List(("range", Array.empty[Byte])))
+    group.add(member)
+    group.addPendingSyncMember(memberId)
+    assertEquals(Set(memberId), group.pendingSyncMembers.toSet)
+    group.removePendingSyncMember(memberId)
+    assertEquals(Set(), group.pendingSyncMembers.toSet)
+  }
+
+  @Test
+  def testRemovalFromPendincSyncWhenMemberIsRemoved(): Unit = {
+    val member = new MemberMetadata(memberId, Some(groupInstanceId), clientId, clientHost,
+      rebalanceTimeoutMs, sessionTimeoutMs, protocolType, List(("range", Array.empty[Byte])))
+    group.add(member)
+    group.addPendingSyncMember(memberId)
+    assertEquals(Set(memberId), group.pendingSyncMembers.toSet)
+    group.remove(memberId)
+    assertEquals(Set(), group.pendingSyncMembers.toSet)
+  }
+
   private def assertState(group: GroupMetadata, targetState: GroupState): Unit = {
     val states: Set[GroupState] = Set(Stable, PreparingRebalance, CompletingRebalance, Dead)
     val otherStates = states - targetState

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -681,9 +681,9 @@ class GroupMetadataTest {
       rebalanceTimeoutMs, sessionTimeoutMs, protocolType, List(("range", Array.empty[Byte])))
     group.add(member)
     group.addPendingSyncMember(memberId)
-    assertEquals(Set(memberId), group.pendingSyncMembers.toSet)
+    assertEquals(Set(memberId), group.allPendingSyncMembers())
     group.removePendingSyncMember(memberId)
-    assertEquals(Set(), group.pendingSyncMembers.toSet)
+    assertEquals(Set(), group.allPendingSyncMembers())
   }
 
   @Test
@@ -692,9 +692,9 @@ class GroupMetadataTest {
       rebalanceTimeoutMs, sessionTimeoutMs, protocolType, List(("range", Array.empty[Byte])))
     group.add(member)
     group.addPendingSyncMember(memberId)
-    assertEquals(Set(memberId), group.pendingSyncMembers.toSet)
+    assertEquals(Set(memberId), group.allPendingSyncMembers())
     group.remove(memberId)
-    assertEquals(Set(), group.pendingSyncMembers.toSet)
+    assertEquals(Set(), group.allPendingSyncMembers())
   }
 
   @Test
@@ -704,9 +704,9 @@ class GroupMetadataTest {
     group.add(member)
     group.transitionTo(PreparingRebalance)
     group.addPendingSyncMember(memberId)
-    assertEquals(Set(memberId), group.pendingSyncMembers.toSet)
+    assertEquals(Set(memberId), group.allPendingSyncMembers())
     group.initNextGeneration()
-    assertEquals(Set(), group.pendingSyncMembers.toSet)
+    assertEquals(Set(), group.allPendingSyncMembers())
   }
 
   private def assertState(group: GroupMetadata, targetState: GroupState): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -681,9 +681,9 @@ class GroupMetadataTest {
       rebalanceTimeoutMs, sessionTimeoutMs, protocolType, List(("range", Array.empty[Byte])))
     group.add(member)
     group.addPendingSyncMember(memberId)
-    assertEquals(Set(memberId), group.allPendingSyncMembers())
+    assertEquals(Set(memberId), group.allPendingSyncMembers)
     group.removePendingSyncMember(memberId)
-    assertEquals(Set(), group.allPendingSyncMembers())
+    assertEquals(Set(), group.allPendingSyncMembers)
   }
 
   @Test
@@ -692,9 +692,9 @@ class GroupMetadataTest {
       rebalanceTimeoutMs, sessionTimeoutMs, protocolType, List(("range", Array.empty[Byte])))
     group.add(member)
     group.addPendingSyncMember(memberId)
-    assertEquals(Set(memberId), group.allPendingSyncMembers())
+    assertEquals(Set(memberId), group.allPendingSyncMembers)
     group.remove(memberId)
-    assertEquals(Set(), group.allPendingSyncMembers())
+    assertEquals(Set(), group.allPendingSyncMembers)
   }
 
   @Test
@@ -704,9 +704,9 @@ class GroupMetadataTest {
     group.add(member)
     group.transitionTo(PreparingRebalance)
     group.addPendingSyncMember(memberId)
-    assertEquals(Set(memberId), group.allPendingSyncMembers())
+    assertEquals(Set(memberId), group.allPendingSyncMembers)
     group.initNextGeneration()
-    assertEquals(Set(), group.allPendingSyncMembers())
+    assertEquals(Set(), group.allPendingSyncMembers)
   }
 
   private def assertState(group: GroupMetadata, targetState: GroupState): Unit = {


### PR DESCRIPTION
When a group transitions to the `CompletingRebalance` state, the group coordinator sets up `DelayedHeartbeat` for each member of the group. It does so to ensure that the member sends a sync request within the session timeout. If it does not, the group coordinator rebalances the group. Note that here, `DelayedHeartbeat` is used here for this purpose. `DelayedHeartbeat` are also completed when member heartbeats.

The issue is that https://github.com/apache/kafka/pull/8834 has changed the heartbeat logic to allow members to heartbeat while the group is in the `CompletingRebalance` state. This was not allowed before. Now, if a member starts to heartbeat while the group is in the `CompletingRebalance`, the heartbeat request will basically complete the pending `DelayedHeartbeat` that was setup previously for catching not receiving the sync request. Therefore, if the sync request never comes, the group coordinator does not notice anymore.

This patch introduced a new delayed operation which effectively ensure that a SyncGroup request is received from any stable members of the groups within the rebalance timeout. The timer starts when the group transitions to the `CompletingRebalance` state.

Note that I think that this is a bit more strict that we used to have prior to https://github.com/apache/kafka/pull/8834 as we were previously relying on the session timeout to expire in this case. Thougths?

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
