### PR TITLE
WIP KIP-709: Implement batching for fetchOffsets

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Admin.java
@@ -888,22 +888,26 @@ public interface Admin extends AutoCloseable {
     }
 
     /**
-     * List the consumer group offsets available in the cluster.
-     *
+     * List the consumer group offsets available in the cluster for the given list of consumer
+     * groups.
+     * @param groupIds List of consumer group ids to list offsets for.
      * @param options The options to use when listing the consumer group offsets.
      * @return The ListGroupOffsetsResult
      */
-    ListConsumerGroupOffsetsResult listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options);
+    ListConsumerGroupOffsetsResult listConsumerGroupOffsets(List<String> groupIds, ListConsumerGroupOffsetsOptions options);
 
     /**
      * List the consumer group offsets available in the cluster with the default options.
      * <p>
-     * This is a convenience method for {@link #listConsumerGroupOffsets(String, ListConsumerGroupOffsetsOptions)} with default options.
+     * This is a convenience method for
+     * {@link #listConsumerGroupOffsets(List, ListConsumerGroupOffsetsOptions)} with
+     * default options.
      *
+     * @param groupIds List of consumer group ids to list offsets for.
      * @return The ListGroupOffsetsResult.
      */
-    default ListConsumerGroupOffsetsResult listConsumerGroupOffsets(String groupId) {
-        return listConsumerGroupOffsets(groupId, new ListConsumerGroupOffsetsOptions());
+    default ListConsumerGroupOffsetsResult listConsumerGroupOffsets(List<String> groupIds) {
+        return listConsumerGroupOffsets(groupIds, new ListConsumerGroupOffsetsOptions(groupIds));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3278,13 +3278,14 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     @Override
-    public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final String groupId,
-                                                                   final ListConsumerGroupOffsetsOptions options) {
+    public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(List<String> groupIds,
+        ListConsumerGroupOffsetsOptions options) {
         SimpleAdminApiFuture<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> future =
-                ListConsumerGroupOffsetsHandler.newFuture(groupId);
-        ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupId, options.topicPartitions(), logContext);
+            ListConsumerGroupOffsetsHandler.newFuture(groupIds);
+        ListConsumerGroupOffsetsHandler handler =
+            new ListConsumerGroupOffsetsHandler(options.groupToTopicPartitions(), logContext);
         invokeDriver(handler, future, options.timeoutMs);
-        return new ListConsumerGroupOffsetsResult(future.get(CoordinatorKey.byGroupId(groupId)));
+        return new ListConsumerGroupOffsetsResult(future.all());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupOffsetsOptions.java
@@ -17,37 +17,51 @@
 
 package org.apache.kafka.clients.admin;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.List;
 
 /**
- * Options for {@link Admin#listConsumerGroupOffsets(String)}.
+ * Options for {@link Admin#listConsumerGroupOffsets(List)}.
  * <p>
  * The API of this class is evolving, see {@link Admin} for details.
  */
 @InterfaceStability.Evolving
 public class ListConsumerGroupOffsetsOptions extends AbstractOptions<ListConsumerGroupOffsetsOptions> {
 
-    private List<TopicPartition> topicPartitions = null;
+    private Map<String, List<TopicPartition>> groupToTopicPartitions = new HashMap<>();
 
     /**
-     * Set the topic partitions to list as part of the result.
-     * {@code null} includes all topic partitions.
-     *
-     * @param topicPartitions List of topic partitions to include
+     * Default constructor for {@code ListConsumerGroupOffsetsOptions}. Sets the topic partitions
+     * to fetch for each group id to {@code null}, which indicates to fetch all offsets for all
+     * topic partitions for that group.
+     * */
+    public ListConsumerGroupOffsetsOptions(List<String> groupIds) {
+        for (String group : groupIds) {
+            groupToTopicPartitions.put(group, null);
+        }
+    }
+
+    /**
+     * Set the topic partitions for each group we want to fetch offsets for as part of the result.
+     * {@code null} mapping for a specific group id means to fetch offsets for all topic
+     * partitions for that specific group.
+     * @param groupToTopicPartitions Map of group id to list of topic partitions to fetch offsets
+     *                              for.
      * @return This ListGroupOffsetsOptions
      */
-    public ListConsumerGroupOffsetsOptions topicPartitions(List<TopicPartition> topicPartitions) {
-        this.topicPartitions = topicPartitions;
+    public ListConsumerGroupOffsetsOptions groupToTopicPartitions(Map<String, List<TopicPartition>> groupToTopicPartitions) {
+        this.groupToTopicPartitions = groupToTopicPartitions;
         return this;
     }
 
     /**
-     * Returns a list of topic partitions to add as part of the result.
+     * Returns a map of group id to topic partitions to fetch offsets for.
      */
-    public List<TopicPartition> topicPartitions() {
-        return topicPartitions;
+    public Map<String, List<TopicPartition>> groupToTopicPartitions() {
+        return groupToTopicPartitions;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -16,10 +16,14 @@
  */
 package org.apache.kafka.common.requests;
 
+import java.util.Collections;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseGroup;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartition;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartitions;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
@@ -65,6 +69,8 @@ public class OffsetFetchResponse extends AbstractResponse {
 
     private final OffsetFetchResponseData data;
     private final Errors error;
+    private final Map<String, Errors> groupLevelErrors = new HashMap<>();
+    private final Map<String, Map<TopicPartition, PartitionData>> groupToPartitionData = new HashMap<>();
 
     public static final class PartitionData {
         public final long offset;
@@ -113,8 +119,14 @@ public class OffsetFetchResponse extends AbstractResponse {
         }
     }
 
+    public OffsetFetchResponse(OffsetFetchResponseData data) {
+        super(ApiKeys.OFFSET_FETCH);
+        this.data = data;
+        this.error = null;
+    }
+
     /**
-     * Constructor for all versions without throttle time.
+     * Constructor without throttle time for version 0 to version 7.
      * @param error Potential coordinator or group level error code (for api version 2 and later)
      * @param responseData Fetched offset information grouped by topic-partition
      */
@@ -123,7 +135,7 @@ public class OffsetFetchResponse extends AbstractResponse {
     }
 
     /**
-     * Constructor with throttle time
+     * Constructor with throttle time for version 0 to 7
      * @param throttleTimeMs The time in milliseconds that this response was throttled
      * @param error Potential coordinator or group level error code (for api version 2 and later)
      * @param responseData Fetched offset information grouped by topic-partition
@@ -154,6 +166,55 @@ public class OffsetFetchResponse extends AbstractResponse {
         this.error = error;
     }
 
+    /**
+     * Constructor without throttle time for version 8 and above.
+     * @param errors Error code on a per group level basis
+     * @param responseData Fetched offset information grouped group id
+     */
+    public OffsetFetchResponse(Map<String, Errors> errors, Map<String, Map<TopicPartition, PartitionData>> responseData) {
+        this(DEFAULT_THROTTLE_TIME, errors, responseData);
+    }
+
+    /**
+     * Constructor with throttle time for version 8 and above.
+     * @param throttleTimeMs The time in milliseconds that this response was throttled
+     * @param errors Potential coordinator or group level error code (for api version 2 and later)
+     * @param responseData Fetched offset information grouped by topic-partition and by group
+     */
+    public OffsetFetchResponse(int throttleTimeMs, Map<String, Errors> errors, Map<String,
+        Map<TopicPartition, PartitionData>> responseData) {
+        super(ApiKeys.OFFSET_FETCH);
+        List<OffsetFetchResponseGroup> groupList = new ArrayList<>();
+        for (String groupId : responseData.keySet()) {
+            Map<String, OffsetFetchResponseTopics> offsetFetchResponseTopicsMap = new HashMap<>();
+            for (Map.Entry<TopicPartition, PartitionData> entry : responseData.get(groupId).entrySet()) {
+                String topicName = entry.getKey().topic();
+                OffsetFetchResponseTopics topic =
+                    offsetFetchResponseTopicsMap.getOrDefault(topicName,
+                        new OffsetFetchResponseTopics().setName(topicName));
+                PartitionData partitionData = entry.getValue();
+                topic.partitions().add(new OffsetFetchResponsePartitions()
+                    .setPartitionIndex(entry.getKey().partition())
+                    .setErrorCode(partitionData.error.code())
+                    .setCommittedOffset(partitionData.offset)
+                    .setCommittedLeaderEpoch(
+                        partitionData.leaderEpoch.orElse(NO_PARTITION_LEADER_EPOCH))
+                    .setMetadata(partitionData.metadata));
+                offsetFetchResponseTopicsMap.put(topicName, topic);
+            }
+            groupList.add(new OffsetFetchResponseGroup()
+                .setGroupId(groupId)
+                .setTopics(new ArrayList<>(offsetFetchResponseTopicsMap.values()))
+                .setErrorCode(errors.get(groupId).code()));
+            groupLevelErrors.put(groupId, errors.get(groupId));
+            groupToPartitionData.put(groupId, responseData.get(groupId));
+        }
+        this.data = new OffsetFetchResponseData()
+            .setGroupIds(groupList)
+            .setThrottleTimeMs(throttleTimeMs);
+        this.error = null;
+    }
+
     public OffsetFetchResponse(OffsetFetchResponseData data, short version) {
         super(ApiKeys.OFFSET_FETCH);
         this.data = data;
@@ -161,7 +222,31 @@ public class OffsetFetchResponse extends AbstractResponse {
         // for older versions there is no top-level error in the response and all errors are partition errors,
         // so if there is a group or coordinator error at the partition level use that as the top-level error.
         // this way clients can depend on the top-level error regardless of the offset fetch version.
-        this.error = version >= 2 ? Errors.forCode(data.errorCode()) : topLevelError(data);
+        // we return the error differently starting with version 8, so we will only populate the
+        // error field if we are between version 2 and 7. if we are in version 8 or greater, then
+        // we will populate the map of group id to error codes.
+        if (version < 8) {
+            this.error = version >= 2 ? Errors.forCode(data.errorCode()) : topLevelError(data);
+        } else {
+            for (OffsetFetchResponseGroup group : data.groupIds()) {
+                this.groupLevelErrors.put(group.groupId(), Errors.forCode(group.errorCode()));
+                Map<TopicPartition, PartitionData> partitionDataMap = new HashMap<>();
+                for (OffsetFetchResponseTopics topic : group.topics()) {
+                    for (OffsetFetchResponsePartitions partition : topic.partitions()) {
+                        TopicPartition tp = new TopicPartition(topic.name(),
+                            partition.partitionIndex());
+                        PartitionData pd = new PartitionData(
+                            partition.committedOffset(),
+                            Optional.of(partition.committedLeaderEpoch()),
+                            partition.metadata(),
+                            Errors.forCode(partition.errorCode()));
+                        partitionDataMap.put(tp, pd);
+                    }
+                }
+                this.groupToPartitionData.put(group.groupId(), partitionDataMap);
+            }
+            this.error = null;
+        }
     }
 
     private static Errors topLevelError(OffsetFetchResponseData data) {
@@ -185,21 +270,42 @@ public class OffsetFetchResponse extends AbstractResponse {
         return error != Errors.NONE;
     }
 
+    public boolean groupHasError(String groupId) {
+        return groupLevelErrors.get(groupId) != Errors.NONE;
+    }
+
     public Errors error() {
         return error;
+    }
+
+    public Errors groupLevelError(String groupId) {
+        return groupLevelErrors.get(groupId);
     }
 
     @Override
     public Map<Errors, Integer> errorCounts() {
         Map<Errors, Integer> counts = new HashMap<>();
-        updateErrorCounts(counts, error);
-        data.topics().forEach(topic ->
-                topic.partitions().forEach(partition ->
+        if (!groupLevelErrors.isEmpty()) {
+            // built response with v8 or above
+            for (Map.Entry<String, Errors> entry : groupLevelErrors.entrySet()) {
+                updateErrorCounts(counts, entry.getValue());
+            }
+            for (OffsetFetchResponseGroup group : data.groupIds()) {
+                group.topics().forEach(topic ->
+                    topic.partitions().forEach(partition ->
                         updateErrorCounts(counts, Errors.forCode(partition.errorCode()))));
+            }
+        } else {
+            // built response with v0-v7
+            updateErrorCounts(counts, error);
+            data.topics().forEach(topic ->
+                topic.partitions().forEach(partition ->
+                    updateErrorCounts(counts, Errors.forCode(partition.errorCode()))));
+        }
         return counts;
     }
 
-    public Map<TopicPartition, PartitionData> responseData() {
+    public Map<TopicPartition, PartitionData> oldResponseData() {
         Map<TopicPartition, PartitionData> responseData = new HashMap<>();
         for (OffsetFetchResponseTopic topic : data.topics()) {
             for (OffsetFetchResponsePartition partition : topic.partitions()) {
@@ -212,6 +318,10 @@ public class OffsetFetchResponse extends AbstractResponse {
             }
         }
         return responseData;
+    }
+
+    public Map<TopicPartition, PartitionData> responseData(String groupId) {
+        return groupToPartitionData.get(groupId);
     }
 
     public static OffsetFetchResponse parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/resources/common/message/OffsetFetchRequest.json
+++ b/clients/src/main/resources/common/message/OffsetFetchRequest.json
@@ -31,19 +31,33 @@
   // Version 6 is the first flexible version.
   //
   // Version 7 is adding the require stable flag.
-  "validVersions": "0-7",
+  //
+  // Version 8 is adding support for fetching offsets for multiple groups at a time
+  "validVersions": "0-8",
   "flexibleVersions": "6+",
   "fields": [
-    { "name": "GroupId", "type": "string", "versions": "0+", "entityType": "groupId",
+    { "name": "GroupId", "type": "string", "versions": "0-7", "entityType": "groupId",
       "about": "The group to fetch offsets for." },
-    { "name": "Topics", "type": "[]OffsetFetchRequestTopic", "versions": "0+", "nullableVersions": "2+",
+    { "name": "Topics", "type": "[]OffsetFetchRequestTopic", "versions": "0-7", "nullableVersions": "2-7",
       "about": "Each topic we would like to fetch offsets for, or null to fetch offsets for all topics.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Name", "type": "string", "versions": "0-7", "entityType": "topicName",
         "about": "The topic name."},
-      { "name": "PartitionIndexes", "type": "[]int32", "versions": "0+",
+      { "name": "PartitionIndexes", "type": "[]int32", "versions": "0-7",
         "about": "The partition indexes we would like to fetch offsets for." }
     ]},
+    { "name": "GroupIds", "type": "[]OffsetFetchRequestGroup", "versions": "8+",
+      "about": "Each group we would like to fetch offsets for", "fields": [
+      { "name": "groupId", "type": "string", "versions": "8+", "entityType": "groupId",
+        "about": "The group ID."},
+      { "name": "Topics", "type": "[]OffsetFetchRequestTopics", "versions": "8+", "nullableVersions": "8+",
+        "about": "Each topic we would like to fetch offsets for, or null to fetch offsets for all topics.", "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The topic name."},
+        { "name": "PartitionIndexes", "type": "[]int32", "versions": "8+",
+          "about": "The partition indexes we would like to fetch offsets for." }
+      ]}
+    ]},
     {"name": "RequireStable", "type": "bool", "versions": "7+", "default": "false",
-     "about": "Whether broker should hold on returning unstable offsets but set a retriable error code for the partition."}
+     "about": "Whether broker should hold on returning unstable offsets but set a retriable error code for the partitions."}
   ]
 }

--- a/clients/src/main/resources/common/message/OffsetFetchResponse.json
+++ b/clients/src/main/resources/common/message/OffsetFetchResponse.json
@@ -30,30 +30,57 @@
   // Version 6 is the first flexible version.
   //
   // Version 7 adds pending offset commit as new error response on partition level.
-  "validVersions": "0-7",
+  //
+  // Version 8 is adding support for fetching offsets for multiple groups
+  "validVersions": "0-8",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "3+", "ignorable": true,
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "Topics", "type": "[]OffsetFetchResponseTopic", "versions": "0+", 
+    { "name": "Topics", "type": "[]OffsetFetchResponseTopic", "versions": "0-7",
       "about": "The responses per topic.", "fields": [
-      { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+      { "name": "Name", "type": "string", "versions": "0-7", "entityType": "topicName",
         "about": "The topic name." },
-      { "name": "Partitions", "type": "[]OffsetFetchResponsePartition", "versions": "0+",
+      { "name": "Partitions", "type": "[]OffsetFetchResponsePartition", "versions": "0-7",
         "about": "The responses per partition", "fields": [
-        { "name": "PartitionIndex", "type": "int32", "versions": "0+",
+        { "name": "PartitionIndex", "type": "int32", "versions": "0-7",
           "about": "The partition index." },
-        { "name": "CommittedOffset", "type": "int64", "versions": "0+",
+        { "name": "CommittedOffset", "type": "int64", "versions": "0-7",
           "about": "The committed message offset." },
-        { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "5+", "default": "-1",
+        { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "5-7", "default": "-1",
           "ignorable": true, "about": "The leader epoch." },
-        { "name": "Metadata", "type": "string", "versions": "0+", "nullableVersions": "0+",
+        { "name": "Metadata", "type": "string", "versions": "0-7", "nullableVersions": "0-7",
           "about": "The partition metadata." },
-        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+        { "name": "ErrorCode", "type": "int16", "versions": "0-7",
           "about": "The error code, or 0 if there was no error." }
       ]}
     ]},
-    { "name": "ErrorCode", "type": "int16", "versions": "2+", "default": "0", "ignorable": true,
-      "about": "The top-level error code, or 0 if there was no error." }
+    { "name": "ErrorCode", "type": "int16", "versions": "2-7", "default": "0", "ignorable": true,
+      "about": "The top-level error code, or 0 if there was no error." },
+    {"name": "GroupIds", "type": "[]OffsetFetchResponseGroup", "versions": "8+",
+      "about": "The responses per group id.", "fields": [
+      { "name": "groupId", "type": "string", "versions": "8+", "entityType": "groupId",
+        "about": "The group ID." },
+      { "name": "Topics", "type": "[]OffsetFetchResponseTopics", "versions": "8+",
+        "about": "The responses per topic.", "fields": [
+        { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",
+          "about": "The topic name." },
+        { "name": "Partitions", "type": "[]OffsetFetchResponsePartitions", "versions": "8+",
+          "about": "The responses per partition", "fields": [
+          { "name": "PartitionIndex", "type": "int32", "versions": "8+",
+            "about": "The partition index." },
+          { "name": "CommittedOffset", "type": "int64", "versions": "8+",
+            "about": "The committed message offset." },
+          { "name": "CommittedLeaderEpoch", "type": "int32", "versions": "8+", "default": "-1",
+            "ignorable": true, "about": "The leader epoch." },
+          { "name": "Metadata", "type": "string", "versions": "8+", "nullableVersions": "0+",
+            "about": "The partition metadata." },
+          { "name": "ErrorCode", "type": "int16", "versions": "8+",
+            "about": "The partition-level error code, or 0 if there was no error." }
+        ]}
+      ]},
+      { "name": "ErrorCode", "type": "int16", "versions": "8+", "default": "0", "ignorable": true,
+        "about": "The group-level error code, or 0 if there was no error." }
+    ]}
   ]
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
@@ -17,10 +17,12 @@
 package org.apache.kafka.clients.admin;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.admin.CreateTopicsResult.TopicMetadataAndConfig;
+import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
@@ -99,7 +101,16 @@ public class AdminClientTestUtils {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> KafkaFuture.completedFuture(e.getValue()))));
     }
 
-    public static ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult(Map<TopicPartition, OffsetAndMetadata> offsets) {
-        return new ListConsumerGroupOffsetsResult(KafkaFuture.completedFuture(offsets));
+    public static ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult(Map<String,
+        Map<TopicPartition, OffsetAndMetadata>> offsets) {
+        Map<CoordinatorKey, KafkaFutureImpl<Map<TopicPartition, OffsetAndMetadata>>> resultMap =
+            new HashMap<>();
+        for (String group : offsets.keySet()) {
+            CoordinatorKey key = CoordinatorKey.byGroupId(group);
+            KafkaFutureImpl<Map<TopicPartition, OffsetAndMetadata>> future =
+                (KafkaFutureImpl<Map<TopicPartition, OffsetAndMetadata>>) KafkaFutureImpl.completedFuture(offsets.get(group));
+            resultMap.put(key, future);
+        }
+        return new ListConsumerGroupOffsetsResult(resultMap);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -512,7 +512,7 @@ public class MockAdminClient extends AdminClient {
     }
 
     @Override
-    synchronized public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(String groupId, ListConsumerGroupOffsetsOptions options) {
+    public ListConsumerGroupOffsetsResult listConsumerGroupOffsets(final List<String> groupIds, final ListConsumerGroupOffsetsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/internals/ListConsumerGroupOffsetsHandlerTest.java
@@ -24,16 +24,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestGroup;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.OffsetFetchRequest;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
@@ -44,21 +50,66 @@ import org.junit.jupiter.api.Test;
 public class ListConsumerGroupOffsetsHandlerTest {
 
     private final LogContext logContext = new LogContext();
-    private final String groupId = "group-id";
+    private final String groupZero = "group0";
+    private final String groupOne = "group1";
+    private final String groupTwo = "group2";
     private final TopicPartition t0p0 = new TopicPartition("t0", 0);
     private final TopicPartition t0p1 = new TopicPartition("t0", 1);
     private final TopicPartition t1p0 = new TopicPartition("t1", 0);
     private final TopicPartition t1p1 = new TopicPartition("t1", 1);
+    private final TopicPartition t2p0 = new TopicPartition("t2", 0);
+    private final TopicPartition t2p1 = new TopicPartition("t2", 1);
+    private final TopicPartition t2p2 = new TopicPartition("t2", 2);
     private final List<TopicPartition> tps = Arrays.asList(t0p0, t0p1, t1p0, t1p1);
+    private final List<TopicPartition> tp0 = singletonList(t0p0);
+    private final List<TopicPartition> tp1 = Arrays.asList(t0p0, t1p0, t1p1);
+    private final List<TopicPartition> tp2 = Arrays.asList(t0p0, t1p0, t1p1, t2p0, t2p1, t2p2);
 
     @Test
     public void testBuildRequest() {
-        ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupId, tps, logContext);
-        OffsetFetchRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(groupId))).build();
-        assertEquals(groupId, request.data().groupId());
-        assertEquals(2, request.data().topics().size());
-        assertEquals(2, request.data().topics().get(0).partitionIndexes().size());
-        assertEquals(2, request.data().topics().get(1).partitionIndexes().size());
+        ListConsumerGroupOffsetsHandler handler =
+            new ListConsumerGroupOffsetsHandler(Collections.singletonMap(groupZero, tps), logContext);
+        OffsetFetchRequest request = handler.buildRequest(1, singleton(CoordinatorKey.byGroupId(
+            groupZero))).build();
+        assertEquals(groupZero, request.data().groupIds().get(0).groupId());
+        assertEquals(2, request.data().groupIds().get(0).topics().size());
+        assertEquals(2, request.data().groupIds().get(0).topics().get(0).partitionIndexes().size());
+        assertEquals(2, request.data().groupIds().get(0).topics().get(1).partitionIndexes().size());
+    }
+
+    @Test
+    public void testBuildRequestWithMultipleGroups() {
+        Map<String, List<TopicPartition>> requestMap = new HashMap<>();
+        requestMap.put(groupZero, tp0);
+        requestMap.put(groupOne, tp1);
+        requestMap.put(groupTwo, tp2);
+        ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(requestMap, logContext);
+        OffsetFetchRequest request = handler.buildRequest(
+            1,
+            new HashSet<>(Arrays.asList(
+                CoordinatorKey.byGroupId(groupZero),
+                CoordinatorKey.byGroupId(groupOne),
+                CoordinatorKey.byGroupId(groupTwo)))).build();
+
+        assertEquals(new HashSet<>(Arrays.asList(groupZero, groupOne, groupTwo)),
+            request.data().groupIds()
+                .stream()
+                .map(OffsetFetchRequestGroup::groupId)
+                .collect(Collectors.toSet()));
+
+        assertEquals(requestMap, request.groupIdsToPartitions());
+        Map<String, List<OffsetFetchRequestTopics>> groupIdsToTopics = request.groupIdsToTopics();
+
+        assertEquals(1, groupIdsToTopics.get(groupZero).size());
+        assertEquals(2, groupIdsToTopics.get(groupOne).size());
+        assertEquals(3, groupIdsToTopics.get(groupTwo).size());
+
+        assertEquals(1, groupIdsToTopics.get(groupZero).get(0).partitionIndexes().size());
+        assertEquals(1, groupIdsToTopics.get(groupOne).get(0).partitionIndexes().size());
+        assertEquals(2, groupIdsToTopics.get(groupOne).get(1).partitionIndexes().size());
+        assertEquals(1, groupIdsToTopics.get(groupTwo).get(0).partitionIndexes().size());
+        assertEquals(2, groupIdsToTopics.get(groupTwo).get(1).partitionIndexes().size());
+        assertEquals(3, groupIdsToTopics.get(groupTwo).get(2).partitionIndexes().size());
     }
 
     @Test
@@ -68,8 +119,35 @@ public class ListConsumerGroupOffsetsHandlerTest {
     }
 
     @Test
+    public void testSuccessfulHandleResponseWithMultipleGroups() {
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> expected = new HashMap<>();
+        Map<String, Errors> errorMap = new HashMap<>();
+        errorMap.put(groupZero, Errors.NONE);
+        errorMap.put(groupOne, Errors.NONE);
+        errorMap.put(groupTwo, Errors.NONE);
+        Map<String, List<TopicPartition>> partitionMap = new HashMap<>();
+        partitionMap.put(groupZero, tp0);
+        partitionMap.put(groupOne, tp1);
+        partitionMap.put(groupTwo, tp2);
+        assertCompletedForMultipleGroups(handleWithErrorWithMultipleGroups(errorMap, partitionMap), expected);
+    }
+
+    @Test
     public void testUnmappedHandleResponse() {
         assertUnmapped(handleWithError(Errors.NOT_COORDINATOR));
+    }
+
+    @Test
+    public void testUnmappedHandleResponseWithMultipleGroups() {
+        Map<String, Errors> errorMap = new HashMap<>();
+        errorMap.put(groupZero, Errors.NOT_COORDINATOR);
+        errorMap.put(groupOne, Errors.NOT_COORDINATOR);
+        errorMap.put(groupTwo, Errors.NOT_COORDINATOR);
+        Map<String, List<TopicPartition>> partitionMap = new HashMap<>();
+        partitionMap.put(groupZero, tp0);
+        partitionMap.put(groupOne, tp1);
+        partitionMap.put(groupTwo, tp2);
+        assertUnmappedWithMultipleGroups(handleWithErrorWithMultipleGroups(errorMap, partitionMap));
     }
 
     @Test
@@ -79,32 +157,97 @@ public class ListConsumerGroupOffsetsHandlerTest {
     }
 
     @Test
+    public void testRetriableHandleResponseWithMultipleGroups() {
+        Map<String, Errors> errorMap = new HashMap<>();
+        errorMap.put(groupZero, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        errorMap.put(groupOne, Errors.COORDINATOR_NOT_AVAILABLE);
+        errorMap.put(groupTwo, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        Map<String, List<TopicPartition>> partitionMap = new HashMap<>();
+        partitionMap.put(groupZero, tp0);
+        partitionMap.put(groupOne, tp1);
+        partitionMap.put(groupTwo, tp2);
+        assertRetriable(handleWithErrorWithMultipleGroups(errorMap, partitionMap));
+    }
+
+    @Test
     public void testFailedHandleResponse() {
         assertFailed(GroupAuthorizationException.class, handleWithError(Errors.GROUP_AUTHORIZATION_FAILED));
         assertFailed(GroupIdNotFoundException.class, handleWithError(Errors.GROUP_ID_NOT_FOUND));
         assertFailed(InvalidGroupIdException.class, handleWithError(Errors.INVALID_GROUP_ID));
     }
 
+    @Test
+    public void testFailedHandleResponseWithMultipleGroups() {
+        Map<String, Errors> errorMap = new HashMap<>();
+        errorMap.put(groupZero, Errors.GROUP_AUTHORIZATION_FAILED);
+        errorMap.put(groupOne, Errors.GROUP_ID_NOT_FOUND);
+        errorMap.put(groupTwo, Errors.INVALID_GROUP_ID);
+        Map<String, List<TopicPartition>> partitionMap = new HashMap<>();
+        partitionMap.put(groupZero, tp0);
+        partitionMap.put(groupOne, tp1);
+        partitionMap.put(groupTwo, tp2);
+        Map<String, Class<? extends Throwable>> groupToExceptionMap = new HashMap<>();
+        groupToExceptionMap.put(groupZero, GroupAuthorizationException.class);
+        groupToExceptionMap.put(groupOne, GroupIdNotFoundException.class);
+        groupToExceptionMap.put(groupTwo, InvalidGroupIdException.class);
+        assertFailedForMultipleGroups(groupToExceptionMap,
+            handleWithErrorWithMultipleGroups(errorMap, partitionMap));
+    }
+
     private OffsetFetchResponse buildResponse(Errors error) {
-        Map<TopicPartition, PartitionData> responseData = new HashMap<>();
-        OffsetFetchResponse response = new OffsetFetchResponse(error, responseData);
-        return response;
+        return new OffsetFetchResponse(
+            Collections.singletonMap(groupZero, error),
+            Collections.singletonMap(groupZero, new HashMap<>()));
+    }
+
+    private OffsetFetchResponse buildResponseWithMultipleGroups(
+        Map<String, Errors> errorMap,
+        Map<String, Map<TopicPartition, PartitionData>> responseData) {
+        return new OffsetFetchResponse(errorMap, responseData);
+    }
+
+    private AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> handleWithErrorWithMultipleGroups(
+        Map<String, Errors> errorMap,
+        Map<String, List<TopicPartition>> groupToPartitionMap) {
+        ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupToPartitionMap, logContext);
+        Map<String, Map<TopicPartition, PartitionData>> responseData = new HashMap<>();
+        for (String group : errorMap.keySet()) {
+            responseData.put(group, new HashMap<>());
+        }
+        OffsetFetchResponse response = buildResponseWithMultipleGroups(errorMap, responseData);
+        return handler.handleResponse(new Node(1, "host", 1234),
+            errorMap.keySet()
+                .stream()
+                .map(CoordinatorKey::byGroupId)
+                .collect(Collectors.toSet()),
+            response);
     }
 
     private AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> handleWithError(
         Errors error
     ) {
-        ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(groupId, tps, logContext);
+        ListConsumerGroupOffsetsHandler handler = new ListConsumerGroupOffsetsHandler(
+            Collections.singletonMap(groupZero, tps), logContext);
         OffsetFetchResponse response = buildResponse(error);
-        return handler.handleResponse(new Node(1, "host", 1234), singleton(CoordinatorKey.byGroupId(groupId)), response);
+        return handler.handleResponse(new Node(1, "host", 1234), singleton(CoordinatorKey.byGroupId(
+            groupZero)), response);
     }
 
     private void assertUnmapped(
-        AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result
-    ) {
+        AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result) {
         assertEquals(emptySet(), result.completedKeys.keySet());
         assertEquals(emptySet(), result.failedKeys.keySet());
-        assertEquals(singletonList(CoordinatorKey.byGroupId(groupId)), result.unmappedKeys);
+        assertEquals(singletonList(CoordinatorKey.byGroupId(groupZero)), result.unmappedKeys);
+    }
+
+    private void assertUnmappedWithMultipleGroups(
+        AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result) {
+        assertEquals(emptySet(), result.completedKeys.keySet());
+        assertEquals(emptySet(), result.failedKeys.keySet());
+        assertEquals(Stream.of(groupZero, groupOne, groupTwo)
+                .map(CoordinatorKey::byGroupId)
+                .collect(Collectors.toSet()),
+            new HashSet<>(result.unmappedKeys));
     }
 
     private void assertRetriable(
@@ -119,21 +262,45 @@ public class ListConsumerGroupOffsetsHandlerTest {
         AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result,
         Map<TopicPartition, OffsetAndMetadata> expected
     ) {
-        CoordinatorKey key = CoordinatorKey.byGroupId(groupId);
+        CoordinatorKey key = CoordinatorKey.byGroupId(groupZero);
         assertEquals(emptySet(), result.failedKeys.keySet());
         assertEquals(emptyList(), result.unmappedKeys);
         assertEquals(singleton(key), result.completedKeys.keySet());
-        assertEquals(expected, result.completedKeys.get(CoordinatorKey.byGroupId(groupId)));
+        assertEquals(expected, result.completedKeys.get(key));
+    }
+
+    private void assertCompletedForMultipleGroups (
+        AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result,
+        Map<String, Map<TopicPartition, OffsetAndMetadata>> expected) {
+        assertEquals(emptySet(), result.failedKeys.keySet());
+        assertEquals(emptyList(), result.unmappedKeys);
+        for (String g : expected.keySet()) {
+            CoordinatorKey key = CoordinatorKey.byGroupId(g);
+            assertTrue(result.completedKeys.containsKey(key));
+            assertEquals(expected.get(g), result.completedKeys.get(key));
+        }
     }
 
     private void assertFailed(
         Class<? extends Throwable> expectedExceptionType,
         AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result
     ) {
-        CoordinatorKey key = CoordinatorKey.byGroupId(groupId);
+        CoordinatorKey key = CoordinatorKey.byGroupId(groupZero);
         assertEquals(emptySet(), result.completedKeys.keySet());
         assertEquals(emptyList(), result.unmappedKeys);
         assertEquals(singleton(key), result.failedKeys.keySet());
         assertTrue(expectedExceptionType.isInstance(result.failedKeys.get(key)));
+    }
+
+    private void assertFailedForMultipleGroups(
+        Map<String, Class<? extends Throwable>> groupToExceptionMap,
+        AdminApiHandler.ApiResult<CoordinatorKey, Map<TopicPartition, OffsetAndMetadata>> result) {
+        assertEquals(emptySet(), result.completedKeys.keySet());
+        assertEquals(emptyList(), result.unmappedKeys);
+        for (String g : groupToExceptionMap.keySet()) {
+            CoordinatorKey key = CoordinatorKey.byGroupId(g);
+            assertTrue(result.failedKeys.containsKey(key));
+            assertTrue(groupToExceptionMap.get(g).isInstance(result.failedKeys.get(key)));
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -2338,7 +2338,9 @@ public class KafkaConsumerTest {
             partitionData.put(entry.getKey(), new OffsetFetchResponse.PartitionData(entry.getValue(),
                     Optional.empty(), "", error));
         }
-        return new OffsetFetchResponse(Errors.NONE, partitionData);
+        return new OffsetFetchResponse(
+            Collections.singletonMap(groupId, Errors.NONE),
+            Collections.singletonMap(groupId, partitionData));
     }
 
     private ListOffsetsResponse listOffsetsResponse(Map<TopicPartition, Long> offsets) {

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchRequestTest.java
@@ -18,10 +18,12 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.OffsetFetchRequestData.OffsetFetchRequestTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.OffsetFetchRequest.Builder;
+import org.apache.kafka.common.requests.OffsetFetchRequest.NoBatchedOffsetFetchRequestException;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -34,7 +36,9 @@ import java.util.Optional;
 import static org.apache.kafka.common.requests.AbstractResponse.DEFAULT_THROTTLE_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,25 +48,20 @@ public class OffsetFetchRequestTest {
     private final int partitionOne = 1;
     private final String topicTwo = "topic2";
     private final int partitionTwo = 2;
-    private final String groupId = "groupId";
+    private final String topicThree = "topic3";
+    private final String group1 = "group1";
+    private final String group2 = "group2";
+    private final String group3 = "group3";
+    private final String group4 = "group4";
+    private final String group5 = "group5";
 
     private OffsetFetchRequest.Builder builder;
-    private List<TopicPartition> partitions;
-
-    @BeforeEach
-    public void setUp() {
-        partitions = Arrays.asList(new TopicPartition(topicOne, partitionOne),
-                                   new TopicPartition(topicTwo, partitionTwo));
-        builder = new OffsetFetchRequest.Builder(
-            groupId,
-            false,
-            partitions,
-            false);
-    }
 
     @Test
     public void testConstructor() {
-        assertFalse(builder.isAllTopicPartitions());
+        List<TopicPartition> partitions = Arrays.asList(
+            new TopicPartition(topicOne, partitionOne),
+            new TopicPartition(topicTwo, partitionTwo));
         int throttleTimeMs = 10;
 
         Map<TopicPartition, PartitionData> expectedData = new HashMap<>();
@@ -76,25 +75,113 @@ public class OffsetFetchRequestTest {
         }
 
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            OffsetFetchRequest request = builder.build(version);
-            assertFalse(request.isAllPartitions());
-            assertEquals(groupId, request.groupId());
-            assertEquals(partitions, request.partitions());
+            if (version < 8) {
+                builder = new OffsetFetchRequest.Builder(
+                    group1,
+                    false,
+                    partitions,
+                    false);
+                assertFalse(builder.isAllTopicPartitions());
+                OffsetFetchRequest request = builder.build(version);
+                assertFalse(request.isAllPartitions());
+                assertEquals(group1, request.groupId());
+                assertEquals(partitions, request.partitions());
 
-            OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
-            assertEquals(Errors.NONE, response.error());
-            assertFalse(response.hasError());
-            assertEquals(Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(),
-                "Incorrect error count for version " + version);
+                OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
+                assertEquals(Errors.NONE, response.error());
+                assertFalse(response.hasError());
+                assertEquals(Collections.singletonMap(Errors.NONE, version <= (short) 1 ? 3 : 1), response.errorCounts(),
+                    "Incorrect error count for version " + version);
 
-            if (version <= 1) {
-                assertEquals(expectedData, response.responseData());
-            }
+                if (version <= 1) {
+                    assertEquals(expectedData, response.oldResponseData());
+                }
 
-            if (version >= 3) {
-                assertEquals(throttleTimeMs, response.throttleTimeMs());
+                if (version >= 3) {
+                    assertEquals(throttleTimeMs, response.throttleTimeMs());
+                } else {
+                    assertEquals(DEFAULT_THROTTLE_TIME, response.throttleTimeMs());
+                }
             } else {
-                assertEquals(DEFAULT_THROTTLE_TIME, response.throttleTimeMs());
+                builder = new Builder(Collections.singletonMap(group1, partitions), false, false);
+                OffsetFetchRequest request = builder.build(version);
+                Map<String, List<TopicPartition>> groupToPartitionMap =
+                    request.groupIdsToPartitions();
+                Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
+                    request.groupIdsToTopics();
+                assertNotSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertTrue(groupToPartitionMap.containsKey(group1) && groupToTopicMap.containsKey(
+                    group1));
+                assertEquals(partitions, groupToPartitionMap.get(group1));
+                OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
+                assertEquals(Errors.NONE, response.groupLevelError(group1));
+                assertFalse(response.groupHasError(group1));
+                assertEquals(Collections.singletonMap(Errors.NONE, 1), response.errorCounts(),
+                    "Incorrect error count for version " + version);
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+            }
+        }
+    }
+
+    @Test
+    public void testConstructorWithMultipleGroups() {
+        List<TopicPartition> topic1Partitions = Arrays.asList(
+            new TopicPartition(topicOne, partitionOne),
+            new TopicPartition(topicOne, partitionTwo));
+        List<TopicPartition> topic2Partitions = Arrays.asList(
+            new TopicPartition(topicTwo, partitionOne),
+            new TopicPartition(topicTwo, partitionTwo));
+        List<TopicPartition> topic3Partitions = Arrays.asList(
+            new TopicPartition(topicThree, partitionOne),
+            new TopicPartition(topicThree, partitionTwo));
+        Map<String, List<TopicPartition>> groupToTp = new HashMap<>();
+        groupToTp.put(group1, topic1Partitions);
+        groupToTp.put(group2, topic2Partitions);
+        groupToTp.put(group3, topic3Partitions);
+        groupToTp.put(group4, null);
+        groupToTp.put(group5, null);
+        int throttleTimeMs = 10;
+
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version >= 8) {
+                builder = new Builder(groupToTp, false, false);
+                OffsetFetchRequest request = builder.build(version);
+                Map<String, List<TopicPartition>> groupToPartitionMap =
+                    request.groupIdsToPartitions();
+                Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
+                    request.groupIdsToTopics();
+                assertEquals(groupToTp.keySet(), groupToTopicMap.keySet());
+                assertEquals(groupToTp.keySet(), groupToPartitionMap.keySet());
+                assertNotSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertNotSame(groupToTopicMap.get(group2), request.isAllPartitionsForGroup());
+                assertNotSame(groupToTopicMap.get(group3), request.isAllPartitionsForGroup());
+                assertSame(groupToTopicMap.get(group4), request.isAllPartitionsForGroup());
+                assertSame(groupToTopicMap.get(group5), request.isAllPartitionsForGroup());
+                OffsetFetchResponse response = request.getErrorResponse(throttleTimeMs, Errors.NONE);
+                assertEquals(Errors.NONE, response.groupLevelError(group1));
+                assertEquals(Errors.NONE, response.groupLevelError(group2));
+                assertEquals(Errors.NONE, response.groupLevelError(group3));
+                assertEquals(Errors.NONE, response.groupLevelError(group4));
+                assertEquals(Errors.NONE, response.groupLevelError(group5));
+                assertFalse(response.groupHasError(group1));
+                assertFalse(response.groupHasError(group2));
+                assertFalse(response.groupHasError(group3));
+                assertFalse(response.groupHasError(group4));
+                assertFalse(response.groupHasError(group5));
+                assertEquals(Collections.singletonMap(Errors.NONE, 5), response.errorCounts(),
+                    "Incorrect error count for version " + version);
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+            }
+        }
+    }
+
+    @Test
+    public void testBuildThrowForUnsupportedBatchRequest() {
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version < 8) {
+                builder = new Builder(Collections.singletonMap(group1, null), true, false);
+                final short finalVersion = version;
+                assertThrows(NoBatchedOffsetFetchRequestException.class, () -> builder.build(finalVersion));
             }
         }
     }
@@ -102,21 +189,35 @@ public class OffsetFetchRequestTest {
     @Test
     public void testConstructorFailForUnsupportedRequireStable() {
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            // The builder needs to be initialized every cycle as the internal data `requireStable` flag is flipped.
-            builder = new OffsetFetchRequest.Builder(groupId, true, null, false);
-            final short finalVersion = version;
-            if (version < 2) {
-                assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
-            } else {
-                OffsetFetchRequest request = builder.build(finalVersion);
-                assertEquals(groupId, request.groupId());
-                assertNull(request.partitions());
-                assertTrue(request.isAllPartitions());
-                if (version < 7) {
-                    assertFalse(request.requireStable());
+            if (version < 8) {
+                // The builder needs to be initialized every cycle as the internal data `requireStable` flag is flipped.
+                builder = new OffsetFetchRequest.Builder(group1, true, null, false);
+                final short finalVersion = version;
+                if (version < 2) {
+                    assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
                 } else {
-                    assertTrue(request.requireStable());
+                    OffsetFetchRequest request = builder.build(finalVersion);
+                    assertEquals(group1, request.groupId());
+                    assertNull(request.partitions());
+                    assertTrue(request.isAllPartitions());
+                    if (version < 7) {
+                        assertFalse(request.requireStable());
+                    } else {
+                        assertTrue(request.requireStable());
+                    }
                 }
+            } else {
+                builder = new Builder(Collections.singletonMap(group1, null), true, false);
+                OffsetFetchRequest request = builder.build(version);
+                Map<String, List<TopicPartition>> groupToPartitionMap =
+                    request.groupIdsToPartitions();
+                Map<String, List<OffsetFetchRequestTopics>> groupToTopicMap =
+                    request.groupIdsToTopics();
+                assertTrue(groupToPartitionMap.containsKey(group1) && groupToTopicMap.containsKey(
+                    group1));
+                assertNull(groupToPartitionMap.get(group1));
+                assertSame(groupToTopicMap.get(group1), request.isAllPartitionsForGroup());
+                assertTrue(request.requireStable());
             }
         }
     }
@@ -124,13 +225,15 @@ public class OffsetFetchRequestTest {
     @Test
     public void testBuildThrowForUnsupportedRequireStable() {
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            builder = new OffsetFetchRequest.Builder(groupId, true, null, true);
-            if (version < 7) {
-                final short finalVersion = version;
-                assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
-            } else {
-                OffsetFetchRequest request = builder.build(version);
-                assertTrue(request.requireStable());
+            if (version < 8) {
+                builder = new OffsetFetchRequest.Builder(group1, true, null, true);
+                if (version < 7) {
+                    final short finalVersion = version;
+                    assertThrows(UnsupportedVersionException.class, () -> builder.build(finalVersion));
+                } else {
+                    OffsetFetchRequest request = builder.build(version);
+                    assertTrue(request.requireStable());
+                }
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/OffsetFetchResponseTest.java
@@ -18,8 +18,11 @@ package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.message.OffsetFetchResponseData;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseGroup;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartition;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponsePartitions;
 import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopic;
+import org.apache.kafka.common.message.OffsetFetchResponseData.OffsetFetchResponseTopics;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
@@ -44,12 +47,19 @@ public class OffsetFetchResponseTest {
     private final int offset = 100;
     private final String metadata = "metadata";
 
+    private final String groupOne = "group1";
+    private final String groupTwo = "group2";
+    private final String groupThree = "group3";
     private final String topicOne = "topic1";
     private final int partitionOne = 1;
     private final Optional<Integer> leaderEpochOne = Optional.of(1);
     private final String topicTwo = "topic2";
     private final int partitionTwo = 2;
     private final Optional<Integer> leaderEpochTwo = Optional.of(2);
+    private final String topicThree = "topic3";
+    private final int partitionThree = 3;
+    private final Optional<Integer> leaderEpochThree = Optional.of(3);
+
 
     private Map<TopicPartition, PartitionData> partitionDataMap;
 
@@ -72,21 +82,102 @@ public class OffsetFetchResponseTest {
 
     @Test
     public void testConstructor() {
-        OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NOT_COORDINATOR, partitionDataMap);
-        assertEquals(Errors.NOT_COORDINATOR, response.error());
-        assertEquals(3, response.errorCounts().size());
-        assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
-                Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
-                Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
-                response.errorCounts());
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version < 8) {
+                OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NOT_COORDINATOR, partitionDataMap);
+                assertEquals(Errors.NOT_COORDINATOR, response.error());
+                assertEquals(3, response.errorCounts().size());
+                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
+                    response.errorCounts());
 
-        assertEquals(throttleTimeMs, response.throttleTimeMs());
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
 
-        Map<TopicPartition, PartitionData> responseData = response.responseData();
-        assertEquals(partitionDataMap, responseData);
-        responseData.forEach(
-            (tp, data) -> assertTrue(data.hasError())
-        );
+                Map<TopicPartition, PartitionData> responseData = response.oldResponseData();
+                assertEquals(partitionDataMap, responseData);
+                responseData.forEach((tp, data) -> assertTrue(data.hasError()));
+            } else {
+                OffsetFetchResponse response = new OffsetFetchResponse(
+                    throttleTimeMs,
+                    Collections.singletonMap(groupOne, Errors.NOT_COORDINATOR),
+                    Collections.singletonMap(groupOne, partitionDataMap));
+                assertEquals(Errors.NOT_COORDINATOR, response.groupLevelError(groupOne));
+                assertEquals(3, response.errorCounts().size());
+                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1)),
+                    response.errorCounts());
+
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+
+                Map<TopicPartition, PartitionData> responseData = response.responseData(groupOne);
+                assertEquals(partitionDataMap, responseData);
+                responseData.forEach((tp, data) -> assertTrue(data.hasError()));
+            }
+        }
+    }
+
+    @Test
+    public void testConstructorWithMultipleGroups() {
+        Map<String, Map<TopicPartition, PartitionData>> responseData = new HashMap<>();
+        Map<String, Errors> errorMap = new HashMap<>();
+        Map<TopicPartition, PartitionData> pd1 = new HashMap<>();
+        Map<TopicPartition, PartitionData> pd2 = new HashMap<>();
+        Map<TopicPartition, PartitionData> pd3 = new HashMap<>();
+        pd1.put(new TopicPartition(topicOne, partitionOne), new PartitionData(
+            offset,
+            leaderEpochOne,
+            metadata,
+            Errors.TOPIC_AUTHORIZATION_FAILED));
+        pd2.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
+            offset,
+            leaderEpochTwo,
+            metadata,
+            Errors.UNKNOWN_TOPIC_OR_PARTITION));
+        pd3.put(new TopicPartition(topicThree, partitionThree), new PartitionData(
+            offset,
+            leaderEpochThree,
+            metadata,
+            Errors.NONE));
+        responseData.put(groupOne, pd1);
+        responseData.put(groupTwo, pd2);
+        responseData.put(groupThree, pd3);
+        errorMap.put(groupOne, Errors.NOT_COORDINATOR);
+        errorMap.put(groupTwo, Errors.COORDINATOR_LOAD_IN_PROGRESS);
+        errorMap.put(groupThree, Errors.NONE);
+        for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
+            if (version >= 8) {
+                OffsetFetchResponse response = new OffsetFetchResponse(
+                    throttleTimeMs, errorMap, responseData);
+
+                assertEquals(Errors.NOT_COORDINATOR, response.groupLevelError(groupOne));
+                assertEquals(Errors.COORDINATOR_LOAD_IN_PROGRESS, response.groupLevelError(groupTwo));
+                assertEquals(Errors.NONE, response.groupLevelError(groupThree));
+                assertTrue(response.groupHasError(groupOne));
+                assertTrue(response.groupHasError(groupTwo));
+                assertFalse(response.groupHasError(groupThree));
+                assertEquals(5, response.errorCounts().size());
+                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.NOT_COORDINATOR, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.UNKNOWN_TOPIC_OR_PARTITION, 1),
+                    Utils.mkEntry(Errors.COORDINATOR_LOAD_IN_PROGRESS, 1),
+                    Utils.mkEntry(Errors.NONE, 2)),
+                    response.errorCounts());
+
+                assertEquals(throttleTimeMs, response.throttleTimeMs());
+
+                Map<TopicPartition, PartitionData> responseData1 = response.responseData(groupOne);
+                assertEquals(pd1, responseData1);
+                responseData1.forEach((tp, data) -> assertTrue(data.hasError()));
+                Map<TopicPartition, PartitionData> responseData2 = response.responseData(groupTwo);
+                assertEquals(pd2, responseData2);
+                responseData2.forEach((tp, data) -> assertTrue(data.hasError()));
+                Map<TopicPartition, PartitionData> responseData3 = response.responseData(groupThree);
+                assertEquals(pd3, responseData3);
+                responseData3.forEach((tp, data) -> assertFalse(data.hasError()));
+            }
+        }
     }
 
     /**
@@ -94,77 +185,125 @@ public class OffsetFetchResponseTest {
      */
     @Test
     public void testStructBuild() {
-        partitionDataMap.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
-            offset,
-            leaderEpochTwo,
-            metadata,
-            Errors.GROUP_AUTHORIZATION_FAILED
-        ));
-
-        OffsetFetchResponse latestResponse = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
-
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            OffsetFetchResponseData data = new OffsetFetchResponseData(
-                new ByteBufferAccessor(latestResponse.serialize(version)), version);
+            if (version < 8) {
+                partitionDataMap.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
+                    offset,
+                    leaderEpochTwo,
+                    metadata,
+                    Errors.GROUP_AUTHORIZATION_FAILED
+                ));
 
-            OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
+                OffsetFetchResponse latestResponse = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
+                OffsetFetchResponseData data = new OffsetFetchResponseData(
+                    new ByteBufferAccessor(latestResponse.serialize(version)), version);
 
-            if (version <= 1) {
-                assertEquals(Errors.NONE.code(), data.errorCode());
+                OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
 
-                // Partition level error populated in older versions.
-                assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, oldResponse.error());
-                assertEquals(Utils.mkMap(Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 2),
-                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)), oldResponse.errorCounts());
+                if (version <= 1) {
+                    assertEquals(Errors.NONE.code(), data.errorCode());
 
-            } else {
-                assertEquals(Errors.NONE.code(), data.errorCode());
+                    // Partition level error populated in older versions.
+                    assertEquals(Errors.GROUP_AUTHORIZATION_FAILED, oldResponse.error());
+                    assertEquals(Utils.mkMap(Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 2),
+                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                        oldResponse.errorCounts());
+                } else {
+                    assertEquals(Errors.NONE.code(), data.errorCode());
 
-                assertEquals(Errors.NONE, oldResponse.error());
-                assertEquals(Utils.mkMap(
+                    assertEquals(Errors.NONE, oldResponse.error());
+                    assertEquals(Utils.mkMap(
                         Utils.mkEntry(Errors.NONE, 1),
                         Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
-                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)), oldResponse.errorCounts());
-            }
+                        Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                        oldResponse.errorCounts());
+                }
 
-            if (version <= 2) {
-                assertEquals(DEFAULT_THROTTLE_TIME, oldResponse.throttleTimeMs());
+                if (version <= 2) {
+                    assertEquals(DEFAULT_THROTTLE_TIME, oldResponse.throttleTimeMs());
+                } else {
+                    assertEquals(throttleTimeMs, oldResponse.throttleTimeMs());
+                }
+
+                Map<TopicPartition, PartitionData> expectedDataMap = new HashMap<>();
+                for (Map.Entry<TopicPartition, PartitionData> entry : partitionDataMap.entrySet()) {
+                    PartitionData partitionData = entry.getValue();
+                    expectedDataMap.put(entry.getKey(), new PartitionData(
+                        partitionData.offset,
+                        version <= 4 ? Optional.empty() : partitionData.leaderEpoch,
+                        partitionData.metadata,
+                        partitionData.error
+                    ));
+                }
+
+                Map<TopicPartition, PartitionData> responseData = oldResponse.oldResponseData();
+                assertEquals(expectedDataMap, responseData);
+
+                responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
             } else {
+                partitionDataMap.put(new TopicPartition(topicTwo, partitionTwo), new PartitionData(
+                    offset,
+                    leaderEpochTwo,
+                    metadata,
+                    Errors.GROUP_AUTHORIZATION_FAILED));
+                OffsetFetchResponse latestResponse = new OffsetFetchResponse(
+                    throttleTimeMs,
+                    Collections.singletonMap(groupOne, Errors.NONE),
+                    Collections.singletonMap(groupOne, partitionDataMap));
+                OffsetFetchResponseData data = new OffsetFetchResponseData(
+                    new ByteBufferAccessor(latestResponse.serialize(version)), version);
+                OffsetFetchResponse oldResponse = new OffsetFetchResponse(data, version);
+                assertEquals(Errors.NONE.code(), data.groupIds().get(0).errorCode());
+
+                assertEquals(Errors.NONE, oldResponse.groupLevelError(groupOne));
+                assertEquals(Utils.mkMap(
+                    Utils.mkEntry(Errors.NONE, 1),
+                    Utils.mkEntry(Errors.GROUP_AUTHORIZATION_FAILED, 1),
+                    Utils.mkEntry(Errors.TOPIC_AUTHORIZATION_FAILED, 1)),
+                    oldResponse.errorCounts());
                 assertEquals(throttleTimeMs, oldResponse.throttleTimeMs());
+
+                Map<TopicPartition, PartitionData> expectedDataMap = new HashMap<>();
+                for (Map.Entry<TopicPartition, PartitionData> entry : partitionDataMap.entrySet()) {
+                    PartitionData partitionData = entry.getValue();
+                    expectedDataMap.put(entry.getKey(), new PartitionData(
+                        partitionData.offset,
+                        partitionData.leaderEpoch,
+                        partitionData.metadata,
+                        partitionData.error
+                    ));
+                }
+
+                Map<TopicPartition, PartitionData> responseData = oldResponse.responseData(groupOne);
+                assertEquals(expectedDataMap, responseData);
+
+                responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
             }
-
-            Map<TopicPartition, PartitionData> expectedDataMap = new HashMap<>();
-            for (Map.Entry<TopicPartition, PartitionData> entry : partitionDataMap.entrySet()) {
-                PartitionData partitionData = entry.getValue();
-                expectedDataMap.put(entry.getKey(), new PartitionData(
-                    partitionData.offset,
-                    version <= 4 ? Optional.empty() : partitionData.leaderEpoch,
-                    partitionData.metadata,
-                    partitionData.error
-                ));
-            }
-
-            Map<TopicPartition, PartitionData> responseData = oldResponse.responseData();
-            assertEquals(expectedDataMap, responseData);
-
-            responseData.forEach((tp, rdata) -> assertTrue(rdata.hasError()));
         }
     }
 
     @Test
     public void testShouldThrottle() {
-        OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
         for (short version : ApiKeys.OFFSET_FETCH.allVersions()) {
-            if (version >= 4) {
-                assertTrue(response.shouldClientThrottle(version));
+            if (version < 8) {
+                OffsetFetchResponse response = new OffsetFetchResponse(throttleTimeMs, Errors.NONE, partitionDataMap);
+                if (version >= 4) {
+                    assertTrue(response.shouldClientThrottle(version));
+                } else {
+                    assertFalse(response.shouldClientThrottle(version));
+                }
             } else {
-                assertFalse(response.shouldClientThrottle(version));
+                OffsetFetchResponse response = new OffsetFetchResponse(
+                    throttleTimeMs,
+                    Collections.singletonMap(groupOne, Errors.NOT_COORDINATOR),
+                    Collections.singletonMap(groupOne, partitionDataMap));
+                assertTrue(response.shouldClientThrottle(version));
             }
         }
     }
 
     @Test
-    public void testNullableMetadata() {
+    public void testNullableMetadataV0ToV7() {
         PartitionData pd = new PartitionData(
             offset,
             leaderEpochOne,
@@ -196,7 +335,43 @@ public class OffsetFetchResponseTest {
     }
 
     @Test
-    public void testUseDefaultLeaderEpoch() {
+    public void testNullableMetadataV8AndAbove() {
+        PartitionData pd = new PartitionData(
+            offset,
+            leaderEpochOne,
+            null,
+            Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        // test PartitionData.equals with null metadata
+        assertEquals(pd, pd);
+        partitionDataMap.clear();
+        partitionDataMap.put(new TopicPartition(topicOne, partitionOne), pd);
+
+        OffsetFetchResponse response = new OffsetFetchResponse(
+            throttleTimeMs,
+            Collections.singletonMap(groupOne, Errors.GROUP_AUTHORIZATION_FAILED),
+            Collections.singletonMap(groupOne, partitionDataMap));
+        OffsetFetchResponseData expectedData =
+            new OffsetFetchResponseData()
+                .setGroupIds(Collections.singletonList(
+                    new OffsetFetchResponseGroup()
+                        .setGroupId(groupOne)
+                        .setTopics(Collections.singletonList(
+                            new OffsetFetchResponseTopics()
+                                .setName(topicOne)
+                                .setPartitions(Collections.singletonList(
+                                    new OffsetFetchResponsePartitions()
+                                        .setPartitionIndex(partitionOne)
+                                        .setCommittedOffset(offset)
+                                        .setCommittedLeaderEpoch(leaderEpochOne.orElse(-1))
+                                        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+                                        .setMetadata(null)))))
+                        .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())))
+                .setThrottleTimeMs(throttleTimeMs);
+        assertEquals(expectedData, response.data());
+    }
+
+    @Test
+    public void testUseDefaultLeaderEpochV0ToV7() {
         final Optional<Integer> emptyLeaderEpoch = Optional.empty();
         partitionDataMap.clear();
 
@@ -225,6 +400,42 @@ public class OffsetFetchResponseTest {
                             .setMetadata(metadata))
                     ))
                 );
+        assertEquals(expectedData, response.data());
+    }
+
+    @Test
+    public void testUseDefaultLeaderEpochV8() {
+        final Optional<Integer> emptyLeaderEpoch = Optional.empty();
+        partitionDataMap.clear();
+
+        partitionDataMap.put(new TopicPartition(topicOne, partitionOne),
+            new PartitionData(
+                offset,
+                emptyLeaderEpoch,
+                metadata,
+                Errors.UNKNOWN_TOPIC_OR_PARTITION)
+        );
+        OffsetFetchResponse response = new OffsetFetchResponse(
+            throttleTimeMs,
+            Collections.singletonMap(groupOne, Errors.NOT_COORDINATOR),
+            Collections.singletonMap(groupOne, partitionDataMap));
+        OffsetFetchResponseData expectedData =
+            new OffsetFetchResponseData()
+                .setGroupIds(Collections.singletonList(
+                    new OffsetFetchResponseGroup()
+                        .setGroupId(groupOne)
+                        .setTopics(Collections.singletonList(
+                            new OffsetFetchResponseTopics()
+                                .setName(topicOne)
+                                .setPartitions(Collections.singletonList(
+                                    new OffsetFetchResponsePartitions()
+                                        .setPartitionIndex(partitionOne)
+                                        .setCommittedOffset(offset)
+                                        .setCommittedLeaderEpoch(RecordBatch.NO_PARTITION_LEADER_EPOCH)
+                                        .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+                                        .setMetadata(metadata)))))
+                        .setErrorCode(Errors.NOT_COORDINATOR.code())))
+                .setThrottleTimeMs(throttleTimeMs);
         assertEquals(expectedData, response.data());
     }
 }

--- a/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
+++ b/connect/mirror/src/test/java/org/apache/kafka/connect/mirror/integration/MirrorConnectorsIntegrationBaseTest.java
@@ -398,7 +398,10 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
         try (Admin backupClient = backup.kafka().createAdminClient()) {
             // retrieve the consumer group offset from backup cluster
             Map<TopicPartition, OffsetAndMetadata> remoteOffsets =
-                backupClient.listConsumerGroupOffsets(consumerGroupName).partitionsToOffsetAndMetadata().get();
+                backupClient.listConsumerGroupOffsets(Collections.singletonList(consumerGroupName))
+                    .groupIdsToPartitionsAndOffsetAndMetadata()
+                    .get(consumerGroupName)
+                    .get();
 
             // pinpoint the offset of the last partition which does not receive records
             OffsetAndMetadata offset = remoteOffsets.get(new TopicPartition(backupTopic, NUM_PARTITIONS - 1));
@@ -613,7 +616,10 @@ public abstract class MirrorConnectorsIntegrationBaseTest {
 
             waitForCondition(() -> {
                 Map<TopicPartition, OffsetAndMetadata> consumerGroupOffsets =
-                    adminClient.listConsumerGroupOffsets(consumerGroupId).partitionsToOffsetAndMetadata().get();
+                    adminClient.listConsumerGroupOffsets(Collections.singletonList(consumerGroupId))
+                        .groupIdsToPartitionsAndOffsetAndMetadata()
+                        .get(consumerGroupId)
+                        .get();
                 long consumerGroupOffsetTotal = consumerGroupOffsets.values().stream()
                     .mapToLong(OffsetAndMetadata::offset).sum();
 

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -18,7 +18,7 @@
 package kafka.admin
 
 import java.time.{Duration, Instant}
-import java.util.Properties
+import java.util.{Collections, Properties}
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import kafka.utils._
@@ -753,9 +753,11 @@ object ConsumerGroupCommand extends Logging {
 
     private def getCommittedOffsets(groupId: String): Map[TopicPartition, OffsetAndMetadata] = {
       adminClient.listConsumerGroupOffsets(
-        groupId,
-        withTimeoutMs(new ListConsumerGroupOffsetsOptions)
-      ).partitionsToOffsetAndMetadata.get.asScala
+        Collections.singletonList(groupId),
+        withTimeoutMs(new ListConsumerGroupOffsetsOptions(Collections.singletonList(groupId))))
+        .groupIdsToPartitionsAndOffsetAndMetadata
+        .get(groupId)
+        .get().asScala
     }
 
     type GroupMetadata = immutable.Map[String, immutable.Map[TopicPartition, OffsetAndMetadata]]

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -62,6 +62,7 @@ import org.apache.kafka.common.record._
 import org.apache.kafka.common.replica.ClientMetadata
 import org.apache.kafka.common.replica.ClientMetadata.DefaultClientMetadata
 import org.apache.kafka.common.requests.FindCoordinatorRequest.CoordinatorType
+import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData
 import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse
 import org.apache.kafka.common.requests._
 import org.apache.kafka.common.resource.Resource.CLUSTER_NAME
@@ -1255,80 +1256,147 @@ class KafkaApis(val requestChannel: RequestChannel,
    * Handle an offset fetch request
    */
   def handleOffsetFetchRequest(request: RequestChannel.Request): Unit = {
+    val version = request.header.apiVersion
+    if (version == 0) {
+      // reading offsets from ZK
+      handleOffsetFetchRequestV0(request)
+    } else if (version >= 1 && version <= 7) {
+      // reading offsets from Kafka
+      handleOffsetFetchRequestBetweenV1AndV7(request)
+    } else {
+      // batching offset reads for multiple groups starts with version 8 and greater
+      handleOffsetFetchRequestV8AndAbove(request)
+    }
+  }
+
+  private def handleOffsetFetchRequestV0(request: RequestChannel.Request): Unit = {
     val header = request.header
     val offsetFetchRequest = request.body[OffsetFetchRequest]
 
-    def partitionByAuthorized(seq: Seq[TopicPartition]): (Seq[TopicPartition], Seq[TopicPartition]) =
-      authHelper.partitionSeqByAuthorized(request.context, DESCRIBE, TOPIC, seq)(_.topic)
-
     def createResponse(requestThrottleMs: Int): AbstractResponse = {
       val offsetFetchResponse =
-        // reject the request if not authorized to the group
+      // reject the request if not authorized to the group
         if (!authHelper.authorize(request.context, DESCRIBE, GROUP, offsetFetchRequest.groupId))
           offsetFetchRequest.getErrorResponse(requestThrottleMs, Errors.GROUP_AUTHORIZATION_FAILED)
         else {
-          if (header.apiVersion == 0) {
-            val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.unsupported("Version 0 offset fetch requests"))
-            val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
-              offsetFetchRequest.partitions.asScala)
+          val zkSupport = metadataSupport.requireZkOrThrow(KafkaApis.unsupported("Version 0 offset fetch requests"))
+          val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
+            offsetFetchRequest.partitions.asScala, request.context)
 
-            // version 0 reads offsets from ZK
-            val authorizedPartitionData = authorizedPartitions.map { topicPartition =>
-              try {
-                if (!metadataCache.contains(topicPartition))
-                  (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
-                else {
-                  val payloadOpt = zkSupport.zkClient.getConsumerOffset(offsetFetchRequest.groupId, topicPartition)
-                  payloadOpt match {
-                    case Some(payload) =>
-                      (topicPartition, new OffsetFetchResponse.PartitionData(payload.toLong,
-                        Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.NONE))
-                    case None =>
-                      (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
-                  }
+          // version 0 reads offsets from ZK
+          val authorizedPartitionData = authorizedPartitions.map { topicPartition =>
+            try {
+              if (!metadataCache.contains(topicPartition))
+                (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
+              else {
+                val payloadOpt = zkSupport.zkClient.getConsumerOffset(offsetFetchRequest.groupId, topicPartition)
+                payloadOpt match {
+                  case Some(payload) =>
+                    (topicPartition, new OffsetFetchResponse.PartitionData(payload.toLong,
+                      Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.NONE))
+                  case None =>
+                    (topicPartition, OffsetFetchResponse.UNKNOWN_PARTITION)
                 }
-              } catch {
-                case e: Throwable =>
-                  (topicPartition, new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
-                    Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.forException(e)))
               }
-            }.toMap
-
-            val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
-            new OffsetFetchResponse(requestThrottleMs, Errors.NONE, (authorizedPartitionData ++ unauthorizedPartitionData).asJava)
-          } else {
-            // versions 1 and above read offsets from Kafka
-            if (offsetFetchRequest.isAllPartitions) {
-              val (error, allPartitionData) = groupCoordinator.handleFetchOffsets(offsetFetchRequest.groupId, offsetFetchRequest.requireStable)
-              if (error != Errors.NONE)
-                offsetFetchRequest.getErrorResponse(requestThrottleMs, error)
-              else {
-                // clients are not allowed to see offsets for topics that are not authorized for Describe
-                val (authorizedPartitionData, _) = authHelper.partitionMapByAuthorized(request.context,
-                  DESCRIBE, TOPIC, allPartitionData)(_.topic)
-                new OffsetFetchResponse(requestThrottleMs, Errors.NONE, authorizedPartitionData.asJava)
-              }
-            } else {
-              val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
-                offsetFetchRequest.partitions.asScala)
-              val (error, authorizedPartitionData) = groupCoordinator.handleFetchOffsets(offsetFetchRequest.groupId,
-                offsetFetchRequest.requireStable, Some(authorizedPartitions))
-              if (error != Errors.NONE)
-                offsetFetchRequest.getErrorResponse(requestThrottleMs, error)
-              else {
-                val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
-                new OffsetFetchResponse(requestThrottleMs, Errors.NONE, (authorizedPartitionData ++ unauthorizedPartitionData).asJava)
-              }
+            } catch {
+              case e: Throwable =>
+                (topicPartition, new OffsetFetchResponse.PartitionData(OffsetFetchResponse.INVALID_OFFSET,
+                  Optional.empty(), OffsetFetchResponse.NO_METADATA, Errors.forException(e)))
             }
-          }
-        }
+          }.toMap
 
+          val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
+          new OffsetFetchResponse(requestThrottleMs, Errors.NONE, (authorizedPartitionData ++ unauthorizedPartitionData).asJava)
+        }
+      trace(s"Sending offset fetch response $offsetFetchResponse for correlation id ${header.correlationId} to client ${header.clientId}.")
+      offsetFetchResponse
+    }
+    requestHelper.sendResponseMaybeThrottle(request, createResponse)
+  }
+
+  private def handleOffsetFetchRequestBetweenV1AndV7(request: RequestChannel.Request): Unit = {
+    val header = request.header
+    val offsetFetchRequest = request.body[OffsetFetchRequest]
+    val groupId = offsetFetchRequest.groupId()
+    val (error, partitionData) = fetchOffsets(groupId, offsetFetchRequest.isAllPartitions,
+      offsetFetchRequest.requireStable, offsetFetchRequest.partitions, request.context)
+    def createResponse(requestThrottleMs: Int): AbstractResponse = {
+      val offsetFetchResponse =
+        if (error != Errors.NONE) {
+          offsetFetchRequest.getErrorResponse(requestThrottleMs, error)
+        } else {
+          new OffsetFetchResponse(requestThrottleMs, Errors.NONE, partitionData.asJava)
+        }
+      trace(s"Sending offset fetch response $offsetFetchResponse for correlation id ${header.correlationId} to client ${header.clientId}.")
+      offsetFetchResponse
+    }
+    requestHelper.sendResponseMaybeThrottle(request, createResponse)
+  }
+
+  private def handleOffsetFetchRequestV8AndAbove(request: RequestChannel.Request): Unit = {
+    val header = request.header
+    val offsetFetchRequest = request.body[OffsetFetchRequest]
+    val groupIds = offsetFetchRequest.groupIds().asScala
+    val groupToErrorMap =  mutable.Map.empty[String, Errors]
+    val groupToPartitionData =  mutable.Map.empty[String, util.Map[TopicPartition, PartitionData]]
+    val groupToTopics = offsetFetchRequest.groupIdsToTopics()
+    val groupToTopicPartitions = offsetFetchRequest.groupIdsToPartitions()
+    groupIds.foreach(g => {
+      val (error, partitionData) = fetchOffsets(g,
+        groupToTopics.get(g) == offsetFetchRequest.isAllPartitionsForGroup,
+        offsetFetchRequest.requireStable(),
+        groupToTopicPartitions.get(g), request.context)
+      groupToErrorMap += (g -> error)
+      groupToPartitionData += (g -> partitionData.asJava)
+    })
+
+    def createResponse(requestThrottleMs: Int): AbstractResponse = {
+      val offsetFetchResponse = new OffsetFetchResponse(requestThrottleMs,
+        groupToErrorMap.asJava, groupToPartitionData.asJava)
       trace(s"Sending offset fetch response $offsetFetchResponse for correlation id ${header.correlationId} to client ${header.clientId}.")
       offsetFetchResponse
     }
 
     requestHelper.sendResponseMaybeThrottle(request, createResponse)
   }
+
+  private def fetchOffsets(groupId: String, isAllPartitions: Boolean, requireStable: Boolean,
+                           partitions: util.List[TopicPartition], context: RequestContext): (Errors, Map[TopicPartition, OffsetFetchResponse.PartitionData]) = {
+    if (!authHelper.authorize(context, DESCRIBE, GROUP, groupId)) {
+      (Errors.GROUP_AUTHORIZATION_FAILED, Map.empty)
+    } else {
+      if (isAllPartitions) {
+        val (error, allPartitionData) = groupCoordinator.handleFetchOffsets(groupId, requireStable)
+        if (error != Errors.NONE) {
+          (error, allPartitionData)
+        } else {
+          // clients are not allowed to see offsets for topics that are not authorized for Describe
+          val (authorizedPartitionData, _) = authHelper.partitionMapByAuthorized(context,
+            DESCRIBE, TOPIC, allPartitionData)(_.topic)
+          (Errors.NONE, authorizedPartitionData)
+        }
+      } else {
+        val (authorizedPartitions, unauthorizedPartitions) = partitionByAuthorized(
+          partitions.asScala, context)
+        val (error, authorizedPartitionData) = groupCoordinator.handleFetchOffsets(groupId,
+          requireStable, Some(authorizedPartitions))
+        if (error != Errors.NONE) {
+          (error, authorizedPartitionData)
+        } else {
+          val unauthorizedPartitionData = unauthorizedPartitions.map(_ -> OffsetFetchResponse.UNAUTHORIZED_PARTITION).toMap
+          if (unauthorizedPartitionData.nonEmpty) {
+            (OffsetFetchResponse.UNAUTHORIZED_PARTITION.error, authorizedPartitionData ++ unauthorizedPartitionData)
+          } else {
+            (Errors.NONE, authorizedPartitionData ++ unauthorizedPartitionData)
+          }
+        }
+      }
+    }
+  }
+
+  private def partitionByAuthorized(seq: Seq[TopicPartition], context: RequestContext):
+  (Seq[TopicPartition], Seq[TopicPartition]) =
+    authHelper.partitionSeqByAuthorized(context, DESCRIBE, TOPIC, seq)(_.topic)
 
   def handleFindCoordinatorRequest(request: RequestChannel.Request): Unit = {
     val version = request.header.apiVersion

--- a/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextAdminIntegrationTest.scala
@@ -1103,7 +1103,9 @@ class PlaintextAdminIntegrationTest extends BaseAdminIntegrationTest {
 
           // Test listConsumerGroupOffsets
           TestUtils.waitUntilTrue(() => {
-            val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+            val parts = client.listConsumerGroupOffsets(Collections.singletonList(testGroupId))
+              .groupIdsToPartitionsAndOffsetAndMetadata()
+              .get(testGroupId).get()
             val part = new TopicPartition(testTopicName, 0)
             parts.containsKey(part) && (parts.get(part).offset() == 1)
           }, s"Expected the offset for partition 0 to eventually become 1.")

--- a/core/src/test/scala/unit/kafka/admin/ConsumerGroupServiceTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConsumerGroupServiceTest.scala
@@ -50,8 +50,8 @@ class ConsumerGroupServiceTest {
 
     when(admin.describeConsumerGroups(ArgumentMatchers.eq(Collections.singletonList(group)), any()))
       .thenReturn(describeGroupsResult(ConsumerGroupState.STABLE))
-    when(admin.listConsumerGroupOffsets(ArgumentMatchers.eq(group), any()))
-      .thenReturn(listGroupOffsetsResult)
+    when(admin.listConsumerGroupOffsets(ArgumentMatchers.eq(Collections.singletonList(group)), any()))
+      .thenReturn(listGroupOffsetsResult(group))
     when(admin.listOffsets(offsetsArgMatcher, any()))
       .thenReturn(listOffsetsResult)
 
@@ -61,7 +61,7 @@ class ConsumerGroupServiceTest {
     assertEquals(topicPartitions.size, assignments.get.size)
 
     verify(admin, times(1)).describeConsumerGroups(ArgumentMatchers.eq(Collections.singletonList(group)), any())
-    verify(admin, times(1)).listConsumerGroupOffsets(ArgumentMatchers.eq(group), any())
+    verify(admin, times(1)).listConsumerGroupOffsets(ArgumentMatchers.eq(Collections.singletonList(group)), any())
     verify(admin, times(1)).listOffsets(offsetsArgMatcher, any())
   }
 
@@ -193,9 +193,9 @@ class ConsumerGroupServiceTest {
     new DescribeConsumerGroupsResult(Collections.singletonMap(CoordinatorKey.byGroupId(group), future))
   }
 
-  private def listGroupOffsetsResult: ListConsumerGroupOffsetsResult = {
+  private def listGroupOffsetsResult(groupId: String): ListConsumerGroupOffsetsResult = {
     val offsets = topicPartitions.map(_ -> new OffsetAndMetadata(100)).toMap.asJava
-    AdminClientTestUtils.listConsumerGroupOffsetsResult(offsets)
+    AdminClientTestUtils.listConsumerGroupOffsetsResult(Map(groupId -> offsets).asJava)
   }
 
   private def offsetsArgMatcher: util.Map[TopicPartition, OffsetSpec] = {

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -321,7 +321,7 @@ class RequestQuotaTest extends BaseRequestTest {
               )
           )
         case ApiKeys.OFFSET_FETCH =>
-          new OffsetFetchRequest.Builder("test-group", false, List(tp).asJava, false)
+          new OffsetFetchRequest.Builder(Map("test-group"-> List(tp).asJava).asJava, false, false)
 
         case ApiKeys.FIND_COORDINATOR =>
           new FindCoordinatorRequest.Builder(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Tue Jun 29 23:29:14 PDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -182,7 +182,13 @@ public class EosIntegrationTest {
             final TopicPartition topicPartition = new TopicPartition(SINGLE_PARTITION_INPUT_TOPIC, 0);
             final Collection<TopicPartition> topicPartitions = Collections.singleton(topicPartition);
 
-            final long committedOffset = adminClient.listConsumerGroupOffsets(applicationId).partitionsToOffsetAndMetadata().get().get(topicPartition).offset();
+            final long committedOffset =
+                adminClient.listConsumerGroupOffsets(Collections.singletonList(applicationId))
+                    .groupIdsToPartitionsAndOffsetAndMetadata()
+                    .get(applicationId)
+                    .get()
+                    .get(topicPartition)
+                    .offset();
 
             consumer.assign(topicPartitions);
             final long consumerPosition = consumer.position(topicPartition);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.tests;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.internals.CoordinatorKey;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -272,8 +273,12 @@ public class EosTestDriver extends SmokeTestUtil {
         final Map<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataMap;
 
         try {
-            final ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(EosTestClient.APP_ID);
-            topicPartitionOffsetAndMetadataMap = listConsumerGroupOffsetsResult.partitionsToOffsetAndMetadata().get(10, TimeUnit.SECONDS);
+            final ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult =
+                adminClient.listConsumerGroupOffsets(Collections.singletonList(EosTestClient.APP_ID));
+            topicPartitionOffsetAndMetadataMap =
+                listConsumerGroupOffsetsResult.groupIdsToPartitionsAndOffsetAndMetadata()
+                    .get(EosTestClient.APP_ID)
+                    .get(10, TimeUnit.SECONDS);
         } catch (final Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);


### PR DESCRIPTION
This implements the AdminAPI portion of KIP-709: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=173084258. The request/response changes was implemented in https://github.com/apache/kafka/pull/10954.

It updates the Admin APIs associated with the `OffsetFetch` API. This PR deprecates the old single group ID API and adds new APIs to take in multiple groups at a time for fetching consumer group offsets.