### PR TITLE
MINOR: Loose verification of startup in EOS system tests

### DIFF
--- a/tests/kafkatest/tests/streams/streams_eos_test.py
+++ b/tests/kafkatest/tests/streams/streams_eos_test.py
@@ -166,7 +166,6 @@ class StreamsEosTest(KafkaTest):
 
     def wait_for_startup(self, monitor, processor):
         self.wait_for(monitor, processor, "StateChange: REBALANCING -> RUNNING")
-        self.wait_for(monitor, processor, "processed [0-9]* records from topic")
 
     def wait_for(self, monitor, processor, output):
         monitor.wait_until(output,


### PR DESCRIPTION
Currently, we verify that a Streams client transitioned
from REBALANCING to RUNNING and that it processes some records
in the EOS system test. However, if the Streams client only
has standby tasks assigned, the client will never process
records. Hence, the test will fail although everything is
fine.

This commit removes the verification that checks whether
records are processed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
