### PR TITLE
KAFKA-12955: Fix LogLoader to pass materialized view of segments for deletion

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1879,9 +1879,10 @@ class Log(@volatile private var _dir: File,
                                       reason: SegmentDeletionReason): Unit = {
     if (segments.nonEmpty) {
       lock synchronized {
-        // As most callers hold an iterator into the `segments` collection and `removeAndDeleteSegment` mutates it by
+        // Most callers hold an iterator into the `segments` collection and `removeAndDeleteSegment` mutates it by
         // removing the deleted segment, we should force materialization of the iterator here, so that results of the
-        // iteration remain valid and deterministic.
+        // iteration remain valid and deterministic. We should also pass only the materialized view of the
+        // iterator to the logic that actually deletes the segments.
         val toDelete = segments.toList
         reason.logReason(this, toDelete)
         toDelete.foreach { segment =>

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -45,7 +45,7 @@ import org.apache.kafka.common.{InvalidRecordException, KafkaException, TopicPar
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
-import scala.collection.{Seq, mutable}
+import scala.collection.{Seq, immutable, mutable}
 
 object LogAppendInfo {
   val UnknownLogAppendInfo = LogAppendInfo(None, -1, None, RecordBatch.NO_TIMESTAMP, -1L, RecordBatch.NO_TIMESTAMP, -1L,
@@ -1893,7 +1893,7 @@ class Log(@volatile private var _dir: File,
     }
   }
 
-  private def deleteSegmentFiles(segments: Iterable[LogSegment], asyncDelete: Boolean, deleteProducerStateSnapshots: Boolean = true): Unit = {
+  private def deleteSegmentFiles(segments: immutable.Iterable[LogSegment], asyncDelete: Boolean, deleteProducerStateSnapshots: Boolean = true): Unit = {
     Log.deleteSegmentFiles(segments, asyncDelete, deleteProducerStateSnapshots, dir, topicPartition,
       config, scheduler, logDirFailureChannel, producerStateManager, this.logIdent)
   }
@@ -2379,7 +2379,7 @@ object Log extends Logging {
    * @param logPrefix The logging prefix
    * @throws IOException if the file can't be renamed and still exists
    */
-  private[log] def deleteSegmentFiles(segmentsToDelete: Iterable[LogSegment],
+  private[log] def deleteSegmentFiles(segmentsToDelete: immutable.Iterable[LogSegment],
                                       asyncDelete: Boolean,
                                       deleteProducerStateSnapshots: Boolean = true,
                                       dir: File,

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -748,39 +748,6 @@ class LogTest {
   }
 
   @Test
-  def testLogEndLessThanStartAfterReopen(): Unit = {
-    val logConfig = LogTestUtils.createLogConfig()
-    var log = createLog(logDir, logConfig)
-    for (i <- 0 until 5) {
-      val record = new SimpleRecord(mockTime.milliseconds, i.toString.getBytes)
-      log.appendAsLeader(TestUtils.records(List(record)), leaderEpoch = 0)
-      log.roll()
-    }
-    assertEquals(6, log.logSegments.size)
-
-    // Increment the log start offset
-    val startOffset = 4
-    log.updateHighWatermark(log.logEndOffset)
-    log.maybeIncrementLogStartOffset(startOffset, ClientRecordDeletion)
-    assertTrue(log.logEndOffset > log.logStartOffset)
-
-    // Append garbage to a segment below the current log start offset
-    val segmentToForceTruncation = log.logSegments.take(2).last
-    val bw = new BufferedWriter(new FileWriter(segmentToForceTruncation.log.file))
-    bw.write("corruptRecord")
-    bw.close()
-    log.close()
-
-    // Reopen the log. This will cause truncate the segment to which we appended garbage and delete all other segments.
-    // All remaining segments will be lower than the current log start offset, which will force deletion of all segments
-    // and recreation of a single, active segment starting at logStartOffset.
-    log = createLog(logDir, logConfig, logStartOffset = startOffset, lastShutdownClean = false)
-    assertEquals(1, log.logSegments.size)
-    assertEquals(startOffset, log.logStartOffset)
-    assertEquals(startOffset, log.logEndOffset)
-  }
-
-  @Test
   def testNonActiveSegmentsFrom(): Unit = {
     val logConfig = LogTestUtils.createLogConfig()
     val log = createLog(logDir, logConfig)


### PR DESCRIPTION
Within `LogLoader.removeAndDeleteSegmentsAsync()`, we should force materialization of the `segmentsToDelete` iterable, to make sure the results of the iteration remain valid and deterministic. We should also pass only the materialized view to the logic that deletes the segments, as otherwise we could end up deleting the wrong segments.

Note: At another spot where there is similar logic, we already do things right: https://github.com/apache/kafka/blob/6b005b2b4eece81a5500fb0080ef5354b4240681/core/src/main/scala/kafka/log/Log.scala#L1890

**Tests:**
Added the missing unit test coverage to `LogLoaderTest.testLogEndLessThanStartAfterReopen()`.
Previously the test was in `LogTest` suite but it has been moved over now to `LogLoaderTest` suite, as it deserves to be there instead.
This test fails without the fix, but passes with the fix. These are the important lines in the test that provides the necessary assertions:
```
@Test
def testLogEndLessThanStartAfterReopen(): Unit = {
   ...
   ...
   ...
   // Validate that the remaining segment matches our expectations
   val onlySegment = log.segments.firstSegment.get
   assertEquals(startOffset, onlySegment.baseOffset)
   assertTrue(onlySegment.log.file().exists())
   assertTrue(onlySegment.lazyOffsetIndex.file.exists())
   assertTrue(onlySegment.lazyTimeIndex.file.exists())
}
```
