### PR TITLE
KAFKA-8940: decrease session timeout to make test faster and reliable

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestClient.java
@@ -126,13 +126,14 @@ public class SmokeTestClient extends SmokeTestUtil {
         try {
             if (!countDownLatch.await(1, TimeUnit.MINUTES)) {
                 System.out.println(name + ": SMOKE-TEST-CLIENT-EXCEPTION: Didn't start in one minute");
+            } else {
+                System.out.println(name + ": SMOKE-TEST-CLIENT-STARTED");
+                System.out.println(name + " started at " + Instant.now());
             }
         } catch (final InterruptedException e) {
             System.out.println(name + ": SMOKE-TEST-CLIENT-EXCEPTION: " + e);
             e.printStackTrace(System.out);
         }
-        System.out.println(name + ": SMOKE-TEST-CLIENT-STARTED");
-        System.out.println(name + " started at " + Instant.now());
     }
 
     public void closeAsync() {
@@ -145,7 +146,7 @@ public class SmokeTestClient extends SmokeTestUtil {
         if (wasClosed && !uncaughtException) {
             System.out.println(name + ": SMOKE-TEST-CLIENT-CLOSED");
         } else if (wasClosed) {
-            System.out.println(name + ": SMOKE-TEST-CLIENT-EXCEPTION");
+            System.out.println(name + ": SMOKE-TEST-CLIENT-EXCEPTION: Got an uncaught exception");
         } else {
             System.out.println(name + ": SMOKE-TEST-CLIENT-EXCEPTION: Didn't close in time.");
         }


### PR DESCRIPTION
While there might still be some issue about the test as described [here](https://issues.apache.org/jira/browse/KAFKA-8940?focusedCommentId=17214850&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17214850) by @ableegoldman , but I found the reason why this test failed quite frequently recently. It's because we increased the session timeout to 45 sec in KIP-735.

The failed messages is like this:
```
java.lang.AssertionError: tagg is missing
verifying suppressed min-suppressed
verifying min-suppressed with 10 keys
verifying suppressed sws-suppressed
verifying min with 10 keys
verifying max with 10 keys
verifying dif with 10 keys
verifying sum with 10 keys
verifying cnt with 10 keys
verifying avg with 10 keys
```
Or
```
java.lang.AssertionError: verifying tagg
fail: key=562 tagg=[ConsumerRecord(topic = tagg, partition = 0, leaderEpoch = 0, offset = 2, CreateTime = 1623347258886, serialized key size = 3, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = 562, value = 1)] expected=0
	 taggEvents: [ConsumerRecord(topic = tagg, partition = 0, leaderEpoch = 0, offset = 2, CreateTime = 1623347258886, serialized key size = 3, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = 562, value = 1)]
verifying suppressed min-suppressed
verifying min-suppressed with 10 keys
verifying suppressed sws-suppressed
verifying min with 10 keys
verifying max with 10 keys
verifying dif with 10 keys
verifying sum with 10 keys
verifying cnt with 10 keys
verifying avg with 10 keys
avg fail: key=7-1006 actual=300.5952380952381 expected=506.5
```
Or
```
java.lang.AssertionError: verifying tagg
fail: key=694 tagg=[ConsumerRecord(topic = tagg, partition = 0, leaderEpoch = 0, offset = 9, CreateTime = 1623338149617, serialized key size = 3, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = 694, value = 1)] expected=0
	 taggEvents: [ConsumerRecord(topic = tagg, partition = 0, leaderEpoch = 0, offset = 9, CreateTime = 1623338149617, serialized key size = 3, serialized value size = 8, headers = RecordHeaders(headers = [], isReadOnly = false), key = 694, value = 1)]
verifying suppressed min-suppressed
verifying min-suppressed with 10 keys
verifying suppressed sws-suppressed
verifying min with 10 keys
verifying max with 10 keys
verifying dif with 10 keys
verifying sum with 10 keys
verifying cnt with 10 keys
verifying avg with 10 keys
```
The failure are due to the processing is not completed in time as described below.


We can check the jenkins failing trend in `trunk` branch [here](https://ci-builds.apache.org/job/Kafka/job/kafka/job/trunk/217/testReport/junit/org.apache.kafka.streams.integration/SmokeTestDriverIntegrationTest/history/):
![image](https://user-images.githubusercontent.com/43372967/121793776-0ee2a700-cc35-11eb-9648-f93fe3e34976.png)
This test never failed since build # 168, until build # 206 and later

The reason why increasing session timeout affected this test is because in this test, we will keep adding new stream clients and remove old one, to maintain only 3 stream clients alive. The problem here is, when old stream closed, we won't trigger rebalance immediately due to the stream clients are all static members as described in KIP-345, which means, we will trigger trigger group rebalance only when `session.timeout` expired. That said, when old client closed, we'll have at least 45 sec with some tasks not working. 

Also, in this test, we have 2 timeout conditions to fail this test before verification passed:
1. 6 minutes timeout
2. polling 30 times (each with 5 seconds) without getting any data. (that is, 5 * 30 = 150 sec without consuming any data)

For (1), in my test under 45 session timeout, we'll create 8 stream clients, which means, we'll have 5 clients got closed. And each closed client need 45 sec to trigger rebalance, so we'll have 45 * 5 = 225 sec (~4 mins) of the time having some tasks not working. 
For (2), during new client created and old client closed, it need some time to do rebalance. With 45 session timeout, we only got ~100 sec left. In slow jenkins env, it might reach the 30 retries without getting any data timeout.

Therefore, decreasing session timeout can make this test completes faster and more reliable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
