### PR TITLE
KAFKA-12844: KIP-740 follow up: clean up TaskId

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -17,42 +17,33 @@
 package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.streams.errors.TaskIdFormatException;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Objects;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.kafka.streams.processor.internals.assignment.ConsumerProtocolUtils.readTaskIdFrom;
-import static org.apache.kafka.streams.processor.internals.assignment.ConsumerProtocolUtils.writeTaskIdTo;
-
 /**
- * The task ID representation composed as subtopology (aka topicGroupId) plus the assigned partition ID.
+ * The task ID representation composed as subtopology plus the assigned partition ID.
  */
 public class TaskId implements Comparable<TaskId> {
 
     private static final Logger LOG = LoggerFactory.getLogger(TaskId.class);
 
-    /** The ID of the subtopology, aka topicGroupId. */
+    /** The ID of the subtopology. */
     @Deprecated
-    public final int topicGroupId;
+    private final int subtopology;
     /** The ID of the partition. */
     @Deprecated
-    public final int partition;
+    private final int partition;
 
     /** The namedTopology that this task belongs to, or null if it does not belong to one */
     private final String namedTopology;
 
-    public TaskId(final int topicGroupId, final int partition) {
-        this(topicGroupId, partition, null);
+    public TaskId(final int subtopology, final int partition) {
+        this(subtopology, partition, null);
     }
 
-    public TaskId(final int topicGroupId, final int partition, final String namedTopology) {
-        this.topicGroupId = topicGroupId;
+    public TaskId(final int subtopology, final int partition, final String namedTopology) {
+        this.subtopology = subtopology;
         this.partition = partition;
         if (namedTopology != null && namedTopology.length() == 0) {
             LOG.warn("Empty string passed in for task's namedTopology, since NamedTopology name cannot be empty, we "
@@ -64,7 +55,7 @@ public class TaskId implements Comparable<TaskId> {
     }
 
     public int subtopology() {
-        return topicGroupId;
+        return subtopology;
     }
 
     public int partition() {
@@ -80,7 +71,7 @@ public class TaskId implements Comparable<TaskId> {
 
     @Override
     public String toString() {
-        return namedTopology != null ? namedTopology + "_" + topicGroupId + "_" + partition : topicGroupId + "_" + partition;
+        return namedTopology != null ? namedTopology + "_" + subtopology + "_" + partition : subtopology + "_" + partition;
     }
 
     /**
@@ -112,40 +103,6 @@ public class TaskId implements Comparable<TaskId> {
         }
     }
 
-    /**
-     * @throws IOException if cannot write to output stream
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public void writeTo(final DataOutputStream out, final int version) throws IOException {
-        writeTaskIdTo(this, out, version);
-    }
-
-    /**
-     * @throws IOException if cannot read from input stream
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public static TaskId readFrom(final DataInputStream in, final int version) throws IOException {
-        return readTaskIdFrom(in, version);
-    }
-
-    /**
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public void writeTo(final ByteBuffer buf, final int version) {
-        writeTaskIdTo(this, buf, version);
-    }
-
-    /**
-     * @deprecated since 3.0, for internal use, will be removed
-     */
-    @Deprecated
-    public static TaskId readFrom(final ByteBuffer buf, final int version) {
-        return readTaskIdFrom(buf, version);
-    }
-
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -156,7 +113,7 @@ public class TaskId implements Comparable<TaskId> {
         }
         final TaskId taskId = (TaskId) o;
 
-        if (topicGroupId != taskId.topicGroupId || partition != taskId.partition) {
+        if (subtopology != taskId.subtopology || partition != taskId.partition) {
             return false;
         }
 
@@ -169,7 +126,7 @@ public class TaskId implements Comparable<TaskId> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(topicGroupId, partition, namedTopology);
+        return Objects.hash(subtopology, partition, namedTopology);
     }
 
     @Override
@@ -183,7 +140,7 @@ public class TaskId implements Comparable<TaskId> {
             LOG.error("Tried to compare this = {} with other = {}, but only one had a valid named topology", this, other);
             throw new IllegalStateException("Can't compare a TaskId with a namedTopology to one without");
         }
-        final int comparingTopicGroupId = Integer.compare(this.topicGroupId, other.topicGroupId);
+        final int comparingTopicGroupId = Integer.compare(this.subtopology, other.subtopology);
         return comparingTopicGroupId != 0 ? comparingTopicGroupId : Integer.compare(this.partition, other.partition);
     }
 }


### PR DESCRIPTION
See KIP-740 – for the TaskId class, we need to remove the following deprecated APIs:

The public partition and topicGroupId fields should be "removed", ie made private (can also now rename topicGroupId to subtopology to match the getter)
The two #readFrom and two #writeTo methods can be removed (they have already been converted to internal utility methods we now use instead, so just remove them)