### PR TITLE
KAFKA-13018: test_multi_version failures

### DIFF
--- a/tests/kafkatest/sanity_checks/test_kafka_version.py
+++ b/tests/kafkatest/sanity_checks/test_kafka_version.py
@@ -50,9 +50,9 @@ class KafkaVersionTest(Test):
         the other on the current development branch."""
         self.kafka = KafkaService(self.test_context, num_nodes=2, zk=self.zk,
                                   topics={self.topic: {"partitions": 1, "replication-factor": 2}})
-        self.kafka.nodes[1].version = LATEST_0_8_2
-        self.kafka.nodes[1].config[config_property.INTER_BROKER_PROTOCOL_VERSION] = "0.8.2.X"
+        self.kafka.nodes[0].version = LATEST_0_8_2
+        self.kafka.nodes[0].config[config_property.INTER_BROKER_PROTOCOL_VERSION] = "0.8.2.X"
         self.kafka.start()
 
-        assert is_version(self.kafka.nodes[0], [DEV_BRANCH.vstring], logger=self.logger)
-        assert is_version(self.kafka.nodes[1], [LATEST_0_8_2], logger=self.logger)
+        assert is_version(self.kafka.nodes[0], [LATEST_0_8_2], logger=self.logger)
+        assert is_version(self.kafka.nodes[1], [DEV_BRANCH.vstring], logger=self.logger)


### PR DESCRIPTION
I noticed test_mult_version was consistently failing. The issue was with the zookeeper option in the create topic call from a dev version node. I switched this so the 0 node was the old version, since the default in kafka.py is for node 0 to make the create topics call. I've confirmed the test now passes. 

Going forward, we may want to consider how we are choosing to use the ZK option in the future. Right now it checks if all nodes support the bootstrap server, rather than the node making the call.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
