### PR TITLE
KAFKA-13060: Replace EasyMock and PowerMock with Mockito in WorkerGroupMemberTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2365,6 +2365,8 @@ project(':connect:runtime') {
     testImplementation libs.powermockJunit4
     testImplementation libs.powermockEasymock
     testImplementation libs.mockitoCore
+    testImplementation libs.mockitoInline // supports mocking static methods, final classes, etc.
+    testImplementation libs.mockitoJunitJupiter // supports MockitoExtension
     testImplementation libs.httpclient
 
     testRuntimeOnly libs.slf4jlog4j

--- a/build.gradle
+++ b/build.gradle
@@ -368,7 +368,7 @@ subprojects {
       "**/ConnectorsResourceTest.*", "**/DistributedHerderTest.*", "**/FileOffsetBakingStoreTest.*",
       "**/ErrorHandlingTaskTest.*", "**/KafkaConfigBackingStoreTest.*", "**/KafkaOffsetBackingStoreTest.*",
       "**/KafkaBasedLogTest.*", "**/OffsetStorageWriterTest.*", "**/StandaloneHerderTest.*",
-      "**/SourceTaskOffsetCommitterTest.*", "**/WorkerConfigTransformerTest.*", "**/WorkerGroupMemberTest.*",
+      "**/SourceTaskOffsetCommitterTest.*", "**/WorkerConfigTransformerTest.*",
       "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*", "**/WorkerSourceTaskTest.*",
       "**/WorkerTaskTest.*", "**/WorkerTest.*", "**/RestServerTest.*",
       // streams tests


### PR DESCRIPTION
Replace EasyMock and PowerMock with Mockito in WorkerGroupMemberTest
https://issues.apache.org/jira/browse/KAFKA-13060

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
