### PR TITLE
KAFKA-12843: KIP-740 follow up: clean up TaskMetadata

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
@@ -40,18 +40,6 @@ public class TaskMetadata {
 
     private final Optional<Long> timeCurrentIdlingStarted;
 
-    /**
-     * @deprecated since 3.0, not intended for public use
-     */
-    @Deprecated
-    public TaskMetadata(final String taskId,
-                        final Set<TopicPartition> topicPartitions,
-                        final Map<TopicPartition, Long> committedOffsets,
-                        final Map<TopicPartition, Long> endOffsets,
-                        final Optional<Long> timeCurrentIdlingStarted) {
-        this(TaskId.parse(taskId), topicPartitions, committedOffsets, endOffsets, timeCurrentIdlingStarted);
-    }
-
     // For internal use -- not a public API
     public TaskMetadata(final TaskId taskId,
                         final Set<TopicPartition> topicPartitions,
@@ -67,18 +55,15 @@ public class TaskMetadata {
 
     /**
      * @return the basic task metadata such as subtopology and partition id
+     * @deprecated since 4.0, not intended for public use
      */
+    @Deprecated
     public TaskId getTaskId() {
         return taskId;
     }
 
-    /**
-     * @return the basic task metadata such as subtopology and partition id
-     * @deprecated please use {@link #getTaskId()} instead.
-     */
-    @Deprecated
-    public String taskId() {
-        return taskId.toString();
+    public TaskId taskId() {
+        return taskId;
     }
 
     public Set<TopicPartition> topicPartitions() {


### PR DESCRIPTION
See KIP-740 – for the TaskMetadata class, we need to:

Deprecate the TaskMetadata#getTaskId method
"Remove" the deprecated TaskMetadata#taskId method, then re-add a taskId() API that returns a TaskId instead of a String
Remove the deprecated constructor