### PR TITLE
KAFKA-12938: fix and reenable testChrootExistsAndRootIsLocked test

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -152,10 +152,11 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     // root is read-only
     zkClient.setAcl(root, ZooDefs.Ids.READ_ACL_UNSAFE.asScala)
 
-    // we should not be able to create under chroot folder
+    // we should not be able to create node under chroot folder
     assertThrows(classOf[NoAuthException], () => zkClient.makeSurePersistentPathExists(chroot))
 
-    // this client won't create permission to the root and chroot, but the chroot already exists
+    // this client doesn't have create permission to the root and chroot, but the chroot already exists
+    // Expect that no exception thrown
     val chrootClient = KafkaZkClient(zkConnect + chroot, zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled), zkSessionTimeout,
       zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM, createChrootIfNecessary = true)
     chrootClient.close()

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -155,15 +155,19 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     val id = "test"
     val pwd = "12345"
     val digest = DigestAuthenticationProvider.generateDigest(s"$id:$pwd")
-    val authInfo = s"$id:$pwd".getBytes()
+//    val authInfo = s"$id:$pwd".getBytes()
+    val acl = new ACL(ZooDefs.Perms.ALL, new Id(scheme, digest))
 
-    zkClient.currentZooKeeper.addAuthInfo(scheme, authInfo)
-    zkClient.setAcl(root, Seq(new ACL(ZooDefs.Perms.ALL, new Id(scheme, digest))))
+//    zkClient.currentZooKeeper.addAuthInfo(scheme, authInfo)
+    zkClient.setAcl(root, Seq(acl))
 
     // this client won't have access to the root, but the chroot already exists
     val chrootClient = KafkaZkClient(zkConnect + chroot, zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled), zkSessionTimeout,
       zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM, createChrootIfNecessary = true)
     chrootClient.close()
+
+    zkClient.setAcl(root, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala)
+    zkClient.deletePath(root)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -155,7 +155,7 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     // we should not be able to create under chroot folder
     assertThrows(classOf[NoAuthException], () => zkClient.makeSurePersistentPathExists(chroot))
 
-    // this client won't have access to the root, but the chroot already exists
+    // this client won't create permission to the root and chroot, but the chroot already exists
     val chrootClient = KafkaZkClient(zkConnect + chroot, zkAclsEnabled.getOrElse(JaasUtils.isZkSaslEnabled), zkSessionTimeout,
       zkConnectionTimeout, zkMaxInFlightRequests, Time.SYSTEM, createChrootIfNecessary = true)
     chrootClient.close()

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -147,6 +147,7 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     // chroot is accessible
     val root = "/testChrootExistsAndRootIsLocked"
     val chroot = s"$root/chroot"
+
     zkClient.makeSurePersistentPathExists(chroot)
     zkClient.setAcl(chroot, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala)
 
@@ -155,10 +156,10 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     val id = "test"
     val pwd = "12345"
     val digest = DigestAuthenticationProvider.generateDigest(s"$id:$pwd")
-//    val authInfo = s"$id:$pwd".getBytes()
+    val authInfo = s"$id:$pwd".getBytes()
     val acl = new ACL(ZooDefs.Perms.ALL, new Id(scheme, digest))
 
-//    zkClient.currentZooKeeper.addAuthInfo(scheme, authInfo)
+    zkClient.currentZooKeeper.addAuthInfo(scheme, authInfo)
     zkClient.setAcl(root, Seq(acl))
 
     // this client won't have access to the root, but the chroot already exists
@@ -167,6 +168,7 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     chrootClient.close()
 
     zkClient.setAcl(root, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala)
+    zkClient.deletePath(chroot)
     zkClient.deletePath(root)
   }
 


### PR DESCRIPTION
I've tried many solutions and found the addAuthInfo and set Acl to a new digest ID would fail the build, somehow. So, I changed the test method, to use the acl `ZooDefs.Ids.READ_ACL_UNSAFE` to simulate the root is locked case. Because root is read-only, so the chroot can't have permission to create node. This test can test what the original issue/fix in KAFKA-12866. 

The latest 5 builds are all in yellow light, which is after I changed the solution to use `ZooDefs.Ids.READ_ACL_UNSAFE` to simulate it.
![image](https://user-images.githubusercontent.com/43372967/123353600-703f3a00-d594-11eb-9305-599b294a1b37.png)


The failed tests are unrelated.
```
    Build / JDK 15 and Scala 2.13 / kafka.server.RaftClusterTest.testCreateClusterAndCreateAndManyTopics()
    Build / JDK 15 and Scala 2.13 / kafka.server.RaftClusterTest.testCreateClusterAndCreateListDeleteTopic()
    Build / JDK 8 and Scala 2.12 / kafka.server.RaftClusterTest.testCreateClusterAndCreateAndManyTopicsWithManyPartitions()
    Build / JDK 8 and Scala 2.12 / org.apache.kafka.common.network.SslTransportLayerTest.[1] tlsProtocol=TLSv1.2, useInlinePem=false
    Build / JDK 8 and Scala 2.12 / org.apache.kafka.common.network.SslTransportLayerTest.[2] tlsProtocol=TLSv1.2, useInlinePem=true
    Build / JDK 8 and Scala 2.12 / org.apache.kafka.common.network.SslTransportLayerTest.[1] tlsProtocol=TLSv1.2, useInlinePem=false
    Build / JDK 8 and Scala 2.12 / org.apache.kafka.common.network.SslTransportLayerTest.[2] tlsProtocol=TLSv1.2, useInlinePem=true
    Build / JDK 11 and Scala 2.13 / org.apache.kafka.common.network.SslTransportLayerTest.[1] tlsProtocol=TLSv1.2, useInlinePem=false
    Build / JDK 11 and Scala 2.13 / org.apache.kafka.common.network.SslTransportLayerTest.[2] tlsProtocol=TLSv1.2, useInlinePem=true
    Build / JDK 11 and Scala 2.13 / org.apache.kafka.common.network.SslTransportLayerTest.[3] tlsProtocol=TLSv1.3, useInlinePem=false
    Build / JDK 11 and Scala 2.13 / org.apache.kafka.common.network.SslTransportLayerTest.[1] tlsProtocol=TLSv1.2, useInlinePem=false
    Build / JDK 11 and Scala 2.13 / org.apache.kafka.common.network.SslTransportLayerTest.[2] tlsProtocol=TLSv1.2, useInlinePem=true
    Build / JDK 11 and Scala 2.13 / org.apache.kafka.common.network.SslTransportLayerTest.[3] tlsProtocol=TLSv1.3, useInlinePem=false
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
