### PR TITLE
Avoid increasing app ID when test is executed multiple times

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -77,7 +77,8 @@ public class TaskMetadataIntegrationTest {
     private String inputTopic;
     private static StreamsBuilder builder;
     private static Properties properties;
-    private static String appId = "TaskMetadataTest_";
+    private static String appIdPrefix = "TaskMetadataTest_";
+    private static String appId;
     private AtomicBoolean process;
     private AtomicBoolean commit;
 
@@ -85,7 +86,7 @@ public class TaskMetadataIntegrationTest {
     @Before
     public void setup() {
         final String testId = safeUniqueTestName(getClass(), testName);
-        appId = appId + testId;
+        appId = appIdPrefix + testId;
         inputTopic = "input" + testId;
         IntegrationTestUtils.cleanStateBeforeTest(CLUSTER, inputTopic);
 


### PR DESCRIPTION
The integration test TaskMetadataIntegrationTest will increase
the length of the app ID when its test methods are called multiple
times in one execution. This is for example the case if you
repeatedly run the test until failure in IntelliJ IDEA. This might
also lead to exceptions because the state directory depends on the
app ID and directory names have a length limit.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
