### PR TITLE
KAFKA-10847: improve throughput of stream-stream join with spurious left/outer join fix

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -938,6 +938,9 @@ public class StreamsConfig extends AbstractConfig {
         // Private API used to disable the fix on left/outer joins (https://issues.apache.org/jira/browse/KAFKA-10847)
         public static final String ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "__enable.kstreams.outer.join.spurious.results.fix__";
 
+        // Private API used to control the emit latency for left/outer join results (https://issues.apache.org/jira/browse/KAFKA-10847)
+        public static final String EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "emit.interval.ms.kstreams.outer.join.spurious.results.fix__";
+
         public static boolean getBoolean(final Map<String, Object> configs, final String key, final boolean defaultValue) {
             final Object value = configs.getOrDefault(key, defaultValue);
             if (value instanceof Boolean) {

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -952,6 +952,18 @@ public class StreamsConfig extends AbstractConfig {
                 return defaultValue;
             }
         }
+
+        public static long getLong(final Map<String, Object> configs, final String key, final long defaultValue) {
+            final Object value = configs.getOrDefault(key, defaultValue);
+            if (value instanceof Number) {
+                return ((Number) value).longValue();
+            } else if (value instanceof String) {
+                return Long.parseLong((String) value);
+            } else {
+                log.warn("Invalid value (" + value + ") on internal configuration '" + key + "'. Please specify a numeric value.");
+                return defaultValue;
+            }
+        }
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -939,7 +939,7 @@ public class StreamsConfig extends AbstractConfig {
         public static final String ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "__enable.kstreams.outer.join.spurious.results.fix__";
 
         // Private API used to control the emit latency for left/outer join results (https://issues.apache.org/jira/browse/KAFKA-10847)
-        public static final String EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "emit.interval.ms.kstreams.outer.join.spurious.results.fix__";
+        public static final String EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX = "__emit.interval.ms.kstreams.outer.join.spurious.results.fix__";
 
         public static boolean getBoolean(final Map<String, Object> configs, final String key, final boolean defaultValue) {
             final Object value = configs.getOrDefault(key, defaultValue);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -69,6 +69,10 @@ class KStreamImplJoin {
         }
     }
 
+    static class MinTime {
+        long minTime = Long.MAX_VALUE;
+    }
+
     KStreamImplJoin(final InternalStreamsBuilder builder,
                     final boolean leftOuter,
                     final boolean rightOuter) {
@@ -149,6 +153,7 @@ class KStreamImplJoin {
 
         // Time shared between joins to keep track of the maximum stream time
         final MaxObservedStreamTime maxObservedStreamTime = new MaxObservedStreamTime();
+        final MinTime minTime = new MinTime();
 
         final JoinWindowsInternal internalWindows = new JoinWindowsInternal(windows);
         final KStreamKStreamJoin<K1, R, V1, V2> joinThis = new KStreamKStreamJoin<>(
@@ -158,7 +163,8 @@ class KStreamImplJoin {
             joiner,
             leftOuter,
             outerJoinWindowStore.map(StoreBuilder::name),
-            maxObservedStreamTime
+            maxObservedStreamTime,
+            minTime
         );
 
         final KStreamKStreamJoin<K1, R, V2, V1> joinOther = new KStreamKStreamJoin<>(
@@ -168,7 +174,8 @@ class KStreamImplJoin {
             AbstractStream.reverseJoinerWithKey(joiner),
             rightOuter,
             outerJoinWindowStore.map(StoreBuilder::name),
-            maxObservedStreamTime
+            maxObservedStreamTime,
+            minTime
         );
 
         final PassThrough<K1, R> joinMerge = new PassThrough<>();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -61,7 +61,7 @@ class KStreamImplJoin {
         private long emitIntervalMs = 50L;
         long streamTime = ConsumerRecord.NO_TIMESTAMP;
         long minTime = Long.MAX_VALUE;
-        long nextTimeToEmit = Long.MAX_VALUE;
+        long nextTimeToEmit;
 
         public void setEmitInterval(final long emitIntervalMs) {
             this.emitIntervalMs = emitIntervalMs;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImplJoin.java
@@ -58,8 +58,14 @@ class KStreamImplJoin {
     private final boolean rightOuter;
 
     static class TimeTracker {
+        private long emitIntervalMs = 50L;
         long streamTime = ConsumerRecord.NO_TIMESTAMP;
         long minTime = Long.MAX_VALUE;
+        long nextTimeToEmit = Long.MAX_VALUE;
+
+        public void setEmitInterval(final long emitIntervalMs) {
+            this.emitIntervalMs = emitIntervalMs;
+        }
 
         public void advanceStreamTime(final long recordTimestamp) {
             streamTime = Math.max(recordTimestamp, streamTime);
@@ -67,6 +73,10 @@ class KStreamImplJoin {
 
         public void updatedMinTime(final long recordTimestamp) {
             minTime = Math.min(recordTimestamp, minTime);
+        }
+
+        public void advanceNextTimeToEmit() {
+            nextTimeToEmit += emitIntervalMs;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.KStreamImplJoin.TimeTracker;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -109,7 +109,7 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                     StreamsConfig.InternalConfig.getLong(
                         context.appConfigs(),
                         EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
-                        100L
+                        1000L
                     )
                 );
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoin.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
+import static org.apache.kafka.streams.StreamsConfig.InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX;
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.ENABLE_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX;
 import static org.apache.kafka.streams.processor.internals.metrics.TaskMetrics.droppedRecordsSensor;
 
@@ -105,13 +106,13 @@ class KStreamKStreamJoin<K, R, V1, V2> implements org.apache.kafka.streams.proce
                 outerJoinWindowStore = outerJoinWindowName.map(context::getStateStore);
                 sharedTimeTracker.nextTimeToEmit = context.currentSystemTimeMs();
 
-                final Object emitIntervalConfig = context.appConfigs()
-                    .get(InternalConfig.EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX);
-                if (emitIntervalConfig instanceof Number) {
-                    sharedTimeTracker.setEmitInterval(((Number) emitIntervalConfig).longValue());
-                } else if (emitIntervalConfig instanceof String) {
-                    sharedTimeTracker.setEmitInterval(Long.parseLong((String) emitIntervalConfig));
-                }
+                sharedTimeTracker.setEmitInterval(
+                    StreamsConfig.InternalConfig.getLong(
+                        context.appConfigs(),
+                        EMIT_INTERVAL_MS_KSTREAMS_OUTER_JOIN_SPURIOUS_RESULTS_FIX,
+                        100L
+                    )
+                );
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -664,25 +664,23 @@ public class KStreamKStreamLeftJoinTest {
             // push two items to the primary stream; the other window is empty; this should not produce any item yet
             // w1 = {}
             // w2 = {}
-            // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100), 1:A2 (ts: 200) }
+            // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100) }
             // --> w2 = {}
             inputTopic1.pipeInput(0, "A0", 0L);
-            inputTopic1.pipeInput(1, "A1", 101L);
-            inputTopic1.pipeInput(1, "A2", 200L);
+            inputTopic1.pipeInput(1, "A1", 100L);
             processor.checkAndClearProcessResult();
 
             // push one item to the other window that has a join; this should produce non-joined records with a closed window first, then
             // the joined records
             // by the time they were produced before
-            // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100), 1:A2 (ts: 200) }
+            // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100) }
             // w2 = { }
-            // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100), 1:A2 (ts: 200) }
-            // --> w2 = { 1:a1 (ts: 200) }
-            inputTopic2.pipeInput(1, "a1", 201L);
+            // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100) }
+            // --> w2 = { 1:a1 (ts: 110) }
+            inputTopic2.pipeInput(1, "a1", 110L);
             processor.checkAndClearProcessResult(
                 new KeyValueTimestamp<>(0, "A0+null", 0L),
-                new KeyValueTimestamp<>(1, "A1+a1", 201L),
-                new KeyValueTimestamp<>(1, "A2+a1", 201L)
+                new KeyValueTimestamp<>(1, "A1+a1", 110L)
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -465,25 +465,23 @@ public class KStreamKStreamOuterJoinTest {
             // push two items to the primary stream; the other window is empty; this should not produce any item yet
             // w1 = {}
             // w2 = {}
-            // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 101), 1:A2 (ts: 200) }
+            // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100) }
             // --> w2 = {}
             inputTopic1.pipeInput(0, "A0", 0L);
-            inputTopic1.pipeInput(1, "A1", 101L);
-            inputTopic1.pipeInput(1, "A2", 200L);
+            inputTopic1.pipeInput(1, "A1", 100L);
             processor.checkAndClearProcessResult();
 
             // push one item to the other window that has a join; this should produce non-joined records with a closed window first, then
             // the joined records
             // by the time they were produced before
-            // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 101), 1:A2 (ts: 200) }
+            // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 100) }
             // w2 = { }
             // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0) }
-            // --> w2 = { 0:a0 (ts: 201) }
-            inputTopic2.pipeInput(1, "a1", 201L);
+            // --> w2 = { 0:a0 (ts: 110) }
+            inputTopic2.pipeInput(1, "a1", 110L);
             processor.checkAndClearProcessResult(
                 new KeyValueTimestamp<>(0, "A0+null", 0L),
-                new KeyValueTimestamp<>(1, "A1+a1", 201L),
-                new KeyValueTimestamp<>(1, "A2+a1", 201L)
+                new KeyValueTimestamp<>(1, "A1+a1", 110L)
             );
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamOuterJoinTest.java
@@ -475,7 +475,7 @@ public class KStreamKStreamOuterJoinTest {
             // push one item to the other window that has a join; this should produce non-joined records with a closed window first, then
             // the joined records
             // by the time they were produced before
-            // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 101), 1:A2 (ts: (200: }
+            // w1 = { 0:A0 (ts: 0), 1:A1 (ts: 101), 1:A2 (ts: 200) }
             // w2 = { }
             // --> w1 = { 0:A0 (ts: 0), 1:A1 (ts: 0) }
             // --> w2 = { 0:a0 (ts: 201) }


### PR DESCRIPTION
The fix to avoid spurious left/outer stream-stream join results, showed
very low throughput for RocksDB, due to excessive creation of iterators.
Instead of trying to emit left/outer stream-stream join result for every
input record, this PR adds tracking of the lower timestamp bound of
left/outer join candidates, and only tries to emit them (and create an
iterator) if they are potentially old enough.

In our benchmarks, we use a 1-sec join window for inner/left/outer join. Inner join is always stable at 20K rec/sec using RocksDB and 35K rec/sec using in-memory store. Without this fix, throughput for left/outer join with RocksDB drops to 500 rec/sec. Inner join, and in-memory store are not affected. With this fix, we get left/outer join with RocksDB back up to 12K rec/sec.

Call for review @guozhangwang @spena @vcrfxia