### PR TITLE
KAFKA-12985: CVE-2021-28169 - Upgrade jetty to 9.4.42

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ versions += [
   jackson: "2.12.3",
   jacoco: "0.8.7",
   javassist: "3.27.0-GA",
-  jetty: "9.4.39.v20210325",
+  jetty: "9.4.42.v20210604",
   jersey: "2.34",
   jline: "3.12.1",
   jmh: "1.32",


### PR DESCRIPTION
[Jetty 9.4.41.v20210516](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.41.v20210516) resolves following security vulnerabilities.

- [CVE-2021-28169](https://nvd.nist.gov/vuln/detail/CVE-2021-28169) (described in the issue)
- [CVE-2021-34428](https://nvd.nist.gov/vuln/detail/CVE-2021-34428)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
