### PR TITLE
KAFKA-12257:  Consumer mishandles topics deleted and recreated with the same name

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -221,7 +221,7 @@ public class Metadata implements Closeable {
         return cache.topicId(topicName);
     }
 
-    public synchronized  String topicName(Uuid topicId) {
+    public synchronized String topicName(Uuid topicId) {
         return cache.topicName(topicId);
     }
 
@@ -382,7 +382,7 @@ public class Metadata implements Closeable {
 
     /**
      * Compute the latest partition metadata to cache given ordering by leader epochs (if both
-     * available and reliable).
+     * available and reliable) and whether the topic ID changed.
      */
     private Optional<MetadataResponse.PartitionMetadata> updateLatestMetadata(
             MetadataResponse.PartitionMetadata partitionMetadata,
@@ -397,6 +397,7 @@ public class Metadata implements Closeable {
                 log.debug("Updating last seen epoch for partition {} from {} to epoch {} from new metadata", tp, currentEpoch, newEpoch);
                 lastSeenLeaderEpochs.put(tp, newEpoch);
                 return Optional.of(partitionMetadata);
+            // If the topic ID changed, updated the metadata
             } else if (changedTopicId) {
                 log.debug("Topic ID changed, so this topic must have been recreated. " +
                         "Removing last seen epoch {} for the old partition {} and adding epoch {} from new metadata", currentEpoch, tp, newEpoch);

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -399,8 +399,8 @@ public class Metadata implements Closeable {
                 return Optional.of(partitionMetadata);
             // If the topic ID changed, updated the metadata
             } else if (changedTopicId) {
-                log.debug("Topic ID changed, so this topic must have been recreated. " +
-                        "Removing last seen epoch {} for the old partition {} and adding epoch {} from new metadata", currentEpoch, tp, newEpoch);
+                log.debug("Topic ID for partition {} changed from {}, so this topic must have been recreated. " +
+                                "Using the newly updated metadata.", tp, cache.topicId(tp.topic()));
                 lastSeenLeaderEpochs.put(tp, newEpoch);
                 return Optional.of(partitionMetadata);
             } else {

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -392,16 +392,16 @@ public class Metadata implements Closeable {
         TopicPartition tp = partitionMetadata.topicPartition;
         if (hasReliableLeaderEpoch && partitionMetadata.leaderEpoch.isPresent()) {
             int newEpoch = partitionMetadata.leaderEpoch.get();
-            // If the received leader epoch is at least the same as the previous one, update the metadata
             Integer currentEpoch = lastSeenLeaderEpochs.get(tp);
-            if (currentEpoch == null || newEpoch >= currentEpoch) {
-                log.debug("Updating last seen epoch for partition {} from {} to epoch {} from new metadata", tp, currentEpoch, newEpoch);
-                lastSeenLeaderEpochs.put(tp, newEpoch);
-                return Optional.of(partitionMetadata);
-            } else if (topicId != null && oldTopicId != null && !topicId.equals(oldTopicId)) {
+            if (topicId != null && oldTopicId != null && !topicId.equals(oldTopicId)) {
                 // If both topic IDs were valid and the topic ID changed, update the metadata
                 log.debug("Topic ID for partition {} changed from {} to {}, so this topic must have been recreated. " +
-                                "Resetting the last seen epoch to {}.", tp, oldTopicId, topicId, newEpoch);
+                          "Resetting the last seen epoch to {}.", tp, oldTopicId, topicId, newEpoch);
+                lastSeenLeaderEpochs.put(tp, newEpoch);
+                return Optional.of(partitionMetadata);
+            } else if (currentEpoch == null || newEpoch >= currentEpoch) {
+                // If the received leader epoch is at least the same as the previous one, update the metadata
+                log.debug("Updating last seen epoch for partition {} from {} to epoch {} from new metadata", tp, currentEpoch, newEpoch);
                 lastSeenLeaderEpochs.put(tp, newEpoch);
                 return Optional.of(partitionMetadata);
             } else {

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.ClusterResource;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
 
@@ -49,6 +50,8 @@ public class MetadataCache {
     private final Set<String> internalTopics;
     private final Node controller;
     private final Map<TopicPartition, PartitionMetadata> metadataByPartition;
+    private final Map<String, Uuid> topicIds;
+    private final Map<Uuid, String> topicNames;
 
     private Cluster clusterInstance;
 
@@ -58,8 +61,9 @@ public class MetadataCache {
                   Set<String> unauthorizedTopics,
                   Set<String> invalidTopics,
                   Set<String> internalTopics,
-                  Node controller) {
-        this(clusterId, nodes, partitions, unauthorizedTopics, invalidTopics, internalTopics, controller, null);
+                  Node controller,
+                  Map<String, Uuid> topicIds) {
+        this(clusterId, nodes, partitions, unauthorizedTopics, invalidTopics, internalTopics, controller, topicIds, null);
     }
 
     private MetadataCache(String clusterId,
@@ -69,6 +73,7 @@ public class MetadataCache {
                           Set<String> invalidTopics,
                           Set<String> internalTopics,
                           Node controller,
+                          Map<String, Uuid> topicIds,
                           Cluster clusterInstance) {
         this.clusterId = clusterId;
         this.nodes = nodes;
@@ -76,6 +81,12 @@ public class MetadataCache {
         this.invalidTopics = invalidTopics;
         this.internalTopics = internalTopics;
         this.controller = controller;
+        this.topicIds = topicIds;
+
+        this.topicNames = new HashMap<>(topicIds.size());
+        for (Map.Entry<String, Uuid> entry : topicIds.entrySet()) {
+            this.topicNames.put(entry.getValue(), entry.getKey());
+        }
 
         this.metadataByPartition = new HashMap<>(partitions.size());
         for (PartitionMetadata p : partitions) {
@@ -91,6 +102,14 @@ public class MetadataCache {
 
     Optional<PartitionMetadata> partitionMetadata(TopicPartition topicPartition) {
         return Optional.ofNullable(metadataByPartition.get(topicPartition));
+    }
+
+    Map<String, Uuid> topicIds() {
+        return topicIds;
+    }
+
+    Map<Uuid, String> topicNames() {
+        return topicNames;
     }
 
     Optional<Node> nodeById(int id) {
@@ -120,6 +139,7 @@ public class MetadataCache {
      * @param addUnauthorizedTopics unauthorized topics to add
      * @param addInternalTopics internal topics to add
      * @param newController the new controller node
+     * @param topicIds the mapping from topic name to topic ID from the MetadataResponse
      * @param retainTopic returns whether a topic's metadata should be retained
      * @return the merged metadata cache
      */
@@ -130,13 +150,30 @@ public class MetadataCache {
                             Set<String> addInvalidTopics,
                             Set<String> addInternalTopics,
                             Node newController,
+                            Map<String, Uuid> topicIds,
                             BiPredicate<String, Boolean> retainTopic) {
 
         Predicate<String> shouldRetainTopic = topic -> retainTopic.test(topic, internalTopics.contains(topic));
 
         Map<TopicPartition, PartitionMetadata> newMetadataByPartition = new HashMap<>(addPartitions.size());
+        Map<String, Uuid> newTopicIds = new HashMap<>(topicIds.size());
+
+        // We want the most recent topic ID. We add the old one here for retained topics and then update with newest information in the MetadataResponse
+        // we add if a new topic ID is added or remove if the request did not support topic IDs for this topic.
+        for (Map.Entry<String, Uuid> entry : this.topicIds.entrySet()) {
+            if (shouldRetainTopic.test(entry.getKey())) {
+                newTopicIds.put(entry.getKey(), entry.getValue());
+            }
+        }
+
         for (PartitionMetadata partition : addPartitions) {
             newMetadataByPartition.put(partition.topicPartition, partition);
+            Uuid id = topicIds.get(partition.topic());
+            if (id != null)
+                newTopicIds.put(partition.topic(), id);
+            else
+                // Remove if the latest metadata does not have a topic ID
+                newTopicIds.remove(partition.topic());
         }
         for (Map.Entry<TopicPartition, PartitionMetadata> entry : metadataByPartition.entrySet()) {
             if (shouldRetainTopic.test(entry.getKey().topic())) {
@@ -149,7 +186,7 @@ public class MetadataCache {
         Set<String> newInternalTopics = fillSet(addInternalTopics, internalTopics, shouldRetainTopic);
 
         return new MetadataCache(newClusterId, newNodes, newMetadataByPartition.values(), newUnauthorizedTopics,
-                newInvalidTopics, newInternalTopics, newController);
+                newInvalidTopics, newInternalTopics, newController, newTopicIds);
     }
 
     /**
@@ -177,7 +214,7 @@ public class MetadataCache {
                 .map(metadata -> MetadataResponse.toPartitionInfo(metadata, nodes))
                 .collect(Collectors.toList());
         this.clusterInstance = new Cluster(clusterId, nodes.values(), partitionInfos, unauthorizedTopics,
-                invalidTopics, internalTopics, controller);
+                invalidTopics, internalTopics, controller, topicIds);
     }
 
     static MetadataCache bootstrap(List<InetSocketAddress> addresses) {
@@ -189,12 +226,12 @@ public class MetadataCache {
         }
         return new MetadataCache(null, nodes, Collections.emptyList(),
                 Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
-                null, Cluster.bootstrap(addresses));
+                null, Collections.emptyMap(), Cluster.bootstrap(addresses));
     }
 
     static MetadataCache empty() {
         return new MetadataCache(null, Collections.emptyMap(), Collections.emptyList(),
-                Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), null, Cluster.empty());
+                Collections.emptySet(), Collections.emptySet(), Collections.emptySet(), null, Collections.emptyMap(), Cluster.empty());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -107,6 +107,7 @@ public class MetadataCache {
     Uuid topicId(String topicName) {
         return topicIds.get(topicName);
     }
+
     String topicName(Uuid topicId) {
         return topicNames.get(topicId);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -104,12 +104,11 @@ public class MetadataCache {
         return Optional.ofNullable(metadataByPartition.get(topicPartition));
     }
 
-    Map<String, Uuid> topicIds() {
-        return topicIds;
+    Uuid topicId(String topicName) {
+        return topicIds.get(topicName);
     }
-
-    Map<Uuid, String> topicNames() {
-        return topicNames;
+    String topicName(Uuid topicId) {
+        return topicNames.get(topicId);
     }
 
     Optional<Node> nodeById(int id) {
@@ -160,11 +159,11 @@ public class MetadataCache {
 
         // We want the most recent topic ID. We add the old one here for retained topics and then update with newest information in the MetadataResponse
         // we add if a new topic ID is added or remove if the request did not support topic IDs for this topic.
-        for (Map.Entry<String, Uuid> entry : this.topicIds.entrySet()) {
-            if (shouldRetainTopic.test(entry.getKey())) {
-                newTopicIds.put(entry.getKey(), entry.getValue());
+        this.topicIds.forEach((topicName, topicId) -> {
+            if (shouldRetainTopic.test(topicName)) {
+                newTopicIds.put(topicName, topicId);
             }
-        }
+        });
 
         for (PartitionMetadata partition : addPartitions) {
             newMetadataByPartition.put(partition.topicPartition, partition);

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -157,8 +157,14 @@ public class MetadataCache {
         Map<TopicPartition, PartitionMetadata> newMetadataByPartition = new HashMap<>(addPartitions.size());
         Map<String, Uuid> newTopicIds = new HashMap<>(topicIds.size());
 
-        // We want the most recent topic ID. We add the old one here for retained topics and then update with newest information in the MetadataResponse
-        // we add if a new topic ID is added or remove if the request did not support topic IDs for this topic.
+        // We want the most recent topic ID. We start with the previous ID stored for retained topics and then
+        // update with newest information in the MetadataResponse.
+        // If the newest MetadataResponse:
+        //    - contains a new topic with no ID, add no IDs to newTopicIds
+        //    - contains a new topic and ID, we add it to newTopicIds
+        //    - contains the same ID for an existing topic, we keep it the same in newTopicIds
+        //    - contains a new topic ID for an existing topic, we change it to the new one in newTopicIds
+        //    - has no topic ID for an existing topic, we remove any previous ID from newTopicIds
         this.topicIds.forEach((topicName, topicId) -> {
             if (shouldRetainTopic.test(topicName)) {
                 newTopicIds.put(topicName, topicId);

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataCache.java
@@ -51,7 +51,6 @@ public class MetadataCache {
     private final Node controller;
     private final Map<TopicPartition, PartitionMetadata> metadataByPartition;
     private final Map<String, Uuid> topicIds;
-    private final Map<Uuid, String> topicNames;
 
     private Cluster clusterInstance;
 
@@ -83,11 +82,6 @@ public class MetadataCache {
         this.controller = controller;
         this.topicIds = topicIds;
 
-        this.topicNames = new HashMap<>(topicIds.size());
-        for (Map.Entry<String, Uuid> entry : topicIds.entrySet()) {
-            this.topicNames.put(entry.getValue(), entry.getKey());
-        }
-
         this.metadataByPartition = new HashMap<>(partitions.size());
         for (PartitionMetadata p : partitions) {
             this.metadataByPartition.put(p.topicPartition, p);
@@ -106,10 +100,6 @@ public class MetadataCache {
 
     Uuid topicId(String topicName) {
         return topicIds.get(topicName);
-    }
-
-    String topicName(Uuid topicId) {
-        return topicNames.get(topicId);
     }
 
     Optional<Node> nodeById(int id) {
@@ -159,13 +149,8 @@ public class MetadataCache {
         Map<String, Uuid> newTopicIds = new HashMap<>(topicIds.size());
 
         // We want the most recent topic ID. We start with the previous ID stored for retained topics and then
-        // update with newest information in the MetadataResponse.
-        // If the newest MetadataResponse:
-        //    - contains a new topic with no ID, add no IDs to newTopicIds
-        //    - contains a new topic and ID, we add it to newTopicIds
-        //    - contains the same ID for an existing topic, we keep it the same in newTopicIds
-        //    - contains a new topic ID for an existing topic, we change it to the new one in newTopicIds
-        //    - has no topic ID for an existing topic, we remove any previous ID from newTopicIds
+        // update with newest information from the MetadataResponse. We always take the latest state, removing existing
+        // topic IDs if the latest state contains the topic name but not a topic ID.
         this.topicIds.forEach((topicName, topicId) -> {
             if (shouldRetainTopic.test(topicName)) {
                 newTopicIds.put(topicName, topicId);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataCacheTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataCacheTest.java
@@ -67,7 +67,8 @@ public class MetadataCacheTest {
                 Collections.emptySet(),
                 Collections.emptySet(),
                 Collections.emptySet(),
-                null);
+                null,
+                Collections.emptyMap());
 
         Cluster cluster = cache.cluster();
         assertNull(cluster.leaderFor(topicPartition));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.consumer.internals;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.MetadataRequest;
@@ -111,9 +112,12 @@ public class ConsumerMetadataTest {
 
     @Test
     public void testTransientTopics() {
+        Map<String, Uuid> topicIds = new HashMap<>();
+        topicIds.put("foo", Uuid.randomUuid());
         subscription.subscribe(singleton("foo"), new NoOpConsumerRebalanceListener());
         ConsumerMetadata metadata = newConsumerMetadata(false);
-        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWith(1, singletonMap("foo", 1)), false, time.milliseconds());
+        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds(1, singletonMap("foo", 1), topicIds), false, time.milliseconds());
+        assertEquals(topicIds, metadata.topicIds());
         assertFalse(metadata.updateRequested());
 
         metadata.addTransientTopics(singleton("foo"));
@@ -125,14 +129,18 @@ public class ConsumerMetadataTest {
         Map<String, Integer> topicPartitionCounts = new HashMap<>();
         topicPartitionCounts.put("foo", 1);
         topicPartitionCounts.put("bar", 1);
-        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWith(1, topicPartitionCounts), false, time.milliseconds());
+        topicIds.put("bar", Uuid.randomUuid());
+        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds(1, topicPartitionCounts, topicIds), false, time.milliseconds());
+        assertEquals(topicIds, metadata.topicIds());
         assertFalse(metadata.updateRequested());
 
         assertEquals(Utils.mkSet("foo", "bar"), new HashSet<>(metadata.fetch().topics()));
 
         metadata.clearTransientTopics();
-        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWith(1, topicPartitionCounts), false, time.milliseconds());
+        topicIds.remove("bar");
+        metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds(1, topicPartitionCounts, topicIds), false, time.milliseconds());
         assertEquals(singleton("foo"), new HashSet<>(metadata.fetch().topics()));
+        assertEquals(topicIds, metadata.topicIds());
     }
 
     private void testBasicSubscription(Set<String> expectedTopics, Set<String> expectedInternalTopics) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerMetadataTest.java
@@ -117,7 +117,7 @@ public class ConsumerMetadataTest {
         subscription.subscribe(singleton("foo"), new NoOpConsumerRebalanceListener());
         ConsumerMetadata metadata = newConsumerMetadata(false);
         metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds(1, singletonMap("foo", 1), topicIds), false, time.milliseconds());
-        assertEquals(topicIds, metadata.topicIds());
+        assertEquals(topicIds.get("foo"), metadata.topicId("foo"));
         assertFalse(metadata.updateRequested());
 
         metadata.addTransientTopics(singleton("foo"));
@@ -131,7 +131,7 @@ public class ConsumerMetadataTest {
         topicPartitionCounts.put("bar", 1);
         topicIds.put("bar", Uuid.randomUuid());
         metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds(1, topicPartitionCounts, topicIds), false, time.milliseconds());
-        assertEquals(topicIds, metadata.topicIds());
+        topicIds.forEach((topicName, topicId) -> assertEquals(topicId, metadata.topicId(topicName)));
         assertFalse(metadata.updateRequested());
 
         assertEquals(Utils.mkSet("foo", "bar"), new HashSet<>(metadata.fetch().topics()));
@@ -140,7 +140,8 @@ public class ConsumerMetadataTest {
         topicIds.remove("bar");
         metadata.updateWithCurrentRequestVersion(RequestTestUtils.metadataUpdateWithIds(1, topicPartitionCounts, topicIds), false, time.milliseconds());
         assertEquals(singleton("foo"), new HashSet<>(metadata.fetch().topics()));
-        assertEquals(topicIds, metadata.topicIds());
+        assertEquals(topicIds.get("foo"), metadata.topicId("foo"));
+        assertEquals(topicIds.get("bar"), null);
     }
 
     private void testBasicSubscription(Set<String> expectedTopics, Set<String> expectedInternalTopics) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestTestUtils.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -78,6 +79,7 @@ public class RequestTestUtils {
             metadataResponseTopic
                     .setErrorCode(topicMetadata.error().code())
                     .setName(topicMetadata.topic())
+                    .setTopicId(topicMetadata.topicId())
                     .setIsInternal(topicMetadata.isInternal())
                     .setTopicAuthorizedOperations(topicMetadata.authorizedOperations());
 
@@ -105,14 +107,14 @@ public class RequestTestUtils {
                                                       final Map<String, Integer> topicPartitionCounts,
                                                       final Function<TopicPartition, Integer> epochSupplier) {
         return metadataUpdateWith("kafka-cluster", numNodes, Collections.emptyMap(),
-                topicPartitionCounts, epochSupplier, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion());
+                topicPartitionCounts, epochSupplier, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion(), Collections.emptyMap());
     }
 
     public static MetadataResponse metadataUpdateWith(final String clusterId,
                                                       final int numNodes,
                                                       final Map<String, Integer> topicPartitionCounts) {
         return metadataUpdateWith(clusterId, numNodes, Collections.emptyMap(),
-                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion());
+                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion(), Collections.emptyMap());
     }
 
     public static MetadataResponse metadataUpdateWith(final String clusterId,
@@ -120,7 +122,7 @@ public class RequestTestUtils {
                                                       final Map<String, Errors> topicErrors,
                                                       final Map<String, Integer> topicPartitionCounts) {
         return metadataUpdateWith(clusterId, numNodes, topicErrors,
-                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion());
+                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion(), Collections.emptyMap());
     }
 
     public static MetadataResponse metadataUpdateWith(final String clusterId,
@@ -129,7 +131,7 @@ public class RequestTestUtils {
                                                       final Map<String, Integer> topicPartitionCounts,
                                                       final short responseVersion) {
         return metadataUpdateWith(clusterId, numNodes, topicErrors,
-                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, responseVersion);
+                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, responseVersion, Collections.emptyMap());
     }
 
     public static MetadataResponse metadataUpdateWith(final String clusterId,
@@ -138,7 +140,25 @@ public class RequestTestUtils {
                                                       final Map<String, Integer> topicPartitionCounts,
                                                       final Function<TopicPartition, Integer> epochSupplier) {
         return metadataUpdateWith(clusterId, numNodes, topicErrors,
-                topicPartitionCounts, epochSupplier, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion());
+                topicPartitionCounts, epochSupplier, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion(), Collections.emptyMap());
+    }
+
+    public static MetadataResponse metadataUpdateWithIds(final int numNodes,
+                                                         final Map<String, Integer> topicPartitionCounts,
+                                                         final Map<String, Uuid> topicIds) {
+        return metadataUpdateWith("kafka-cluster", numNodes, Collections.emptyMap(),
+                topicPartitionCounts, tp -> null, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion(),
+                topicIds);
+    }
+
+    public static MetadataResponse metadataUpdateWithIds(final String clusterId,
+                                                         final int numNodes,
+                                                         final Map<String, Errors> topicErrors,
+                                                         final Map<String, Integer> topicPartitionCounts,
+                                                         final Function<TopicPartition, Integer> epochSupplier,
+                                                         final Map<String, Uuid> topicIds) {
+        return metadataUpdateWith(clusterId, numNodes, topicErrors,
+                topicPartitionCounts, epochSupplier, MetadataResponse.PartitionMetadata::new, ApiKeys.METADATA.latestVersion(), topicIds);
     }
 
     public static MetadataResponse metadataUpdateWith(final String clusterId,
@@ -147,7 +167,8 @@ public class RequestTestUtils {
                                                       final Map<String, Integer> topicPartitionCounts,
                                                       final Function<TopicPartition, Integer> epochSupplier,
                                                       final PartitionMetadataSupplier partitionSupplier,
-                                                      final short responseVersion) {
+                                                      final short responseVersion,
+                                                      final Map<String, Uuid> topicIds) {
         final List<Node> nodes = new ArrayList<>(numNodes);
         for (int i = 0; i < numNodes; i++)
             nodes.add(new Node(i, "localhost", 1969 + i));
@@ -167,8 +188,8 @@ public class RequestTestUtils {
                         replicaIds, replicaIds, replicaIds));
             }
 
-            topicMetadata.add(new MetadataResponse.TopicMetadata(Errors.NONE, topic,
-                    Topic.isInternal(topic), partitionMetadata));
+            topicMetadata.add(new MetadataResponse.TopicMetadata(Errors.NONE, topic, topicIds.getOrDefault(topic, Uuid.ZERO_UUID),
+                    Topic.isInternal(topic), partitionMetadata, MetadataResponse.AUTHORIZED_OPERATIONS_OMITTED));
         }
 
         for (Map.Entry<String, Errors> topicErrorEntry : topicErrors.entrySet()) {


### PR DESCRIPTION
Store topic ID info in consumer metadata. We will always take the topic ID from the latest metadata response and remove any topic IDs from the cache if the metadata response did not return a topic ID for the topic. 

With the addition of topic IDs, when we encounter a new topic ID (recreated topic) we can choose to get the topic's metadata even if the epoch is lower than the deleted topic.

The idea is that when we update from no topic IDs to using topic IDs, we will not count the topic as new (It could be the same topic but with a new ID). We will only take the update if the topic ID changed.

Added tests for this scenario as well as some tests for storing the topic IDs. Also added tests for topic IDs in metadata cache.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
