### PR TITLE
MINOR: fix round_trip_fault_test.py - don't assign replicas to nonexi…

### DIFF
--- a/tests/kafkatest/tests/core/round_trip_fault_test.py
+++ b/tests/kafkatest/tests/core/round_trip_fault_test.py
@@ -46,7 +46,8 @@ class RoundTripFaultTest(Test):
                                       client_services=trogdor_client_services)
         topic_name = "round_trip_topic%d" % RoundTripFaultTest.topic_name_index
         RoundTripFaultTest.topic_name_index = RoundTripFaultTest.topic_name_index + 1
-        active_topics={topic_name : {"partitionAssignments":{"0": [0,1,2]}}}
+        # note that the broker.id values will be 1..num_nodes
+        active_topics={topic_name : {"partitionAssignments":{"0": [1,2,3]}}}
         self.round_trip_spec = RoundTripWorkloadSpec(0, TaskSpec.MAX_DURATION_MS,
                                      self.workload_service.client_node,
                                      self.workload_service.bootstrap_servers,


### PR DESCRIPTION
The broker id starts with 1 (https://github.com/apache/kafka/blob/trunk/tests/kafkatest/services/kafka/kafka.py#L207) so `round_trip_fault_test.py` fails because it assigns replica to nonexistent broker.

The interesting story is the failure happens only on KRaft only. KRaft mode checks the existent ids (https://github.com/apache/kafka/blob/trunk/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java#L950). By contrast, ZK mode has no such check and the `min.insync.replicas` is set to `1` so this test works with ZK mode even though there is one replica is always off-line.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
