### PR TITLE
KAFKA-10587 Rename kafka-mirror-maker CLI command line arguments for KIP-629

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -98,7 +98,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
   def createConsumers(numStreams: Int,
                       consumerConfigProps: Properties,
                       customRebalanceListener: Option[ConsumerRebalanceListener],
-                      whitelist: Option[String]): Seq[ConsumerWrapper] = {
+                      include: Option[String]): Seq[ConsumerWrapper] = {
     // Disable consumer auto offsets commit to prevent data loss.
     maybeSetDefaultProperty(consumerConfigProps, "enable.auto.commit", "false")
     // Hardcode the deserializer to ByteArrayDeserializer
@@ -110,8 +110,8 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       consumerConfigProps.setProperty("client.id", groupIdString + "-" + i.toString)
       new KafkaConsumer[Array[Byte], Array[Byte]](consumerConfigProps)
     }
-    whitelist.getOrElse(throw new IllegalArgumentException("White list cannot be empty"))
-    consumers.map(consumer => new ConsumerWrapper(consumer, customRebalanceListener, whitelist))
+    include.getOrElse(throw new IllegalArgumentException("include list cannot be empty"))
+    consumers.map(consumer => new ConsumerWrapper(consumer, customRebalanceListener, include))
   }
 
   def commitOffsets(consumerWrapper: ConsumerWrapper): Unit = {
@@ -293,8 +293,8 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
   // Visible for testing
   private[tools] class ConsumerWrapper(private[tools] val consumer: Consumer[Array[Byte], Array[Byte]],
                                        customRebalanceListener: Option[ConsumerRebalanceListener],
-                                       whitelistOpt: Option[String]) {
-    val regex = whitelistOpt.getOrElse(throw new IllegalArgumentException("New consumer only supports whitelist."))
+                                       includeOpt: Option[String]) {
+    val regex = includeOpt.getOrElse(throw new IllegalArgumentException("New consumer only supports include."))
     var recordIter: java.util.Iterator[ConsumerRecord[Array[Byte], Array[Byte]]] = null
 
     // We manually maintain the consumed offsets for historical reasons and it could be simplified
@@ -304,12 +304,12 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
     def init(): Unit = {
       debug("Initiating consumer")
       val consumerRebalanceListener = new InternalRebalanceListener(this, customRebalanceListener)
-      whitelistOpt.foreach { whitelist =>
+      includeOpt.foreach { include =>
         try {
-          consumer.subscribe(Pattern.compile(IncludeList(whitelist).regex), consumerRebalanceListener)
+          consumer.subscribe(Pattern.compile(IncludeList(include).regex), consumerRebalanceListener)
         } catch {
           case pse: RuntimeException =>
-            error(s"Invalid expression syntax: $whitelist")
+            error(s"Invalid expression syntax: $include")
             throw pse
         }
       }
@@ -455,7 +455,13 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       .defaultsTo(1)
 
     val whitelistOpt = parser.accepts("whitelist",
-      "Whitelist of topics to mirror.")
+      "DEPRECATED, use --include instead; ignored if --include specified. List of included topics to mirror.")
+      .withRequiredArg()
+      .describedAs("Java regex (String)")
+      .ofType(classOf[String])
+
+    val includeOpt = parser.accepts("include",
+      "List of included topics to mirror.")
       .withRequiredArg()
       .describedAs("Java regex (String)")
       .ofType(classOf[String])
@@ -504,8 +510,9 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       CommandLineUtils.checkRequiredArgs(parser, options, consumerConfigOpt, producerConfigOpt)
       val consumerProps = Utils.loadProps(options.valueOf(consumerConfigOpt))
 
-      if (!options.has(whitelistOpt)) {
-        error("whitelist must be specified")
+
+      if (!options.has(includeOpt) && !options.has(whitelistOpt)) {
+        error("include list must be specified")
         sys.exit(1)
       }
 
@@ -548,11 +555,17 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
           None
         }
       }
+
+      val includedTopicsValue = if (options.has(includeOpt))
+        Option(options.valueOf(includeOpt))
+      else
+        Option(options.valueOf(whitelistOpt))
+
       val mirrorMakerConsumers = createConsumers(
         numStreams,
         consumerProps,
         customRebalanceListener,
-        Option(options.valueOf(whitelistOpt)))
+        includedTopicsValue)
 
       // Create mirror maker threads.
       mirrorMakerThreads = (0 until numStreams) map (i =>

--- a/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/MirrorMakerIntegrationTest.scala
@@ -66,7 +66,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     consumerProps.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "1")
     val consumer = new KafkaConsumer(consumerProps, new ByteArrayDeserializer, new ByteArrayDeserializer)
-    val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, whitelistOpt = Some("any"))
+    val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, includeOpt = Some("any"))
     mirrorMakerConsumer.offsets.put(new TopicPartition("test", 0), 0L)
     assertThrows(classOf[TimeoutException], () => mirrorMakerConsumer.commit())
   }
@@ -79,7 +79,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     consumerProps.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "2000")
     val consumer = new KafkaConsumer(consumerProps, new ByteArrayDeserializer, new ByteArrayDeserializer)
-    val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, whitelistOpt = Some("any"))
+    val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, includeOpt = Some("any"))
     mirrorMakerConsumer.offsets.put(new TopicPartition("nonexistent-topic1", 0), 0L)
     mirrorMakerConsumer.offsets.put(new TopicPartition("nonexistent-topic2", 0), 0L)
     MirrorMaker.commitOffsets(mirrorMakerConsumer)
@@ -107,7 +107,7 @@ class MirrorMakerIntegrationTest extends KafkaServerTestHarness {
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     val consumer = new KafkaConsumer(consumerProps, new ByteArrayDeserializer, new ByteArrayDeserializer)
 
-    val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, whitelistOpt = Some("another_topic,new.*,foo"))
+    val mirrorMakerConsumer = new ConsumerWrapper(consumer, None, includeOpt = Some("another_topic,new.*,foo"))
     mirrorMakerConsumer.init()
     try {
       TestUtils.waitUntilTrue(() => {


### PR DESCRIPTION
[KAFKA-10587](https://issues.apache.org/jira/browse/KAFKA-10587) Rename kafka-mirror-maker CLI command line arguments for KIP-629
Replace "whitelist" argument in kafka-mirror-maker cli command with "include"

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
