### PR TITLE
KAFKA-12976: Remove UNSUPPORTED_VERSION error from delete topics call

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1899,10 +1899,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         results.asScala.filter(result => result.name() != null))(_.name)
       results.forEach { topic =>
         val unresolvedTopicId = topic.topicId() != Uuid.ZERO_UUID && topic.name() == null
-        if (!config.usesTopicId && topicIdsFromRequest.contains(topic.topicId)) {
-          topic.setErrorCode(Errors.UNSUPPORTED_VERSION.code)
-          topic.setErrorMessage("Topic IDs are not supported on the server.")
-        } else if (unresolvedTopicId) {
+        if (unresolvedTopicId) {
           topic.setErrorCode(Errors.UNKNOWN_TOPIC_ID.code)
         } else if (topicIdsFromRequest.contains(topic.topicId) && !authorizedDescribeTopics.contains(topic.name)) {
 

--- a/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
@@ -94,7 +94,8 @@ class TopicIdWithOldInterBrokerProtocolTest extends BaseRequestTest {
         )).setTimeoutMs(timeout)).build()
     val response = sendDeleteTopicsRequest(request)
     val error = response.errorCounts.asScala
-    assertEquals(2, error(Errors.UNSUPPORTED_VERSION))
+    // Previous versions of the code returned UNSUPPORTED_VERSION
+    assertEquals(2, error(Errors.UNKNOWN_TOPIC_ID))
   }
 
   private def sendMetadataRequest(request: MetadataRequest, destination: Option[SocketServer]): MetadataResponse = {

--- a/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
+++ b/core/src/test/scala/unit/kafka/server/TopicIdWithOldInterBrokerProtocolTest.scala
@@ -94,7 +94,6 @@ class TopicIdWithOldInterBrokerProtocolTest extends BaseRequestTest {
         )).setTimeoutMs(timeout)).build()
     val response = sendDeleteTopicsRequest(request)
     val error = response.errorCounts.asScala
-    // Previous versions of the code returned UNSUPPORTED_VERSION
     assertEquals(2, error(Errors.UNKNOWN_TOPIC_ID))
   }
 


### PR DESCRIPTION
Removed the condition to throw the error. Now we only throw when we didn't find the topic ID. 
Updated the test for IBP < 2.8 that tries to delete topics using ID.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
