### PR TITLE
MINOR: Add `KafkaAdminClient.getListOffsetsCalls` benchmark

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3678,7 +3678,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     // visible for benchmark
-    public List<Call> getListOffsetsCalls(MetadataOperationContext<ListOffsetsResultInfo, ListOffsetsOptions> context,
+    List<Call> getListOffsetsCalls(MetadataOperationContext<ListOffsetsResultInfo, ListOffsetsOptions> context,
                                            Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
                                            Map<TopicPartition, KafkaFutureImpl<ListOffsetsResultInfo>> futures) {
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3679,8 +3679,8 @@ public class KafkaAdminClient extends AdminClient {
 
     // visible for benchmark
     List<Call> getListOffsetsCalls(MetadataOperationContext<ListOffsetsResultInfo, ListOffsetsOptions> context,
-                                           Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
-                                           Map<TopicPartition, KafkaFutureImpl<ListOffsetsResultInfo>> futures) {
+                                   Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
+                                   Map<TopicPartition, KafkaFutureImpl<ListOffsetsResultInfo>> futures) {
 
         MetadataResponse mr = context.response().orElseThrow(() -> new IllegalStateException("No Metadata response"));
         Cluster clusterSnapshot = mr.buildCluster();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -3677,7 +3677,8 @@ public class KafkaAdminClient extends AdminClient {
         return new ListOffsetsResult(new HashMap<>(futures));
     }
 
-    private List<Call> getListOffsetsCalls(MetadataOperationContext<ListOffsetsResultInfo, ListOffsetsOptions> context,
+    // visible for benchmark
+    public List<Call> getListOffsetsCalls(MetadataOperationContext<ListOffsetsResultInfo, ListOffsetsOptions> context,
                                            Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
                                            Map<TopicPartition, KafkaFutureImpl<ListOffsetsResultInfo>> futures) {
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
@@ -110,9 +110,9 @@ public class AdminClientTestUtils {
      * from within the admin package.
      */
     public static List<KafkaAdminClient.Call> getListOffsetsCalls(KafkaAdminClient adminClient, 
-                                                   MetadataOperationContext<ListOffsetsResult.ListOffsetsResultInfo, ListOffsetsOptions> context,
-                                                   Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
-                                                   Map<TopicPartition, KafkaFutureImpl<ListOffsetsResult.ListOffsetsResultInfo>> futures) {
+                                                                  MetadataOperationContext<ListOffsetsResult.ListOffsetsResultInfo, ListOffsetsOptions> context,
+                                                                  Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
+                                                                  Map<TopicPartition, KafkaFutureImpl<ListOffsetsResult.ListOffsetsResultInfo>> futures) {
         return adminClient.getListOffsetsCalls(context, topicPartitionOffsets, futures); 
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientTestUtils.java
@@ -17,10 +17,12 @@
 package org.apache.kafka.clients.admin;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.admin.CreateTopicsResult.TopicMetadataAndConfig;
+import org.apache.kafka.clients.admin.internals.MetadataOperationContext;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
@@ -101,5 +103,16 @@ public class AdminClientTestUtils {
 
     public static ListConsumerGroupOffsetsResult listConsumerGroupOffsetsResult(Map<TopicPartition, OffsetAndMetadata> offsets) {
         return new ListConsumerGroupOffsetsResult(KafkaFuture.completedFuture(offsets));
+    }
+
+    /**
+     * Used for benchmark. KafkaAdminClient.getListOffsetsCalls is only accessible
+     * from within the admin package.
+     */
+    public static List<KafkaAdminClient.Call> getListOffsetsCalls(KafkaAdminClient adminClient, 
+                                                   MetadataOperationContext<ListOffsetsResult.ListOffsetsResultInfo, ListOffsetsOptions> context,
+                                                   Map<TopicPartition, OffsetSpec> topicPartitionOffsets,
+                                                   Map<TopicPartition, KafkaFutureImpl<ListOffsetsResult.ListOffsetsResultInfo>> futures) {
+        return adminClient.getListOffsetsCalls(context, topicPartitionOffsets, futures); 
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/admin/GetListOffsetsCallsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/admin/GetListOffsetsCallsBenchmark.java
@@ -15,8 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.clients.admin;
+package org.apache.kafka.jmh.admin;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.AdminClientTestUtils;
 import org.apache.kafka.clients.admin.AdminClientUnitTestEnv;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.ListOffsetsOptions;
@@ -44,17 +56,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
@@ -124,8 +125,8 @@ public class GetListOffsetsCallsBenchmark {
     }
 
     @Benchmark
-    public List<KafkaAdminClient.Call> testGetListOffsetsCalls() {
-        return admin.getListOffsetsCalls(context, topicPartitionOffsets, futures);
+    public Object testGetListOffsetsCalls() {
+        return AdminClientTestUtils.getListOffsetsCalls(admin, context, topicPartitionOffsets, futures);
     }
 
     private Cluster mockCluster() {

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/admin/GetListOffsetsCallsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/admin/GetListOffsetsCallsBenchmark.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.admin;
+
+import org.apache.kafka.clients.admin.AdminClientUnitTestEnv;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.admin.ListOffsetsOptions;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.internals.MetadataOperationContext;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponsePartition;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class GetListOffsetsCallsBenchmark {
+    @Param({"1", "10"})
+    private int topicCount;
+
+    @Param({"100", "1000", "10000"})
+    private int partitionCount;
+
+    private KafkaAdminClient admin;
+    private MetadataOperationContext<ListOffsetsResult.ListOffsetsResultInfo, ListOffsetsOptions> context;
+    private final Map<TopicPartition, OffsetSpec> topicPartitionOffsets = new HashMap<>();
+    private final Map<TopicPartition, KafkaFutureImpl<ListOffsetsResult.ListOffsetsResultInfo>> futures = new HashMap<>();
+    private final int numNodes = 3;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        MetadataResponseData data = new MetadataResponseData();
+        List<MetadataResponseTopic> mrTopicList = new ArrayList<>();
+        Set<String> topics = new HashSet<>();
+
+        for (int topicIndex = 0; topicIndex < topicCount; topicIndex++) {
+            Uuid topicId = Uuid.randomUuid();
+            String topicName = "topic-" + topicIndex;
+            MetadataResponseTopic mrTopic = new MetadataResponseTopic()
+                    .setTopicId(topicId)
+                    .setName(topicName)
+                    .setErrorCode((short) 0)
+                    .setIsInternal(false);
+
+            List<MetadataResponsePartition> mrPartitionList = new ArrayList<>();
+
+            for (int partition = 0; partition < partitionCount; partition++) {
+                TopicPartition tp = new TopicPartition(topicName, partition);
+                topics.add(tp.topic());
+                futures.put(tp, new KafkaFutureImpl<>());
+                topicPartitionOffsets.put(tp, OffsetSpec.latest());
+
+                MetadataResponsePartition mrPartition = new MetadataResponsePartition()
+                        .setLeaderId(partition % numNodes)
+                        .setPartitionIndex(partition)
+                        .setIsrNodes(Arrays.asList(0, 1, 2))
+                        .setReplicaNodes(Arrays.asList(0, 1, 2))
+                        .setOfflineReplicas(Collections.emptyList())
+                        .setErrorCode((short) 0);
+
+                mrPartitionList.add(mrPartition);
+            }
+
+            mrTopic.setPartitions(mrPartitionList);
+            mrTopicList.add(mrTopic);
+        }
+        data.setTopics(new MetadataResponseData.MetadataResponseTopicCollection(mrTopicList.listIterator()));
+
+        long deadline = 0L;
+        short version = 0;
+        context = new MetadataOperationContext<>(topics, new ListOffsetsOptions(), deadline, futures);
+        context.setResponse(Optional.of(new MetadataResponse(data, version)));
+
+        AdminClientUnitTestEnv adminEnv = new AdminClientUnitTestEnv(mockCluster());
+        admin = (KafkaAdminClient) adminEnv.adminClient();
+    }
+
+    @Benchmark
+    public Object testGetListOffsetsCalls() {
+        return admin.getListOffsetsCalls(context, topicPartitionOffsets, futures);
+    }
+
+    private Cluster mockCluster() {
+        final int controllerIndex = 0;
+
+        HashMap<Integer, Node> nodes = new HashMap<>();
+        for (int i = 0; i < numNodes; i++)
+            nodes.put(i, new Node(i, "localhost", 8121 + i));
+        return new Cluster("mockClusterId", nodes.values(),
+                Collections.emptySet(), Collections.emptySet(),
+                Collections.emptySet(), nodes.get(controllerIndex));
+    }
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/admin/GetListOffsetsCallsBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/admin/GetListOffsetsCallsBenchmark.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.jmh.admin;
+package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.clients.admin.AdminClientUnitTestEnv;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -124,7 +124,7 @@ public class GetListOffsetsCallsBenchmark {
     }
 
     @Benchmark
-    public Object testGetListOffsetsCalls() {
+    public List<KafkaAdminClient.Call> testGetListOffsetsCalls() {
         return admin.getListOffsetsCalls(context, topicPartitionOffsets, futures);
     }
 


### PR DESCRIPTION
new benchmark to test KafkaAdminClient.getListOffsetsCalls
originated from https://github.com/apache/kafka/pull/10940

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
