### PR TITLE
KAFKA-12952 Adding Delimiters to Metadata Snapshot

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -435,6 +435,7 @@
 
   <subpackage name="snapshot">
     <allow pkg="org.apache.kafka.common.record" />
+    <allow pkg="org.apache.kafka.common.message" />
     <allow pkg="org.apache.kafka.raft" />
     <allow pkg="org.apache.kafka.server.common" />
     <allow pkg="org.apache.kafka.test"/>

--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordType.java
@@ -43,9 +43,11 @@ import java.nio.ByteBuffer;
 public enum ControlRecordType {
     ABORT((short) 0),
     COMMIT((short) 1),
+
     // Raft quorum related control messages.
-    QUORUM_REASSIGNMENT((short) 2),
-    LEADER_CHANGE((short) 3),
+    LEADER_CHANGE((short) 2),
+    SNAPSHOT_HEADER((short) 3),
+    SNAPSHOT_FOOTER((short) 4),
 
     // UNKNOWN is used to indicate a control type which the client is not aware of and should be ignored
     UNKNOWN((short) -1);
@@ -97,9 +99,12 @@ public enum ControlRecordType {
             case 1:
                 return COMMIT;
             case 2:
-                return QUORUM_REASSIGNMENT;
-            case 3:
                 return LEADER_CHANGE;
+            case 3:
+                return SNAPSHOT_HEADER;
+            case 4:
+                return SNAPSHOT_FOOTER;
+
             default:
                 return UNKNOWN;
         }

--- a/clients/src/main/java/org/apache/kafka/common/record/ControlRecordUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/ControlRecordUtils.java
@@ -17,6 +17,8 @@
 package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.SnapshotHeaderRecord;
+import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 
 import java.nio.ByteBuffer;
@@ -26,19 +28,49 @@ import java.nio.ByteBuffer;
  */
 public class ControlRecordUtils {
 
-    public static final short LEADER_CHANGE_SCHEMA_VERSION = new LeaderChangeMessage().highestSupportedVersion();
+    public static final short LEADER_CHANGE_SCHEMA_HIGHEST_VERSION = new LeaderChangeMessage().highestSupportedVersion();
+    public static final short SNAPSHOT_HEADER_HIGHEST_VERSION = new SnapshotHeaderRecord().highestSupportedVersion();
+    public static final short SNAPSHOT_FOOTER_HIGHEST_VERSION = new SnapshotFooterRecord().highestSupportedVersion();
 
     public static LeaderChangeMessage deserializeLeaderChangeMessage(Record record) {
         ControlRecordType recordType = ControlRecordType.parse(record.key());
         if (recordType != ControlRecordType.LEADER_CHANGE) {
             throw new IllegalArgumentException(
-                "Expected LEADER_CHANGE control record type(3), but found " + recordType.toString());
+                "Expected LEADER_CHANGE control record type(2), but found " + recordType.toString());
         }
         return deserializeLeaderChangeMessage(record.value().duplicate());
     }
 
     public static LeaderChangeMessage deserializeLeaderChangeMessage(ByteBuffer data) {
         ByteBufferAccessor byteBufferAccessor = new ByteBufferAccessor(data.duplicate());
-        return new LeaderChangeMessage(byteBufferAccessor, LEADER_CHANGE_SCHEMA_VERSION);
+        return new LeaderChangeMessage(byteBufferAccessor, LEADER_CHANGE_SCHEMA_HIGHEST_VERSION);
+    }
+
+    public static SnapshotHeaderRecord deserializedSnapshotHeaderRecord(Record record) {
+        ControlRecordType recordType = ControlRecordType.parse(record.key());
+        if (recordType != ControlRecordType.SNAPSHOT_HEADER) {
+            throw new IllegalArgumentException(
+                "Expected SNAPSHOT_HEADER control record type(3), but found " + recordType.toString());
+        }
+        return deserializedSnapshotHeaderRecord(record.value().duplicate());
+    }
+
+    public static SnapshotHeaderRecord deserializedSnapshotHeaderRecord(ByteBuffer data) {
+        ByteBufferAccessor byteBufferAccessor = new ByteBufferAccessor(data.duplicate());
+        return new SnapshotHeaderRecord(byteBufferAccessor, SNAPSHOT_HEADER_HIGHEST_VERSION);
+    }
+
+    public static SnapshotFooterRecord deserializedSnapshotFooterRecord(Record record) {
+        ControlRecordType recordType = ControlRecordType.parse(record.key());
+        if (recordType != ControlRecordType.SNAPSHOT_FOOTER) {
+            throw new IllegalArgumentException(
+                "Expected SNAPSHOT_FOOTER control record type(4), but found " + recordType.toString());
+        }
+        return deserializedSnapshotFooterRecord(record.value().duplicate());
+    }
+
+    public static SnapshotFooterRecord deserializedSnapshotFooterRecord(ByteBuffer data) {
+        ByteBufferAccessor byteBufferAccessor = new ByteBufferAccessor(data.duplicate());
+        return new SnapshotFooterRecord(byteBufferAccessor, SNAPSHOT_FOOTER_HIGHEST_VERSION);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -713,13 +713,13 @@ public class MemoryRecords extends AbstractRecords {
         int leaderEpoch,
         SnapshotFooterRecord snapshotFooterRecord
     ) {
-        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
+        try (MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
             buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
             TimestampType.CREATE_TIME, initialOffset, timestamp,
             RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
-            false, true, leaderEpoch, buffer.capacity()
-        );
-        builder.appendSnapshotFooterMessage(timestamp, snapshotFooterRecord);
-        builder.close();
+            false, true, leaderEpoch, buffer.capacity())
+        ) {
+            builder.appendSnapshotFooterMessage(timestamp, snapshotFooterRecord);
+        }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -19,6 +19,8 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.SnapshotHeaderRecord;
+import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.network.TransferableChannel;
 import org.apache.kafka.common.record.MemoryRecords.RecordFilter.BatchRetention;
 import org.apache.kafka.common.utils.AbstractIterator;
@@ -629,12 +631,13 @@ public class MemoryRecords extends AbstractRecords {
                                                    int partitionLeaderEpoch, long producerId, short producerEpoch,
                                                    EndTransactionMarker marker) {
         boolean isTransactional = true;
-        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+        try (MemoryRecordsBuilder builder = new MemoryRecordsBuilder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
                 TimestampType.CREATE_TIME, initialOffset, timestamp, producerId, producerEpoch,
                 RecordBatch.NO_SEQUENCE, isTransactional, true, partitionLeaderEpoch,
-                buffer.capacity());
-        builder.appendEndTxnMarker(timestamp, marker);
-        builder.close();
+                buffer.capacity())
+        ) {
+            builder.appendEndTxnMarker(timestamp, marker);
+        }
     }
 
     public static MemoryRecords withLeaderChangeMessage(
@@ -654,14 +657,69 @@ public class MemoryRecords extends AbstractRecords {
                                                  long timestamp,
                                                  int leaderEpoch,
                                                  LeaderChangeMessage leaderChangeMessage) {
+        try (MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
+            buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+            TimestampType.CREATE_TIME, initialOffset, timestamp,
+            RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
+            false, true, leaderEpoch, buffer.capacity())
+        ) {
+            builder.appendLeaderChangeMessage(timestamp, leaderChangeMessage);
+        }
+    }
+
+    public static MemoryRecords withSnapshotHeaderRecord(
+        long initialOffset,
+        long timestamp,
+        int leaderEpoch,
+        ByteBuffer buffer,
+        SnapshotHeaderRecord snapshotHeaderRecord
+    ) {
+        writeSnapshotHeaderRecord(buffer, initialOffset, timestamp, leaderEpoch, snapshotHeaderRecord);
+        buffer.flip();
+        return MemoryRecords.readableRecords(buffer);
+    }
+
+    private static void writeSnapshotHeaderRecord(ByteBuffer buffer,
+        long initialOffset,
+        long timestamp,
+        int leaderEpoch,
+        SnapshotHeaderRecord snapshotHeaderRecord
+    ) {
+        try (MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
+            buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+            TimestampType.CREATE_TIME, initialOffset, timestamp,
+            RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
+            false, true, leaderEpoch, buffer.capacity())
+        ) {
+            builder.appendSnapshotHeaderMessage(timestamp, snapshotHeaderRecord);
+        }
+    }
+
+    public static MemoryRecords withSnapshotFooterRecord(
+        long initialOffset,
+        long timestamp,
+        int leaderEpoch,
+        ByteBuffer buffer,
+        SnapshotFooterRecord snapshotFooterRecord
+    ) {
+        writeSnapshotFooterRecord(buffer, initialOffset, timestamp, leaderEpoch, snapshotFooterRecord);
+        buffer.flip();
+        return MemoryRecords.readableRecords(buffer);
+    }
+
+    private static void writeSnapshotFooterRecord(ByteBuffer buffer,
+        long initialOffset,
+        long timestamp,
+        int leaderEpoch,
+        SnapshotFooterRecord snapshotFooterRecord
+    ) {
         MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
             buffer, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
             TimestampType.CREATE_TIME, initialOffset, timestamp,
             RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE,
             false, true, leaderEpoch, buffer.capacity()
         );
-        builder.appendLeaderChangeMessage(timestamp, leaderChangeMessage);
+        builder.appendSnapshotFooterMessage(timestamp, snapshotFooterRecord);
         builder.close();
     }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecordsBuilder.java
@@ -19,6 +19,8 @@ package org.apache.kafka.common.record;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.message.LeaderChangeMessage;
+import org.apache.kafka.common.message.SnapshotHeaderRecord;
+import org.apache.kafka.common.message.SnapshotFooterRecord;
 import org.apache.kafka.common.protocol.MessageUtil;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
@@ -579,7 +581,17 @@ public class MemoryRecordsBuilder implements AutoCloseable {
             throw new IllegalArgumentException("Partition leader epoch must be valid, but get " + partitionLeaderEpoch);
         }
         appendControlRecord(timestamp, ControlRecordType.LEADER_CHANGE,
-                MessageUtil.toByteBuffer(leaderChangeMessage, ControlRecordUtils.LEADER_CHANGE_SCHEMA_VERSION));
+                MessageUtil.toByteBuffer(leaderChangeMessage, ControlRecordUtils.LEADER_CHANGE_SCHEMA_HIGHEST_VERSION));
+    }
+
+    public void appendSnapshotHeaderMessage(long timestamp, SnapshotHeaderRecord snapshotHeaderRecord) {
+        appendControlRecord(timestamp, ControlRecordType.SNAPSHOT_HEADER,
+            MessageUtil.toByteBuffer(snapshotHeaderRecord, ControlRecordUtils.SNAPSHOT_HEADER_HIGHEST_VERSION));
+    }
+
+    public void appendSnapshotFooterMessage(long timestamp, SnapshotFooterRecord snapshotHeaderRecord) {
+        appendControlRecord(timestamp, ControlRecordType.SNAPSHOT_FOOTER,
+            MessageUtil.toByteBuffer(snapshotHeaderRecord, ControlRecordUtils.SNAPSHOT_FOOTER_HIGHEST_VERSION));
     }
 
     /**

--- a/clients/src/main/resources/common/message/SnapshotFooterRecord.json
+++ b/clients/src/main/resources/common/message/SnapshotFooterRecord.json
@@ -15,22 +15,11 @@
 
 {
   "type": "data",
-  "name": "LeaderChangeMessage",
+  "name": "SnapshotFooterRecord",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
     {"name": "Version", "type": "int16", "versions": "0+",
-      "about": "The version of the leader change message"},
-    {"name": "LeaderId", "type": "int32", "versions": "0+", "entityType": "brokerId",
-      "about": "The ID of the newly elected leader"},
-    {"name": "Voters", "type": "[]Voter", "versions": "0+",
-      "about": "The set of voters in the quorum for this epoch"},
-    {"name": "GrantingVoters", "type": "[]Voter", "versions": "0+",
-      "about": "The voters who voted for the leader at the time of election"}
-  ],
-  "commonStructs": [
-    { "name": "Voter", "versions": "0+", "fields": [
-      {"name": "VoterId", "type": "int32", "versions": "0+"}
-    ]}
+      "about": "The version of the snapshot footer record"}
   ]
 }

--- a/clients/src/main/resources/common/message/SnapshotHeaderRecord.json
+++ b/clients/src/main/resources/common/message/SnapshotHeaderRecord.json
@@ -15,22 +15,13 @@
 
 {
   "type": "data",
-  "name": "LeaderChangeMessage",
+  "name": "SnapshotHeaderRecord",
   "validVersions": "0",
   "flexibleVersions": "0+",
   "fields": [
     {"name": "Version", "type": "int16", "versions": "0+",
-      "about": "The version of the leader change message"},
-    {"name": "LeaderId", "type": "int32", "versions": "0+", "entityType": "brokerId",
-      "about": "The ID of the newly elected leader"},
-    {"name": "Voters", "type": "[]Voter", "versions": "0+",
-      "about": "The set of voters in the quorum for this epoch"},
-    {"name": "GrantingVoters", "type": "[]Voter", "versions": "0+",
-      "about": "The voters who voted for the leader at the time of election"}
-  ],
-  "commonStructs": [
-    { "name": "Voter", "versions": "0+", "fields": [
-      {"name": "VoterId", "type": "int32", "versions": "0+"}
-    ]}
+      "about": "The version of the snapshot header record"},
+    {"name": "LastContainedLogTimestamp", "type": "int64", "versions": "0+",
+      "about": "The append time of the last record from the log contained in this snapshot"}
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/ControlRecordUtilsTest.java
@@ -35,7 +35,7 @@ public class ControlRecordUtilsTest {
     public void testInvalidControlRecordType() {
         IllegalArgumentException thrown = assertThrows(
             IllegalArgumentException.class, () -> testDeserializeRecord(ControlRecordType.COMMIT));
-        assertEquals("Expected LEADER_CHANGE control record type(3), but found COMMIT", thrown.getMessage());
+        assertEquals("Expected LEADER_CHANGE control record type(2), but found COMMIT", thrown.getMessage());
     }
 
     @Test

--- a/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/QuorumController.java
@@ -345,7 +345,8 @@ public final class QuorumController implements Controller {
             }
             Optional<SnapshotWriter<ApiMessageAndVersion>> writer = raftClient.createSnapshot(
                 committedOffset,
-                committedEpoch
+                committedEpoch,
+                0
             );
             if (writer.isPresent()) {
                 generator = new SnapshotGenerator(

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -35,6 +35,7 @@ import org.apache.kafka.server.common.ApiMessageAndVersion;
 import org.apache.kafka.snapshot.MockRawSnapshotReader;
 import org.apache.kafka.snapshot.MockRawSnapshotWriter;
 import org.apache.kafka.snapshot.RawSnapshotReader;
+import org.apache.kafka.snapshot.RawSnapshotWriter;
 import org.apache.kafka.snapshot.SnapshotReader;
 import org.apache.kafka.snapshot.SnapshotWriter;
 import org.slf4j.Logger;
@@ -539,19 +540,28 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
     }
 
     @Override
-    public Optional<SnapshotWriter<ApiMessageAndVersion>> createSnapshot(long committedOffset, int committedEpoch) {
+    public Optional<SnapshotWriter<ApiMessageAndVersion>> createSnapshot(
+        long committedOffset,
+        int committedEpoch,
+        long lastContainedLogTime
+    ) {
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(committedOffset + 1, committedEpoch);
+        return SnapshotWriter.createWithHeader(
+            () -> createNewSnapshot(snapshotId),
+            1024,
+            MemoryPool.NONE,
+            new MockTime(),
+            lastContainedLogTime,
+            CompressionType.NONE,
+            new MetadataRecordSerde()
+        );
+    }
+
+    private Optional<RawSnapshotWriter> createNewSnapshot(OffsetAndEpoch snapshotId) {
         return Optional.of(
-            new SnapshotWriter<>(
-                new MockRawSnapshotWriter(snapshotId, buffer -> {
-                    shared.addSnapshot(new MockRawSnapshotReader(snapshotId, buffer));
-                }),
-                1024,
-                MemoryPool.NONE,
-                new MockTime(),
-                CompressionType.NONE,
-                new MetadataRecordSerde()
-            )
+            new MockRawSnapshotWriter(snapshotId, buffer -> {
+                shared.addSnapshot(new MockRawSnapshotReader(snapshotId, buffer));
+            })
         );
     }
 

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2254,19 +2254,20 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
     }
 
     @Override
-    public Optional<SnapshotWriter<T>> createSnapshot(long committedOffset, int committedEpoch) {
-        return log.createNewSnapshot(
-            new OffsetAndEpoch(committedOffset + 1, committedEpoch)
-        ).map(snapshot -> {
-            return new SnapshotWriter<>(
-                snapshot,
+    public Optional<SnapshotWriter<T>> createSnapshot(
+        long committedOffset,
+        int committedEpoch,
+        long lastContainedLogTime
+    ) {
+        return SnapshotWriter.createWithHeader(
+                () -> log.createNewSnapshot(new OffsetAndEpoch(committedOffset + 1, committedEpoch)),
                 MAX_BATCH_SIZE_BYTES,
                 memoryPool,
                 time,
+                lastContainedLogTime,
                 CompressionType.NONE,
                 serde
             );
-        });
     }
 
     @Override

--- a/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
+++ b/raft/src/main/java/org/apache/kafka/raft/LeaderState.java
@@ -22,6 +22,8 @@ import org.slf4j.Logger;
 
 import org.apache.kafka.common.message.LeaderChangeMessage;
 import org.apache.kafka.common.message.LeaderChangeMessage.Voter;
+import org.apache.kafka.common.record.ControlRecordUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -92,6 +94,7 @@ public class LeaderState<T> implements EpochState {
         List<Voter> grantingVoters = convertToVoters(this.grantingVoters());
 
         LeaderChangeMessage leaderChangeMessage = new LeaderChangeMessage()
+            .setVersion(ControlRecordUtils.LEADER_CHANGE_SCHEMA_HIGHEST_VERSION)
             .setLeaderId(this.election().leaderId())
             .setVoters(voters)
             .setGrantingVoters(grantingVoters);

--- a/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/RaftClient.java
@@ -188,11 +188,12 @@ public interface RaftClient<T> extends AutoCloseable {
      * how to use this object. If a snapshot already exists then returns an
      * {@link Optional#empty()}.
      *
-     * @param committedOffset the last committed offset that will be included in the snapshot
      * @param committedEpoch the epoch of the committed offset
+     * @param committedOffset the last committed offset that will be included in the snapshot
+     * @param lastContainedLogTime The append time of the highest record contained in this snapshot
      * @return a writable snapshot if it doesn't already exists
      * @throws IllegalArgumentException if the committed offset is greater than the high-watermark
      *         or less than the log start offset.
      */
-    Optional<SnapshotWriter<T>> createSnapshot(long committedOffset, int committedEpoch);
+    Optional<SnapshotWriter<T>> createSnapshot(long committedOffset, int committedEpoch, long lastContainedLogTime);
 }

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
@@ -106,7 +106,7 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
                     lastCommittedEpoch,
                     lastOffsetSnapshotted
                 );
-                Optional<SnapshotWriter<Integer>> snapshot = client.createSnapshot(lastCommittedOffset, lastCommittedEpoch);
+                Optional<SnapshotWriter<Integer>> snapshot = client.createSnapshot(lastCommittedOffset, lastCommittedEpoch, 0);
                 if (snapshot.isPresent()) {
                     try {
                         snapshot.get().append(singletonList(committed));

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotReader.java
@@ -124,9 +124,7 @@ public final class SnapshotReader<T> implements AutoCloseable, Iterator<Batch<T>
         while (iterator.hasNext()) {
             Batch<T> batch = iterator.next();
 
-            if (batch.records().isEmpty()) {
-                continue;
-            } else {
+            if (!batch.records().isEmpty()) {
                 return Optional.of(batch);
             }
         }

--- a/raft/src/main/java/org/apache/kafka/snapshot/SnapshotReader.java
+++ b/raft/src/main/java/org/apache/kafka/snapshot/SnapshotReader.java
@@ -18,6 +18,9 @@
 package org.apache.kafka.snapshot;
 
 import java.util.Iterator;
+import java.util.Optional;
+import java.util.NoSuchElementException;
+
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.raft.Batch;
 import org.apache.kafka.raft.OffsetAndEpoch;
@@ -42,6 +45,8 @@ import org.apache.kafka.raft.internals.RecordsIterator;
 public final class SnapshotReader<T> implements AutoCloseable, Iterator<Batch<T>> {
     private final OffsetAndEpoch snapshotId;
     private final RecordsIterator<T> iterator;
+
+    private Optional<Batch<T>> nextBatch = Optional.empty();
 
     private SnapshotReader(
         OffsetAndEpoch snapshotId,
@@ -74,12 +79,23 @@ public final class SnapshotReader<T> implements AutoCloseable, Iterator<Batch<T>
 
     @Override
     public boolean hasNext() {
-        return iterator.hasNext();
+        if (!nextBatch.isPresent()) {
+            nextBatch = nextBatch();
+        }
+
+        return nextBatch.isPresent();
     }
 
     @Override
     public Batch<T> next() {
-        return iterator.next();
+        if (!hasNext()) {
+            throw new NoSuchElementException("Snapshot reader doesn't have any more elements");
+        }
+
+        Batch<T> batch = nextBatch.get();
+        nextBatch = Optional.empty();
+
+        return batch;
     }
 
     /**
@@ -99,5 +115,22 @@ public final class SnapshotReader<T> implements AutoCloseable, Iterator<Batch<T>
             snapshot.snapshotId(),
             new RecordsIterator<>(snapshot.records(), serde, bufferSupplier, maxBatchSize)
         );
+    }
+
+    /**
+     * Returns the next non-control Batch
+     */
+    private Optional<Batch<T>> nextBatch() {
+        while (iterator.hasNext()) {
+            Batch<T> batch = iterator.next();
+
+            if (batch.records().isEmpty()) {
+                continue;
+            } else {
+                return Optional.of(batch);
+            }
+        }
+
+        return Optional.empty();
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/KafkaRaftClientSnapshotTest.java
@@ -192,7 +192,7 @@ final public class KafkaRaftClientSnapshotTest {
 
         // Generate a new snapshot
         OffsetAndEpoch secondSnapshotId = new OffsetAndEpoch(localLogEndOffset, epoch);
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(secondSnapshotId.offset - 1, secondSnapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(secondSnapshotId.offset - 1, secondSnapshotId.epoch, 0).get()) {
             assertEquals(secondSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -240,7 +240,7 @@ final public class KafkaRaftClientSnapshotTest {
         assertEquals(localLogEndOffset, context.client.highWatermark().getAsLong());
 
         OffsetAndEpoch snapshotId = new OffsetAndEpoch(localLogEndOffset, epoch);
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch, 0).get()) {
             assertEquals(snapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -286,7 +286,7 @@ final public class KafkaRaftClientSnapshotTest {
         assertEquals(localLogEndOffset, context.client.highWatermark().getAsLong());
 
         // Create a snapshot at the high watermark
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch, 0).get()) {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -330,7 +330,7 @@ final public class KafkaRaftClientSnapshotTest {
         assertEquals(context.log.endOffset().offset, context.client.highWatermark().getAsLong());
 
         // Create a snapshot at the high watermark
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch, 0).get()) {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -378,7 +378,7 @@ final public class KafkaRaftClientSnapshotTest {
         assertEquals(context.log.endOffset().offset, context.client.highWatermark().getAsLong());
 
         // Create a snapshot at the high watermark
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch, 0).get()) {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -421,7 +421,7 @@ final public class KafkaRaftClientSnapshotTest {
         assertEquals(context.log.endOffset().offset, context.client.highWatermark().getAsLong());
 
         // Create a snapshot at the high watermark
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch, 0).get()) {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -469,7 +469,7 @@ final public class KafkaRaftClientSnapshotTest {
         assertEquals(context.log.endOffset().offset, context.client.highWatermark().getAsLong());
 
         // Create a snapshot at the high watermark
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(oldestSnapshotId.offset - 1, oldestSnapshotId.epoch, 0).get()) {
             assertEquals(oldestSnapshotId, snapshot.snapshotId());
             snapshot.freeze();
         }
@@ -559,7 +559,7 @@ final public class KafkaRaftClientSnapshotTest {
 
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
 
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch, 0).get()) {
             assertEquals(snapshotId, snapshot.snapshotId());
             snapshot.append(records);
             snapshot.freeze();
@@ -608,7 +608,7 @@ final public class KafkaRaftClientSnapshotTest {
 
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
 
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch, 0).get()) {
             assertEquals(snapshotId, snapshot.snapshotId());
             snapshot.append(records);
             snapshot.freeze();
@@ -717,7 +717,7 @@ final public class KafkaRaftClientSnapshotTest {
 
         context.advanceLocalLeaderHighWatermarkToLogEndOffset();
 
-        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch).get()) {
+        try (SnapshotWriter<String> snapshot = context.client.createSnapshot(snapshotId.offset - 1, snapshotId.epoch, 0).get()) {
             assertEquals(snapshotId, snapshot.snapshotId());
             snapshot.append(records);
             snapshot.freeze();
@@ -1634,14 +1634,15 @@ final public class KafkaRaftClientSnapshotTest {
     }
 
     private static SnapshotWriter<String> snapshotWriter(RaftClientTestContext context, RawSnapshotWriter snapshot) {
-        return new SnapshotWriter<>(
-            snapshot,
+        return SnapshotWriter.createWithHeader(
+            () -> Optional.of(snapshot),
             4 * 1024,
             MemoryPool.NONE,
             context.time,
+            0,
             CompressionType.NONE,
             new StringSerde()
-        );
+        ).get();
     }
 
     private final static class MemorySnapshotWriter implements RawSnapshotWriter {


### PR DESCRIPTION
This PR implements part of the changes discussed in https://issues.apache.org/jira/browse/KAFKA-12952.

The following high level changes are made:
* Add a header record to the metadata snapshot
  * The header contains a Version and the append time
            for the last log in the snapshot
* Add a footer record to the metadata snapshot
  * The footer contains a Version
* Add a version to the leader change control message

[NOTE] Added a field lastContainedLogTimestamp to the SnapshotHeader

The field is currently defaulted to 0 in all callers.
KAFKA-12997 will add in the necessary wiring to use the correct timestamp
