### PR TITLE
[DO NOT MERGE] Scala3 test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -825,7 +825,6 @@ project(':core') {
     api project(':clients')
     if (versions.baseScala != '3') {
       api libs.scalaLibrary
-      implementation libs.scalaCollectionCompat
       // only needed transitively, but set it explicitly to ensure it has the same version as scala-library
       implementation libs.scalaReflect
     } else {

--- a/build.gradle
+++ b/build.gradle
@@ -77,19 +77,36 @@ allprojects {
     // zinc is the Scala incremental compiler, it has a configuration for its own dependencies
     // that are unrelated to the project dependencies, we should not change them
     if (name != "zinc") {
-      resolutionStrategy {
-        force(
-          // be explicit about the javassist dependency version instead of relying on the transitive version
-          libs.javassist,
-          // ensure we have a single version in the classpath despite transitive dependencies
-          libs.scalaLibrary,
-          libs.scalaReflect,
-          libs.jacksonAnnotations,
-          // be explicit about the Netty dependency version instead of relying on the version set by
-          // ZooKeeper (potentially older and containing CVEs)
-          libs.nettyHandler,
-          libs.nettyTransportNativeEpoll
-        )
+      if (versions.baseScala != '3') {
+        resolutionStrategy {
+          force(
+                  // be explicit about the javassist dependency version instead of relying on the transitive version
+                  libs.javassist,
+                  // ensure we have a single version in the classpath despite transitive dependencies
+                  libs.scalaLibrary,
+                  libs.scalaReflect,
+                  libs.jacksonAnnotations,
+                  // be explicit about the Netty dependency version instead of relying on the version set by
+                  // ZooKeeper (potentially older and containing CVEs)
+                  libs.nettyHandler,
+                  libs.nettyTransportNativeEpoll
+          )
+        }
+      } else {
+        resolutionStrategy {
+          force(
+                  // be explicit about the javassist dependency version instead of relying on the transitive version
+                  libs.javassist,
+                  // ensure we have a single version in the classpath despite transitive dependencies
+                  libs.scala3Library,
+                  libs.scala3Compiler,
+                  libs.jacksonAnnotations,
+                  // be explicit about the Netty dependency version instead of relying on the version set by
+                  // ZooKeeper (potentially older and containing CVEs)
+                  libs.nettyHandler,
+                  libs.nettyTransportNativeEpoll
+          )
+        }
       }
     }
   }
@@ -590,6 +607,10 @@ subprojects {
       scalaCompileOptions.additionalParameters += ["-Xfatal-warnings"]
     }
 
+    if (versions.baseScala == '3') {
+      scalaCompileOptions.additionalParameters += ["-Ytasty-reader"]
+    }
+
     // these options are valid for Scala versions < 2.13 only
     // Scala 2.13 removes them, see https://github.com/scala/scala/pull/6502 and https://github.com/scala/scala/pull/5969
     if (versions.baseScala == '2.12') {
@@ -802,7 +823,15 @@ project(':core') {
     // `core` is often used in users' tests, define the following dependencies as `api` for backwards compatibility
     // even though the `core` module doesn't expose any public API
     api project(':clients')
-    api libs.scalaLibrary
+    if (versions.baseScala != '3') {
+      api libs.scalaLibrary
+      implementation libs.scalaCollectionCompat
+      // only needed transitively, but set it explicitly to ensure it has the same version as scala-library
+      implementation libs.scalaReflect
+    } else {
+      api libs.scala3Library
+      api libs.scala3Compiler
+    }
 
     implementation project(':server-common')
     implementation project(':metadata')
@@ -816,10 +845,9 @@ project(':core') {
     implementation libs.jacksonJDK8Datatypes
     implementation libs.joptSimple
     implementation libs.metrics
-    implementation libs.scalaCollectionCompat
+
     implementation libs.scalaJava8Compat
-    // only needed transitively, but set it explicitly to ensure it has the same version as scala-library
-    implementation libs.scalaReflect
+
     implementation libs.scalaLogging
     implementation libs.slf4jApi
     implementation(libs.zookeeper) {
@@ -1838,8 +1866,13 @@ project(':streams:streams-scala') {
   dependencies {
     api project(':streams')
 
-    api libs.scalaLibrary
-    api libs.scalaCollectionCompat
+    if (versions.baseScala != '3') {
+      api libs.scalaLibrary
+      api libs.scalaCollectionCompat
+    } else {
+      api libs.scala3Library
+      api libs.scala3Compiler
+    }
 
     testImplementation project(':core')
     testImplementation project(':core').sourceSets.test.output
@@ -2153,7 +2186,12 @@ project(':jmh-benchmarks') {
     implementation libs.metrics
     implementation libs.mockitoCore
     implementation libs.slf4jlog4j
-    implementation libs.scalaLibrary
+    if (versions.baseScala != '3') {
+      implementation libs.scalaLibrary
+    } else {
+      implementation libs.scala3Library
+      implementation libs.scala3Compiler
+    }
     implementation libs.scalaJava8Compat
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -845,9 +845,6 @@ project(':core') {
     implementation libs.jacksonJDK8Datatypes
     implementation libs.joptSimple
     implementation libs.metrics
-
-    implementation libs.scalaJava8Compat
-
     implementation libs.scalaLogging
     implementation libs.slf4jApi
     implementation(libs.zookeeper) {
@@ -1868,7 +1865,6 @@ project(':streams:streams-scala') {
 
     if (versions.baseScala != '3') {
       api libs.scalaLibrary
-      api libs.scalaCollectionCompat
     } else {
       api libs.scala3Library
       api libs.scala3Compiler
@@ -2192,7 +2188,6 @@ project(':jmh-benchmarks') {
       implementation libs.scala3Library
       implementation libs.scala3Compiler
     }
-    implementation libs.scalaJava8Compat
   }
 
   tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -77,37 +77,21 @@ allprojects {
     // zinc is the Scala incremental compiler, it has a configuration for its own dependencies
     // that are unrelated to the project dependencies, we should not change them
     if (name != "zinc") {
-      if (versions.baseScala != '3') {
-        resolutionStrategy {
-          force(
-                  // be explicit about the javassist dependency version instead of relying on the transitive version
-                  libs.javassist,
-                  // ensure we have a single version in the classpath despite transitive dependencies
-                  libs.scalaLibrary,
-                  libs.scalaReflect,
-                  libs.jacksonAnnotations,
-                  // be explicit about the Netty dependency version instead of relying on the version set by
-                  // ZooKeeper (potentially older and containing CVEs)
-                  libs.nettyHandler,
-                  libs.nettyTransportNativeEpoll
-          )
-        }
-      } else {
-        resolutionStrategy {
-          force(
-                  // be explicit about the javassist dependency version instead of relying on the transitive version
-                  libs.javassist,
-                  // ensure we have a single version in the classpath despite transitive dependencies
-                  libs.scala3Library,
-                  libs.scala3Compiler,
-                  libs.jacksonAnnotations,
-                  // be explicit about the Netty dependency version instead of relying on the version set by
-                  // ZooKeeper (potentially older and containing CVEs)
-                  libs.nettyHandler,
-                  libs.nettyTransportNativeEpoll
-          )
-        }
+      resolutionStrategy {
+        force(
+                // be explicit about the javassist dependency version instead of relying on the transitive version
+                libs.javassist,
+                // ensure we have a single version in the classpath despite transitive dependencies
+                libs.scalaLibrary,
+                libs.scalaCompiler,
+                libs.jacksonAnnotations,
+                // be explicit about the Netty dependency version instead of relying on the version set by
+                // ZooKeeper (potentially older and containing CVEs)
+                libs.nettyHandler,
+                libs.nettyTransportNativeEpoll
+        )
       }
+
     }
   }
 }
@@ -823,14 +807,8 @@ project(':core') {
     // `core` is often used in users' tests, define the following dependencies as `api` for backwards compatibility
     // even though the `core` module doesn't expose any public API
     api project(':clients')
-    if (versions.baseScala != '3') {
-      api libs.scalaLibrary
-      // only needed transitively, but set it explicitly to ensure it has the same version as scala-library
-      implementation libs.scalaReflect
-    } else {
-      api libs.scala3Library
-      api libs.scala3Compiler
-    }
+    api libs.scalaLibrary
+    api libs.scalaCompiler
 
     implementation project(':server-common')
     implementation project(':metadata')
@@ -1861,13 +1839,8 @@ project(':streams:streams-scala') {
   archivesBaseName = "kafka-streams-scala_${versions.baseScala}"
   dependencies {
     api project(':streams')
-
-    if (versions.baseScala != '3') {
-      api libs.scalaLibrary
-    } else {
-      api libs.scala3Library
-      api libs.scala3Compiler
-    }
+    api libs.scalaLibrary
+    api libs.scalaCompiler
 
     testImplementation project(':core')
     testImplementation project(':core').sourceSets.test.output
@@ -2181,12 +2154,8 @@ project(':jmh-benchmarks') {
     implementation libs.metrics
     implementation libs.mockitoCore
     implementation libs.slf4jlog4j
-    if (versions.baseScala != '3') {
-      implementation libs.scalaLibrary
-    } else {
-      implementation libs.scala3Library
-      implementation libs.scala3Compiler
-    }
+    implementation libs.scalaLibrary
+    implementation libs.scalaCompiler
   }
 
   tasks.withType(JavaCompile) {

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -20,7 +20,6 @@ package kafka.admin
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Properties}
-
 import joptsimple._
 import kafka.common.Config
 import kafka.log.LogConfig

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -19,7 +19,6 @@ package kafka.admin
 
 import java.util
 import java.util.{Collections, Properties}
-
 import joptsimple._
 import kafka.common.AdminCommandFailedException
 import kafka.log.LogConfig
@@ -38,8 +37,8 @@ import org.apache.kafka.common.utils.Utils
 
 import scala.jdk.CollectionConverters._
 import scala.collection._
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionException
+import scala.jdk.OptionConverters.RichOption
 
 object TopicCommand extends Logging {
 
@@ -231,8 +230,8 @@ object TopicCommand extends Logging {
         else {
           new NewTopic(
             topic.name,
-            topic.partitions.asJava,
-            topic.replicationFactor.map(_.toShort).map(Short.box).asJava)
+            topic.partitions.toJava,
+            topic.replicationFactor.map(_.toShort).map(Short.box).toJava)
         }
 
         val configsMap = topic.configsToAdd.stringPropertyNames()

--- a/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/authorizer/AclAuthorizer.scala
@@ -39,7 +39,6 @@ import org.apache.kafka.server.authorizer.AclDeleteResult.AclBindingDeleteResult
 import org.apache.kafka.server.authorizer._
 import org.apache.zookeeper.client.ZKClientConfig
 
-import scala.annotation.nowarn
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.{Seq, immutable, mutable}
 import scala.jdk.CollectionConverters._
@@ -503,7 +502,6 @@ class AclAuthorizer extends Authorizer with Logging {
     } else false
   }
 
-  @nowarn("cat=deprecation")
   private def matchingAcls(resourceType: ResourceType, resourceName: String): AclSeqs = {
     // this code is performance sensitive, make sure to run AclAuthorizerBenchmark after any changes
 
@@ -519,8 +517,8 @@ class AclAuthorizer extends Authorizer with Logging {
 
     val prefixed = new ArrayBuffer[AclEntry]
     aclCacheSnapshot
-      .from(new ResourcePattern(resourceType, resourceName, PatternType.PREFIXED))
-      .to(new ResourcePattern(resourceType, resourceName.take(1), PatternType.PREFIXED))
+      .rangeFrom(new ResourcePattern(resourceType, resourceName, PatternType.PREFIXED))
+      .rangeTo(new ResourcePattern(resourceType, resourceName.take(1), PatternType.PREFIXED))
       .forKeyValue { (resource, acls) =>
         if (resourceName.startsWith(resource.name)) prefixed ++= acls.acls
       }

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -42,8 +42,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantLock
 import scala.collection.{Map, Set, mutable}
-import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
 import scala.math._
 
 /**
@@ -270,7 +270,7 @@ abstract class AbstractFetcherThread(name: String,
 
         case Errors.FENCED_LEADER_EPOCH =>
           val currentLeaderEpoch = latestEpochsForPartitions.get(tp)
-            .map(epochEndOffset => Int.box(epochEndOffset.currentLeaderEpoch)).asJava
+            .map(epochEndOffset => Int.box(epochEndOffset.currentLeaderEpoch)).toJava
           if (onPartitionFenced(tp, currentLeaderEpoch))
             partitionsWithError += tp
 

--- a/core/src/main/scala/kafka/server/AclApis.scala
+++ b/core/src/main/scala/kafka/server/AclApis.scala
@@ -30,12 +30,12 @@ import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
 import org.apache.kafka.common.resource.ResourceType
 import org.apache.kafka.server.authorizer._
-import java.util
 
+import java.util
 import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable
-import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptional
 
 /**
  * Logic to handle ACL requests.
@@ -109,7 +109,7 @@ class AclApis(authHelper: AuthHelper,
           val aclCreationResults = allBindings.map { acl =>
             val result = errorResults.getOrElse(acl, createResults(validBindings.indexOf(acl)).get)
             val creationResult = new AclCreationResult()
-            result.exception.asScala.foreach { throwable =>
+            result.exception.toScala.foreach { throwable =>
               val apiError = ApiError.fromThrowable(throwable)
               creationResult
                 .setErrorCode(apiError.error.code)

--- a/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/server/BrokerToControllerChannelManager.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.atomic.AtomicReference
-
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.raft.RaftManager
 import kafka.utils.Logging
@@ -32,11 +31,11 @@ import org.apache.kafka.common.requests.AbstractRequest
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.{LogContext, Time}
-import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.ApiMessageAndVersion
 
 import scala.collection.Seq
-import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptionalInt
 
 trait ControllerNodeProvider {
   def get(): Option[Node]
@@ -108,7 +107,7 @@ class RaftControllerNodeProvider(val raftManager: RaftManager[ApiMessageAndVersi
   val idToNode = controllerQuorumVoterNodes.map(node => node.id() -> node).toMap
 
   override def get(): Option[Node] = {
-    raftManager.leaderAndEpoch.leaderId.asScala.map(idToNode)
+    raftManager.leaderAndEpoch.leaderId.toScala.map(idToNode)
   }
 }
 

--- a/core/src/main/scala/kafka/server/EnvelopeUtils.scala
+++ b/core/src/main/scala/kafka/server/EnvelopeUtils.scala
@@ -19,14 +19,14 @@ package kafka.server
 
 import java.net.{InetAddress, UnknownHostException}
 import java.nio.ByteBuffer
-
 import kafka.network.RequestChannel
 import org.apache.kafka.common.errors.{InvalidRequestException, PrincipalDeserializationException, UnsupportedVersionException}
 import org.apache.kafka.common.network.ClientInformation
 import org.apache.kafka.common.requests.{EnvelopeRequest, RequestContext, RequestHeader}
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters.RichOptional
+
 
 object EnvelopeUtils {
   def handleEnvelopeRequest(
@@ -120,7 +120,7 @@ object EnvelopeUtils {
     envelopeContext: RequestContext,
     principalBytes: Array[Byte]
   ): KafkaPrincipal = {
-    envelopeContext.principalSerde.asScala match {
+    envelopeContext.principalSerde.toScala match {
       case Some(serde) =>
         try {
           serde.deserialize(principalBytes)

--- a/core/src/main/scala/kafka/server/ForwardingManager.scala
+++ b/core/src/main/scala/kafka/server/ForwardingManager.scala
@@ -18,7 +18,6 @@
 package kafka.server
 
 import java.nio.ByteBuffer
-
 import kafka.network.RequestChannel
 import kafka.utils.Logging
 import org.apache.kafka.clients.{ClientResponse, NodeApiVersions}
@@ -26,7 +25,7 @@ import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, EnvelopeRequest, EnvelopeResponse, RequestContext, RequestHeader}
 
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters.RichOptional
 
 trait ForwardingManager {
   def forwardRequest(
@@ -46,7 +45,7 @@ object ForwardingManager {
 
   private[server] def buildEnvelopeRequest(context: RequestContext,
                                            forwardRequestBuffer: ByteBuffer): EnvelopeRequest.Builder = {
-    val principalSerde = context.principalSerde.asScala.getOrElse(
+    val principalSerde = context.principalSerde.toScala.getOrElse(
       throw new IllegalArgumentException(s"Cannot deserialize principal from request context $context " +
         "since there is no serde defined")
     )

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -33,8 +33,8 @@ import org.apache.kafka.common.requests.{FetchRequest, FetchResponse, RequestUti
 import java.util
 import java.util.Optional
 import scala.collection.{Map, Seq, Set, mutable}
-import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOption
 
 class ReplicaAlterLogDirsThread(name: String,
                                 sourceBroker: BrokerEndPoint,
@@ -260,7 +260,7 @@ class ReplicaAlterLogDirsThread(name: String,
     try {
       val logStartOffset = replicaMgr.futureLocalLogOrException(tp).logStartOffset
       val lastFetchedEpoch = if (isTruncationOnFetchSupported)
-        fetchState.lastFetchedEpoch.map(_.asInstanceOf[Integer]).asJava
+        fetchState.lastFetchedEpoch.map(_.asInstanceOf[Integer]).toJava
       else
         Optional.empty[Integer]
       requestMap.put(tp, new FetchRequest.PartitionData(fetchState.fetchOffset, logStartOffset,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -19,7 +19,6 @@ package kafka.server
 
 import java.util.Collections
 import java.util.Optional
-
 import kafka.api._
 import kafka.cluster.BrokerEndPoint
 import kafka.log.{LeaderOffsetIncremented, LogAppendInfo}
@@ -41,7 +40,7 @@ import org.apache.kafka.common.utils.{LogContext, Time}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, mutable}
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters.RichOption
 
 class ReplicaFetcherThread(name: String,
                            fetcherId: Int,
@@ -272,7 +271,7 @@ class ReplicaFetcherThread(name: String,
         try {
           val logStartOffset = this.logStartOffset(topicPartition)
           val lastFetchedEpoch = if (isTruncationOnFetchSupported)
-            fetchState.lastFetchedEpoch.map(_.asInstanceOf[Integer]).asJava
+            fetchState.lastFetchedEpoch.map(_.asInstanceOf[Integer]).toJava
           else
             Optional.empty[Integer]
           builder.add(topicPartition, new FetchRequest.PartitionData(

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -62,7 +62,7 @@ import org.apache.kafka.common.utils.Time
 
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, Set, mutable}
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters.RichOptional
 
 /*
  * Result metadata of a log append operation on the log
@@ -1270,7 +1270,7 @@ class ReplicaManager(val config: KafkaConfig,
           val replicaInfoSet = mutable.Set[ReplicaView]() ++= replicaInfos += leaderReplica
 
           val partitionInfo = new DefaultPartitionView(replicaInfoSet.asJava, leaderReplica)
-          replicaSelector.select(partition.topicPartition, clientMetadata, partitionInfo).asScala.collect {
+          replicaSelector.select(partition.topicPartition, clientMetadata, partitionInfo).toScala.collect {
             // Even though the replica selector can return the leader, we don't want to send it out with the
             // FetchResponse, so we exclude it here
             case selected if !selected.endpoint.isEmpty && selected != leaderReplica => selected.endpoint.id

--- a/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
+++ b/core/src/main/scala/kafka/server/metadata/BrokerMetadataListener.scala
@@ -17,7 +17,6 @@
 package kafka.server.metadata
 
 import java.util.concurrent.TimeUnit
-
 import kafka.coordinator.group.GroupCoordinator
 import kafka.coordinator.transaction.TransactionCoordinator
 import kafka.metrics.KafkaMetricsGroup
@@ -29,11 +28,11 @@ import org.apache.kafka.common.protocol.ApiMessage
 import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.queue.{EventQueue, KafkaEventQueue}
 import org.apache.kafka.raft.{Batch, BatchReader, LeaderAndEpoch, RaftClient}
-import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.ApiMessageAndVersion
 import org.apache.kafka.snapshot.SnapshotReader
 
-import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters.RichOptionalInt
 
 object BrokerMetadataListener{
   val MetadataBatchProcessingTimeUs = "MetadataBatchProcessingTimeUs"
@@ -270,7 +269,7 @@ class BrokerMetadataListener(
     override def run(): Unit = {
       val imageBuilder =
         MetadataImageBuilder(brokerId, log, metadataCache.currentImage())
-      imageBuilder.controllerId(leaderAndEpoch.leaderId.asScala)
+      imageBuilder.controllerId(leaderAndEpoch.leaderId.toScala)
       metadataCache.image(imageBuilder.build())
     }
   }

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.CountDownLatch
 import java.util.regex.Pattern
 import java.util.{Collections, Properties}
-
 import kafka.consumer.BaseConsumerRecord
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils._

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Utils
 import org.slf4j.event.Level
 
-import scala.annotation.nowarn
 
 /**
  * General helper functions!
@@ -317,10 +316,8 @@ object CoreUtils {
     }
   }
 
-  @nowarn("cat=unused") // see below for explanation
   def groupMapReduce[T, K, B](elements: Iterable[T])(key: T => K)(f: T => B)(reduce: (B, B) => B): Map[K, B] = {
     // required for Scala 2.12 compatibility, unused in Scala 2.13 and hence we need to suppress the unused warning
-    import scala.collection.compat._
     elements.groupMapReduce(key)(f)(reduce)
   }
 

--- a/core/src/main/scala/kafka/utils/Implicits.scala
+++ b/core/src/main/scala/kafka/utils/Implicits.scala
@@ -57,7 +57,6 @@ object Implicits {
    */
   @nowarn("cat=unused-imports")
   implicit class MapExtensionMethods[K, V](private val self: scala.collection.Map[K, V]) extends AnyVal {
-    import scala.collection.compat._
     def forKeyValue[U](f: (K, V) => U): Unit = {
       self.foreachEntry { (k, v) => f(k, v) }
     }

--- a/core/src/main/scala/kafka/utils/Implicits.scala
+++ b/core/src/main/scala/kafka/utils/Implicits.scala
@@ -20,7 +20,6 @@ package kafka.utils
 import java.util
 import java.util.Properties
 
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 /**
@@ -55,7 +54,6 @@ object Implicits {
    * This was not named `foreachEntry` to avoid `unused import` warnings in Scala 2.13 (the implicit
    * would not be triggered in Scala 2.13 since `Map.foreachEntry` would have precedence).
    */
-  @nowarn("cat=unused-imports")
   implicit class MapExtensionMethods[K, V](private val self: scala.collection.Map[K, V]) extends AnyVal {
     def forKeyValue[U](f: (K, V) => U): Unit = {
       self.foreachEntry { (k, v) => f(k, v) }

--- a/core/src/main/scala/kafka/utils/json/DecodeJson.scala
+++ b/core/src/main/scala/kafka/utils/json/DecodeJson.scala
@@ -17,10 +17,8 @@
 
 package kafka.utils.json
 
-import scala.collection.{Map, Seq}
-import scala.collection.Factory
+import scala.collection.{Factory, Map, Seq}
 import scala.jdk.CollectionConverters._
-
 import com.fasterxml.jackson.databind.{JsonMappingException, JsonNode}
 
 /**

--- a/core/src/main/scala/kafka/utils/json/DecodeJson.scala
+++ b/core/src/main/scala/kafka/utils/json/DecodeJson.scala
@@ -18,7 +18,7 @@
 package kafka.utils.json
 
 import scala.collection.{Map, Seq}
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.jdk.CollectionConverters._
 
 import com.fasterxml.jackson.databind.{JsonMappingException, JsonNode}

--- a/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
+++ b/core/src/test/java/kafka/test/junit/ZkClusterInvocationContext.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import scala.Option;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
-import scala.compat.java8.OptionConverters;
+import scala.jdk.javaapi.OptionConverters;
 
 import java.io.File;
 import java.util.Arrays;

--- a/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseAdminIntegrationTest.scala
@@ -34,7 +34,8 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test, Timeout}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters.RichOption
+
 
 /**
  * Base integration test cases for [[Admin]]. Each test case added here will be executed
@@ -70,7 +71,7 @@ abstract class BaseAdminIntegrationTest extends IntegrationTestHarness with Logg
     val newTopics = Seq(
       new NewTopic("mytopic", Map((0: Integer) -> Seq[Integer](1, 2).asJava, (1: Integer) -> Seq[Integer](2, 0).asJava).asJava),
       new NewTopic("mytopic2", 3, 3.toShort),
-      new NewTopic("mytopic3", Option.empty[Integer].asJava, Option.empty[java.lang.Short].asJava)
+      new NewTopic("mytopic3", Option.empty[Integer].toJava, Option.empty[java.lang.Short].toJava)
     )
     val validateResult = client.createTopics(newTopics.asJava, new CreateTopicsOptions().validateOnly(true))
     validateResult.all.get()

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.concurrent.{CountDownLatch, ExecutionException, TimeUnit}
 import java.util.{Collections, Optional, Properties}
 import java.{time, util}
-
 import kafka.log.LogConfig
 import kafka.security.authorizer.AclEntry
 import kafka.server.{Defaults, DynamicConfig, KafkaConfig, KafkaServer}
@@ -48,9 +47,9 @@ import org.slf4j.LoggerFactory
 import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
+import scala.jdk.OptionConverters.RichOption
 import scala.util.Random
 
 /**
@@ -123,7 +122,7 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
     val newTopics = Seq(
       new NewTopic("mytopic", Map((0: Integer) -> Seq[Integer](1, 2).asJava, (1: Integer) -> Seq[Integer](2, 0).asJava).asJava),
       new NewTopic("mytopic2", 3, 3.toShort),
-      new NewTopic("mytopic3", Option.empty[Integer].asJava, Option.empty[java.lang.Short].asJava)
+      new NewTopic("mytopic3", Option.empty[Integer].toJava, Option.empty[java.lang.Short].toJava)
     )
     val createResult = client.createTopics(newTopics.asJava)
     createResult.all.get()

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminIntegrationTest.scala
@@ -38,8 +38,8 @@ import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
 import java.util.Collections
 import scala.jdk.CollectionConverters._
 import scala.collection.Seq
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionException
+import scala.jdk.OptionConverters.RichOption
 import scala.util.{Failure, Success, Try}
 
 class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetup {
@@ -394,7 +394,7 @@ class SaslSslAdminIntegrationTest extends BaseAdminIntegrationTest with SaslSetu
     val configsOverride = Map(LogConfig.SegmentBytesProp -> "100000").asJava
     val newTopics = Seq(
       new NewTopic(topic1, 2, 3.toShort).configs(configsOverride),
-      new NewTopic(topic2, Option.empty[Integer].asJava, Option.empty[java.lang.Short].asJava).configs(configsOverride))
+      new NewTopic(topic2, Option.empty[Integer].toJava, Option.empty[java.lang.Short].toJava).configs(configsOverride))
     val validateResult = client.createTopics(newTopics.asJava, new CreateTopicsOptions().validateOnly(true))
     validateResult.all.get()
     waitForTopics(client, List(), topics)

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -44,9 +44,8 @@ import org.junit.jupiter.api.{BeforeEach, Test}
 import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Set, mutable}
 import scala.util.Random
-
 import scala.collection.mutable.ArrayBuffer
-import scala.compat.java8.OptionConverters._
+import scala.jdk.OptionConverters.{RichOption, RichOptional}
 
 class AbstractFetcherThreadTest {
 
@@ -982,7 +981,7 @@ class AbstractFetcherThreadTest {
         if (state.isReadyForFetch) {
           val replicaState = replicaPartitionState(partition)
           val lastFetchedEpoch = if (isTruncationOnFetchSupported)
-            state.lastFetchedEpoch.map(_.asInstanceOf[Integer]).asJava
+            state.lastFetchedEpoch.map(_.asInstanceOf[Integer]).toJava
           else
             Optional.empty[Integer]
           fetchData.put(partition, new FetchRequest.PartitionData(state.fetchOffset, replicaState.logStartOffset,
@@ -1047,7 +1046,7 @@ class AbstractFetcherThreadTest {
                                         lastFetchedEpoch: Optional[Integer],
                                         fetchOffset: Long,
                                         partitionState: PartitionState): Option[FetchResponseData.EpochEndOffset] = {
-      lastFetchedEpoch.asScala.flatMap { fetchEpoch =>
+      lastFetchedEpoch.toScala.flatMap { fetchEpoch =>
         val epochEndOffset = fetchEpochEndOffsets(
           Map(topicPartition -> new EpochData()
             .setPartition(topicPartition.partition)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,17 +23,14 @@ ext {
 
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
   // a higher minimum Java requirement than Kafka. This was previously the case for Scala 2.12 and Java 7.
-  availableScalaVersions = [ '2.12', '2.13', '3.0' ]
+  availableScalaVersions = [ '2.13', '3.0' ]
 }
 
 // Add Scala version
-def defaultScala212Version = '2.12.14'
 def defaultScala213Version = '2.13.6'
 def defaultScala30Version = '3.0.0'
 if (hasProperty('scalaVersion')) {
-  if (scalaVersion == '2.12') {
-    versions["scala"] = defaultScala212Version
-  } else if (scalaVersion == '2.13') {
+  if (scalaVersion == '2.13') {
     versions["scala"] = defaultScala213Version
   } else if (scalaVersion == '3.0') {
     versions["scala"] = defaultScala30Version
@@ -43,7 +40,7 @@ if (hasProperty('scalaVersion')) {
     versions["scala"] = scalaVersion
   }
 } else {
-  versions["scala"] = defaultScala212Version
+  versions["scala"] = defaultScala213Version
 }
 
 /* Resolve base Scala version according to these patterns:
@@ -112,9 +109,7 @@ versions += [
   powermock: "2.0.9",
   reflections: "0.9.12",
   rocksDB: "6.19.3",
-  scalaCollectionCompat: "2.4.4",
   scalafmt: "1.5.1",
-  scalaJava8Compat : "1.0.0",
   scoverage: "1.4.1",
   slf4j: "1.7.30",
   snappy: "1.1.8.1",
@@ -188,12 +183,10 @@ libs += [
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",
-  scalaCollectionCompat: "org.scala-lang.modules:scala-collection-compat_$versions.baseScala:$versions.scalaCollectionCompat",
-  scalaJava8Compat: "org.scala-lang.modules:scala-java8-compat_$versions.baseScala:$versions.scalaJava8Compat",
   scalaLibrary: "org.scala-lang:scala-library:$versions.scala",
   scala3Library: "org.scala-lang:scala3-library_3:3.0.0",
   scala3Compiler: "org.scala-lang:scala3-compiler_3:3.0.0",
-  scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScala:$versions.scalaLogging",
+  scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScalaJackson:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",
   slf4jlog4j: "org.slf4j:slf4j-log4j12:$versions.slf4j",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,6 +36,8 @@ if (hasProperty('scalaVersion')) {
     versions["scala"] = defaultScala30Version
     versions["baseScala"] = '3'
     versions["baseScalaJackson"] = '2.13'
+    versions["postfixScala"] = '3'
+    versions["postfixScalaOptionalVersion"] = '_3'
   }  else {
     versions["scala"] = scalaVersion
   }
@@ -57,6 +59,8 @@ if (versions.baseScala != '3') {
     versions["baseScala"] = versions.scala
     versions["baseScalaJackson"] = versions.scala
   }
+  versions["postfixScala"] = ''
+  versions["postfixScalaOptionalVersion"] = ''
 }
 
 versions += [
@@ -183,9 +187,8 @@ libs += [
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",
-  scalaLibrary: "org.scala-lang:scala-library:$versions.scala",
-  scala3Library: "org.scala-lang:scala3-library_3:3.0.0",
-  scala3Compiler: "org.scala-lang:scala3-compiler_3:3.0.0",
+  scalaLibrary: "org.scala-lang:scala$versions.postfixScala-library$versions.postfixScalaOptionalVersion:$versions.scala",
+  scalaCompiler: "org.scala-lang:scala$versions.postfixScala-compiler$versions.postfixScalaOptionalVersion:$versions.scala",
   scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScalaJackson:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,17 +23,22 @@ ext {
 
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
   // a higher minimum Java requirement than Kafka. This was previously the case for Scala 2.12 and Java 7.
-  availableScalaVersions = [ '2.12', '2.13' ]
+  availableScalaVersions = [ '2.12', '2.13', '3.0' ]
 }
 
 // Add Scala version
 def defaultScala212Version = '2.12.14'
 def defaultScala213Version = '2.13.6'
+def defaultScala30Version = '3.0.0'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version
   } else if (scalaVersion == '2.13') {
     versions["scala"] = defaultScala213Version
+  } else if (scalaVersion == '3.0') {
+    versions["scala"] = defaultScala30Version
+    versions["baseScala"] = '3'
+    versions["baseScalaJackson"] = '2.13'
   }  else {
     versions["scala"] = scalaVersion
   }
@@ -47,10 +52,14 @@ if (hasProperty('scalaVersion')) {
     rationale: pre-release Scala versions are not binary compatible with each other and that's the reason why libraries include the full
     Scala release string in their name for pre-releases (see dependencies below with an artifact name suffix '_$versions.baseScala')
 */
-if ( !versions.scala.contains('-') ) {
-  versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
-} else {
-  versions["baseScala"] = versions.scala
+if (versions.baseScala != '3') {
+  if ( !versions.scala.contains('-') ) {
+    versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
+    versions["baseScalaJackson"] = versions.baseScala
+  } else {
+    versions["baseScala"] = versions.scala
+    versions["baseScalaJackson"] = versions.scala
+  }
 }
 
 versions += [
@@ -74,7 +83,7 @@ versions += [
   jmh: "1.32",
   hamcrest: "2.2",
   log4j: "1.2.17",
-  scalaLogging: "3.9.3",
+  scalaLogging: "3.9.4",
   jaxb: "2.3.0",
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
@@ -132,7 +141,7 @@ libs += [
   jacksonAnnotations: "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
   jacksonDataformatCsv: "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:$versions.jackson",
-  jacksonModuleScala: "com.fasterxml.jackson.module:jackson-module-scala_$versions.baseScala:$versions.jackson",
+  jacksonModuleScala: "com.fasterxml.jackson.module:jackson-module-scala_$versions.baseScalaJackson:$versions.jackson",
   jacksonJDK8Datatypes: "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$versions.jackson",
   jacksonJaxrsJsonProvider: "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$versions.jackson",
   jaxbApi: "javax.xml.bind:jaxb-api:$versions.jaxb",
@@ -182,6 +191,8 @@ libs += [
   scalaCollectionCompat: "org.scala-lang.modules:scala-collection-compat_$versions.baseScala:$versions.scalaCollectionCompat",
   scalaJava8Compat: "org.scala-lang.modules:scala-java8-compat_$versions.baseScala:$versions.scalaJava8Compat",
   scalaLibrary: "org.scala-lang:scala-library:$versions.scala",
+  scala3Library: "org.scala-lang:scala3-library_3:3.0.0",
+  scala3Compiler: "org.scala-lang:scala3-compiler_3:3.0.0",
   scalaLogging: "com.typesafe.scala-logging:scala-logging_$versions.baseScala:$versions.scalaLogging",
   scalaReflect: "org.scala-lang:scala-reflect:$versions.scala",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",


### PR DESCRIPTION
This is a draft PR to showcase how complicated is to migrate to Scala3.

It includes a necessary change as well (removal of Scala Collections Compat and Java8 Compat libraries). This is needed as those libraries' only purpose was to cross-compile to Scala 2.11 and 2.12.

After this is done, only a bit of workaround gradle was needed (library names for Scala 3 compiler changed).

The only code change needed is the renaming of methods like `asJava`, `asScala`, `until`, `from`, and `to` which  were since Scala 2.13.0 (Compat libraries were shadowing those). And this change is pretty automatic.
On the test file (only 1 didn't really compile) only the right new import needed to be brought in.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
