### PR TITLE
KAFKA-12958: add an invariant that notified leaders are never asked to load snapshot

### DIFF
--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
@@ -160,7 +160,7 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
     public synchronized void handleLeaderChange(LeaderAndEpoch newLeader) {
         if (newLeader.isLeader(nodeId)) {
             log.debug("Counter uncommitted value initialized to {} after claiming leadership in epoch {}",
-                    committed, newLeader);
+                committed, newLeader);
             uncommitted = committed;
             claimedEpoch = OptionalInt.of(newLeader.epoch());
         } else {
@@ -171,6 +171,7 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
         handleSnapshotCalls = 0;
     }
 
+    /** Use handleSnapshotCalls to verify leader is never asked to load snapshot */
     public int handleSnapshotCalls() {
         return handleSnapshotCalls;
     }

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
@@ -171,7 +171,7 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
         handleSnapshotCalls = 0;
     }
 
-    public int getHandleSnapshotCalls() {
+    public int handleSnapshotCalls() {
         return handleSnapshotCalls;
     }
 }

--- a/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
+++ b/raft/src/main/java/org/apache/kafka/raft/ReplicatedCounter.java
@@ -39,7 +39,6 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
     private long lastOffsetSnapshotted = -1;
 
     private int handleSnapshotCalls = 0;
-    private boolean handleSnapshotCalled = false;
 
     public ReplicatedCounter(
         int nodeId,
@@ -150,7 +149,6 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
                 }
             }
             lastOffsetSnapshotted = reader.lastContainedLogOffset();
-            handleSnapshotCalled = true;
             handleSnapshotCalls += 1;
             log.debug("Finished loading snapshot. Set value: {}", committed);
         } finally {
@@ -170,19 +168,10 @@ public class ReplicatedCounter implements RaftClient.Listener<Integer> {
             uncommitted = -1;
             claimedEpoch = OptionalInt.empty();
         }
-        handleSnapshotCalled = false;
         handleSnapshotCalls = 0;
-    }
-
-    public boolean isLeader() {
-        return this.client.leaderAndEpoch().isLeader(nodeId);
     }
 
     public int getHandleSnapshotCalls() {
         return handleSnapshotCalls;
-    }
-
-    public boolean isHandleSnapshotCalled() {
-        return handleSnapshotCalled;
     }
 }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -1026,9 +1026,9 @@ public class RaftEventSimulationTest {
         public void verify() {
             for (RaftNode raftNode : cluster.running()) {
                 if (raftNode.counter.isWritable()) {
-                    assertTrue(raftNode.counter.getHandleSnapshotCalls() == 0);
+                    assertEquals(0, raftNode.counter.handleSnapshotCalls());
                 } else {
-                    assertTrue(raftNode.counter.getHandleSnapshotCalls() >= 0);
+                    assertTrue(raftNode.counter.handleSnapshotCalls() >= 0);
                 }
 
             }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -1027,10 +1027,7 @@ public class RaftEventSimulationTest {
             for (RaftNode raftNode : cluster.running()) {
                 if (raftNode.counter.isWritable()) {
                     assertEquals(0, raftNode.counter.handleSnapshotCalls());
-                } else {
-                    assertTrue(raftNode.counter.handleSnapshotCalls() >= 0);
                 }
-
             }
         }
     }

--- a/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
+++ b/raft/src/test/java/org/apache/kafka/raft/RaftEventSimulationTest.java
@@ -1017,8 +1017,6 @@ public class RaftEventSimulationTest {
 
     private static class LeaderNeverLoadSnapshot implements Invariant {
         final Cluster cluster;
-        int epoch = 0;
-        OptionalInt leaderId = OptionalInt.empty();
 
         private LeaderNeverLoadSnapshot(Cluster cluster) {
             this.cluster = cluster;
@@ -1027,15 +1025,10 @@ public class RaftEventSimulationTest {
         @Override
         public void verify() {
             for (RaftNode raftNode : cluster.running()) {
-                if (raftNode.counter.isLeader()) {
-                    assertFalse(raftNode.counter.isHandleSnapshotCalled());
+                if (raftNode.counter.isWritable()) {
                     assertTrue(raftNode.counter.getHandleSnapshotCalls() == 0);
                 } else {
-                    if (raftNode.counter.isHandleSnapshotCalled()) {
-                        assertTrue(raftNode.counter.getHandleSnapshotCalls() > 0);
-                    } else {
-                        assertTrue(raftNode.counter.getHandleSnapshotCalls() == 0);
-                    }
+                    assertTrue(raftNode.counter.getHandleSnapshotCalls() >= 0);
                 }
 
             }


### PR DESCRIPTION
The state machine always sees the following sequence of callback calls:

Leaders see:
...
handleLeaderChange state machine is notify of leadership
handleSnapshot is never called

Non-leader see:
...
handleLeaderChange state machine is notify that is not leader
handleSnapshot is called 0 or more times

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
