### PR TITLE
KAFKA-12948: Remove node from ClusterConnectionStates.connectingNodes when node is removed

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -387,6 +387,7 @@ final class ClusterConnectionStates {
      */
     public void remove(String id) {
         nodeState.remove(id);
+        connectingNodes.remove(id);
     }
 
     /**


### PR DESCRIPTION
NetworkClient.poll() throws IllegalStateException when checking `isConnectionSetupTimeout` if all nodes in `ClusterConnectionStates.connectingNodes` aren't present in `ClusterConnectionStates.nodeState`. When we remove a node from `nodeState`, we should also remove from `connectingNodes`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
