### PR TITLE
MINOR: Add reset to SnapshotRegistry and Revertable

### DIFF
--- a/metadata/src/main/java/org/apache/kafka/controller/ProducerIdControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ProducerIdControlManager.java
@@ -37,7 +37,7 @@ public class ProducerIdControlManager {
 
     ProducerIdControlManager(ClusterControlManager clusterControlManager, SnapshotRegistry snapshotRegistry) {
         this.clusterControlManager = clusterControlManager;
-        this.lastProducerId = new TimelineLong(snapshotRegistry, 0L);
+        this.lastProducerId = new TimelineLong(snapshotRegistry);
     }
 
     ControllerResult<ProducerIdsBlock> generateNextProducerId(int brokerId, long brokerEpoch) {

--- a/metadata/src/main/java/org/apache/kafka/timeline/Revertable.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/Revertable.java
@@ -29,4 +29,9 @@ interface Revertable {
      * @param delta         The delta associated with this epoch for this object.
      */
     void executeRevert(long targetEpoch, Delta delta);
+
+    /**
+     * Reverts to the initial value.
+     */
+    void reset();
 }

--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
@@ -19,10 +19,8 @@ package org.apache.kafka.timeline;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.utils.LogContext;
@@ -110,7 +108,7 @@ public class SnapshotRegistry {
     /**
      * Collection of all Revertable registered with this registry
      */
-    private final Set<Revertable> revertables = new HashSet<>();
+    private final List<Revertable> revertables = new ArrayList<>();
 
     public SnapshotRegistry(LogContext logContext) {
         this.log = logContext.logger(SnapshotRegistry.class);

--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
@@ -270,7 +270,7 @@ public class SnapshotRegistry {
     }
 
     /**
-     * Resets all of the Revertable object registered to their initial value.
+     * Delete all snapshots and resets all of the Revertable object registered.
      */
     public void reset() {
         deleteSnapshotsUpTo(LATEST_EPOCH);

--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshotRegistry.java
@@ -19,8 +19,10 @@ package org.apache.kafka.timeline;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.utils.LogContext;
@@ -104,6 +106,11 @@ public class SnapshotRegistry {
      * The head of a list of snapshots, sorted by epoch.
      */
     private final Snapshot head = new Snapshot(Long.MIN_VALUE);
+
+    /**
+     * Collection of all Revertable registered with this registry
+     */
+    private final Set<Revertable> revertables = new HashSet<>();
 
     public SnapshotRegistry(LogContext logContext) {
         this.log = logContext.logger(SnapshotRegistry.class);
@@ -253,5 +260,23 @@ public class SnapshotRegistry {
      */
     public long latestEpoch() {
         return head.prev().epoch();
+    }
+
+    /**
+     * Associate with this registry.
+     */
+    public void register(Revertable revertable) {
+        revertables.add(revertable);
+    }
+
+    /**
+     * Resets all of the Revertable object registered to their initial value.
+     */
+    public void reset() {
+        deleteSnapshotsUpTo(LATEST_EPOCH);
+
+        for (Revertable revertable : revertables) {
+            revertable.reset();
+        }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/SnapshottableHashTable.java
@@ -280,6 +280,7 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
     SnapshottableHashTable(SnapshotRegistry snapshotRegistry, int expectedSize) {
         super(expectedSize);
         this.snapshotRegistry = snapshotRegistry;
+        snapshotRegistry.register(this);
     }
 
     int snapshottableSize(long epoch) {
@@ -450,6 +451,15 @@ class SnapshottableHashTable<T extends SnapshottableHashTable.ElementWithStartEp
                 }
                 out.clear();
             }
+        }
+    }
+
+    @Override
+    public void reset() {
+        Iterator<T> iter = snapshottableIterator(SnapshottableHashTable.LATEST_EPOCH);
+        while (iter.hasNext()) {
+            iter.next();
+            iter.remove();
         }
     }
 }

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineHashMap.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineHashMap.java
@@ -179,11 +179,7 @@ public class TimelineHashMap<K, V>
 
     @Override
     public void clear() {
-        Iterator<TimelineHashMapEntry<K, V>> iter = snapshottableIterator(SnapshottableHashTable.LATEST_EPOCH);
-        while (iter.hasNext()) {
-            iter.next();
-            iter.remove();
-        }
+        reset();
     }
 
     final class KeySet extends AbstractSet<K> {

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineHashSet.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineHashSet.java
@@ -225,12 +225,7 @@ public class TimelineHashSet<T>
 
     @Override
     public void clear() {
-        Iterator<TimelineHashSetEntry<T>> iter =
-            snapshottableIterator(SnapshottableHashTable.LATEST_EPOCH);
-        while (iter.hasNext()) {
-            iter.next();
-            iter.remove();
-        }
+        reset();
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
@@ -26,8 +26,10 @@ import java.util.Iterator;
  * This class requires external synchronization.
  */
 public class TimelineInteger implements Revertable {
+    public static final int INIT = 0;
+
     static class IntegerContainer implements Delta {
-        private int value = 0;
+        private int value = INIT;
 
         int value() {
             return value;
@@ -44,17 +46,11 @@ public class TimelineInteger implements Revertable {
     }
 
     private final SnapshotRegistry snapshotRegistry;
-    private final int init;
     private int value;
 
     public TimelineInteger(SnapshotRegistry snapshotRegistry) {
-        this(snapshotRegistry, 0);
-    }
-
-    public TimelineInteger(SnapshotRegistry snapshotRegistry, int value) {
         this.snapshotRegistry = snapshotRegistry;
-        this.init = value;
-        this.value = value;
+        this.value = INIT;
 
         snapshotRegistry.register(this);
     }
@@ -105,7 +101,7 @@ public class TimelineInteger implements Revertable {
 
     @Override
     public void reset() {
-        set(init);
+        set(INIT);
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
@@ -105,7 +105,7 @@ public class TimelineInteger implements Revertable {
 
     @Override
     public void reset() {
-        value = init;
+        set(init);
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineInteger.java
@@ -44,11 +44,19 @@ public class TimelineInteger implements Revertable {
     }
 
     private final SnapshotRegistry snapshotRegistry;
+    private final int init;
     private int value;
 
     public TimelineInteger(SnapshotRegistry snapshotRegistry) {
+        this(snapshotRegistry, 0);
+    }
+
+    public TimelineInteger(SnapshotRegistry snapshotRegistry, int value) {
         this.snapshotRegistry = snapshotRegistry;
-        this.value = 0;
+        this.init = value;
+        this.value = value;
+
+        snapshotRegistry.register(this);
     }
 
     public int get() {
@@ -93,6 +101,11 @@ public class TimelineInteger implements Revertable {
     public void executeRevert(long targetEpoch, Delta delta) {
         IntegerContainer container = (IntegerContainer) delta;
         this.value = container.value;
+    }
+
+    @Override
+    public void reset() {
+        value = init;
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
@@ -105,7 +105,7 @@ public class TimelineLong implements Revertable {
 
     @Override
     public void reset() {
-        value = init;
+        set(init);
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
@@ -44,15 +44,19 @@ public class TimelineLong implements Revertable {
     }
 
     private final SnapshotRegistry snapshotRegistry;
+    private final long init;
     private long value;
 
     public TimelineLong(SnapshotRegistry snapshotRegistry) {
-        this(snapshotRegistry, 0L);
+        this(snapshotRegistry, 0);
     }
 
     public TimelineLong(SnapshotRegistry snapshotRegistry, long value) {
         this.snapshotRegistry = snapshotRegistry;
+        this.init = value;
         this.value = value;
+
+        snapshotRegistry.register(this);
     }
 
     public long get() {
@@ -97,6 +101,11 @@ public class TimelineLong implements Revertable {
     public void executeRevert(long targetEpoch, Delta delta) {
         LongContainer container = (LongContainer) delta;
         this.value = container.value();
+    }
+
+    @Override
+    public void reset() {
+        value = init;
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
+++ b/metadata/src/main/java/org/apache/kafka/timeline/TimelineLong.java
@@ -26,8 +26,10 @@ import java.util.Iterator;
  * This class requires external synchronization.
  */
 public class TimelineLong implements Revertable {
+    public static final long INIT = 0;
+
     static class LongContainer implements Delta {
-        private long value = 0;
+        private long value = INIT;
 
         long value() {
             return value;
@@ -44,17 +46,11 @@ public class TimelineLong implements Revertable {
     }
 
     private final SnapshotRegistry snapshotRegistry;
-    private final long init;
     private long value;
 
     public TimelineLong(SnapshotRegistry snapshotRegistry) {
-        this(snapshotRegistry, 0);
-    }
-
-    public TimelineLong(SnapshotRegistry snapshotRegistry, long value) {
         this.snapshotRegistry = snapshotRegistry;
-        this.init = value;
-        this.value = value;
+        this.value = INIT;
 
         snapshotRegistry.register(this);
     }
@@ -105,7 +101,7 @@ public class TimelineLong implements Revertable {
 
     @Override
     public void reset() {
-        set(init);
+        set(INIT);
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
@@ -207,6 +207,26 @@ public class SnapshottableHashTableTest {
         assertIteratorYields(table.snapshottableIterator(Long.MAX_VALUE), E_1A, E_2A, E_3A);
     }
 
+    @Test
+    public void testReset() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        SnapshottableHashTable<TestElement> table =
+            new SnapshottableHashTable<>(registry, 1);
+        assertEquals(null, table.snapshottableAddOrReplace(E_1A));
+        assertEquals(null, table.snapshottableAddOrReplace(E_2A));
+        assertEquals(null, table.snapshottableAddOrReplace(E_3A));
+        registry.createSnapshot(0);
+        assertEquals(E_1A, table.snapshottableAddOrReplace(E_1B));
+        assertEquals(E_3A, table.snapshottableAddOrReplace(E_3B));
+        registry.createSnapshot(1);
+
+        registry.reset();
+
+        assertTrue(registry.epochsList().isEmpty());
+        // Check that the table is empty
+        assertIteratorYields(table.snapshottableIterator(Long.MAX_VALUE));
+    }
+
     /**
      * Assert that the given iterator contains the given elements, in any order.
      * We compare using reference equality here, rather than object equality.

--- a/metadata/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/SnapshottableHashTableTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.timeline;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -222,7 +223,7 @@ public class SnapshottableHashTableTest {
 
         registry.reset();
 
-        assertTrue(registry.epochsList().isEmpty());
+        assertEquals(Collections.emptyList(), registry.epochsList());
         // Check that the table is empty
         assertIteratorYields(table.snapshottableIterator(Long.MAX_VALUE));
     }

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
@@ -76,8 +76,7 @@ public class TimelineIntegerTest {
     @Test
     public void testReset() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        int initialValue = 10;
-        TimelineInteger value = new TimelineInteger(registry, initialValue);
+        TimelineInteger value = new TimelineInteger(registry);
         registry.createSnapshot(2);
         value.set(1);
         registry.createSnapshot(3);
@@ -86,6 +85,6 @@ public class TimelineIntegerTest {
         registry.reset();
 
         assertEquals(Collections.emptyList(), registry.epochsList());
-        assertEquals(initialValue, value.get());
+        assertEquals(TimelineInteger.INIT, value.get());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @Timeout(value = 40)
@@ -69,5 +70,21 @@ public class TimelineIntegerTest {
         assertEquals(1, integer.get());
         registry.revertToSnapshot(2);
         assertEquals(0, integer.get());
+    }
+
+    @Test
+    public void testReset() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        int initialValue = 10;
+        TimelineInteger value = new TimelineInteger(registry, initialValue);
+        registry.createSnapshot(2);
+        value.set(1);
+        registry.createSnapshot(3);
+        value.set(2);
+
+        registry.reset();
+
+        assertTrue(registry.epochsList().isEmpty());
+        assertEquals(initialValue, value.get());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineIntegerTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.kafka.timeline;
 
+import java.util.Collections;
+
 import org.apache.kafka.common.utils.LogContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @Timeout(value = 40)
@@ -84,7 +85,7 @@ public class TimelineIntegerTest {
 
         registry.reset();
 
-        assertTrue(registry.epochsList().isEmpty());
+        assertEquals(Collections.emptyList(), registry.epochsList());
         assertEquals(initialValue, value.get());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @Timeout(value = 40)
@@ -69,5 +70,21 @@ public class TimelineLongTest {
         assertEquals(1L, value.get());
         registry.revertToSnapshot(2);
         assertEquals(0L, value.get());
+    }
+
+    @Test
+    public void testReset() {
+        SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
+        long initialValue = 10;
+        TimelineLong value = new TimelineLong(registry, initialValue);
+        registry.createSnapshot(2);
+        value.set(1L);
+        registry.createSnapshot(3);
+        value.set(2L);
+
+        registry.reset();
+
+        assertTrue(registry.epochsList().isEmpty());
+        assertEquals(initialValue, value.get());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
@@ -17,12 +17,13 @@
 
 package org.apache.kafka.timeline;
 
+import java.util.Collections;
+
 import org.apache.kafka.common.utils.LogContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @Timeout(value = 40)
@@ -84,7 +85,7 @@ public class TimelineLongTest {
 
         registry.reset();
 
-        assertTrue(registry.epochsList().isEmpty());
+        assertEquals(Collections.emptyList(), registry.epochsList());
         assertEquals(initialValue, value.get());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
+++ b/metadata/src/test/java/org/apache/kafka/timeline/TimelineLongTest.java
@@ -76,8 +76,7 @@ public class TimelineLongTest {
     @Test
     public void testReset() {
         SnapshotRegistry registry = new SnapshotRegistry(new LogContext());
-        long initialValue = 10;
-        TimelineLong value = new TimelineLong(registry, initialValue);
+        TimelineLong value = new TimelineLong(registry);
         registry.createSnapshot(2);
         value.set(1L);
         registry.createSnapshot(3);
@@ -86,6 +85,6 @@ public class TimelineLongTest {
         registry.reset();
 
         assertEquals(Collections.emptyList(), registry.epochsList());
-        assertEquals(initialValue, value.get());
+        assertEquals(TimelineLong.INIT, value.get());
     }
 }


### PR DESCRIPTION
Allow Revertable types to reset to their initial values by calling SnapshotRegistry::reset. This is needed to be able to support re-loading snapshots in the inactive/follower controllers.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
