### PR TITLE
KAFKA-12949: TestRaftServer's scala.MatchError: null on test-kraft-server-start.sh

### DIFF
--- a/core/src/main/scala/kafka/tools/TestRaftServer.scala
+++ b/core/src/main/scala/kafka/tools/TestRaftServer.scala
@@ -238,6 +238,8 @@ class TestRaftServer(
           reader.close()
 
         case Shutdown => // Ignore shutdown command
+
+        case null => // Ignore null when timeout expires.
       }
     }
 


### PR DESCRIPTION
**Jira:** https://issues.apache.org/jira/browse/KAFKA-12949
Encounter the following exception when trying to run the TestRaftServer:

`bin/test-kraft-server-start.sh --config config/kraft.properties`
```
[2021-06-14 17:15:43,232] ERROR [raft-workload-generator]: Error due to (kafka.tools.TestRaftServer$RaftWorkloadGenerator)
 scala.MatchError: null
 at kafka.tools.TestRaftServer$RaftWorkloadGenerator.doWork(TestRaftServer.scala:220)
 at kafka.utils.ShutdownableThread.run(ShutdownableThread.scala:96)
 [2021-06-14 17:15:43,253] INFO [raft-workload-generator]: Stopped (kafka.tools.TestRaftServer$RaftWorkloadGenerator)
```

Caused because of a not contemplated *null* on eventQueue.poll:

```
eventQueue.poll(eventTimeoutMs, TimeUnit.MILLISECONDS) match {
    case HandleClaim(epoch) =>
      claimedEpoch = Some(epoch)
      throttler.reset()
      pendingAppends.clear()
      recordCount.set(0)

    case HandleResign =>
      claimedEpoch = None
      pendingAppends.clear()

    case HandleCommit(reader) =>
      try {
        while (reader.hasNext) {
          val batch = reader.next()
          claimedEpoch.foreach { leaderEpoch =>
            handleLeaderCommit(leaderEpoch, batch)
          }
        }
      } finally {
        reader.close()
      }

    case HandleSnapshot(reader) =>
      // Ignore snapshots; only interested in records appended by this leader
      reader.close()

    case Shutdown => // Ignore shutdown command
  }
```
This makes raft-workload-generator's thread to stop.

Proposal: 
Add a catch case on the match statement.
 
`case _ => // Ignore other events (such as null)`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
