### PR TITLE
MINOR: Some broker code cleanups

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -25,7 +25,6 @@ import kafka.log._
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpoints
-import kafka.server.metadata.ConfigRepository
 import kafka.utils.CoreUtils.{inReadLock, inWriteLock}
 import kafka.utils._
 import kafka.zookeeper.ZooKeeperClientException
@@ -68,7 +67,6 @@ class DelayedOperations(topicPartition: TopicPartition,
 object Partition extends KafkaMetricsGroup {
   def apply(topicPartition: TopicPartition,
             time: Time,
-            configRepository: ConfigRepository,
             replicaManager: ReplicaManager): Partition = {
 
     val isrChangeListener = new IsrChangeListener {

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -325,7 +325,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
    *
    * @param request client request
    * @param throttleTimeMs Duration in milliseconds for which the channel is to be muted.
-   * @param channelThrottlingCallback Callback for channel throttling
+   * @param throttleCallback Callback for channel throttling
    */
   def throttle(
     request: RequestChannel.Request,

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -51,7 +51,8 @@ trait ConfigHandler {
   * The TopicConfigHandler will process topic config changes in ZK.
   * The callback provides the topic name and the full properties set read from ZK
   */
-class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaConfig, val quotas: QuotaManagers, kafkaController: KafkaController) extends ConfigHandler with Logging  {
+class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaConfig,
+                         val quotas: QuotaManagers, kafkaController: Option[KafkaController]) extends ConfigHandler with Logging  {
 
   private def updateLogConfig(topic: String,
                               topicConfig: Properties,
@@ -89,7 +90,7 @@ class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaC
     updateThrottledList(LogConfig.FollowerReplicationThrottledReplicasProp, quotas.follower)
 
     if (Try(topicConfig.getProperty(KafkaConfig.UncleanLeaderElectionEnableProp).toBoolean).getOrElse(false)) {
-      kafkaController.enableTopicUncleanLeaderElection(topic)
+      kafkaController.foreach(_.enableTopicUncleanLeaderElection(topic))
     }
   }
 

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -404,7 +404,7 @@ class KafkaServer(
         config.dynamicConfig.addReconfigurables(this)
 
         /* start dynamic config manager */
-        dynamicConfigHandlers = Map[String, ConfigHandler](ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers, kafkaController),
+        dynamicConfigHandlers = Map[String, ConfigHandler](ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers, Some(kafkaController)),
                                                            ConfigType.Client -> new ClientIdConfigHandler(quotaManagers),
                                                            ConfigType.User -> new UserConfigHandler(quotaManagers, credentialProvider),
                                                            ConfigType.Broker -> new BrokerConfigHandler(config, quotaManagers),

--- a/core/src/main/scala/kafka/server/RaftReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/RaftReplicaManager.scala
@@ -243,7 +243,7 @@ class RaftReplicaManager(config: KafkaConfig,
 
             case HostedPartition.None =>
               // Create the partition instance since it does not yet exist
-              (Some(Partition(topicPartition, time, configRepository, this)), None)
+              (Some(Partition(topicPartition, time, this)), None)
           }
           partition.foreach { partition =>
             checkTopicId(builder.topicNameToId(partition.topic), partition.topicId, partition.topicPartition)
@@ -277,7 +277,7 @@ class RaftReplicaManager(config: KafkaConfig,
 
             case HostedPartition.None =>
               // it's a partition that we don't know about yet, so create it and mark it online
-              val partition = Partition(topicPartition, time, configRepository, this)
+              val partition = Partition(topicPartition, time, this)
               allPartitions.putIfNotExists(topicPartition, HostedPartition.Online(partition))
               Some(partition)
           }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -249,7 +249,7 @@ class ReplicaManager(val config: KafkaConfig,
   @volatile private[server] var controllerEpoch: Int = KafkaController.InitialControllerEpoch
   protected val localBrokerId = config.brokerId
   protected val allPartitions = new Pool[TopicPartition, HostedPartition](
-    valueFactory = Some(tp => HostedPartition.Online(Partition(tp, time, configRepository, this)))
+    valueFactory = Some(tp => HostedPartition.Online(Partition(tp, time, this)))
   )
   protected val replicaStateChangeLock = new Object
   val replicaFetcherManager = createReplicaFetcherManager(metrics, time, threadNamePrefix, quotaManagers.follower)
@@ -500,7 +500,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   // Visible for testing
   def createPartition(topicPartition: TopicPartition): Partition = {
-    val partition = Partition(topicPartition, time, configRepository, this)
+    val partition = Partition(topicPartition, time, this)
     allPartitions.put(topicPartition, HostedPartition.Online(partition))
     partition
   }
@@ -1365,7 +1365,7 @@ class ReplicaManager(val config: KafkaConfig,
                 Some(partition)
 
               case HostedPartition.None =>
-                val partition = Partition(topicPartition, time, configRepository, this)
+                val partition = Partition(topicPartition, time, this)
                 allPartitions.putIfNotExists(topicPartition, HostedPartition.Online(partition))
                 Some(partition)
             }

--- a/core/src/test/scala/unit/kafka/cluster/BrokerEndPointTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/BrokerEndPointTest.scala
@@ -19,7 +19,6 @@ package kafka.cluster
 
 import java.nio.charset.StandardCharsets
 
-import kafka.utils.TestUtils
 import kafka.zk.BrokerIdZNode
 import org.apache.kafka.common.feature.{Features, SupportedVersionRange}
 import org.apache.kafka.common.feature.Features._
@@ -34,10 +33,10 @@ class BrokerEndPointTest {
 
   @Test
   def testHashAndEquals(): Unit = {
-    val broker1 = TestUtils.createBroker(1, "myhost", 9092)
-    val broker2 = TestUtils.createBroker(1, "myhost", 9092)
-    val broker3 = TestUtils.createBroker(2, "myhost", 1111)
-    val broker4 = TestUtils.createBroker(1, "other", 1111)
+    val broker1 = new BrokerEndPoint(1, "myhost", 9092)
+    val broker2 = new BrokerEndPoint(1, "myhost", 9092)
+    val broker3 = new BrokerEndPoint(2, "myhost", 1111)
+    val broker4 = new BrokerEndPoint(1, "other", 1111)
 
     assertEquals(broker1, broker2)
     assertNotEquals(broker1, broker3)

--- a/core/src/test/scala/unit/kafka/server/RaftReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RaftReplicaManagerTest.scala
@@ -130,8 +130,8 @@ class RaftReplicaManagerTest {
   def testDefersChangesImmediatelyThenAppliesChanges(): Unit = {
     val rrm = createRaftReplicaManager()
     rrm.delegate = mockDelegate
-    val partition0 =  Partition(topicPartition0, time, configRepository, rrm)
-    val partition1 =  Partition(topicPartition1, time, configRepository, rrm)
+    val partition0 =  Partition(topicPartition0, time, rrm)
+    val partition1 =  Partition(topicPartition1, time, rrm)
 
     processTopicPartitionMetadata(rrm)
     // verify changes would have been deferred
@@ -179,8 +179,8 @@ class RaftReplicaManagerTest {
   def testAppliesChangesWhenNotDeferring(): Unit = {
     val rrm = createRaftReplicaManager()
     rrm.delegate = mockDelegate
-    val partition0 = Partition(topicPartition0, time, configRepository, rrm)
-    val partition1 = Partition(topicPartition1, time, configRepository, rrm)
+    val partition0 = Partition(topicPartition0, time, rrm)
+    val partition1 = Partition(topicPartition1, time, rrm)
 
     rrm.endMetadataChangeDeferral(onLeadershipChange)
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -677,12 +677,6 @@ object TestUtils extends Logging {
     brokers
   }
 
-  def deleteBrokersInZk(zkClient: KafkaZkClient, ids: Seq[Int]): Seq[MetadataBroker] = {
-    val brokers = ids.map(createBroker(_, "localhost", 6667, SecurityProtocol.PLAINTEXT))
-    ids.foreach(b => zkClient.deletePath(BrokerIdsZNode.path + "/" + b))
-    brokers
-  }
-
   def getMsgStrings(n: Int): Seq[String] = {
     val buffer = new ListBuffer[String]
     for (i <- 0 until  n)


### PR DESCRIPTION
Fix the JavaDoc for the ClientQuotaManagerConfig#throttle function to
refer to the correct parameter name.

BrokerEndPointTest#testHashAndEquals should test the BrokerEndPoint
class, rather than the MetadataBroker class.

TopicConfigHandler: make the kafkaController argument optional, since we won't
have it when in KRaft mode.

Remove the unecessary ConfigRepository argument for the Partition class.

Remove the unused TestUtils#deleteBrokersInZk function.