### PR TITLE
KAFKA-12967; KRaft broker should forward DescribeQuorum to controller

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -96,7 +96,7 @@ public enum ApiKeys {
     VOTE(ApiMessageType.VOTE, true, RecordBatch.MAGIC_VALUE_V0, false),
     BEGIN_QUORUM_EPOCH(ApiMessageType.BEGIN_QUORUM_EPOCH, true, RecordBatch.MAGIC_VALUE_V0, false),
     END_QUORUM_EPOCH(ApiMessageType.END_QUORUM_EPOCH, true, RecordBatch.MAGIC_VALUE_V0, false),
-    DESCRIBE_QUORUM(ApiMessageType.DESCRIBE_QUORUM, true, RecordBatch.MAGIC_VALUE_V0, false),
+    DESCRIBE_QUORUM(ApiMessageType.DESCRIBE_QUORUM, true, RecordBatch.MAGIC_VALUE_V0, true),
     ALTER_ISR(ApiMessageType.ALTER_ISR, true),
     UPDATE_FEATURES(ApiMessageType.UPDATE_FEATURES, false, true),
     ENVELOPE(ApiMessageType.ENVELOPE, true, RecordBatch.MAGIC_VALUE_V0, false),

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -141,6 +141,16 @@ class KafkaApis(val requestChannel: RequestChannel,
     metadataSupport.maybeForward(request, handler, responseCallback)
   }
 
+  private def forwardToControllerOrFail(
+    request: RequestChannel.Request
+  ): Unit = {
+    def errorHandler(request: RequestChannel.Request): Unit = {
+      throw new IllegalStateException(s"Unable to forward $request to the controller")
+    }
+
+    maybeForwardToController(request, errorHandler)
+  }
+
   /**
    * Top-level method that handles all requests and multiplexes to the right api
    */
@@ -217,6 +227,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.DESCRIBE_TRANSACTIONS => handleDescribeTransactionsRequest(request)
         case ApiKeys.LIST_TRANSACTIONS => handleListTransactionsRequest(request)
         case ApiKeys.ALLOCATE_PRODUCER_IDS => maybeForwardToController(request, handleAllocateProducerIdsRequest)
+        case ApiKeys.DESCRIBE_QUORUM => forwardToControllerOrFail(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {

--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -86,7 +86,7 @@ public class ClusterTestExtensionsTest {
             @ClusterConfigProperty(key = "foo", value = "bar"),
             @ClusterConfigProperty(key = "spam", value = "eggs")
         }),
-        @ClusterTest(name = "cluster-tests-2", clusterType = Type.RAFT, serverProperties = {
+        @ClusterTest(name = "cluster-tests-2", clusterType = Type.KRAFT, serverProperties = {
             @ClusterConfigProperty(key = "foo", value = "baz"),
             @ClusterConfigProperty(key = "spam", value = "eggz")
         })

--- a/core/src/test/java/kafka/test/annotation/Type.java
+++ b/core/src/test/java/kafka/test/annotation/Type.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
  * The type of cluster config being requested. Used by {@link kafka.test.ClusterConfig} and the test annotations.
  */
 public enum Type {
-    RAFT {
+    KRAFT {
         @Override
         public void invocationContexts(ClusterConfig config, Consumer<TestTemplateInvocationContext> invocationConsumer) {
             invocationConsumer.accept(new RaftClusterInvocationContext(config.copyOf()));

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -45,7 +45,7 @@ class ProducerIdsIntegrationTest {
   @ClusterTests(Array(
     new ClusterTest(clusterType = Type.ZK, brokers = 3, ibp = "2.8"),
     new ClusterTest(clusterType = Type.ZK, brokers = 3, ibp = "3.0-IV0"),
-    new ClusterTest(clusterType = Type.RAFT, brokers = 3, ibp = "3.0-IV0")
+    new ClusterTest(clusterType = Type.KRAFT, brokers = 3, ibp = "3.0-IV0")
   ))
   def testUniqueProducerIds(clusterInstance: ClusterInstance): Unit = {
     verifyUniqueIds(clusterInstance)

--- a/core/src/test/scala/unit/kafka/server/DescribeQuorumRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeQuorumRequestTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import kafka.server.IntegrationTestUtils.connectAndReceive
+import kafka.test.ClusterInstance
+import kafka.test.annotation.{ClusterTest, ClusterTestDefaults, Type}
+import kafka.test.junit.ClusterTestExtensions
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.DescribeQuorumRequest.singletonRequest
+import org.apache.kafka.common.requests.{DescribeQuorumRequest, DescribeQuorumResponse}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.extension.ExtendWith
+
+import scala.jdk.CollectionConverters._
+
+@ExtendWith(value = Array(classOf[ClusterTestExtensions]))
+@ClusterTestDefaults(clusterType = Type.KRAFT)
+class DescribeQuorumRequestTest(cluster: ClusterInstance) {
+
+  @ClusterTest
+  def testDescribeQuorum(): Unit = {
+    val request = new DescribeQuorumRequest.Builder(
+      singletonRequest(KafkaRaftServer.MetadataPartition)
+    ).build()
+
+    val response = connectAndReceive[DescribeQuorumResponse](
+      request,
+      cluster.brokerSocketServers().asScala.head,
+      cluster.clientListener()
+    )
+
+    assertEquals(Errors.NONE, Errors.forCode(response.data.errorCode))
+    assertEquals(1, response.data.topics.size)
+
+    val topicData = response.data.topics.get(0)
+    assertEquals(KafkaRaftServer.MetadataTopic, topicData.topicName)
+    assertEquals(1, topicData.partitions.size)
+
+    val partitionData = topicData.partitions.get(0)
+    assertEquals(KafkaRaftServer.MetadataPartition.partition, partitionData.partitionIndex)
+    assertEquals(Errors.NONE, Errors.forCode(partitionData.errorCode))
+    assertTrue(partitionData.leaderEpoch > 0)
+
+    val leaderId = partitionData.leaderId
+    assertTrue(leaderId > 0)
+
+    val leaderState = partitionData.currentVoters.asScala.find(_.replicaId == leaderId)
+      .getOrElse(throw new AssertionError("Failed to find leader among current voter states"))
+    assertTrue(leaderState.logEndOffset > 0)
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -452,8 +452,7 @@ class KafkaApisTest {
 
     createKafkaApis(authorizer = Some(authorizer)).handleAlterConfigsRequest(request)
 
-    verifyAlterConfigResult(alterConfigsRequest,
-      capturedResponse, Map(authorizedTopic -> Errors.NONE,
+    verifyAlterConfigResult(capturedResponse, Map(authorizedTopic -> Errors.NONE,
         unauthorizedTopic -> Errors.TOPIC_AUTHORIZATION_FAILED))
 
     verify(authorizer, adminManager)
@@ -462,16 +461,55 @@ class KafkaApisTest {
   @Test
   def testAlterConfigsWithForwarding(): Unit = {
     val requestBuilder = new AlterConfigsRequest.Builder(Collections.emptyMap(), false)
-    testForwardableAPI(ApiKeys.ALTER_CONFIGS, requestBuilder)
+    testForwardableApi(ApiKeys.ALTER_CONFIGS, requestBuilder)
   }
 
-  private def testForwardableAPI(apiKey: ApiKeys, requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): Unit = {
+  @Test
+  def testDescribeQuorumNotAllowedForZkClusters(): Unit = {
+    val requestData = DescribeQuorumRequest.singletonRequest(KafkaRaftServer.MetadataPartition)
+    val requestBuilder = new DescribeQuorumRequest.Builder(requestData)
+    val request = buildRequest(requestBuilder.build())
+
+    val capturedResponse = expectNoThrottling(request)
+    EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, adminManager, controller)
+    createKafkaApis(enableForwarding = true).handle(request, RequestLocal.withThreadConfinedCaching)
+
+    val response = capturedResponse.getValue.asInstanceOf[DescribeQuorumResponse]
+    assertEquals(Errors.UNKNOWN_SERVER_ERROR, Errors.forCode(response.data.errorCode))
+  }
+
+  @Test
+  def testDescribeQuorumForwardedForKRaftClusters(): Unit = {
+    val requestData = DescribeQuorumRequest.singletonRequest(KafkaRaftServer.MetadataPartition)
+    val requestBuilder = new DescribeQuorumRequest.Builder(requestData)
+    metadataCache = MetadataCache.raftMetadataCache(brokerId)
+
+    testForwardableApi(
+      createKafkaApis(raftSupport = true),
+      ApiKeys.DESCRIBE_QUORUM,
+      requestBuilder
+    )
+  }
+
+  private def testForwardableApi(apiKey: ApiKeys, requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest]): Unit = {
+    testForwardableApi(
+      createKafkaApis(enableForwarding = true),
+      apiKey,
+      requestBuilder
+    )
+  }
+
+  private def testForwardableApi(
+    kafkaApis: KafkaApis,
+    apiKey: ApiKeys,
+    requestBuilder: AbstractRequest.Builder[_ <: AbstractRequest],
+  ): Unit = {
     val topicHeader = new RequestHeader(apiKey, apiKey.latestVersion,
       clientId, 0)
 
     val request = buildRequest(requestBuilder.build(topicHeader.apiVersion))
 
-    EasyMock.expect(controller.isActive).andReturn(false)
+    EasyMock.expect(controller.isActive).andStubReturn(false)
 
     expectNoThrottling(request)
 
@@ -482,7 +520,7 @@ class KafkaApisTest {
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel, controller, forwardingManager)
 
-    createKafkaApis(enableForwarding = true).handle(request, RequestLocal.withThreadConfinedCaching)
+    kafkaApis.handle(request, RequestLocal.withThreadConfinedCaching)
 
     EasyMock.verify(controller, forwardingManager)
   }
@@ -508,8 +546,7 @@ class KafkaApisTest {
       .once()
   }
 
-  private def verifyAlterConfigResult(alterConfigsRequest: AlterConfigsRequest,
-                                      capturedResponse: Capture[AbstractResponse],
+  private def verifyAlterConfigResult(capturedResponse: Capture[AbstractResponse],
                                       expectedResults: Map[String, Errors]): Unit = {
     val response = capturedResponse.getValue.asInstanceOf[AlterConfigsResponse]
     val responseMap = response.data.responses().asScala.map { resourceResponse =>
@@ -569,7 +606,7 @@ class KafkaApisTest {
   def testIncrementalAlterConfigsWithForwarding(): Unit = {
     val requestBuilder = new IncrementalAlterConfigsRequest.Builder(
       new IncrementalAlterConfigsRequestData())
-    testForwardableAPI(ApiKeys.INCREMENTAL_ALTER_CONFIGS, requestBuilder)
+    testForwardableApi(ApiKeys.INCREMENTAL_ALTER_CONFIGS, requestBuilder)
   }
 
   private def getIncrementalAlterConfigRequestBuilder(configResources: Seq[ConfigResource]): IncrementalAlterConfigsRequest.Builder = {
@@ -624,7 +661,7 @@ class KafkaApisTest {
   @Test
   def testAlterClientQuotasWithForwarding(): Unit = {
     val requestBuilder = new AlterClientQuotasRequest.Builder(List.empty.asJava, false)
-    testForwardableAPI(ApiKeys.ALTER_CLIENT_QUOTAS, requestBuilder)
+    testForwardableApi(ApiKeys.ALTER_CLIENT_QUOTAS, requestBuilder)
   }
 
   private def verifyAlterClientQuotaResult(capturedResponse: Capture[AbstractResponse],
@@ -715,7 +752,7 @@ class KafkaApisTest {
         new CreatableTopicCollection(Collections.singleton(
           new CreatableTopic().setName("topic").setNumPartitions(1).
             setReplicationFactor(1.toShort)).iterator())))
-    testForwardableAPI(ApiKeys.CREATE_TOPICS, requestBuilder)
+    testForwardableApi(ApiKeys.CREATE_TOPICS, requestBuilder)
   }
 
   private def createTopicAuthorization(authorizer: Authorizer,
@@ -771,61 +808,61 @@ class KafkaApisTest {
   @Test
   def testCreateAclWithForwarding(): Unit = {
     val requestBuilder = new CreateAclsRequest.Builder(new CreateAclsRequestData())
-    testForwardableAPI(ApiKeys.CREATE_ACLS, requestBuilder)
+    testForwardableApi(ApiKeys.CREATE_ACLS, requestBuilder)
   }
 
   @Test
   def testDeleteAclWithForwarding(): Unit = {
     val requestBuilder = new DeleteAclsRequest.Builder(new DeleteAclsRequestData())
-    testForwardableAPI(ApiKeys.DELETE_ACLS, requestBuilder)
+    testForwardableApi(ApiKeys.DELETE_ACLS, requestBuilder)
   }
 
   @Test
   def testCreateDelegationTokenWithForwarding(): Unit = {
     val requestBuilder = new CreateDelegationTokenRequest.Builder(new CreateDelegationTokenRequestData())
-    testForwardableAPI(ApiKeys.CREATE_DELEGATION_TOKEN, requestBuilder)
+    testForwardableApi(ApiKeys.CREATE_DELEGATION_TOKEN, requestBuilder)
   }
 
   @Test
   def testRenewDelegationTokenWithForwarding(): Unit = {
     val requestBuilder = new RenewDelegationTokenRequest.Builder(new RenewDelegationTokenRequestData())
-    testForwardableAPI(ApiKeys.RENEW_DELEGATION_TOKEN, requestBuilder)
+    testForwardableApi(ApiKeys.RENEW_DELEGATION_TOKEN, requestBuilder)
   }
 
   @Test
   def testExpireDelegationTokenWithForwarding(): Unit = {
     val requestBuilder = new ExpireDelegationTokenRequest.Builder(new ExpireDelegationTokenRequestData())
-    testForwardableAPI(ApiKeys.EXPIRE_DELEGATION_TOKEN, requestBuilder)
+    testForwardableApi(ApiKeys.EXPIRE_DELEGATION_TOKEN, requestBuilder)
   }
 
   @Test
   def testAlterPartitionReassignmentsWithForwarding(): Unit = {
     val requestBuilder = new AlterPartitionReassignmentsRequest.Builder(new AlterPartitionReassignmentsRequestData())
-    testForwardableAPI(ApiKeys.ALTER_PARTITION_REASSIGNMENTS, requestBuilder)
+    testForwardableApi(ApiKeys.ALTER_PARTITION_REASSIGNMENTS, requestBuilder)
   }
 
   @Test
   def testCreatePartitionsWithForwarding(): Unit = {
     val requestBuilder = new CreatePartitionsRequest.Builder(new CreatePartitionsRequestData())
-    testForwardableAPI(ApiKeys.CREATE_PARTITIONS, requestBuilder)
+    testForwardableApi(ApiKeys.CREATE_PARTITIONS, requestBuilder)
   }
 
   @Test
   def testDeleteTopicsWithForwarding(): Unit = {
     val requestBuilder = new DeleteTopicsRequest.Builder(new DeleteTopicsRequestData())
-    testForwardableAPI(ApiKeys.DELETE_TOPICS, requestBuilder)
+    testForwardableApi(ApiKeys.DELETE_TOPICS, requestBuilder)
   }
 
   @Test
   def testUpdateFeaturesWithForwarding(): Unit = {
     val requestBuilder = new UpdateFeaturesRequest.Builder(new UpdateFeaturesRequestData())
-    testForwardableAPI(ApiKeys.UPDATE_FEATURES, requestBuilder)
+    testForwardableApi(ApiKeys.UPDATE_FEATURES, requestBuilder)
   }
 
   @Test
   def testAlterScramWithForwarding(): Unit = {
     val requestBuilder = new AlterUserScramCredentialsRequest.Builder(new AlterUserScramCredentialsRequestData())
-    testForwardableAPI(ApiKeys.ALTER_USER_SCRAM_CREDENTIALS, requestBuilder)
+    testForwardableApi(ApiKeys.ALTER_USER_SCRAM_CREDENTIALS, requestBuilder)
   }
 
   @Test


### PR DESCRIPTION
We added the DescribeQuorum API in KIP-595. This patch adds the logic to forward DescribeQuorum requests to the controller when KRaft is enabled.

Note that the KRaft broker listener has already been enabled in DescribeQuorumRequest.json. The zk broker is not enabled, however, so DescribeQuorum requests will not be advertised and will be rejected at the network layer.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
