### PR TITLE
KAFKA-13017: Remove excessive logging for sink task deserialization errors

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -490,10 +490,10 @@ class WorkerSinkTask extends WorkerTask {
     }
 
     private SinkRecord convertAndTransformRecord(final ConsumerRecord<byte[], byte[]> msg) {
-        SchemaAndValue keyAndSchema = retryWithToleranceOperator.execute(() -> convertKey(msg),
+        SchemaAndValue keyAndSchema = retryWithToleranceOperator.execute(() -> keyConverter.toConnectData(msg.topic(), msg.headers(), msg.key()),
                 Stage.KEY_CONVERTER, keyConverter.getClass());
 
-        SchemaAndValue valueAndSchema = retryWithToleranceOperator.execute(() -> convertValue(msg),
+        SchemaAndValue valueAndSchema = retryWithToleranceOperator.execute(() -> valueConverter.toConnectData(msg.topic(), msg.headers(), msg.value()),
                 Stage.VALUE_CONVERTER, valueConverter.getClass());
 
         Headers headers = retryWithToleranceOperator.execute(() -> convertHeadersFor(msg), Stage.HEADER_CONVERTER, headerConverter.getClass());
@@ -523,26 +523,6 @@ class WorkerSinkTask extends WorkerTask {
         }
         // Error reporting will need to correlate each sink record with the original consumer record
         return new InternalSinkRecord(msg, transformedRecord);
-    }
-
-    private SchemaAndValue convertKey(ConsumerRecord<byte[], byte[]> msg) {
-        try {
-            return keyConverter.toConnectData(msg.topic(), msg.headers(), msg.key());
-        } catch (Exception e) {
-            log.error("{} Error converting message key in topic '{}' partition {} at offset {} and timestamp {}: {}",
-                    this, msg.topic(), msg.partition(), msg.offset(), msg.timestamp(), e.getMessage(), e);
-            throw e;
-        }
-    }
-
-    private SchemaAndValue convertValue(ConsumerRecord<byte[], byte[]> msg) {
-        try {
-            return valueConverter.toConnectData(msg.topic(), msg.headers(), msg.value());
-        } catch (Exception e) {
-            log.error("{} Error converting message value in topic '{}' partition {} at offset {} and timestamp {}: {}",
-                    this, msg.topic(), msg.partition(), msg.offset(), msg.timestamp(), e.getMessage(), e);
-            throw e;
-        }
     }
 
     private Headers convertHeadersFor(ConsumerRecord<byte[], byte[]> record) {


### PR DESCRIPTION
[Jira](https://issues.apache.org/jira/browse/KAFKA-13017)

Reverts https://github.com/apache/kafka/pull/7496, which added `ERROR`-level logging for deserialization errors in sink tasks even when connectors had logging for these errors disabled.

No information is lost by this change that cannot be retained in an opt-in fashion by setting `errors.log.enable` and `errors.log.include.messages` to `true` in a connector config.

No testing is added. This commit was created via the GitHub UI; best to wait for a clean(ish) CI build before reviewing/merging.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
