### PR TITLE
KAFKA-13003: In kraft mode also advertise configured advertised port instead of socket port

### DIFF
--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -304,7 +304,7 @@ class BrokerServer(
         networkListeners.add(new Listener().
           setHost(if (Utils.isBlank(ep.host)) InetAddress.getLocalHost.getCanonicalHostName else ep.host).
           setName(ep.listenerName.value()).
-          setPort(socketServer.boundPort(ep.listenerName)).
+          setPort(ep.port).
           setSecurityProtocol(ep.securityProtocol.id))
       }
       lifecycleManager.start(() => metadataListener.highestMetadataOffset(),

--- a/core/src/main/scala/kafka/server/BrokerServer.scala
+++ b/core/src/main/scala/kafka/server/BrokerServer.scala
@@ -304,7 +304,7 @@ class BrokerServer(
         networkListeners.add(new Listener().
           setHost(if (Utils.isBlank(ep.host)) InetAddress.getLocalHost.getCanonicalHostName else ep.host).
           setName(ep.listenerName.value()).
-          setPort(ep.port).
+          setPort(if (ep.port == 0) socketServer.boundPort(ep.listenerName) else ep.port).
           setSecurityProtocol(ep.securityProtocol.id))
       }
       lifecycleManager.start(() => metadataListener.highestMetadataOffset(),

--- a/core/src/test/java/kafka/testkit/BrokerNode.java
+++ b/core/src/test/java/kafka/testkit/BrokerNode.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
+
 public class BrokerNode implements TestKitNode {
     public static class Builder {
         private int id = -1;
@@ -76,11 +78,19 @@ public class BrokerNode implements TestKitNode {
                Uuid incarnationId,
                String metadataDirectory,
                List<String> logDataDirectories) {
+        this(id, incarnationId, metadataDirectory, logDataDirectories, emptyMap());
+    }
+
+    BrokerNode(int id,
+               Uuid incarnationId,
+               String metadataDirectory,
+               List<String> logDataDirectories,
+               Map<String, String> propertyOverrides) {
         this.id = id;
         this.incarnationId = incarnationId;
         this.metadataDirectory = metadataDirectory;
         this.logDataDirectories = new ArrayList<>(logDataDirectories);
-        this.propertyOverrides = new HashMap<>();
+        this.propertyOverrides = new HashMap<>(propertyOverrides);
     }
 
     @Override

--- a/core/src/test/java/kafka/testkit/TestKitNodes.java
+++ b/core/src/test/java/kafka/testkit/TestKitNodes.java
@@ -159,7 +159,7 @@ public class TestKitNodes {
             BrokerNode node = entry.getValue();
             newBrokerNodes.put(entry.getKey(), new BrokerNode(node.id(),
                 node.incarnationId(), absolutize(baseDirectory, node.metadataDirectory()),
-                absolutize(baseDirectory, node.logDataDirectories())));
+                absolutize(baseDirectory, node.logDataDirectories()), node.propertyOverrides()));
         }
         return new TestKitNodes(clusterId, newControllerNodes, newBrokerNodes);
     }

--- a/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
@@ -19,7 +19,7 @@ package kafka.server
 
 import kafka.network.SocketServer
 import kafka.server.IntegrationTestUtils.connectAndReceive
-import kafka.testkit.{KafkaClusterTestKit, TestKitNodes}
+import kafka.testkit.{BrokerNode, KafkaClusterTestKit, TestKitNodes}
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.admin.{Admin, NewTopic}
 import org.apache.kafka.common.message.DescribeClusterRequestData
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.{Test, Timeout}
 
 import java.util
 import java.util.Collections
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, SECONDS}
 import scala.jdk.CollectionConverters._
 
 @Timeout(120000)
@@ -321,87 +322,100 @@ class RaftClusterTest {
 
   @Test
   def testCreateClusterWithAdvertisedPortZero(): Unit = {
-    val nodes = new TestKitNodes.Builder()
-      .setNumControllerNodes(1)
-      .setNumBrokerNodes(3)
-      .build()
-    nodes.brokerNodes().values().forEach { broker =>
-      broker.propertyOverrides().put(KafkaConfig.ListenersProp,
-        s"${nodes.externalListenerName().value()}://localhost:0")
-      broker.propertyOverrides().put(KafkaConfig.AdvertisedListenersProp,
-        s"${nodes.externalListenerName().value()}://localhost:0")
-    }
-    val cluster = new KafkaClusterTestKit.Builder(nodes).build()
-    try {
-      cluster.format()
-      cluster.startup()
+    val brokerPropertyOverrides: (TestKitNodes, BrokerNode) => Map[String, String] = (nodes, _) => Map(
+      (KafkaConfig.ListenersProp, s"${nodes.externalListenerName.value}://localhost:0"),
+      (KafkaConfig.AdvertisedListenersProp, s"${nodes.externalListenerName.value}://localhost:0"))
 
-      val (runningBrokerServer, foundRunningBroker) = TestUtils.computeUntilTrue(anyBrokerServer(cluster)){
-        brokerServer => brokerServer.currentState() == BrokerState.RUNNING
-      }
-      assertTrue(foundRunningBroker, "No Broker never made it to RUNNING state.")
-
-      val (describeClusterResponse, metadataUpToDate) = TestUtils.computeUntilTrue(
-        sendDescribeClusterRequest(runningBrokerServer.socketServer, nodes.externalListenerName())
-      ) {
-        response => response.nodes().size() == nodes.brokerNodes().size()
-      }
-      assertTrue(metadataUpToDate, s"Broker never reached expected cluster size of ${nodes.brokerNodes().size()}")
-
-      describeClusterResponse.nodes().values().forEach { node =>
-        assertEquals("localhost", node.host,
-          "Did not advertise configured advertised host")
-        assertEquals(cluster.brokers().get(node.id).socketServer.boundPort(nodes.externalListenerName()), node.port,
-          "Did not advertise bound socket port")
-      }
-    } finally {
-      cluster.close()
+    doOnStartedKafkaCluster(numBrokerNodes = 3, brokerPropertyOverrides = brokerPropertyOverrides) { implicit cluster =>
+      sendDescribeClusterRequestToBoundPortUntilAllBrokersPropagated(cluster.nodes.externalListenerName, (15L, SECONDS))
+        .nodes.values.forEach { broker =>
+          assertEquals("localhost", broker.host,
+            "Did not advertise configured advertised host")
+          assertEquals(cluster.brokers.get(broker.id).socketServer.boundPort(cluster.nodes.externalListenerName), broker.port,
+            "Did not advertise bound socket port")
+        }
     }
   }
 
   @Test
   def testCreateClusterWithAdvertisedHostAndPortDifferentFromSocketServer(): Unit = {
+    val brokerPropertyOverrides: (TestKitNodes, BrokerNode) => Map[String, String] = (nodes, broker) => Map(
+      (KafkaConfig.ListenersProp, s"${nodes.externalListenerName.value}://localhost:0"),
+      (KafkaConfig.AdvertisedListenersProp, s"${nodes.externalListenerName.value}://advertised-host-${broker.id}:${broker.id + 100}"))
+
+    doOnStartedKafkaCluster(numBrokerNodes = 3, brokerPropertyOverrides = brokerPropertyOverrides) { implicit cluster =>
+      sendDescribeClusterRequestToBoundPortUntilAllBrokersPropagated(cluster.nodes.externalListenerName, (15L, SECONDS))
+        .nodes.values.forEach { broker =>
+          assertEquals(s"advertised-host-${broker.id}", broker.host, "Did not advertise configured advertised host")
+          assertEquals(broker.id + 100, broker.port, "Did not advertise configured advertised port")
+        }
+    }
+  }
+
+  private def doOnStartedKafkaCluster(numControllerNodes: Int = 1,
+                                      numBrokerNodes: Int,
+                                      brokerPropertyOverrides: (TestKitNodes, BrokerNode) => Map[String, String])
+                                     (action: KafkaClusterTestKit => Unit): Unit = {
     val nodes = new TestKitNodes.Builder()
-      .setNumControllerNodes(1)
-      .setNumBrokerNodes(3)
+      .setNumControllerNodes(numControllerNodes)
+      .setNumBrokerNodes(numBrokerNodes)
       .build()
-    nodes.brokerNodes().values().forEach { broker =>
-      broker.propertyOverrides().put(KafkaConfig.ListenersProp,
-        s"${nodes.externalListenerName().value()}://localhost:0")
-      broker.propertyOverrides().put(KafkaConfig.AdvertisedListenersProp,
-        s"${nodes.externalListenerName().value()}://advertised-host-${broker.id}:${broker.id + 100}")
+    nodes.brokerNodes.values.forEach {
+      broker => broker.propertyOverrides.putAll(brokerPropertyOverrides(nodes, broker).asJava)
     }
     val cluster = new KafkaClusterTestKit.Builder(nodes).build()
     try {
       cluster.format()
       cluster.startup()
-
-      val (runningBrokerServer, foundRunningBroker) = TestUtils.computeUntilTrue(anyBrokerServer(cluster)){
-        brokerServer => brokerServer.currentState() == BrokerState.RUNNING
-      }
-      assertTrue(foundRunningBroker, "No Broker never made it to RUNNING state.")
-
-      val (describeClusterResponse, metadataUpToDate) = TestUtils.computeUntilTrue(
-        sendDescribeClusterRequest(runningBrokerServer.socketServer, nodes.externalListenerName())
-      ) {
-        response => response.nodes().size() == nodes.brokerNodes().size()
-      }
-      assertTrue(metadataUpToDate, s"Broker never reached expected cluster size of ${nodes.brokerNodes().size()}")
-
-      describeClusterResponse.nodes().values().forEach { broker =>
-        assertEquals(s"advertised-host-${broker.id}", broker.host,
-          "Did not advertise configured advertised host")
-        assertEquals(broker.id + 100, broker.port,
-          "Did not advertise configured advertised port")
-      }
+      action(cluster)
     } finally {
       cluster.close()
     }
   }
 
-  private def anyBrokerServer(cluster: KafkaClusterTestKit): BrokerServer = cluster.brokers().values().asScala.head
+  private def sendDescribeClusterRequestToBoundPortUntilAllBrokersPropagated(listenerName: ListenerName,
+                                                                             waitTime: FiniteDuration)
+                                                                            (implicit cluster: KafkaClusterTestKit): DescribeClusterResponse = {
+    val startTime = System.currentTimeMillis
+    val runningBrokerServers = waitForRunningBrokers(1, waitTime)
+    val remainingWaitTime = waitTime - (System.currentTimeMillis - startTime, MILLISECONDS)
+    sendDescribeClusterRequestToBoundPortUntilBrokersPropagated(
+      runningBrokerServers.head, listenerName,
+      cluster.nodes.brokerNodes.size, remainingWaitTime)
+  }
 
-  private def sendDescribeClusterRequest(destination: SocketServer, listenerName: ListenerName): DescribeClusterResponse =
+  private def waitForRunningBrokers(count: Int, waitTime: FiniteDuration)
+                                   (implicit cluster: KafkaClusterTestKit): Seq[BrokerServer] = {
+    def getRunningBrokerServers: Seq[BrokerServer] = cluster.brokers.values.asScala.toSeq
+      .filter(brokerServer => brokerServer.currentState() == BrokerState.RUNNING)
+
+    val (runningBrokerServers, hasRunningBrokers) = TestUtils.computeUntilTrue(getRunningBrokerServers, waitTime.toMillis)(_.nonEmpty)
+    assertTrue(hasRunningBrokers,
+      s"After ${waitTime.toMillis} ms at least $count broker(s) should be in RUNNING state, " +
+        s"but only ${runningBrokerServers.size} broker(s) are.")
+    runningBrokerServers
+  }
+
+  private def sendDescribeClusterRequestToBoundPortUntilBrokersPropagated(destination: BrokerServer,
+                                                                          listenerName: ListenerName,
+                                                                          expectedBrokerCount: Int,
+                                                                          waitTime: FiniteDuration): DescribeClusterResponse = {
+    val (describeClusterResponse, metadataUpToDate) = TestUtils.computeUntilTrue(
+      compute = sendDescribeClusterRequestToBoundPort(destination.socketServer, listenerName),
+      waitTime = waitTime.toMillis
+    ) {
+      response => response.nodes.size == expectedBrokerCount
+    }
+
+    assertTrue(metadataUpToDate,
+      s"After ${waitTime.toMillis} ms Broker is only aware of ${describeClusterResponse.nodes.size} brokers, " +
+        s"but $expectedBrokerCount are expected.")
+
+    describeClusterResponse
+  }
+
+  private def sendDescribeClusterRequestToBoundPort(destination: SocketServer,
+                                                    listenerName: ListenerName): DescribeClusterResponse =
     connectAndReceive[DescribeClusterResponse](
       request = new DescribeClusterRequest.Builder(new DescribeClusterRequestData()).build(),
       destination = destination,

--- a/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
+++ b/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala
@@ -393,9 +393,9 @@ class RaftClusterTest {
   }
 
   private def anyBrokerSocketServer(cluster: KafkaClusterTestKit): SocketServer =
-    cluster.brokers.values.stream
+    cluster.brokers.values.asScala
       .map(b => b.socketServer)
-      .findFirst
-      .orElseThrow(() => new RuntimeException("No broker SocketServers found"))
+      .find(_ => true)
+      .getOrElse(throw new RuntimeException("No broker SocketServers found"))
 
 }


### PR DESCRIPTION
In Kraft mode Apache Kafka 2.8.0 does advertise the socket port instead of the configured advertised port.

A broker given with the following configuration
```
listeners=PUBLIC://0.0.0.0:19092,REPLICATION://0.0.0.0:9091
advertised.listeners=PUBLIC://envoy-kafka-broker:9091,REPLICATION://kafka-broker1:9091
```
advertises on the _PUBLIC_ listener _envoy-kafka-broker:19092_, however I would expect that _envoy-kafka-broker:9091_ is advertised. In ZooKeeper mode it works as expected.

The reason is that in the BrokerServer at the moment the socket server port is used for registration at the controller: https://github.com/apache/kafka/blob/2beaf9a720330615bc5474ec079f8b4b105eff91/core/src/main/scala/kafka/server/BrokerServer.scala#L286

In KafkaServer class which is used in ZooKeeper mode the configured advertised port is used: https://github.com/apache/kafka/blob/2beaf9a720330615bc5474ec079f8b4b105eff91/core/src/main/scala/kafka/server/KafkaServer.scala#L462

I changed the BrokerServer class, so that in Kraft mode like in ZooKeeper mode also the configured advertised port is registered.

I manually tested it with a Docker-Compose setup. It basically runs 3 Kafka Broker with Apache Kafka 2.8 in Kraft mode and an Envoy proxy in front of them. With Apache Kafka 2.8.0 it does not work, because Kafka does not advertise the configured advertised port. For more details about the setup see: https://github.com/ueisele/kafka/tree/fix/kraft-advertisedlisteners-build/proxy-examples/proxyl4-kafkakraft-bug-2.8

The same Docker-Compose setup with the fix (proposed in this pull request) works and advertises the configured advertised port. For more details see: https://github.com/ueisele/kafka/tree/fix/kraft-advertisedlisteners-build/proxy-examples/proxyl4-kafkakraft-fix-2.8

At the moment there is no dedicated test for BrokerServer class. Therefore I did not create a test so far. Where such a test should be added? Is https://github.com/apache/kafka/blob/trunk/core/src/test/scala/integration/kafka/server/RaftClusterTest.scala a good place?