### PR TITLE
KAFKA-13007: KafkaAdminClient getListOffsetsCalls reuse cluster snapshot

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -4200,6 +4200,7 @@ public class KafkaAdminClient extends AdminClient {
                                            Map<TopicPartition, KafkaFutureImpl<ListOffsetsResultInfo>> futures) {
 
         MetadataResponse mr = context.response().orElseThrow(() -> new IllegalStateException("No Metadata response"));
+        Cluster clusterSnapshot = mr.cluster();
         List<Call> calls = new ArrayList<>();
         // grouping topic partitions per leader
         Map<Node, Map<String, ListOffsetsTopic>> leaders = new HashMap<>();
@@ -4212,7 +4213,7 @@ public class KafkaAdminClient extends AdminClient {
             long offsetQuery = getOffsetFromOffsetSpec(offsetSpec);
             // avoid sending listOffsets request for topics with errors
             if (!mr.errors().containsKey(tp.topic())) {
-                Node node = mr.cluster().leaderFor(tp);
+                Node node = clusterSnapshot.leaderFor(tp);
                 if (node != null) {
                     Map<String, ListOffsetsTopic> leadersOnNode = leaders.computeIfAbsent(node, k -> new HashMap<>());
                     ListOffsetsTopic topic = leadersOnNode.computeIfAbsent(tp.topic(), k -> new ListOffsetsTopic().setName(tp.topic()));

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1498,7 +1498,7 @@ public class KafkaAdminClient extends AdminClient {
                 public void handleResponse(AbstractResponse abstractResponse) {
                     MetadataResponse response = (MetadataResponse) abstractResponse;
                     long now = time.milliseconds();
-                    metadataManager.update(response.cluster(), now);
+                    metadataManager.update(response.buildCluster(), now);
 
                     // Unassign all unsent requests after a metadata refresh to allow for a new
                     // destination to be selected from the new metadata
@@ -1953,7 +1953,7 @@ public class KafkaAdminClient extends AdminClient {
             void handleResponse(AbstractResponse abstractResponse) {
                 MetadataResponse response = (MetadataResponse) abstractResponse;
                 // Handle server responses for particular topics.
-                Cluster cluster = response.cluster();
+                Cluster cluster = response.buildCluster();
                 Map<String, Errors> errors = response.errors();
                 for (Map.Entry<String, KafkaFutureImpl<TopicDescription>> entry : topicFutures.entrySet()) {
                     String topicName = entry.getKey();
@@ -2869,7 +2869,7 @@ public class KafkaAdminClient extends AdminClient {
                 MetadataResponse response = (MetadataResponse) abstractResponse;
 
                 Map<String, Errors> errors = response.errors();
-                Cluster cluster = response.cluster();
+                Cluster cluster = response.buildCluster();
 
                 // Group topic partitions by leader
                 Map<Node, Map<String, DeleteRecordsTopic>> leaders = new HashMap<>();
@@ -4200,7 +4200,7 @@ public class KafkaAdminClient extends AdminClient {
                                            Map<TopicPartition, KafkaFutureImpl<ListOffsetsResultInfo>> futures) {
 
         MetadataResponse mr = context.response().orElseThrow(() -> new IllegalStateException("No Metadata response"));
-        Cluster clusterSnapshot = mr.cluster();
+        Cluster clusterSnapshot = mr.buildCluster();
         List<Call> calls = new ArrayList<>();
         // grouping topic partitions per leader
         Map<Node, Map<String, ListOffsetsTopic>> leaders = new HashMap<>();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -379,7 +379,7 @@ public class Fetcher<K, V> implements Closeable {
 
             if (future.succeeded()) {
                 MetadataResponse response = (MetadataResponse) future.value().responseBody();
-                Cluster cluster = response.cluster();
+                Cluster cluster = response.buildCluster();
 
                 Set<String> unauthorizedTopics = cluster.unauthorizedTopics();
                 if (!unauthorizedTopics.isEmpty())

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -123,7 +123,7 @@ public class MetadataResponse extends AbstractResponse {
      * Get a snapshot of the cluster metadata from this response
      * @return the cluster snapshot
      */
-    public Cluster cluster() {
+    public Cluster buildCluster() {
         Set<String> internalTopics = new HashSet<>();
         List<PartitionInfo> partitions = new ArrayList<>();
         Map<String, Uuid> topicIds = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -2539,8 +2539,8 @@ public class FetcherTest {
         MetadataResponse updatedMetadata = RequestTestUtils.metadataUpdateWith("dummy", 3,
             singletonMap(topicName, Errors.NONE), singletonMap(topicName, 4), tp -> newLeaderEpoch);
 
-        Node originalLeader = initialUpdateResponse.cluster().leaderFor(tp1);
-        Node newLeader = updatedMetadata.cluster().leaderFor(tp1);
+        Node originalLeader = initialUpdateResponse.buildCluster().leaderFor(tp1);
+        Node newLeader = updatedMetadata.buildCluster().leaderFor(tp1);
         assertNotEquals(originalLeader, newLeader);
 
         for (Errors retriableError : retriableErrors) {
@@ -3615,7 +3615,7 @@ public class FetcherTest {
         partitionNumByTopic.put(topicName, 2);
         partitionNumByTopic.put(topicName2, 1);
         MetadataResponse updateMetadataResponse = RequestTestUtils.metadataUpdateWith(2, partitionNumByTopic);
-        Cluster updatedCluster = updateMetadataResponse.cluster();
+        Cluster updatedCluster = updateMetadataResponse.buildCluster();
 
         // The metadata refresh should contain all the topics.
         client.prepareMetadataUpdate(updateMetadataResponse, true);

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -180,7 +180,7 @@ object BrokerApiVersionsCommand {
       val errors = response.errors
       if (!errors.isEmpty)
         debug(s"Metadata request contained errors: $errors")
-      response.cluster.nodes.asScala.toList
+      response.buildCluster.nodes.asScala.toList
     }
 
     def listAllBrokerVersionInfo(): Map[Node, Try[NodeApiVersions]] =

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -102,7 +102,7 @@ class MetadataRequestTest extends AbstractMetadataRequestTest {
     assertTrue(internalTopicMetadata.isInternal, "internalTopic should show isInternal")
     assertFalse(notInternalTopicMetadata.isInternal, "notInternalTopic topic not should show isInternal")
 
-    assertEquals(Set(internalTopic).asJava, metadataResponse.cluster.internalTopics)
+    assertEquals(Set(internalTopic).asJava, metadataResponse.buildCluster().internalTopics)
   }
 
   @Test


### PR DESCRIPTION
in getListOffsetsCalls, we rebuild the cluster snapshot for every topic partition. instead, we should reuse a snapshot. this will reduce the time complexity from O(n^2) to O(n).

for manual testing (used AK 2.8), i've passed in a map of 6K topic partitions to listOffsets

without snapshot reuse:
duration of building futures from metadata response: **15582** milliseconds
total duration of listOffsets: **15743** milliseconds

with reuse:
duration of building futures from metadata response: **24** milliseconds
total duration of listOffsets: **235** milliseconds

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
