### PR TITLE
KAFKA-12837: Process entire batch reader in the commit handler

### DIFF
--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -101,7 +101,9 @@ class BrokerMetadataListener(
   ) extends EventQueue.FailureLoggingEvent(log) {
     override def run(): Unit = {
       try {
-        apply(reader.next())
+        while (reader.hasNext()) {
+          apply(reader.next())
+        }
       } finally {
         reader.close()
       }

--- a/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
+++ b/metadata/src/test/java/org/apache/kafka/metalog/LocalLogManager.java
@@ -406,7 +406,7 @@ public final class LocalLogManager implements RaftClient<ApiMessageAndVersion>, 
                             log.trace("Node {}: handling LocalRecordBatch with offset {}.",
                                 nodeId, entryOffset);
                             listenerData.listener.handleCommit(
-                                new MemoryBatchReader<>(
+                                MemoryBatchReader.of(
                                     Collections.singletonList(
                                         Batch.of(
                                             entryOffset - batch.records.size() + 1,

--- a/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
+++ b/raft/src/main/java/org/apache/kafka/raft/KafkaRaftClient.java
@@ -2410,7 +2410,7 @@ public class KafkaRaftClient<T> implements RaftClient<T> {
          */
         public void fireHandleCommit(long baseOffset, int epoch, List<T> records) {
             Batch<T> batch = Batch.of(baseOffset, epoch, records);
-            MemoryBatchReader<T> reader = new MemoryBatchReader<>(Collections.singletonList(batch), this);
+            MemoryBatchReader<T> reader = MemoryBatchReader.of(Collections.singletonList(batch), this);
             fireHandleCommit(reader);
         }
 

--- a/raft/src/test/java/org/apache/kafka/raft/internals/MemoryBatchReaderTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/internals/MemoryBatchReaderTest.java
@@ -44,7 +44,7 @@ class MemoryBatchReaderTest {
 
         @SuppressWarnings("unchecked")
         CloseListener<BatchReader<String>> listener = Mockito.mock(CloseListener.class);
-        MemoryBatchReader<String> reader = new MemoryBatchReader<>(
+        MemoryBatchReader<String> reader = MemoryBatchReader.of(
             Arrays.asList(batch1, batch2, batch3),
             listener
         );

--- a/shell/src/main/java/org/apache/kafka/shell/SnapshotFileReader.java
+++ b/shell/src/main/java/org/apache/kafka/shell/SnapshotFileReader.java
@@ -153,7 +153,7 @@ public final class SnapshotFileReader implements AutoCloseable {
             }
         }
         listener.handleCommit(
-            new MemoryBatchReader<>(
+            MemoryBatchReader.of(
                 Collections.singletonList(
                     Batch.of(
                         batch.baseOffset(),


### PR DESCRIPTION
Process entire batch and make sure that `hasNext` is called before calling `next` on the iterator.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
