### PR TITLE
KAFKA-13028: Enable the AbstractConfig to resolve variables in ConfigProviders

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -516,6 +517,7 @@ public class AbstractConfig {
             providerConfigString = extractPotentialVariables(configProviderProps);
             configProperties = configProviderProps;
         }
+        providerConfigString = new RecordingMap<>(providerConfigString);
         Map<String, ConfigProvider> providers = instantiateConfigProviders(providerConfigString, configProperties);
 
         if (!providers.isEmpty()) {
@@ -558,7 +560,7 @@ public class AbstractConfig {
             return Collections.emptyMap();
         }
 
-        Map<String, String> providerMap = new HashMap<>();
+        Map<String, String> providerMap = new LinkedHashMap<>(); // maintain order
 
         for (String provider: configProviders.split(",")) {
             String providerClass = CONFIG_PROVIDERS_CONFIG + "." + provider + ".class";
@@ -573,7 +575,22 @@ public class AbstractConfig {
                 String prefix = CONFIG_PROVIDERS_CONFIG + "." + entry.getKey() + CONFIG_PROVIDERS_PARAM;
                 Map<String, ?> configProperties = configProviderProperties(prefix, providerConfigProperties);
                 ConfigProvider provider = Utils.newInstance(entry.getValue(), ConfigProvider.class);
-                provider.configure(configProperties);
+                Map<String, Object> resolvedOriginals = new HashMap<>(configProperties);
+
+                if (!configProviderInstances.isEmpty()) {
+                    // Try to resolve this config provider's properties using already-instantiated providers
+                    Map<String, String> configStringProps = extractPotentialVariables(configProperties);
+                    if (!configStringProps.isEmpty()) {
+                        // There is at least one string property that could be a variable
+                        ConfigTransformer configTransformer = new ConfigTransformer(configProviderInstances);
+                        ConfigTransformerResult result = configTransformer.transform(configStringProps);
+                        if (!result.data().isEmpty()) {
+                            resolvedOriginals.putAll(result.data());
+                        }
+                    }
+                }
+
+                provider.configure(new RecordingMap<>(resolvedOriginals, prefix, false)); // ignore unprefixed as used
                 configProviderInstances.put(entry.getKey(), provider);
             } catch (ClassNotFoundException e) {
                 log.error("ClassNotFoundException exception occurred: " + entry.getValue());

--- a/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/AbstractConfigTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.common.config;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.provider.MockDependentConfigProvider;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.metrics.FakeMetricsReporter;
 import org.apache.kafka.common.metrics.JmxReporter;
@@ -399,23 +400,64 @@ public class AbstractConfigTest {
     @Test
     public void testAutoConfigResolutionWithMultipleConfigProviders() {
         // Test Case: Valid Test Case With Multiple ConfigProviders as a separate variable
-        Properties providers = new Properties();
-        providers.put("config.providers", "file,vault");
-        providers.put("config.providers.file.class", MockFileConfigProvider.class.getName());
         String id = UUID.randomUUID().toString();
-        providers.put("config.providers.file.param.testId", id);
-        providers.put("config.providers.vault.class", MockVaultConfigProvider.class.getName());
         Properties props = new Properties();
+        props.put("config.providers", "file,vault");
+        props.put("config.providers.file.class", MockFileConfigProvider.class.getName());
+        props.put("config.providers.file.param.testId", id);
+        props.put("config.providers.vault.class", MockVaultConfigProvider.class.getName());
         props.put("sasl.kerberos.key", "${file:/usr/kerberos:key}");
         props.put("sasl.kerberos.password", "${file:/usr/kerberos:password}");
         props.put("sasl.truststore.key", "${vault:/usr/truststore:truststoreKey}");
         props.put("sasl.truststore.password", "${vault:/usr/truststore:truststorePassword}");
-        TestIndirectConfigResolution config = new TestIndirectConfigResolution(props, convertPropertiesToMap(providers));
+        TestIndirectConfigResolution config = new TestIndirectConfigResolution(props);
         assertEquals("testKey", config.originals().get("sasl.kerberos.key"));
         assertEquals("randomPassword", config.originals().get("sasl.kerberos.password"));
         assertEquals("testTruststoreKey", config.originals().get("sasl.truststore.key"));
         assertEquals("randomtruststorePassword", config.originals().get("sasl.truststore.password"));
         MockFileConfigProvider.assertClosed(id);
+    }
+
+    @Test
+    public void testAutoConfigResolutionWithMultipleConfigProvidersWhenSecondUsesVariablesFromFirst() {
+        Properties providers = new Properties();
+        providers.put("config.providers", "file,vault");
+        providers.put("config.providers.file.class", MockFileConfigProvider.class.getName());
+        String id = UUID.randomUUID().toString();
+        providers.put("config.providers.file.param.testId", id);
+        providers.put("config.providers.vault.class", MockDependentConfigProvider.class.getName());
+        // Use the password from the 'file' config provider in the configuration for the 'vault' config provider
+        providers.put("config.providers.vault.param.secret.key", "${file:/usr/kerberos:password}");
+        Properties props = new Properties();
+        props.put("sasl.kerberos.key", "${file:/usr/kerberos:key}");
+        props.put("sasl.kerberos.password", "${file:/usr/kerberos:password}");
+        props.put("sasl.truststore.key", "${vault:/usr/truststore:app.key}");
+        props.put("sasl.truststore.password", "${vault:/usr/truststore:app.password}");
+        TestIndirectConfigResolution config = new TestIndirectConfigResolution(props, convertPropertiesToMap(providers));
+        assertEquals("testKey", config.originals().get("sasl.kerberos.key"));
+        assertEquals("randomPassword", config.originals().get("sasl.kerberos.password"));
+        assertEquals("appKey", config.originals().get("sasl.truststore.key"));
+        assertEquals("appPassword", config.originals().get("sasl.truststore.password"));
+        MockFileConfigProvider.assertClosed(id);
+    }
+
+    @Test
+    public void testAutoConfigResolutionFailsWithMultipleConfigProvidersWhenFirstUsesVariablesFromSecond() {
+        Properties providers = new Properties();
+        providers.put("config.providers", "vault,file"); // wrong order
+        providers.put("config.providers.file.class", MockFileConfigProvider.class.getName());
+        String id = UUID.randomUUID().toString();
+        providers.put("config.providers.file.param.testId", id);
+        providers.put("config.providers.vault.class", MockDependentConfigProvider.class.getName());
+        // Use the password from the 'file' config provider in the configuration for the 'vault' config provider
+        providers.put("config.providers.vault.param.secret.key", "${file:/usr/kerberos:password}");
+        Properties props = new Properties();
+        props.put("sasl.kerberos.key", "${file:/usr/kerberos:key}");
+        props.put("sasl.kerberos.password", "${file:/usr/kerberos:password}");
+        props.put("sasl.truststore.key", "${vault:/usr/truststore:truststoreKey}");
+        props.put("sasl.truststore.password", "${vault:/usr/truststore:truststorePassword}");
+        RuntimeException e = assertThrows(RuntimeException.class, () -> new TestIndirectConfigResolution(props, convertPropertiesToMap(providers)));
+        assertTrue(e.getMessage().contains("expected 'secret.key=randomPassword', but found 'secret.key=${file:/usr/kerberos:password}'"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/config/provider/MockDependentConfigProvider.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/provider/MockDependentConfigProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.config.provider;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MockDependentConfigProvider extends FileConfigProvider {
+
+    private static final Map<String, MockDependentConfigProvider> INSTANCES = Collections.synchronizedMap(new HashMap<>());
+    private String key;
+    private boolean closed = false;
+
+    public void configure(Map<String, ?> configs) {
+        Object key = configs.get("secret.key");
+        if (key == null) {
+            throw new RuntimeException(getClass().getName() + " missing 'secret.key' config");
+        }
+        // The value is expected to match the 'password' property in the MockFileConfigProvider
+        if (!key.equals("randomPassword")) {
+            throw new RuntimeException(getClass().getName() + " expected 'secret.key=randomPassword', but found 'secret.key=" + key + "'");
+        }
+        if (this.key != null) {
+            throw new RuntimeException(getClass().getName() + " instance was configured twice");
+        }
+        this.key = key.toString();
+        INSTANCES.put(key.toString(), this);
+    }
+
+    @Override
+    protected Reader reader(String path) throws IOException {
+        return new StringReader("app.key=appKey\napp.password=appPassword");
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+    }
+
+    public static void assertClosed(String id) {
+        MockDependentConfigProvider instance = INSTANCES.remove(id);
+        assertNotNull(instance);
+        synchronized (instance) {
+            assertTrue(instance.closed);
+        }
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE UNTIL IT IS DETERMINED WHETHER THIS REQUIRED A KIP.**

See [KAFKA-13028](https://issues.apache.org/jira/browse/KAFKA-13028)

The AbstractConfig constructor is changed to instantiate and configure each ConfigProvider instance
in the same order as defined by the 'config.providers' property. And when configuring a ConfigProvider,
it uses any previously-configured ConfigProvider instances to potentially resolve any variables in
that ConfigProvider's configuration.

New unit tests are added to verify this change in behavior.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
