### PR TITLE
KAFKA-12790: Remove SslTransportLayerTest.testUnsupportedTlsVersion

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -646,7 +646,8 @@ public class SslTransportLayerTest {
             checkAuthenticationFailed(args, "0", "TLSv1");
             server.verifyAuthenticationMetrics(0, 2);
         } finally {
-            Security.setProperty("jdk.tls.disabledAlgorithms", disabledAlgorithms);
+            if (disabledAlgorithms != null)
+                Security.setProperty("jdk.tls.disabledAlgorithms", disabledAlgorithms);
         }
     }
 


### PR DESCRIPTION
Support for TLS 1.0/1.1 was disabled in recent versions of Java 8/11
and all versions of 16 causing this test to fail.

It is possible to make it work by updating the relevant security property,
but it has to be done before the affected classes are loaded and it can
not be disabled after that. Given the low value of the test, we remove
it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
