### PR TITLE
KAFKA-12934: Move some controller classes to the metadata package

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/BrokersToIsrs.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.controller;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
@@ -30,7 +31,8 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-import static org.apache.kafka.controller.ReplicationControlManager.NO_LEADER;
+import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
+import static org.apache.kafka.metadata.Replicas.NONE;
 
 
 /**
@@ -49,8 +51,6 @@ import static org.apache.kafka.controller.ReplicationControlManager.NO_LEADER;
  * works because partition IDs cannot be negative.
  */
 public class BrokersToIsrs {
-    private final static int[] EMPTY = new int[0];
-
     private final static int LEADER_FLAG = 0x8000_0000;
 
     private final static int REPLICA_MASK = 0x7fff_ffff;
@@ -95,7 +95,7 @@ public class BrokersToIsrs {
         private final boolean leaderOnly;
         private int offset = 0;
         Uuid uuid = Uuid.ZERO_UUID;
-        int[] replicas = EMPTY;
+        int[] replicas = NONE;
         private TopicIdPartition next = null;
 
         PartitionsOnReplicaIterator(Map<Uuid, int[]> topicMap, boolean leaderOnly) {
@@ -163,7 +163,7 @@ public class BrokersToIsrs {
                 int prevLeader, int nextLeader) {
         int[] prev;
         if (prevIsr == null) {
-            prev = EMPTY;
+            prev = NONE;
         } else {
             if (prevLeader == NO_LEADER) {
                 prev = Replicas.copyWith(prevIsr, NO_LEADER);
@@ -177,7 +177,7 @@ public class BrokersToIsrs {
         }
         int[] next;
         if (nextIsr == null) {
-            next = EMPTY;
+            next = NONE;
         } else {
             if (nextLeader == NO_LEADER) {
                 next = Replicas.copyWith(nextIsr, NO_LEADER);

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -63,6 +63,8 @@ import org.apache.kafka.controller.BrokersToIsrs.TopicIdPartition;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
 import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.metadata.Replicas;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.apache.kafka.timeline.TimelineHashMap;
 import org.apache.kafka.timeline.TimelineInteger;
@@ -81,7 +83,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.OptionalInt;
 
 import static org.apache.kafka.clients.admin.AlterConfigOp.OpType.SET;
@@ -89,6 +90,8 @@ import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 import static org.apache.kafka.common.protocol.Errors.INVALID_REQUEST;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION;
+import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
+import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER_CHANGE;
 
 
 /**
@@ -97,175 +100,16 @@ import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_OR_PARTITION
  * of each partition, as well as administrative tasks like creating or deleting topics.
  */
 public class ReplicationControlManager {
-    /**
-     * A special value used to represent the leader for a partition with no leader. 
-     */
-    public static final int NO_LEADER = -1;
-
-    /**
-     * A special value used to represent a PartitionChangeRecord that does not change the
-     * partition leader.
-     */
-    public static final int NO_LEADER_CHANGE = -2;
 
     static class TopicControlInfo {
         private final String name;
         private final Uuid id;
-        private final TimelineHashMap<Integer, PartitionControlInfo> parts;
+        private final TimelineHashMap<Integer, PartitionRegistration> parts;
 
         TopicControlInfo(String name, SnapshotRegistry snapshotRegistry, Uuid id) {
             this.name = name;
             this.id = id;
             this.parts = new TimelineHashMap<>(snapshotRegistry, 0);
-        }
-    }
-
-    static class PartitionControlInfo {
-        public final int[] replicas;
-        public final int[] isr;
-        public final int[] removingReplicas;
-        public final int[] addingReplicas;
-        public final int leader;
-        public final int leaderEpoch;
-        public final int partitionEpoch;
-
-        PartitionControlInfo(PartitionRecord record) {
-            this(Replicas.toArray(record.replicas()),
-                Replicas.toArray(record.isr()),
-                Replicas.toArray(record.removingReplicas()),
-                Replicas.toArray(record.addingReplicas()),
-                record.leader(),
-                record.leaderEpoch(),
-                record.partitionEpoch());
-        }
-
-        PartitionControlInfo(int[] replicas, int[] isr, int[] removingReplicas,
-                             int[] addingReplicas, int leader, int leaderEpoch,
-                             int partitionEpoch) {
-            this.replicas = replicas;
-            this.isr = isr;
-            this.removingReplicas = removingReplicas;
-            this.addingReplicas = addingReplicas;
-            this.leader = leader;
-            this.leaderEpoch = leaderEpoch;
-            this.partitionEpoch = partitionEpoch;
-        }
-
-        PartitionControlInfo merge(PartitionChangeRecord record) {
-            int[] newIsr = (record.isr() == null) ? isr : Replicas.toArray(record.isr());
-            int newLeader;
-            int newLeaderEpoch;
-            if (record.leader() == NO_LEADER_CHANGE) {
-                newLeader = leader;
-                newLeaderEpoch = leaderEpoch;
-            } else {
-                newLeader = record.leader();
-                newLeaderEpoch = leaderEpoch + 1;
-            }
-            return new PartitionControlInfo(replicas,
-                newIsr,
-                removingReplicas,
-                addingReplicas,
-                newLeader,
-                newLeaderEpoch,
-                partitionEpoch + 1);
-        }
-
-        String diff(PartitionControlInfo prev) {
-            StringBuilder builder = new StringBuilder();
-            String prefix = "";
-            if (!Arrays.equals(replicas, prev.replicas)) {
-                builder.append(prefix).append("replicas: ").
-                    append(Arrays.toString(prev.replicas)).
-                    append(" -> ").append(Arrays.toString(replicas));
-                prefix = ", ";
-            }
-            if (!Arrays.equals(isr, prev.isr)) {
-                builder.append(prefix).append("isr: ").
-                    append(Arrays.toString(prev.isr)).
-                    append(" -> ").append(Arrays.toString(isr));
-                prefix = ", ";
-            }
-            if (!Arrays.equals(removingReplicas, prev.removingReplicas)) {
-                builder.append(prefix).append("removingReplicas: ").
-                    append(Arrays.toString(prev.removingReplicas)).
-                    append(" -> ").append(Arrays.toString(removingReplicas));
-                prefix = ", ";
-            }
-            if (!Arrays.equals(addingReplicas, prev.addingReplicas)) {
-                builder.append(prefix).append("addingReplicas: ").
-                    append(Arrays.toString(prev.addingReplicas)).
-                    append(" -> ").append(Arrays.toString(addingReplicas));
-                prefix = ", ";
-            }
-            if (leader != prev.leader) {
-                builder.append(prefix).append("leader: ").
-                    append(prev.leader).append(" -> ").append(leader);
-                prefix = ", ";
-            }
-            if (leaderEpoch != prev.leaderEpoch) {
-                builder.append(prefix).append("leaderEpoch: ").
-                    append(prev.leaderEpoch).append(" -> ").append(leaderEpoch);
-                prefix = ", ";
-            }
-            if (partitionEpoch != prev.partitionEpoch) {
-                builder.append(prefix).append("partitionEpoch: ").
-                    append(prev.partitionEpoch).append(" -> ").append(partitionEpoch);
-            }
-            return builder.toString();
-        }
-
-        void maybeLogPartitionChange(Logger log, String description, PartitionControlInfo prev) {
-            if (!electionWasClean(leader, prev.isr)) {
-                log.info("UNCLEAN partition change for {}: {}", description, diff(prev));
-            } else if (log.isDebugEnabled()) {
-                log.debug("partition change for {}: {}", description, diff(prev));
-            }
-        }
-
-        boolean hasLeader() {
-            return leader != NO_LEADER;
-        }
-
-        boolean hasPreferredLeader() {
-            return leader == preferredReplica();
-        }
-
-        int preferredReplica() {
-            return replicas.length == 0 ? NO_LEADER : replicas[0];
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(replicas, isr, removingReplicas, addingReplicas, leader,
-                leaderEpoch, partitionEpoch);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!(o instanceof PartitionControlInfo)) return false;
-            PartitionControlInfo other = (PartitionControlInfo) o;
-            return Arrays.equals(replicas, other.replicas) &&
-                Arrays.equals(isr, other.isr) &&
-                Arrays.equals(removingReplicas, other.removingReplicas) &&
-                Arrays.equals(addingReplicas, other.addingReplicas) &&
-                leader == other.leader &&
-                leaderEpoch == other.leaderEpoch &&
-                partitionEpoch == other.partitionEpoch;
-        }
-
-        @Override
-        public String toString() {
-            StringBuilder builder = new StringBuilder("PartitionControlInfo(");
-            builder.append("replicas=").append(Arrays.toString(replicas));
-            builder.append(", isr=").append(Arrays.toString(isr));
-            builder.append(", removingReplicas=").append(Arrays.toString(removingReplicas));
-            builder.append(", addingReplicas=").append(Arrays.toString(addingReplicas));
-            builder.append(", leader=").append(leader);
-            builder.append(", leaderEpoch=").append(leaderEpoch);
-            builder.append(", partitionEpoch=").append(partitionEpoch);
-            builder.append(")");
-            return builder.toString();
         }
     }
 
@@ -359,8 +203,8 @@ public class ReplicationControlManager {
             throw new RuntimeException("Tried to create partition " + record.topicId() +
                 ":" + record.partitionId() + ", but no topic with that ID was found.");
         }
-        PartitionControlInfo newPartInfo = new PartitionControlInfo(record);
-        PartitionControlInfo prevPartInfo = topicInfo.parts.get(record.partitionId());
+        PartitionRegistration newPartInfo = new PartitionRegistration(record);
+        PartitionRegistration prevPartInfo = topicInfo.parts.get(record.partitionId());
         String description = topicInfo.name + "-" + record.partitionId() +
             " with topic ID " + record.topicId();
         if (prevPartInfo == null) {
@@ -389,12 +233,12 @@ public class ReplicationControlManager {
             throw new RuntimeException("Tried to create partition " + record.topicId() +
                 ":" + record.partitionId() + ", but no topic with that ID was found.");
         }
-        PartitionControlInfo prevPartitionInfo = topicInfo.parts.get(record.partitionId());
+        PartitionRegistration prevPartitionInfo = topicInfo.parts.get(record.partitionId());
         if (prevPartitionInfo == null) {
             throw new RuntimeException("Tried to create partition " + record.topicId() +
                 ":" + record.partitionId() + ", but no partition with that id was found.");
         }
-        PartitionControlInfo newPartitionInfo = prevPartitionInfo.merge(record);
+        PartitionRegistration newPartitionInfo = prevPartitionInfo.merge(record);
         topicInfo.parts.put(record.partitionId(), newPartitionInfo);
         brokersToIsrs.update(record.topicId(), record.partitionId(),
             prevPartitionInfo.isr, newPartitionInfo.isr, prevPartitionInfo.leader,
@@ -422,7 +266,7 @@ public class ReplicationControlManager {
         configurationControl.deleteTopicConfigs(topic.name);
 
         // Remove the entries for this topic in brokersToIsrs.
-        for (PartitionControlInfo partition : topic.parts.values()) {
+        for (PartitionRegistration partition : topic.parts.values()) {
             for (int i = 0; i < partition.isr.length; i++) {
                 brokersToIsrs.removeTopicEntryForBroker(topic.id, partition.isr[i]);
             }
@@ -504,7 +348,7 @@ public class ReplicationControlManager {
     private ApiError createTopic(CreatableTopic topic,
                                  List<ApiMessageAndVersion> records,
                                  Map<String, CreatableTopicResult> successes) {
-        Map<Integer, PartitionControlInfo> newParts = new HashMap<>();
+        Map<Integer, PartitionRegistration> newParts = new HashMap<>();
         if (!topic.assignments().isEmpty()) {
             if (topic.replicationFactor() != -1) {
                 return new ApiError(INVALID_REQUEST,
@@ -526,7 +370,7 @@ public class ReplicationControlManager {
                 validateManualPartitionAssignment(assignment.brokerIds(), replicationFactor);
                 replicationFactor = OptionalInt.of(assignment.brokerIds().size());
                 int[] replicas = Replicas.toArray(assignment.brokerIds());
-                newParts.put(assignment.partitionIndex(), new PartitionControlInfo(
+                newParts.put(assignment.partitionIndex(), new PartitionRegistration(
                     replicas, replicas, null, null, replicas[0], 0, 0));
             }
         } else if (topic.replicationFactor() < -1 || topic.replicationFactor() == 0) {
@@ -550,7 +394,7 @@ public class ReplicationControlManager {
                 for (int partitionId = 0; partitionId < replicas.size(); partitionId++) {
                     int[] r = Replicas.toArray(replicas.get(partitionId));
                     newParts.put(partitionId,
-                        new PartitionControlInfo(r, r, null, null, r[0], 0, 0));
+                        new PartitionRegistration(r, r, null, null, r[0], 0, 0));
                 }
             } catch (InvalidReplicationFactorException e) {
                 return new ApiError(Errors.INVALID_REPLICATION_FACTOR,
@@ -569,19 +413,10 @@ public class ReplicationControlManager {
         records.add(new ApiMessageAndVersion(new TopicRecord().
             setName(topic.name()).
             setTopicId(topicId), (short) 0));
-        for (Entry<Integer, PartitionControlInfo> partEntry : newParts.entrySet()) {
+        for (Entry<Integer, PartitionRegistration> partEntry : newParts.entrySet()) {
             int partitionIndex = partEntry.getKey();
-            PartitionControlInfo info = partEntry.getValue();
-            records.add(new ApiMessageAndVersion(new PartitionRecord().
-                setPartitionId(partitionIndex).
-                setTopicId(topicId).
-                setReplicas(Replicas.toList(info.replicas)).
-                setIsr(Replicas.toList(info.isr)).
-                setRemovingReplicas(null).
-                setAddingReplicas(null).
-                setLeader(info.leader).
-                setLeaderEpoch(info.leaderEpoch).
-                setPartitionEpoch(0), (short) 0));
+            PartitionRegistration info = partEntry.getValue();
+            records.add(info.toRecord(topicId, partitionIndex));
         }
         return ApiError.NONE;
     }
@@ -679,7 +514,7 @@ public class ReplicationControlManager {
     }
 
     // VisibleForTesting
-    PartitionControlInfo getPartition(Uuid topicId, int partitionId) {
+    PartitionRegistration getPartition(Uuid topicId, int partitionId) {
         TopicControlInfo topic = topics.get(topicId);
         if (topic == null) {
             return null;
@@ -711,7 +546,7 @@ public class ReplicationControlManager {
             }
             TopicControlInfo topic = topics.get(topicId);
             for (AlterIsrRequestData.PartitionData partitionData : topicData.partitions()) {
-                PartitionControlInfo partition = topic.parts.get(partitionData.partitionIndex());
+                PartitionRegistration partition = topic.parts.get(partitionData.partitionIndex());
                 if (partition == null) {
                     responseTopicData.partitions().add(new AlterIsrResponseData.PartitionData().
                         setPartitionIndex(partitionData.partitionIndex()).
@@ -888,7 +723,7 @@ public class ReplicationControlManager {
             return new ApiError(UNKNOWN_TOPIC_OR_PARTITION,
                 "No such topic id as " + topicId);
         }
-        PartitionControlInfo partitionInfo = topicInfo.parts.get(partitionId);
+        PartitionRegistration partitionInfo = topicInfo.parts.get(partitionId);
         if (partitionInfo == null) {
             return new ApiError(UNKNOWN_TOPIC_OR_PARTITION,
                 "No such partition as " + topic + "-" + partitionId);
@@ -914,7 +749,7 @@ public class ReplicationControlManager {
             setPartitionId(partitionId).
             setTopicId(topicId).
             setLeader(newLeader);
-        if (!electionWasClean(newLeader, partitionInfo.isr)) {
+        if (!PartitionRegistration.electionWasClean(newLeader, partitionInfo.isr)) {
             // If the election was unclean, we have to forcibly set the ISR to just the
             // new leader. This can result in data loss!
             record.setIsr(Collections.singletonList(newLeader));
@@ -977,10 +812,6 @@ public class ReplicationControlManager {
             }
         }
         return uncleanOk ? bestUnclean : NO_LEADER;
-    }
-
-    static boolean electionWasClean(int newLeader, int[] isr) {
-        return newLeader == NO_LEADER || Replicas.contains(isr, newLeader);
     }
 
     public ControllerResult<Void> unregisterBroker(int brokerId) {
@@ -1054,12 +885,12 @@ public class ReplicationControlManager {
                     " assignment(s) were specified.");
             }
         }
-        Iterator<PartitionControlInfo> iterator = topicInfo.parts.values().iterator();
+        Iterator<PartitionRegistration> iterator = topicInfo.parts.values().iterator();
         if (!iterator.hasNext()) {
             throw new UnknownServerException("Invalid state: topic " + topic.name() +
                 " appears to have no partitions.");
         }
-        PartitionControlInfo partitionInfo = iterator.next();
+        PartitionRegistration partitionInfo = iterator.next();
         if (partitionInfo.replicas.length > Short.MAX_VALUE) {
             throw new UnknownServerException("Invalid replication factor " +
                 partitionInfo.replicas.length + ": expected a number equal to less than " +
@@ -1154,7 +985,7 @@ public class ReplicationControlManager {
                 throw new RuntimeException("Topic ID " + topicIdPart.topicId() +
                         " existed in isrMembers, but not in the topics map.");
             }
-            PartitionControlInfo partition = topic.parts.get(topicIdPart.partitionId());
+            PartitionRegistration partition = topic.parts.get(topicIdPart.partitionId());
             if (partition == null) {
                 throw new RuntimeException("Partition " + topicIdPart +
                     " existed in isrMembers, but not in the partitions map.");
@@ -1169,7 +1000,7 @@ public class ReplicationControlManager {
                 boolean uncleanOk = configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name);
                 newLeader = bestLeader(partition.replicas, newIsr, uncleanOk, isAcceptableLeader);
             }
-            if (!electionWasClean(newLeader, newIsr)) {
+            if (!PartitionRegistration.electionWasClean(newLeader, newIsr)) {
                 // After an unclean leader election, the ISR is reset to just the new leader.
                 newIsr = new int[] {newLeader};
             } else if (newIsr.length == 0) {
@@ -1226,18 +1057,8 @@ public class ReplicationControlManager {
             records.add(new ApiMessageAndVersion(new TopicRecord().
                 setName(topic.name).
                 setTopicId(topic.id), (short) 0));
-            for (Entry<Integer, PartitionControlInfo> entry : topic.parts.entrySet(epoch)) {
-                PartitionControlInfo partition = entry.getValue();
-                records.add(new ApiMessageAndVersion(new PartitionRecord().
-                    setPartitionId(entry.getKey()).
-                    setTopicId(topic.id).
-                    setReplicas(Replicas.toList(partition.replicas)).
-                    setIsr(Replicas.toList(partition.isr)).
-                    setRemovingReplicas(Replicas.toList(partition.removingReplicas)).
-                    setAddingReplicas(Replicas.toList(partition.addingReplicas)).
-                    setLeader(partition.leader).
-                    setLeaderEpoch(partition.leaderEpoch).
-                    setPartitionEpoch(partition.partitionEpoch), (short) 0));
+            for (Entry<Integer, PartitionRegistration> entry : topic.parts.entrySet(epoch)) {
+                records.add(entry.getValue().toRecord(topic.id, entry.getKey()));
             }
             return records;
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/LeaderConstants.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/LeaderConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata;
+
+
+public class LeaderConstants {
+    /**
+     * A special value used to represent the leader for a partition with no leader.
+     */
+    public static final int NO_LEADER = -1;
+
+    /**
+     * A special value used to represent a PartitionChangeRecord that does not change the
+     * partition leader.
+     */
+    public static final int NO_LEADER_CHANGE = -2;
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.slf4j.Logger;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_RECORD;
+import static org.apache.kafka.metadata.LeaderConstants.NO_LEADER;
+
+
+public class PartitionRegistration {
+    public final int[] replicas;
+    public final int[] isr;
+    public final int[] removingReplicas;
+    public final int[] addingReplicas;
+    public final int leader;
+    public final int leaderEpoch;
+    public final int partitionEpoch;
+
+    public static boolean electionWasClean(int newLeader, int[] isr) {
+        return newLeader == NO_LEADER || Replicas.contains(isr, newLeader);
+    }
+
+    public PartitionRegistration(PartitionRecord record) {
+        this(Replicas.toArray(record.replicas()),
+            Replicas.toArray(record.isr()),
+            Replicas.toArray(record.removingReplicas()),
+            Replicas.toArray(record.addingReplicas()),
+            record.leader(),
+            record.leaderEpoch(),
+            record.partitionEpoch());
+    }
+
+    public PartitionRegistration(int[] replicas, int[] isr, int[] removingReplicas,
+                                 int[] addingReplicas, int leader, int leaderEpoch,
+                                 int partitionEpoch) {
+        this.replicas = replicas;
+        this.isr = isr;
+        this.removingReplicas = removingReplicas;
+        this.addingReplicas = addingReplicas;
+        this.leader = leader;
+        this.leaderEpoch = leaderEpoch;
+        this.partitionEpoch = partitionEpoch;
+    }
+
+    public PartitionRegistration merge(PartitionChangeRecord record) {
+        int[] newIsr = (record.isr() == null) ? isr : Replicas.toArray(record.isr());
+        int newLeader;
+        int newLeaderEpoch;
+        if (record.leader() == LeaderConstants.NO_LEADER_CHANGE) {
+            newLeader = leader;
+            newLeaderEpoch = leaderEpoch;
+        } else {
+            newLeader = record.leader();
+            newLeaderEpoch = leaderEpoch + 1;
+        }
+        return new PartitionRegistration(replicas,
+            newIsr,
+            removingReplicas,
+            addingReplicas,
+            newLeader,
+            newLeaderEpoch,
+            partitionEpoch + 1);
+    }
+
+    public String diff(PartitionRegistration prev) {
+        StringBuilder builder = new StringBuilder();
+        String prefix = "";
+        if (!Arrays.equals(replicas, prev.replicas)) {
+            builder.append(prefix).append("replicas: ").
+                append(Arrays.toString(prev.replicas)).
+                append(" -> ").append(Arrays.toString(replicas));
+            prefix = ", ";
+        }
+        if (!Arrays.equals(isr, prev.isr)) {
+            builder.append(prefix).append("isr: ").
+                append(Arrays.toString(prev.isr)).
+                append(" -> ").append(Arrays.toString(isr));
+            prefix = ", ";
+        }
+        if (!Arrays.equals(removingReplicas, prev.removingReplicas)) {
+            builder.append(prefix).append("removingReplicas: ").
+                append(Arrays.toString(prev.removingReplicas)).
+                append(" -> ").append(Arrays.toString(removingReplicas));
+            prefix = ", ";
+        }
+        if (!Arrays.equals(addingReplicas, prev.addingReplicas)) {
+            builder.append(prefix).append("addingReplicas: ").
+                append(Arrays.toString(prev.addingReplicas)).
+                append(" -> ").append(Arrays.toString(addingReplicas));
+            prefix = ", ";
+        }
+        if (leader != prev.leader) {
+            builder.append(prefix).append("leader: ").
+                append(prev.leader).append(" -> ").append(leader);
+            prefix = ", ";
+        }
+        if (leaderEpoch != prev.leaderEpoch) {
+            builder.append(prefix).append("leaderEpoch: ").
+                append(prev.leaderEpoch).append(" -> ").append(leaderEpoch);
+            prefix = ", ";
+        }
+        if (partitionEpoch != prev.partitionEpoch) {
+            builder.append(prefix).append("partitionEpoch: ").
+                append(prev.partitionEpoch).append(" -> ").append(partitionEpoch);
+        }
+        return builder.toString();
+    }
+
+    public void maybeLogPartitionChange(Logger log, String description, PartitionRegistration prev) {
+        if (!electionWasClean(leader, prev.isr)) {
+            log.info("UNCLEAN partition change for {}: {}", description, diff(prev));
+        } else if (log.isDebugEnabled()) {
+            log.debug("partition change for {}: {}", description, diff(prev));
+        }
+    }
+
+    public boolean hasLeader() {
+        return leader != LeaderConstants.NO_LEADER;
+    }
+
+    public boolean hasPreferredLeader() {
+        return leader == preferredReplica();
+    }
+
+    public int preferredReplica() {
+        return replicas.length == 0 ? LeaderConstants.NO_LEADER : replicas[0];
+    }
+
+    public ApiMessageAndVersion toRecord(Uuid topicId, int partitionId) {
+        return new ApiMessageAndVersion(new PartitionRecord().
+            setPartitionId(partitionId).
+            setTopicId(topicId).
+            setReplicas(Replicas.toList(replicas)).
+            setIsr(Replicas.toList(isr)).
+            setRemovingReplicas(Replicas.toList(removingReplicas)).
+            setAddingReplicas(Replicas.toList(addingReplicas)).
+            setLeader(leader).
+            setLeaderEpoch(leaderEpoch).
+            setPartitionEpoch(partitionEpoch), PARTITION_RECORD.highestSupportedVersion());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(replicas, isr, removingReplicas, addingReplicas, leader,
+            leaderEpoch, partitionEpoch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof PartitionRegistration)) return false;
+        PartitionRegistration other = (PartitionRegistration) o;
+        return Arrays.equals(replicas, other.replicas) &&
+            Arrays.equals(isr, other.isr) &&
+            Arrays.equals(removingReplicas, other.removingReplicas) &&
+            Arrays.equals(addingReplicas, other.addingReplicas) &&
+            leader == other.leader &&
+            leaderEpoch == other.leaderEpoch &&
+            partitionEpoch == other.partitionEpoch;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("PartitionRegistration(");
+        builder.append("replicas=").append(Arrays.toString(replicas));
+        builder.append(", isr=").append(Arrays.toString(isr));
+        builder.append(", removingReplicas=").append(Arrays.toString(removingReplicas));
+        builder.append(", addingReplicas=").append(Arrays.toString(addingReplicas));
+        builder.append(", leader=").append(leader);
+        builder.append(", leaderEpoch=").append(leaderEpoch);
+        builder.append(", partitionEpoch=").append(partitionEpoch);
+        builder.append(")");
+        return builder.toString();
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/metadata/Replicas.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/Replicas.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.controller;
+package org.apache.kafka.metadata;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/metadata/src/test/java/org/apache/kafka/controller/ClientQuotaControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClientQuotaControlManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.quota.ClientQuotaAlteration;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.Test;
@@ -206,7 +207,7 @@ public class ClientQuotaControlManagerTest {
         quotasToTest.forEach((entity, quota) -> entityQuotaToAlterations(entity, quota, alters::add));
         alterQuotas(alters, manager);
 
-        ControllerTestUtils.assertBatchIteratorContains(Arrays.asList(
+        RecordTestUtils.assertBatchIteratorContains(Arrays.asList(
             Arrays.asList(new ApiMessageAndVersion(new QuotaRecord().setEntity(Arrays.asList(
                 new EntityData().setEntityType("user").setEntityName("user-1"),
                 new EntityData().setEntityType("client-id").setEntityName("client-id-1"))).

--- a/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ClusterControlManagerTest.java
@@ -26,16 +26,17 @@ import java.util.Random;
 import org.apache.kafka.common.Endpoint;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
-import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord.BrokerEndpoint;
 import org.apache.kafka.common.metadata.RegisterBrokerRecord.BrokerEndpointCollection;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord;
 import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
 import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -176,7 +177,7 @@ public class ClusterControlManagerTest {
                 new UnfenceBrokerRecord().setId(i).setEpoch(100);
             clusterControl.replay(unfenceBrokerRecord);
         }
-        ControllerTestUtils.assertBatchIteratorContains(Arrays.asList(
+        RecordTestUtils.assertBatchIteratorContains(Arrays.asList(
             Arrays.asList(new ApiMessageAndVersion(new RegisterBrokerRecord().
                 setBrokerEpoch(100).setBrokerId(0).setRack(null).
                 setEndPoints(new BrokerEndpointCollection(Collections.singleton(

--- a/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ConfigurationControlManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 
@@ -103,7 +104,7 @@ public class ConfigurationControlManagerTest {
             setName("def").setValue("blah"));
         assertEquals(toMap(entry("abc", "x,y,z"), entry("def", "blah")),
             manager.getConfigs(MYTOPIC));
-        ControllerTestUtils.assertBatchIteratorContains(Arrays.asList(
+        RecordTestUtils.assertBatchIteratorContains(Arrays.asList(
             Arrays.asList(new ApiMessageAndVersion(new ConfigRecord().
                     setResourceType(TOPIC.id()).setResourceName("mytopic").
                     setName("abc").setValue("x,y,z"), (short) 0),

--- a/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/FeatureControlManagerTest.java
@@ -27,10 +27,11 @@ import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.metadata.FeatureMap;
 import org.apache.kafka.metadata.FeatureMapAndEpoch;
+import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.metadata.VersionRange;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.timeline.SnapshotRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -161,8 +162,8 @@ public class FeatureControlManagerTest {
         ControllerResult<Map<String, ApiError>> result = manager.
             updateFeatures(rangeMap("foo", 1, 5, "bar", 1, 1),
                 Collections.emptySet(), Collections.emptyMap());
-        ControllerTestUtils.replayAll(manager, result.records());
-        ControllerTestUtils.assertBatchIteratorContains(Arrays.asList(
+        RecordTestUtils.replayAll(manager, result.records());
+        RecordTestUtils.assertBatchIteratorContains(Arrays.asList(
             Arrays.asList(new ApiMessageAndVersion(new FeatureLevelRecord().
                 setName("foo").
                 setMinFeatureLevel((short) 1).

--- a/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/QuorumControllerTest.java
@@ -66,6 +66,7 @@ import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.controller.BrokersToIsrs.TopicIdPartition;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
 import org.apache.kafka.metadata.BrokerRegistrationReply;
+import org.apache.kafka.metadata.RecordTestUtils;
 import org.apache.kafka.metalog.LocalLogManagerTestEnv;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.junit.jupiter.api.Test;
@@ -296,7 +297,7 @@ public class QuorumControllerTest {
     private void checkSnapshotContents(Uuid fooId,
                                        Map<Integer, Long> brokerEpochs,
                                        Iterator<List<ApiMessageAndVersion>> iterator) throws Exception {
-        ControllerTestUtils.assertBatchIteratorContains(Arrays.asList(
+        RecordTestUtils.assertBatchIteratorContains(Arrays.asList(
             Arrays.asList(new ApiMessageAndVersion(new TopicRecord().
                     setName("foo").setTopicId(fooId), (short) 0),
                 new ApiMessageAndVersion(new PartitionRecord().setPartitionId(0).

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.metadata;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@Timeout(40)
+public class PartitionRegistrationTest {
+    @Test
+    public void testElectionWasClean() {
+        assertTrue(PartitionRegistration.electionWasClean(1, new int[] {1, 2}));
+        assertFalse(PartitionRegistration.electionWasClean(1, new int[] {0, 2}));
+        assertFalse(PartitionRegistration.electionWasClean(1, new int[] {}));
+        assertTrue(PartitionRegistration.electionWasClean(3, new int[] {1, 2, 3, 4, 5, 6}));
+    }
+
+    @Test
+    public void testPartitionControlInfoMergeAndDiff() {
+        PartitionRegistration a = new PartitionRegistration(
+            new int[]{1, 2, 3}, new int[]{1, 2}, null, null, 1, 0, 0);
+        PartitionRegistration b = new PartitionRegistration(
+            new int[]{1, 2, 3}, new int[]{3}, null, null, 3, 1, 1);
+        PartitionRegistration c = new PartitionRegistration(
+            new int[]{1, 2, 3}, new int[]{1}, null, null, 1, 0, 1);
+        assertEquals(b, a.merge(new PartitionChangeRecord().
+            setLeader(3).setIsr(Arrays.asList(3))));
+        assertEquals("isr: [1, 2] -> [3], leader: 1 -> 3, leaderEpoch: 0 -> 1, partitionEpoch: 0 -> 1",
+            b.diff(a));
+        assertEquals("isr: [1, 2] -> [1], partitionEpoch: 0 -> 1",
+            c.diff(a));
+    }
+
+    @Test
+    public void testRecordRoundTrip() {
+        PartitionRegistration registrationA = new PartitionRegistration(
+            new int[]{1, 2, 3}, new int[]{1, 2}, new int[]{1}, null, 1, 0, 0);
+        Uuid topicId = Uuid.fromString("OGdAI5nxT_m-ds3rJMqPLA");
+        int partitionId = 4;
+        ApiMessageAndVersion record = registrationA.toRecord(topicId, partitionId);
+        PartitionRegistration registrationB =
+            new PartitionRegistration((PartitionRecord) record.message());
+        assertEquals(registrationA, registrationB);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/ReplicasTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/ReplicasTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.controller;
+package org.apache.kafka.metadata;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;


### PR DESCRIPTION
Move some controller classes to the metadata package so that they can be
used with broker snapshots. Rename ControllerTestUtils to
RecordTestUtils. Move PartitionInfo to PartitionRegistration.