### PR TITLE
KAFKA-13019: Add MetadataImage and MetadataDelta classes for KRaft Snapshots

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -230,6 +230,17 @@
     <allow pkg="org.apache.kafka.timeline" />
   </subpackage>
 
+  <subpackage name="image">
+    <allow pkg="org.apache.kafka.common.config" />
+    <allow pkg="org.apache.kafka.common.message" />
+    <allow pkg="org.apache.kafka.common.metadata" />
+    <allow pkg="org.apache.kafka.common.protocol" />
+    <allow pkg="org.apache.kafka.common.quota" />
+    <allow pkg="org.apache.kafka.common.requests" />
+    <allow pkg="org.apache.kafka.metadata" />
+    <allow pkg="org.apache.kafka.server.common" />
+  </subpackage>
+
   <subpackage name="metadata">
     <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.common.annotation" />

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -276,9 +276,9 @@
     <suppress checks="ParameterNumber"
               files="(QuorumController).java"/>
     <suppress checks="CyclomaticComplexity"
-              files="(ReplicationControlManager).java"/>
+              files="(ClientQuotasImage|ReplicationControlManager).java"/>
     <suppress checks="NPathComplexity"
-              files="(KafkaEventQueue|ReplicationControlManager).java"/>
+              files="(ClientQuotasImage|KafkaEventQueue|ReplicationControlManager).java"/>
     <suppress checks="(NPathComplexity|ClassFanOutComplexity|CyclomaticComplexity|ClassDataAbstractionCoupling|LocalVariableName|MemberName|ParameterName|MethodLength|JavaNCSS|AvoidStarImport)"
             files="metadata[\\/]src[\\/](generated|generated-test)[\\/].+.java$"/>
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasRequest.java
@@ -30,9 +30,9 @@ import java.util.List;
 
 public class DescribeClientQuotasRequest extends AbstractRequest {
     // These values must not change.
-    private static final byte MATCH_TYPE_EXACT = 0;
-    private static final byte MATCH_TYPE_DEFAULT = 1;
-    private static final byte MATCH_TYPE_SPECIFIED = 2;
+    public static final byte MATCH_TYPE_EXACT = 0;
+    public static final byte MATCH_TYPE_DEFAULT = 1;
+    public static final byte MATCH_TYPE_SPECIFIED = 2;
 
     public static class Builder extends AbstractRequest.Builder<DescribeClientQuotasRequest> {
 

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaDelta.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.ClientQuotaRecord;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Map.Entry;
+
+
+public final class ClientQuotaDelta {
+    private final ClientQuotaImage image;
+    private final Map<String, Optional<Double>> changes = new HashMap<>();
+
+    public ClientQuotaDelta(ClientQuotaImage image) {
+        this.image = image;
+    }
+
+    public Map<String, Optional<Double>> changes() {
+        return changes;
+    }
+
+    public void finishSnapshot() {
+        for (String key : image.quotas().keySet()) {
+            if (!changes.containsKey(key)) {
+                changes.put(key, Optional.empty());
+            }
+        }
+    }
+
+    public void replay(ClientQuotaRecord record) {
+        if (record.remove()) {
+            changes.put(record.key(), Optional.empty());
+        } else {
+            changes.put(record.key(), Optional.of(record.value()));
+        }
+    }
+
+    public ClientQuotaImage apply() {
+        Map<String, Double> newQuotas = new HashMap<>(image.quotas().size());
+        for (Entry<String, Double> entry : image.quotas().entrySet()) {
+            Optional<Double> change = changes.get(entry.getKey());
+            if (change == null) {
+                newQuotas.put(entry.getKey(), entry.getValue());
+            } else if (change.isPresent()) {
+                newQuotas.put(entry.getKey(), change.get());
+            }
+        }
+        for (Entry<String, Optional<Double>> entry : changes.entrySet()) {
+            if (!newQuotas.containsKey(entry.getKey())) {
+                if (entry.getValue().isPresent()) {
+                    newQuotas.put(entry.getKey(), entry.getValue().get());
+                }
+            }
+        }
+        return new ClientQuotaImage(newQuotas);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.message.DescribeClientQuotasResponseData.ValueData;
+import org.apache.kafka.common.metadata.ClientQuotaRecord;
+import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.CLIENT_QUOTA_RECORD;
+
+
+/**
+ * Represents a quota for a client entity in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class ClientQuotaImage {
+    public final static ClientQuotaImage EMPTY = new ClientQuotaImage(Collections.emptyMap());
+
+    private final Map<String, Double> quotas;
+
+    public ClientQuotaImage(Map<String, Double> quotas) {
+        this.quotas = quotas;
+    }
+
+    Map<String, Double> quotas() {
+        return quotas;
+    }
+
+    public void write(ClientQuotaEntity entity, Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+        for (Entry<String, Double> entry : quotas.entrySet()) {
+            records.add(new ApiMessageAndVersion(new ClientQuotaRecord().
+                setEntity(entityToData(entity)).
+                setKey(entry.getKey()).
+                setValue(entry.getValue()).
+                setRemove(false),
+                CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+        }
+        out.accept(records);
+    }
+
+    public static List<EntityData> entityToData(ClientQuotaEntity entity) {
+        List<EntityData> entityData = new ArrayList<>(entity.entries().size());
+        for (Entry<String, String> entry : entity.entries().entrySet()) {
+            entityData.add(new EntityData().
+                setEntityType(entry.getKey()).
+                setEntityName(entry.getValue()));
+        }
+        return entityData;
+    }
+
+    public static ClientQuotaEntity dataToEntity(List<EntityData> entityData) {
+        Map<String, String> entries = new HashMap<>();
+        for (EntityData data : entityData) {
+            entries.put(data.entityType(), data.entityName());
+        }
+        return new ClientQuotaEntity(Collections.unmodifiableMap(entries));
+    }
+
+    public List<ValueData> toDescribeValues() {
+        List<ValueData> values = new ArrayList<>();
+        for (Entry<String, Double> entry : quotas.entrySet()) {
+            values.add(new ValueData().setKey(entry.getKey()).setValue(entry.getValue()));
+        }
+        return values;
+    }
+
+    public boolean isEmpty() {
+        return quotas.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ClientQuotaImage)) return false;
+        ClientQuotaImage other = (ClientQuotaImage) o;
+        return quotas.equals(other.quotas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(quotas);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientQuotaImage(quotas=" + quotas.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", ")) +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotaImage.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData;
 import org.apache.kafka.common.quota.ClientQuotaEntity;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,8 +54,8 @@ public final class ClientQuotaImage {
         return quotas;
     }
 
-    public void write(ClientQuotaEntity entity, Consumer<List<ApiMessageAndVersion>> out) throws IOException {
-        List<ApiMessageAndVersion> records = new ArrayList<>();
+    public void write(ClientQuotaEntity entity, Consumer<List<ApiMessageAndVersion>> out) {
+        List<ApiMessageAndVersion> records = new ArrayList<>(quotas.size());
         for (Entry<String, Double> entry : quotas.entrySet()) {
             records.add(new ApiMessageAndVersion(new ClientQuotaRecord().
                 setEntity(entityToData(entity)).
@@ -87,7 +86,7 @@ public final class ClientQuotaImage {
     }
 
     public List<ValueData> toDescribeValues() {
-        List<ValueData> values = new ArrayList<>();
+        List<ValueData> values = new ArrayList<>(quotas.size());
         for (Entry<String, Double> entry : quotas.entrySet()) {
             values.add(new ValueData().setKey(entry.getKey()).setValue(entry.getValue()));
         }

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotasDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotasDelta.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.ClientQuotaRecord;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+
+public final class ClientQuotasDelta {
+    private final ClientQuotasImage image;
+    private final Map<ClientQuotaEntity, ClientQuotaDelta> changes = new HashMap<>();
+
+    public ClientQuotasDelta(ClientQuotasImage image) {
+        this.image = image;
+    }
+
+    public Map<ClientQuotaEntity, ClientQuotaDelta> changes() {
+        return changes;
+    }
+
+    public void finishSnapshot() {
+        for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : image.entities().entrySet()) {
+            ClientQuotaEntity entity = entry.getKey();
+            ClientQuotaImage quotaImage = entry.getValue();
+            ClientQuotaDelta quotaDelta = changes.computeIfAbsent(entity,
+                __ -> new ClientQuotaDelta(quotaImage));
+            quotaDelta.finishSnapshot();
+        }
+    }
+
+    public void replay(ClientQuotaRecord record) {
+        ClientQuotaEntity entity = ClientQuotaImage.dataToEntity(record.entity());
+        ClientQuotaDelta change = changes.get(entity);
+        if (change == null) {
+            change = new ClientQuotaDelta(image.entities().
+                getOrDefault(entity, ClientQuotaImage.EMPTY));
+            changes.put(entity, change);
+        }
+        change.replay(record);
+    }
+
+    public ClientQuotasImage apply() {
+        Map<ClientQuotaEntity, ClientQuotaImage> newEntities =
+            new HashMap<>(image.entities().size());
+        for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : image.entities().entrySet()) {
+            ClientQuotaEntity entity = entry.getKey();
+            ClientQuotaDelta change = changes.get(entity);
+            if (change == null) {
+                newEntities.put(entity, entry.getValue());
+            } else {
+                ClientQuotaImage quotaImage = change.apply();
+                if (!quotaImage.isEmpty()) {
+                    newEntities.put(entity, quotaImage);
+                }
+            }
+        }
+        for (Entry<ClientQuotaEntity, ClientQuotaDelta> entry : changes.entrySet()) {
+            ClientQuotaEntity entity = entry.getKey();
+            if (!newEntities.containsKey(entity)) {
+                ClientQuotaImage quotaImage = entry.getValue().apply();
+                if (!quotaImage.isEmpty()) {
+                    newEntities.put(entity, quotaImage);
+                }
+            }
+        }
+        return new ClientQuotasImage(newEntities);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotasDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotasDelta.java
@@ -49,12 +49,9 @@ public final class ClientQuotasDelta {
 
     public void replay(ClientQuotaRecord record) {
         ClientQuotaEntity entity = ClientQuotaImage.dataToEntity(record.entity());
-        ClientQuotaDelta change = changes.get(entity);
-        if (change == null) {
-            change = new ClientQuotaDelta(image.entities().
-                getOrDefault(entity, ClientQuotaImage.EMPTY));
-            changes.put(entity, change);
-        }
+        ClientQuotaDelta change = changes.computeIfAbsent(entity, __ ->
+            new ClientQuotaDelta(image.entities().
+                getOrDefault(entity, ClientQuotaImage.EMPTY)));
         change.replay(record);
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClientQuotasImage.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.message.DescribeClientQuotasRequestData;
+import org.apache.kafka.common.message.DescribeClientQuotasResponseData;
+import org.apache.kafka.common.message.DescribeClientQuotasResponseData.EntityData;
+import org.apache.kafka.common.message.DescribeClientQuotasResponseData.EntryData;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.protocol.Errors.INVALID_REQUEST;
+import static org.apache.kafka.common.protocol.Errors.UNSUPPORTED_VERSION;
+import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_EXACT;
+import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_DEFAULT;
+import static org.apache.kafka.common.requests.DescribeClientQuotasRequest.MATCH_TYPE_SPECIFIED;
+
+
+/**
+ * Represents the client quotas in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class ClientQuotasImage {
+    public final static ClientQuotasImage EMPTY = new ClientQuotasImage(Collections.emptyMap());
+
+    private final Map<ClientQuotaEntity, ClientQuotaImage> entities;
+
+    public ClientQuotasImage(Map<ClientQuotaEntity, ClientQuotaImage> entities) {
+        this.entities = entities;
+    }
+
+    public boolean isEmpty() {
+        return entities.isEmpty();
+    }
+
+    Map<ClientQuotaEntity, ClientQuotaImage> entities() {
+        return entities;
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : entities.entrySet()) {
+            ClientQuotaEntity entity = entry.getKey();
+            ClientQuotaImage clientQuotaImage = entry.getValue();
+            clientQuotaImage.write(entity, out);
+        }
+    }
+
+    public DescribeClientQuotasResponseData describe(DescribeClientQuotasRequestData request) {
+        DescribeClientQuotasResponseData response = new DescribeClientQuotasResponseData();
+        Map<String, String> exactMatch = new HashMap<>();
+        Set<String> typeMatch = new HashSet<>();
+        for (DescribeClientQuotasRequestData.ComponentData component : request.components()) {
+            if (component.entityType().isEmpty()) {
+                response.setErrorCode(INVALID_REQUEST.code());
+                response.setErrorMessage("Invalid empty entity type.");
+                return response;
+            } else if (exactMatch.containsKey(component.entityType()) ||
+                    typeMatch.contains(component.entityType())) {
+                response.setErrorCode(INVALID_REQUEST.code());
+                response.setErrorMessage("Entity type " + component.entityType() +
+                    " cannot appear more than once in the filter.");
+                return response;
+            }
+            switch (component.matchType()) {
+                case MATCH_TYPE_EXACT:
+                    if (component.match() == null) {
+                        response.setErrorCode(INVALID_REQUEST.code());
+                        response.setErrorMessage("Request specified MATCH_TYPE_EXACT, " +
+                            "but set match string to null.");
+                        return response;
+                    }
+                    exactMatch.put(component.entityType(), component.match());
+                    break;
+                case MATCH_TYPE_DEFAULT:
+                    if (component.match() != null) {
+                        response.setErrorCode(INVALID_REQUEST.code());
+                        response.setErrorMessage("Request specified MATCH_TYPE_DEFAULT, " +
+                            "but also specified a match string.");
+                        return response;
+                    }
+                    exactMatch.put(component.entityType(), null);
+                    break;
+                case MATCH_TYPE_SPECIFIED:
+                    if (component.match() != null) {
+                        response.setErrorCode(INVALID_REQUEST.code());
+                        response.setErrorMessage("Request specified MATCH_TYPE_SPECIFIED, " +
+                            "but also specified a match string.");
+                        return response;
+                    }
+                    typeMatch.add(component.entityType());
+                    break;
+                default:
+                    response.setErrorCode(UNSUPPORTED_VERSION.code());
+                    response.setErrorMessage("Unknown match type " + component.matchType());
+                    return response;
+            }
+        }
+        // TODO: this is O(N). We should do some indexing here to speed it up.
+        for (Entry<ClientQuotaEntity, ClientQuotaImage> entry : entities.entrySet()) {
+            ClientQuotaEntity entity = entry.getKey();
+            ClientQuotaImage quotaImage = entry.getValue();
+            if (matches(entity, exactMatch, typeMatch, request.strict())) {
+                response.entries().add(toDescribeEntry(entity, quotaImage));
+            }
+        }
+        return response;
+    }
+
+    private static boolean matches(ClientQuotaEntity entity,
+                                   Map<String, String> exactMatch,
+                                   Set<String> typeMatch,
+                                   boolean strict) {
+        if (strict) {
+            if (entity.entries().size() != exactMatch.size() + typeMatch.size()) {
+                return false;
+            }
+        }
+        for (Entry<String, String> entry : exactMatch.entrySet()) {
+            if (!Objects.equals(entity.entries().get(entry.getKey()), entry.getValue())) {
+                return false;
+            }
+        }
+        for (String type : typeMatch) {
+            if (!entity.entries().containsKey(type)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static EntryData toDescribeEntry(ClientQuotaEntity entity,
+                                             ClientQuotaImage quotaImage) {
+        EntryData data = new EntryData();
+        for (Entry<String, String> entry : entity.entries().entrySet()) {
+            data.entity().add(new EntityData().
+                setEntityType(entry.getKey()).
+                setEntityName(entry.getValue()));
+        }
+        data.setValues(quotaImage.toDescribeValues());
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ClientQuotasImage)) return false;
+        ClientQuotasImage other = (ClientQuotasImage) o;
+        return entities.equals(other.entities);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entities);
+    }
+
+    @Override
+    public String toString() {
+        return "ClientQuotasImage(entities=" + entities.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", ")) +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClusterDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterDelta.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
+import org.apache.kafka.common.metadata.FenceBrokerRecord;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord;
+import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
+import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
+import org.apache.kafka.metadata.BrokerRegistration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+
+/**
+ * Represents changes to the cluster in the metadata image.
+ */
+public final class ClusterDelta {
+    private final ClusterImage image;
+    private final HashMap<Integer, Optional<BrokerRegistration>> changedBrokers = new HashMap<>();
+
+    public ClusterDelta(ClusterImage image) {
+        this.image = image;
+    }
+
+    public HashMap<Integer, Optional<BrokerRegistration>> changedBrokers() {
+        return changedBrokers;
+    }
+
+    public BrokerRegistration broker(int nodeId) {
+        Optional<BrokerRegistration> result = changedBrokers.get(nodeId);
+        if (result != null) {
+            return result.orElse(null);
+        }
+        return image.broker(nodeId);
+    }
+
+    public void finishSnapshot() {
+        for (Integer brokerId : image.brokers().keySet()) {
+            if (!changedBrokers.containsKey(brokerId)) {
+                changedBrokers.put(brokerId, Optional.empty());
+            }
+        }
+    }
+
+    public void replay(RegisterBrokerRecord record) {
+        BrokerRegistration broker = BrokerRegistration.fromRecord(record);
+        changedBrokers.put(broker.id(), Optional.of(broker));
+    }
+
+    public void replay(UnregisterBrokerRecord record) {
+        changedBrokers.put(record.brokerId(), Optional.empty());
+    }
+
+    public void replay(FenceBrokerRecord record) {
+        BrokerRegistration broker = broker(record.id());
+        if (broker == null) {
+            throw new RuntimeException("Tried to fence broker " + record.id() +
+                ", but that broker was not registered.");
+        }
+        changedBrokers.put(record.id(), Optional.of(broker.cloneWithFencing(true)));
+    }
+
+    public void replay(UnfenceBrokerRecord record) {
+        BrokerRegistration broker = broker(record.id());
+        if (broker == null) {
+            throw new RuntimeException("Tried to unfence broker " + record.id() +
+                ", but that broker was not registered.");
+        }
+        changedBrokers.put(record.id(), Optional.of(broker.cloneWithFencing(false)));
+    }
+
+    public void replay(BrokerRegistrationChangeRecord record) {
+        BrokerRegistration broker = broker(record.brokerId());
+        if (broker == null) {
+            throw new RuntimeException("Tried to change broker " + record.brokerId() +
+                ", but that broker was not registered.");
+        }
+        if (record.fenced() < 0) {
+            changedBrokers.put(record.brokerId(), Optional.of(broker.cloneWithFencing(false)));
+        } else if (record.fenced() > 0) {
+            changedBrokers.put(record.brokerId(), Optional.of(broker.cloneWithFencing(true)));
+        }
+    }
+
+    public ClusterImage apply() {
+        Map<Integer, BrokerRegistration> newBrokers = new HashMap<>(image.brokers().size());
+        for (Entry<Integer, BrokerRegistration> entry : image.brokers().entrySet()) {
+            int nodeId = entry.getKey();
+            Optional<BrokerRegistration> change = changedBrokers.get(nodeId);
+            if (change == null) {
+                newBrokers.put(nodeId, entry.getValue());
+            } else if (change.isPresent()) {
+                newBrokers.put(nodeId, change.get());
+            }
+        }
+        for (Entry<Integer, Optional<BrokerRegistration>> entry : changedBrokers.entrySet()) {
+            int nodeId = entry.getKey();
+            Optional<BrokerRegistration> brokerRegistration = entry.getValue();
+            if (!newBrokers.containsKey(nodeId)) {
+                if (brokerRegistration.isPresent()) {
+                    newBrokers.put(nodeId, brokerRegistration.get());
+                }
+            }
+        }
+        return new ClusterImage(newBrokers);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+
+/**
+ * Represents the cluster in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class ClusterImage {
+    public static final ClusterImage EMPTY = new ClusterImage(Collections.emptyMap());
+
+    private final Map<Integer, BrokerRegistration> brokers;
+
+    public ClusterImage(Map<Integer, BrokerRegistration> brokers) {
+        this.brokers = brokers;
+    }
+
+    public boolean isEmpty() {
+        return brokers.isEmpty();
+    }
+
+    public Map<Integer, BrokerRegistration> brokers() {
+        return brokers;
+    }
+
+    public BrokerRegistration broker(int nodeId) {
+        return brokers.get(nodeId);
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        List<ApiMessageAndVersion> batch = new ArrayList<>();
+        for (BrokerRegistration broker : brokers.values()) {
+            batch.add(broker.toRecord());
+        }
+        out.accept(batch);
+    }
+
+    @Override
+    public int hashCode() {
+        return brokers.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ClusterImage)) return false;
+        ClusterImage other = (ClusterImage) o;
+        return brokers.equals(other.brokers);
+    }
+
+    @Override
+    public String toString() {
+        return brokers.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", "));
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ClusterImage.java
@@ -20,7 +20,6 @@ package org.apache.kafka.image;
 import org.apache.kafka.metadata.BrokerRegistration;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,7 +39,7 @@ public final class ClusterImage {
     private final Map<Integer, BrokerRegistration> brokers;
 
     public ClusterImage(Map<Integer, BrokerRegistration> brokers) {
-        this.brokers = brokers;
+        this.brokers = Collections.unmodifiableMap(brokers);
     }
 
     public boolean isEmpty() {
@@ -55,7 +54,7 @@ public final class ClusterImage {
         return brokers.get(nodeId);
     }
 
-    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(Consumer<List<ApiMessageAndVersion>> out) {
         List<ApiMessageAndVersion> batch = new ArrayList<>();
         for (BrokerRegistration broker : brokers.values()) {
             batch.add(broker.toRecord());

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationDelta.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.ConfigRecord;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+
+/**
+ * Represents changes to the configurations in the metadata image.
+ */
+public final class ConfigurationDelta {
+    private final ConfigurationImage image;
+    private final Map<String, Optional<String>> changes = new HashMap<>();
+
+    public ConfigurationDelta(ConfigurationImage image) {
+        this.image = image;
+    }
+
+    public void finishSnapshot() {
+        for (String key : image.data().keySet()) {
+            if (!changes.containsKey(key)) {
+                changes.put(key, Optional.empty());
+            }
+        }
+    }
+
+    public void replay(ConfigRecord record) {
+        changes.put(record.name(), Optional.ofNullable(record.value()));
+    }
+
+    public void deleteAll() {
+        changes.clear();
+        for (String key : image.data().keySet()) {
+            changes.put(key, Optional.empty());
+        }
+    }
+
+    public ConfigurationImage apply() {
+        Map<String, String> newData = new HashMap<>(image.data().size());
+        for (Entry<String, String> entry : image.data().entrySet()) {
+            Optional<String> change = changes.get(entry.getKey());
+            if (change == null) {
+                newData.put(entry.getKey(), entry.getValue());
+            } else if (change.isPresent()) {
+                newData.put(entry.getKey(), change.get());
+            }
+        }
+        for (Entry<String, Optional<String>> entry : changes.entrySet()) {
+            if (!newData.containsKey(entry.getKey())) {
+                if (entry.getValue().isPresent()) {
+                    newData.put(entry.getKey(), entry.getValue().get());
+                }
+            }
+        }
+        return new ConfigurationImage(newData);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationImage.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
+
+
+/**
+ * Represents the configuration of a resource.
+ *
+ * This class is thread-safe.
+ */
+public final class ConfigurationImage {
+    public static final ConfigurationImage EMPTY = new ConfigurationImage(Collections.emptyMap());
+
+    private final Map<String, String> data;
+
+    public ConfigurationImage(Map<String, String> data) {
+        this.data = data;
+    }
+
+    Map<String, String> data() {
+        return data;
+    }
+
+    public boolean isEmpty() {
+        return data.isEmpty();
+    }
+
+    public Properties toProperties() {
+        Properties properties = new Properties();
+        properties.putAll(data);
+        return properties;
+    }
+
+    public void write(ConfigResource configResource, Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        List<ApiMessageAndVersion> records = new ArrayList<>();
+        for (Map.Entry<String, String> entry : data.entrySet()) {
+            records.add(new ApiMessageAndVersion(new ConfigRecord().
+                setResourceType(configResource.type().id()).
+                setResourceName(configResource.name()).
+                setName(entry.getKey()).
+                setValue(entry.getValue()), CONFIG_RECORD.highestSupportedVersion()));
+        }
+        out.accept(records);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ConfigurationImage)) return false;
+        ConfigurationImage other = (ConfigurationImage) o;
+        return data.equals(other.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigurationImage(data=" + data.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", ")) +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationImage.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.metadata.ConfigRecord;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -62,7 +61,7 @@ public final class ConfigurationImage {
         return properties;
     }
 
-    public void write(ConfigResource configResource, Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(ConfigResource configResource, Consumer<List<ApiMessageAndVersion>> out) {
         List<ApiMessageAndVersion> records = new ArrayList<>();
         for (Map.Entry<String, String> entry : data.entrySet()) {
             records.add(new ApiMessageAndVersion(new ConfigRecord().

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.ConfigResource.Type;
+import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.RemoveTopicRecord;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+
+/**
+ * Represents changes to the configurations in the metadata image.
+ */
+public final class ConfigurationsDelta {
+    private final ConfigurationsImage image;
+    private final Map<ConfigResource, ConfigurationDelta> changes = new HashMap<>();
+
+    public ConfigurationsDelta(ConfigurationsImage image) {
+        this.image = image;
+    }
+
+    public Map<ConfigResource, ConfigurationDelta> changes() {
+        return changes;
+    }
+
+    public void finishSnapshot() {
+        for (Entry<ConfigResource, ConfigurationImage> entry : image.resourceData().entrySet()) {
+            ConfigResource resource = entry.getKey();
+            ConfigurationImage configurationImage = entry.getValue();
+            ConfigurationDelta configurationDelta = changes.computeIfAbsent(resource,
+                __ -> new ConfigurationDelta(configurationImage));
+            configurationDelta.finishSnapshot();
+        }
+    }
+
+    public void replay(ConfigRecord record) {
+        ConfigResource resource =
+            new ConfigResource(Type.forId(record.resourceType()), record.resourceName());
+        ConfigurationImage configImage =
+            image.resourceData().getOrDefault(resource, ConfigurationImage.EMPTY);
+        ConfigurationDelta delta = changes.computeIfAbsent(resource,
+            __ -> new ConfigurationDelta(configImage));
+        delta.replay(record);
+    }
+
+    public void replay(RemoveTopicRecord record, String topicName) {
+        ConfigResource resource =
+            new ConfigResource(Type.TOPIC, topicName);
+        ConfigurationImage configImage =
+            image.resourceData().getOrDefault(resource, ConfigurationImage.EMPTY);
+        ConfigurationDelta delta = changes.computeIfAbsent(resource,
+            __ -> new ConfigurationDelta(configImage));
+        delta.deleteAll();
+    }
+
+    public ConfigurationsImage apply() {
+        Map<ConfigResource, ConfigurationImage> newData = new HashMap<>();
+        for (Entry<ConfigResource, ConfigurationImage> entry : image.resourceData().entrySet()) {
+            ConfigResource resource = entry.getKey();
+            ConfigurationDelta delta = changes.get(resource);
+            if (delta == null) {
+                newData.put(resource, entry.getValue());
+            } else {
+                ConfigurationImage newImage = delta.apply();
+                if (!newImage.isEmpty()) {
+                    newData.put(resource, newImage);
+                }
+            }
+        }
+        for (Entry<ConfigResource, ConfigurationDelta> entry : changes.entrySet()) {
+            if (!newData.containsKey(entry.getKey())) {
+                ConfigurationImage newImage = entry.getValue().apply();
+                if (!newImage.isEmpty()) {
+                    newData.put(entry.getKey(), newImage);
+                }
+            }
+        }
+        return new ConfigurationsImage(newData);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsDelta.java
@@ -45,10 +45,10 @@ public final class ConfigurationsDelta {
     public void finishSnapshot() {
         for (Entry<ConfigResource, ConfigurationImage> entry : image.resourceData().entrySet()) {
             ConfigResource resource = entry.getKey();
-            ConfigurationImage configurationImage = entry.getValue();
-            ConfigurationDelta configurationDelta = changes.computeIfAbsent(resource,
-                __ -> new ConfigurationDelta(configurationImage));
-            configurationDelta.finishSnapshot();
+            ConfigurationImage configImage = entry.getValue();
+            ConfigurationDelta configDelta = changes.computeIfAbsent(resource,
+                __ -> new ConfigurationDelta(configImage));
+            configDelta.finishSnapshot();
         }
     }
 

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsImage.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+
+/**
+ * Represents the configurations in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class ConfigurationsImage {
+    public static final ConfigurationsImage EMPTY =
+        new ConfigurationsImage(Collections.emptyMap());
+
+    private final Map<ConfigResource, ConfigurationImage> data;
+
+    public ConfigurationsImage(Map<ConfigResource, ConfigurationImage> data) {
+        this.data = data;
+    }
+
+    public boolean isEmpty() {
+        return data.isEmpty();
+    }
+
+    Map<ConfigResource, ConfigurationImage> resourceData() {
+        return data;
+    }
+
+    public Properties configProperties(ConfigResource configResource) {
+        ConfigurationImage configurationImage = data.get(configResource);
+        if (configurationImage != null) {
+            return configurationImage.toProperties();
+        } else {
+            return new Properties();
+        }
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        for (Entry<ConfigResource, ConfigurationImage> entry : data.entrySet()) {
+            ConfigResource configResource = entry.getKey();
+            ConfigurationImage configImage = entry.getValue();
+            configImage.write(configResource, out);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ConfigurationsImage)) return false;
+        ConfigurationsImage other = (ConfigurationsImage) o;
+        return data.equals(other.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(data);
+    }
+
+    @Override
+    public String toString() {
+        return "ConfigurationsImage(data=" + data.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", ")) +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/ConfigurationsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/ConfigurationsImage.java
@@ -20,7 +20,6 @@ package org.apache.kafka.image;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
@@ -43,7 +42,7 @@ public final class ConfigurationsImage {
     private final Map<ConfigResource, ConfigurationImage> data;
 
     public ConfigurationsImage(Map<ConfigResource, ConfigurationImage> data) {
-        this.data = data;
+        this.data = Collections.unmodifiableMap(data);
     }
 
     public boolean isEmpty() {
@@ -63,7 +62,7 @@ public final class ConfigurationsImage {
         }
     }
 
-    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(Consumer<List<ApiMessageAndVersion>> out) {
         for (Entry<ConfigResource, ConfigurationImage> entry : data.entrySet()) {
             ConfigResource configResource = entry.getKey();
             ConfigurationImage configImage = entry.getValue();

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesDelta.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.common.metadata.RemoveFeatureLevelRecord;
+import org.apache.kafka.metadata.VersionRange;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+
+/**
+ * Represents changes to the cluster in the metadata image.
+ */
+public final class FeaturesDelta {
+    private final FeaturesImage image;
+
+    private final Map<String, Optional<VersionRange>> changes = new HashMap<>();
+
+    public FeaturesDelta(FeaturesImage image) {
+        this.image = image;
+    }
+
+    public Map<String, Optional<VersionRange>> changes() {
+        return changes;
+    }
+
+    public void finishSnapshot() {
+        for (String featureName : image.finalizedVersions().keySet()) {
+            if (!changes.containsKey(featureName)) {
+                changes.put(featureName, Optional.empty());
+            }
+        }
+    }
+
+    public void replay(FeatureLevelRecord record) {
+        changes.put(record.name(), Optional.of(
+            new VersionRange(record.minFeatureLevel(), record.maxFeatureLevel())));
+    }
+
+    public void replay(RemoveFeatureLevelRecord record) {
+        changes.put(record.name(), Optional.empty());
+    }
+
+    public FeaturesImage apply() {
+        Map<String, VersionRange> newFinalizedVersions =
+            new HashMap<>(image.finalizedVersions().size());
+        for (Entry<String, VersionRange> entry : image.finalizedVersions().entrySet()) {
+            String name = entry.getKey();
+            Optional<VersionRange> change = changes.get(name);
+            if (change == null) {
+                newFinalizedVersions.put(name, entry.getValue());
+            } else if (change.isPresent()) {
+                newFinalizedVersions.put(name, change.get());
+            }
+        }
+        for (Entry<String, Optional<VersionRange>> entry : changes.entrySet()) {
+            String name = entry.getKey();
+            Optional<VersionRange> change = entry.getValue();
+            if (!newFinalizedVersions.containsKey(name)) {
+                if (change.isPresent()) {
+                    newFinalizedVersions.put(name, change.get());
+                }
+            }
+        }
+        return new FeaturesImage(newFinalizedVersions);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.metadata.VersionRange;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.FEATURE_LEVEL_RECORD;
+
+
+/**
+ * Represents the feature levels in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class FeaturesImage {
+    public static final FeaturesImage EMPTY = new FeaturesImage(Collections.emptyMap());
+
+    private final Map<String, VersionRange> finalizedVersions;
+
+    public FeaturesImage(Map<String, VersionRange> finalizedVersions) {
+        this.finalizedVersions = finalizedVersions;
+    }
+
+    public boolean isEmpty() {
+        return finalizedVersions.isEmpty();
+    }
+
+    Map<String, VersionRange> finalizedVersions() {
+        return finalizedVersions;
+    }
+
+    private Optional<VersionRange> finalizedVersion(String feature) {
+        return Optional.ofNullable(finalizedVersions.get(feature));
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        List<ApiMessageAndVersion> batch = new ArrayList<>();
+        for (Entry<String, VersionRange> entry : finalizedVersions.entrySet()) {
+            batch.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+                setName(entry.getKey()).
+                setMinFeatureLevel(entry.getValue().min()).
+                setMaxFeatureLevel(entry.getValue().max()),
+                FEATURE_LEVEL_RECORD.highestSupportedVersion()));
+        }
+        out.accept(batch);
+    }
+
+    @Override
+    public int hashCode() {
+        return finalizedVersions.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof FeaturesImage)) return false;
+        FeaturesImage other = (FeaturesImage) o;
+        return finalizedVersions.equals(other.finalizedVersions);
+    }
+
+    @Override
+    public String toString() {
+        return finalizedVersions.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", "));
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/FeaturesImage.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.metadata.FeatureLevelRecord;
 import org.apache.kafka.metadata.VersionRange;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,7 +44,7 @@ public final class FeaturesImage {
     private final Map<String, VersionRange> finalizedVersions;
 
     public FeaturesImage(Map<String, VersionRange> finalizedVersions) {
-        this.finalizedVersions = finalizedVersions;
+        this.finalizedVersions = Collections.unmodifiableMap(finalizedVersions);
     }
 
     public boolean isEmpty() {
@@ -60,7 +59,7 @@ public final class FeaturesImage {
         return Optional.ofNullable(finalizedVersions.get(feature));
     }
 
-    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(Consumer<List<ApiMessageAndVersion>> out) {
         List<ApiMessageAndVersion> batch = new ArrayList<>();
         for (Entry<String, VersionRange> entry : finalizedVersions.entrySet()) {
             batch.add(new ApiMessageAndVersion(new FeatureLevelRecord().

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataDelta.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.BrokerRegistrationChangeRecord;
+import org.apache.kafka.common.metadata.ClientQuotaRecord;
+import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.common.metadata.FenceBrokerRecord;
+import org.apache.kafka.common.metadata.MetadataRecordType;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord;
+import org.apache.kafka.common.metadata.RemoveFeatureLevelRecord;
+import org.apache.kafka.common.metadata.RemoveTopicRecord;
+import org.apache.kafka.common.metadata.TopicRecord;
+import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
+import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.util.Iterator;
+import java.util.List;
+
+
+/**
+ * A change to the broker metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class MetadataDelta {
+    private final MetadataImage image;
+
+    private FeaturesDelta featuresDelta = null;
+
+    private ClusterDelta clusterDelta = null;
+
+    private TopicsDelta topicsDelta = null;
+
+    private ConfigurationsDelta configsDelta = null;
+
+    private ClientQuotasDelta clientQuotasDelta = null;
+
+    public MetadataDelta(MetadataImage image) {
+        this.image = image;
+    }
+
+    public MetadataImage image() {
+        return image;
+    }
+
+    public FeaturesDelta featuresDelta() {
+        return featuresDelta;
+    }
+
+    public ClusterDelta clusterDelta() {
+        return clusterDelta;
+    }
+
+    public TopicsDelta topicsDelta() {
+        return topicsDelta;
+    }
+
+    public ConfigurationsDelta configsDelta() {
+        return configsDelta;
+    }
+
+    public ClientQuotasDelta clientQuotasDelta() {
+        return clientQuotasDelta;
+    }
+
+    public void read(Iterator<List<ApiMessageAndVersion>> reader) {
+        while (reader.hasNext()) {
+            List<ApiMessageAndVersion> batch = reader.next();
+            for (ApiMessageAndVersion messageAndVersion : batch) {
+                replay(messageAndVersion.message());
+            }
+        }
+    }
+
+    public void replay(ApiMessage record) {
+        MetadataRecordType type = MetadataRecordType.fromId(record.apiKey());
+        switch (type) {
+            case REGISTER_BROKER_RECORD:
+                replay((RegisterBrokerRecord) record);
+                break;
+            case UNREGISTER_BROKER_RECORD:
+                replay((UnregisterBrokerRecord) record);
+                break;
+            case TOPIC_RECORD:
+                replay((TopicRecord) record);
+                break;
+            case PARTITION_RECORD:
+                replay((PartitionRecord) record);
+                break;
+            case CONFIG_RECORD:
+                replay((ConfigRecord) record);
+                break;
+            case PARTITION_CHANGE_RECORD:
+                replay((PartitionChangeRecord) record);
+                break;
+            case FENCE_BROKER_RECORD:
+                replay((FenceBrokerRecord) record);
+                break;
+            case UNFENCE_BROKER_RECORD:
+                replay((UnfenceBrokerRecord) record);
+                break;
+            case REMOVE_TOPIC_RECORD:
+                replay((RemoveTopicRecord) record);
+                break;
+            case FEATURE_LEVEL_RECORD:
+                replay((FeatureLevelRecord) record);
+                break;
+            case CLIENT_QUOTA_RECORD:
+                replay((ClientQuotaRecord) record);
+                break;
+            case PRODUCER_IDS_RECORD:
+                // Nothing to do.
+                break;
+            case REMOVE_FEATURE_LEVEL_RECORD:
+                replay((RemoveFeatureLevelRecord) record);
+                break;
+            case BROKER_REGISTRATION_CHANGE_RECORD:
+                replay((BrokerRegistrationChangeRecord) record);
+                break;
+            default:
+                throw new RuntimeException("Unknown metadata record type " + type);
+        }
+    }
+
+    public void replay(RegisterBrokerRecord record) {
+        if (clusterDelta == null) clusterDelta = new ClusterDelta(image.cluster());
+        clusterDelta.replay(record);
+    }
+
+    public void replay(UnregisterBrokerRecord record) {
+        if (clusterDelta == null) clusterDelta = new ClusterDelta(image.cluster());
+        clusterDelta.replay(record);
+    }
+
+    public void replay(TopicRecord record) {
+        if (topicsDelta == null) topicsDelta = new TopicsDelta(image.topics());
+        topicsDelta.replay(record);
+    }
+
+    public void replay(PartitionRecord record) {
+        if (topicsDelta == null) topicsDelta = new TopicsDelta(image.topics());
+        topicsDelta.replay(record);
+    }
+
+    public void replay(ConfigRecord record) {
+        if (configsDelta == null) configsDelta = new ConfigurationsDelta(image.configs());
+        configsDelta.replay(record);
+    }
+
+    public void replay(PartitionChangeRecord record) {
+        if (topicsDelta == null) topicsDelta = new TopicsDelta(image.topics());
+        topicsDelta.replay(record);
+    }
+
+    public void replay(FenceBrokerRecord record) {
+        if (clusterDelta == null) clusterDelta = new ClusterDelta(image.cluster());
+        clusterDelta.replay(record);
+    }
+
+    public void replay(UnfenceBrokerRecord record) {
+        if (clusterDelta == null) clusterDelta = new ClusterDelta(image.cluster());
+        clusterDelta.replay(record);
+    }
+
+    public void replay(RemoveTopicRecord record) {
+        if (topicsDelta == null) topicsDelta = new TopicsDelta(image.topics());
+        String topicName = topicsDelta.replay(record);
+        if (configsDelta == null) configsDelta = new ConfigurationsDelta(image.configs());
+        configsDelta.replay(record, topicName);
+    }
+
+    public void replay(FeatureLevelRecord record) {
+        if (featuresDelta == null) featuresDelta = new FeaturesDelta(image.features());
+        featuresDelta.replay(record);
+    }
+
+    public void replay(BrokerRegistrationChangeRecord record) {
+        if (clusterDelta == null) clusterDelta = new ClusterDelta(image.cluster());
+        clusterDelta.replay(record);
+    }
+
+    public void replay(ClientQuotaRecord record) {
+        if (clientQuotasDelta == null) clientQuotasDelta = new ClientQuotasDelta(image.clientQuotas());
+        clientQuotasDelta.replay(record);
+    }
+
+    public void replay(RemoveFeatureLevelRecord record) {
+        if (featuresDelta == null) featuresDelta = new FeaturesDelta(image.features());
+        featuresDelta.replay(record);
+    }
+
+    public void finishSnapshot() {
+        if (featuresDelta != null) featuresDelta.finishSnapshot();
+        if (clusterDelta != null) clusterDelta.finishSnapshot();
+        if (topicsDelta != null) topicsDelta.finishSnapshot();
+        if (configsDelta != null) configsDelta.finishSnapshot();
+        if (clientQuotasDelta != null) clientQuotasDelta.finishSnapshot();
+    }
+
+    public MetadataImage apply() {
+        FeaturesImage newFeatures;
+        if (featuresDelta == null) {
+            newFeatures = image.features();
+        } else {
+            newFeatures = featuresDelta.apply();
+        }
+        ClusterImage newCluster;
+        if (clusterDelta == null) {
+            newCluster = image.cluster();
+        } else {
+            newCluster = clusterDelta.apply();
+        }
+        TopicsImage newTopics;
+        if (topicsDelta == null) {
+            newTopics = image.topics();
+        } else {
+            newTopics = topicsDelta.apply();
+        }
+        ConfigurationsImage newConfigs;
+        if (configsDelta == null) {
+            newConfigs = image.configs();
+        } else {
+            newConfigs = configsDelta.apply();
+        }
+        ClientQuotasImage newClientQuotas;
+        if (clientQuotasDelta == null) {
+            newClientQuotas = image.clientQuotas();
+        } else {
+            newClientQuotas = clientQuotasDelta.apply();
+        }
+        return new MetadataImage(newFeatures, newCluster, newTopics, newConfigs,
+            newClientQuotas);
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+
+/**
+ * The broker metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class MetadataImage {
+    public final static MetadataImage EMPTY = new MetadataImage(
+        FeaturesImage.EMPTY,
+        ClusterImage.EMPTY,
+        TopicsImage.EMPTY,
+        ConfigurationsImage.EMPTY,
+        ClientQuotasImage.EMPTY);
+
+    private final FeaturesImage features;
+
+    private final ClusterImage cluster;
+
+    private final TopicsImage topics;
+
+    private final ConfigurationsImage configs;
+
+    private final ClientQuotasImage clientQuotas;
+
+    public MetadataImage(FeaturesImage features,
+                         ClusterImage cluster,
+                         TopicsImage topics,
+                         ConfigurationsImage configs,
+                         ClientQuotasImage clientQuotas) {
+        this.features = features;
+        this.cluster = cluster;
+        this.topics = topics;
+        this.configs = configs;
+        this.clientQuotas = clientQuotas;
+    }
+
+    public boolean isEmpty() {
+        return features.isEmpty() &&
+            cluster.isEmpty() &&
+            topics.isEmpty() &&
+            configs.isEmpty() &&
+            clientQuotas.isEmpty();
+    }
+
+    public FeaturesImage features() {
+        return features;
+    }
+
+    public ClusterImage cluster() {
+        return cluster;
+    }
+
+    public TopicsImage topics() {
+        return topics;
+    }
+
+    public ConfigurationsImage configs() {
+        return configs;
+    }
+
+    public ClientQuotasImage clientQuotas() {
+        return clientQuotas;
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        features.write(out);
+        cluster.write(out);
+        topics.write(out);
+        configs.write(out);
+        clientQuotas.write(out);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MetadataImage)) return false;
+        MetadataImage other = (MetadataImage) o;
+        return features.equals(other.features) &&
+            cluster.equals(other.cluster) &&
+            topics.equals(other.topics) &&
+            configs.equals(other.configs) &&
+            clientQuotas.equals(other.clientQuotas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(features, cluster, topics, configs, clientQuotas);
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataImage(features=" + features +
+            ", cluster=" + cluster +
+            ", topics=" + topics +
+            ", configs=" + configs +
+            ", clientQuotas=" + clientQuotas +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/MetadataImage.java
@@ -19,7 +19,6 @@ package org.apache.kafka.image;
 
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -88,7 +87,7 @@ public final class MetadataImage {
         return clientQuotas;
     }
 
-    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(Consumer<List<ApiMessageAndVersion>> out) {
         features.write(out);
         cluster.write(out);
         topics.write(out);

--- a/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicDelta.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.metadata.Replicas;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+
+/**
+ * Represents changes to a topic in the metadata image.
+ */
+public final class TopicDelta {
+    private final TopicImage image;
+    private final Map<Integer, PartitionRegistration> partitionChanges = new HashMap<>();
+
+    public TopicDelta(TopicImage image) {
+        this.image = image;
+    }
+
+    public TopicImage image() {
+        return image;
+    }
+
+    public Map<Integer, PartitionRegistration> partitionChanges() {
+        return partitionChanges;
+    }
+
+    public String name() {
+        return image.name();
+    }
+
+    public Uuid id() {
+        return image.id();
+    }
+
+    public void replay(PartitionRecord record) {
+        partitionChanges.put(record.partitionId(), new PartitionRegistration(record));
+    }
+
+    public void replay(PartitionChangeRecord record) {
+        PartitionRegistration partition = partitionChanges.get(record.partitionId());
+        if (partition == null) {
+            partition = image.partitions().get(record.partitionId());
+            if (partition == null) {
+                throw new RuntimeException("Unable to find partition " +
+                    record.topicId() + ":" + record.partitionId());
+            }
+        }
+        partitionChanges.put(record.partitionId(), partition.merge(record));
+    }
+
+    public TopicImage apply() {
+        Map<Integer, PartitionRegistration> newPartitions = new HashMap<>();
+        for (Entry<Integer, PartitionRegistration> entry : image.partitions().entrySet()) {
+            int partitionId = entry.getKey();
+            PartitionRegistration changedPartition = partitionChanges.get(partitionId);
+            if (changedPartition == null) {
+                newPartitions.put(partitionId, entry.getValue());
+            } else {
+                newPartitions.put(partitionId, changedPartition);
+            }
+        }
+        for (Entry<Integer, PartitionRegistration> entry : partitionChanges.entrySet()) {
+            if (!newPartitions.containsKey(entry.getKey())) {
+                newPartitions.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return new TopicImage(image.name(), image.id(), newPartitions);
+    }
+
+    /**
+     * Find the partitions that we are now leading, that we were not leading before.
+     *
+     * @param brokerId  The broker id.
+     * @return          A list of (partition ID, partition registration) entries.
+     */
+    public List<Entry<Integer, PartitionRegistration>> newLocalLeaders(int brokerId) {
+        List<Entry<Integer, PartitionRegistration>> results = new ArrayList<>();
+        for (Entry<Integer, PartitionRegistration> entry : partitionChanges.entrySet()) {
+            if (entry.getValue().leader == brokerId) {
+                PartitionRegistration prevPartition = image.partitions().get(entry.getKey());
+                if (prevPartition == null || prevPartition.leader != brokerId) {
+                    results.add(entry);
+                }
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Find the partitions that we are now following, that we were not following before.
+     *
+     * @param brokerId  The broker id.
+     * @return          A list of (partition ID, partition registration) entries.
+     */
+    public List<Entry<Integer, PartitionRegistration>> newLocalFollowers(int brokerId) {
+        List<Entry<Integer, PartitionRegistration>> results = new ArrayList<>();
+        for (Entry<Integer, PartitionRegistration> entry : partitionChanges.entrySet()) {
+            if (entry.getValue().leader != brokerId &&
+                    Replicas.contains(entry.getValue().replicas, brokerId)) {
+                PartitionRegistration prevPartition = image.partitions().get(entry.getKey());
+                if (prevPartition == null || prevPartition.leader == brokerId) {
+                    results.add(entry);
+                }
+            }
+        }
+        return results;
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.TopicRecord;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.TOPIC_RECORD;
+
+
+/**
+ * Represents a topic in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class TopicImage {
+    private final String name;
+
+    private final Uuid id;
+
+    private final Map<Integer, PartitionRegistration> partitions;
+
+    public TopicImage(String name,
+                      Uuid id,
+                      Map<Integer, PartitionRegistration> partitions) {
+        this.name = name;
+        this.id = id;
+        this.partitions = partitions;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Uuid id() {
+        return id;
+    }
+
+    public Map<Integer, PartitionRegistration> partitions() {
+        return partitions;
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        List<ApiMessageAndVersion> batch = new ArrayList<>();
+        batch.add(new ApiMessageAndVersion(new TopicRecord().
+            setName(name).
+            setTopicId(id), TOPIC_RECORD.highestSupportedVersion()));
+        for (Entry<Integer, PartitionRegistration> entry : partitions.entrySet()) {
+            int partitionId = entry.getKey();
+            PartitionRegistration partition = entry.getValue();
+            batch.add(partition.toRecord(id, partitionId));
+        }
+        out.accept(batch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TopicImage)) return false;
+        TopicImage other = (TopicImage) o;
+        return name.equals(other.name) &&
+            id.equals(other.id) &&
+            partitions.equals(other.partitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, id, partitions);
+    }
+
+    @Override
+    public String toString() {
+        return "TopicImage(name=" + name + ", id=" + id + ", partitions=" +
+            partitions.entrySet().stream().
+                map(e -> e.getKey() + ":" + e.getValue()).
+                collect(Collectors.joining(", ")) + ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicImage.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -66,7 +65,7 @@ public final class TopicImage {
         return partitions;
     }
 
-    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(Consumer<List<ApiMessageAndVersion>> out) {
         List<ApiMessageAndVersion> batch = new ArrayList<>();
         batch.add(new ApiMessageAndVersion(new TopicRecord().
             setName(name).

--- a/metadata/src/main/java/org/apache/kafka/image/TopicsDelta.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsDelta.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.common.metadata.RemoveTopicRecord;
+import org.apache.kafka.common.metadata.TopicRecord;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+
+/**
+ * Represents changes to the topics in the metadata image.
+ */
+public final class TopicsDelta {
+    private final TopicsImage image;
+
+    /**
+     * A map from topic IDs to the topic deltas for each topic. Topics which have been
+     * deleted will not appear in this map.
+     */
+    private final Map<Uuid, TopicDelta> changedTopics = new HashMap<>();
+
+    /**
+     * The IDs of topics that exist in the image but that have been deleted. Note that if
+     * a topic does not exist in the image, it will also not exist in this set. Topics
+     * that are created and then deleted within the same delta will leave no trace.
+     */
+    private final Set<Uuid> deletedTopicIds = new HashSet<>();
+
+    public TopicsDelta(TopicsImage image) {
+        this.image = image;
+    }
+
+    public TopicsImage image() {
+        return image;
+    }
+
+    public Map<Uuid, TopicDelta> changedTopics() {
+        return changedTopics;
+    }
+
+    public void replay(TopicRecord record) {
+        TopicDelta delta = new TopicDelta(
+            new TopicImage(record.name(), record.topicId(), Collections.emptyMap()));
+        changedTopics.put(record.topicId(), delta);
+    }
+
+    TopicDelta getOrCreateTopicDelta(Uuid id) {
+        TopicDelta topicDelta = changedTopics.get(id);
+        if (topicDelta == null) {
+            topicDelta = new TopicDelta(image.getTopic(id));
+            changedTopics.put(id, topicDelta);
+        }
+        return topicDelta;
+    }
+
+    public void replay(PartitionRecord record) {
+        TopicDelta topicDelta = getOrCreateTopicDelta(record.topicId());
+        topicDelta.replay(record);
+    }
+
+    public void replay(PartitionChangeRecord record) {
+        TopicDelta topicDelta = getOrCreateTopicDelta(record.topicId());
+        topicDelta.replay(record);
+    }
+
+    public String replay(RemoveTopicRecord record) {
+        TopicDelta topicDelta = changedTopics.remove(record.topicId());
+        String topicName;
+        if (topicDelta != null) {
+            topicName = topicDelta.image().name();
+            if (image.topicsById().containsKey(record.topicId())) {
+                deletedTopicIds.add(record.topicId());
+            }
+        } else {
+            TopicImage topicImage = image.getTopic(record.topicId());
+            if (topicImage == null) {
+                throw new RuntimeException("Unable to delete topic with id " +
+                    record.topicId() + ": no such topic found.");
+            }
+            topicName = topicImage.name();
+            deletedTopicIds.add(record.topicId());
+        }
+        return topicName;
+    }
+
+    public void finishSnapshot() {
+        for (Uuid topicId : image.topicsById().keySet()) {
+            if (!changedTopics.containsKey(topicId)) {
+                deletedTopicIds.add(topicId);
+            }
+        }
+    }
+
+    public TopicsImage apply() {
+        Map<Uuid, TopicImage> newTopicsById = new HashMap<>(image.topicsById().size());
+        Map<String, TopicImage> newTopicsByName = new HashMap<>(image.topicsByName().size());
+        for (Entry<Uuid, TopicImage> entry : image.topicsById().entrySet()) {
+            Uuid id = entry.getKey();
+            TopicImage prevTopicImage = entry.getValue();
+            TopicDelta delta = changedTopics.get(id);
+            if (delta == null) {
+                if (!deletedTopicIds.contains(id)) {
+                    newTopicsById.put(id, prevTopicImage);
+                    newTopicsByName.put(prevTopicImage.name(), prevTopicImage);
+                }
+            } else {
+                TopicImage newTopicImage = delta.apply();
+                newTopicsById.put(id, newTopicImage);
+                newTopicsByName.put(delta.name(), newTopicImage);
+            }
+        }
+        for (Entry<Uuid, TopicDelta> entry : changedTopics.entrySet()) {
+            if (!newTopicsById.containsKey(entry.getKey())) {
+                TopicImage newTopicImage = entry.getValue().apply();
+                newTopicsById.put(newTopicImage.id(), newTopicImage);
+                newTopicsByName.put(newTopicImage.name(), newTopicImage);
+            }
+        }
+        return new TopicsImage(newTopicsById, newTopicsByName);
+    }
+
+    public TopicDelta changedTopic(Uuid topicId) {
+        return changedTopics.get(topicId);
+    }
+
+    /**
+     * Returns true if the topic with the given name was deleted. Note: this will return
+     * true even if a new topic with the same name was subsequently created.
+     */
+    public boolean topicWasDeleted(String topicName) {
+        TopicImage topicImage = image.getTopic(topicName);
+        if (topicImage == null) {
+            return false;
+        }
+        return deletedTopicIds.contains(topicImage.id());
+    }
+
+    public Set<Uuid> deletedTopicIds() {
+        return deletedTopicIds;
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+
+/**
+ * Represents the topics in the metadata image.
+ *
+ * This class is thread-safe.
+ */
+public final class TopicsImage {
+    public static final TopicsImage EMPTY =
+        new TopicsImage(Collections.emptyMap(), Collections.emptyMap());
+
+    private final Map<Uuid, TopicImage> topicsById;
+    private final Map<String, TopicImage> topicsByName;
+
+    public TopicsImage(Map<Uuid, TopicImage> topicsById,
+                       Map<String, TopicImage> topicsByName) {
+        this.topicsById = topicsById;
+        this.topicsByName = topicsByName;
+    }
+
+    public boolean isEmpty() {
+        return topicsById.isEmpty() && topicsByName.isEmpty();
+    }
+
+    public Map<Uuid, TopicImage> topicsById() {
+        return topicsById;
+    }
+
+    public Map<String, TopicImage> topicsByName() {
+        return topicsByName;
+    }
+
+    public PartitionRegistration getPartition(Uuid id, int partitionId) {
+        TopicImage topicImage = topicsById.get(id);
+        if (topicImage == null) return null;
+        return topicImage.partitions().get(partitionId);
+    }
+
+    public TopicImage getTopic(Uuid id) {
+        return topicsById.get(id);
+    }
+
+    public TopicImage getTopic(String name) {
+        return topicsByName.get(name);
+    }
+
+    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+        for (TopicImage topicImage : topicsById.values()) {
+            topicImage.write(out);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof TopicsImage)) return false;
+        TopicsImage other = (TopicsImage) o;
+        return topicsById.equals(other.topicsById) &&
+            topicsByName.equals(other.topicsByName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(topicsById, topicsByName);
+    }
+
+    @Override
+    public String toString() {
+        return "TopicsImage(topicsById=" + topicsById.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", ")) +
+            ", topicsByName=" + topicsByName.entrySet().stream().
+            map(e -> e.getKey() + ":" + e.getValue()).collect(Collectors.joining(", ")) +
+            ")";
+    }
+}

--- a/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
+++ b/metadata/src/main/java/org/apache/kafka/image/TopicsImage.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.Uuid;
 import org.apache.kafka.metadata.PartitionRegistration;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -44,8 +43,8 @@ public final class TopicsImage {
 
     public TopicsImage(Map<Uuid, TopicImage> topicsById,
                        Map<String, TopicImage> topicsByName) {
-        this.topicsById = topicsById;
-        this.topicsByName = topicsByName;
+        this.topicsById = Collections.unmodifiableMap(topicsById);
+        this.topicsByName = Collections.unmodifiableMap(topicsByName);
     }
 
     public boolean isEmpty() {
@@ -74,7 +73,7 @@ public final class TopicsImage {
         return topicsByName.get(name);
     }
 
-    public void write(Consumer<List<ApiMessageAndVersion>> out) throws IOException {
+    public void write(Consumer<List<ApiMessageAndVersion>> out) {
         for (TopicImage topicImage : topicsById.values()) {
             topicImage.write(out);
         }

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -18,20 +18,39 @@
 package org.apache.kafka.metadata;
 
 import org.apache.kafka.common.Endpoint;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord.BrokerEndpoint;
+import org.apache.kafka.common.metadata.RegisterBrokerRecord.BrokerFeature;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.REGISTER_BROKER_RECORD;
+
 
 /**
  * An immutable class which represents broker registrations.
  */
 public class BrokerRegistration {
+    private static Map<String, Endpoint> listenersToMap(Collection<Endpoint> listeners) {
+        Map<String, Endpoint> listenersMap = new HashMap<>();
+        for (Endpoint endpoint : listeners) {
+            listenersMap.put(endpoint.listenerName().get(), endpoint);
+        }
+        return listenersMap;
+    }
+
     private final int id;
     private final long epoch;
     private final Uuid incarnationId;
@@ -47,19 +66,7 @@ public class BrokerRegistration {
                               Map<String, VersionRange> supportedFeatures,
                               Optional<String> rack,
                               boolean fenced) {
-        this.id = id;
-        this.epoch = epoch;
-        this.incarnationId = incarnationId;
-        Map<String, Endpoint> listenersMap = new HashMap<>();
-        for (Endpoint endpoint : listeners) {
-            listenersMap.put(endpoint.listenerName().get(), endpoint);
-        }
-        this.listeners = Collections.unmodifiableMap(listenersMap);
-        Objects.requireNonNull(supportedFeatures);
-        this.supportedFeatures = new HashMap<>(supportedFeatures);
-        Objects.requireNonNull(rack);
-        this.rack = rack;
-        this.fenced = fenced;
+        this(id, epoch, incarnationId, listenersToMap(listeners), supportedFeatures, rack, fenced);
     }
 
     public BrokerRegistration(int id,
@@ -72,10 +79,34 @@ public class BrokerRegistration {
         this.id = id;
         this.epoch = epoch;
         this.incarnationId = incarnationId;
-        this.listeners = new HashMap<>(listeners);
+        this.listeners = Collections.unmodifiableMap(new HashMap<>(listeners));
+        Objects.requireNonNull(supportedFeatures);
         this.supportedFeatures = new HashMap<>(supportedFeatures);
+        Objects.requireNonNull(rack);
         this.rack = rack;
         this.fenced = fenced;
+    }
+
+    public static BrokerRegistration fromRecord(RegisterBrokerRecord record) {
+        Map<String, Endpoint> listeners = new HashMap<>();
+        for (BrokerEndpoint endpoint : record.endPoints()) {
+            listeners.put(endpoint.name(), new Endpoint(endpoint.name(),
+                SecurityProtocol.forId(endpoint.securityProtocol()),
+                endpoint.host(),
+                endpoint.port()));
+        }
+        Map<String, VersionRange> supportedFeatures = new HashMap<>();
+        for (BrokerFeature feature : record.features()) {
+            supportedFeatures.put(feature.name(), new VersionRange(
+                feature.minSupportedVersion(), feature.maxSupportedVersion()));
+        }
+        return new BrokerRegistration(record.brokerId(),
+            record.brokerEpoch(),
+            record.incarnationId(),
+            listeners,
+            supportedFeatures,
+            Optional.ofNullable(record.rack()),
+            record.fenced());
     }
 
     public int id() {
@@ -94,6 +125,14 @@ public class BrokerRegistration {
         return listeners;
     }
 
+    public Optional<Node> node(String listenerName) {
+        Endpoint endpoint = listeners().get(listenerName);
+        if (endpoint == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Node(id, endpoint.host(), endpoint.port(), rack.orElse(null)));
+    }
+
     public Map<String, VersionRange> supportedFeatures() {
         return supportedFeatures;
     }
@@ -104,6 +143,31 @@ public class BrokerRegistration {
 
     public boolean fenced() {
         return fenced;
+    }
+
+    public ApiMessageAndVersion toRecord() {
+        RegisterBrokerRecord registrationRecord = new RegisterBrokerRecord().
+            setBrokerId(id).
+            setRack(rack.orElse(null)).
+            setBrokerEpoch(epoch).
+            setIncarnationId(incarnationId).
+            setFenced(fenced);
+        for (Entry<String, Endpoint> entry : listeners.entrySet()) {
+            Endpoint endpoint = entry.getValue();
+            registrationRecord.endPoints().add(new BrokerEndpoint().
+                setName(entry.getKey()).
+                setHost(endpoint.host()).
+                setPort(endpoint.port()).
+                setSecurityProtocol(endpoint.securityProtocol().id));
+        }
+        for (Entry<String, VersionRange> entry : supportedFeatures.entrySet()) {
+            registrationRecord.features().add(new BrokerFeature().
+                setName(entry.getKey()).
+                setMinSupportedVersion(entry.getValue().min()).
+                setMaxSupportedVersion(entry.getValue().max()));
+        }
+        return new ApiMessageAndVersion(registrationRecord,
+                REGISTER_BROKER_RECORD.highestSupportedVersion());
     }
 
     @Override

--- a/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/BrokerRegistration.java
@@ -79,7 +79,14 @@ public class BrokerRegistration {
         this.id = id;
         this.epoch = epoch;
         this.incarnationId = incarnationId;
-        this.listeners = Collections.unmodifiableMap(new HashMap<>(listeners));
+        Map<String, Endpoint> newListeners = new HashMap<>(listeners.size());
+        for (Entry<String, Endpoint> entry : listeners.entrySet()) {
+            if (!entry.getValue().listenerName().isPresent()) {
+                throw new IllegalArgumentException("Broker listeners must be named.");
+            }
+            newListeners.put(entry.getKey(), entry.getValue());
+        }
+        this.listeners = Collections.unmodifiableMap(newListeners);
         Objects.requireNonNull(supportedFeatures);
         this.supportedFeatures = new HashMap<>(supportedFeatures);
         Objects.requireNonNull(rack);

--- a/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
+++ b/metadata/src/main/java/org/apache/kafka/metadata/PartitionRegistration.java
@@ -17,7 +17,9 @@
 
 package org.apache.kafka.metadata;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -160,6 +162,22 @@ public class PartitionRegistration {
             setLeader(leader).
             setLeaderEpoch(leaderEpoch).
             setPartitionEpoch(partitionEpoch), PARTITION_RECORD.highestSupportedVersion());
+    }
+
+    public LeaderAndIsrPartitionState toLeaderAndIsrPartitionState(TopicPartition tp,
+                                                                   boolean isNew) {
+        return new LeaderAndIsrPartitionState().
+            setTopicName(tp.topic()).
+            setPartitionIndex(tp.partition()).
+            setControllerEpoch(-1).
+            setLeader(leader).
+            setLeaderEpoch(leaderEpoch).
+            setIsr(Replicas.toList(isr)).
+            setZkVersion(partitionEpoch).
+            setReplicas(Replicas.toList(replicas)).
+            setAddingReplicas(Replicas.toList(addingReplicas)).
+            setRemovingReplicas(Replicas.toList(removingReplicas)).
+            setIsNew(isNew);
     }
 
     @Override

--- a/metadata/src/test/java/org/apache/kafka/image/ClientQuotasImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClientQuotasImageTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.config.internals.QuotaConfigs;
+import org.apache.kafka.common.metadata.ClientQuotaRecord;
+import org.apache.kafka.common.metadata.ClientQuotaRecord.EntityData;
+import org.apache.kafka.common.quota.ClientQuotaEntity;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.CLIENT_QUOTA_RECORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class ClientQuotasImageTest {
+    final static ClientQuotasImage IMAGE1;
+
+    final static List<ApiMessageAndVersion> DELTA1_RECORDS;
+
+    final static ClientQuotasDelta DELTA1;
+
+    final static ClientQuotasImage IMAGE2;
+
+    static {
+        Map<ClientQuotaEntity, ClientQuotaImage> entities1 = new HashMap<>();
+        Map<String, String> fooUser = new HashMap<>();
+        fooUser.put(ClientQuotaEntity.USER, "foo");
+        Map<String, Double> fooUserQuotas = new HashMap<>();
+        fooUserQuotas.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, 123.0);
+        entities1.put(new ClientQuotaEntity(fooUser), new ClientQuotaImage(fooUserQuotas));
+        Map<String, String> barUserAndIp = new HashMap<>();
+        barUserAndIp.put(ClientQuotaEntity.USER, "bar");
+        barUserAndIp.put(ClientQuotaEntity.IP, "127.0.0.1");
+        Map<String, Double> barUserAndIpQuotas = new HashMap<>();
+        barUserAndIpQuotas.put(QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG, 456.0);
+        entities1.put(new ClientQuotaEntity(barUserAndIp),
+            new ClientQuotaImage(barUserAndIpQuotas));
+        IMAGE1 = new ClientQuotasImage(entities1);
+
+        DELTA1_RECORDS = new ArrayList<>();
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().
+                setEntity(Arrays.asList(
+                    new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("bar"),
+                    new EntityData().setEntityType(ClientQuotaEntity.IP).setEntityName("127.0.0.1"))).
+                setKey(QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG).
+                setRemove(true), CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ClientQuotaRecord().
+            setEntity(Arrays.asList(
+                new EntityData().setEntityType(ClientQuotaEntity.USER).setEntityName("foo"))).
+            setKey(QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG).
+            setValue(999.0), CLIENT_QUOTA_RECORD.highestSupportedVersion()));
+
+        DELTA1 = new ClientQuotasDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
+
+        Map<ClientQuotaEntity, ClientQuotaImage> entities2 = new HashMap<>();
+        Map<String, Double> fooUserQuotas2 = new HashMap<>();
+        fooUserQuotas2.put(QuotaConfigs.PRODUCER_BYTE_RATE_OVERRIDE_CONFIG, 123.0);
+        fooUserQuotas2.put(QuotaConfigs.CONSUMER_BYTE_RATE_OVERRIDE_CONFIG, 999.0);
+        entities2.put(new ClientQuotaEntity(fooUser), new ClientQuotaImage(fooUserQuotas2));
+        IMAGE2 = new ClientQuotasImage(entities2);
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(ClientQuotasImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(ClientQuotasImage image) throws Throwable {
+        MockSnapshotConsumer writer = new MockSnapshotConsumer();
+        image.write(writer);
+        ClientQuotasDelta delta = new ClientQuotasDelta(ClientQuotasImage.EMPTY);
+        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        ClientQuotasImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.Endpoint;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.FenceBrokerRecord;
+import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
+import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.metadata.BrokerRegistration;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.metadata.VersionRange;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.FENCE_BROKER_RECORD;
+import static org.apache.kafka.common.metadata.MetadataRecordType.UNFENCE_BROKER_RECORD;
+import static org.apache.kafka.common.metadata.MetadataRecordType.UNREGISTER_BROKER_RECORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class ClusterImageTest {
+    final static ClusterImage IMAGE1;
+
+    static final List<ApiMessageAndVersion> DELTA1_RECORDS;
+
+    final static ClusterDelta DELTA1;
+
+    final static ClusterImage IMAGE2;
+
+    static {
+        Map<Integer, BrokerRegistration> map1 = new HashMap<>();
+        map1.put(0, new BrokerRegistration(0,
+            1000,
+            Uuid.fromString("vZKYST0pSA2HO5x_6hoO2Q"),
+            Arrays.asList(new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 9092)),
+            Collections.singletonMap("foo", new VersionRange((short) 1, (short) 3)),
+            Optional.empty(),
+            true));
+        map1.put(1, new BrokerRegistration(1,
+            1001,
+            Uuid.fromString("U52uRe20RsGI0RvpcTx33Q"),
+            Arrays.asList(new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 9093)),
+            Collections.singletonMap("foo", new VersionRange((short) 1, (short) 3)),
+            Optional.empty(),
+            false));
+        map1.put(2, new BrokerRegistration(2,
+            123,
+            Uuid.fromString("hr4TVh3YQiu3p16Awkka6w"),
+            Arrays.asList(new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 9093)),
+            Collections.emptyMap(),
+            Optional.of("arack"),
+            false));
+        IMAGE1 = new ClusterImage(map1);
+
+        DELTA1_RECORDS = new ArrayList<>();
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new UnfenceBrokerRecord().
+            setId(0).setEpoch(1000), UNFENCE_BROKER_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new FenceBrokerRecord().
+            setId(1).setEpoch(1000), FENCE_BROKER_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new UnregisterBrokerRecord().
+            setBrokerId(2).setBrokerEpoch(123),
+            UNREGISTER_BROKER_RECORD.highestSupportedVersion()));
+
+        DELTA1 = new ClusterDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
+
+        Map<Integer, BrokerRegistration> map2 = new HashMap<>();
+        map2.put(0, new BrokerRegistration(0,
+            1000,
+            Uuid.fromString("vZKYST0pSA2HO5x_6hoO2Q"),
+            Arrays.asList(new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 9092)),
+            Collections.singletonMap("foo", new VersionRange((short) 1, (short) 3)),
+            Optional.empty(),
+            false));
+        map2.put(1, new BrokerRegistration(1,
+            1001,
+            Uuid.fromString("U52uRe20RsGI0RvpcTx33Q"),
+            Arrays.asList(new Endpoint("PLAINTEXT", SecurityProtocol.PLAINTEXT, "localhost", 9093)),
+            Collections.singletonMap("foo", new VersionRange((short) 1, (short) 3)),
+            Optional.empty(),
+            true));
+        IMAGE2 = new ClusterImage(map2);
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(ClusterImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(ClusterImage image) throws Throwable {
+        MockSnapshotConsumer writer = new MockSnapshotConsumer();
+        image.write(writer);
+        ClusterDelta delta = new ClusterDelta(ClusterImage.EMPTY);
+        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        ClusterImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ClusterImageTest.java
@@ -83,7 +83,7 @@ public class ClusterImageTest {
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new UnfenceBrokerRecord().
             setId(0).setEpoch(1000), UNFENCE_BROKER_RECORD.highestSupportedVersion()));
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new FenceBrokerRecord().
-            setId(1).setEpoch(1000), FENCE_BROKER_RECORD.highestSupportedVersion()));
+            setId(1).setEpoch(1001), FENCE_BROKER_RECORD.highestSupportedVersion()));
         DELTA1_RECORDS.add(new ApiMessageAndVersion(new UnregisterBrokerRecord().
             setBrokerId(2).setBrokerEpoch(123),
             UNREGISTER_BROKER_RECORD.highestSupportedVersion()));

--- a/metadata/src/test/java/org/apache/kafka/image/ConfigurationsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/ConfigurationsImageTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.metadata.ConfigRecord;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.config.ConfigResource.Type.BROKER;
+import static org.apache.kafka.common.metadata.MetadataRecordType.CONFIG_RECORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class ConfigurationsImageTest {
+    final static ConfigurationsImage IMAGE1;
+
+    final static List<ApiMessageAndVersion> DELTA1_RECORDS;
+
+    final static ConfigurationsDelta DELTA1;
+
+    final static ConfigurationsImage IMAGE2;
+
+    static {
+        Map<ConfigResource, ConfigurationImage> map1 = new HashMap<>();
+        Map<String, String> broker0Map = new HashMap<>();
+        broker0Map.put("foo", "bar");
+        broker0Map.put("baz", "quux");
+        map1.put(new ConfigResource(BROKER, "0"),
+            new ConfigurationImage(broker0Map));
+        Map<String, String> broker1Map = new HashMap<>();
+        broker1Map.put("foobar", "foobaz");
+        map1.put(new ConfigResource(BROKER, "1"),
+            new ConfigurationImage(broker1Map));
+        IMAGE1 = new ConfigurationsImage(map1);
+
+        DELTA1_RECORDS = new ArrayList<>();
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ConfigRecord().setResourceType(BROKER.id()).
+            setResourceName("0").setName("foo").setValue(null),
+            CONFIG_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new ConfigRecord().setResourceType(BROKER.id()).
+            setResourceName("1").setName("barfoo").setValue("bazfoo"),
+            CONFIG_RECORD.highestSupportedVersion()));
+
+        DELTA1 = new ConfigurationsDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
+
+        Map<ConfigResource, ConfigurationImage> map2 = new HashMap<>();
+        Map<String, String> broker0Map2 = new HashMap<>();
+        broker0Map2.put("baz", "quux");
+        map2.put(new ConfigResource(BROKER, "0"),
+            new ConfigurationImage(broker0Map2));
+        Map<String, String> broker1Map2 = new HashMap<>();
+        broker1Map2.put("foobar", "foobaz");
+        broker1Map2.put("barfoo", "bazfoo");
+        map2.put(new ConfigResource(BROKER, "1"),
+            new ConfigurationImage(broker1Map2));
+        IMAGE2 = new ConfigurationsImage(map2);
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(ConfigurationsImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(ConfigurationsImage image) throws Throwable {
+        MockSnapshotConsumer writer = new MockSnapshotConsumer();
+        image.write(writer);
+        ConfigurationsDelta delta = new ConfigurationsDelta(ConfigurationsImage.EMPTY);
+        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        ConfigurationsImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/FeaturesImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/FeaturesImageTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.common.metadata.RemoveFeatureLevelRecord;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.metadata.VersionRange;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.FEATURE_LEVEL_RECORD;
+import static org.apache.kafka.common.metadata.MetadataRecordType.REMOVE_FEATURE_LEVEL_RECORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class FeaturesImageTest {
+    final static FeaturesImage IMAGE1;
+    final static List<ApiMessageAndVersion> DELTA1_RECORDS;
+    final static FeaturesDelta DELTA1;
+    final static FeaturesImage IMAGE2;
+
+    static {
+        Map<String, VersionRange> map1 = new HashMap<>();
+        map1.put("foo", new VersionRange((short) 1, (short) 2));
+        map1.put("bar", new VersionRange((short) 1, (short) 1));
+        map1.put("baz", new VersionRange((short) 1, (short) 8));
+        IMAGE1 = new FeaturesImage(map1);
+
+        DELTA1_RECORDS = new ArrayList<>();
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new FeatureLevelRecord().
+            setName("foo").setMinFeatureLevel((short) 1).setMaxFeatureLevel((short) 3),
+            FEATURE_LEVEL_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new RemoveFeatureLevelRecord().
+            setName("bar"), REMOVE_FEATURE_LEVEL_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new RemoveFeatureLevelRecord().
+            setName("baz"), REMOVE_FEATURE_LEVEL_RECORD.highestSupportedVersion()));
+
+        DELTA1 = new FeaturesDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
+
+        Map<String, VersionRange> map2 = new HashMap<>();
+        map2.put("foo", new VersionRange((short) 1, (short) 3));
+        IMAGE2 = new FeaturesImage(map2);
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(FeaturesImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(FeaturesImage image) throws Throwable {
+        MockSnapshotConsumer writer = new MockSnapshotConsumer();
+        image.write(writer);
+        FeaturesDelta delta = new FeaturesDelta(FeaturesImage.EMPTY);
+        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        FeaturesImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MetadataImageTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class MetadataImageTest {
+    private final static MetadataImage IMAGE1;
+
+    private final static MetadataDelta DELTA1;
+
+    private final static MetadataImage IMAGE2;
+
+    static {
+        IMAGE1 = new MetadataImage(FeaturesImageTest.IMAGE1,
+            ClusterImageTest.IMAGE1,
+            TopicsImageTest.IMAGE1,
+            ConfigurationsImageTest.IMAGE1,
+            ClientQuotasImageTest.IMAGE1);
+
+        DELTA1 = new MetadataDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, FeaturesImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, ClusterImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, TopicsImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, ConfigurationsImageTest.DELTA1_RECORDS);
+        RecordTestUtils.replayAll(DELTA1, ClientQuotasImageTest.DELTA1_RECORDS);
+
+        IMAGE2 = new MetadataImage(FeaturesImageTest.IMAGE2,
+            ClusterImageTest.IMAGE2,
+            TopicsImageTest.IMAGE2,
+            ConfigurationsImageTest.IMAGE2,
+            ClientQuotasImageTest.IMAGE2);
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(MetadataImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(MetadataImage image) throws Throwable {
+        MockSnapshotConsumer writer = new MockSnapshotConsumer();
+        image.write(writer);
+        MetadataDelta delta = new MetadataDelta(MetadataImage.EMPTY);
+        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        MetadataImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/MockSnapshotConsumer.java
+++ b/metadata/src/test/java/org/apache/kafka/image/MockSnapshotConsumer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+
+public class MockSnapshotConsumer implements Consumer<List<ApiMessageAndVersion>> {
+    private final List<List<ApiMessageAndVersion>> batches = new ArrayList<>();
+
+    @Override
+    public void accept(List<ApiMessageAndVersion> batch) {
+        batches.add(batch);
+    }
+
+    public List<List<ApiMessageAndVersion>> batches() {
+        return batches;
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
+++ b/metadata/src/test/java/org/apache/kafka/image/TopicsImageTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.image;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metadata.PartitionChangeRecord;
+import org.apache.kafka.common.metadata.PartitionRecord;
+import org.apache.kafka.common.metadata.RemoveTopicRecord;
+import org.apache.kafka.common.metadata.TopicRecord;
+import org.apache.kafka.metadata.PartitionRegistration;
+import org.apache.kafka.metadata.RecordTestUtils;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_CHANGE_RECORD;
+import static org.apache.kafka.common.metadata.MetadataRecordType.PARTITION_RECORD;
+import static org.apache.kafka.common.metadata.MetadataRecordType.REMOVE_TOPIC_RECORD;
+import static org.apache.kafka.common.metadata.MetadataRecordType.TOPIC_RECORD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@Timeout(value = 40)
+public class TopicsImageTest {
+    final static TopicsImage IMAGE1;
+
+    static final List<ApiMessageAndVersion> DELTA1_RECORDS;
+
+    final static TopicsDelta DELTA1;
+
+    final static TopicsImage IMAGE2;
+
+    private static TopicImage newTopicImage(String name, Uuid id, PartitionRegistration... partitions) {
+        Map<Integer, PartitionRegistration> partitionMap = new HashMap<>();
+        int i = 0;
+        for (PartitionRegistration partition : partitions) {
+            partitionMap.put(i++, partition);
+        }
+        return new TopicImage(name, id, partitionMap);
+    }
+
+    private static Map<Uuid, TopicImage> newTopicsByIdMap(Collection<TopicImage> topics) {
+        Map<Uuid, TopicImage> map = new HashMap<>();
+        for (TopicImage topic : topics) {
+            map.put(topic.id(), topic);
+        }
+        return map;
+    }
+
+    private static Map<String, TopicImage> newTopicsByNameMap(Collection<TopicImage> topics) {
+        Map<String, TopicImage> map = new HashMap<>();
+        for (TopicImage topic : topics) {
+            map.put(topic.name(), topic);
+        }
+        return map;
+    }
+
+    static {
+        List<TopicImage> topics1 = Arrays.asList(
+            newTopicImage("foo", Uuid.fromString("ThIaNwRnSM2Nt9Mx1v0RvA"),
+            new PartitionRegistration(new int[] {2, 3, 4},
+                new int[] {2, 3}, new int[0], new int[0], 2, 1, 345),
+            new PartitionRegistration(new int[] {3, 4, 5},
+                new int[] {3, 4, 5}, new int[0], new int[0], 3, 4, 684)),
+            newTopicImage("bar", Uuid.fromString("f62ptyETTjet8SL5ZeREiw"),
+                new PartitionRegistration(new int[] {0, 1, 2, 3, 4},
+                    new int[] {0, 1, 2, 3}, new int[] {1}, new int[] {3, 4}, 0, 1, 345)));
+        IMAGE1 = new TopicsImage(newTopicsByIdMap(topics1), newTopicsByNameMap(topics1));
+
+        DELTA1_RECORDS = new ArrayList<>();
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new RemoveTopicRecord().
+            setTopicId(Uuid.fromString("ThIaNwRnSM2Nt9Mx1v0RvA")),
+            REMOVE_TOPIC_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new PartitionChangeRecord().
+            setTopicId(Uuid.fromString("f62ptyETTjet8SL5ZeREiw")).
+            setPartitionId(0).setLeader(1),
+            PARTITION_CHANGE_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new TopicRecord().
+            setName("baz").setTopicId(Uuid.fromString("tgHBnRglT5W_RlENnuG5vg")),
+            TOPIC_RECORD.highestSupportedVersion()));
+        DELTA1_RECORDS.add(new ApiMessageAndVersion(new PartitionRecord().
+            setPartitionId(0).
+            setTopicId(Uuid.fromString("tgHBnRglT5W_RlENnuG5vg")).
+            setReplicas(Arrays.asList(1, 2, 3, 4)).
+            setIsr(Arrays.asList(3, 4)).
+            setRemovingReplicas(Collections.singletonList(2)).
+            setAddingReplicas(Collections.singletonList(1)).
+            setLeader(3).
+            setLeaderEpoch(2).
+            setPartitionEpoch(1), PARTITION_RECORD.highestSupportedVersion()));
+
+        DELTA1 = new TopicsDelta(IMAGE1);
+        RecordTestUtils.replayAll(DELTA1, DELTA1_RECORDS);
+
+        List<TopicImage> topics2 = Arrays.asList(
+            newTopicImage("bar", Uuid.fromString("f62ptyETTjet8SL5ZeREiw"),
+                new PartitionRegistration(new int[] {0, 1, 2, 3, 4},
+                    new int[] {0, 1, 2, 3}, new int[] {1}, new int[] {3, 4}, 1, 2, 346)),
+            newTopicImage("baz", Uuid.fromString("tgHBnRglT5W_RlENnuG5vg"),
+                new PartitionRegistration(new int[] {1, 2, 3, 4},
+                    new int[] {3, 4}, new int[] {2}, new int[] {1}, 3, 2, 1)));
+        IMAGE2 = new TopicsImage(newTopicsByIdMap(topics2), newTopicsByNameMap(topics2));
+    }
+
+    @Test
+    public void testEmptyImageRoundTrip() throws Throwable {
+        testToImageAndBack(TopicsImage.EMPTY);
+    }
+
+    @Test
+    public void testImage1RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE1);
+    }
+
+    @Test
+    public void testApplyDelta1() throws Throwable {
+        assertEquals(IMAGE2, DELTA1.apply());
+    }
+
+    @Test
+    public void testImage2RoundTrip() throws Throwable {
+        testToImageAndBack(IMAGE2);
+    }
+
+    private void testToImageAndBack(TopicsImage image) throws Throwable {
+        MockSnapshotConsumer writer = new MockSnapshotConsumer();
+        image.write(writer);
+        TopicsDelta delta = new TopicsDelta(TopicsImage.EMPTY);
+        RecordTestUtils.replayAllBatches(delta, writer.batches());
+        TopicsImage nextImage = delta.apply();
+        assertEquals(image, nextImage);
+    }
+}

--- a/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/PartitionRegistrationTest.java
@@ -17,7 +17,9 @@
 
 package org.apache.kafka.metadata;
 
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -35,20 +38,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PartitionRegistrationTest {
     @Test
     public void testElectionWasClean() {
-        assertTrue(PartitionRegistration.electionWasClean(1, new int[] {1, 2}));
-        assertFalse(PartitionRegistration.electionWasClean(1, new int[] {0, 2}));
-        assertFalse(PartitionRegistration.electionWasClean(1, new int[] {}));
-        assertTrue(PartitionRegistration.electionWasClean(3, new int[] {1, 2, 3, 4, 5, 6}));
+        assertTrue(PartitionRegistration.electionWasClean(1, new int[]{1, 2}));
+        assertFalse(PartitionRegistration.electionWasClean(1, new int[]{0, 2}));
+        assertFalse(PartitionRegistration.electionWasClean(1, new int[]{}));
+        assertTrue(PartitionRegistration.electionWasClean(3, new int[]{1, 2, 3, 4, 5, 6}));
     }
 
     @Test
     public void testPartitionControlInfoMergeAndDiff() {
         PartitionRegistration a = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1, 2}, null, null, 1, 0, 0);
+            new int[]{1, 2, 3}, new int[]{1, 2}, new int[]{}, new int[]{}, 1, 0, 0);
         PartitionRegistration b = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{3}, null, null, 3, 1, 1);
+            new int[]{1, 2, 3}, new int[]{3}, new int[]{}, new int[]{}, 3, 1, 1);
         PartitionRegistration c = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1}, null, null, 1, 0, 1);
+            new int[]{1, 2, 3}, new int[]{1}, new int[]{}, new int[]{}, 1, 0, 1);
         assertEquals(b, a.merge(new PartitionChangeRecord().
             setLeader(3).setIsr(Arrays.asList(3))));
         assertEquals("isr: [1, 2] -> [3], leader: 1 -> 3, leaderEpoch: 0 -> 1, partitionEpoch: 0 -> 1",
@@ -60,12 +63,46 @@ public class PartitionRegistrationTest {
     @Test
     public void testRecordRoundTrip() {
         PartitionRegistration registrationA = new PartitionRegistration(
-            new int[]{1, 2, 3}, new int[]{1, 2}, new int[]{1}, null, 1, 0, 0);
+            new int[]{1, 2, 3}, new int[]{1, 2}, new int[]{1}, new int[]{}, 1, 0, 0);
         Uuid topicId = Uuid.fromString("OGdAI5nxT_m-ds3rJMqPLA");
         int partitionId = 4;
         ApiMessageAndVersion record = registrationA.toRecord(topicId, partitionId);
         PartitionRegistration registrationB =
             new PartitionRegistration((PartitionRecord) record.message());
         assertEquals(registrationA, registrationB);
+    }
+
+    @Test
+    public void testToLeaderAndIsrPartitionState() {
+        PartitionRegistration a = new PartitionRegistration(
+            new int[]{1, 2, 3}, new int[]{1, 2}, new int[]{}, new int[]{}, 1, 123, 456);
+        PartitionRegistration b = new PartitionRegistration(
+            new int[]{2, 3, 4}, new int[]{2, 3, 4}, new int[]{}, new int[]{}, 2, 234, 567);
+        assertEquals(new LeaderAndIsrPartitionState().
+                setTopicName("foo").
+                setPartitionIndex(1).
+                setControllerEpoch(-1).
+                setLeader(1).
+                setLeaderEpoch(123).
+                setIsr(Arrays.asList(1, 2)).
+                setZkVersion(456).
+                setReplicas(Arrays.asList(1, 2, 3)).
+                setAddingReplicas(Collections.emptyList()).
+                setRemovingReplicas(Collections.emptyList()).
+                setIsNew(true).toString(),
+            a.toLeaderAndIsrPartitionState(new TopicPartition("foo", 1), true).toString());
+        assertEquals(new LeaderAndIsrPartitionState().
+                setTopicName("bar").
+                setPartitionIndex(0).
+                setControllerEpoch(-1).
+                setLeader(2).
+                setLeaderEpoch(234).
+                setIsr(Arrays.asList(2, 3, 4)).
+                setZkVersion(567).
+                setReplicas(Arrays.asList(2, 3, 4)).
+                setAddingReplicas(Collections.emptyList()).
+                setRemovingReplicas(Collections.emptyList()).
+                setIsNew(false).toString(),
+            b.toLeaderAndIsrPartitionState(new TopicPartition("bar", 0), false).toString());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/metadata/RecordTestUtils.java
+++ b/metadata/src/test/java/org/apache/kafka/metadata/RecordTestUtils.java
@@ -163,7 +163,7 @@ public class RecordTestUtils {
         List<ApiMessageAndVersion> curRecords = new ArrayList<>();
         while (true) {
             if (!iterator.hasNext() || curRecords.size() >= 2) {
-                batches.add(Batch.of(offset, 0, curRecords));
+                batches.add(Batch.of(offset, 0, 0, curRecords));
                 if (!iterator.hasNext()) {
                     break;
                 }


### PR DESCRIPTION
Create the image/ module for storing, reading, and writing broker metadata
images. Metadat images are immutable. New images are produced from existing images
using delta classes. Delta classes are mutable, and represent changes to a base
image.

MetadataImage objects can be converted to lists of KRaft metadata records. This
is essentially writing a KRaft snapshot. The resulting snapshot can be read
back into a MetadataDelta object. In practice, we will typically read the
snapshot, and then read a few more records to get fully up to date. After that,
the MetadataDelta can be converted to a MetadataImage as usual.

Sometimes, we have to load a snapshot even though we already have an existing
non-empty MetadataImage. We would do this if the broker fell too far behind and
needed to receive a snapshot to catch up. This is handled just like the normal
snapshot loading process. Anything that is not in the snapshot will be marked
as deleted in the MetadataDelta once finishSnapshot() is called.

In addition to being used for reading and writing snapshots, MetadataImage also
serves as a cache for broker information in memory. A follow-up PR will replace
MetadataCache, CachedConfigRepository, and the client quotas cache with the
corresponding Image classes.  TopicsDelta also replaces the "deferred
partition" state that the RaftReplicaManager currently implements. (That change
is also in a follow-up PR.)