### PR TITLE
KAFKA-12964: Collect and rename snapshot files prior to async deletion.

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2403,10 +2403,9 @@ object Log extends Logging {
         segmentsToDelete.foreach { segment =>
           segment.deleteIfExists()
         }
-        snapshotsToDelete.foreach( snapshot => {
+        snapshotsToDelete.foreach { snapshot =>
           snapshot.deleteIfExists()
         }
-        )
       }
     }
 

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -19,17 +19,16 @@ package kafka.log
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
-import java.nio.file.{Files, StandardOpenOption}
+import java.nio.file.{Files, NoSuchFileException, StandardOpenOption}
 import java.util.concurrent.ConcurrentSkipListMap
 import kafka.log.Log.offsetFromFile
 import kafka.server.LogOffsetMetadata
-import kafka.utils.{Logging, nonthreadsafe, threadsafe}
+import kafka.utils.{CoreUtils, Logging, nonthreadsafe, threadsafe}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.protocol.types._
 import org.apache.kafka.common.record.{ControlRecordType, DefaultRecordBatch, EndTransactionMarker, RecordBatch}
-import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.utils.{ByteUtils, Crc32C}
+import org.apache.kafka.common.utils.{ByteUtils, Crc32C, Time, Utils}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.mutable.ListBuffer
@@ -749,6 +748,13 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   def oldestSnapshotOffset: Option[Long] = oldestSnapshotFile.map(_.offset)
 
   /**
+   * Visible for testing
+   */
+  private[log] def snapshotFileForOffset(offset: Long): Option[SnapshotFile] = {
+    Option(snapshots.get(offset))
+  }
+
+  /**
    * Remove any unreplicated transactions lower than the provided logStartOffset and bring the lastMapOffset forward
    * if necessary.
    */
@@ -828,12 +834,41 @@ class ProducerStateManager(val topicPartition: TopicPartition,
    * Removes the producer state snapshot file metadata corresponding to the provided offset if it exists from this
    * ProducerStateManager, and deletes the backing snapshot file.
    */
-  private[log] def removeAndDeleteSnapshot(snapshotOffset: Long): Unit = {
+  private def removeAndDeleteSnapshot(snapshotOffset: Long): Unit = {
     Option(snapshots.remove(snapshotOffset)).foreach(_.deleteIfExists())
+  }
+
+  /**
+   * Removes the producer state snapshot file metadata corresponding to the provided offset if it exists from this
+   * ProducerStateManager, and renames the backing snapshot file to have the Log.DeletionSuffix.
+   *
+   * Note: This method is safe to use with async deletes. If a race occurs and the snapshot file
+   *       is deleted without this ProducerStateManager instance knowing, the resulting exception on
+   *       SnapshotFile rename will be ignored and None will be returned.
+   */
+  private[log] def removeAndMarkSnapshotForDeletion(snapshotOffset: Long): Option[SnapshotFile] = {
+    Option(snapshots.remove(snapshotOffset)).flatMap { snapshot => {
+      // If the file cannot be renamed, it likely means that the file was deleted already.
+      // This can happen due to the way we construct an intermediate producer state manager
+      // during log recovery, and use it to issue asynch deletions prior to creating the "real"
+      // producer state manager.
+      //
+      // In any case, removeAndStageSnapshotDeletion is intended to be used for snapshot file
+      // deletion, so ignoring the exception here just means that the intended operation was
+      // already completed.
+      try {
+        snapshot.renameTo("", Log.DeletedFileSuffix)
+      } catch {
+        case _: NoSuchFileException =>
+          return None
+      }
+      return Some(snapshot)
+    }
+    }
   }
 }
 
-case class SnapshotFile private[log] (private var _file: File,
+case class SnapshotFile private[log] (@volatile private var _file: File,
                                       offset: Long) {
   def deleteIfExists(): Boolean = {
     Files.deleteIfExists(file.toPath)
@@ -845,6 +880,15 @@ case class SnapshotFile private[log] (private var _file: File,
 
   def file: File = {
     _file
+  }
+
+  def renameTo(oldSuffix: String, newSuffix: String): Unit = {
+    val renamed = new File(CoreUtils.replaceSuffix(_file.getPath, oldSuffix, newSuffix))
+    try {
+      Utils.atomicMoveWithFallback(_file.toPath, renamed.toPath)
+    } finally {
+      _file = renamed
+    }
   }
 }
 

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -858,11 +858,12 @@ class ProducerStateManager(val topicPartition: TopicPartition,
       // already completed.
       try {
         snapshot.renameTo(Log.DeletedFileSuffix)
+        Some(snapshot)
       } catch {
         case _: NoSuchFileException =>
-          return None
+          info(s"Failed to rename producer state snapshot ${snapshot.file.getAbsoluteFile} with deletion suffix because it was already deleted")
+          None
       }
-      return Some(snapshot)
     }
     }
   }

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -850,7 +850,7 @@ class ProducerStateManager(val topicPartition: TopicPartition,
     Option(snapshots.remove(snapshotOffset)).flatMap { snapshot => {
       // If the file cannot be renamed, it likely means that the file was deleted already.
       // This can happen due to the way we construct an intermediate producer state manager
-      // during log recovery, and use it to issue asynch deletions prior to creating the "real"
+      // during log recovery, and use it to issue deletions prior to creating the "real"
       // producer state manager.
       //
       // In any case, removeAndMarkSnapshotForDeletion is intended to be used for snapshot file

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -1624,6 +1624,13 @@ class LogLoaderTest {
       assertTrue(snapshotFileBeforeDeletion.get.file.exists)
     }
 
+    val offsetsWithSnapshotFiles = (1 until 5)
+        .map(offset => SnapshotFile(Log.producerSnapshotFile(logDir, offset)))
+        .filter(snapshotFile => snapshotFile.file.exists())
+        .map(_.offset)
+        .toList
+    assertTrue(offsetsWithSnapshotFiles.isEmpty, s"Found offsets with producer state snapshot files: $offsetsWithSnapshotFiles, while none was expected.")
+
     // Wait for all async segment deletions scheduled during Log recovery to complete.
     // The expected segments and producer state snapshot after the deletions, is as shown below:
     // [4-4], [5-5], [6-6], [7-7], [8-8], [9-]

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -21,7 +21,6 @@ import java.io.{BufferedWriter, File, FileWriter}
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
 import java.util.Properties
-
 import kafka.api.{ApiVersion, KAFKA_0_11_0_IV0}
 import kafka.server.epoch.{EpochEntry, LeaderEpochFileCache}
 import kafka.server.{BrokerTopicStats, FetchDataInfo, KafkaConfig, LogDirFailureChannel}
@@ -1534,5 +1533,116 @@ class LogLoaderTest {
     assertTrue(onlySegment.log.file().exists())
     assertTrue(onlySegment.lazyOffsetIndex.file.exists())
     assertTrue(onlySegment.lazyTimeIndex.file.exists())
+  }
+
+  @Test
+  def testCorruptedLogRecoveryDoesNotDeleteProducerStateSnapshotsPostRecovery(): Unit = {
+    val logConfig = LogTestUtils.createLogConfig()
+    var log = createLog(logDir, logConfig)
+    // Create segments: [0-0], [1-1], [2-2], [3-3], [4-4], [5-5], [6-6], [7-7], [8-8], [9-]
+    //                   |---> logStartOffset                                           |---> active segment (empty)
+    //                                                                                  |---> logEndOffset
+    for (i <- 0 until 9) {
+      val record = new SimpleRecord(mockTime.milliseconds, i.toString.getBytes)
+      log.appendAsLeader(TestUtils.records(List(record)), leaderEpoch = 0)
+      log.roll()
+    }
+    assertEquals(10, log.logSegments.size)
+    assertEquals(0, log.logStartOffset)
+    assertEquals(9, log.activeSegment.baseOffset)
+    assertEquals(9, log.logEndOffset)
+    for (offset <- 1 until 10) {
+      val snapshotFileBeforeDeletion = log.producerStateManager.snapshotFileForOffset(offset)
+      assertTrue(snapshotFileBeforeDeletion.isDefined)
+      assertTrue(snapshotFileBeforeDeletion.get.file.exists)
+    }
+
+    // Increment the log start offset to 4.
+    // After this step, the segments should be:
+    //                              |---> logStartOffset
+    // [0-0], [1-1], [2-2], [3-3], [4-4], [5-5], [6-6], [7-7], [8-8], [9-]
+    //                                                                 |---> active segment (empty)
+    //                                                                 |---> logEndOffset
+    val newLogStartOffset = 4
+    log.updateHighWatermark(log.logEndOffset)
+    log.maybeIncrementLogStartOffset(newLogStartOffset, ClientRecordDeletion)
+    assertEquals(4, log.logStartOffset)
+    assertEquals(9, log.logEndOffset)
+
+    // Append garbage to a segment at baseOffset 1, which is below the current log start offset 4.
+    // After this step, the segments should be:
+    //
+    // [0-0], [1-1], [2-2], [3-3], [4-4], [5-5], [6-6], [7-7], [8-8], [9-]
+    //           |                  |---> logStartOffset               |---> active segment  (empty)
+    //           |                                                     |---> logEndOffset
+    // corrupt record inserted
+    //
+    val segmentToForceTruncation = log.logSegments.take(2).last
+    assertEquals(1, segmentToForceTruncation.baseOffset)
+    val bw = new BufferedWriter(new FileWriter(segmentToForceTruncation.log.file))
+    bw.write("corruptRecord")
+    bw.close()
+    log.close()
+
+    // Reopen the log. This will do the following:
+    // - Truncate the segment above to which we appended garbage and will schedule async deletion of all other
+    //   segments from base offsets 2 to 9.
+    // - The remaining segments at base offsets 0 and 1 will be lower than the current logStartOffset 4.
+    //   This will cause async deletion of both remaining segments. Finally a single, active segment is created
+    //   starting at logStartOffset 4.
+    //
+    // Expected segments after the log is opened again:
+    // [4-]
+    //  |---> active segment (empty)
+    //  |---> logStartOffset
+    //  |---> logEndOffset
+    log = createLog(logDir, logConfig, logStartOffset = newLogStartOffset, lastShutdownClean = false)
+    assertEquals(1, log.logSegments.size)
+    assertEquals(4, log.logStartOffset)
+    assertEquals(4, log.activeSegment.baseOffset)
+    assertEquals(4, log.logEndOffset)
+
+    // Append records, roll the segments and check that the producer state snapshots are defined.
+    // The expected segments and producer state snapshots, after the appends are complete and segments are rolled,
+    // is as shown below:
+    // [4-4], [5-5], [6-6], [7-7], [8-8], [9-]
+    //  |      |      |      |      |      |---> active segment (empty)
+    //  |      |      |      |      |      |---> logEndOffset
+    //  |      |      |      |      |      |
+    //  |      |------.------.------.------.-----> producer state snapshot files are DEFINED for each offset in: [5-9]
+    //  |----------------------------------------> logStartOffset
+    for (i <- 0 until 5) {
+      val record = new SimpleRecord(mockTime.milliseconds, i.toString.getBytes)
+      log.appendAsLeader(TestUtils.records(List(record)), leaderEpoch = 0)
+      log.roll()
+    }
+    assertEquals(9, log.activeSegment.baseOffset)
+    assertEquals(9, log.logEndOffset)
+    for (offset <- 5 until 10) {
+      val snapshotFileBeforeDeletion = log.producerStateManager.snapshotFileForOffset(offset)
+      assertTrue(snapshotFileBeforeDeletion.isDefined)
+      assertTrue(snapshotFileBeforeDeletion.get.file.exists)
+    }
+
+    // Wait for all async segment deletions scheduled during Log recovery to complete.
+    // The expected segments and producer state snapshot after the deletions, is as shown below:
+    // [4-4], [5-5], [6-6], [7-7], [8-8], [9-]
+    //  |      |      |      |      |      |---> active segment (empty)
+    //  |      |      |      |      |      |---> logEndOffset
+    //  |      |      |      |      |      |
+    //  |      |------.------.------.------.-----> producer state snapshot files should be defined for each offset in: [5-9].
+    //  |----------------------------------------> logStartOffset
+    mockTime.sleep(logConfig.fileDeleteDelayMs)
+    assertEquals(newLogStartOffset, log.logStartOffset)
+    assertEquals(9, log.logEndOffset)
+    val offsetsWithMissingSnapshotFiles = ListBuffer[Long]()
+    for (offset <- 5 until 10) {
+      val snapshotFile = log.producerStateManager.snapshotFileForOffset(offset)
+      if (!snapshotFile.isDefined || !snapshotFile.get.file.exists) {
+        offsetsWithMissingSnapshotFiles.append(offset)
+      }
+    }
+    assertTrue(offsetsWithMissingSnapshotFiles.isEmpty,
+      s"Found offsets with missing producer state snapshot files: $offsetsWithMissingSnapshotFiles")
   }
 }

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -1628,8 +1628,11 @@ class LogLoaderTest {
         .map(offset => SnapshotFile(Log.producerSnapshotFile(logDir, offset)))
         .filter(snapshotFile => snapshotFile.file.exists())
         .map(_.offset)
-        .toList
-    assertTrue(offsetsWithSnapshotFiles.isEmpty, s"Found offsets with producer state snapshot files: $offsetsWithSnapshotFiles, while none was expected.")
+    val inMemorySnapshotFiles = (1 until 5)
+        .flatMap(offset => log.producerStateManager.snapshotFileForOffset(offset))
+
+    assertTrue(offsetsWithSnapshotFiles.isEmpty, s"Found offsets with producer state snapshot files: $offsetsWithSnapshotFiles while none were expected.")
+    assertTrue(inMemorySnapshotFiles.isEmpty, s"Found in-memory producer state snapshot files: $inMemorySnapshotFiles while none were expected.")
 
     // Wait for all async segment deletions scheduled during Log recovery to complete.
     // The expected segments and producer state snapshot after the deletions, is as shown below:

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -1648,7 +1648,7 @@ class LogLoaderTest {
     val offsetsWithMissingSnapshotFiles = ListBuffer[Long]()
     for (offset <- 5 until 10) {
       val snapshotFile = log.producerStateManager.snapshotFileForOffset(offset)
-      if (!snapshotFile.isDefined || !snapshotFile.get.file.exists) {
+      if (snapshotFile.isEmpty || !snapshotFile.get.file.exists) {
         offsetsWithMissingSnapshotFiles.append(offset)
       }
     }

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -900,6 +900,14 @@ class ProducerStateManagerTest {
     assertEquals(Seq(42), ProducerStateManager.listSnapshotFiles(logDir).map(_.offset).sorted)
   }
 
+  @Test
+  def testRemoveAndMarkSnapshotForDeletion(): Unit = {
+    Log.producerSnapshotFile(logDir, 5).createNewFile()
+    val manager = new ProducerStateManager(partition, logDir, time = time)
+    val snapshot = manager.removeAndMarkSnapshotForDeletion(5).get
+    assertTrue(snapshot.file.toPath.toString.endsWith(Log.DeletedFileSuffix))
+  }
+
   private def testLoadFromCorruptSnapshot(makeFileCorrupt: FileChannel => Unit): Unit = {
     val epoch = 0.toShort
     val producerId = 1L

--- a/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/ProducerStateManagerTest.scala
@@ -20,7 +20,7 @@ package kafka.log
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
-import java.nio.file.StandardOpenOption
+import java.nio.file.{Files, StandardOpenOption}
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -900,12 +900,36 @@ class ProducerStateManagerTest {
     assertEquals(Seq(42), ProducerStateManager.listSnapshotFiles(logDir).map(_.offset).sorted)
   }
 
+  /**
+   * Test that removeAndMarkSnapshotForDeletion will rename the SnapshotFile with
+   * the deletion suffix and remove it from the producer state.
+   */
   @Test
   def testRemoveAndMarkSnapshotForDeletion(): Unit = {
     Log.producerSnapshotFile(logDir, 5).createNewFile()
     val manager = new ProducerStateManager(partition, logDir, time = time)
+    assertTrue(manager.latestSnapshotOffset.isDefined)
     val snapshot = manager.removeAndMarkSnapshotForDeletion(5).get
     assertTrue(snapshot.file.toPath.toString.endsWith(Log.DeletedFileSuffix))
+    assertTrue(manager.latestSnapshotOffset.isEmpty)
+  }
+
+  /**
+   * Test that marking a snapshot for deletion when the file has already been deleted
+   * returns None instead of the SnapshotFile. The snapshot file should be removed from
+   * the in-memory state of the ProducerStateManager. This scenario can occur during log
+   * recovery when the intermediate ProducerStateManager instance deletes a file without
+   * updating the state of the "real" ProducerStateManager instance which is passed to the Log.
+   */
+  @Test
+  def testRemoveAndMarkSnapshotForDeletionAlreadyDeleted(): Unit = {
+    val file = Log.producerSnapshotFile(logDir, 5)
+    file.createNewFile()
+    val manager = new ProducerStateManager(partition, logDir, time = time)
+    assertTrue(manager.latestSnapshotOffset.isDefined)
+    Files.delete(file.toPath)
+    assertTrue(manager.removeAndMarkSnapshotForDeletion(5).isEmpty)
+    assertTrue(manager.latestSnapshotOffset.isEmpty)
   }
 
   private def testLoadFromCorruptSnapshot(makeFileCorrupt: FileChannel => Unit): Unit = {


### PR DESCRIPTION
Segment and index files are currently renamed with a .deleted
suffix prior to async deletion. This serves two purposes, to
resume deletion on broker failure and also protect against
deletion of new segments during truncation (due to deletion
being async).

We should do the same for snapshot files. While they are not subject
to issues around resuming deletion due to the stray snapshot
scanning which is performed on log initialization, we can end up
with situations where truncation queues snapshots for deletion, but
prior to deletion new segments with the same snapshot file name are
created. Async deletion can then delete these new snapshots.

This patch offers a two-stage snapshot deletion which first renames
and removes the segments in question from the ProducerStateManager,
allowing the Log to asynchronously delete them.

Credit to Kowshik Prakasam <kowshik@gmail.com> for finding this issue
and creating the test demonstrating the failure.

Co-authored-by: Kowshik Prakasam <kowshik@gmail.com>