### PR TITLE
Fix StringSerializer could not be found when it not in ContextClassLoader

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -725,14 +725,21 @@ public class ConfigDef {
                     if (value instanceof Class)
                         return value;
                     else if (value instanceof String) {
-                        ClassLoader contextOrKafkaClassLoader = Utils.getContextOrKafkaClassLoader();
-                        // Use loadClass here instead of Class.forName because the name we use here may be an alias
-                        // and not match the name of the class that gets loaded. If that happens, Class.forName can
-                        // throw an exception.
-                        Class<?> klass = contextOrKafkaClassLoader.loadClass(trimmed);
-                        // Invoke forName here with the true name of the requested class to cause class
-                        // initialization to take place.
-                        return Class.forName(klass.getName(), true, contextOrKafkaClassLoader);
+                        try {
+                            ClassLoader contextOrKafkaClassLoader = Utils.getContextOrKafkaClassLoader();
+                            // Use loadClass here instead of Class.forName because the name we use here may be an alias
+                            // and not match the name of the class that gets loaded. If that happens, Class.forName can
+                            // throw an exception.
+                            Class<?> klass = contextOrKafkaClassLoader.loadClass(trimmed);
+                            // Invoke forName here with the true name of the requested class to cause class
+                            // initialization to take place.
+                            return Class.forName(klass.getName(), true, contextOrKafkaClassLoader);
+                        } catch (ClassNotFoundException e) {
+                            // load class from kafkaClassLoader when it not in ContextClassLoader
+                            ClassLoader kafkaClassLoader = Utils.getKafkaClassLoader();
+                            Class<?> klass = kafkaClassLoader.loadClass(trimmed);
+                            return Class.forName(klass.getName(), true, kafkaClassLoader);
+                        }
                     } else
                         throw new ConfigException(name, value, "Expected a Class instance or class name.");
                 default:


### PR DESCRIPTION
ref: https://stackoverflow.com/q/37363119/1120863
      https://github.com/holgerbrandl/kscript/issues/131

`org.apache.kafka.common.serialization.StringSerializer` may be not in ContextClassLoader, when using some custom classloader. So try load class from kafkaClassLoader itself while failed load class.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
