### PR TITLE
Fix NPE on concurrent RecordHeader.key() access

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeader.java
@@ -40,7 +40,7 @@ public class RecordHeader implements Header {
         this.valueBuffer = valueBuffer;
     }
     
-    public String key() {
+    public synchronized String key() {
         if (key == null) {
             key = Utils.utf8(keyBuffer, keyBuffer.remaining());
             keyBuffer = null;
@@ -48,7 +48,7 @@ public class RecordHeader implements Header {
         return key;
     }
 
-    public byte[] value() {
+    public synchronized byte[] value() {
         if (value == null && valueBuffer != null) {
             value = Utils.toArray(valueBuffer);
             valueBuffer = null;

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeaderConcurrentTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeaderConcurrentTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.header.internals;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecordHeaderConcurrentTest {
+
+    private static final int ITERATIONS = 100_000;
+
+    private final byte[] keyBytes = "key".getBytes(StandardCharsets.UTF_8);
+    private final byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
+    private final ByteBuffer keyBuffer = ByteBuffer.wrap(keyBytes);
+    private final ByteBuffer valueBuffer = ByteBuffer.wrap(valueBytes);
+
+    private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    @AfterAll
+    public static void shutdownExecutor() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testConcurrentKeyInit() throws ExecutionException, InterruptedException {
+        for (int i = 0; i < ITERATIONS; i++) {
+            RecordHeader header = new RecordHeader(keyBuffer, valueBuffer);
+            Future<String> future = executorService.submit(header::key);
+            assertEquals("key", header.key());
+            assertEquals("key", future.get());
+        }
+    }
+
+    @Test
+    public void testConcurrentValueInit() throws ExecutionException, InterruptedException {
+        for (int i = 0; i < ITERATIONS; i++) {
+            RecordHeader header = new RecordHeader(keyBuffer, valueBuffer);
+            Future<byte[]> future = executorService.submit(header::value);
+            assertArrayEquals(valueBytes, header.value());
+            assertArrayEquals(valueBytes, future.get());
+        }
+    }
+
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordHeaderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordHeaderBenchmark.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.jmh.record;
+
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.openjdk.jmh.annotations.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.*;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RecordHeaderBenchmark {
+
+    private final ByteBuffer keyBuffer = ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8));
+    private final ByteBuffer valueBuffer = ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8));
+
+    @Benchmark
+    public void key() {
+        new RecordHeader(keyBuffer, valueBuffer).key();
+    }
+
+    @Benchmark
+    public void value() {
+        new RecordHeader(keyBuffer, valueBuffer).value();
+    }
+
+}


### PR DESCRIPTION
Jira issue (detailed description): https://issues.apache.org/jira/browse/KAFKA-12999

## Summary
After upgrading clients to `2.8.0`, reading `ConsumerRecord`'s header keys started resulting in occasional `java.lang.NullPointerException` in case of concurrent access from multiple(2) threads.

### NPE location
NPE happens here RecordHeader.java:45:
```java
public String key() {
    if (key == null) {
        key = Utils.utf8(keyBuffer, keyBuffer.remaining()); // NPE here 
        keyBuffer = null;
    }
    return key;
}
```

### What introduced issue
Cause of issue is introduced by changes of apache#9223

### Consequences
Current implementation renders RecordHeader not thread-safe for read-only access.

### Reproducibility
Since issue s concurrent race condition, reproducibility is non-deterministic but easy to reproduce with enough re-attempts
This PR has test which almost always reproduces issue (wiithout `synchronized`)

### Fix strategy
This PR avoids race-condition by having `synchronized` on `key()` and `value()` methods

### Benchmark
Comparison between with and without `synchronized` on `RecordHeader.key()` method
```
Benchmark                              Mode  Cnt   Score   Error  Units
RecordHeaderBenchmark.key              avgt    15  31.308 ± 7.862  ns/op
RecordHeaderBenchmark.synchronizedKey  avgt    15  31.853 ± 7.096  ns/op
````

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
