### PR TITLE
KAFKA-12841: NPE from the provided metadata in client callback in case of ApiException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -110,8 +110,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                     interceptor.onAcknowledgement(null, exception);
                 } else {
                     if (interceptTopicPartition == null) {
-                        interceptTopicPartition = new TopicPartition(record.topic(),
-                                record.partition() == null ? RecordMetadata.UNKNOWN_PARTITION : record.partition());
+                        interceptTopicPartition = createTopicPartition(record);
                     }
                     interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1,
                                     RecordBatch.NO_TIMESTAMP, -1, -1), exception);
@@ -121,6 +120,10 @@ public class ProducerInterceptors<K, V> implements Closeable {
                 log.warn("Error executing interceptor onAcknowledgement callback", e);
             }
         }
+    }
+
+    public static <K, V> TopicPartition createTopicPartition(ProducerRecord<K, V> record) {
+        return new TopicPartition(record.topic(), record.partition() == null ? RecordMetadata.UNKNOWN_PARTITION : record.partition());
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.network.Selectable;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
 import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
@@ -54,6 +55,7 @@ import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.InitProducerIdResponse;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.RequestTestUtils;
 import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
@@ -1291,6 +1293,58 @@ public class KafkaProducerTest {
         // send a record with null topic should fail
         assertThrows(IllegalArgumentException.class, () -> new ProducerRecord<>(null, 1,
             "key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testCallbackHandlesError() throws Exception {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9000");
+        configs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "1000");
+
+        Time time = new MockTime();
+        ProducerMetadata producerMetadata = newMetadata(0, Long.MAX_VALUE);
+        MockClient client = new MockClient(time, producerMetadata);
+
+        String invalidTopicName = "topic abc"; // Invalid topic name due to space
+
+        try (Producer<String, String> producer = kafkaProducer(configs, new StringSerializer(), new StringSerializer(),
+                producerMetadata, client, null, time)) {
+            ProducerRecord<String, String> record = new ProducerRecord<>(invalidTopicName, "HelloKafka");
+
+            // Here's the important piece of the test. Let's make sure that the RecordMetadata we get
+            // is non-null and adheres to the onCompletion contract.
+            Callback callBack = (recordMetadata, exception) -> {
+                assertNotNull(exception);
+                exception.printStackTrace();
+
+                assertNotNull(recordMetadata);
+
+                try {
+                    assertNotNull(recordMetadata.topic());
+                } catch (NullPointerException e) {
+                    fail("Topic name should be valid even on send failure", e);
+                }
+
+                assertEquals(invalidTopicName, recordMetadata.topic());
+
+                try {
+                    assertEquals(RecordMetadata.UNKNOWN_PARTITION, recordMetadata.partition());
+                } catch (NullPointerException e) {
+                    fail("Partition should be valid even on send failure", e);
+                }
+
+                assertFalse(recordMetadata.hasOffset());
+                assertEquals(ProduceResponse.INVALID_OFFSET, recordMetadata.offset());
+
+                assertFalse(recordMetadata.hasTimestamp());
+                assertEquals(RecordBatch.NO_TIMESTAMP, recordMetadata.timestamp());
+
+                assertEquals(-1, recordMetadata.serializedKeySize());
+                assertEquals(-1, recordMetadata.serializedValueSize());
+            };
+
+            producer.send(record, callBack);
+        }
     }
 
     private static final List<String> CLIENT_IDS = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -1315,8 +1315,6 @@ public class KafkaProducerTest {
             // is non-null and adheres to the onCompletion contract.
             Callback callBack = (recordMetadata, exception) -> {
                 assertNotNull(exception);
-                exception.printStackTrace();
-
                 assertNotNull(recordMetadata);
 
                 try {


### PR DESCRIPTION
Jira: https://issues.apache.org/jira/browse/KAFKA-12841

Using the `InterceptorCallback` wrapper in the case of `ApiException` so
that we will adhere correctly to the `Callback` contract for `onCompletion`
specifying a valid (dummy) `TopicPartition`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

I'm also supposed to add:

> The contribution is my original work and that I license the work to the project under the project's open source license.